### PR TITLE
feat: React 19 migration Phase 5 - complex components

### DIFF
--- a/packages/ui/src/components/Breadcrumb.tsx
+++ b/packages/ui/src/components/Breadcrumb.tsx
@@ -21,7 +21,7 @@
  * Context awareness: Adapts to sidebar visibility and responsive breakpoints
  */
 import { ChevronRight, Home, MoreHorizontal } from 'lucide-react';
-import { createContext, forwardRef, useCallback, useContext, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
 import { cn } from '../lib/utils';
 
 export type BreadcrumbSeparator =
@@ -62,6 +62,8 @@ export interface BreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
 
   // Enhanced accessibility
   'aria-describedby'?: string;
+
+  ref?: React.Ref<HTMLElement>;
 }
 
 export interface BreadcrumbItemProps extends React.HTMLAttributes<HTMLLIElement> {
@@ -69,14 +71,17 @@ export interface BreadcrumbItemProps extends React.HTMLAttributes<HTMLLIElement>
   href?: string;
   active?: boolean;
   truncated?: boolean;
+  ref?: React.Ref<HTMLLIElement>;
 }
 
 export interface BreadcrumbLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   children: React.ReactNode;
+  ref?: React.Ref<HTMLAnchorElement>;
 }
 
 export interface BreadcrumbPageProps extends React.HTMLAttributes<HTMLSpanElement> {
   children: React.ReactNode;
+  ref?: React.Ref<HTMLSpanElement>;
 }
 
 // Separator intelligence with cognitive load ratings
@@ -137,150 +142,146 @@ const BreadcrumbContext = createContext<{
   separatorProps: undefined,
 });
 
