### PR TITLE
fix(api): remove AI-based naming from intelligence module

### DIFF
--- a/apps/api/src/lib/color/intelligence.ts
+++ b/apps/api/src/lib/color/intelligence.ts
@@ -13,7 +13,6 @@ interface ColorContext {
 }
 
 interface ColorIntelligence {
-  suggestedName: string;
   reasoning: string;
   emotionalImpact: string;
   culturalContext: string;
@@ -52,15 +51,7 @@ async function generateWithWorkersAI(
   const messages = [
     {
       role: 'system',
-      content: `You are a color naming specialist. Your job is to create UNIQUE, MEMORABLE names for colors.
-
-CRITICAL RULES:
-- NEVER use generic words: Azure, Ocean, Sky, Forest, Midnight, Royal, Deep, Soft, Light, Dark, Pale, Bright
-- NEVER use compound words like "Something Blue" or "Blue Something"
-- Names should be 1-2 words maximum, evocative and unexpected
-- Think: places, materials, moments, textures, emotions, objects
-- Good examples: Corsica, Patina, Driftwood, Verdigris, Clementine, Pewter, Thistle, Celadon
-- Bad examples: Ocean Blue, Deep Azure, Soft Sky, Royal Purple, Midnight Blue`,
+      content: `You are a color analysis specialist. Your job is to provide insights about colors in OKLCH color space, focusing on emotional impact, cultural context, accessibility, and usage guidance.`,
     },
     {
       role: 'user',
@@ -71,7 +62,6 @@ Hue: ${roundedColor.h}deg${contextInfo}
 
 Generate JSON:
 {
-  "suggestedName": "Single unique word or short phrase. NO generic color words.",
   "reasoning": "Why this OKLCH combination works. Reference L=${roundedColor.l}, C=${roundedColor.c}, H=${roundedColor.h} specifically.",
   "emotionalImpact": "Psychological response. Be specific to THIS color's unique position in OKLCH space.",
   "culturalContext": "Cross-cultural associations for this specific hue/chroma/lightness combination.",
@@ -112,7 +102,6 @@ Generate JSON:
   }
 
   return {
-    suggestedName: parsedResponse.suggestedName || 'Unknown Color',
     reasoning: parsedResponse.reasoning || 'No reasoning provided',
     emotionalImpact: parsedResponse.emotionalImpact || 'No emotional impact analysis',
     culturalContext: parsedResponse.culturalContext || 'No cultural context provided',
@@ -182,7 +171,6 @@ export async function generateColorIntelligence(
         intelligenceGenerated: true,
         responseQuality: scoreResponseQuality(intelligence),
         completeness: {
-          suggestedName: !!intelligence.suggestedName,
           reasoning: !!intelligence.reasoning,
           emotionalImpact: !!intelligence.emotionalImpact,
           culturalContext: !!intelligence.culturalContext,

--- a/apps/api/src/lib/color/vector.ts
+++ b/apps/api/src/lib/color/vector.ts
@@ -85,21 +85,20 @@ export function buildVectorMetadata(color: ColorValue): VectorMetadata {
 }
 
 /**
- * Combine intelligence fields into a single searchable text
- * Prioritizes name and emotional content for better semantic matching
+ * Combine color fields into a single searchable text
+ * Prioritizes deterministic name and emotional content for better semantic matching
  */
 export function buildEmbeddingText(color: ColorValue): string {
   const parts: string[] = [];
 
-  // Name is most important for searches like "ocean blue"
+  // Deterministic name is most important for searches like "ocean blue"
   if (color.name) {
     parts.push(color.name);
     parts.push(color.name); // Repeat for emphasis
   }
 
-  // Intelligence fields
+  // Intelligence fields (AI-generated analysis, not naming)
   if (color.intelligence) {
-    parts.push(color.intelligence.suggestedName);
     parts.push(color.intelligence.emotionalImpact);
     parts.push(color.intelligence.reasoning);
     parts.push(color.intelligence.culturalContext);

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -239,8 +239,8 @@ export type Example = z.infer<typeof ExampleSchema>;
 export type Intelligence = z.infer<typeof IntelligenceSchema>;
 
 // Color Intelligence Schema (from API with uncertainty quantification)
+// Note: Color naming is now deterministic via generateColorName() in @rafters/color-utils
 export const ColorIntelligenceSchema = z.object({
-  suggestedName: z.string(),
   reasoning: z.string(),
   emotionalImpact: z.string(),
   culturalContext: z.string(),

--- a/packages/shared/test/types.test.ts
+++ b/packages/shared/test/types.test.ts
@@ -42,8 +42,8 @@ describe('OKLCH Schema', () => {
 
 describe('ColorIntelligence Schema', () => {
   it('validates complete color intelligence', () => {
+    // Note: suggestedName removed - naming is now deterministic via generateColorName()
     const intelligence = {
-      suggestedName: 'Ocean Blue',
       reasoning: 'Resembles deep ocean water',
       emotionalImpact: 'Calm and trustworthy',
       culturalContext: 'Associated with stability in Western cultures',
@@ -67,7 +67,6 @@ describe('ColorIntelligence Schema', () => {
 
   it('validates without optional metadata', () => {
     const intelligence = {
-      suggestedName: 'Ocean Blue',
       reasoning: 'Resembles deep ocean water',
       emotionalImpact: 'Calm',
       culturalContext: 'Western stability',
@@ -80,7 +79,6 @@ describe('ColorIntelligence Schema', () => {
 
   it('rejects invalid confidence values', () => {
     const intelligence = {
-      suggestedName: 'Ocean Blue',
       reasoning: 'Test',
       emotionalImpact: 'Test',
       culturalContext: 'Test',
@@ -192,7 +190,6 @@ describe('ColorValue Schema', () => {
       token: 'primary',
       value: '500',
       intelligence: {
-        suggestedName: 'Ocean Blue',
         reasoning: 'Deep ocean color',
         emotionalImpact: 'Calm',
         culturalContext: 'Stability',


### PR DESCRIPTION
## Summary

- Remove `suggestedName` from ColorIntelligence interface and AI prompt
- Update vector.ts to use deterministic name instead of AI suggestedName  
- Update shared types schema to remove suggestedName field
- Update tests to reflect the schema change

This completes the transition to deterministic color naming started in #386. Color naming is now fully deterministic via `generateColorName()` in `@rafters/color-utils`, while the intelligence module focuses purely on analysis (reasoning, emotional impact, cultural context, etc.).

## Test plan

- [x] All unit tests pass (30 API, 21 shared types)
- [x] Typecheck passes
- [x] Lint passes
- [x] A11y tests pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)