### PR TITLE
feat(api): add adhoc flag to GET /color for instant math-only responses

### DIFF
--- a/apps/api/src/routes/color/color.routes.ts
+++ b/apps/api/src/routes/color/color.routes.ts
@@ -56,12 +56,18 @@ export const getColor = createRoute({
     }),
     query: z.object({
       sync: z.coerce.boolean().default(false).describe('Wait for AI generation if not cached'),
+      adhoc: z.coerce
+        .boolean()
+        .default(false)
+        .describe(
+          'Return ad-hoc math-only response (no AI, no vector lookup). Returns full ColorValue schema using pure calculations. Ideal for design token generators and testing where sub-second response is needed.',
+        ),
     }),
   },
   tags: ['Color'],
   summary: 'Get color by OKLCH values',
   description:
-    'Retrieves a color from the cache or generates it. Use sync=true to wait for generation.',
+    'Retrieves a color from the cache or generates it. Use sync=true to wait for generation. Use adhoc=true for instant math-only responses (no AI/vector lookup) - ideal for design token generators and testing.',
   responses: {
     [HttpStatusCodes.OK]: jsonContent(ColorResponseSchema, 'Color found or generated'),
     [HttpStatusCodes.ACCEPTED]: jsonContent(ColorResponseSchema, 'Color queued for generation'),


### PR DESCRIPTION
Adds an `adhoc=true` query parameter that returns the full ColorValue schema using pure math calculations (no AI, no vector lookup). This enables sub-second responses for design token generators and testing.

The buildMathOnlyColorValue function computes:
- 11-position OKLCH scale
- Color harmonies (complementary, triadic, analogous, tetradic, monochromatic)
- WCAG and APCA accessibility metadata
- Color temperature and lightness analysis
- Atmospheric and perceptual weight
- Semantic color suggestions (danger, success, warning, info)

Includes comprehensive tests for all ColorValue fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)