-export const Breadcrumb = forwardRef<HTMLElement, BreadcrumbProps>(
-  (
-    {
-      maxItems = 5,
-      truncationMode = 'smart',
-      separator = 'chevron-right',
-      separatorProps,
-      showHome = true,
-      homeIcon: HomeIcon = Home,
-      homeLabel = 'Home',
-      size = 'md',
-      variant = 'default',
-      expandable = true,
-      responsive = true,
-      className,
-      children,
-      ...props
-    },
-    ref
-  ) => {
-    const [expanded, setExpanded] = useState(false);
+export function Breadcrumb({
+  maxItems = 5,
+  truncationMode = 'smart',
+  separator = 'chevron-right',
+  separatorProps,
+  showHome = true,
+  homeIcon: HomeIcon = Home,
+  homeLabel = 'Home',
+  size = 'md',
+  variant = 'default',
+  expandable = true,
+  responsive = true,
+  className,
+  children,
+  ref,
+  ...props
+}: BreadcrumbProps) {
+  const [expanded, setExpanded] = useState(false);
 
-    const renderSeparator = useCallback(() => {
-      if (typeof separator === 'string') {
-        const separatorMap = {
-          'chevron-right': <ChevronRight className="w-4 h-4" aria-hidden="true" />,
-          slash: SAFE_SEPARATORS.slash,
-          angle: SAFE_SEPARATORS.angle,
-          arrow: SAFE_SEPARATORS.arrow,
-          pipe: SAFE_SEPARATORS.pipe,
-          dot: SAFE_SEPARATORS.dot,
-        };
+  const renderSeparator = useCallback(() => {
+    if (typeof separator === 'string') {
+      const separatorMap = {
+        'chevron-right': <ChevronRight className="w-4 h-4" aria-hidden="true" />,
+        slash: SAFE_SEPARATORS.slash,
+        angle: SAFE_SEPARATORS.angle,
+        arrow: SAFE_SEPARATORS.arrow,
+        pipe: SAFE_SEPARATORS.pipe,
+        dot: SAFE_SEPARATORS.dot,
+      };
 
-        const separatorContent = separatorMap[separator];
+      const separatorContent = separatorMap[separator];
 
-        if (typeof separatorContent === 'string') {
-          return (
-            <span aria-hidden="true" className="select-none text-muted-foreground">
-              {separatorContent}
-            </span>
-          );
-        }
-
-        return separatorContent;
+      if (typeof separatorContent === 'string') {
+        return (
+          <span aria-hidden="true" className="select-none text-muted-foreground">
+            {separatorContent}
+          </span>
+        );
       }
 
-      // Custom Lucide icon
-      const CustomIcon = separator;
-      return (
-        <CustomIcon
-          aria-hidden={true}
-          className="w-4 h-4 text-muted-foreground"
-          {...separatorProps}
-        />
-      );
-    }, [separator, separatorProps]);
+      return separatorContent;
+    }
 
+    // Custom Lucide icon
+    const CustomIcon = separator;
     return (
-      <BreadcrumbContext.Provider value={{ separator, separatorProps }}>
-        <nav
-          ref={ref}
-          aria-label="Breadcrumb navigation"
-          aria-describedby={props['aria-describedby']}
-          className={cn(
-            // Base styles with semantic tokens
-            'flex items-center text-sm text-muted-foreground',
-
-            // Size variants
-            {
-              'text-xs': size === 'sm',
-              'text-sm': size === 'md',
-              'text-base': size === 'lg',
-            },
-
-            // Variant styles
-            {
-              'opacity-100': variant === 'default',
-              'opacity-75': variant === 'minimal',
-            },
-
-            className
-          )}
-          {...props}
-        >
-          <ol className="flex items-center space-x-2">{children}</ol>
-        </nav>
-      </BreadcrumbContext.Provider>
+      <CustomIcon
+        aria-hidden={true}
+        className="w-4 h-4 text-muted-foreground"
+        {...separatorProps}
+      />
     );
-  }
-);
+  }, [separator, separatorProps]);
 
-export const BreadcrumbItem = forwardRef<HTMLLIElement, BreadcrumbItemProps>(
-  ({ children, className, ...props }, ref) => {
-    return (
-      <li ref={ref} className={cn('flex items-center', className)} {...props}>
-        {children}
-      </li>
-    );
-  }
-);
-
-export const BreadcrumbLink = forwardRef<HTMLAnchorElement, BreadcrumbLinkProps>(
-  ({ children, className, ...props }, ref) => {
-    return (
-      <a
+  return (
+    <BreadcrumbContext.Provider value={{ separator, separatorProps }}>
+      <nav
         ref={ref}
+        aria-label="Breadcrumb navigation"
+        aria-describedby={props['aria-describedby']}
         className={cn(
-          // Base interactive styles with semantic tokens
-          'text-muted-foreground hover:text-foreground transition-colors',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+          // Base styles with semantic tokens
+          'flex items-center text-sm text-muted-foreground',
 
-          // Enhanced touch targets (WCAG AAA)
-          'min-h-11 min-w-11 flex items-center justify-center rounded px-2 py-1',
-          'touch-manipulation',
+          // Size variants
+          {
+            'text-xs': size === 'sm',
+            'text-sm': size === 'md',
+            'text-base': size === 'lg',
+          },
+
+          // Variant styles
+          {
+            'opacity-100': variant === 'default',
+            'opacity-75': variant === 'minimal',
+          },
 
           className
         )}
         {...props}
       >
-        {children}
-      </a>
-    );
-  }
-);
+        <ol className="flex items-center space-x-2">{children}</ol>
+      </nav>
+    </BreadcrumbContext.Provider>
+  );
+}
 
-export const BreadcrumbPage = forwardRef<HTMLSpanElement, BreadcrumbPageProps>(
-  ({ children, className, ...props }, ref) => {
-    return (
-      <span
-        ref={ref}
-        aria-current="page"
-        className={cn('text-foreground font-medium', className)}
-        {...props}
-      >
-        {children}
-      </span>
-    );
-  }
-);
+export function BreadcrumbItem({ children, className, ref, ...props }: BreadcrumbItemProps) {
+  return (
+    <li ref={ref} className={cn('flex items-center', className)} {...props}>
+      {children}
+    </li>
+  );
+}
 
-export const BreadcrumbSeparator = forwardRef<
-  HTMLSpanElement,
-  React.HTMLAttributes<HTMLSpanElement>
->(({ children, className, ...props }, ref) => {
+export function BreadcrumbLink({ children, className, ref, ...props }: BreadcrumbLinkProps) {
+  return (
+    <a
+      ref={ref}
+      className={cn(
+        // Base interactive styles with semantic tokens
+        'text-muted-foreground hover:text-foreground transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+
+        // Enhanced touch targets (WCAG AAA)
+        'min-h-11 min-w-11 flex items-center justify-center rounded px-2 py-1',
+        'touch-manipulation',
+
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </a>
+  );
+}
+
+export function BreadcrumbPage({ children, className, ref, ...props }: BreadcrumbPageProps) {
+  return (
+    <span
+      ref={ref}
+      aria-current="page"
+      className={cn('text-foreground font-medium', className)}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}
+
+export interface BreadcrumbSeparatorProps extends React.HTMLAttributes<HTMLSpanElement> {
+  ref?: React.Ref<HTMLSpanElement>;
+}
+
+export function BreadcrumbSeparator({
+  children,
+  className,
+  ref,
+  ...props
+}: BreadcrumbSeparatorProps) {
   const { separator, separatorProps } = useContext(BreadcrumbContext);
 
   const renderSeparatorContent = () => {
@@ -333,12 +334,13 @@ export const BreadcrumbSeparator = forwardRef<
       {renderSeparatorContent()}
     </span>
   );
-});
+}
 
-export const BreadcrumbEllipsis = forwardRef<
-  HTMLButtonElement,
-  React.ButtonHTMLAttributes<HTMLButtonElement>
->(({ className, onClick, ...props }, ref) => {
+export interface BreadcrumbEllipsisProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  ref?: React.Ref<HTMLButtonElement>;
+}
+
+export function BreadcrumbEllipsis({ className, onClick, ref, ...props }: BreadcrumbEllipsisProps) {
   return (
     <button
       ref={ref}
@@ -357,12 +359,4 @@ export const BreadcrumbEllipsis = forwardRef<
       <MoreHorizontal className="w-4 h-4" aria-hidden="true" />
     </button>
   );
-});
-
-// Export display names for better debugging
-Breadcrumb.displayName = 'Breadcrumb';
-BreadcrumbItem.displayName = 'BreadcrumbItem';
-BreadcrumbLink.displayName = 'BreadcrumbLink';
-BreadcrumbPage.displayName = 'BreadcrumbPage';
-BreadcrumbSeparator.displayName = 'BreadcrumbSeparator';
-BreadcrumbEllipsis.displayName = 'BreadcrumbEllipsis';
+}

--- a/packages/ui/src/components/Card.tsx
+++ b/packages/ui/src/components/Card.tsx
@@ -19,7 +19,6 @@ import { contextEasing, contextTiming } from '@rafters/design-tokens/motion';
  *
  * Token knowledge: .rafters/tokens/registry.json
  */
-import { forwardRef } from 'react';
 import { cn } from '../lib/utils';
 
 export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -29,13 +28,18 @@ export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   interactive?: boolean;
   /** Scanability: Visual prominence for important cards */
   prominence?: 'subtle' | 'default' | 'elevated';
+  ref?: React.Ref<HTMLDivElement>;
 }
 
-export const Card = forwardRef<HTMLDivElement, CardProps>(
-  (
-    { className, density = 'comfortable', interactive = false, prominence = 'default', ...props },
-    ref
-  ) => (
+export function Card({
+  className,
+  density = 'comfortable',
+  interactive = false,
+  prominence = 'default',
+  ref,
+  ...props
+}: CardProps) {
+  return (
     <div
       ref={ref}
       className={cn(
@@ -59,17 +63,17 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(
       tabIndex={interactive ? 0 : undefined}
       {...props}
     />
-  )
-);
-Card.displayName = 'Card';
+  );
+}
 
 export interface CardHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Cognitive load: Header density for information hierarchy */
   density?: 'compact' | 'comfortable' | 'spacious';
+  ref?: React.Ref<HTMLDivElement>;
 }
 
-export const CardHeader = forwardRef<HTMLDivElement, CardHeaderProps>(
-  ({ className, density = 'comfortable', ...props }, ref) => (
+export function CardHeader({ className, density = 'comfortable', ref, ...props }: CardHeaderProps) {
+  return (
     <div
       ref={ref}
       className={cn(
@@ -84,59 +88,69 @@ export const CardHeader = forwardRef<HTMLDivElement, CardHeaderProps>(
       )}
       {...props}
     />
-  )
-);
-CardHeader.displayName = 'CardHeader';
+  );
+}
 
 export interface CardTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {
   /** Information hierarchy: Semantic heading level */
   level?: 1 | 2 | 3 | 4 | 5 | 6;
   /** Scanability: Visual weight for content hierarchy */
   weight?: 'normal' | 'medium' | 'semibold';
+  ref?: React.Ref<HTMLHeadingElement>;
 }
 
-export const CardTitle = forwardRef<HTMLHeadingElement, CardTitleProps>(
-  ({ className, level = 3, weight = 'semibold', ...props }, ref) => {
-    const HeadingTag = `h${level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+export function CardTitle({
+  className,
+  level = 3,
+  weight = 'semibold',
+  ref,
+  ...props
+}: CardTitleProps) {
+  const HeadingTag = `h${level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
-    return (
-      <HeadingTag
-        ref={ref}
-        className={cn(
-          'leading-none tracking-tight',
-          // Information hierarchy: Semantic sizing based on heading level
-          {
-            'text-3xl': level === 1,
-            'text-2xl': level === 2,
-            'text-xl': level === 3,
-            'text-lg': level === 4,
-            'text-base': level === 5,
-            'text-sm': level === 6,
-          },
-          // Scanability: Visual weight options
-          {
-            'font-normal': weight === 'normal',
-            'font-medium': weight === 'medium',
-            'font-semibold': weight === 'semibold',
-          },
-          className
-        )}
-        {...props}
-      />
-    );
-  }
-);
-CardTitle.displayName = 'CardTitle';
+  return (
+    <HeadingTag
+      ref={ref}
+      className={cn(
+        'leading-none tracking-tight',
+        // Information hierarchy: Semantic sizing based on heading level
+        {
+          'text-3xl': level === 1,
+          'text-2xl': level === 2,
+          'text-xl': level === 3,
+          'text-lg': level === 4,
+          'text-base': level === 5,
+          'text-sm': level === 6,
+        },
+        // Scanability: Visual weight options
+        {
+          'font-normal': weight === 'normal',
+          'font-medium': weight === 'medium',
+          'font-semibold': weight === 'semibold',
+        },
+        className
+      )}
+      {...props}
+    />
+  );
+}
 
 export interface CardDescriptionProps extends React.HTMLAttributes<HTMLParagraphElement> {
   /** Cognitive load: Text length awareness for readability */
   truncate?: boolean;
   /** Information hierarchy: Subtle vs prominent descriptions */
   prominence?: 'subtle' | 'default';
+  ref?: React.Ref<HTMLParagraphElement>;
 }
 
-export const CardDescription = forwardRef<HTMLParagraphElement, CardDescriptionProps>(
-  ({ className, truncate = false, prominence = 'default', ...props }, ref) => (
+export function CardDescription({
+  className,
+  truncate = false,
+  prominence = 'default',
+  ref,
+  ...props
+}: CardDescriptionProps) {
+  return (
     <p
       ref={ref}
       className={cn(
@@ -152,19 +166,25 @@ export const CardDescription = forwardRef<HTMLParagraphElement, CardDescriptionP
       )}
       {...props}
     />
-  )
-);
-CardDescription.displayName = 'CardDescription';
+  );
+}
 
 export interface CardContentProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Cognitive load: Content density for information hierarchy */
   density?: 'compact' | 'comfortable' | 'spacious';
   /** Scanability: Content organization patterns */
   layout?: 'default' | 'grid' | 'list';
+  ref?: React.Ref<HTMLDivElement>;
 }
 
-export const CardContent = forwardRef<HTMLDivElement, CardContentProps>(
-  ({ className, density = 'comfortable', layout = 'default', ...props }, ref) => (
+export function CardContent({
+  className,
+  density = 'comfortable',
+  layout = 'default',
+  ref,
+  ...props
+}: CardContentProps) {
+  return (
     <div
       ref={ref}
       className={cn(
@@ -185,19 +205,25 @@ export const CardContent = forwardRef<HTMLDivElement, CardContentProps>(
       )}
       {...props}
     />
-  )
-);
-CardContent.displayName = 'CardContent';
+  );
+}
 
 export interface CardFooterProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Cognitive load: Footer density and action clarity */
   density?: 'compact' | 'comfortable' | 'spacious';
   /** Scanability: Action hierarchy in footer */
   justify?: 'start' | 'center' | 'end' | 'between';
+  ref?: React.Ref<HTMLDivElement>;
 }
 
-export const CardFooter = forwardRef<HTMLDivElement, CardFooterProps>(
-  ({ className, density = 'comfortable', justify = 'start', ...props }, ref) => (
+export function CardFooter({
+  className,
+  density = 'comfortable',
+  justify = 'start',
+  ref,
+  ...props
+}: CardFooterProps) {
+  return (
     <div
       ref={ref}
       className={cn(
@@ -219,6 +245,5 @@ export const CardFooter = forwardRef<HTMLDivElement, CardFooterProps>(
       )}
       {...props}
     />
-  )
-);
-CardFooter.displayName = 'CardFooter';
+  );
+}

--- a/packages/ui/src/components/Container.tsx
+++ b/packages/ui/src/components/Container.tsx
@@ -24,7 +24,6 @@
  *
  * Token knowledge: Uses --spacing-* tokens from design system
  */
-import { forwardRef } from 'react';
 import { cn } from '../lib/utils';
 import './article-prose.css';
 
@@ -218,6 +217,7 @@ export interface ContainerProps extends React.HTMLAttributes<HTMLElement> {
    * article: standalone content
    */
   as?: 'div' | 'main' | 'section' | 'article';
+  ref?: React.Ref<RefType>;
 }
 
 /**
@@ -234,289 +234,283 @@ type RefType = HTMLDivElement | HTMLElement;
  * - Semantic HTML support for accessibility
  * - Builds on existing Tailwind utilities and design tokens
  */
-export const Container = forwardRef<RefType, ContainerProps>(
-  (
-    {
-      size,
-      padding,
-      columns,
-      aspectRatio,
-      boxSizing,
-      overflow,
-      overflowX,
-      overflowY,
-      overscrollBehavior,
-      overscrollBehaviorX,
-      overscrollBehaviorY,
-      zIndex,
-      containerQuery,
-      containerType = 'inline-size',
-      as = 'div',
-      className,
-      children,
-      ...props
-    },
-    ref
-  ) => {
-    // Polymorphic component - render as specified element
-    const Component = as;
+export function Container({
+  size,
+  padding,
+  columns,
+  aspectRatio,
+  boxSizing,
+  overflow,
+  overflowX,
+  overflowY,
+  overscrollBehavior,
+  overscrollBehaviorX,
+  overscrollBehaviorY,
+  zIndex,
+  containerQuery,
+  containerType = 'inline-size',
+  as = 'div',
+  className,
+  children,
+  ref,
+  ...props
+}: ContainerProps) {
+  // Polymorphic component - render as specified element
+  const Component = as;
 
-    // Semantic defaults based on HTML element type
-    const getSemanticDefaults = (element: string) => {
-      switch (element) {
-        case 'main':
-          return {
-            size: size ?? 'full', // Main content takes full width
-            padding: padding ?? '8', // Comfortable breathing room
-            overflow: overflow ?? 'auto', // Handle long content gracefully
-            boxSizing: boxSizing ?? 'border-box',
-            zIndex: zIndex ?? 'base', // Standard document flow
-            containerQuery: containerQuery ?? true, // Enable container queries for responsive children
-            containerType: containerType ?? 'inline-size',
-          };
+  // Semantic defaults based on HTML element type
+  const getSemanticDefaults = (element: string) => {
+    switch (element) {
+      case 'main':
+        return {
+          size: size ?? 'full', // Main content takes full width
+          padding: padding ?? '8', // Comfortable breathing room
+          overflow: overflow ?? 'auto', // Handle long content gracefully
+          boxSizing: boxSizing ?? 'border-box',
+          zIndex: zIndex ?? 'base', // Standard document flow
+          containerQuery: containerQuery ?? true, // Enable container queries for responsive children
+          containerType: containerType ?? 'inline-size',
+        };
 
-        case 'article':
-          return {
-            size: size ?? '4xl', // Optimal reading width ~65 characters
-            padding: padding ?? '6', // Article breathing room
-            overflow: overflow ?? 'visible', // Let content flow naturally
-            boxSizing: boxSizing ?? 'border-box',
-            zIndex: zIndex ?? 'base', // Standard document flow
-            articleProse: true, // Enable automatic prose styling
-            containerQuery: containerQuery ?? true, // Enable container queries for responsive children
-            containerType: containerType ?? 'inline-size',
-          };
+      case 'article':
+        return {
+          size: size ?? '4xl', // Optimal reading width ~65 characters
+          padding: padding ?? '6', // Article breathing room
+          overflow: overflow ?? 'visible', // Let content flow naturally
+          boxSizing: boxSizing ?? 'border-box',
+          zIndex: zIndex ?? 'base', // Standard document flow
+          articleProse: true, // Enable automatic prose styling
+          containerQuery: containerQuery ?? true, // Enable container queries for responsive children
+          containerType: containerType ?? 'inline-size',
+        };
 
-        case 'section':
-          return {
-            size: size ?? '5xl', // Section container width
-            padding: padding ?? '4', // Moderate section spacing
-            overflow: overflow ?? 'visible', // Sections don't typically scroll
-            boxSizing: boxSizing ?? 'border-box',
-            zIndex: zIndex ?? 'base', // Standard document flow
-            containerQuery: containerQuery ?? true, // Enable container queries for responsive children
-            containerType: containerType ?? 'inline-size',
-          };
+      case 'section':
+        return {
+          size: size ?? '5xl', // Section container width
+          padding: padding ?? '4', // Moderate section spacing
+          overflow: overflow ?? 'visible', // Sections don't typically scroll
+          boxSizing: boxSizing ?? 'border-box',
+          zIndex: zIndex ?? 'base', // Standard document flow
+          containerQuery: containerQuery ?? true, // Enable container queries for responsive children
+          containerType: containerType ?? 'inline-size',
+        };
 
-        default: // div
-          return {
-            size: size ?? '4xl', // Generic container default
-            padding: padding ?? '4', // Standard padding
-            overflow: overflow, // No overflow default for divs
-            boxSizing: boxSizing ?? 'border-box',
-            zIndex: zIndex, // No z-index default for divs
-            containerQuery: containerQuery ?? true, // Enable container queries for responsive children
-            containerType: containerType ?? 'inline-size',
-          };
-      }
-    };
+      default: // div
+        return {
+          size: size ?? '4xl', // Generic container default
+          padding: padding ?? '4', // Standard padding
+          overflow: overflow, // No overflow default for divs
+          boxSizing: boxSizing ?? 'border-box',
+          zIndex: zIndex, // No z-index default for divs
+          containerQuery: containerQuery ?? true, // Enable container queries for responsive children
+          containerType: containerType ?? 'inline-size',
+        };
+    }
+  };
 
-    const defaults = getSemanticDefaults(as);
+  const defaults = getSemanticDefaults(as);
 
-    // Container sizes using standard Tailwind max-width utilities
-    const sizeVariants = {
-      sm: 'max-w-sm mx-auto', // 24rem
-      md: 'max-w-md mx-auto', // 28rem
-      lg: 'max-w-lg mx-auto', // 32rem
-      xl: 'max-w-xl mx-auto', // 36rem
-      '2xl': 'max-w-2xl mx-auto', // 42rem
-      '3xl': 'max-w-3xl mx-auto', // 48rem
-      '4xl': 'max-w-4xl mx-auto', // 56rem
-      '5xl': 'max-w-5xl mx-auto', // 64rem
-      '6xl': 'max-w-6xl mx-auto', // 72rem
-      '7xl': 'max-w-7xl mx-auto', // 80rem
-      full: 'w-full', // 100%
-    };
+  // Container sizes using standard Tailwind max-width utilities
+  const sizeVariants = {
+    sm: 'max-w-sm mx-auto', // 24rem
+    md: 'max-w-md mx-auto', // 28rem
+    lg: 'max-w-lg mx-auto', // 32rem
+    xl: 'max-w-xl mx-auto', // 36rem
+    '2xl': 'max-w-2xl mx-auto', // 42rem
+    '3xl': 'max-w-3xl mx-auto', // 48rem
+    '4xl': 'max-w-4xl mx-auto', // 56rem
+    '5xl': 'max-w-5xl mx-auto', // 64rem
+    '6xl': 'max-w-6xl mx-auto', // 72rem
+    '7xl': 'max-w-7xl mx-auto', // 80rem
+    full: 'w-full', // 100%
+  };
 
-    // Spacing variants using Tailwind native spacing tokens from design system
-    const paddingVariants = {
-      '0': 'p-0', // --spacing-0
-      px: 'p-px', // --spacing-px
-      '0.5': 'p-0.5', // --spacing-0.5
-      '1': 'p-1', // --spacing-1
-      '1.5': 'p-1.5', // --spacing-1.5
-      '2': 'p-2', // --spacing-2
-      '2.5': 'p-2.5', // --spacing-2.5
-      '3': 'p-3', // --spacing-3
-      '3.5': 'p-3.5', // --spacing-3.5
-      '4': 'p-4', // --spacing-4 (default)
-      '5': 'p-5', // --spacing-5
-      '6': 'p-6', // --spacing-6
-      '8': 'p-8', // --spacing-8
-      '10': 'p-10', // --spacing-10
-      '12': 'p-12', // --spacing-12
-      '16': 'p-16', // --spacing-16
-      '20': 'p-20', // --spacing-20
-      '24': 'p-24', // --spacing-24
-      '32': 'p-32', // --spacing-32
-      '40': 'p-40', // --spacing-40
-      '48': 'p-48', // --spacing-48
-      '56': 'p-56', // --spacing-56
-      '64': 'p-64', // --spacing-64
-    };
+  // Spacing variants using Tailwind native spacing tokens from design system
+  const paddingVariants = {
+    '0': 'p-0', // --spacing-0
+    px: 'p-px', // --spacing-px
+    '0.5': 'p-0.5', // --spacing-0.5
+    '1': 'p-1', // --spacing-1
+    '1.5': 'p-1.5', // --spacing-1.5
+    '2': 'p-2', // --spacing-2
+    '2.5': 'p-2.5', // --spacing-2.5
+    '3': 'p-3', // --spacing-3
+    '3.5': 'p-3.5', // --spacing-3.5
+    '4': 'p-4', // --spacing-4 (default)
+    '5': 'p-5', // --spacing-5
+    '6': 'p-6', // --spacing-6
+    '8': 'p-8', // --spacing-8
+    '10': 'p-10', // --spacing-10
+    '12': 'p-12', // --spacing-12
+    '16': 'p-16', // --spacing-16
+    '20': 'p-20', // --spacing-20
+    '24': 'p-24', // --spacing-24
+    '32': 'p-32', // --spacing-32
+    '40': 'p-40', // --spacing-40
+    '48': 'p-48', // --spacing-48
+    '56': 'p-56', // --spacing-56
+    '64': 'p-64', // --spacing-64
+  };
 
-    // Column variants using Tailwind columns utilities
-    const columnVariants = {
-      auto: 'columns-auto',
-      '1': 'columns-1',
-      '2': 'columns-2',
-      '3': 'columns-3',
-      '4': 'columns-4',
-      '5': 'columns-5',
-      '6': 'columns-6',
-      '7': 'columns-7',
-      '8': 'columns-8',
-      '9': 'columns-9',
-      '10': 'columns-10',
-      '11': 'columns-11',
-      '12': 'columns-12',
-      '3xs': 'columns-3xs',
-      '2xs': 'columns-2xs',
-      xs: 'columns-xs',
-      sm: 'columns-sm',
-      md: 'columns-md',
-      lg: 'columns-lg',
-      xl: 'columns-xl',
-      '2xl': 'columns-2xl',
-      '3xl': 'columns-3xl',
-      '4xl': 'columns-4xl',
-      '5xl': 'columns-5xl',
-      '6xl': 'columns-6xl',
-      '7xl': 'columns-7xl',
-    };
+  // Column variants using Tailwind columns utilities
+  const columnVariants = {
+    auto: 'columns-auto',
+    '1': 'columns-1',
+    '2': 'columns-2',
+    '3': 'columns-3',
+    '4': 'columns-4',
+    '5': 'columns-5',
+    '6': 'columns-6',
+    '7': 'columns-7',
+    '8': 'columns-8',
+    '9': 'columns-9',
+    '10': 'columns-10',
+    '11': 'columns-11',
+    '12': 'columns-12',
+    '3xs': 'columns-3xs',
+    '2xs': 'columns-2xs',
+    xs: 'columns-xs',
+    sm: 'columns-sm',
+    md: 'columns-md',
+    lg: 'columns-lg',
+    xl: 'columns-xl',
+    '2xl': 'columns-2xl',
+    '3xl': 'columns-3xl',
+    '4xl': 'columns-4xl',
+    '5xl': 'columns-5xl',
+    '6xl': 'columns-6xl',
+    '7xl': 'columns-7xl',
+  };
 
-    // Aspect ratio variants using Tailwind utilities and golden ratio
-    const aspectRatioVariants = {
-      auto: 'aspect-auto',
-      square: 'aspect-square',
-      video: 'aspect-video',
-      '4/3': 'aspect-[4/3]',
-      '3/2': 'aspect-[3/2]',
-      '16/9': 'aspect-[16/9]',
-      '21/9': 'aspect-[21/9]',
-      phi: 'aspect-[1.618/1]', // Golden ratio: φ:1 (landscape)
-      'phi-inverse': 'aspect-[1/1.618]', // Golden ratio inverse: 1:φ (portrait)
-    };
+  // Aspect ratio variants using Tailwind utilities and golden ratio
+  const aspectRatioVariants = {
+    auto: 'aspect-auto',
+    square: 'aspect-square',
+    video: 'aspect-video',
+    '4/3': 'aspect-[4/3]',
+    '3/2': 'aspect-[3/2]',
+    '16/9': 'aspect-[16/9]',
+    '21/9': 'aspect-[21/9]',
+    phi: 'aspect-[1.618/1]', // Golden ratio: φ:1 (landscape)
+    'phi-inverse': 'aspect-[1/1.618]', // Golden ratio inverse: 1:φ (portrait)
+  };
 
-    // Box-sizing variants for predictable layout behavior
-    const boxSizingVariants = {
-      'border-box': 'box-border', // padding/border included in width/height
-      'content-box': 'box-content', // padding/border added to width/height
-    };
+  // Box-sizing variants for predictable layout behavior
+  const boxSizingVariants = {
+    'border-box': 'box-border', // padding/border included in width/height
+    'content-box': 'box-content', // padding/border added to width/height
+  };
 
-    // Overflow variants for content handling
-    const overflowVariants = {
-      visible: 'overflow-visible',
-      hidden: 'overflow-hidden',
-      clip: 'overflow-clip',
-      scroll: 'overflow-scroll',
-      auto: 'overflow-auto',
-    };
+  // Overflow variants for content handling
+  const overflowVariants = {
+    visible: 'overflow-visible',
+    hidden: 'overflow-hidden',
+    clip: 'overflow-clip',
+    scroll: 'overflow-scroll',
+    auto: 'overflow-auto',
+  };
 
-    const overflowXVariants = {
-      visible: 'overflow-x-visible',
-      hidden: 'overflow-x-hidden',
-      clip: 'overflow-x-clip',
-      scroll: 'overflow-x-scroll',
-      auto: 'overflow-x-auto',
-    };
+  const overflowXVariants = {
+    visible: 'overflow-x-visible',
+    hidden: 'overflow-x-hidden',
+    clip: 'overflow-x-clip',
+    scroll: 'overflow-x-scroll',
+    auto: 'overflow-x-auto',
+  };
 
-    const overflowYVariants = {
-      visible: 'overflow-y-visible',
-      hidden: 'overflow-y-hidden',
-      clip: 'overflow-y-clip',
-      scroll: 'overflow-y-scroll',
-      auto: 'overflow-y-auto',
-    };
+  const overflowYVariants = {
+    visible: 'overflow-y-visible',
+    hidden: 'overflow-y-hidden',
+    clip: 'overflow-y-clip',
+    scroll: 'overflow-y-scroll',
+    auto: 'overflow-y-auto',
+  };
 
-    // Overscroll behavior variants for scroll boundary handling
-    const overscrollBehaviorVariants = {
-      auto: 'overscroll-auto',
-      contain: 'overscroll-contain',
-      none: 'overscroll-none',
-    };
+  // Overscroll behavior variants for scroll boundary handling
+  const overscrollBehaviorVariants = {
+    auto: 'overscroll-auto',
+    contain: 'overscroll-contain',
+    none: 'overscroll-none',
+  };
 
-    const overscrollBehaviorXVariants = {
-      auto: 'overscroll-x-auto',
-      contain: 'overscroll-x-contain',
-      none: 'overscroll-x-none',
-    };
+  const overscrollBehaviorXVariants = {
+    auto: 'overscroll-x-auto',
+    contain: 'overscroll-x-contain',
+    none: 'overscroll-x-none',
+  };
 
-    const overscrollBehaviorYVariants = {
-      auto: 'overscroll-y-auto',
-      contain: 'overscroll-y-contain',
-      none: 'overscroll-y-none',
-    };
+  const overscrollBehaviorYVariants = {
+    auto: 'overscroll-y-auto',
+    contain: 'overscroll-y-contain',
+    none: 'overscroll-y-none',
+  };
 
-    // Z-index variants with semantic AI-friendly stacking layers
-    const zIndexVariants = {
-      auto: 'z-auto', // Default stacking context
-      behind: 'z-[-1]', // Behind normal flow
-      base: 'z-0', // Base layer
-      raised: 'z-10', // Slightly elevated (dropdowns, tooltips)
-      overlay: 'z-20', // Overlays, popovers
-      modal: 'z-30', // Modal dialogs
-      notification: 'z-40', // Toasts, notifications
-      menu: 'z-50', // Navigation menus, mobile menus
-      tooltip: 'z-[60]', // Tooltips above everything
-      top: 'z-[9999]', // Emergency top layer
-    };
+  // Z-index variants with semantic AI-friendly stacking layers
+  const zIndexVariants = {
+    auto: 'z-auto', // Default stacking context
+    behind: 'z-[-1]', // Behind normal flow
+    base: 'z-0', // Base layer
+    raised: 'z-10', // Slightly elevated (dropdowns, tooltips)
+    overlay: 'z-20', // Overlays, popovers
+    modal: 'z-30', // Modal dialogs
+    notification: 'z-40', // Toasts, notifications
+    menu: 'z-50', // Navigation menus, mobile menus
+    tooltip: 'z-[60]', // Tooltips above everything
+    top: 'z-[9999]', // Emergency top layer
+  };
 
-    // Container query variants for Tailwind v4 native support
-    const containerQueryVariants = {
-      'inline-size': '@container/inline-size', // Query based on width
-      'block-size': '@container/block-size', // Query based on height
-      size: '@container', // Query based on both dimensions (default)
-      normal: '@container/normal', // Normal container context
-    };
+  // Container query variants for Tailwind v4 native support
+  const containerQueryVariants = {
+    'inline-size': '@container/inline-size', // Query based on width
+    'block-size': '@container/block-size', // Query based on height
+    size: '@container', // Query based on both dimensions (default)
+    normal: '@container/normal', // Normal container context
+  };
 
-    return (
-      <Component
-        ref={ref as React.ForwardedRef<HTMLDivElement>}
-        className={cn(
-          // Box-sizing for predictable layout behavior (semantic defaults applied)
-          boxSizingVariants[defaults.boxSizing],
+  return (
+    <Component
+      ref={ref as React.ForwardedRef<HTMLDivElement>}
+      className={cn(
+        // Box-sizing for predictable layout behavior (semantic defaults applied)
+        boxSizingVariants[defaults.boxSizing],
 
-          // Container size using Tailwind max-width utilities (semantic defaults)
-          sizeVariants[defaults.size],
+        // Container size using Tailwind max-width utilities (semantic defaults)
+        sizeVariants[defaults.size],
 
-          // Tailwind native spacing using design system --spacing-* tokens (semantic defaults)
-          paddingVariants[defaults.padding],
+        // Tailwind native spacing using design system --spacing-* tokens (semantic defaults)
+        paddingVariants[defaults.padding],
 
-          // Multi-column layout if specified
-          columns && columnVariants[columns],
+        // Multi-column layout if specified
+        columns && columnVariants[columns],
 
-          // Aspect ratio if specified
-          aspectRatio && aspectRatioVariants[aspectRatio],
+        // Aspect ratio if specified
+        aspectRatio && aspectRatioVariants[aspectRatio],
 
-          // Overflow behavior (semantic defaults applied)
-          defaults.overflow && overflowVariants[defaults.overflow],
-          overflowX && overflowXVariants[overflowX],
-          overflowY && overflowYVariants[overflowY],
+        // Overflow behavior (semantic defaults applied)
+        defaults.overflow && overflowVariants[defaults.overflow],
+        overflowX && overflowXVariants[overflowX],
+        overflowY && overflowYVariants[overflowY],
 
-          // Overscroll behavior
-          overscrollBehavior && overscrollBehaviorVariants[overscrollBehavior],
-          overscrollBehaviorX && overscrollBehaviorXVariants[overscrollBehaviorX],
-          overscrollBehaviorY && overscrollBehaviorYVariants[overscrollBehaviorY],
+        // Overscroll behavior
+        overscrollBehavior && overscrollBehaviorVariants[overscrollBehavior],
+        overscrollBehaviorX && overscrollBehaviorXVariants[overscrollBehaviorX],
+        overscrollBehaviorY && overscrollBehaviorYVariants[overscrollBehaviorY],
 
-          // Z-index stacking layer (semantic defaults applied)
-          defaults.zIndex && zIndexVariants[defaults.zIndex],
+        // Z-index stacking layer (semantic defaults applied)
+        defaults.zIndex && zIndexVariants[defaults.zIndex],
 
-          // Container query context (Tailwind v4 native support)
-          containerQuery && containerQueryVariants[containerType],
+        // Container query context (Tailwind v4 native support)
+        containerQuery && containerQueryVariants[containerType],
 
-          // Article prose styling using design system tokens
-          defaults.articleProse && 'article-prose',
+        // Article prose styling using design system tokens
+        defaults.articleProse && 'article-prose',
 
-          // Custom classes
-          className
-        )}
-        {...props}
-      >
-        {children}
-      </Component>
-    );
-  }
-);
-
-Container.displayName = 'Container';
+        // Custom classes
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/packages/ui/src/components/Label.tsx
+++ b/packages/ui/src/components/Label.tsx
@@ -20,7 +20,6 @@
  * Token knowledge: .rafters/tokens/registry.json
  */
 import * as LabelPrimitive from '@radix-ui/react-label';
-import { forwardRef } from 'react';
 import { cn } from '../lib/utils';
 
 export interface LabelProps extends React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> {
@@ -30,23 +29,22 @@ export interface LabelProps extends React.ComponentPropsWithoutRef<typeof LabelP
   validationState?: 'error' | 'warning' | 'success' | 'default';
   helpText?: string;
   semantic?: boolean;
+  ref?: React.Ref<React.ElementRef<typeof LabelPrimitive.Root>>;
 }
 
-export const Label = forwardRef<React.ElementRef<typeof LabelPrimitive.Root>, LabelProps>(
-  (
-    {
-      className,
-      required,
-      importance = 'standard',
-      context = 'form',
-      validationState = 'default',
-      helpText,
-      semantic = true,
-      children,
-      ...props
-    },
-    ref
-  ) => (
+export function Label({
+  className,
+  required,
+  importance = 'standard',
+  context = 'form',
+  validationState = 'default',
+  helpText,
+  semantic = true,
+  children,
+  ref,
+  ...props
+}: LabelProps) {
+  return (
     <div className={cn('space-y-1', semantic && 'semantic-label-container')}>
       <LabelPrimitive.Root
         ref={ref}
@@ -111,7 +109,5 @@ export const Label = forwardRef<React.ElementRef<typeof LabelPrimitive.Root>, La
         </p>
       )}
     </div>
-  )
-);
-
-Label.displayName = LabelPrimitive.Root.displayName;
+  );
+}

--- a/packages/ui/src/components/Progress.tsx
+++ b/packages/ui/src/components/Progress.tsx
@@ -1,7 +1,7 @@
 import * as ProgressPrimitive from '@radix-ui/react-progress';
 import { contextEasing, contextTiming, easing, timing } from '@rafters/design-tokens/motion';
 import { type VariantProps, cva } from 'class-variance-authority';
-import { type ComponentPropsWithoutRef, type ElementRef, forwardRef } from 'react';
+import type { ComponentPropsWithoutRef, ElementRef } from 'react';
 import { cn } from '../lib/utils';
 import { Button } from './Button';
 
@@ -181,218 +181,126 @@ export interface ProgressProps
    * Complete handler
    */
   onComplete?: () => void;
+
+  ref?: React.Ref<ElementRef<typeof ProgressPrimitive.Root>>;
 }
 
-const Progress = forwardRef<ElementRef<typeof ProgressPrimitive.Root>, ProgressProps>(
-  (
-    {
-      className,
-      value = 0,
-      variant = 'bar',
-      pattern = 'linear',
-      complexity = 'simple',
-      status = 'default',
-      showPercentage = false,
-      showTime = false,
-      showDescription = false,
-      showSteps = false,
-      estimatedTime,
-      timeRemaining,
-      completionMessage,
-      nextAction,
-      pausable = false,
-      cancellable = false,
-      currentStep,
-      totalSteps,
-      label,
-      description,
-      onPause,
-      onCancel,
-      onComplete,
-      ...props
-    },
-    ref
-  ) => {
-    const isComplete = value === 100;
-    const isIndeterminate = value === undefined || value === null;
-    const descriptionId = description
-      ? `progress-desc-${Math.random().toString(36).substr(2, 9)}`
-      : undefined;
+export function Progress({
+  className,
+  value = 0,
+  variant = 'bar',
+  pattern = 'linear',
+  complexity = 'simple',
+  status = 'default',
+  showPercentage = false,
+  showTime = false,
+  showDescription = false,
+  showSteps = false,
+  estimatedTime,
+  timeRemaining,
+  completionMessage,
+  nextAction,
+  pausable = false,
+  cancellable = false,
+  currentStep,
+  totalSteps,
+  label,
+  description,
+  onPause,
+  onCancel,
+  onComplete,
+  ref,
+  ...props
+}: ProgressProps) {
+  const isComplete = value === 100;
+  const isIndeterminate = value === undefined || value === null;
+  const descriptionId = description
+    ? `progress-desc-${Math.random().toString(36).substr(2, 9)}`
+    : undefined;
 
-    // Helper functions for time calculation and formatting
-    const calculateRemainingMilliseconds = (): number | null => {
-      if (timeRemaining) return timeRemaining;
-      if (estimatedTime && value != null && value > 0) {
-        return (estimatedTime * (100 - value)) / 100;
-      }
-      return null;
-    };
-
-    const formatTimeRemaining = (milliseconds: number): string => {
-      const minutes = Math.floor(milliseconds / 60000);
-      const seconds = Math.floor((milliseconds % 60000) / 1000);
-
-      if (minutes > 0) {
-        return `About ${minutes}m ${seconds}s remaining`;
-      }
-      return seconds > 0 ? `About ${seconds}s remaining` : 'Almost done...';
-    };
-
-    const getTimeDisplay = (): string | null => {
-      if (!showTime) return null;
-      if (isComplete) return null;
-      if (isIndeterminate) return 'Calculating...';
-
-      const remainingMs = calculateRemainingMilliseconds();
-      return remainingMs ? formatTimeRemaining(remainingMs) : null;
-    };
-
-    const timeDisplay = getTimeDisplay();
-    const percentageDisplay = showPercentage && !isIndeterminate ? `${Math.round(value)}%` : null;
-
-    if (variant === 'steps' && showSteps) {
-      return (
-        <div className={cn('space-y-2', className)}>
-          {(label || percentageDisplay || timeDisplay) && (
-            <div className="flex items-center justify-between text-sm">
-              <span className="font-medium text-foreground">{label}</span>
-              <div className="flex items-center gap-2 text-muted-foreground">
-                {currentStep && totalSteps && (
-                  <span>
-                    {currentStep} of {totalSteps}
-                  </span>
-                )}
-                {timeDisplay && <span>{timeDisplay}</span>}
-              </div>
-            </div>
-          )}
-
-          <div className="flex items-center justify-between">
-            <div className="flex-1 space-y-1">
-              {totalSteps && currentStep && (
-                <ol
-                  aria-label={`Progress steps: ${currentStep} of ${totalSteps}`}
-                  className="flex items-center gap-2"
-                >
-                  {Array.from({ length: totalSteps }, (_, i) => {
-                    const stepNumber = i + 1;
-                    const isCompleted = stepNumber < currentStep;
-                    const isCurrent = stepNumber === currentStep;
-                    return (
-                      <li
-                        key={`step-${stepNumber}`}
-                        aria-label={`Step ${stepNumber} of ${totalSteps}: ${
-                          isCompleted ? 'Completed' : isCurrent ? 'In Progress' : 'Not Started'
-                        }`}
-                        className={cn(
-                          `h-2 flex-1 rounded-full transition-colors ${contextTiming.progress} ${contextEasing.progress}`,
-                          isCompleted && 'bg-primary',
-                          isCurrent && 'bg-primary/50',
-                          !isCompleted && !isCurrent && 'bg-background-subtle'
-                        )}
-                      />
-                    );
-                  })}
-                </ol>
-              )}
-              {showDescription && description && (
-                <p className="text-sm text-muted-foreground">{description}</p>
-              )}
-            </div>
-          </div>
-
-          {(pausable || cancellable) && (
-            <div className="flex gap-2">
-              {pausable && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={onPause}
-                  className="h-auto p-1 text-xs text-muted-foreground hover:text-foreground"
-                >
-                  Pause
-                </Button>
-              )}
-              {cancellable && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={onCancel}
-                  className="h-auto p-1 text-xs text-muted-foreground hover:text-foreground"
-                >
-                  Cancel
-                </Button>
-              )}
-            </div>
-          )}
-        </div>
-      );
+  // Helper functions for time calculation and formatting
+  const calculateRemainingMilliseconds = (): number | null => {
+    if (timeRemaining) return timeRemaining;
+    if (estimatedTime && value != null && value > 0) {
+      return (estimatedTime * (100 - value)) / 100;
     }
+    return null;
+  };
 
+  const formatTimeRemaining = (milliseconds: number): string => {
+    const minutes = Math.floor(milliseconds / 60000);
+    const seconds = Math.floor((milliseconds % 60000) / 1000);
+
+    if (minutes > 0) {
+      return `About ${minutes}m ${seconds}s remaining`;
+    }
+    return seconds > 0 ? `About ${seconds}s remaining` : 'Almost done...';
+  };
+
+  const getTimeDisplay = (): string | null => {
+    if (!showTime) return null;
+    if (isComplete) return null;
+    if (isIndeterminate) return 'Calculating...';
+
+    const remainingMs = calculateRemainingMilliseconds();
+    return remainingMs ? formatTimeRemaining(remainingMs) : null;
+  };
+
+  const timeDisplay = getTimeDisplay();
+  const percentageDisplay = showPercentage && !isIndeterminate ? `${Math.round(value)}%` : null;
+
+  if (variant === 'steps' && showSteps) {
     return (
       <div className={cn('space-y-2', className)}>
-        {/* Header with label and time/percentage */}
         {(label || percentageDisplay || timeDisplay) && (
           <div className="flex items-center justify-between text-sm">
             <span className="font-medium text-foreground">{label}</span>
             <div className="flex items-center gap-2 text-muted-foreground">
-              {percentageDisplay && <span>{percentageDisplay}</span>}
+              {currentStep && totalSteps && (
+                <span>
+                  {currentStep} of {totalSteps}
+                </span>
+              )}
               {timeDisplay && <span>{timeDisplay}</span>}
             </div>
           </div>
         )}
 
-        {/* Progress bar */}
-        <ProgressPrimitive.Root
-          ref={ref}
-          className={cn(
-            progressVariants({ variant, pattern, complexity }),
-            isComplete && status === 'success' && 'bg-success/10'
-          )}
-          value={isIndeterminate ? undefined : value}
-          aria-label={label || 'Progress indicator'}
-          aria-describedby={descriptionId}
-          {...props}
-        >
-          <ProgressPrimitive.Indicator
-            className={cn(
-              progressIndicatorVariants({
-                pattern,
-                status: isComplete ? 'success' : status,
-              })
-            )}
-            style={{
-              transform: isIndeterminate ? undefined : `translateX(-${100 - value}%)`,
-            }}
-          />
-        </ProgressPrimitive.Root>
-
-        {/* Description */}
-        {showDescription && description && (
-          <p id={descriptionId} className="text-sm text-muted-foreground">
-            {description}
-          </p>
-        )}
-
-        {/* Completion message */}
-        {isComplete && completionMessage && (
-          <div className="flex items-center justify-between text-sm">
-            <span className="text-success">{completionMessage}</span>
-            {nextAction && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={onComplete}
-                className="h-auto p-1 text-primary hover:text-primary/80 underline underline-offset-4"
+        <div className="flex items-center justify-between">
+          <div className="flex-1 space-y-1">
+            {totalSteps && currentStep && (
+              <ol
+                aria-label={`Progress steps: ${currentStep} of ${totalSteps}`}
+                className="flex items-center gap-2"
               >
-                {nextAction}
-              </Button>
+                {Array.from({ length: totalSteps }, (_, i) => {
+                  const stepNumber = i + 1;
+                  const isCompleted = stepNumber < currentStep;
+                  const isCurrent = stepNumber === currentStep;
+                  return (
+                    <li
+                      key={`step-${stepNumber}`}
+                      aria-label={`Step ${stepNumber} of ${totalSteps}: ${
+                        isCompleted ? 'Completed' : isCurrent ? 'In Progress' : 'Not Started'
+                      }`}
+                      className={cn(
+                        `h-2 flex-1 rounded-full transition-colors ${contextTiming.progress} ${contextEasing.progress}`,
+                        isCompleted && 'bg-primary',
+                        isCurrent && 'bg-primary/50',
+                        !isCompleted && !isCurrent && 'bg-background-subtle'
+                      )}
+                    />
+                  );
+                })}
+              </ol>
+            )}
+            {showDescription && description && (
+              <p className="text-sm text-muted-foreground">{description}</p>
             )}
           </div>
-        )}
+        </div>
 
-        {/* Controls */}
-        {!isComplete && (pausable || cancellable) && (
+        {(pausable || cancellable) && (
           <div className="flex gap-2">
             {pausable && (
               <Button
@@ -419,43 +327,138 @@ const Progress = forwardRef<ElementRef<typeof ProgressPrimitive.Root>, ProgressP
       </div>
     );
   }
-);
 
-Progress.displayName = ProgressPrimitive.Root.displayName;
+  return (
+    <div className={cn('space-y-2', className)}>
+      {/* Header with label and time/percentage */}
+      {(label || percentageDisplay || timeDisplay) && (
+        <div className="flex items-center justify-between text-sm">
+          <span className="font-medium text-foreground">{label}</span>
+          <div className="flex items-center gap-2 text-muted-foreground">
+            {percentageDisplay && <span>{percentageDisplay}</span>}
+            {timeDisplay && <span>{timeDisplay}</span>}
+          </div>
+        </div>
+      )}
+
+      {/* Progress bar */}
+      <ProgressPrimitive.Root
+        ref={ref}
+        className={cn(
+          progressVariants({ variant, pattern, complexity }),
+          isComplete && status === 'success' && 'bg-success/10'
+        )}
+        value={isIndeterminate ? undefined : value}
+        aria-label={label || 'Progress indicator'}
+        aria-describedby={descriptionId}
+        {...props}
+      >
+        <ProgressPrimitive.Indicator
+          className={cn(
+            progressIndicatorVariants({
+              pattern,
+              status: isComplete ? 'success' : status,
+            })
+          )}
+          style={{
+            transform: isIndeterminate ? undefined : `translateX(-${100 - value}%)`,
+          }}
+        />
+      </ProgressPrimitive.Root>
+
+      {/* Description */}
+      {showDescription && description && (
+        <p id={descriptionId} className="text-sm text-muted-foreground">
+          {description}
+        </p>
+      )}
+
+      {/* Completion message */}
+      {isComplete && completionMessage && (
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-success">{completionMessage}</span>
+          {nextAction && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onComplete}
+              className="h-auto p-1 text-primary hover:text-primary/80 underline underline-offset-4"
+            >
+              {nextAction}
+            </Button>
+          )}
+        </div>
+      )}
+
+      {/* Controls */}
+      {!isComplete && (pausable || cancellable) && (
+        <div className="flex gap-2">
+          {pausable && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onPause}
+              className="h-auto p-1 text-xs text-muted-foreground hover:text-foreground"
+            >
+              Pause
+            </Button>
+          )}
+          {cancellable && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onCancel}
+              className="h-auto p-1 text-xs text-muted-foreground hover:text-foreground"
+            >
+              Cancel
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
 
 // Additional helper components for step progress
-const ProgressStep = forwardRef<
-  HTMLDivElement,
-  {
-    children: React.ReactNode;
-    completed?: boolean;
-    current?: boolean;
-    className?: string;
-  }
->(({ children, completed = false, current = false, className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      'flex items-center gap-2 text-sm',
-      current && 'font-medium text-primary',
-      completed && 'text-muted-foreground',
-      !completed && !current && 'text-muted-foreground/50',
-      className
-    )}
-    {...props}
-  >
+export interface ProgressStepProps {
+  children: React.ReactNode;
+  completed?: boolean;
+  current?: boolean;
+  className?: string;
+  ref?: React.Ref<HTMLDivElement>;
+}
+
+export function ProgressStep({
+  children,
+  completed = false,
+  current = false,
+  className,
+  ref,
+  ...props
+}: ProgressStepProps) {
+  return (
     <div
+      ref={ref}
       className={cn(
-        'h-2 w-2 rounded-full',
-        current && 'bg-primary',
-        completed && 'bg-success',
-        !completed && !current && 'bg-muted-foreground/20'
+        'flex items-center gap-2 text-sm',
+        current && 'font-medium text-primary',
+        completed && 'text-muted-foreground',
+        !completed && !current && 'text-muted-foreground/50',
+        className
       )}
-    />
-    {children}
-  </div>
-));
+      {...props}
+    >
+      <div
+        className={cn(
+          'h-2 w-2 rounded-full',
+          current && 'bg-primary',
+          completed && 'bg-success',
+          !completed && !current && 'bg-muted-foreground/20'
+        )}
+      />
+      {children}
+    </div>
+  );
+}
 
-ProgressStep.displayName = 'ProgressStep';
-
-export { Progress, ProgressStep, progressVariants };
+export { progressVariants };

--- a/packages/ui/src/components/Slider.tsx
+++ b/packages/ui/src/components/Slider.tsx
@@ -21,7 +21,6 @@
  */
 import * as SliderPrimitive from '@radix-ui/react-slider';
 import { contextEasing, contextTiming } from '@rafters/design-tokens/motion';
-import { forwardRef } from 'react';
 import { cn } from '../lib/utils';
 
 export interface SliderProps extends React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> {
@@ -35,107 +34,101 @@ export interface SliderProps extends React.ComponentPropsWithoutRef<typeof Slide
   unit?: string;
   /** Motor accessibility: Enhanced track height */
   trackSize?: 'default' | 'large';
+  ref?: React.Ref<React.ElementRef<typeof SliderPrimitive.Root>>;
 }
 
-const Slider = forwardRef<React.ElementRef<typeof SliderPrimitive.Root>, SliderProps>(
-  (
-    {
-      className,
-      thumbSize = 'default',
-      showValue = false,
-      showSteps = false,
-      unit = '',
-      trackSize = 'default',
-      value,
-      step,
-      min = 0,
-      max = 100,
-      ...props
-    },
-    ref
-  ) => {
-    const currentValue = Array.isArray(value) ? value[0] : value;
-    const displayValue = currentValue !== undefined ? `${currentValue}${unit}` : '';
+export function Slider({
+  className,
+  thumbSize = 'default',
+  showValue = false,
+  showSteps = false,
+  unit = '',
+  trackSize = 'default',
+  value,
+  step,
+  min = 0,
+  max = 100,
+  ref,
+  ...props
+}: SliderProps) {
+  const currentValue = Array.isArray(value) ? value[0] : value;
+  const displayValue = currentValue !== undefined ? `${currentValue}${unit}` : '';
 
-    return (
-      <div className="relative w-full">
-        {showValue && currentValue !== undefined && (
-          <div className="flex justify-between items-center mb-2">
-            <span className="text-sm font-medium">Value</span>
-            <span className="text-sm text-muted-foreground font-mono">{displayValue}</span>
-          </div>
+  return (
+    <div className="relative w-full">
+      {showValue && currentValue !== undefined && (
+        <div className="flex justify-between items-center mb-2">
+          <span className="text-sm font-medium">Value</span>
+          <span className="text-sm text-muted-foreground font-mono">{displayValue}</span>
+        </div>
+      )}
+
+      <SliderPrimitive.Root
+        ref={ref}
+        className={cn(
+          'relative flex w-full touch-none select-none items-center',
+          'data-[disabled]:pointer-events-none data-[disabled]:opacity-disabled',
+          // Motor accessibility: Enhanced interaction area
+          trackSize === 'default' && 'py-2',
+          trackSize === 'large' && 'py-4',
+          className
         )}
-
-        <SliderPrimitive.Root
-          ref={ref}
+        value={value}
+        step={step}
+        min={min}
+        max={max}
+        {...props}
+      >
+        <SliderPrimitive.Track
           className={cn(
-            'relative flex w-full touch-none select-none items-center',
-            'data-[disabled]:pointer-events-none data-[disabled]:opacity-disabled',
-            // Motor accessibility: Enhanced interaction area
-            trackSize === 'default' && 'py-2',
-            trackSize === 'large' && 'py-4',
-            className
+            'relative w-full grow overflow-hidden rounded-full bg-secondary',
+            // Motor accessibility: Enhanced track size for easier targeting
+            trackSize === 'default' && 'h-2',
+            trackSize === 'large' && 'h-3'
           )}
-          value={value}
-          step={step}
-          min={min}
-          max={max}
-          {...props}
         >
-          <SliderPrimitive.Track
+          <SliderPrimitive.Range
             className={cn(
-              'relative w-full grow overflow-hidden rounded-full bg-secondary',
-              // Motor accessibility: Enhanced track size for easier targeting
-              trackSize === 'default' && 'h-2',
-              trackSize === 'large' && 'h-3'
-            )}
-          >
-            <SliderPrimitive.Range
-              className={cn(
-                'absolute h-full bg-primary transition-all',
-                contextTiming.hover,
-                contextEasing.hover
-              )}
-            />
-          </SliderPrimitive.Track>
-
-          <SliderPrimitive.Thumb
-            className={cn(
-              'block rounded-full border-2 border-primary bg-background ring-offset-background',
-              'transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+              'absolute h-full bg-primary transition-all',
               contextTiming.hover,
-              contextEasing.hover,
-              'hover:scale-110 active:scale-95 disabled:pointer-events-none disabled:opacity-disabled',
-              // Motor accessibility: Enhanced thumb sizes for easier manipulation
-              thumbSize === 'default' && 'h-5 w-5',
-              thumbSize === 'large' && 'h-6 w-6',
-              // Enhanced touch targets for mobile
-              'min-h-[44px] min-w-[44px] sm:min-h-[20px] sm:min-w-[20px]'
+              contextEasing.hover
             )}
-            aria-label={`Slider value ${displayValue}`}
           />
-        </SliderPrimitive.Root>
+        </SliderPrimitive.Track>
 
-        {showSteps && step && (
-          <div className="flex justify-between mt-2 px-1">
-            {Array.from({ length: Math.floor((max - min) / step) + 1 }, (_, i) => {
-              const stepValue = min + i * step;
-              return (
-                <div key={stepValue} className="flex flex-col items-center">
-                  <div className="w-px h-2 bg-muted" />
-                  <span className="text-xs text-muted-foreground mt-1">
-                    {stepValue}
-                    {unit}
-                  </span>
-                </div>
-              );
-            })}
-          </div>
-        )}
-      </div>
-    );
-  }
-);
-Slider.displayName = SliderPrimitive.Root.displayName;
+        <SliderPrimitive.Thumb
+          className={cn(
+            'block rounded-full border-2 border-primary bg-background ring-offset-background',
+            'transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+            contextTiming.hover,
+            contextEasing.hover,
+            'hover:scale-110 active:scale-95 disabled:pointer-events-none disabled:opacity-disabled',
+            // Motor accessibility: Enhanced thumb sizes for easier manipulation
+            thumbSize === 'default' && 'h-5 w-5',
+            thumbSize === 'large' && 'h-6 w-6',
+            // Enhanced touch targets for mobile
+            'min-h-[44px] min-w-[44px] sm:min-h-[20px] sm:min-w-[20px]'
+          )}
+          aria-label={`Slider value ${displayValue}`}
+        />
+      </SliderPrimitive.Root>
 
-export { Slider };
+      {showSteps && step && (
+        <div className="flex justify-between mt-2 px-1">
+          {Array.from({ length: Math.floor((max - min) / step) + 1 }, (_, i) => {
+            const stepValue = min + i * step;
+            return (
+              <div key={stepValue} className="flex flex-col items-center">
+                <div className="w-px h-2 bg-muted" />
+                <span className="text-xs text-muted-foreground mt-1">
+                  {stepValue}
+                  {unit}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/Toast.tsx
+++ b/packages/ui/src/components/Toast.tsx
@@ -22,25 +22,27 @@
 import * as ToastPrimitives from '@radix-ui/react-toast';
 import { contextEasing, contextTiming } from '@rafters/design-tokens/motion';
 import { type VariantProps, cva } from 'class-variance-authority';
-import * as React from 'react';
 import { cn } from '../lib/utils';
 
 const ToastProvider = ToastPrimitives.Provider;
 
-const ToastViewport = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Viewport>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Viewport
-    ref={ref}
-    className={cn(
-      'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
-      className
-    )}
-    {...props}
-  />
-));
-ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
+export interface ToastViewportProps
+  extends React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport> {
+  ref?: React.Ref<React.ElementRef<typeof ToastPrimitives.Viewport>>;
+}
+
+export function ToastViewport({ className, ref, ...props }: ToastViewportProps) {
+  return (
+    <ToastPrimitives.Viewport
+      ref={ref}
+      className={cn(
+        'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
+        className
+      )}
+      {...props}
+    />
+  );
+}
 
 const toastVariants = cva(
   cn(
@@ -70,125 +72,125 @@ const toastVariants = cva(
   }
 );
 
-const Toast = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
-    VariantProps<typeof toastVariants> & {
-      urgency?: 'low' | 'medium' | 'high';
-      interruption?: 'polite' | 'assertive' | 'demanding';
-      persistent?: boolean;
-    }
->(
-  (
-    {
-      className,
-      variant,
-      urgency = 'medium',
-      interruption = 'polite',
-      persistent = false,
-      ...props
-    },
-    ref
-  ) => {
-    return (
-      <ToastPrimitives.Root
-        ref={ref}
-        className={cn(toastVariants({ variant }), className)}
-        duration={
-          persistent
-            ? Number.POSITIVE_INFINITY
-            : urgency === 'high'
-              ? 8000
-              : urgency === 'medium'
-                ? 5000
-                : 3000
-        }
-        {...props}
-      />
-    );
-  }
-);
-Toast.displayName = ToastPrimitives.Root.displayName;
+export interface ToastProps
+  extends React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root>,
+    VariantProps<typeof toastVariants> {
+  urgency?: 'low' | 'medium' | 'high';
+  interruption?: 'polite' | 'assertive' | 'demanding';
+  persistent?: boolean;
+  ref?: React.Ref<React.ElementRef<typeof ToastPrimitives.Root>>;
+}
 
-const ToastAction = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Action>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Action
-    ref={ref}
-    className={cn(
-      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive',
-      className
-    )}
-    {...props}
-  />
-));
-ToastAction.displayName = ToastPrimitives.Action.displayName;
+export function Toast({
+  className,
+  variant,
+  urgency = 'medium',
+  interruption = 'polite',
+  persistent = false,
+  ref,
+  ...props
+}: ToastProps) {
+  return (
+    <ToastPrimitives.Root
+      ref={ref}
+      className={cn(toastVariants({ variant }), className)}
+      duration={
+        persistent
+          ? Number.POSITIVE_INFINITY
+          : urgency === 'high'
+            ? 8000
+            : urgency === 'medium'
+              ? 5000
+              : 3000
+      }
+      {...props}
+    />
+  );
+}
 
-const ToastClose = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Close>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Close
-    ref={ref}
-    className={cn(
-      'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
-      className
-    )}
-    toast-close=""
-    {...props}
-  >
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-label="Close toast"
+export interface ToastActionProps
+  extends React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action> {
+  ref?: React.Ref<React.ElementRef<typeof ToastPrimitives.Action>>;
+}
+
+export function ToastAction({ className, ref, ...props }: ToastActionProps) {
+  return (
+    <ToastPrimitives.Action
+      ref={ref}
+      className={cn(
+        'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export interface ToastCloseProps
+  extends React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close> {
+  ref?: React.Ref<React.ElementRef<typeof ToastPrimitives.Close>>;
+}
+
+export function ToastClose({ className, ref, ...props }: ToastCloseProps) {
+  return (
+    <ToastPrimitives.Close
+      ref={ref}
+      className={cn(
+        'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
+        className
+      )}
+      toast-close=""
+      {...props}
     >
-      <title>Close toast</title>
-      <path d="m3 3 18 18" />
-      <path d="m21 3-18 18" />
-    </svg>
-  </ToastPrimitives.Close>
-));
-ToastClose.displayName = ToastPrimitives.Close.displayName;
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-label="Close toast"
+      >
+        <title>Close toast</title>
+        <path d="m3 3 18 18" />
+        <path d="m21 3-18 18" />
+      </svg>
+    </ToastPrimitives.Close>
+  );
+}
 
-const ToastTitle = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Title>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Title ref={ref} className={cn('text-sm font-semibold', className)} {...props} />
-));
-ToastTitle.displayName = ToastPrimitives.Title.displayName;
+export interface ToastTitleProps
+  extends React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title> {
+  ref?: React.Ref<React.ElementRef<typeof ToastPrimitives.Title>>;
+}
 
-const ToastDescription = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Description>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Description
-    ref={ref}
-    className={cn('text-sm opacity-90', className)}
-    {...props}
-  />
-));
-ToastDescription.displayName = ToastPrimitives.Description.displayName;
+export function ToastTitle({ className, ref, ...props }: ToastTitleProps) {
+  return (
+    <ToastPrimitives.Title
+      ref={ref}
+      className={cn('text-sm font-semibold', className)}
+      {...props}
+    />
+  );
+}
 
-type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
+export interface ToastDescriptionProps
+  extends React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description> {
+  ref?: React.Ref<React.ElementRef<typeof ToastPrimitives.Description>>;
+}
+
+export function ToastDescription({ className, ref, ...props }: ToastDescriptionProps) {
+  return (
+    <ToastPrimitives.Description
+      ref={ref}
+      className={cn('text-sm opacity-90', className)}
+      {...props}
+    />
+  );
+}
 
 type ToastActionElement = React.ReactElement<typeof ToastAction>;
 
-export {
-  type ToastProps,
-  type ToastActionElement,
-  ToastProvider,
-  ToastViewport,
-  Toast,
-  ToastTitle,
-  ToastDescription,
-  ToastClose,
-  ToastAction,
-};
+export { type ToastActionElement, ToastProvider };


### PR DESCRIPTION
- Migrated Label from forwardRef to React 19 direct ref pattern
- Migrated Slider from forwardRef to React 19 direct ref pattern
- Migrated Progress and ProgressStep from forwardRef to React 19 direct ref patterns
- Migrated Toast components (ToastViewport, Toast, ToastAction, ToastClose, ToastTitle, ToastDescription) from forwardRef to React 19 direct ref patterns
- Migrated Breadcrumb components (Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbPage, BreadcrumbSeparator, BreadcrumbEllipsis) from forwardRef to React 19 direct ref patterns
- Sidebar component already used React 19 patterns (no changes needed)
- Fixed TypeScript export conflicts by removing duplicate exports
- All components now use React 19 direct ref pattern
- Preflight passes with all tests green

Phase 5 of React 19 migration complete (5/6 components migrated + Sidebar confirmed)

🤖 Generated with [Claude Code](https://claude.ai/code)