### PR TITLE
feat: mock Workers AI and Vectorize bindings in tests

### DIFF
--- a/apps/api/test/index.spec.ts
+++ b/apps/api/test/index.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { env } from 'cloudflare:test';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import worker from '@/index';
 
 describe('Main App', () => {
@@ -49,6 +49,20 @@ describe('Main App', () => {
 
   test('routes to color-intel endpoint', async () => {
     env.SEED_QUEUE_API_KEY = 'test-key';
+
+    // Mock Workers AI binding to prevent real API calls and usage charges
+    env.AI.run = vi.fn().mockResolvedValue({
+      response: 'Mock AI intelligence response for testing',
+    });
+
+    // Mock Vectorize binding to prevent real vector DB calls and usage charges
+    env.VECTORIZE.getByIds = vi.fn().mockResolvedValue({
+      count: 0,
+      vectors: [],
+    });
+    env.VECTORIZE.upsert = vi.fn().mockResolvedValue({
+      mutationId: 'mock-mutation-123',
+    });
 
     const res = await worker.fetch(
       new Request('http://localhost/api/color-intel', {


### PR DESCRIPTION
## Summary

Mock Workers AI and Vectorize bindings in the color-intel route integration test to prevent real API calls and usage charges during testing.

## Problem

Cloudflare documentation explicitly states:

> Workers AI and Vectorize bindings do not have a local simulator, usage of these bindings will always access your Cloudflare account, and so will incur usage charges even in local development and testing.

The test in `apps/api/test/index.spec.ts` for the color-intel endpoint was hitting real Workers AI and Vectorize services during every test run, incurring unnecessary costs.

## Solution

Following [Cloudflare's official mocking pattern](https://github.com/cloudflare/workers-sdk/blob/main/packages/vitest-pool-workers/README.md#mocking-bindings), added proper mocks for:

- `env.AI.run` - Returns mock intelligence response
- `env.VECTORIZE.getByIds` - Returns empty cache (no cached vectors)
- `env.VECTORIZE.upsert` - Returns mock mutation ID

## Changes

- Add `vi` import from vitest for mocking
- Mock AI binding with mock response
- Mock Vectorize getByIds method
- Mock Vectorize upsert method
- Add comments explaining cost prevention rationale

## Testing

- All 6 tests in `index.spec.ts` pass
- Full preflight suite passes (1,423 tests)
- Test execution remains fast
- No real API calls made during testing

## References

- Cloudflare Workers AI docs: https://developers.cloudflare.com/workers-ai
- Cloudflare Vectorize docs: https://developers.cloudflare.com/vectorize
- vitest-pool-workers mocking: https://github.com/cloudflare/workers-sdk/blob/main/packages/vitest-pool-workers/README.md#mocking-bindings

Resolves #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)