### PR TITLE
feat(design-tokens): add PersistenceAdapter and NodePersistenceAdapter

### DIFF
--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -7,6 +7,7 @@ export * from './dependencies.js';
 export * from './generation-rules.js';
 // Generators - produce complete base design system tokens
 export * from './generators/index.js';
+export * from './persistence/index.js';
 // Subdirectories
 export * from './plugins/calc.js';
 export * from './plugins/contrast.js';

--- a/packages/design-tokens/src/persistence/index.ts
+++ b/packages/design-tokens/src/persistence/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Persistence Layer Exports
+ */
+
+export { NodePersistenceAdapter } from './node-adapter.js';
+export type { NamespaceFile, PersistenceAdapter } from './types.js';

--- a/packages/design-tokens/src/persistence/node-adapter.ts
+++ b/packages/design-tokens/src/persistence/node-adapter.ts
@@ -1,0 +1,80 @@
+/**
+ * Node.js Persistence Adapter
+ *
+ * Reads/writes token files to the filesystem in .rafters/tokens/ directory.
+ */
+
+import { access, mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { NamespaceFileSchema, type Token } from '@rafters/shared';
+import type { NamespaceFile, PersistenceAdapter } from './types.js';
+
+const SCHEMA_URL = 'https://rafters.studio/schemas/namespace-tokens.json';
+const VERSION = '1.0.0';
+
+export class NodePersistenceAdapter implements PersistenceAdapter {
+  private readonly tokensDir: string;
+
+  constructor(projectRoot: string) {
+    this.tokensDir = join(projectRoot, '.rafters', 'tokens');
+  }
+
+  private getFilePath(namespace: string): string {
+    return join(this.tokensDir, `${namespace}.rafters.json`);
+  }
+
+  async loadNamespace(namespace: string): Promise<Token[]> {
+    const filePath = this.getFilePath(namespace);
+    const content = await readFile(filePath, 'utf-8');
+    const json = JSON.parse(content);
+
+    // Validate with Zod schema
+    const data = NamespaceFileSchema.parse(json);
+    return data.tokens;
+  }
+
+  async saveNamespace(namespace: string, tokens: Token[]): Promise<void> {
+    await mkdir(this.tokensDir, { recursive: true });
+
+    const filePath = this.getFilePath(namespace);
+    const data: NamespaceFile = {
+      $schema: SCHEMA_URL,
+      namespace,
+      version: VERSION,
+      generatedAt: new Date().toISOString(),
+      tokens,
+    };
+
+    // Validate before writing
+    NamespaceFileSchema.parse(data);
+
+    await writeFile(filePath, JSON.stringify(data, null, 2));
+  }
+
+  async listNamespaces(): Promise<string[]> {
+    try {
+      const files = await readdir(this.tokensDir);
+      const namespaces: string[] = [];
+
+      for (const file of files) {
+        if (file.endsWith('.rafters.json')) {
+          namespaces.push(file.replace('.rafters.json', ''));
+        }
+      }
+
+      return namespaces;
+    } catch {
+      // Directory does not exist
+      return [];
+    }
+  }
+
+  async namespaceExists(namespace: string): Promise<boolean> {
+    try {
+      await access(this.getFilePath(namespace));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/packages/design-tokens/src/persistence/types.ts
+++ b/packages/design-tokens/src/persistence/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Persistence Adapter Types
+ *
+ * Defines the interface for reading/writing token files to storage.
+ * Only Node.js implementation is provided (browser uses API).
+ */
+
+import type { Token } from '@rafters/shared';
+
+// Re-export NamespaceFile from shared for convenience
+export { type NamespaceFile, NamespaceFileSchema } from '@rafters/shared';
+
+/**
+ * Adapter interface for reading/writing token files
+ * Implementations handle storage-specific logic (filesystem, API, etc.)
+ */
+export interface PersistenceAdapter {
+  /**
+   * Load tokens for a namespace
+   * @throws If file does not exist
+   */
+  loadNamespace(namespace: string): Promise<Token[]>;
+
+  /**
+   * Save tokens for a namespace
+   * Creates parent directory if it does not exist
+   */
+  saveNamespace(namespace: string, tokens: Token[]): Promise<void>;
+
+  /**
+   * List available namespaces
+   * @returns Array of namespace names (without .rafters.json extension)
+   */
+  listNamespaces(): Promise<string[]>;
+
+  /**
+   * Check if a namespace exists
+   * @returns true if file exists, false otherwise
+   */
+  namespaceExists(namespace: string): Promise<boolean>;
+}

--- a/packages/design-tokens/test/persistence.test.ts
+++ b/packages/design-tokens/test/persistence.test.ts
@@ -1,0 +1,131 @@
+import { mkdir, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { Token } from '@rafters/shared';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { NodePersistenceAdapter } from '../src/persistence/node-adapter.js';
+
+describe('NodePersistenceAdapter', () => {
+  const testDir = '/tmp/rafters-test-persistence';
+  let adapter: NodePersistenceAdapter;
+
+  beforeEach(async () => {
+    await mkdir(testDir, { recursive: true });
+    adapter = new NodePersistenceAdapter(testDir);
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('should save and load namespace tokens', async () => {
+    const tokens: Token[] = [
+      {
+        name: 'test-token',
+        value: '1rem',
+        category: 'spacing',
+        namespace: 'spacing',
+      },
+    ];
+
+    await adapter.saveNamespace('spacing', tokens);
+    const loaded = await adapter.loadNamespace('spacing');
+
+    // Zod adds defaults (e.g., containerQueryAware), so check core properties
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]).toMatchObject({
+      name: 'test-token',
+      value: '1rem',
+      category: 'spacing',
+      namespace: 'spacing',
+    });
+  });
+
+  it('should create directory structure on save', async () => {
+    const tokens: Token[] = [
+      {
+        name: 'test',
+        value: '1',
+        category: 'test',
+        namespace: 'test',
+      },
+    ];
+
+    await adapter.saveNamespace('test', tokens);
+
+    const content = await readFile(
+      join(testDir, '.rafters', 'tokens', 'test.rafters.json'),
+      'utf-8',
+    );
+    const data = JSON.parse(content);
+    expect(data.namespace).toBe('test');
+    expect(data.tokens).toEqual(tokens);
+  });
+
+  it('should include schema and version in saved files', async () => {
+    await adapter.saveNamespace('color', []);
+
+    const content = await readFile(
+      join(testDir, '.rafters', 'tokens', 'color.rafters.json'),
+      'utf-8',
+    );
+    const data = JSON.parse(content);
+
+    expect(data.$schema).toBe('https://rafters.studio/schemas/namespace-tokens.json');
+    expect(data.version).toBe('1.0.0');
+    expect(data.generatedAt).toBeDefined();
+  });
+
+  it('should list available namespaces', async () => {
+    await adapter.saveNamespace('color', []);
+    await adapter.saveNamespace('spacing', []);
+
+    const namespaces = await adapter.listNamespaces();
+
+    expect(namespaces).toContain('color');
+    expect(namespaces).toContain('spacing');
+  });
+
+  it('should return empty array if tokens directory does not exist', async () => {
+    const namespaces = await adapter.listNamespaces();
+    expect(namespaces).toEqual([]);
+  });
+
+  it('should check namespace existence', async () => {
+    await adapter.saveNamespace('color', []);
+
+    expect(await adapter.namespaceExists('color')).toBe(true);
+    expect(await adapter.namespaceExists('nonexistent')).toBe(false);
+  });
+
+  it('should handle multiple tokens in a namespace', async () => {
+    const tokens: Token[] = [
+      { name: 'spacing-1', value: '0.25rem', category: 'spacing', namespace: 'spacing' },
+      { name: 'spacing-2', value: '0.5rem', category: 'spacing', namespace: 'spacing' },
+      { name: 'spacing-4', value: '1rem', category: 'spacing', namespace: 'spacing' },
+    ];
+
+    await adapter.saveNamespace('spacing', tokens);
+    const loaded = await adapter.loadNamespace('spacing');
+
+    expect(loaded).toHaveLength(3);
+    expect(loaded[0]?.name).toBe('spacing-1');
+    expect(loaded[2]?.name).toBe('spacing-4');
+  });
+
+  it('should overwrite existing namespace on save', async () => {
+    const tokens1: Token[] = [{ name: 'old', value: '1', category: 'test', namespace: 'test' }];
+    const tokens2: Token[] = [{ name: 'new', value: '2', category: 'test', namespace: 'test' }];
+
+    await adapter.saveNamespace('test', tokens1);
+    await adapter.saveNamespace('test', tokens2);
+
+    const loaded = await adapter.loadNamespace('test');
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]?.name).toBe('new');
+  });
+
+  it('should throw when loading non-existent namespace', async () => {
+    await expect(adapter.loadNamespace('nonexistent')).rejects.toThrow();
+  });
+});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -524,3 +524,17 @@ export type TokenUsagePatterns = NonNullable<Token['usagePatterns']>;
 // Legacy alias for backward compatibility
 export const SemanticTokenSchema = TokenSchema;
 export type SemanticToken = Token;
+
+/**
+ * Namespace File Schema
+ * File format for .rafters/tokens/{namespace}.rafters.json files
+ */
+export const NamespaceFileSchema = z.object({
+  $schema: z.string(),
+  namespace: z.string(),
+  version: z.string(),
+  generatedAt: z.string(),
+  tokens: z.array(TokenSchema),
+});
+
+export type NamespaceFile = z.infer<typeof NamespaceFileSchema>;


### PR DESCRIPTION
## Summary
- Add `PersistenceAdapter` interface for namespace-based token storage
- Implement `NodePersistenceAdapter` for Node.js file system operations
- Store tokens in `.rafters/tokens/{namespace}.rafters.json` format with schema, version, and metadata

Closes #390

## Test plan
- [x] Unit tests for save/load/list/exists operations
- [x] Tests verify directory structure creation
- [x] Tests verify schema and version metadata in saved files
- [x] Tests verify namespace listing and existence checking
- [x] TypeScript type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)