### PR TITLE
feat(color-utils): add buildColorValue() for instant math-only ColorValue generation

### DIFF
--- a/packages/color-utils/src/builder.ts
+++ b/packages/color-utils/src/builder.ts
@@ -1,0 +1,199 @@
+/**
+ * ColorValue Builder
+ *
+ * Builds a complete ColorValue from an OKLCH input using pure math.
+ * No AI, no network calls - just deterministic color calculations.
+ *
+ * This is the single source of truth for constructing ColorValue objects
+ * with all computed properties (scale, harmonies, accessibility, etc.)
+ */
+
+import type { ColorValue, OKLCH } from '@rafters/shared';
+import {
+  calculateAPCAContrast,
+  calculateWCAGContrast,
+  generateAccessibilityMetadata,
+} from './accessibility.js';
+import { getColorTemperature, isLightColor } from './analysis.js';
+import {
+  calculateAtmosphericWeight,
+  calculatePerceptualWeight,
+  generateHarmony,
+  generateOKLCHScale,
+  generateSemanticColorSuggestions,
+} from './harmony.js';
+import { generateColorName } from './naming/index.js';
+
+/** Standard scale positions used in design systems */
+const SCALE_POSITIONS = [
+  '50',
+  '100',
+  '200',
+  '300',
+  '400',
+  '500',
+  '600',
+  '700',
+  '800',
+  '900',
+  '950',
+];
+
+/** White reference color for contrast calculations */
+const WHITE: OKLCH = { l: 1, c: 0, h: 0, alpha: 1 };
+
+/** Black reference color for contrast calculations */
+const BLACK: OKLCH = { l: 0, c: 0, h: 0, alpha: 1 };
+
+/**
+ * Options for building a ColorValue
+ */
+export interface BuildColorValueOptions {
+  /**
+   * Semantic token assignment (e.g., "primary", "destructive")
+   */
+  token?: string;
+
+  /**
+   * Scale position reference (e.g., "500", "400")
+   */
+  value?: string;
+
+  /**
+   * Human notes about the color choice
+   */
+  use?: string;
+
+  /**
+   * State mappings (e.g., { hover: "blue-900", focus: "blue-700" })
+   */
+  states?: Record<string, string>;
+}
+
+/**
+ * Build a complete ColorValue from OKLCH using pure math calculations.
+ *
+ * This function computes:
+ * - 11-position scale (50-950)
+ * - Color harmonies (complementary, triadic, analogous, tetradic, monochromatic)
+ * - Accessibility metadata (WCAG AA/AAA, APCA, contrast on white/black)
+ * - Color analysis (temperature, lightness)
+ * - Atmospheric and perceptual weights
+ * - Semantic color suggestions (danger, success, warning, info)
+ *
+ * @param oklch - The base color in OKLCH format
+ * @param options - Optional metadata (token, value, use, states)
+ * @returns A complete ColorValue with all computed properties
+ *
+ * @example
+ * ```ts
+ * import { buildColorValue } from '@rafters/color-utils';
+ *
+ * const primary = buildColorValue(
+ *   { l: 0.5, c: 0.15, h: 240, alpha: 1 },
+ *   { token: 'primary', use: 'Brand primary color' }
+ * );
+ *
+ * console.log(primary.name); // e.g., "slate-bold-sapphire"
+ * console.log(primary.scale.length); // 11
+ * console.log(primary.accessibility.onWhite.wcagAA); // true/false
+ * ```
+ */
+export function buildColorValue(oklch: OKLCH, options: BuildColorValueOptions = {}): ColorValue {
+  // Generate the 11-position scale
+  const scaleRecord = generateOKLCHScale(oklch);
+  const scale = SCALE_POSITIONS.map((pos) => scaleRecord[pos]).filter(
+    (v): v is OKLCH => v !== undefined,
+  );
+
+  // Generate harmonies
+  const harmony = generateHarmony(oklch);
+
+  // Generate accessibility metadata from the scale
+  const accessibilityMeta = generateAccessibilityMetadata(scale);
+
+  // Calculate contrast ratios against white and black
+  const contrastOnWhite = calculateWCAGContrast(oklch, WHITE);
+  const contrastOnBlack = calculateWCAGContrast(oklch, BLACK);
+  const apcaOnWhite = calculateAPCAContrast(oklch, WHITE);
+  const apcaOnBlack = calculateAPCAContrast(oklch, BLACK);
+
+  // Get color analysis
+  const temperature = getColorTemperature(oklch);
+  const light = isLightColor(oklch);
+
+  // Get perceptual weights
+  const atmospheric = calculateAtmosphericWeight(oklch);
+  const perceptual = calculatePerceptualWeight(oklch);
+
+  // Get semantic suggestions
+  const semanticSuggestions = generateSemanticColorSuggestions(oklch);
+
+  // Generate the color name
+  const name = generateColorName(oklch);
+
+  // Build the complete ColorValue
+  const colorValue: ColorValue = {
+    name,
+    scale,
+    tokenId: `color-${oklch.l.toFixed(3)}-${oklch.c.toFixed(3)}-${Math.round(oklch.h)}`,
+
+    // Optional metadata from options
+    ...(options.token && { token: options.token }),
+    ...(options.value && { value: options.value }),
+    ...(options.use && { use: options.use }),
+    ...(options.states && { states: options.states }),
+
+    // Harmonies - map to schema format
+    harmonies: {
+      complementary: harmony.complementary,
+      triadic: [harmony.triadic1, harmony.triadic2],
+      analogous: [harmony.analogous1, harmony.analogous2],
+      tetradic: [harmony.tetradic1, harmony.tetradic2, harmony.tetradic3],
+      monochromatic: scale.slice(0, 5), // First 5 scale positions
+    },
+
+    // Accessibility
+    accessibility: {
+      wcagAA: accessibilityMeta.wcagAA,
+      wcagAAA: accessibilityMeta.wcagAAA,
+      onWhite: {
+        wcagAA: contrastOnWhite >= 4.5,
+        wcagAAA: contrastOnWhite >= 7,
+        contrastRatio: contrastOnWhite,
+        aa: accessibilityMeta.onWhite.aa,
+        aaa: accessibilityMeta.onWhite.aaa,
+      },
+      onBlack: {
+        wcagAA: contrastOnBlack >= 4.5,
+        wcagAAA: contrastOnBlack >= 7,
+        contrastRatio: contrastOnBlack,
+        aa: accessibilityMeta.onBlack.aa,
+        aaa: accessibilityMeta.onBlack.aaa,
+      },
+      apca: {
+        onWhite: apcaOnWhite,
+        onBlack: apcaOnBlack,
+        minFontSize: Math.abs(apcaOnWhite) >= 60 ? 16 : Math.abs(apcaOnWhite) >= 45 ? 24 : 32,
+      },
+    },
+
+    // Analysis
+    analysis: {
+      temperature,
+      isLight: light,
+      name,
+    },
+
+    // Atmospheric weight
+    atmosphericWeight: atmospheric,
+
+    // Perceptual weight
+    perceptualWeight: perceptual,
+
+    // Semantic suggestions
+    semanticSuggestions,
+  };
+
+  return colorValue;
+}

