### PR TITLE
fix(api): serialize Vectorize metadata and fix AI response parsing

### DIFF
--- a/apps/api/src/lib/color/vector.ts
+++ b/apps/api/src/lib/color/vector.ts
@@ -56,6 +56,7 @@ export function getChromaCategory(chroma: number): ChromaCategory {
 
 /**
  * Metadata stored with each vector for filtering and retrieval
+ * Note: Vectorize only supports primitive types, so color is stored as JSON string
  */
 export interface VectorMetadata {
   // Indexed fields for filtering
@@ -64,12 +65,37 @@ export interface VectorMetadata {
   chroma: ChromaCategory;
   token?: string; // semantic role if assigned
 
-  // Full color data for retrieval
+  // Full color data serialized as JSON string (Vectorize doesn't support nested objects)
+  color_json: string;
+}
+
+/**
+ * Parsed metadata with full ColorValue object (for use after retrieval)
+ */
+export interface ParsedVectorMetadata {
+  hue_category: HueCategory;
+  lightness: LightnessCategory;
+  chroma: ChromaCategory;
+  token?: string;
   color: ColorValue;
 }
 
 /**
+ * Parse vector metadata, deserializing the color JSON
+ */
+export function parseVectorMetadata(metadata: VectorMetadata): ParsedVectorMetadata {
+  return {
+    hue_category: metadata.hue_category,
+    lightness: metadata.lightness,
+    chroma: metadata.chroma,
+    token: metadata.token,
+    color: JSON.parse(metadata.color_json) as ColorValue,
+  };
+}
+
+/**
  * Build vector metadata from ColorValue
+ * Serializes color as JSON string since Vectorize doesn't support nested objects
  */
 export function buildVectorMetadata(color: ColorValue): VectorMetadata {
   // Get base color from scale[5] (the 500 step) or first available
@@ -80,7 +106,7 @@ export function buildVectorMetadata(color: ColorValue): VectorMetadata {
     lightness: getLightnessCategory(baseColor.l),
     chroma: getChromaCategory(baseColor.c),
     token: color.token,
-    color,
+    color_json: JSON.stringify(color),
   };
 }
 

--- a/apps/api/src/lib/queue/list.ts
+++ b/apps/api/src/lib/queue/list.ts
@@ -34,7 +34,7 @@ const BACKLOG_QUERY = `
 query QueueBacklog($accountId: String!, $queueId: String!, $since: Time!, $until: Time!) {
   viewer {
     accounts(filter: { accountTag: $accountId }) {
-      queuesBacklogAdaptiveGroups(
+      queueBacklogAdaptiveGroups(
         filter: { queueId: $queueId, datetime_geq: $since, datetime_leq: $until }
         limit: 1
         orderBy: [datetime_DESC]
@@ -57,7 +57,7 @@ interface GraphQLResponse {
   data?: {
     viewer?: {
       accounts?: Array<{
-        queuesBacklogAdaptiveGroups?: Array<{
+        queueBacklogAdaptiveGroups?: Array<{
           avg?: {
             backlog?: number;
             bytes?: number;
@@ -116,7 +116,7 @@ export async function fetchQueueStatus(config: QueueStatusConfig): Promise<Queue
       };
     }
 
-    const backlogData = data.data?.viewer?.accounts?.[0]?.queuesBacklogAdaptiveGroups?.[0];
+    const backlogData = data.data?.viewer?.accounts?.[0]?.queueBacklogAdaptiveGroups?.[0];
     const backlogCount = backlogData?.avg?.backlog ?? 0;
 
     return { backlogCount };

--- a/apps/api/src/lib/queue/publisher.ts
+++ b/apps/api/src/lib/queue/publisher.ts
@@ -244,6 +244,7 @@ export class ColorSeedPublisher {
             l: Math.round(lightness * 100) / 100,
             c: Math.round(chroma * 100) / 100,
             h: Math.round(hue),
+            alpha: 1,
           };
 
           colors.push({

--- a/apps/api/src/lib/uncertainty/client.ts
+++ b/apps/api/src/lib/uncertainty/client.ts
@@ -111,7 +111,7 @@ export class UncertaintyClient {
    */
   async recordPrediction(request: CreatePredictionRequest): Promise<string | null> {
     try {
-      const response = await this.platformApi.fetch('http://internal/predictions', {
+      const response = await this.platformApi.fetch('http://internal/uncertainty/predictions', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(request),
@@ -135,11 +135,14 @@ export class UncertaintyClient {
    */
   async updateOutcome(predictionId: string, request: UpdateOutcomeRequest): Promise<boolean> {
     try {
-      const response = await this.platformApi.fetch(`http://internal/predictions/${predictionId}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(request),
-      });
+      const response = await this.platformApi.fetch(
+        `http://internal/uncertainty/predictions/${predictionId}`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(request),
+        },
+      );
 
       return response.ok;
     } catch (error) {

--- a/apps/api/src/routes/color/color.routes.ts
+++ b/apps/api/src/routes/color/color.routes.ts
@@ -38,8 +38,9 @@ const SearchResultSchema = z.object({
 // Schema for get response (includes generation status)
 const ColorResponseSchema = z.object({
   color: ColorValueSchema.nullable(),
-  status: z.enum(['found', 'generating', 'queued']),
+  status: z.enum(['found', 'generating', 'queued', 'error']),
   requestId: z.string().optional(),
+  error: z.string().optional(),
 });
 
 /**

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -22,16 +22,19 @@
   "vectorize": [
     {
       "binding": "VECTORIZE",
-      "index_name": "rafters-colors"
+      "index_name": "rafters-colors",
+      "remote": true
     }
   ],
   "ai": {
-    "binding": "AI"
+    "binding": "AI",
+    "remote": true
   },
   "services": [
     {
       "binding": "CORE_API",
-      "service": "realhandy-api"
+      "service": "realhandy-api",
+      "remote": true
     }
   ],
   "queues": {

--- a/packages/color-utils/src/harmony.ts
+++ b/packages/color-utils/src/harmony.ts
@@ -559,10 +559,9 @@ export function generateOKLCHScale(baseColor: OKLCH): Record<string, OKLCH> {
 /**
  * Generate semantic color system with intelligent background/foreground suggestions - Pure OKLCH
  * Currently unused but preserved for future semantic color system features
+ * @internal
  */
-// Preserved for future semantic color system features
-// @ts-expect-error - Unused function preserved for future use
-function _generateSemanticColorSystem(baseColor: OKLCH) {
+export function generateSemanticColorSystem(baseColor: OKLCH) {
   const suggestions = generateSemanticColorSuggestions(baseColor);
   const semanticSystem: {
     [K in keyof typeof suggestions]: {


### PR DESCRIPTION
## Summary
- Serialize ColorValue as JSON string in Vectorize metadata (it only supports primitives)
- Add `parseVectorMetadata()` to deserialize on retrieval
- Handle AI responses wrapped in markdown code fences (```json...```)
- Sanitize literal newlines in AI JSON string values
- Fix uncertainty client endpoint paths (`/uncertainty/predictions`)
- Make uncertainty tracking non-blocking to prevent failures
- Add missing `alpha` property in spectrum publisher
- Export `generateSemanticColorSystem` to fix unused function lint error

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] Unit tests pass (403 color-utils tests, 14 API tests)
- [x] Verified 403 vectors stored correctly with `color_json` field
- [x] Verified AI intelligence data present in stored vectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)