--- a/packages/color-utils/src/index.ts
+++ b/packages/color-utils/src/index.ts
@@ -3,10 +3,87 @@
  * OKLCH color manipulation utilities for Rafters design system
  */
 
-export * from './accessibility.js';
-export * from './analysis.js';
-export * from './conversion.js';
-export * from './harmony.js';
-export * from './manipulation.js';
-export * from './naming/index.js';
-export * from './validation-alerts.js';
+// Accessibility
+export {
+  type AccessibilityMetadata,
+  calculateAPCAContrast,
+  calculateWCAGContrast,
+  findAccessibleColor,
+  generateAccessibilityMetadata,
+  meetsAPCAStandard,
+  meetsWCAGStandard,
+} from './accessibility.js';
+
+// Analysis
+export { calculateColorDistance, getColorTemperature, isLightColor } from './analysis.js';
+
+// Builder
+export { type BuildColorValueOptions, buildColorValue } from './builder.js';
+
+// Conversion
+export { hexToOKLCH, oklchToCSS, oklchToHex, roundOKLCH } from './conversion.js';
+
+// Harmony
+export {
+  calculateAtmosphericWeight,
+  calculatePerceptualWeight,
+  generateHarmony,
+  generateOKLCHScale,
+  generateRaftersHarmony,
+  generateSemanticColorSuggestions,
+  generateSemanticColorSystem,
+  generateSemanticColors,
+} from './harmony.js';
+
+// Manipulation
+export {
+  adjustChroma,
+  adjustHue,
+  adjustLightness,
+  blendColors,
+  darken,
+  generateNeutralColor,
+  generateSurfaceColor,
+  lighten,
+} from './manipulation.js';
+
+// Naming
+export {
+  BLUE_HUB,
+  C_BUCKET_COUNT,
+  type ChromaBand,
+  GREEN_HUB,
+  generateColorName,
+  generateColorNameWithMetadata,
+  getAllBuckets,
+  getCBucket,
+  getChromaBand,
+  getExpandedMaterialWord,
+  getHBucket,
+  getLBucket,
+  getLightnessBand,
+  getSubIndex,
+  H_BUCKET_COUNT,
+  HUE_HUBS,
+  type HueCell,
+  type HueHub,
+  type HueMatrix,
+  hasExpandedHub,
+  INTENSITY_WORDS,
+  type IntensityWord,
+  L_BUCKET_COUNT,
+  type LightnessBand,
+  LUMINOSITY_WORDS,
+  type LuminosityWord,
+  MATERIAL_WORDS,
+  type MaterialWord,
+  RED_HUB,
+  TOTAL_COMBINATIONS,
+} from './naming/index.js';
+
+// Validation
+export {
+  type AccessibilityAlert,
+  type SemanticMapping,
+  validateSemanticMappings,
+} from './validation-alerts.js';

--- a/packages/color-utils/test/builder.test.ts
+++ b/packages/color-utils/test/builder.test.ts
@@ -1,0 +1,468 @@
+/**
+ * Tests for buildColorValue() - the main entry point for generating complete ColorValue objects
+ */
+
+import type { OKLCH } from '@rafters/shared';
+import { describe, expect, it } from 'vitest';
+import { buildColorValue } from '../src/builder.js';
+
+describe('buildColorValue', () => {
+  // Reference colors for testing
+  const blue: OKLCH = { l: 0.5, c: 0.15, h: 240, alpha: 1 };
+  const red: OKLCH = { l: 0.5, c: 0.2, h: 25, alpha: 1 };
+  const _green: OKLCH = { l: 0.6, c: 0.15, h: 145, alpha: 1 };
+  const gray: OKLCH = { l: 0.5, c: 0.01, h: 0, alpha: 1 }; // Achromatic
+  const white: OKLCH = { l: 0.98, c: 0, h: 0, alpha: 1 };
+  const black: OKLCH = { l: 0.05, c: 0, h: 0, alpha: 1 };
+
+  describe('basic structure', () => {
+    it('returns a ColorValue with required fields', () => {
+      const result = buildColorValue(blue);
+
+      expect(result).toHaveProperty('name');
+      expect(result).toHaveProperty('scale');
+      expect(result).toHaveProperty('tokenId');
+      expect(result).toHaveProperty('harmonies');
+      expect(result).toHaveProperty('accessibility');
+      expect(result).toHaveProperty('analysis');
+      expect(result).toHaveProperty('atmosphericWeight');
+      expect(result).toHaveProperty('perceptualWeight');
+      expect(result).toHaveProperty('semanticSuggestions');
+    });
+
+    it('generates a deterministic name', () => {
+      const result1 = buildColorValue(blue);
+      const result2 = buildColorValue(blue);
+
+      expect(result1.name).toBe(result2.name);
+      expect(typeof result1.name).toBe('string');
+      expect(result1.name.length).toBeGreaterThan(0);
+    });
+
+    it('generates a tokenId in correct format', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.tokenId).toMatch(/^color-\d+\.\d{3}-\d+\.\d{3}-\d+$/);
+      expect(result.tokenId).toBe('color-0.500-0.150-240');
+    });
+  });
+
+  describe('scale generation', () => {
+    it('generates an 11-position scale', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.scale).toHaveLength(11);
+    });
+
+    it('generates OKLCH objects in the scale', () => {
+      const result = buildColorValue(blue);
+
+      for (const color of result.scale) {
+        expect(color).toHaveProperty('l');
+        expect(color).toHaveProperty('c');
+        expect(color).toHaveProperty('h');
+        expect(typeof color.l).toBe('number');
+        expect(typeof color.c).toBe('number');
+        expect(typeof color.h).toBe('number');
+      }
+    });
+
+    it('scale progresses from light to dark', () => {
+      const result = buildColorValue(blue);
+
+      // First position (50) should be lightest
+      expect(result.scale[0]?.l).toBeGreaterThan(0.9);
+      // Last position (950) should be darkest
+      expect(result.scale[10]?.l).toBeLessThan(0.1);
+    });
+
+    it('maintains the base hue throughout scale', () => {
+      const result = buildColorValue(blue);
+
+      for (const color of result.scale) {
+        // Hue should be preserved (with rounding tolerance)
+        expect(color.h).toBe(240);
+      }
+    });
+  });
+
+  describe('harmonies', () => {
+    it('generates all harmony types', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.harmonies).toHaveProperty('complementary');
+      expect(result.harmonies).toHaveProperty('triadic');
+      expect(result.harmonies).toHaveProperty('analogous');
+      expect(result.harmonies).toHaveProperty('tetradic');
+      expect(result.harmonies).toHaveProperty('monochromatic');
+    });
+
+    it('complementary is approximately opposite hue', () => {
+      const result = buildColorValue(blue);
+
+      // Blue (240°) complementary should be around orange/yellow (60°)
+      const complementaryHue = result.harmonies?.complementary.h;
+      expect(complementaryHue).toBeGreaterThan(30);
+      expect(complementaryHue).toBeLessThan(90);
+    });
+
+    it('triadic has 2 colors', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.harmonies?.triadic).toHaveLength(2);
+    });
+
+    it('analogous has 2 colors', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.harmonies?.analogous).toHaveLength(2);
+    });
+
+    it('tetradic has 3 colors', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.harmonies?.tetradic).toHaveLength(3);
+    });
+
+    it('monochromatic is first 5 scale positions', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.harmonies?.monochromatic).toHaveLength(5);
+      expect(result.harmonies?.monochromatic).toEqual(result.scale.slice(0, 5));
+    });
+  });
+
+  describe('accessibility', () => {
+    it('includes WCAG AA and AAA matrices', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.accessibility).toHaveProperty('wcagAA');
+      expect(result.accessibility).toHaveProperty('wcagAAA');
+      expect(result.accessibility?.wcagAA).toHaveProperty('normal');
+      expect(result.accessibility?.wcagAA).toHaveProperty('large');
+    });
+
+    it('includes onWhite accessibility data', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.accessibility?.onWhite).toHaveProperty('wcagAA');
+      expect(result.accessibility?.onWhite).toHaveProperty('wcagAAA');
+      expect(result.accessibility?.onWhite).toHaveProperty('contrastRatio');
+      expect(typeof result.accessibility?.onWhite.contrastRatio).toBe('number');
+    });
+
+    it('includes onBlack accessibility data', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.accessibility?.onBlack).toHaveProperty('wcagAA');
+      expect(result.accessibility?.onBlack).toHaveProperty('wcagAAA');
+      expect(result.accessibility?.onBlack).toHaveProperty('contrastRatio');
+    });
+
+    it('includes APCA data', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.accessibility?.apca).toHaveProperty('onWhite');
+      expect(result.accessibility?.apca).toHaveProperty('onBlack');
+      expect(result.accessibility?.apca).toHaveProperty('minFontSize');
+    });
+
+    it('dark colors pass AA on white', () => {
+      const darkBlue: OKLCH = { l: 0.3, c: 0.15, h: 240, alpha: 1 };
+      const result = buildColorValue(darkBlue);
+
+      expect(result.accessibility?.onWhite.wcagAA).toBe(true);
+    });
+
+    it('light colors pass AA on black', () => {
+      const lightBlue: OKLCH = { l: 0.85, c: 0.1, h: 240, alpha: 1 };
+      const result = buildColorValue(lightBlue);
+
+      expect(result.accessibility?.onBlack.wcagAA).toBe(true);
+    });
+  });
+
+  describe('analysis', () => {
+    it('includes temperature analysis', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.analysis).toHaveProperty('temperature');
+      expect(['warm', 'cool', 'neutral']).toContain(result.analysis?.temperature);
+    });
+
+    it('blue is cool', () => {
+      const result = buildColorValue(blue);
+      expect(result.analysis?.temperature).toBe('cool');
+    });
+
+    it('red is warm', () => {
+      const result = buildColorValue(red);
+      expect(result.analysis?.temperature).toBe('warm');
+    });
+
+    it('gray is neutral', () => {
+      const result = buildColorValue(gray);
+      expect(result.analysis?.temperature).toBe('neutral');
+    });
+
+    it('includes isLight boolean', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.analysis).toHaveProperty('isLight');
+      expect(typeof result.analysis?.isLight).toBe('boolean');
+    });
+
+    it('includes name in analysis', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.analysis).toHaveProperty('name');
+      expect(result.analysis?.name).toBe(result.name);
+    });
+  });
+
+  describe('atmospheric weight', () => {
+    it('includes distanceWeight', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.atmosphericWeight).toHaveProperty('distanceWeight');
+      expect(result.atmosphericWeight?.distanceWeight).toBeGreaterThanOrEqual(0);
+      expect(result.atmosphericWeight?.distanceWeight).toBeLessThanOrEqual(1);
+    });
+
+    it('includes temperature', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.atmosphericWeight).toHaveProperty('temperature');
+      expect(['warm', 'cool', 'neutral']).toContain(result.atmosphericWeight?.temperature);
+    });
+
+    it('includes atmosphericRole', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.atmosphericWeight).toHaveProperty('atmosphericRole');
+      expect(['background', 'midground', 'foreground']).toContain(
+        result.atmosphericWeight?.atmosphericRole,
+      );
+    });
+  });
+
+  describe('perceptual weight', () => {
+    it('includes weight value', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.perceptualWeight).toHaveProperty('weight');
+      expect(result.perceptualWeight?.weight).toBeGreaterThanOrEqual(0);
+      expect(result.perceptualWeight?.weight).toBeLessThanOrEqual(1);
+    });
+
+    it('includes density', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.perceptualWeight).toHaveProperty('density');
+      expect(['light', 'medium', 'heavy']).toContain(result.perceptualWeight?.density);
+    });
+
+    it('red has higher weight than blue', () => {
+      const redResult = buildColorValue(red);
+      const blueResult = buildColorValue(blue);
+
+      // Red is perceptually heavier
+      expect(redResult.perceptualWeight?.weight).toBeGreaterThan(
+        blueResult.perceptualWeight?.weight,
+      );
+    });
+  });
+
+  describe('semantic suggestions', () => {
+    it('includes all semantic categories', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.semanticSuggestions).toHaveProperty('danger');
+      expect(result.semanticSuggestions).toHaveProperty('success');
+      expect(result.semanticSuggestions).toHaveProperty('warning');
+      expect(result.semanticSuggestions).toHaveProperty('info');
+    });
+
+    it('each category has 3 suggestions', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.semanticSuggestions?.danger).toHaveLength(3);
+      expect(result.semanticSuggestions?.success).toHaveLength(3);
+      expect(result.semanticSuggestions?.warning).toHaveLength(3);
+      expect(result.semanticSuggestions?.info).toHaveLength(3);
+    });
+
+    it('danger suggestions are in red hue range', () => {
+      const result = buildColorValue(blue);
+      const danger = result.semanticSuggestions?.danger ?? [];
+
+      for (const color of danger) {
+        // Red hues: 0-30 or 330-360
+        expect(color.h <= 30 || color.h >= 330).toBe(true);
+      }
+    });
+
+    it('success suggestions are in green hue range', () => {
+      const result = buildColorValue(blue);
+      const success = result.semanticSuggestions?.success ?? [];
+
+      for (const color of success) {
+        // Green hues: roughly 120-150
+        expect(color.h).toBeGreaterThanOrEqual(100);
+        expect(color.h).toBeLessThanOrEqual(170);
+      }
+    });
+  });
+
+  describe('options', () => {
+    it('accepts token option', () => {
+      const result = buildColorValue(blue, { token: 'primary' });
+
+      expect(result.token).toBe('primary');
+    });
+
+    it('accepts value option', () => {
+      const result = buildColorValue(blue, { value: '500' });
+
+      expect(result.value).toBe('500');
+    });
+
+    it('accepts use option', () => {
+      const result = buildColorValue(blue, { use: 'Brand primary color' });
+
+      expect(result.use).toBe('Brand primary color');
+    });
+
+    it('accepts states option', () => {
+      const states = { hover: 'blue-600', focus: 'blue-700' };
+      const result = buildColorValue(blue, { states });
+
+      expect(result.states).toEqual(states);
+    });
+
+    it('combines all options', () => {
+      const result = buildColorValue(blue, {
+        token: 'primary',
+        value: '500',
+        use: 'Main brand color',
+        states: { hover: 'primary-600' },
+      });
+
+      expect(result.token).toBe('primary');
+      expect(result.value).toBe('500');
+      expect(result.use).toBe('Main brand color');
+      expect(result.states).toEqual({ hover: 'primary-600' });
+    });
+
+    it('does not include undefined options', () => {
+      const result = buildColorValue(blue);
+
+      expect(result).not.toHaveProperty('token');
+      expect(result).not.toHaveProperty('value');
+      expect(result).not.toHaveProperty('use');
+      expect(result).not.toHaveProperty('states');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles pure white', () => {
+      const result = buildColorValue(white);
+
+      expect(result.name).toBeDefined();
+      expect(result.scale).toHaveLength(11);
+      expect(result.analysis?.isLight).toBe(true);
+    });
+
+    it('handles pure black', () => {
+      const result = buildColorValue(black);
+
+      expect(result.name).toBeDefined();
+      expect(result.scale).toHaveLength(11);
+      expect(result.analysis?.isLight).toBe(false);
+    });
+
+    it('handles achromatic gray', () => {
+      const result = buildColorValue(gray);
+
+      expect(result.name).toBeDefined();
+      expect(result.analysis?.temperature).toBe('neutral');
+    });
+
+    it('handles high chroma colors', () => {
+      const vivid: OKLCH = { l: 0.5, c: 0.35, h: 30, alpha: 1 };
+      const result = buildColorValue(vivid);
+
+      expect(result.name).toBeDefined();
+      expect(result.scale).toHaveLength(11);
+    });
+
+    it('handles edge hues (0° and 359°)', () => {
+      const hue0: OKLCH = { l: 0.5, c: 0.15, h: 0, alpha: 1 };
+      const hue359: OKLCH = { l: 0.5, c: 0.15, h: 359, alpha: 1 };
+
+      const result0 = buildColorValue(hue0);
+      const result359 = buildColorValue(hue359);
+
+      expect(result0.name).toBeDefined();
+      expect(result359.name).toBeDefined();
+    });
+
+    it('handles missing alpha (defaults to 1)', () => {
+      const noAlpha = { l: 0.5, c: 0.15, h: 240 } as OKLCH;
+      const result = buildColorValue(noAlpha);
+
+      expect(result.name).toBeDefined();
+      expect(result.scale).toHaveLength(11);
+    });
+  });
+
+  describe('determinism', () => {
+    it('produces identical results for same input', () => {
+      const result1 = buildColorValue(blue);
+      const result2 = buildColorValue(blue);
+
+      expect(result1.name).toBe(result2.name);
+      expect(result1.tokenId).toBe(result2.tokenId);
+      expect(result1.scale).toEqual(result2.scale);
+      expect(result1.harmonies).toEqual(result2.harmonies);
+      expect(result1.accessibility).toEqual(result2.accessibility);
+    });
+
+    it('produces different results for different inputs', () => {
+      const resultBlue = buildColorValue(blue);
+      const resultRed = buildColorValue(red);
+
+      expect(resultBlue.name).not.toBe(resultRed.name);
+      expect(resultBlue.tokenId).not.toBe(resultRed.tokenId);
+    });
+  });
+
+  describe('performance', () => {
+    it('completes quickly for single color', () => {
+      const start = performance.now();
+      buildColorValue(blue);
+      const duration = performance.now() - start;
+
+      // Should complete in under 50ms
+      expect(duration).toBeLessThan(50);
+    });
+
+    it('handles batch generation efficiently', () => {
+      const colors: OKLCH[] = Array.from({ length: 100 }, (_, i) => ({
+        l: 0.5,
+        c: 0.15,
+        h: (i * 3.6) % 360,
+        alpha: 1,
+      }));
+
+      const start = performance.now();
+      for (const color of colors) {
+        buildColorValue(color);
+      }
+      const duration = performance.now() - start;
+
+      // 100 colors should complete in under 2 seconds
+      expect(duration).toBeLessThan(2000);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `buildColorValue()` to `@rafters/color-utils` as single source of truth for generating complete ColorValue objects from OKLCH
- Generates: scale (11 positions), harmonies, accessibility metadata, analysis, atmospheric/perceptual weights, semantic suggestions
- Switch API to use `buildColorValue()` from color-utils (removes duplicate code)
- Replace barrel exports with explicit named exports for edge compatibility
- Add 51 comprehensive tests covering all ColorValue properties

## Test plan
- [x] All 80 color-utils tests pass
- [x] All 32 API color tests pass
- [x] Typecheck passes
- [x] Lint passes
- [x] Performance: <50ms single color, <2s for 100 colors

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)