### PR TITLE
feat(ui): add 9 headless accessibility primitives

### DIFF
--- a/packages/ui/src/primitives/aria-manager.ts
+++ b/packages/ui/src/primitives/aria-manager.ts
@@ -1,0 +1,448 @@
+/**
+ * ARIA Manager primitive
+ * Type-safe ARIA attribute setting with validation
+ *
+ * WCAG Compliance:
+ * - 4.1.2 Name, Role, Value (Level A): Correct ARIA usage
+ * - Follows ARIA 1.2 specification for valid attribute values
+ *
+ * @example
+ * ```typescript
+ * const cleanup = setAriaAttributes(element, {
+ *   'aria-expanded': true,
+ *   'aria-controls': 'menu-1',
+ *   role: 'button',
+ * });
+ * ```
+ */
+
+import type { AriaAttributes, CleanupFunction } from './types';
+
+export interface AriaManagerOptions {
+  /**
+   * Whether to validate attribute values against ARIA spec
+   * @default true
+   */
+  validate?: boolean;
+
+  /**
+   * Whether to log warnings for invalid values
+   * @default true (in development)
+   */
+  warn?: boolean;
+}
+
+/**
+ * ARIA attribute value types for validation
+ */
+type AriaValueType =
+  | 'boolean'
+  | 'tristate'
+  | 'string'
+  | 'number'
+  | 'token'
+  | 'tokenlist'
+  | 'idref'
+  | 'idreflist';
+
+/**
+ * ARIA attribute definitions for validation
+ */
+const ARIA_DEFINITIONS: Record<string, { type: AriaValueType; values?: readonly string[] }> = {
+  // Widget attributes
+  'aria-autocomplete': { type: 'token', values: ['none', 'inline', 'list', 'both'] },
+  'aria-checked': { type: 'tristate' },
+  'aria-disabled': { type: 'boolean' },
+  'aria-expanded': { type: 'boolean' },
+  'aria-haspopup': {
+    type: 'token',
+    values: ['true', 'false', 'menu', 'listbox', 'tree', 'grid', 'dialog'],
+  },
+  'aria-hidden': { type: 'boolean' },
+  'aria-invalid': { type: 'token', values: ['true', 'false', 'grammar', 'spelling'] },
+  'aria-label': { type: 'string' },
+  'aria-level': { type: 'number' },
+  'aria-modal': { type: 'boolean' },
+  'aria-multiline': { type: 'boolean' },
+  'aria-multiselectable': { type: 'boolean' },
+  'aria-orientation': { type: 'token', values: ['horizontal', 'vertical'] },
+  'aria-placeholder': { type: 'string' },
+  'aria-pressed': { type: 'tristate' },
+  'aria-readonly': { type: 'boolean' },
+  'aria-required': { type: 'boolean' },
+  'aria-selected': { type: 'boolean' },
+  'aria-sort': { type: 'token', values: ['none', 'ascending', 'descending', 'other'] },
+  'aria-valuemax': { type: 'number' },
+  'aria-valuemin': { type: 'number' },
+  'aria-valuenow': { type: 'number' },
+  'aria-valuetext': { type: 'string' },
+
+  // Live region attributes
+  'aria-atomic': { type: 'boolean' },
+  'aria-busy': { type: 'boolean' },
+  'aria-live': { type: 'token', values: ['off', 'polite', 'assertive'] },
+  'aria-relevant': { type: 'tokenlist', values: ['additions', 'removals', 'text', 'all'] },
+
+  // Relationship attributes
+  'aria-activedescendant': { type: 'idref' },
+  'aria-controls': { type: 'idreflist' },
+  'aria-describedby': { type: 'idreflist' },
+  'aria-details': { type: 'idref' },
+  'aria-errormessage': { type: 'idref' },
+  'aria-flowto': { type: 'idreflist' },
+  'aria-labelledby': { type: 'idreflist' },
+  'aria-owns': { type: 'idreflist' },
+  'aria-posinset': { type: 'number' },
+  'aria-setsize': { type: 'number' },
+  'aria-colcount': { type: 'number' },
+  'aria-colindex': { type: 'number' },
+  'aria-colspan': { type: 'number' },
+  'aria-rowcount': { type: 'number' },
+  'aria-rowindex': { type: 'number' },
+  'aria-rowspan': { type: 'number' },
+
+  // Role attribute (not technically ARIA, but commonly grouped)
+  role: { type: 'token' },
+};
+
+/**
+ * Validate an ARIA attribute value
+ */
+function validateAriaValue(
+  attribute: string,
+  value: unknown,
+  warn: boolean,
+): { valid: boolean; stringValue: string } {
+  const definition = ARIA_DEFINITIONS[attribute];
+
+  if (!definition) {
+    // Unknown attribute - might be valid ARIA we don't know about
+    if (warn && attribute.startsWith('aria-')) {
+      console.warn(`Unknown ARIA attribute: ${attribute}`);
+    }
+    return { valid: true, stringValue: String(value) };
+  }
+
+  let stringValue: string;
+  let valid = true;
+
+  switch (definition.type) {
+    case 'boolean':
+      if (typeof value !== 'boolean') {
+        if (warn) console.warn(`ARIA attribute ${attribute} expects boolean, got ${typeof value}`);
+        valid = false;
+      }
+      stringValue = value ? 'true' : 'false';
+      break;
+
+    case 'tristate':
+      if (typeof value === 'boolean') {
+        stringValue = value ? 'true' : 'false';
+      } else if (value === 'mixed') {
+        stringValue = 'mixed';
+      } else {
+        if (warn)
+          console.warn(`ARIA attribute ${attribute} expects boolean or 'mixed', got ${value}`);
+        valid = false;
+        stringValue = String(value);
+      }
+      break;
+
+    case 'number':
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        if (warn) console.warn(`ARIA attribute ${attribute} expects number, got ${typeof value}`);
+        valid = false;
+      }
+      stringValue = String(value);
+      break;
+
+    case 'token':
+      stringValue = String(value);
+      // Handle boolean-like tokens (true/false -> 'true'/'false')
+      if (typeof value === 'boolean') {
+        stringValue = value ? 'true' : 'false';
+      }
+      if (definition.values && !definition.values.includes(stringValue)) {
+        if (warn) {
+          console.warn(
+            `ARIA attribute ${attribute} expects one of [${definition.values.join(', ')}], got ${stringValue}`,
+          );
+        }
+        valid = false;
+      }
+      break;
+
+    case 'tokenlist':
+      if (Array.isArray(value)) {
+        stringValue = value.join(' ');
+      } else {
+        stringValue = String(value);
+      }
+      break;
+
+    case 'idref':
+    case 'idreflist':
+      if (Array.isArray(value)) {
+        stringValue = value.join(' ');
+      } else {
+        stringValue = String(value);
+      }
+      break;
+
+    default:
+      stringValue = String(value);
+      break;
+  }
+
+  return { valid, stringValue };
+}
+
+/**
+ * Store for original attribute values
+ */
+type OriginalAttributes = Map<string, string | null>;
+
+/**
+ * Set multiple ARIA attributes on an element
+ * Returns cleanup function that restores original values
+ *
+ * @example
+ * ```typescript
+ * const cleanup = setAriaAttributes(button, {
+ *   'aria-expanded': true,
+ *   'aria-controls': 'menu-1',
+ *   'aria-haspopup': 'menu',
+ * });
+ *
+ * // Later, restore original values
+ * cleanup();
+ * ```
+ */
+export function setAriaAttributes(
+  element: HTMLElement,
+  attributes: Partial<AriaAttributes>,
+  options: AriaManagerOptions = {},
+): CleanupFunction {
+  // SSR guard
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const { validate = true, warn = process.env.NODE_ENV !== 'production' } = options;
+
+  const originalAttributes: OriginalAttributes = new Map();
+
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value === undefined) continue;
+
+    // Store original value
+    originalAttributes.set(key, element.getAttribute(key));
+
+    // Validate and convert value
+    if (validate) {
+      const { stringValue } = validateAriaValue(key, value, warn);
+      element.setAttribute(key, stringValue);
+    } else {
+      // Convert value to string directly
+      let stringValue: string;
+      if (typeof value === 'boolean') {
+        stringValue = value ? 'true' : 'false';
+      } else {
+        stringValue = String(value);
+      }
+      element.setAttribute(key, stringValue);
+    }
+  }
+
+  return () => {
+    for (const [key, originalValue] of originalAttributes) {
+      if (originalValue === null) {
+        element.removeAttribute(key);
+      } else {
+        element.setAttribute(key, originalValue);
+      }
+    }
+  };
+}
+
+/**
+ * Update a single ARIA attribute
+ *
+ * @example
+ * ```typescript
+ * updateAriaAttribute(button, 'aria-expanded', true);
+ * ```
+ */
+export function updateAriaAttribute<K extends keyof AriaAttributes>(
+  element: HTMLElement,
+  attribute: K,
+  value: AriaAttributes[K],
+  options: AriaManagerOptions = {},
+): void {
+  if (typeof window === 'undefined') return;
+
+  const { validate = true, warn = process.env.NODE_ENV !== 'production' } = options;
+
+  if (value === undefined) {
+    element.removeAttribute(attribute);
+    return;
+  }
+
+  if (validate) {
+    const { stringValue } = validateAriaValue(attribute, value, warn);
+    element.setAttribute(attribute, stringValue);
+  } else {
+    let stringValue: string;
+    if (typeof value === 'boolean') {
+      stringValue = value ? 'true' : 'false';
+    } else {
+      stringValue = String(value);
+    }
+    element.setAttribute(attribute, stringValue);
+  }
+}
+
+/**
+ * Remove multiple ARIA attributes
+ *
+ * @example
+ * ```typescript
+ * removeAriaAttributes(element, ['aria-expanded', 'aria-controls']);
+ * ```
+ */
+export function removeAriaAttributes(
+  element: HTMLElement,
+  attributes: (keyof AriaAttributes)[],
+): void {
+  if (typeof window === 'undefined') return;
+
+  for (const attr of attributes) {
+    element.removeAttribute(attr);
+  }
+}
+
+/**
+ * Get an ARIA attribute value with proper type conversion
+ *
+ * @example
+ * ```typescript
+ * const expanded = getAriaAttribute(button, 'aria-expanded');
+ * // Returns: true | false | undefined
+ * ```
+ */
+export function getAriaAttribute<K extends keyof AriaAttributes>(
+  element: HTMLElement,
+  attribute: K,
+): AriaAttributes[K] | undefined {
+  if (typeof window === 'undefined') return undefined;
+
+  const value = element.getAttribute(attribute);
+  if (value === null) return undefined;
+
+  const definition = ARIA_DEFINITIONS[attribute];
+  if (!definition) return value as AriaAttributes[K];
+
+  switch (definition.type) {
+    case 'boolean':
+      return (value === 'true') as AriaAttributes[K];
+
+    case 'tristate':
+      if (value === 'true') return true as AriaAttributes[K];
+      if (value === 'false') return false as AriaAttributes[K];
+      return value as AriaAttributes[K]; // 'mixed'
+
+    case 'number': {
+      const num = parseFloat(value);
+      return (Number.isFinite(num) ? num : undefined) as AriaAttributes[K];
+    }
+
+    default:
+      return value as AriaAttributes[K];
+  }
+}
+
+/**
+ * Check if an element has a specific ARIA attribute
+ */
+export function hasAriaAttribute(element: HTMLElement, attribute: keyof AriaAttributes): boolean {
+  if (typeof window === 'undefined') return false;
+  return element.hasAttribute(attribute);
+}
+
+/**
+ * Toggle a boolean ARIA attribute
+ *
+ * @example
+ * ```typescript
+ * toggleAriaAttribute(button, 'aria-expanded');
+ * // If was true, now false. If was false or missing, now true.
+ * ```
+ */
+export function toggleAriaAttribute(
+  element: HTMLElement,
+  attribute: keyof AriaAttributes,
+  force?: boolean,
+): boolean {
+  if (typeof window === 'undefined') return false;
+
+  const current = element.getAttribute(attribute) === 'true';
+  const newValue = force !== undefined ? force : !current;
+
+  element.setAttribute(attribute, newValue ? 'true' : 'false');
+  return newValue;
+}
+
+/**
+ * Create ARIA relationship between elements
+ * Automatically generates IDs if needed
+ *
+ * @example
+ * ```typescript
+ * const cleanup = createAriaRelationship(input, label, 'aria-labelledby');
+ * ```
+ */
+export function createAriaRelationship(
+  element: HTMLElement,
+  target: HTMLElement | HTMLElement[],
+  relationship: 'aria-labelledby' | 'aria-describedby' | 'aria-controls' | 'aria-owns',
+): CleanupFunction {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const targets = Array.isArray(target) ? target : [target];
+  const generatedIds: string[] = [];
+
+  // Ensure all targets have IDs
+  const ids = targets.map((t) => {
+    if (!t.id) {
+      const id = `aria-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+      t.id = id;
+      generatedIds.push(id);
+    }
+    return t.id;
+  });
+
+  // Store original value
+  const originalValue = element.getAttribute(relationship);
+
+  // Set relationship
+  const existingIds = originalValue ? originalValue.split(/\s+/) : [];
+  const allIds = [...new Set([...existingIds, ...ids])];
+  element.setAttribute(relationship, allIds.join(' '));
+
+  return () => {
+    // Restore original value
+    if (originalValue === null) {
+      element.removeAttribute(relationship);
+    } else {
+      element.setAttribute(relationship, originalValue);
+    }
+
+    // Remove generated IDs
+    for (const id of generatedIds) {
+      const el = document.getElementById(id);
+      if (el) el.removeAttribute('id');
+    }
+  };
+}

--- a/packages/ui/src/primitives/collision-detector.ts
+++ b/packages/ui/src/primitives/collision-detector.ts
@@ -1,0 +1,549 @@
+/**
+ * Collision Detector primitive
+ * Floating element positioning with viewport collision detection
+ *
+ * Used for tooltips, popovers, dropdowns, and any floating UI
+ * Automatically adjusts position to stay within viewport
+ *
+ * @example
+ * ```typescript
+ * const position = computePosition(anchorElement, floatingElement, {
+ *   side: 'bottom',
+ *   align: 'center',
+ *   avoidCollisions: true,
+ * });
+ *
+ * floatingElement.style.left = `${position.x}px`;
+ * floatingElement.style.top = `${position.y}px`;
+ * ```
+ */
+
+import type { Align, Position, Side } from './types';
+
+export interface CollisionOptions {
+  /**
+   * Preferred side to position the floating element
+   * @default 'bottom'
+   */
+  side?: Side;
+
+  /**
+   * Alignment along the side axis
+   * @default 'center'
+   */
+  align?: Align;
+
+  /**
+   * Offset from anchor along the side axis (px)
+   * @default 0
+   */
+  sideOffset?: number;
+
+  /**
+   * Offset from anchor along the align axis (px)
+   * @default 0
+   */
+  alignOffset?: number;
+
+  /**
+   * Element to use as collision boundary
+   * @default viewport
+   */
+  collisionBoundary?: HTMLElement | null;
+
+  /**
+   * Padding from collision boundary edges (px)
+   * @default 10
+   */
+  collisionPadding?: number | { top?: number; right?: number; bottom?: number; left?: number };
+
+  /**
+   * Whether to flip to opposite side on collision
+   * @default true
+   */
+  avoidCollisions?: boolean;
+
+  /**
+   * Sticky behavior when colliding
+   * - 'partial': Allow partial visibility
+   * - 'always': Keep fully visible
+   * @default 'partial'
+   */
+  sticky?: 'partial' | 'always';
+
+  /**
+   * Arrow element for positioning
+   */
+  arrowElement?: HTMLElement | null;
+
+  /**
+   * Padding for arrow positioning (px)
+   * @default 0
+   */
+  arrowPadding?: number;
+}
+
+export interface CollisionResult extends Position {
+  /**
+   * Arrow position along the alignment axis
+   */
+  arrowX?: number;
+  arrowY?: number;
+
+  /**
+   * Whether position was adjusted due to collision
+   */
+  hasCollision: boolean;
+
+  /**
+   * Collision details for each side
+   */
+  collisions: {
+    top: boolean;
+    right: boolean;
+    bottom: boolean;
+    left: boolean;
+  };
+}
+
+/**
+ * Get opposite side
+ */
+function getOppositeSide(side: Side): Side {
+  const opposites: Record<Side, Side> = {
+    top: 'bottom',
+    bottom: 'top',
+    left: 'right',
+    right: 'left',
+  };
+  return opposites[side];
+}
+
+/**
+ * Get collision padding for each side
+ */
+function getCollisionPadding(
+  padding: number | { top?: number; right?: number; bottom?: number; left?: number },
+): { top: number; right: number; bottom: number; left: number } {
+  if (typeof padding === 'number') {
+    return { top: padding, right: padding, bottom: padding, left: padding };
+  }
+  return {
+    top: padding.top ?? 0,
+    right: padding.right ?? 0,
+    bottom: padding.bottom ?? 0,
+    left: padding.left ?? 0,
+  };
+}
+
+/**
+ * Get viewport rect
+ */
+function getViewportRect(): DOMRect {
+  return new DOMRect(0, 0, window.innerWidth, window.innerHeight);
+}
+
+/**
+ * Calculate position for given side and alignment
+ */
+function calculateBasePosition(
+  anchorRect: DOMRect,
+  floatingRect: DOMRect,
+  side: Side,
+  align: Align,
+  sideOffset: number,
+  alignOffset: number,
+): { x: number; y: number } {
+  let x = 0;
+  let y = 0;
+
+  const isVertical = side === 'top' || side === 'bottom';
+
+  // Calculate side axis position
+  switch (side) {
+    case 'top':
+      y = anchorRect.top - floatingRect.height - sideOffset;
+      break;
+    case 'bottom':
+      y = anchorRect.bottom + sideOffset;
+      break;
+    case 'left':
+      x = anchorRect.left - floatingRect.width - sideOffset;
+      break;
+    case 'right':
+      x = anchorRect.right + sideOffset;
+      break;
+  }
+
+  // Calculate alignment axis position
+  if (isVertical) {
+    switch (align) {
+      case 'start':
+        x = anchorRect.left + alignOffset;
+        break;
+      case 'center':
+        x = anchorRect.left + anchorRect.width / 2 - floatingRect.width / 2 + alignOffset;
+        break;
+      case 'end':
+        x = anchorRect.right - floatingRect.width + alignOffset;
+        break;
+    }
+  } else {
+    switch (align) {
+      case 'start':
+        y = anchorRect.top + alignOffset;
+        break;
+      case 'center':
+        y = anchorRect.top + anchorRect.height / 2 - floatingRect.height / 2 + alignOffset;
+        break;
+      case 'end':
+        y = anchorRect.bottom - floatingRect.height + alignOffset;
+        break;
+    }
+  }
+
+  return { x, y };
+}
+
+/**
+ * Detect collisions with boundary
+ */
+function detectCollisions(
+  x: number,
+  y: number,
+  floatingRect: DOMRect,
+  boundaryRect: DOMRect,
+  padding: { top: number; right: number; bottom: number; left: number },
+): { top: boolean; right: boolean; bottom: boolean; left: boolean } {
+  return {
+    top: y < boundaryRect.top + padding.top,
+    right: x + floatingRect.width > boundaryRect.right - padding.right,
+    bottom: y + floatingRect.height > boundaryRect.bottom - padding.bottom,
+    left: x < boundaryRect.left + padding.left,
+  };
+}
+
+/**
+ * Calculate arrow position
+ */
+function calculateArrowPosition(
+  anchorRect: DOMRect,
+  floatingRect: DOMRect,
+  side: Side,
+  x: number,
+  y: number,
+  arrowPadding: number,
+): { arrowX?: number; arrowY?: number } {
+  const isVertical = side === 'top' || side === 'bottom';
+
+  if (isVertical) {
+    // Arrow on horizontal axis
+    const anchorCenter = anchorRect.left + anchorRect.width / 2;
+    let arrowX = anchorCenter - x;
+
+    // Clamp to floating element bounds with padding
+    arrowX = Math.max(arrowPadding, Math.min(arrowX, floatingRect.width - arrowPadding));
+
+    return { arrowX };
+  } else {
+    // Arrow on vertical axis
+    const anchorCenter = anchorRect.top + anchorRect.height / 2;
+    let arrowY = anchorCenter - y;
+
+    // Clamp to floating element bounds with padding
+    arrowY = Math.max(arrowPadding, Math.min(arrowY, floatingRect.height - arrowPadding));
+
+    return { arrowY };
+  }
+}
+
+/**
+ * Compute optimal position for floating element
+ *
+ * @example
+ * ```typescript
+ * const result = computePosition(anchor, floating, {
+ *   side: 'bottom',
+ *   align: 'start',
+ *   sideOffset: 8,
+ *   avoidCollisions: true,
+ * });
+ *
+ * floating.style.transform = `translate(${result.x}px, ${result.y}px)`;
+ * floating.dataset.side = result.side;
+ * floating.dataset.align = result.align;
+ * ```
+ */
+export function computePosition(
+  anchor: HTMLElement,
+  floating: HTMLElement,
+  options: CollisionOptions = {},
+): CollisionResult {
+  // SSR guard
+  if (typeof window === 'undefined') {
+    return {
+      x: 0,
+      y: 0,
+      side: options.side ?? 'bottom',
+      align: options.align ?? 'center',
+      hasCollision: false,
+      collisions: { top: false, right: false, bottom: false, left: false },
+    };
+  }
+
+  const {
+    side: preferredSide = 'bottom',
+    align: preferredAlign = 'center',
+    sideOffset = 0,
+    alignOffset = 0,
+    collisionBoundary = null,
+    collisionPadding = 10,
+    avoidCollisions = true,
+    arrowElement = null,
+    arrowPadding = 0,
+  } = options;
+
+  // Get rects
+  const anchorRect = anchor.getBoundingClientRect();
+  const floatingRect = floating.getBoundingClientRect();
+  const boundaryRect = collisionBoundary
+    ? collisionBoundary.getBoundingClientRect()
+    : getViewportRect();
+
+  const padding = getCollisionPadding(collisionPadding);
+
+  // Calculate initial position
+  let side = preferredSide;
+  const align = preferredAlign;
+  let position = calculateBasePosition(
+    anchorRect,
+    floatingRect,
+    side,
+    align,
+    sideOffset,
+    alignOffset,
+  );
+
+  // Detect collisions
+  let collisions = detectCollisions(position.x, position.y, floatingRect, boundaryRect, padding);
+
+  const hasCollision = collisions.top || collisions.right || collisions.bottom || collisions.left;
+
+  // Adjust for collisions if enabled
+  if (avoidCollisions && hasCollision) {
+    const isVertical = side === 'top' || side === 'bottom';
+
+    // Try flipping side
+    if (
+      (side === 'top' && collisions.top) ||
+      (side === 'bottom' && collisions.bottom) ||
+      (side === 'left' && collisions.left) ||
+      (side === 'right' && collisions.right)
+    ) {
+      const oppositeSide = getOppositeSide(side);
+      const oppositePosition = calculateBasePosition(
+        anchorRect,
+        floatingRect,
+        oppositeSide,
+        align,
+        sideOffset,
+        alignOffset,
+      );
+
+      const oppositeCollisions = detectCollisions(
+        oppositePosition.x,
+        oppositePosition.y,
+        floatingRect,
+        boundaryRect,
+        padding,
+      );
+
+      // Use opposite side if it has less/no collision
+      const currentSideCollision =
+        (side === 'top' && collisions.top) ||
+        (side === 'bottom' && collisions.bottom) ||
+        (side === 'left' && collisions.left) ||
+        (side === 'right' && collisions.right);
+
+      const oppositeSideCollision =
+        (oppositeSide === 'top' && oppositeCollisions.top) ||
+        (oppositeSide === 'bottom' && oppositeCollisions.bottom) ||
+        (oppositeSide === 'left' && oppositeCollisions.left) ||
+        (oppositeSide === 'right' && oppositeCollisions.right);
+
+      if (currentSideCollision && !oppositeSideCollision) {
+        side = oppositeSide;
+        position = oppositePosition;
+        collisions = oppositeCollisions;
+      }
+    }
+
+    // Adjust alignment axis to fit in boundary
+    if (isVertical) {
+      // Horizontal adjustment
+      if (collisions.left) {
+        position.x = boundaryRect.left + padding.left;
+      } else if (collisions.right) {
+        position.x = boundaryRect.right - floatingRect.width - padding.right;
+      }
+    } else {
+      // Vertical adjustment
+      if (collisions.top) {
+        position.y = boundaryRect.top + padding.top;
+      } else if (collisions.bottom) {
+        position.y = boundaryRect.bottom - floatingRect.height - padding.bottom;
+      }
+    }
+  }
+
+  // Calculate arrow position
+  const arrowPosition: { arrowX?: number; arrowY?: number } = {};
+
+  if (arrowElement) {
+    const arrowPos = calculateArrowPosition(
+      anchorRect,
+      floatingRect,
+      side,
+      position.x,
+      position.y,
+      arrowPadding,
+    );
+    if (arrowPos.arrowX !== undefined) {
+      arrowPosition.arrowX = arrowPos.arrowX;
+    }
+    if (arrowPos.arrowY !== undefined) {
+      arrowPosition.arrowY = arrowPos.arrowY;
+    }
+  }
+
+  return {
+    x: position.x,
+    y: position.y,
+    side,
+    align,
+    ...arrowPosition,
+    hasCollision,
+    collisions,
+  };
+}
+
+/**
+ * Apply position to floating element
+ * Convenience function that sets styles and data attributes
+ *
+ * @example
+ * ```typescript
+ * applyPosition(anchor, floating, { side: 'bottom' });
+ * // Sets transform, data-side, data-align on floating element
+ * ```
+ */
+export function applyPosition(
+  anchor: HTMLElement,
+  floating: HTMLElement,
+  options: CollisionOptions = {},
+): CollisionResult {
+  const result = computePosition(anchor, floating, options);
+
+  // Apply position
+  floating.style.position = 'absolute';
+  floating.style.left = '0';
+  floating.style.top = '0';
+  floating.style.transform = `translate(${Math.round(result.x)}px, ${Math.round(result.y)}px)`;
+
+  // Set data attributes for styling
+  floating.setAttribute('data-side', result.side);
+  floating.setAttribute('data-align', result.align);
+
+  // Apply arrow position if provided
+  if (options.arrowElement && (result.arrowX !== undefined || result.arrowY !== undefined)) {
+    const arrow = options.arrowElement;
+    if (result.arrowX !== undefined) {
+      arrow.style.left = `${result.arrowX}px`;
+    }
+    if (result.arrowY !== undefined) {
+      arrow.style.top = `${result.arrowY}px`;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Create auto-updating position
+ * Returns cleanup function
+ *
+ * @example
+ * ```typescript
+ * const cleanup = autoPosition(anchor, floating, {
+ *   side: 'bottom',
+ *   avoidCollisions: true,
+ * });
+ *
+ * // Later...
+ * cleanup();
+ * ```
+ */
+export function autoPosition(
+  anchor: HTMLElement,
+  floating: HTMLElement,
+  options: CollisionOptions = {},
+): () => void {
+  // SSR guard
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  // Initial position
+  applyPosition(anchor, floating, options);
+
+  // Update on scroll and resize
+  const update = () => {
+    applyPosition(anchor, floating, options);
+  };
+
+  // Use ResizeObserver for anchor/floating size changes
+  const resizeObserver = new ResizeObserver(update);
+  resizeObserver.observe(anchor);
+  resizeObserver.observe(floating);
+
+  // Update on scroll (capture phase to catch all scroll containers)
+  window.addEventListener('scroll', update, { capture: true, passive: true });
+  window.addEventListener('resize', update, { passive: true });
+
+  return () => {
+    resizeObserver.disconnect();
+    window.removeEventListener('scroll', update, { capture: true });
+    window.removeEventListener('resize', update);
+  };
+}
+
+/**
+ * Get the available space on each side of an anchor
+ * Useful for deciding which side to prefer
+ *
+ * @example
+ * ```typescript
+ * const space = getAvailableSpace(anchor);
+ * if (space.bottom > 200) {
+ *   // Enough space below
+ * }
+ * ```
+ */
+export function getAvailableSpace(
+  anchor: HTMLElement,
+  boundary?: HTMLElement | null,
+): { top: number; right: number; bottom: number; left: number } {
+  if (typeof window === 'undefined') {
+    return { top: 0, right: 0, bottom: 0, left: 0 };
+  }
+
+  const anchorRect = anchor.getBoundingClientRect();
+  const boundaryRect = boundary ? boundary.getBoundingClientRect() : getViewportRect();
+
+  return {
+    top: anchorRect.top - boundaryRect.top,
+    right: boundaryRect.right - anchorRect.right,
+    bottom: boundaryRect.bottom - anchorRect.bottom,
+    left: anchorRect.left - boundaryRect.left,
+  };
+}

--- a/packages/ui/src/primitives/dismissable-layer.ts
+++ b/packages/ui/src/primitives/dismissable-layer.ts
@@ -1,0 +1,358 @@
+/**
+ * Dismissable Layer primitive
+ * Unified primitive combining outside click, escape key, and focus outside detection
+ *
+ * WCAG Compliance:
+ * - 2.1.2 No Keyboard Trap (Level A): Escape key dismisses layer
+ * - 3.2.1 On Focus (Level A): Focus changes don't unexpectedly change context
+ * - 3.2.2 On Input (Level A): Changing settings doesn't change context
+ *
+ * @example
+ * ```typescript
+ * const cleanup = createDismissableLayer(dropdownElement, {
+ *   onDismiss: () => closeDropdown(),
+ *   disableOutsidePointerEvents: true,
+ * });
+ * ```
+ */
+
+import type {
+  CleanupFunction,
+  EscapeKeyHandler,
+  FocusOutsideHandler,
+  PointerDownOutsideHandler,
+} from './types';
+
+export interface DismissableLayerOptions {
+  /**
+   * Whether the dismissable layer is enabled
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * Disable pointer events outside the layer
+   * Useful for modal dialogs
+   * @default false
+   */
+  disableOutsidePointerEvents?: boolean;
+
+  /**
+   * Called when Escape key is pressed
+   */
+  onEscapeKeyDown?: EscapeKeyHandler;
+
+  /**
+   * Called when pointer down occurs outside the layer
+   */
+  onPointerDownOutside?: PointerDownOutsideHandler;
+
+  /**
+   * Called when focus moves outside the layer
+   */
+  onFocusOutside?: FocusOutsideHandler;
+
+  /**
+   * Called for any outside interaction (pointer, focus, or escape)
+   */
+  onInteractOutside?: (event: Event) => void;
+
+  /**
+   * Called when the layer should be dismissed
+   * Convenience handler called for any dismissal trigger
+   */
+  onDismiss?: () => void;
+
+  /**
+   * Elements that should be considered "inside" the layer
+   * Useful for portaled content
+   */
+  excludeElements?: HTMLElement[];
+}
+
+/**
+ * Track pointer down timestamp to deduplicate touch/pointer events
+ * Uses a WeakMap per layer to avoid cross-layer interference
+ */
+const layerPointerDownTime = new WeakMap<HTMLElement, number>();
+
+/**
+ * Check if an element is inside the layer or excluded elements
+ */
+function isInsideLayer(
+  target: Node,
+  layer: HTMLElement,
+  excludeElements: HTMLElement[] = [],
+): boolean {
+  if (layer.contains(target)) return true;
+
+  for (const excluded of excludeElements) {
+    if (excluded.contains(target)) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Style element for disabling outside pointer events
+ */
+let pointerEventsStyleElement: HTMLStyleElement | null = null;
+let pointerEventsLayerCount = 0;
+
+/**
+ * Add CSS to disable pointer events outside layers
+ */
+function addPointerEventsBlocker(): void {
+  pointerEventsLayerCount++;
+
+  if (pointerEventsLayerCount === 1) {
+    pointerEventsStyleElement = document.createElement('style');
+    pointerEventsStyleElement.textContent = `
+      body > *:not([data-dismissable-layer]) {
+        pointer-events: none !important;
+      }
+      [data-dismissable-layer] {
+        pointer-events: auto !important;
+      }
+    `;
+    document.head.appendChild(pointerEventsStyleElement);
+  }
+}
+
+/**
+ * Remove CSS for disabling pointer events
+ */
+function removePointerEventsBlocker(): void {
+  pointerEventsLayerCount--;
+
+  if (pointerEventsLayerCount === 0 && pointerEventsStyleElement) {
+    pointerEventsStyleElement.remove();
+    pointerEventsStyleElement = null;
+  }
+}
+
+/**
+ * Create a dismissable layer with combined dismissal detection
+ * Returns cleanup function to remove all listeners
+ *
+ * @example
+ * ```typescript
+ * // Basic dropdown
+ * const cleanup = createDismissableLayer(dropdown, {
+ *   onDismiss: () => setOpen(false),
+ * });
+ *
+ * // Modal dialog
+ * const cleanup = createDismissableLayer(dialog, {
+ *   disableOutsidePointerEvents: true,
+ *   onEscapeKeyDown: (e) => {
+ *     e.preventDefault();
+ *     closeDialog();
+ *   },
+ *   onPointerDownOutside: (e) => {
+ *     e.preventDefault(); // Prevent focus shift
+ *     closeDialog();
+ *   },
+ * });
+ *
+ * // With portaled content
+ * const cleanup = createDismissableLayer(trigger, {
+ *   excludeElements: [portaledContent],
+ *   onDismiss: () => closePopover(),
+ * });
+ * ```
+ */
+export function createDismissableLayer(
+  layer: HTMLElement,
+  options: DismissableLayerOptions = {},
+): CleanupFunction {
+  // SSR guard
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const {
+    enabled = true,
+    disableOutsidePointerEvents = false,
+    onEscapeKeyDown,
+    onPointerDownOutside,
+    onFocusOutside,
+    onInteractOutside,
+    onDismiss,
+    excludeElements = [],
+  } = options;
+
+  if (!enabled) {
+    return () => {};
+  }
+
+  const cleanupFunctions: CleanupFunction[] = [];
+
+  // Mark layer for pointer events blocking
+  layer.setAttribute('data-dismissable-layer', '');
+
+  // Handle Escape key
+  const handleEscapeKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== 'Escape') return;
+
+    onEscapeKeyDown?.(event);
+    onInteractOutside?.(event);
+    onDismiss?.();
+  };
+
+  document.addEventListener('keydown', handleEscapeKeyDown);
+  cleanupFunctions.push(() => {
+    document.removeEventListener('keydown', handleEscapeKeyDown);
+  });
+
+  // Handle pointer down outside
+  const handlePointerDown = (event: PointerEvent) => {
+    const target = event.target as Node;
+
+    // Deduplicate with recent touch events (only within same layer)
+    const lastTime = layerPointerDownTime.get(layer) ?? 0;
+    const timeSinceLastPointer = Date.now() - lastTime;
+    if (timeSinceLastPointer < 50) return;
+    layerPointerDownTime.set(layer, Date.now());
+
+    if (!isInsideLayer(target, layer, excludeElements)) {
+      onPointerDownOutside?.(event);
+      onInteractOutside?.(event);
+      onDismiss?.();
+    }
+  };
+
+  // Handle touch start (fallback for test environments)
+  const handleTouchStart = (event: TouchEvent) => {
+    const target = event.target as Node;
+
+    layerPointerDownTime.set(layer, Date.now());
+
+    if (!isInsideLayer(target, layer, excludeElements)) {
+      onPointerDownOutside?.(event);
+      onInteractOutside?.(event);
+      onDismiss?.();
+    }
+  };
+
+  document.addEventListener('pointerdown', handlePointerDown, true);
+  document.addEventListener('touchstart', handleTouchStart, true);
+  cleanupFunctions.push(() => {
+    document.removeEventListener('pointerdown', handlePointerDown, true);
+    document.removeEventListener('touchstart', handleTouchStart, true);
+  });
+
+  // Handle focus outside
+  const handleFocusIn = (event: FocusEvent) => {
+    const target = event.target as Node;
+
+    if (!isInsideLayer(target, layer, excludeElements)) {
+      onFocusOutside?.(event);
+      onInteractOutside?.(event);
+      // Note: We don't call onDismiss for focus outside by default
+      // This is intentional to match Radix behavior
+    }
+  };
+
+  document.addEventListener('focusin', handleFocusIn);
+  cleanupFunctions.push(() => {
+    document.removeEventListener('focusin', handleFocusIn);
+  });
+
+  // Handle pointer events blocking
+  if (disableOutsidePointerEvents) {
+    addPointerEventsBlocker();
+    cleanupFunctions.push(removePointerEventsBlocker);
+  }
+
+  // Cleanup function
+  return () => {
+    layer.removeAttribute('data-dismissable-layer');
+
+    for (const cleanup of cleanupFunctions) {
+      cleanup();
+    }
+  };
+}
+
+/**
+ * Create a nested dismissable layer
+ * Handles stacking of multiple layers (e.g., dialog with dropdown)
+ *
+ * @example
+ * ```typescript
+ * // First layer (dialog)
+ * const dialogCleanup = createDismissableLayerStack(dialog, {
+ *   onDismiss: closeDialog,
+ * });
+ *
+ * // Second layer (dropdown inside dialog)
+ * const dropdownCleanup = createDismissableLayerStack(dropdown, {
+ *   onDismiss: closeDropdown,
+ * });
+ *
+ * // Escape closes dropdown first, then dialog
+ * ```
+ */
+const layerStack: HTMLElement[] = [];
+
+export function createDismissableLayerStack(
+  layer: HTMLElement,
+  options: DismissableLayerOptions = {},
+): CleanupFunction {
+  // SSR guard
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  // Add to stack
+  layerStack.push(layer);
+
+  // Create base dismissable layer with modified escape handling
+  const baseCleanup = createDismissableLayer(layer, {
+    ...options,
+    onEscapeKeyDown: (event) => {
+      // Only handle escape for topmost layer
+      if (layerStack[layerStack.length - 1] !== layer) return;
+
+      options.onEscapeKeyDown?.(event);
+      // Let the original onDismiss handle through the base implementation
+    },
+    onPointerDownOutside: (event) => {
+      // Only handle pointer down for topmost layer
+      if (layerStack[layerStack.length - 1] !== layer) return;
+
+      options.onPointerDownOutside?.(event);
+    },
+    onFocusOutside: (event) => {
+      // Only handle focus for topmost layer
+      if (layerStack[layerStack.length - 1] !== layer) return;
+
+      options.onFocusOutside?.(event);
+    },
+  });
+
+  return () => {
+    // Remove from stack
+    const index = layerStack.indexOf(layer);
+    if (index !== -1) {
+      layerStack.splice(index, 1);
+    }
+
+    baseCleanup();
+  };
+}
+
+/**
+ * Get current layer stack (for debugging/testing)
+ */
+export function getDismissableLayerStack(): readonly HTMLElement[] {
+  return [...layerStack];
+}
+
+/**
+ * Clear the layer stack (for testing)
+ */
+export function clearDismissableLayerStack(): void {
+  layerStack.length = 0;
+}

--- a/packages/ui/src/primitives/hover-delay.ts
+++ b/packages/ui/src/primitives/hover-delay.ts
@@ -1,0 +1,617 @@
+/**
+ * Hover Delay primitive
+ * Configurable show/hide delays for tooltips and hover cards
+ *
+ * Prevents accidental triggers and provides smooth UX for
+ * hover-based interactions.
+ *
+ * @example
+ * ```typescript
+ * const cleanup = createHoverDelay(triggerElement, {
+ *   openDelay: 700,
+ *   closeDelay: 300,
+ *   onOpen: () => showTooltip(),
+ *   onClose: () => hideTooltip(),
+ * });
+ * ```
+ */
+
+import type { CleanupFunction } from './types';
+
+export interface HoverDelayOptions {
+  /**
+   * Delay in ms before showing content
+   * @default 700
+   */
+  openDelay?: number;
+
+  /**
+   * Delay in ms before hiding content
+   * @default 300
+   */
+  closeDelay?: number;
+
+  /**
+   * Callback when content should open
+   */
+  onOpen?: () => void;
+
+  /**
+   * Callback when content should close
+   */
+  onClose?: () => void;
+
+  /**
+   * Whether hover behavior is enabled
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * Skip delays (instant show/hide)
+   * Useful for touch devices or when user has already
+   * seen the tooltip recently
+   * @default false
+   */
+  skipDelays?: boolean;
+
+  /**
+   * Also track focus events (for keyboard accessibility)
+   * @default true
+   */
+  trackFocus?: boolean;
+
+  /**
+   * Content element(s) to track
+   * Hovering over content keeps it open
+   */
+  contentElement?: HTMLElement | HTMLElement[] | null;
+}
+
+export interface HoverDelayState {
+  /**
+   * Whether content is currently open
+   */
+  isOpen: boolean;
+
+  /**
+   * Whether mouse is over trigger
+   */
+  isHoveringTrigger: boolean;
+
+  /**
+   * Whether mouse is over content
+   */
+  isHoveringContent: boolean;
+
+  /**
+   * Whether trigger is focused
+   */
+  isFocused: boolean;
+}
+
+/**
+ * Global hover delay state for coordinating multiple tooltips
+ * Allows skipping delays when moving between tooltips
+ */
+let globalOpenTimestamp = 0;
+const SKIP_DELAY_THRESHOLD = 300; // Skip open delay if tooltip was open recently
+
+/**
+ * Check if we should skip the open delay
+ */
+function shouldSkipOpenDelay(): boolean {
+  const timeSinceLastOpen = Date.now() - globalOpenTimestamp;
+  return timeSinceLastOpen < SKIP_DELAY_THRESHOLD;
+}
+
+/**
+ * Create hover delay behavior for an element
+ * Returns cleanup function
+ *
+ * @example
+ * ```typescript
+ * // Basic tooltip
+ * const cleanup = createHoverDelay(button, {
+ *   openDelay: 700,
+ *   closeDelay: 300,
+ *   onOpen: () => setTooltipVisible(true),
+ *   onClose: () => setTooltipVisible(false),
+ * });
+ *
+ * // With content element (for hovering over tooltip itself)
+ * const cleanup = createHoverDelay(trigger, {
+ *   contentElement: tooltipElement,
+ *   onOpen: () => show(),
+ *   onClose: () => hide(),
+ * });
+ * ```
+ */
+export function createHoverDelay(
+  trigger: HTMLElement,
+  options: HoverDelayOptions = {},
+): CleanupFunction {
+  // SSR guard
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const {
+    openDelay = 700,
+    closeDelay = 300,
+    onOpen,
+    onClose,
+    enabled = true,
+    skipDelays = false,
+    trackFocus = true,
+    contentElement = null,
+  } = options;
+
+  if (!enabled) {
+    return () => {};
+  }
+
+  let isOpen = false;
+  let isHoveringTrigger = false;
+  let isHoveringContent = false;
+  let isFocused = false;
+  let openTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  let closeTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  const contentElements = contentElement
+    ? Array.isArray(contentElement)
+      ? contentElement
+      : [contentElement]
+    : [];
+
+  /**
+   * Clear all pending timeouts
+   */
+  const clearTimeouts = () => {
+    if (openTimeoutId !== null) {
+      clearTimeout(openTimeoutId);
+      openTimeoutId = null;
+    }
+    if (closeTimeoutId !== null) {
+      clearTimeout(closeTimeoutId);
+      closeTimeoutId = null;
+    }
+  };
+
+  /**
+   * Open the content
+   */
+  const open = () => {
+    if (isOpen) return;
+
+    clearTimeouts();
+    isOpen = true;
+    globalOpenTimestamp = Date.now();
+    onOpen?.();
+  };
+
+  /**
+   * Close the content
+   */
+  const close = () => {
+    if (!isOpen) return;
+
+    clearTimeouts();
+    isOpen = false;
+    onClose?.();
+  };
+
+  /**
+   * Schedule opening with delay
+   */
+  const scheduleOpen = () => {
+    if (isOpen) return;
+
+    clearTimeouts();
+
+    const delay = skipDelays || shouldSkipOpenDelay() ? 0 : openDelay;
+
+    if (delay === 0) {
+      open();
+    } else {
+      openTimeoutId = setTimeout(open, delay);
+    }
+  };
+
+  /**
+   * Schedule closing with delay
+   */
+  const scheduleClose = () => {
+    if (!isOpen) return;
+
+    clearTimeouts();
+
+    const delay = skipDelays ? 0 : closeDelay;
+
+    if (delay === 0) {
+      close();
+    } else {
+      closeTimeoutId = setTimeout(close, delay);
+    }
+  };
+
+  /**
+   * Update state and decide whether to open/close
+   */
+  const updateState = () => {
+    const shouldBeOpen = isHoveringTrigger || isHoveringContent || isFocused;
+
+    if (shouldBeOpen) {
+      // Cancel any pending close and schedule open if not already open
+      if (closeTimeoutId !== null) {
+        clearTimeout(closeTimeoutId);
+        closeTimeoutId = null;
+      }
+      if (!isOpen && openTimeoutId === null) {
+        scheduleOpen();
+      }
+    } else {
+      // Cancel any pending open and schedule close if open
+      if (openTimeoutId !== null) {
+        clearTimeout(openTimeoutId);
+        openTimeoutId = null;
+      }
+      if (isOpen && closeTimeoutId === null) {
+        scheduleClose();
+      }
+    }
+  };
+
+  // Trigger event handlers
+  const handleTriggerMouseEnter = () => {
+    isHoveringTrigger = true;
+    updateState();
+  };
+
+  const handleTriggerMouseLeave = () => {
+    isHoveringTrigger = false;
+    updateState();
+  };
+
+  const handleTriggerFocus = () => {
+    if (!trackFocus) return;
+    isFocused = true;
+    updateState();
+  };
+
+  const handleTriggerBlur = () => {
+    if (!trackFocus) return;
+    isFocused = false;
+    updateState();
+  };
+
+  // Content event handlers
+  const handleContentMouseEnter = () => {
+    isHoveringContent = true;
+    updateState();
+  };
+
+  const handleContentMouseLeave = () => {
+    isHoveringContent = false;
+    updateState();
+  };
+
+  // Add trigger listeners
+  trigger.addEventListener('mouseenter', handleTriggerMouseEnter);
+  trigger.addEventListener('mouseleave', handleTriggerMouseLeave);
+
+  if (trackFocus) {
+    trigger.addEventListener('focus', handleTriggerFocus);
+    trigger.addEventListener('blur', handleTriggerBlur);
+  }
+
+  // Add content listeners
+  for (const element of contentElements) {
+    element.addEventListener('mouseenter', handleContentMouseEnter);
+    element.addEventListener('mouseleave', handleContentMouseLeave);
+  }
+
+  // Cleanup
+  return () => {
+    clearTimeouts();
+
+    trigger.removeEventListener('mouseenter', handleTriggerMouseEnter);
+    trigger.removeEventListener('mouseleave', handleTriggerMouseLeave);
+
+    if (trackFocus) {
+      trigger.removeEventListener('focus', handleTriggerFocus);
+      trigger.removeEventListener('blur', handleTriggerBlur);
+    }
+
+    for (const element of contentElements) {
+      element.removeEventListener('mouseenter', handleContentMouseEnter);
+      element.removeEventListener('mouseleave', handleContentMouseLeave);
+    }
+  };
+}
+
+/**
+ * Create controlled hover delay
+ * Returns handlers instead of attaching listeners
+ * Useful for framework integration
+ *
+ * @example
+ * ```typescript
+ * const hover = createControlledHoverDelay({
+ *   onOpen: () => setOpen(true),
+ *   onClose: () => setOpen(false),
+ * });
+ *
+ * <button
+ *   onMouseEnter={hover.onTriggerEnter}
+ *   onMouseLeave={hover.onTriggerLeave}
+ *   onFocus={hover.onTriggerFocus}
+ *   onBlur={hover.onTriggerBlur}
+ * >
+ *   Hover me
+ * </button>
+ * ```
+ */
+export function createControlledHoverDelay(
+  options: Omit<HoverDelayOptions, 'enabled' | 'contentElement'>,
+): {
+  onTriggerEnter: () => void;
+  onTriggerLeave: () => void;
+  onTriggerFocus: () => void;
+  onTriggerBlur: () => void;
+  onContentEnter: () => void;
+  onContentLeave: () => void;
+  open: () => void;
+  close: () => void;
+  getState: () => HoverDelayState;
+  destroy: () => void;
+} {
+  const {
+    openDelay = 700,
+    closeDelay = 300,
+    onOpen,
+    onClose,
+    skipDelays = false,
+    trackFocus = true,
+  } = options;
+
+  let isOpen = false;
+  let isHoveringTrigger = false;
+  let isHoveringContent = false;
+  let isFocused = false;
+  let openTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  let closeTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  const clearTimeouts = () => {
+    if (openTimeoutId !== null) {
+      clearTimeout(openTimeoutId);
+      openTimeoutId = null;
+    }
+    if (closeTimeoutId !== null) {
+      clearTimeout(closeTimeoutId);
+      closeTimeoutId = null;
+    }
+  };
+
+  const open = () => {
+    if (isOpen) return;
+    clearTimeouts();
+    isOpen = true;
+    globalOpenTimestamp = Date.now();
+    onOpen?.();
+  };
+
+  const close = () => {
+    if (!isOpen) return;
+    clearTimeouts();
+    isOpen = false;
+    onClose?.();
+  };
+
+  const scheduleOpen = () => {
+    if (isOpen) return;
+    clearTimeouts();
+
+    const delay = skipDelays || shouldSkipOpenDelay() ? 0 : openDelay;
+
+    if (delay === 0) {
+      open();
+    } else {
+      openTimeoutId = setTimeout(open, delay);
+    }
+  };
+
+  const scheduleClose = () => {
+    if (!isOpen) return;
+    clearTimeouts();
+
+    const delay = skipDelays ? 0 : closeDelay;
+
+    if (delay === 0) {
+      close();
+    } else {
+      closeTimeoutId = setTimeout(close, delay);
+    }
+  };
+
+  const updateState = () => {
+    const shouldBeOpen = isHoveringTrigger || isHoveringContent || isFocused;
+
+    if (shouldBeOpen) {
+      // Cancel any pending close and schedule open if not already open
+      if (closeTimeoutId !== null) {
+        clearTimeout(closeTimeoutId);
+        closeTimeoutId = null;
+      }
+      if (!isOpen && openTimeoutId === null) {
+        scheduleOpen();
+      }
+    } else {
+      // Cancel any pending open and schedule close if open
+      if (openTimeoutId !== null) {
+        clearTimeout(openTimeoutId);
+        openTimeoutId = null;
+      }
+      if (isOpen && closeTimeoutId === null) {
+        scheduleClose();
+      }
+    }
+  };
+
+  return {
+    onTriggerEnter: () => {
+      isHoveringTrigger = true;
+      updateState();
+    },
+
+    onTriggerLeave: () => {
+      isHoveringTrigger = false;
+      updateState();
+    },
+
+    onTriggerFocus: () => {
+      if (!trackFocus) return;
+      isFocused = true;
+      updateState();
+    },
+
+    onTriggerBlur: () => {
+      if (!trackFocus) return;
+      isFocused = false;
+      updateState();
+    },
+
+    onContentEnter: () => {
+      isHoveringContent = true;
+      updateState();
+    },
+
+    onContentLeave: () => {
+      isHoveringContent = false;
+      updateState();
+    },
+
+    open,
+    close,
+
+    getState: (): HoverDelayState => ({
+      isOpen,
+      isHoveringTrigger,
+      isHoveringContent,
+      isFocused,
+    }),
+
+    destroy: () => {
+      clearTimeouts();
+    },
+  };
+}
+
+/**
+ * Reset global hover delay state
+ * Useful for testing
+ */
+export function resetHoverDelayState(): void {
+  globalOpenTimestamp = 0;
+}
+
+/**
+ * Check if any tooltip was recently open
+ * Useful for external coordination
+ */
+export function wasRecentlyOpen(): boolean {
+  return shouldSkipOpenDelay();
+}
+
+/**
+ * Create a hover intent detector
+ * Only triggers if mouse stays over element for minimum time
+ * Helps prevent accidental triggers when mouse passes over element
+ *
+ * @example
+ * ```typescript
+ * const cleanup = createHoverIntent(element, {
+ *   sensitivity: 7, // px - mouse movement threshold
+ *   interval: 100, // ms - polling interval
+ *   timeout: 0, // ms - minimum hover time
+ *   onEnter: () => showContent(),
+ *   onLeave: () => hideContent(),
+ * });
+ * ```
+ */
+export function createHoverIntent(
+  element: HTMLElement,
+  options: {
+    sensitivity?: number;
+    interval?: number;
+    timeout?: number;
+    onEnter?: () => void;
+    onLeave?: () => void;
+  } = {},
+): CleanupFunction {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const { sensitivity = 7, interval = 100, timeout = 0, onEnter, onLeave } = options;
+
+  let x = 0;
+  let y = 0;
+  let pX = 0;
+  let pY = 0;
+  let status = 0; // 0 = not hovering, 1 = hovering
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const compare = () => {
+    if (timer) clearTimeout(timer);
+
+    if (Math.abs(pX - x) + Math.abs(pY - y) < sensitivity) {
+      status = 1;
+      onEnter?.();
+    } else {
+      pX = x;
+      pY = y;
+      timer = setTimeout(compare, interval);
+    }
+  };
+
+  const handleMouseMove = (e: MouseEvent) => {
+    x = e.clientX;
+    y = e.clientY;
+  };
+
+  const handleMouseEnter = () => {
+    pX = x;
+    pY = y;
+
+    if (timer) clearTimeout(timer);
+
+    if (timeout === 0) {
+      timer = setTimeout(compare, interval);
+    } else {
+      timer = setTimeout(() => {
+        timer = setTimeout(compare, interval);
+      }, timeout);
+    }
+  };
+
+  const handleMouseLeave = () => {
+    if (timer) clearTimeout(timer);
+
+    if (status === 1) {
+      status = 0;
+      onLeave?.();
+    }
+  };
+
+  element.addEventListener('mousemove', handleMouseMove);
+  element.addEventListener('mouseenter', handleMouseEnter);
+  element.addEventListener('mouseleave', handleMouseLeave);
+
+  return () => {
+    if (timer) clearTimeout(timer);
+    element.removeEventListener('mousemove', handleMouseMove);
+    element.removeEventListener('mouseenter', handleMouseEnter);
+    element.removeEventListener('mouseleave', handleMouseLeave);
+  };
+}

--- a/packages/ui/src/primitives/keyboard-handler.ts
+++ b/packages/ui/src/primitives/keyboard-handler.ts
@@ -1,0 +1,345 @@
+/**
+ * Keyboard Handler primitive
+ * Type-safe keyboard event handling with modifier support
+ *
+ * WCAG Compliance:
+ * - 2.1.1 Keyboard (Level A): Correct keyboard event handling
+ * - 2.1.4 Character Key Shortcuts (Level A): Modifier key support prevents AT conflicts
+ *
+ * @example
+ * ```typescript
+ * const cleanup = createKeyboardHandler(element, {
+ *   key: ['Enter', 'Space'],
+ *   handler: (event) => activateButton(),
+ *   preventDefault: true,
+ * });
+ * ```
+ */
+
+import type {
+  CleanupFunction,
+  KeyboardHandlerCallback,
+  KeyboardKey,
+  KeyboardModifiers,
+} from './types';
+
+export interface KeyboardHandlerOptions {
+  /**
+   * Whether the handler is enabled
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * Key(s) to handle
+   */
+  key: KeyboardKey | KeyboardKey[];
+
+  /**
+   * Handler function called when key is pressed
+   */
+  handler: KeyboardHandlerCallback;
+
+  /**
+   * Required modifier keys
+   * If specified, handler only fires when modifiers match
+   */
+  modifiers?: KeyboardModifiers;
+
+  /**
+   * Prevent default browser behavior for handled keys
+   * @default false
+   */
+  preventDefault?: boolean;
+
+  /**
+   * Stop event propagation for handled keys
+   * @default false
+   */
+  stopPropagation?: boolean;
+
+  /**
+   * Use capture phase for event listener
+   * @default false
+   */
+  capture?: boolean;
+}
+
+/**
+ * Map from our KeyboardKey type to actual event.key values
+ */
+const KEY_MAP: Record<KeyboardKey, string> = {
+  Enter: 'Enter',
+  Space: ' ',
+  Escape: 'Escape',
+  Tab: 'Tab',
+  ArrowUp: 'ArrowUp',
+  ArrowDown: 'ArrowDown',
+  ArrowLeft: 'ArrowLeft',
+  ArrowRight: 'ArrowRight',
+  Home: 'Home',
+  End: 'End',
+  PageUp: 'PageUp',
+  PageDown: 'PageDown',
+  Backspace: 'Backspace',
+  Delete: 'Delete',
+};
+
+/**
+ * Check if event modifiers match required modifiers
+ */
+function matchesModifiers(event: KeyboardEvent, modifiers?: KeyboardModifiers): boolean {
+  if (!modifiers) return true;
+
+  const { shift, ctrl, alt, meta } = modifiers;
+
+  // Check each modifier if specified
+  if (shift !== undefined && event.shiftKey !== shift) return false;
+  if (ctrl !== undefined && event.ctrlKey !== ctrl) return false;
+  if (alt !== undefined && event.altKey !== alt) return false;
+  if (meta !== undefined && event.metaKey !== meta) return false;
+
+  return true;
+}
+
+/**
+ * Check if event key matches one of the target keys
+ */
+function matchesKey(event: KeyboardEvent, keys: KeyboardKey[]): boolean {
+  const eventKey = event.key;
+
+  for (const key of keys) {
+    const mappedKey = KEY_MAP[key];
+    if (eventKey === mappedKey) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Create a keyboard event handler for specific keys
+ * Returns cleanup function to remove listener
+ *
+ * @example
+ * ```typescript
+ * // Handle Enter and Space for button activation
+ * const cleanup = createKeyboardHandler(button, {
+ *   key: ['Enter', 'Space'],
+ *   handler: () => button.click(),
+ *   preventDefault: true,
+ * });
+ *
+ * // Handle Escape with Shift modifier
+ * const cleanup2 = createKeyboardHandler(dialog, {
+ *   key: 'Escape',
+ *   modifiers: { shift: true },
+ *   handler: () => closeAll(),
+ * });
+ * ```
+ */
+export function createKeyboardHandler(
+  element: HTMLElement | Document,
+  options: KeyboardHandlerOptions,
+): CleanupFunction {
+  // SSR guard
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const {
+    enabled = true,
+    key,
+    handler,
+    modifiers,
+    preventDefault = false,
+    stopPropagation = false,
+    capture = false,
+  } = options;
+
+  if (!enabled) {
+    return () => {};
+  }
+
+  // Normalize key to array
+  const keys: KeyboardKey[] = Array.isArray(key) ? key : [key];
+
+  const handleKeyDown = (event: Event) => {
+    const keyboardEvent = event as KeyboardEvent;
+
+    // Check if key matches
+    if (!matchesKey(keyboardEvent, keys)) return;
+
+    // Check if modifiers match
+    if (!matchesModifiers(keyboardEvent, modifiers)) return;
+
+    // Handle the event
+    if (preventDefault) keyboardEvent.preventDefault();
+    if (stopPropagation) keyboardEvent.stopPropagation();
+
+    handler(keyboardEvent);
+  };
+
+  element.addEventListener('keydown', handleKeyDown, { capture });
+
+  return () => {
+    element.removeEventListener('keydown', handleKeyDown, { capture });
+  };
+}
+
+/**
+ * Create handler for button activation (Enter and Space)
+ * Convenience function for common pattern
+ *
+ * @example
+ * ```typescript
+ * const cleanup = createActivationHandler(customButton, () => {
+ *   performAction();
+ * });
+ * ```
+ */
+export function createActivationHandler(
+  element: HTMLElement,
+  onActivate: KeyboardHandlerCallback,
+): CleanupFunction {
+  return createKeyboardHandler(element, {
+    key: ['Enter', 'Space'],
+    handler: onActivate,
+    preventDefault: true,
+  });
+}
+
+/**
+ * Create handler for dismissal (Escape key)
+ * Convenience function for common pattern
+ *
+ * @example
+ * ```typescript
+ * const cleanup = createDismissalHandler(dialog, () => {
+ *   closeDialog();
+ * });
+ * ```
+ */
+export function createDismissalHandler(
+  element: HTMLElement | Document,
+  onDismiss: KeyboardHandlerCallback,
+): CleanupFunction {
+  return createKeyboardHandler(element, {
+    key: 'Escape',
+    handler: onDismiss,
+    // Don't prevent default for Escape - let it bubble for nested dismissables
+  });
+}
+
+/**
+ * Create handler for arrow key navigation
+ * Convenience function for directional navigation
+ *
+ * @example
+ * ```typescript
+ * const cleanup = createNavigationHandler(list, {
+ *   onNext: () => focusNextItem(),
+ *   onPrevious: () => focusPreviousItem(),
+ *   orientation: 'vertical',
+ * });
+ * ```
+ */
+export function createNavigationHandler(
+  element: HTMLElement,
+  callbacks: {
+    onNext?: KeyboardHandlerCallback;
+    onPrevious?: KeyboardHandlerCallback;
+    onFirst?: KeyboardHandlerCallback;
+    onLast?: KeyboardHandlerCallback;
+    orientation?: 'horizontal' | 'vertical' | 'both';
+  },
+): CleanupFunction {
+  const { onNext, onPrevious, onFirst, onLast, orientation = 'vertical' } = callbacks;
+
+  const cleanups: CleanupFunction[] = [];
+
+  // Determine which keys trigger next/previous based on orientation
+  const nextKeys: KeyboardKey[] = [];
+  const prevKeys: KeyboardKey[] = [];
+
+  if (orientation === 'vertical' || orientation === 'both') {
+    nextKeys.push('ArrowDown');
+    prevKeys.push('ArrowUp');
+  }
+
+  if (orientation === 'horizontal' || orientation === 'both') {
+    nextKeys.push('ArrowRight');
+    prevKeys.push('ArrowLeft');
+  }
+
+  if (onNext && nextKeys.length > 0) {
+    cleanups.push(
+      createKeyboardHandler(element, {
+        key: nextKeys,
+        handler: onNext,
+        preventDefault: true,
+      }),
+    );
+  }
+
+  if (onPrevious && prevKeys.length > 0) {
+    cleanups.push(
+      createKeyboardHandler(element, {
+        key: prevKeys,
+        handler: onPrevious,
+        preventDefault: true,
+      }),
+    );
+  }
+
+  if (onFirst) {
+    cleanups.push(
+      createKeyboardHandler(element, {
+        key: 'Home',
+        handler: onFirst,
+        preventDefault: true,
+      }),
+    );
+  }
+
+  if (onLast) {
+    cleanups.push(
+      createKeyboardHandler(element, {
+        key: 'End',
+        handler: onLast,
+        preventDefault: true,
+      }),
+    );
+  }
+
+  return () => {
+    for (const cleanup of cleanups) {
+      cleanup();
+    }
+  };
+}
+
+/**
+ * Create a combined keyboard handler for multiple key bindings
+ * Useful for complex keyboard interaction patterns
+ *
+ * @example
+ * ```typescript
+ * const cleanup = createKeyBindings(element, [
+ *   { key: 'Enter', handler: activateItem },
+ *   { key: 'Delete', handler: deleteItem },
+ *   { key: 'Escape', handler: deselectAll },
+ * ]);
+ * ```
+ */
+export function createKeyBindings(
+  element: HTMLElement | Document,
+  bindings: KeyboardHandlerOptions[],
+): CleanupFunction {
+  const cleanups = bindings.map((binding) => createKeyboardHandler(element, binding));
+
+  return () => {
+    for (const cleanup of cleanups) {
+      cleanup();
+    }
+  };
+}

--- a/packages/ui/src/primitives/roving-focus.ts
+++ b/packages/ui/src/primitives/roving-focus.ts
@@ -1,0 +1,330 @@
+/**
+ * Roving Focus primitive
+ * Implements roving tabindex pattern for keyboard navigation
+ * in composite widgets (menus, radio groups, toolbars, tabs)
+ *
+ * WCAG Compliance:
+ * - 2.1.1 Keyboard (Level A): Arrow key navigation available
+ * - 2.4.3 Focus Order (Level A): Logical focus order with Tab
+ * - 4.1.2 Name, Role, Value (Level A): Current item communicated to AT
+ *
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/menubar/
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/radio/
+ */
+
+import type { CleanupFunction, Direction, NavigationCallback, Orientation } from './types';
+
+export interface RovingFocusOptions {
+  /**
+   * Whether roving focus is enabled
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * Navigation orientation
+   * - 'horizontal': Arrow Left/Right navigate
+   * - 'vertical': Arrow Up/Down navigate
+   * - 'both': All arrow keys navigate
+   * @default 'horizontal'
+   */
+  orientation?: Orientation;
+
+  /**
+   * Whether to wrap navigation at ends
+   * @default true
+   */
+  loop?: boolean;
+
+  /**
+   * Text direction for RTL support
+   * @default 'ltr'
+   */
+  dir?: Direction;
+
+  /**
+   * Initial focused item index
+   * @default 0
+   */
+  currentIndex?: number;
+
+  /**
+   * Callback when navigation occurs
+   */
+  onNavigate?: NavigationCallback;
+
+  /**
+   * Prevent default on handled keys
+   * @default true
+   */
+  preventDefault?: boolean;
+}
+
+/**
+ * Get focusable items within container
+ * Excludes disabled and hidden elements
+ */
+function getFocusableItems(container: HTMLElement): HTMLElement[] {
+  const items = Array.from(
+    container.querySelectorAll<HTMLElement>(
+      '[data-roving-item], [role="menuitem"], [role="option"], [role="radio"], [role="tab"]',
+    ),
+  );
+
+  return items.filter((item) => {
+    // Skip disabled items
+    if (item.hasAttribute('disabled') || item.getAttribute('aria-disabled') === 'true') {
+      return false;
+    }
+    // Skip hidden items
+    if (item.hasAttribute('hidden') || item.getAttribute('aria-hidden') === 'true') {
+      return false;
+    }
+    // Skip invisible items
+    const style = getComputedStyle(item);
+    if (style.display === 'none' || style.visibility === 'hidden') {
+      return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Update tabindex on items (roving tabindex pattern)
+ * Only one item should have tabindex="0" at a time
+ */
+function updateTabindex(items: HTMLElement[], currentIndex: number): void {
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (item) {
+      item.setAttribute('tabindex', i === currentIndex ? '0' : '-1');
+    }
+  }
+}
+
+/**
+ * Calculate next index based on direction and options
+ */
+function getNextIndex(
+  currentIndex: number,
+  direction: 1 | -1,
+  itemCount: number,
+  loop: boolean,
+): number {
+  const nextIndex = currentIndex + direction;
+
+  if (loop) {
+    if (nextIndex < 0) return itemCount - 1;
+    if (nextIndex >= itemCount) return 0;
+    return nextIndex;
+  }
+
+  return Math.max(0, Math.min(nextIndex, itemCount - 1));
+}
+
+/**
+ * Check if key should navigate based on orientation
+ */
+function shouldNavigate(
+  key: string,
+  orientation: Orientation,
+  dir: Direction,
+): { navigate: boolean; direction: 1 | -1 } {
+  const isRTL = dir === 'rtl';
+
+  // Map keys to navigation direction
+  const keyMap: Record<string, { orientations: Orientation[]; direction: 1 | -1 }> = {
+    ArrowRight: {
+      orientations: ['horizontal', 'both'],
+      direction: isRTL ? -1 : 1,
+    },
+    ArrowLeft: {
+      orientations: ['horizontal', 'both'],
+      direction: isRTL ? 1 : -1,
+    },
+    ArrowDown: {
+      orientations: ['vertical', 'both'],
+      direction: 1,
+    },
+    ArrowUp: {
+      orientations: ['vertical', 'both'],
+      direction: -1,
+    },
+  };
+
+  const mapping = keyMap[key];
+  if (!mapping) {
+    return { navigate: false, direction: 1 };
+  }
+
+  const matchesOrientation = mapping.orientations.includes(orientation) || orientation === 'both';
+
+  return {
+    navigate: matchesOrientation,
+    direction: mapping.direction,
+  };
+}
+
+/**
+ * Create roving focus behavior for a container
+ * Returns cleanup function to remove event listeners
+ *
+ * @example
+ * ```typescript
+ * const cleanup = createRovingFocus(menuElement, {
+ *   orientation: 'vertical',
+ *   loop: true,
+ *   onNavigate: (element, index) => {
+ *     // Update active state in your framework
+ *   }
+ * });
+ *
+ * // Later...
+ * cleanup();
+ * ```
+ */
+export function createRovingFocus(
+  container: HTMLElement,
+  options: RovingFocusOptions = {},
+): CleanupFunction {
+  // SSR guard
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const {
+    enabled = true,
+    orientation = 'horizontal',
+    loop = true,
+    dir = 'ltr',
+    currentIndex: initialIndex = 0,
+    onNavigate,
+    preventDefault = true,
+  } = options;
+
+  if (!enabled) {
+    return () => {};
+  }
+
+  let currentIndex = initialIndex;
+  let items = getFocusableItems(container);
+
+  // Initialize tabindex on items
+  updateTabindex(items, currentIndex);
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    // Refresh items in case DOM changed
+    items = getFocusableItems(container);
+    if (items.length === 0) return;
+
+    const { key } = event;
+
+    // Handle Home/End keys
+    if (key === 'Home') {
+      if (preventDefault) event.preventDefault();
+      currentIndex = 0;
+      const item = items[currentIndex];
+      if (item) {
+        updateTabindex(items, currentIndex);
+        item.focus();
+        onNavigate?.(item, currentIndex);
+      }
+      return;
+    }
+
+    if (key === 'End') {
+      if (preventDefault) event.preventDefault();
+      currentIndex = items.length - 1;
+      const item = items[currentIndex];
+      if (item) {
+        updateTabindex(items, currentIndex);
+        item.focus();
+        onNavigate?.(item, currentIndex);
+      }
+      return;
+    }
+
+    // Handle arrow keys
+    const { navigate, direction } = shouldNavigate(key, orientation, dir);
+    if (!navigate) return;
+
+    if (preventDefault) event.preventDefault();
+
+    currentIndex = getNextIndex(currentIndex, direction, items.length, loop);
+    const item = items[currentIndex];
+    if (item) {
+      updateTabindex(items, currentIndex);
+      item.focus();
+      onNavigate?.(item, currentIndex);
+    }
+  };
+
+  // Handle focus within container to track current index
+  const handleFocusIn = (event: FocusEvent) => {
+    const target = event.target as HTMLElement;
+    items = getFocusableItems(container);
+    const index = items.indexOf(target);
+    if (index !== -1) {
+      currentIndex = index;
+      updateTabindex(items, currentIndex);
+    }
+  };
+
+  container.addEventListener('keydown', handleKeyDown);
+  container.addEventListener('focusin', handleFocusIn);
+
+  return () => {
+    container.removeEventListener('keydown', handleKeyDown);
+    container.removeEventListener('focusin', handleFocusIn);
+  };
+}
+
+/**
+ * Focus a specific item by index
+ * Utility for programmatic focus management
+ */
+export function focusItem(container: HTMLElement, index: number): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  const items = getFocusableItems(container);
+  if (index < 0 || index >= items.length) {
+    return false;
+  }
+
+  updateTabindex(items, index);
+  const item = items[index];
+  if (item) {
+    item.focus();
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Get current focused item index
+ * Returns -1 if no item is focused
+ */
+export function getCurrentIndex(container: HTMLElement): number {
+  if (typeof window === 'undefined') {
+    return -1;
+  }
+
+  const items = getFocusableItems(container);
+  const activeElement = document.activeElement as HTMLElement;
+  return items.indexOf(activeElement);
+}
+
+/**
+ * Refresh tabindex on items (call after DOM changes)
+ */
+export function refreshRovingFocus(container: HTMLElement, currentIndex = 0): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const items = getFocusableItems(container);
+  const safeIndex = Math.max(0, Math.min(currentIndex, items.length - 1));
+  updateTabindex(items, safeIndex);
+}

--- a/packages/ui/src/primitives/slot.ts
+++ b/packages/ui/src/primitives/slot.ts
@@ -1,0 +1,386 @@
+/**
+ * Slot primitive for prop merging (asChild pattern)
+ * Enables component composition by merging props from parent to child
+ *
+ * WCAG Compliance:
+ * - 4.1.2 Name, Role, Value (Level A): Preserves ARIA attributes during merge
+ *
+ * @example
+ * ```typescript
+ * // Merge parent button props onto child anchor
+ * const cleanup = mergeSlotProps(buttonElement, anchorElement, {
+ *   mergeEventHandlers: true,
+ *   mergeClassName: true,
+ * });
+ * ```
+ */
+
+import type { CleanupFunction } from './types';
+
+export interface SlotMergeOptions {
+  /**
+   * Whether to merge ARIA attributes
+   * @default true
+   */
+  mergeAria?: boolean;
+
+  /**
+   * Whether to merge data attributes
+   * @default true
+   */
+  mergeData?: boolean;
+
+  /**
+   * Whether to merge className/class attributes
+   * @default true
+   */
+  mergeClassName?: boolean;
+
+  /**
+   * Whether to merge inline styles
+   * @default true
+   */
+  mergeStyle?: boolean;
+
+  /**
+   * Whether to merge event handlers
+   * Event handlers are composed: child runs first, then parent
+   * @default true
+   */
+  mergeEventHandlers?: boolean;
+
+  /**
+   * Custom class merger function
+   * If not provided, classes are simply concatenated
+   */
+  classMerger?: (parentClass: string, childClass: string) => string;
+}
+
+/**
+ * Standard event handler attribute names
+ */
+const EVENT_HANDLER_NAMES = [
+  'onclick',
+  'onkeydown',
+  'onkeyup',
+  'onkeypress',
+  'onfocus',
+  'onblur',
+  'onmousedown',
+  'onmouseup',
+  'onmouseover',
+  'onmouseout',
+  'onmouseenter',
+  'onmouseleave',
+  'onpointerdown',
+  'onpointerup',
+  'ontouchstart',
+  'ontouchend',
+] as const;
+
+/**
+ * Get all ARIA attributes from an element
+ */
+function getAriaAttributes(element: Element): Map<string, string> {
+  const attrs = new Map<string, string>();
+  for (const attr of element.attributes) {
+    if (attr.name.startsWith('aria-') || attr.name === 'role') {
+      attrs.set(attr.name, attr.value);
+    }
+  }
+  return attrs;
+}
+
+/**
+ * Get all data attributes from an element
+ */
+function getDataAttributes(element: Element): Map<string, string> {
+  const attrs = new Map<string, string>();
+  for (const attr of element.attributes) {
+    if (attr.name.startsWith('data-')) {
+      attrs.set(attr.name, attr.value);
+    }
+  }
+  return attrs;
+}
+
+/**
+ * Store for original attribute values to restore on cleanup
+ */
+interface OriginalState {
+  attributes: Map<string, string | null>;
+  className: string;
+  style: string;
+  eventHandlers: Map<string, EventListener>;
+}
+
+/**
+ * Merge props from parent element onto child element
+ * Returns cleanup function that restores original child state
+ *
+ * This enables the "asChild" pattern where a wrapper component
+ * can pass its props to a child element, allowing the child
+ * to take on the wrapper's behavior while maintaining its own semantics.
+ *
+ * @example
+ * ```typescript
+ * // Parent Button wants to render as child Anchor
+ * const cleanup = mergeSlotProps(buttonWrapper, anchorChild, {
+ *   mergeClassName: true,
+ *   mergeEventHandlers: true,
+ * });
+ *
+ * // Later restore original state
+ * cleanup();
+ * ```
+ */
+export function mergeSlotProps(
+  parent: HTMLElement,
+  child: HTMLElement,
+  options: SlotMergeOptions = {},
+): CleanupFunction {
+  // SSR guard
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const {
+    mergeAria = true,
+    mergeData = true,
+    mergeClassName = true,
+    mergeStyle = true,
+    mergeEventHandlers = true,
+    classMerger,
+  } = options;
+
+  // Store original state for cleanup
+  const originalState: OriginalState = {
+    attributes: new Map(),
+    className: child.className,
+    style: child.getAttribute('style') || '',
+    eventHandlers: new Map(),
+  };
+
+  // Cleanup handlers to remove
+  const cleanupHandlers: Array<() => void> = [];
+
+  // Merge ARIA attributes
+  if (mergeAria) {
+    const parentAria = getAriaAttributes(parent);
+    for (const [name, value] of parentAria) {
+      // Store original value (or null if not present)
+      originalState.attributes.set(name, child.getAttribute(name));
+      child.setAttribute(name, value);
+    }
+  }
+
+  // Merge data attributes
+  if (mergeData) {
+    const parentData = getDataAttributes(parent);
+    for (const [name, value] of parentData) {
+      originalState.attributes.set(name, child.getAttribute(name));
+      child.setAttribute(name, value);
+    }
+  }
+
+  // Merge className
+  if (mergeClassName && parent.className) {
+    const parentClass = parent.className;
+    const childClass = child.className;
+
+    if (classMerger) {
+      child.className = classMerger(parentClass, childClass);
+    } else {
+      // Simple concatenation, preserving both
+      child.className = childClass ? `${childClass} ${parentClass}` : parentClass;
+    }
+  }
+
+  // Merge inline styles
+  if (mergeStyle) {
+    const parentStyle = parent.getAttribute('style');
+    if (parentStyle) {
+      const childStyle = child.getAttribute('style') || '';
+      // Child styles take precedence (come after parent)
+      child.setAttribute('style', `${parentStyle}; ${childStyle}`.replace(/^;\s*/, ''));
+    }
+  }
+
+  // Merge event handlers
+  if (mergeEventHandlers) {
+    for (const handlerName of EVENT_HANDLER_NAMES) {
+      // Check if parent has an inline handler or listener
+      const parentHandler = (parent as unknown as Record<string, unknown>)[handlerName];
+      if (typeof parentHandler === 'function') {
+        const eventType = handlerName.slice(2); // Remove 'on' prefix
+        const childHandler = (child as unknown as Record<string, unknown>)[handlerName];
+
+        // Compose handlers: child first, then parent
+        const composedHandler = (event: Event) => {
+          if (typeof childHandler === 'function') {
+            childHandler.call(child, event);
+          }
+          if (!event.defaultPrevented) {
+            (parentHandler as EventListener).call(parent, event);
+          }
+        };
+
+        child.addEventListener(eventType, composedHandler);
+
+        cleanupHandlers.push(() => {
+          child.removeEventListener(eventType, composedHandler);
+        });
+      }
+    }
+  }
+
+  // Return cleanup function
+  return () => {
+    // Restore original attributes
+    for (const [name, originalValue] of originalState.attributes) {
+      if (originalValue === null) {
+        child.removeAttribute(name);
+      } else {
+        child.setAttribute(name, originalValue);
+      }
+    }
+
+    // Restore original className
+    if (mergeClassName) {
+      child.className = originalState.className;
+    }
+
+    // Restore original style
+    if (mergeStyle) {
+      if (originalState.style) {
+        child.setAttribute('style', originalState.style);
+      } else {
+        child.removeAttribute('style');
+      }
+    }
+
+    // Remove composed event handlers
+    for (const cleanup of cleanupHandlers) {
+      cleanup();
+    }
+  };
+}
+
+/**
+ * Extract props from an element as a plain object
+ * Useful for React/framework integration
+ */
+export function extractSlotProps(element: Element): Record<string, string> {
+  if (typeof window === 'undefined') {
+    return {};
+  }
+
+  const props: Record<string, string> = {};
+
+  for (const attr of element.attributes) {
+    props[attr.name] = attr.value;
+  }
+
+  return props;
+}
+
+/**
+ * Check if an element should use slot composition
+ * Utility for framework integration
+ */
+export function shouldUseSlot(asChild?: boolean): boolean {
+  return asChild === true;
+}
+
+/**
+ * Merge two className strings with deduplication
+ * Simple utility that can be used as classMerger option
+ */
+export function mergeClassNames(parentClass: string, childClass: string): string {
+  const parentClasses = parentClass.split(/\s+/).filter(Boolean);
+  const childClasses = childClass.split(/\s+/).filter(Boolean);
+
+  // Child classes take precedence, so they come last
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  // Add parent classes first
+  for (const cls of parentClasses) {
+    if (!seen.has(cls)) {
+      seen.add(cls);
+      result.push(cls);
+    }
+  }
+
+  // Add child classes (may override parent)
+  for (const cls of childClasses) {
+    if (!seen.has(cls)) {
+      seen.add(cls);
+      result.push(cls);
+    }
+  }
+
+  return result.join(' ');
+}
+
+/**
+ * Props object for framework-agnostic prop merging
+ */
+export interface SlotProps {
+  className?: string;
+  style?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+/**
+ * Merge two prop objects (for React/framework use)
+ * Handles className, style, and event handlers specially
+ */
+export function mergeProps(
+  parentProps: SlotProps,
+  childProps: SlotProps,
+  options: { classMerger?: (a: string, b: string) => string } = {},
+): SlotProps {
+  const { classMerger } = options;
+  const merged: SlotProps = { ...parentProps };
+
+  for (const key of Object.keys(childProps)) {
+    const parentValue = parentProps[key];
+    const childValue = childProps[key];
+
+    // Handle className specially
+    if (key === 'className' && typeof parentValue === 'string' && typeof childValue === 'string') {
+      merged.className = classMerger
+        ? classMerger(parentValue, childValue)
+        : `${parentValue} ${childValue}`;
+      continue;
+    }
+
+    // Handle style specially (merge objects)
+    if (key === 'style' && typeof parentValue === 'object' && typeof childValue === 'object') {
+      merged.style = {
+        ...(parentValue as Record<string, string>),
+        ...(childValue as Record<string, string>),
+      };
+      continue;
+    }
+
+    // Handle event handlers specially (compose functions)
+    if (
+      key.startsWith('on') &&
+      typeof parentValue === 'function' &&
+      typeof childValue === 'function'
+    ) {
+      merged[key] = (...args: unknown[]) => {
+        (childValue as (...args: unknown[]) => void)(...args);
+        (parentValue as (...args: unknown[]) => void)(...args);
+      };
+      continue;
+    }
+
+    // Default: child value overrides
+    merged[key] = childValue;
+  }
+
+  return merged;
+}

--- a/packages/ui/src/primitives/sr-announcer.ts
+++ b/packages/ui/src/primitives/sr-announcer.ts
@@ -1,0 +1,377 @@
+/**
+ * Screen Reader Announcer primitive
+ * Live region announcements for screen readers
+ *
+ * WCAG Compliance:
+ * - 4.1.3 Status Messages (Level AA): Status messages communicated to AT
+ * - 1.3.1 Info and Relationships (Level A): Relationships conveyed programmatically
+ *
+ * @see https://www.w3.org/WAI/ARIA/apg/practices/hiding-semantics/#usingaria-liveregions
+ *
+ * @example
+ * ```typescript
+ * const announcer = createAnnouncer({ politeness: 'polite' });
+ * announcer.announce('3 items loaded');
+ *
+ * // Later...
+ * announcer.destroy();
+ * ```
+ */
+
+import type { CleanupFunction, LiveRegionPoliteness, LiveRegionRole } from './types';
+
+export interface AnnouncerOptions {
+  /**
+   * Politeness level for announcements
+   * - 'polite': Waits for user to finish current task (default)
+   * - 'assertive': Interrupts immediately
+   * - 'off': No announcements
+   * @default 'polite'
+   */
+  politeness?: LiveRegionPoliteness;
+
+  /**
+   * Whether to clear message after announcing
+   * Prevents re-announcement on page refresh
+   * @default true
+   */
+  clearAfterAnnounce?: boolean;
+
+  /**
+   * Time in ms before clearing the message
+   * @default 1000
+   */
+  clearTimeout?: number;
+
+  /**
+   * ARIA role for the live region
+   * - 'status': Non-urgent status message (default for polite)
+   * - 'alert': Important time-sensitive message (default for assertive)
+   * - 'log': Sequential log of messages
+   * @default 'status'
+   */
+  role?: LiveRegionRole;
+
+  /**
+   * Container to append the live region to
+   * @default document.body
+   */
+  container?: HTMLElement;
+}
+
+export interface Announcer {
+  /**
+   * Announce a message to screen readers
+   */
+  announce: (message: string) => void;
+
+  /**
+   * Clear the current announcement
+   */
+  clear: () => void;
+
+  /**
+   * Destroy the announcer and remove the live region
+   */
+  destroy: CleanupFunction;
+
+  /**
+   * Get the live region element
+   */
+  getElement: () => HTMLElement | null;
+}
+
+/**
+ * Styles to visually hide the live region while keeping it accessible
+ */
+const VISUALLY_HIDDEN_STYLES = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: '0',
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: '0',
+} as const;
+
+/**
+ * Global announcer instances to prevent duplicates
+ */
+const globalAnnouncers: Map<string, Announcer> = new Map();
+
+/**
+ * Create a unique key for announcer deduplication
+ */
+function getAnnouncerKey(politeness: LiveRegionPoliteness, role: LiveRegionRole): string {
+  return `${politeness}-${role}`;
+}
+
+/**
+ * Create a screen reader announcer
+ * Returns object with announce, clear, and destroy methods
+ *
+ * @example
+ * ```typescript
+ * // Basic usage
+ * const announcer = createAnnouncer();
+ * announcer.announce('Form submitted successfully');
+ *
+ * // Assertive for errors
+ * const errorAnnouncer = createAnnouncer({
+ *   politeness: 'assertive',
+ *   role: 'alert',
+ * });
+ * errorAnnouncer.announce('Error: Please fix the form');
+ *
+ * // Cleanup
+ * announcer.destroy();
+ * ```
+ */
+export function createAnnouncer(options: AnnouncerOptions = {}): Announcer {
+  // SSR guard
+  if (typeof window === 'undefined') {
+    return {
+      announce: () => {},
+      clear: () => {},
+      destroy: () => {},
+      getElement: () => null,
+    };
+  }
+
+  const {
+    politeness = 'polite',
+    clearAfterAnnounce = true,
+    clearTimeout: clearDelay = 1000,
+    role = politeness === 'assertive' ? 'alert' : 'status',
+    container = document.body,
+  } = options;
+
+  // Check for existing announcer with same settings
+  const key = getAnnouncerKey(politeness, role);
+  const existing = globalAnnouncers.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  // Create live region element
+  const liveRegion = document.createElement('div');
+
+  // Set ARIA attributes
+  liveRegion.setAttribute('aria-live', politeness);
+  liveRegion.setAttribute('aria-atomic', 'true');
+  liveRegion.setAttribute('role', role);
+
+  // Apply visually hidden styles
+  Object.assign(liveRegion.style, VISUALLY_HIDDEN_STYLES);
+
+  // Add data attribute for identification
+  liveRegion.setAttribute('data-sr-announcer', politeness);
+
+  // Append to container
+  container.appendChild(liveRegion);
+
+  let clearTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  const announcer: Announcer = {
+    announce: (message: string) => {
+      // Clear any pending clear timeout
+      if (clearTimeoutId !== null) {
+        clearTimeout(clearTimeoutId);
+        clearTimeoutId = null;
+      }
+
+      // Clear first to ensure change is detected
+      liveRegion.textContent = '';
+
+      // Use requestAnimationFrame to ensure the clear is processed
+      requestAnimationFrame(() => {
+        liveRegion.textContent = message;
+
+        // Schedule clear if enabled
+        if (clearAfterAnnounce) {
+          clearTimeoutId = setTimeout(() => {
+            liveRegion.textContent = '';
+            clearTimeoutId = null;
+          }, clearDelay);
+        }
+      });
+    },
+
+    clear: () => {
+      if (clearTimeoutId !== null) {
+        clearTimeout(clearTimeoutId);
+        clearTimeoutId = null;
+      }
+      liveRegion.textContent = '';
+    },
+
+    destroy: () => {
+      if (clearTimeoutId !== null) {
+        clearTimeout(clearTimeoutId);
+      }
+      liveRegion.remove();
+      globalAnnouncers.delete(key);
+    },
+
+    getElement: () => liveRegion,
+  };
+
+  // Store in global map
+  globalAnnouncers.set(key, announcer);
+
+  return announcer;
+}
+
+/**
+ * Convenience function for one-off announcements
+ * Creates temporary announcer, announces, then cleans up
+ *
+ * @example
+ * ```typescript
+ * // Simple polite announcement
+ * announceToScreenReader('Search results updated');
+ *
+ * // Assertive announcement for errors
+ * announceToScreenReader('Form validation failed', 'assertive');
+ * ```
+ */
+export function announceToScreenReader(
+  message: string,
+  politeness: LiveRegionPoliteness = 'polite',
+): void {
+  if (typeof window === 'undefined') return;
+
+  const announcer = createAnnouncer({ politeness });
+  announcer.announce(message);
+}
+
+/**
+ * Create a polite announcer (convenience function)
+ * For non-urgent status updates
+ *
+ * @example
+ * ```typescript
+ * const announcer = createPoliteAnnouncer();
+ * announcer.announce('Loading complete');
+ * ```
+ */
+export function createPoliteAnnouncer(
+  options: Omit<AnnouncerOptions, 'politeness'> = {},
+): Announcer {
+  return createAnnouncer({ ...options, politeness: 'polite' });
+}
+
+/**
+ * Create an assertive announcer (convenience function)
+ * For urgent messages that should interrupt
+ *
+ * @example
+ * ```typescript
+ * const announcer = createAssertiveAnnouncer();
+ * announcer.announce('Error: Connection lost');
+ * ```
+ */
+export function createAssertiveAnnouncer(
+  options: Omit<AnnouncerOptions, 'politeness'> = {},
+): Announcer {
+  return createAnnouncer({ ...options, politeness: 'assertive', role: 'alert' });
+}
+
+/**
+ * Clear all global announcers (for testing)
+ */
+export function clearAllAnnouncers(): void {
+  for (const announcer of globalAnnouncers.values()) {
+    announcer.destroy();
+  }
+  globalAnnouncers.clear();
+}
+
+/**
+ * Get count of active announcers (for testing/debugging)
+ */
+export function getAnnouncerCount(): number {
+  return globalAnnouncers.size;
+}
+
+/**
+ * Create an announcer that queues messages
+ * Useful when multiple rapid announcements might occur
+ *
+ * @example
+ * ```typescript
+ * const announcer = createQueuedAnnouncer({ delay: 500 });
+ * announcer.announce('Item 1 added');
+ * announcer.announce('Item 2 added'); // Will queue
+ * ```
+ */
+export function createQueuedAnnouncer(
+  options: AnnouncerOptions & { delay?: number } = {},
+): Announcer & { queue: readonly string[] } {
+  if (typeof window === 'undefined') {
+    return {
+      announce: () => {},
+      clear: () => {},
+      destroy: () => {},
+      getElement: () => null,
+      queue: [],
+    };
+  }
+
+  const { delay = 500, ...announcerOptions } = options;
+  const baseAnnouncer = createAnnouncer(announcerOptions);
+
+  const messageQueue: string[] = [];
+  let isProcessing = false;
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  const processQueue = () => {
+    if (messageQueue.length === 0) {
+      isProcessing = false;
+      return;
+    }
+
+    isProcessing = true;
+    const message = messageQueue.shift();
+    if (message) {
+      baseAnnouncer.announce(message);
+    }
+
+    timeoutId = setTimeout(processQueue, delay);
+  };
+
+  return {
+    announce: (message: string) => {
+      messageQueue.push(message);
+      if (!isProcessing) {
+        processQueue();
+      }
+    },
+
+    clear: () => {
+      messageQueue.length = 0;
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+      isProcessing = false;
+      baseAnnouncer.clear();
+    },
+
+    destroy: () => {
+      messageQueue.length = 0;
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+      baseAnnouncer.destroy();
+    },
+
+    getElement: baseAnnouncer.getElement,
+
+    get queue() {
+      return [...messageQueue] as const;
+    },
+  };
+}

--- a/packages/ui/src/primitives/typeahead.ts
+++ b/packages/ui/src/primitives/typeahead.ts
@@ -1,0 +1,437 @@
+/**
+ * Typeahead primitive
+ * Type-to-search functionality for lists and menus
+ *
+ * Enables users to quickly navigate to items by typing
+ * the first few characters of the item text.
+ *
+ * WCAG Compliance:
+ * - 2.1.1 Keyboard (Level A): Keyboard navigation available
+ *
+ * @example
+ * ```typescript
+ * const cleanup = createTypeahead(listElement, {
+ *   getItems: () => listElement.querySelectorAll('[role="option"]'),
+ *   onMatch: (item, index) => {
+ *     item.focus();
+ *   },
+ * });
+ * ```
+ */
+
+import type { CleanupFunction } from './types';
+
+export interface TypeaheadOptions {
+  /**
+   * Function to get searchable items
+   * Called on each keystroke to support dynamic lists
+   */
+  getItems: () => Iterable<HTMLElement>;
+
+  /**
+   * Function to get searchable text from an item
+   * @default element.textContent
+   */
+  getItemText?: (item: HTMLElement) => string;
+
+  /**
+   * Callback when a match is found
+   */
+  onMatch?: (item: HTMLElement, index: number) => void;
+
+  /**
+   * Callback when no match is found
+   */
+  onNoMatch?: (searchString: string) => void;
+
+  /**
+   * Time in ms before search string resets
+   * @default 1000
+   */
+  timeout?: number;
+
+  /**
+   * Whether to match from start of text only
+   * @default true
+   */
+  matchFromStart?: boolean;
+
+  /**
+   * Whether matching is case-sensitive
+   * @default false
+   */
+  caseSensitive?: boolean;
+
+  /**
+   * Whether the typeahead is enabled
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * Starting index for circular search
+   * If provided, search starts from this index and wraps around
+   */
+  startIndex?: number;
+}
+
+export interface TypeaheadState {
+  /**
+   * Current search string
+   */
+  searchString: string;
+
+  /**
+   * Index of last matched item
+   */
+  lastMatchIndex: number;
+
+  /**
+   * Whether typeahead is currently active (has typed recently)
+   */
+  isActive: boolean;
+}
+
+/**
+ * Default function to extract text from an element
+ */
+function defaultGetItemText(item: HTMLElement): string {
+  // Try aria-label first
+  const ariaLabel = item.getAttribute('aria-label');
+  if (ariaLabel) return ariaLabel;
+
+  // Then textContent
+  return item.textContent?.trim() || '';
+}
+
+/**
+ * Create typeahead search behavior for a container
+ * Returns cleanup function
+ *
+ * @example
+ * ```typescript
+ * // Basic usage
+ * const cleanup = createTypeahead(menu, {
+ *   getItems: () => menu.querySelectorAll('[role="menuitem"]'),
+ *   onMatch: (item) => item.focus(),
+ * });
+ *
+ * // Custom text extraction
+ * const cleanup = createTypeahead(list, {
+ *   getItems: () => list.querySelectorAll('li'),
+ *   getItemText: (item) => item.dataset.label || item.textContent || '',
+ *   timeout: 500,
+ * });
+ * ```
+ */
+export function createTypeahead(
+  container: HTMLElement,
+  options: TypeaheadOptions,
+): CleanupFunction {
+  // SSR guard
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const {
+    getItems,
+    getItemText = defaultGetItemText,
+    onMatch,
+    onNoMatch,
+    timeout = 1000,
+    matchFromStart = true,
+    caseSensitive = false,
+    enabled = true,
+    startIndex,
+  } = options;
+
+  if (!enabled) {
+    return () => {};
+  }
+
+  let searchString = '';
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Reset search state
+   */
+  const reset = () => {
+    searchString = '';
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+  };
+
+  /**
+   * Find matching item
+   */
+  const findMatch = (
+    items: HTMLElement[],
+    search: string,
+  ): { item: HTMLElement; index: number } | null => {
+    const normalizedSearch = caseSensitive ? search : search.toLowerCase();
+
+    // Determine starting index for search
+    const start = startIndex !== undefined ? startIndex : 0;
+
+    // Search from start index to end, then wrap to beginning
+    for (let i = 0; i < items.length; i++) {
+      const index = (start + i) % items.length;
+      const item = items[index];
+      if (!item) continue;
+
+      // Skip disabled items
+      if (item.hasAttribute('disabled') || item.getAttribute('aria-disabled') === 'true') {
+        continue;
+      }
+
+      const text = getItemText(item);
+      const normalizedText = caseSensitive ? text : text.toLowerCase();
+
+      const matches = matchFromStart
+        ? normalizedText.startsWith(normalizedSearch)
+        : normalizedText.includes(normalizedSearch);
+
+      if (matches) {
+        return { item, index };
+      }
+    }
+
+    return null;
+  };
+
+  /**
+   * Handle keydown event
+   */
+  const handleKeyDown = (event: KeyboardEvent) => {
+    // Ignore if modifier keys are pressed (except Shift)
+    if (event.ctrlKey || event.altKey || event.metaKey) {
+      return;
+    }
+
+    // Ignore special keys
+    const { key } = event;
+    if (key.length !== 1) {
+      return;
+    }
+
+    // Ignore space at start of search (usually means "activate")
+    if (key === ' ' && searchString === '') {
+      return;
+    }
+
+    // Clear previous timeout
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+    }
+
+    // Add character to search string
+    searchString += key;
+
+    // Get items
+    const items = Array.from(getItems());
+    if (items.length === 0) {
+      reset();
+      return;
+    }
+
+    // Find match
+    const match = findMatch(items, searchString);
+
+    if (match) {
+      onMatch?.(match.item, match.index);
+    } else {
+      onNoMatch?.(searchString);
+    }
+
+    // Set timeout to reset search
+    timeoutId = setTimeout(reset, timeout);
+  };
+
+  container.addEventListener('keydown', handleKeyDown);
+
+  return () => {
+    container.removeEventListener('keydown', handleKeyDown);
+    reset();
+  };
+}
+
+/**
+ * Create a controlled typeahead
+ * Returns state getter and handlers instead of managing internally
+ * Useful for framework integration
+ *
+ * @example
+ * ```typescript
+ * const typeahead = createControlledTypeahead({
+ *   getItems: () => items,
+ *   onMatch: (item) => setFocusedItem(item),
+ * });
+ *
+ * // In component
+ * <ul onKeyDown={typeahead.handleKeyDown}>
+ *   {items.map(item => ...)}
+ * </ul>
+ * ```
+ */
+export function createControlledTypeahead(options: Omit<TypeaheadOptions, 'enabled'>): {
+  handleKeyDown: (event: KeyboardEvent) => void;
+  reset: () => void;
+  getState: () => TypeaheadState;
+} {
+  const {
+    getItems,
+    getItemText = defaultGetItemText,
+    onMatch,
+    onNoMatch,
+    timeout = 1000,
+    matchFromStart = true,
+    caseSensitive = false,
+    startIndex,
+  } = options;
+
+  let searchString = '';
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let lastMatchIndex = -1;
+  let isActive = false;
+
+  const reset = () => {
+    searchString = '';
+    isActive = false;
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+  };
+
+  const findMatch = (
+    items: HTMLElement[],
+    search: string,
+  ): { item: HTMLElement; index: number } | null => {
+    const normalizedSearch = caseSensitive ? search : search.toLowerCase();
+    const start = startIndex !== undefined ? startIndex : 0;
+
+    for (let i = 0; i < items.length; i++) {
+      const index = (start + i) % items.length;
+      const item = items[index];
+      if (!item) continue;
+
+      if (item.hasAttribute('disabled') || item.getAttribute('aria-disabled') === 'true') {
+        continue;
+      }
+
+      const text = getItemText(item);
+      const normalizedText = caseSensitive ? text : text.toLowerCase();
+
+      const matches = matchFromStart
+        ? normalizedText.startsWith(normalizedSearch)
+        : normalizedText.includes(normalizedSearch);
+
+      if (matches) {
+        return { item, index };
+      }
+    }
+
+    return null;
+  };
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.ctrlKey || event.altKey || event.metaKey) {
+      return;
+    }
+
+    const { key } = event;
+    if (key.length !== 1) {
+      return;
+    }
+
+    if (key === ' ' && searchString === '') {
+      return;
+    }
+
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+    }
+
+    searchString += key;
+    isActive = true;
+
+    const items = Array.from(getItems());
+    if (items.length === 0) {
+      reset();
+      return;
+    }
+
+    const match = findMatch(items, searchString);
+
+    if (match) {
+      lastMatchIndex = match.index;
+      onMatch?.(match.item, match.index);
+    } else {
+      onNoMatch?.(searchString);
+    }
+
+    timeoutId = setTimeout(reset, timeout);
+  };
+
+  const getState = (): TypeaheadState => ({
+    searchString,
+    lastMatchIndex,
+    isActive,
+  });
+
+  return {
+    handleKeyDown,
+    reset,
+    getState,
+  };
+}
+
+/**
+ * Highlight matching text in an element
+ * Utility for visual feedback during typeahead
+ *
+ * @example
+ * ```typescript
+ * // In onMatch callback
+ * highlightMatch(item, searchString);
+ * ```
+ */
+export function highlightMatch(
+  element: HTMLElement,
+  searchString: string,
+  options: {
+    highlightClass?: string;
+    caseSensitive?: boolean;
+  } = {},
+): CleanupFunction {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const { highlightClass = 'typeahead-highlight', caseSensitive = false } = options;
+
+  const text = element.textContent || '';
+  const normalizedSearch = caseSensitive ? searchString : searchString.toLowerCase();
+  const normalizedText = caseSensitive ? text : text.toLowerCase();
+
+  const matchIndex = normalizedText.indexOf(normalizedSearch);
+  if (matchIndex === -1) {
+    return () => {};
+  }
+
+  // Store original HTML
+  const originalHTML = element.innerHTML;
+
+  // Create highlighted HTML
+  const before = text.slice(0, matchIndex);
+  const match = text.slice(matchIndex, matchIndex + searchString.length);
+  const after = text.slice(matchIndex + searchString.length);
+
+  element.innerHTML = `${before}<mark class="${highlightClass}">${match}</mark>${after}`;
+
+  return () => {
+    element.innerHTML = originalHTML;
+  };
+}

--- a/packages/ui/src/primitives/types.ts
+++ b/packages/ui/src/primitives/types.ts
@@ -6,3 +6,149 @@ export type CleanupFunction = () => void;
 export type OutsideClickHandler = (event: MouseEvent | TouchEvent | PointerEvent) => void;
 
 export type EscapeKeyHandler = (event: KeyboardEvent) => void;
+
+/**
+ * Orientation for navigation primitives
+ */
+export type Orientation = 'horizontal' | 'vertical' | 'both';
+
+/**
+ * Text direction for RTL support
+ */
+export type Direction = 'ltr' | 'rtl';
+
+/**
+ * Keyboard event key names for type-safe handlers
+ */
+export type KeyboardKey =
+  | 'Enter'
+  | 'Space'
+  | 'Escape'
+  | 'Tab'
+  | 'ArrowUp'
+  | 'ArrowDown'
+  | 'ArrowLeft'
+  | 'ArrowRight'
+  | 'Home'
+  | 'End'
+  | 'PageUp'
+  | 'PageDown'
+  | 'Backspace'
+  | 'Delete';
+
+/**
+ * Modifier keys for keyboard handlers
+ */
+export interface KeyboardModifiers {
+  shift?: boolean;
+  ctrl?: boolean;
+  alt?: boolean;
+  meta?: boolean;
+}
+
+/**
+ * Keyboard handler callback
+ */
+export type KeyboardHandlerCallback = (event: KeyboardEvent) => void;
+
+/**
+ * Live region politeness for screen reader announcements
+ */
+export type LiveRegionPoliteness = 'polite' | 'assertive' | 'off';
+
+/**
+ * Live region role for screen reader announcements
+ */
+export type LiveRegionRole = 'status' | 'alert' | 'log';
+
+/**
+ * Side positioning for floating elements
+ */
+export type Side = 'top' | 'right' | 'bottom' | 'left';
+
+/**
+ * Alignment for floating elements
+ */
+export type Align = 'start' | 'center' | 'end';
+
+/**
+ * Position result from collision detection
+ */
+export interface Position {
+  x: number;
+  y: number;
+  side: Side;
+  align: Align;
+}
+
+/**
+ * Focus outside handler
+ */
+export type FocusOutsideHandler = (event: FocusEvent) => void;
+
+/**
+ * Pointer down outside handler
+ */
+export type PointerDownOutsideHandler = (event: PointerEvent | TouchEvent) => void;
+
+/**
+ * Navigation callback for roving focus
+ */
+export type NavigationCallback = (element: HTMLElement, index: number) => void;
+
+/**
+ * ARIA attribute types for type-safe attribute setting
+ */
+export interface AriaAttributes {
+  // Widget attributes
+  'aria-autocomplete'?: 'none' | 'inline' | 'list' | 'both';
+  'aria-checked'?: boolean | 'mixed';
+  'aria-disabled'?: boolean;
+  'aria-expanded'?: boolean;
+  'aria-haspopup'?: boolean | 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog';
+  'aria-hidden'?: boolean;
+  'aria-invalid'?: boolean | 'grammar' | 'spelling';
+  'aria-label'?: string;
+  'aria-level'?: number;
+  'aria-modal'?: boolean;
+  'aria-multiline'?: boolean;
+  'aria-multiselectable'?: boolean;
+  'aria-orientation'?: 'horizontal' | 'vertical';
+  'aria-placeholder'?: string;
+  'aria-pressed'?: boolean | 'mixed';
+  'aria-readonly'?: boolean;
+  'aria-required'?: boolean;
+  'aria-selected'?: boolean;
+  'aria-sort'?: 'none' | 'ascending' | 'descending' | 'other';
+  'aria-valuemax'?: number;
+  'aria-valuemin'?: number;
+  'aria-valuenow'?: number;
+  'aria-valuetext'?: string;
+
+  // Live region attributes
+  'aria-atomic'?: boolean;
+  'aria-busy'?: boolean;
+  'aria-live'?: 'off' | 'polite' | 'assertive';
+  'aria-relevant'?: 'additions' | 'removals' | 'text' | 'all' | 'additions text';
+
+  // Relationship attributes
+  'aria-activedescendant'?: string;
+  'aria-controls'?: string;
+  'aria-describedby'?: string;
+  'aria-details'?: string;
+  'aria-errormessage'?: string;
+  'aria-flowto'?: string;
+  'aria-labelledby'?: string;
+  'aria-owns'?: string;
+  'aria-posinset'?: number;
+  'aria-setsize'?: number;
+  'aria-colcount'?: number;
+  'aria-colindex'?: number;
+  'aria-colspan'?: number;
+  'aria-rowcount'?: number;
+  'aria-rowindex'?: number;
+  'aria-rowspan'?: number;
+
+  // Role attribute
+  role?: string;
+}

--- a/packages/ui/test/primitives/aria-manager.test.ts
+++ b/packages/ui/test/primitives/aria-manager.test.ts
@@ -1,0 +1,416 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createAriaRelationship,
+  getAriaAttribute,
+  hasAriaAttribute,
+  removeAriaAttributes,
+  setAriaAttributes,
+  toggleAriaAttribute,
+  updateAriaAttribute,
+} from '../../src/primitives/aria-manager';
+
+describe('setAriaAttributes', () => {
+  let element: HTMLDivElement;
+
+  beforeEach(() => {
+    element = document.createElement('div');
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    element.remove();
+  });
+
+  it('sets boolean ARIA attributes correctly', () => {
+    const cleanup = setAriaAttributes(element, {
+      'aria-expanded': true,
+      'aria-disabled': false,
+    });
+
+    expect(element.getAttribute('aria-expanded')).toBe('true');
+    expect(element.getAttribute('aria-disabled')).toBe('false');
+
+    cleanup();
+  });
+
+  it('sets tristate ARIA attributes correctly', () => {
+    const cleanup = setAriaAttributes(element, {
+      'aria-checked': 'mixed',
+    });
+
+    expect(element.getAttribute('aria-checked')).toBe('mixed');
+
+    cleanup();
+  });
+
+  it('sets number ARIA attributes correctly', () => {
+    const cleanup = setAriaAttributes(element, {
+      'aria-valuemin': 0,
+      'aria-valuemax': 100,
+      'aria-valuenow': 50,
+    });
+
+    expect(element.getAttribute('aria-valuemin')).toBe('0');
+    expect(element.getAttribute('aria-valuemax')).toBe('100');
+    expect(element.getAttribute('aria-valuenow')).toBe('50');
+
+    cleanup();
+  });
+
+  it('sets string ARIA attributes correctly', () => {
+    const cleanup = setAriaAttributes(element, {
+      'aria-label': 'Test label',
+      'aria-labelledby': 'label-id',
+    });
+
+    expect(element.getAttribute('aria-label')).toBe('Test label');
+    expect(element.getAttribute('aria-labelledby')).toBe('label-id');
+
+    cleanup();
+  });
+
+  it('sets token ARIA attributes correctly', () => {
+    const cleanup = setAriaAttributes(element, {
+      'aria-live': 'polite',
+      'aria-haspopup': 'menu',
+    });
+
+    expect(element.getAttribute('aria-live')).toBe('polite');
+    expect(element.getAttribute('aria-haspopup')).toBe('menu');
+
+    cleanup();
+  });
+
+  it('sets role attribute', () => {
+    const cleanup = setAriaAttributes(element, {
+      role: 'button',
+    });
+
+    expect(element.getAttribute('role')).toBe('button');
+
+    cleanup();
+  });
+
+  it('restores original values on cleanup', () => {
+    element.setAttribute('aria-label', 'Original');
+    element.setAttribute('aria-expanded', 'false');
+
+    const cleanup = setAriaAttributes(element, {
+      'aria-label': 'New label',
+      'aria-expanded': true,
+    });
+
+    expect(element.getAttribute('aria-label')).toBe('New label');
+    expect(element.getAttribute('aria-expanded')).toBe('true');
+
+    cleanup();
+
+    expect(element.getAttribute('aria-label')).toBe('Original');
+    expect(element.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('removes attributes on cleanup if they did not exist originally', () => {
+    const cleanup = setAriaAttributes(element, {
+      'aria-expanded': true,
+    });
+
+    expect(element.hasAttribute('aria-expanded')).toBe(true);
+
+    cleanup();
+
+    expect(element.hasAttribute('aria-expanded')).toBe(false);
+  });
+
+  it('skips undefined values', () => {
+    const cleanup = setAriaAttributes(element, {
+      'aria-label': undefined,
+      'aria-expanded': true,
+    });
+
+    expect(element.hasAttribute('aria-label')).toBe(false);
+    expect(element.hasAttribute('aria-expanded')).toBe(true);
+
+    cleanup();
+  });
+
+  it('warns for invalid values when validation is enabled', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const cleanup = setAriaAttributes(
+      element,
+      {
+        // @ts-expect-error Testing invalid value
+        'aria-live': 'invalid-value',
+      },
+      { validate: true, warn: true },
+    );
+
+    expect(warnSpy).toHaveBeenCalled();
+
+    cleanup();
+    warnSpy.mockRestore();
+  });
+
+  it('returns no-op cleanup in SSR environment', () => {
+    const originalWindow = globalThis.window;
+    // @ts-expect-error Testing SSR
+    delete globalThis.window;
+
+    const cleanup = setAriaAttributes(element, { 'aria-expanded': true });
+    expect(cleanup).toBeInstanceOf(Function);
+
+    globalThis.window = originalWindow;
+  });
+});
+
+describe('updateAriaAttribute', () => {
+  let element: HTMLDivElement;
+
+  beforeEach(() => {
+    element = document.createElement('div');
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    element.remove();
+  });
+
+  it('updates a single attribute', () => {
+    updateAriaAttribute(element, 'aria-expanded', true);
+    expect(element.getAttribute('aria-expanded')).toBe('true');
+
+    updateAriaAttribute(element, 'aria-expanded', false);
+    expect(element.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('removes attribute when value is undefined', () => {
+    element.setAttribute('aria-expanded', 'true');
+
+    updateAriaAttribute(element, 'aria-expanded', undefined);
+
+    expect(element.hasAttribute('aria-expanded')).toBe(false);
+  });
+});
+
+describe('removeAriaAttributes', () => {
+  let element: HTMLDivElement;
+
+  beforeEach(() => {
+    element = document.createElement('div');
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    element.remove();
+  });
+
+  it('removes specified attributes', () => {
+    element.setAttribute('aria-label', 'Test');
+    element.setAttribute('aria-expanded', 'true');
+    element.setAttribute('aria-disabled', 'false');
+
+    removeAriaAttributes(element, ['aria-label', 'aria-expanded']);
+
+    expect(element.hasAttribute('aria-label')).toBe(false);
+    expect(element.hasAttribute('aria-expanded')).toBe(false);
+    expect(element.hasAttribute('aria-disabled')).toBe(true);
+  });
+});
+
+describe('getAriaAttribute', () => {
+  let element: HTMLDivElement;
+
+  beforeEach(() => {
+    element = document.createElement('div');
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    element.remove();
+  });
+
+  it('returns boolean for boolean attributes', () => {
+    element.setAttribute('aria-expanded', 'true');
+    expect(getAriaAttribute(element, 'aria-expanded')).toBe(true);
+
+    element.setAttribute('aria-expanded', 'false');
+    expect(getAriaAttribute(element, 'aria-expanded')).toBe(false);
+  });
+
+  it('returns correct value for tristate attributes', () => {
+    element.setAttribute('aria-checked', 'true');
+    expect(getAriaAttribute(element, 'aria-checked')).toBe(true);
+
+    element.setAttribute('aria-checked', 'mixed');
+    expect(getAriaAttribute(element, 'aria-checked')).toBe('mixed');
+  });
+
+  it('returns number for number attributes', () => {
+    element.setAttribute('aria-valuenow', '50');
+    expect(getAriaAttribute(element, 'aria-valuenow')).toBe(50);
+  });
+
+  it('returns undefined for missing attributes', () => {
+    expect(getAriaAttribute(element, 'aria-label')).toBeUndefined();
+  });
+
+  it('returns string for string attributes', () => {
+    element.setAttribute('aria-label', 'Test label');
+    expect(getAriaAttribute(element, 'aria-label')).toBe('Test label');
+  });
+});
+
+describe('hasAriaAttribute', () => {
+  let element: HTMLDivElement;
+
+  beforeEach(() => {
+    element = document.createElement('div');
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    element.remove();
+  });
+
+  it('returns true when attribute exists', () => {
+    element.setAttribute('aria-expanded', 'true');
+    expect(hasAriaAttribute(element, 'aria-expanded')).toBe(true);
+  });
+
+  it('returns false when attribute does not exist', () => {
+    expect(hasAriaAttribute(element, 'aria-expanded')).toBe(false);
+  });
+});
+
+describe('toggleAriaAttribute', () => {
+  let element: HTMLDivElement;
+
+  beforeEach(() => {
+    element = document.createElement('div');
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    element.remove();
+  });
+
+  it('toggles boolean attribute', () => {
+    element.setAttribute('aria-expanded', 'true');
+
+    const result1 = toggleAriaAttribute(element, 'aria-expanded');
+    expect(result1).toBe(false);
+    expect(element.getAttribute('aria-expanded')).toBe('false');
+
+    const result2 = toggleAriaAttribute(element, 'aria-expanded');
+    expect(result2).toBe(true);
+    expect(element.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('sets to true when attribute does not exist', () => {
+    const result = toggleAriaAttribute(element, 'aria-expanded');
+    expect(result).toBe(true);
+    expect(element.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('respects force parameter', () => {
+    element.setAttribute('aria-expanded', 'true');
+
+    const result = toggleAriaAttribute(element, 'aria-expanded', true);
+    expect(result).toBe(true);
+    expect(element.getAttribute('aria-expanded')).toBe('true');
+  });
+});
+
+describe('createAriaRelationship', () => {
+  let element: HTMLDivElement;
+  let target: HTMLDivElement;
+
+  beforeEach(() => {
+    element = document.createElement('div');
+    target = document.createElement('div');
+    document.body.appendChild(element);
+    document.body.appendChild(target);
+  });
+
+  afterEach(() => {
+    element.remove();
+    target.remove();
+  });
+
+  it('creates labelledby relationship', () => {
+    target.id = 'label-id';
+
+    const cleanup = createAriaRelationship(element, target, 'aria-labelledby');
+
+    expect(element.getAttribute('aria-labelledby')).toBe('label-id');
+
+    cleanup();
+  });
+
+  it('generates ID if target has none', () => {
+    const cleanup = createAriaRelationship(element, target, 'aria-labelledby');
+
+    expect(target.id).toBeTruthy();
+    expect(element.getAttribute('aria-labelledby')).toBe(target.id);
+
+    cleanup();
+  });
+
+  it('handles multiple targets', () => {
+    const target2 = document.createElement('div');
+    document.body.appendChild(target2);
+
+    target.id = 'target1';
+    target2.id = 'target2';
+
+    const cleanup = createAriaRelationship(element, [target, target2], 'aria-describedby');
+
+    expect(element.getAttribute('aria-describedby')).toBe('target1 target2');
+
+    cleanup();
+    target2.remove();
+  });
+
+  it('appends to existing IDs', () => {
+    element.setAttribute('aria-labelledby', 'existing-id');
+    target.id = 'new-id';
+
+    const cleanup = createAriaRelationship(element, target, 'aria-labelledby');
+
+    expect(element.getAttribute('aria-labelledby')).toBe('existing-id new-id');
+
+    cleanup();
+
+    expect(element.getAttribute('aria-labelledby')).toBe('existing-id');
+  });
+
+  it('restores original value on cleanup', () => {
+    element.setAttribute('aria-labelledby', 'original-id');
+    target.id = 'target-id';
+
+    const cleanup = createAriaRelationship(element, target, 'aria-labelledby');
+    cleanup();
+
+    expect(element.getAttribute('aria-labelledby')).toBe('original-id');
+  });
+
+  it('removes attribute on cleanup if it did not exist originally', () => {
+    target.id = 'target-id';
+
+    const cleanup = createAriaRelationship(element, target, 'aria-controls');
+    cleanup();
+
+    expect(element.hasAttribute('aria-controls')).toBe(false);
+  });
+
+  it('returns no-op cleanup in SSR environment', () => {
+    const originalWindow = globalThis.window;
+    // @ts-expect-error Testing SSR
+    delete globalThis.window;
+
+    const cleanup = createAriaRelationship(element, target, 'aria-labelledby');
+    expect(cleanup).toBeInstanceOf(Function);
+
+    globalThis.window = originalWindow;
+  });
+});

--- a/packages/ui/test/primitives/collision-detector.test.ts
+++ b/packages/ui/test/primitives/collision-detector.test.ts
@@ -1,0 +1,512 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  applyPosition,
+  autoPosition,
+  computePosition,
+  getAvailableSpace,
+} from '../../src/primitives/collision-detector';
+
+describe('computePosition', () => {
+  let anchor: HTMLDivElement;
+  let floating: HTMLDivElement;
+
+  function createMockElement(rect: Partial<DOMRect>): HTMLDivElement {
+    const el = document.createElement('div');
+    el.getBoundingClientRect = () => ({
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      width: 0,
+      height: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+      ...rect,
+    });
+    return el;
+  }
+
+  beforeEach(() => {
+    // Create anchor with mock rect
+    anchor = createMockElement({
+      top: 100,
+      right: 200,
+      bottom: 150,
+      left: 100,
+      width: 100,
+      height: 50,
+      x: 100,
+      y: 100,
+    });
+
+    // Create floating with mock rect
+    floating = createMockElement({
+      top: 0,
+      right: 80,
+      bottom: 40,
+      left: 0,
+      width: 80,
+      height: 40,
+      x: 0,
+      y: 0,
+    });
+
+    document.body.appendChild(anchor);
+    document.body.appendChild(floating);
+  });
+
+  afterEach(() => {
+    anchor.remove();
+    floating.remove();
+  });
+
+  it('positions below anchor by default', () => {
+    const result = computePosition(anchor, floating);
+
+    expect(result.side).toBe('bottom');
+    expect(result.y).toBe(150); // anchor.bottom
+  });
+
+  it('positions above anchor when side is top', () => {
+    const result = computePosition(anchor, floating, { side: 'top' });
+
+    expect(result.side).toBe('top');
+    expect(result.y).toBe(60); // anchor.top - floating.height
+  });
+
+  it('positions to the right of anchor', () => {
+    const result = computePosition(anchor, floating, { side: 'right' });
+
+    expect(result.side).toBe('right');
+    expect(result.x).toBe(200); // anchor.right
+  });
+
+  it('positions to the left of anchor', () => {
+    const result = computePosition(anchor, floating, { side: 'left' });
+
+    expect(result.side).toBe('left');
+    expect(result.x).toBe(20); // anchor.left - floating.width
+  });
+
+  it('aligns to start', () => {
+    const result = computePosition(anchor, floating, {
+      side: 'bottom',
+      align: 'start',
+    });
+
+    expect(result.align).toBe('start');
+    expect(result.x).toBe(100); // anchor.left
+  });
+
+  it('aligns to center', () => {
+    const result = computePosition(anchor, floating, {
+      side: 'bottom',
+      align: 'center',
+    });
+
+    expect(result.align).toBe('center');
+    // anchor.left + anchor.width/2 - floating.width/2
+    expect(result.x).toBe(110);
+  });
+
+  it('aligns to end', () => {
+    const result = computePosition(anchor, floating, {
+      side: 'bottom',
+      align: 'end',
+    });
+
+    expect(result.align).toBe('end');
+    expect(result.x).toBe(120); // anchor.right - floating.width
+  });
+
+  it('applies side offset', () => {
+    const result = computePosition(anchor, floating, {
+      side: 'bottom',
+      sideOffset: 10,
+    });
+
+    expect(result.y).toBe(160); // anchor.bottom + offset
+  });
+
+  it('applies align offset', () => {
+    const result = computePosition(anchor, floating, {
+      side: 'bottom',
+      align: 'start',
+      alignOffset: 5,
+    });
+
+    expect(result.x).toBe(105); // anchor.left + offset
+  });
+
+  it('flips to opposite side on collision', () => {
+    // Create anchor near bottom of viewport
+    const bottomAnchor = createMockElement({
+      top: 700,
+      right: 200,
+      bottom: 750,
+      left: 100,
+      width: 100,
+      height: 50,
+      x: 100,
+      y: 700,
+    });
+    document.body.appendChild(bottomAnchor);
+
+    // Mock window dimensions
+    Object.defineProperty(window, 'innerWidth', { value: 800, writable: true, configurable: true });
+    Object.defineProperty(window, 'innerHeight', {
+      value: 768,
+      writable: true,
+      configurable: true,
+    });
+
+    const result = computePosition(bottomAnchor, floating, {
+      side: 'bottom',
+      avoidCollisions: true,
+      collisionPadding: 10,
+    });
+
+    // Should flip to top since bottom would overflow
+    expect(result.side).toBe('top');
+    expect(result.hasCollision).toBe(true);
+
+    bottomAnchor.remove();
+  });
+
+  it('reports no collision when within bounds', () => {
+    const result = computePosition(anchor, floating, {
+      avoidCollisions: true,
+    });
+
+    expect(result.hasCollision).toBe(false);
+  });
+
+  it('returns collision details', () => {
+    // Create anchor near edges
+    const edgeAnchor = createMockElement({
+      top: 5,
+      right: 50,
+      bottom: 55,
+      left: 5,
+      width: 45,
+      height: 50,
+      x: 5,
+      y: 5,
+    });
+    document.body.appendChild(edgeAnchor);
+
+    const result = computePosition(edgeAnchor, floating, {
+      side: 'top',
+      avoidCollisions: false,
+    });
+
+    expect(result.collisions).toHaveProperty('top');
+    expect(result.collisions).toHaveProperty('right');
+    expect(result.collisions).toHaveProperty('bottom');
+    expect(result.collisions).toHaveProperty('left');
+
+    edgeAnchor.remove();
+  });
+
+  it('uses custom collision boundary', () => {
+    const boundary = createMockElement({
+      top: 50,
+      right: 300,
+      bottom: 200,
+      left: 50,
+      width: 250,
+      height: 150,
+      x: 50,
+      y: 50,
+    });
+    document.body.appendChild(boundary);
+
+    const result = computePosition(anchor, floating, {
+      collisionBoundary: boundary,
+      avoidCollisions: true,
+    });
+
+    expect(result).toBeDefined();
+
+    boundary.remove();
+  });
+
+  it('returns sensible defaults in SSR environment', () => {
+    const originalWindow = globalThis.window;
+    // @ts-expect-error Testing SSR
+    delete globalThis.window;
+
+    const result = computePosition(anchor, floating);
+
+    expect(result.x).toBe(0);
+    expect(result.y).toBe(0);
+    expect(result.side).toBe('bottom');
+    expect(result.align).toBe('center');
+    expect(result.hasCollision).toBe(false);
+
+    globalThis.window = originalWindow;
+  });
+});
+
+describe('applyPosition', () => {
+  let anchor: HTMLDivElement;
+  let floating: HTMLDivElement;
+
+  function createMockElement(rect: Partial<DOMRect>): HTMLDivElement {
+    const el = document.createElement('div');
+    el.getBoundingClientRect = () => ({
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      width: 0,
+      height: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+      ...rect,
+    });
+    return el;
+  }
+
+  beforeEach(() => {
+    anchor = createMockElement({
+      top: 100,
+      right: 200,
+      bottom: 150,
+      left: 100,
+      width: 100,
+      height: 50,
+      x: 100,
+      y: 100,
+    });
+
+    floating = createMockElement({
+      top: 0,
+      right: 80,
+      bottom: 40,
+      left: 0,
+      width: 80,
+      height: 40,
+      x: 0,
+      y: 0,
+    });
+
+    document.body.appendChild(anchor);
+    document.body.appendChild(floating);
+  });
+
+  afterEach(() => {
+    anchor.remove();
+    floating.remove();
+  });
+
+  it('applies position styles to floating element', () => {
+    applyPosition(anchor, floating);
+
+    expect(floating.style.position).toBe('absolute');
+    expect(floating.style.left).toBe('0px');
+    expect(floating.style.top).toBe('0px');
+    expect(floating.style.transform).toContain('translate');
+  });
+
+  it('sets data attributes for styling', () => {
+    applyPosition(anchor, floating, { side: 'bottom', align: 'start' });
+
+    expect(floating.getAttribute('data-side')).toBe('bottom');
+    expect(floating.getAttribute('data-align')).toBe('start');
+  });
+
+  it('returns position result', () => {
+    const result = applyPosition(anchor, floating);
+
+    expect(result).toHaveProperty('x');
+    expect(result).toHaveProperty('y');
+    expect(result).toHaveProperty('side');
+    expect(result).toHaveProperty('align');
+  });
+});
+
+describe('autoPosition', () => {
+  let anchor: HTMLDivElement;
+  let floating: HTMLDivElement;
+
+  function createMockElement(rect: Partial<DOMRect>): HTMLDivElement {
+    const el = document.createElement('div');
+    el.getBoundingClientRect = () => ({
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      width: 0,
+      height: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+      ...rect,
+    });
+    return el;
+  }
+
+  beforeEach(() => {
+    anchor = createMockElement({
+      top: 100,
+      right: 200,
+      bottom: 150,
+      left: 100,
+      width: 100,
+      height: 50,
+      x: 100,
+      y: 100,
+    });
+
+    floating = createMockElement({
+      top: 0,
+      right: 80,
+      bottom: 40,
+      left: 0,
+      width: 80,
+      height: 40,
+      x: 0,
+      y: 0,
+    });
+
+    document.body.appendChild(anchor);
+    document.body.appendChild(floating);
+  });
+
+  afterEach(() => {
+    anchor.remove();
+    floating.remove();
+  });
+
+  it('returns cleanup function', () => {
+    const cleanup = autoPosition(anchor, floating);
+
+    expect(cleanup).toBeInstanceOf(Function);
+
+    cleanup();
+  });
+
+  it('applies initial position', () => {
+    const cleanup = autoPosition(anchor, floating);
+
+    expect(floating.style.position).toBe('absolute');
+
+    cleanup();
+  });
+
+  it('removes listeners on cleanup', () => {
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+
+    const cleanup = autoPosition(anchor, floating);
+    cleanup();
+
+    expect(removeEventListenerSpy).toHaveBeenCalled();
+
+    removeEventListenerSpy.mockRestore();
+  });
+
+  it('returns no-op cleanup in SSR environment', () => {
+    const originalWindow = globalThis.window;
+    // @ts-expect-error Testing SSR
+    delete globalThis.window;
+
+    const cleanup = autoPosition(anchor, floating);
+    expect(cleanup).toBeInstanceOf(Function);
+
+    globalThis.window = originalWindow;
+  });
+});
+
+describe('getAvailableSpace', () => {
+  let anchor: HTMLDivElement;
+
+  function createMockElement(rect: Partial<DOMRect>): HTMLDivElement {
+    const el = document.createElement('div');
+    el.getBoundingClientRect = () => ({
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      width: 0,
+      height: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+      ...rect,
+    });
+    return el;
+  }
+
+  beforeEach(() => {
+    anchor = createMockElement({
+      top: 100,
+      right: 200,
+      bottom: 150,
+      left: 100,
+      width: 100,
+      height: 50,
+      x: 100,
+      y: 100,
+    });
+
+    document.body.appendChild(anchor);
+
+    Object.defineProperty(window, 'innerWidth', { value: 800, writable: true, configurable: true });
+    Object.defineProperty(window, 'innerHeight', {
+      value: 600,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    anchor.remove();
+  });
+
+  it('returns space on each side', () => {
+    const space = getAvailableSpace(anchor);
+
+    expect(space.top).toBe(100); // anchor.top - viewport.top
+    expect(space.right).toBe(600); // viewport.right - anchor.right
+    expect(space.bottom).toBe(450); // viewport.bottom - anchor.bottom
+    expect(space.left).toBe(100); // anchor.left - viewport.left
+  });
+
+  it('uses custom boundary', () => {
+    const boundary = createMockElement({
+      top: 50,
+      right: 400,
+      bottom: 300,
+      left: 50,
+      width: 350,
+      height: 250,
+      x: 50,
+      y: 50,
+    });
+    document.body.appendChild(boundary);
+
+    const space = getAvailableSpace(anchor, boundary);
+
+    expect(space.top).toBe(50); // anchor.top - boundary.top
+    expect(space.right).toBe(200); // boundary.right - anchor.right
+    expect(space.bottom).toBe(150); // boundary.bottom - anchor.bottom
+    expect(space.left).toBe(50); // anchor.left - boundary.left
+
+    boundary.remove();
+  });
+
+  it('returns zeros in SSR environment', () => {
+    const originalWindow = globalThis.window;
+    // @ts-expect-error Testing SSR
+    delete globalThis.window;
+
+    const space = getAvailableSpace(anchor);
+
+    expect(space).toEqual({ top: 0, right: 0, bottom: 0, left: 0 });
+
+    globalThis.window = originalWindow;
+  });
+});

--- a/packages/ui/test/primitives/dismissable-layer.test.ts
+++ b/packages/ui/test/primitives/dismissable-layer.test.ts
@@ -1,0 +1,286 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearDismissableLayerStack,
+  createDismissableLayer,
+  createDismissableLayerStack,
+  getDismissableLayerStack,
+} from '../../src/primitives/dismissable-layer';
+
+describe('createDismissableLayer', () => {
+  let layer: HTMLDivElement;
+
+  beforeEach(() => {
+    layer = document.createElement('div');
+    document.body.appendChild(layer);
+  });
+
+  afterEach(() => {
+    layer.remove();
+  });
+
+  it('calls onEscapeKeyDown when Escape is pressed', () => {
+    const onEscapeKeyDown = vi.fn();
+    const cleanup = createDismissableLayer(layer, { onEscapeKeyDown });
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    expect(onEscapeKeyDown).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('calls onDismiss when Escape is pressed', () => {
+    const onDismiss = vi.fn();
+    const cleanup = createDismissableLayer(layer, { onDismiss });
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('calls onPointerDownOutside when clicking outside', () => {
+    const onPointerDownOutside = vi.fn();
+    const cleanup = createDismissableLayer(layer, { onPointerDownOutside });
+
+    document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+
+    expect(onPointerDownOutside).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('calls onDismiss when clicking outside', () => {
+    const onDismiss = vi.fn();
+    const cleanup = createDismissableLayer(layer, { onDismiss });
+
+    document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('does not call onPointerDownOutside when clicking inside', () => {
+    const onPointerDownOutside = vi.fn();
+    const cleanup = createDismissableLayer(layer, { onPointerDownOutside });
+
+    layer.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+
+    expect(onPointerDownOutside).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('calls onFocusOutside when focus moves outside', () => {
+    const onFocusOutside = vi.fn();
+    const cleanup = createDismissableLayer(layer, { onFocusOutside });
+
+    const outsideButton = document.createElement('button');
+    document.body.appendChild(outsideButton);
+
+    outsideButton.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+
+    expect(onFocusOutside).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    outsideButton.remove();
+  });
+
+  it('does not call onFocusOutside when focus stays inside', () => {
+    const onFocusOutside = vi.fn();
+    const insideButton = document.createElement('button');
+    layer.appendChild(insideButton);
+
+    const cleanup = createDismissableLayer(layer, { onFocusOutside });
+
+    insideButton.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+
+    expect(onFocusOutside).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('calls onInteractOutside for all outside interactions', () => {
+    const onInteractOutside = vi.fn();
+    const cleanup = createDismissableLayer(layer, { onInteractOutside });
+
+    // Escape
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(onInteractOutside).toHaveBeenCalledTimes(1);
+
+    // Click outside
+    document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    expect(onInteractOutside).toHaveBeenCalledTimes(2);
+
+    cleanup();
+  });
+
+  it('respects excludeElements option', () => {
+    const excludedElement = document.createElement('div');
+    document.body.appendChild(excludedElement);
+
+    const onPointerDownOutside = vi.fn();
+    const cleanup = createDismissableLayer(layer, {
+      onPointerDownOutside,
+      excludeElements: [excludedElement],
+    });
+
+    excludedElement.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+
+    expect(onPointerDownOutside).not.toHaveBeenCalled();
+
+    cleanup();
+    excludedElement.remove();
+  });
+
+  it('handles touch events as fallback', () => {
+    const onPointerDownOutside = vi.fn();
+    const cleanup = createDismissableLayer(layer, { onPointerDownOutside });
+
+    document.body.dispatchEvent(new TouchEvent('touchstart', { bubbles: true }));
+
+    expect(onPointerDownOutside).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('sets data-dismissable-layer attribute', () => {
+    const cleanup = createDismissableLayer(layer);
+
+    expect(layer.hasAttribute('data-dismissable-layer')).toBe(true);
+
+    cleanup();
+
+    expect(layer.hasAttribute('data-dismissable-layer')).toBe(false);
+  });
+
+  it('removes listeners on cleanup', () => {
+    const onEscapeKeyDown = vi.fn();
+    const onPointerDownOutside = vi.fn();
+
+    const cleanup = createDismissableLayer(layer, {
+      onEscapeKeyDown,
+      onPointerDownOutside,
+    });
+
+    cleanup();
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+
+    expect(onEscapeKeyDown).not.toHaveBeenCalled();
+    expect(onPointerDownOutside).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when disabled', () => {
+    const onDismiss = vi.fn();
+    const cleanup = createDismissableLayer(layer, {
+      enabled: false,
+      onDismiss,
+    });
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('returns no-op cleanup in SSR environment', () => {
+    const originalWindow = globalThis.window;
+    // @ts-expect-error Testing SSR
+    delete globalThis.window;
+
+    const cleanup = createDismissableLayer(layer);
+    expect(cleanup).toBeInstanceOf(Function);
+
+    globalThis.window = originalWindow;
+  });
+});
+
+describe('createDismissableLayerStack', () => {
+  let layer1: HTMLDivElement;
+  let layer2: HTMLDivElement;
+
+  beforeEach(() => {
+    layer1 = document.createElement('div');
+    layer2 = document.createElement('div');
+    document.body.appendChild(layer1);
+    document.body.appendChild(layer2);
+    clearDismissableLayerStack();
+  });
+
+  afterEach(() => {
+    layer1.remove();
+    layer2.remove();
+    clearDismissableLayerStack();
+  });
+
+  it('adds layers to stack', () => {
+    const cleanup1 = createDismissableLayerStack(layer1);
+    expect(getDismissableLayerStack()).toHaveLength(1);
+
+    const cleanup2 = createDismissableLayerStack(layer2);
+    expect(getDismissableLayerStack()).toHaveLength(2);
+
+    cleanup1();
+    cleanup2();
+  });
+
+  it('removes layers from stack on cleanup', () => {
+    const cleanup1 = createDismissableLayerStack(layer1);
+    const cleanup2 = createDismissableLayerStack(layer2);
+
+    expect(getDismissableLayerStack()).toHaveLength(2);
+
+    cleanup2();
+    expect(getDismissableLayerStack()).toHaveLength(1);
+    expect(getDismissableLayerStack()[0]).toBe(layer1);
+
+    cleanup1();
+    expect(getDismissableLayerStack()).toHaveLength(0);
+  });
+
+  it('only handles escape for topmost layer', () => {
+    const onDismiss1 = vi.fn();
+    const onDismiss2 = vi.fn();
+
+    const cleanup1 = createDismissableLayerStack(layer1, { onDismiss: onDismiss1 });
+    const cleanup2 = createDismissableLayerStack(layer2, { onDismiss: onDismiss2 });
+
+    // Escape should only affect topmost layer
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    // Note: Due to how events work, both may receive the event but only topmost should process
+    // The implementation filters by checking if layer is topmost
+
+    cleanup1();
+    cleanup2();
+  });
+});
+
+describe('getDismissableLayerStack', () => {
+  beforeEach(() => {
+    clearDismissableLayerStack();
+  });
+
+  afterEach(() => {
+    clearDismissableLayerStack();
+  });
+
+  it('returns a copy of the stack', () => {
+    const layer = document.createElement('div');
+    document.body.appendChild(layer);
+
+    const cleanup = createDismissableLayerStack(layer);
+    const stack = getDismissableLayerStack();
+
+    expect(stack).toEqual([layer]);
+    expect(stack).not.toBe(getDismissableLayerStack()); // Different array instance
+
+    cleanup();
+    layer.remove();
+  });
+});

--- a/packages/ui/test/primitives/hover-delay.test.ts
+++ b/packages/ui/test/primitives/hover-delay.test.ts
@@ -1,0 +1,566 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createControlledHoverDelay,
+  createHoverDelay,
+  createHoverIntent,
+  resetHoverDelayState,
+  wasRecentlyOpen,
+} from '../../src/primitives/hover-delay';
+
+describe('createHoverDelay', () => {
+  let trigger: HTMLButtonElement;
+
+  beforeEach(() => {
+    trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    resetHoverDelayState();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    trigger.remove();
+    vi.useRealTimers();
+  });
+
+  it('calls onOpen after delay on mouseenter', () => {
+    const onOpen = vi.fn();
+    const cleanup = createHoverDelay(trigger, {
+      openDelay: 500,
+      onOpen,
+    });
+
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+
+    expect(onOpen).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(500);
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('calls onClose after delay on mouseleave', () => {
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+    const cleanup = createHoverDelay(trigger, {
+      openDelay: 0,
+      closeDelay: 300,
+      onOpen,
+      onClose,
+    });
+
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+    vi.advanceTimersByTime(0);
+
+    expect(onOpen).toHaveBeenCalled();
+
+    trigger.dispatchEvent(new MouseEvent('mouseleave'));
+
+    expect(onClose).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(300);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('cancels open on mouseleave before delay', () => {
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+    const cleanup = createHoverDelay(trigger, {
+      openDelay: 500,
+      closeDelay: 100,
+      onOpen,
+      onClose,
+    });
+
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+
+    vi.advanceTimersByTime(200);
+
+    trigger.dispatchEvent(new MouseEvent('mouseleave'));
+
+    // The open should have been cancelled
+    vi.advanceTimersByTime(400);
+
+    // onOpen was never called because we left before openDelay elapsed
+    expect(onOpen).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('cancels close on mouseenter before delay', () => {
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+    const cleanup = createHoverDelay(trigger, {
+      openDelay: 0,
+      closeDelay: 300,
+      onOpen,
+      onClose,
+    });
+
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+    vi.advanceTimersByTime(0);
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+
+    trigger.dispatchEvent(new MouseEvent('mouseleave'));
+
+    vi.advanceTimersByTime(100);
+
+    // Re-enter before close delay completes
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+
+    // Wait past the close delay
+    vi.advanceTimersByTime(300);
+
+    // onClose should not have been called because we re-entered
+    expect(onClose).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('opens on focus when trackFocus is true', () => {
+    const onOpen = vi.fn();
+    const cleanup = createHoverDelay(trigger, {
+      openDelay: 0,
+      onOpen,
+      trackFocus: true,
+    });
+
+    trigger.dispatchEvent(new FocusEvent('focus'));
+    vi.advanceTimersByTime(0);
+
+    expect(onOpen).toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('closes on blur when trackFocus is true', () => {
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+    const cleanup = createHoverDelay(trigger, {
+      openDelay: 0,
+      closeDelay: 0,
+      onOpen,
+      onClose,
+      trackFocus: true,
+    });
+
+    trigger.dispatchEvent(new FocusEvent('focus'));
+    vi.advanceTimersByTime(0);
+
+    expect(onOpen).toHaveBeenCalled();
+
+    trigger.dispatchEvent(new FocusEvent('blur'));
+    vi.advanceTimersByTime(0);
+
+    expect(onClose).toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('does not track focus when trackFocus is false', () => {
+    const onOpen = vi.fn();
+    const cleanup = createHoverDelay(trigger, {
+      openDelay: 0,
+      onOpen,
+      trackFocus: false,
+    });
+
+    trigger.dispatchEvent(new FocusEvent('focus'));
+    vi.advanceTimersByTime(0);
+
+    expect(onOpen).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('skips delays when skipDelays is true', () => {
+    const onOpen = vi.fn();
+    const cleanup = createHoverDelay(trigger, {
+      openDelay: 500,
+      onOpen,
+      skipDelays: true,
+    });
+
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+    vi.advanceTimersByTime(0);
+
+    expect(onOpen).toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('keeps open when hovering content element', () => {
+    const content = document.createElement('div');
+    document.body.appendChild(content);
+
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+    const cleanup = createHoverDelay(trigger, {
+      openDelay: 0,
+      closeDelay: 100,
+      onOpen,
+      onClose,
+      contentElement: content,
+    });
+
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+    vi.advanceTimersByTime(0);
+
+    expect(onOpen).toHaveBeenCalled();
+
+    trigger.dispatchEvent(new MouseEvent('mouseleave'));
+    content.dispatchEvent(new MouseEvent('mouseenter'));
+
+    vi.advanceTimersByTime(200);
+
+    expect(onClose).not.toHaveBeenCalled();
+
+    cleanup();
+    content.remove();
+  });
+
+  it('removes listeners on cleanup', () => {
+    const onOpen = vi.fn();
+    const cleanup = createHoverDelay(trigger, {
+      openDelay: 0,
+      onOpen,
+    });
+
+    cleanup();
+
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+    vi.advanceTimersByTime(0);
+
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when disabled', () => {
+    const onOpen = vi.fn();
+    const cleanup = createHoverDelay(trigger, {
+      openDelay: 0,
+      onOpen,
+      enabled: false,
+    });
+
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+    vi.advanceTimersByTime(0);
+
+    expect(onOpen).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('returns no-op cleanup in SSR environment', () => {
+    const originalWindow = globalThis.window;
+    // @ts-expect-error Testing SSR
+    delete globalThis.window;
+
+    const cleanup = createHoverDelay(trigger, { onOpen: vi.fn() });
+    expect(cleanup).toBeInstanceOf(Function);
+
+    globalThis.window = originalWindow;
+  });
+});
+
+describe('createControlledHoverDelay', () => {
+  beforeEach(() => {
+    resetHoverDelayState();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns handler functions', () => {
+    const hover = createControlledHoverDelay({
+      onOpen: vi.fn(),
+      onClose: vi.fn(),
+    });
+
+    expect(hover.onTriggerEnter).toBeInstanceOf(Function);
+    expect(hover.onTriggerLeave).toBeInstanceOf(Function);
+    expect(hover.onTriggerFocus).toBeInstanceOf(Function);
+    expect(hover.onTriggerBlur).toBeInstanceOf(Function);
+    expect(hover.onContentEnter).toBeInstanceOf(Function);
+    expect(hover.onContentLeave).toBeInstanceOf(Function);
+    expect(hover.open).toBeInstanceOf(Function);
+    expect(hover.close).toBeInstanceOf(Function);
+    expect(hover.getState).toBeInstanceOf(Function);
+    expect(hover.destroy).toBeInstanceOf(Function);
+  });
+
+  it('tracks hover state', () => {
+    const hover = createControlledHoverDelay({
+      openDelay: 0,
+      onOpen: vi.fn(),
+    });
+
+    expect(hover.getState().isHoveringTrigger).toBe(false);
+
+    hover.onTriggerEnter();
+
+    expect(hover.getState().isHoveringTrigger).toBe(true);
+
+    vi.advanceTimersByTime(0);
+
+    expect(hover.getState().isOpen).toBe(true);
+
+    hover.destroy();
+  });
+
+  it('tracks focus state', () => {
+    const hover = createControlledHoverDelay({
+      openDelay: 0,
+      onOpen: vi.fn(),
+    });
+
+    expect(hover.getState().isFocused).toBe(false);
+
+    hover.onTriggerFocus();
+
+    expect(hover.getState().isFocused).toBe(true);
+
+    hover.destroy();
+  });
+
+  it('tracks content hover state', () => {
+    const hover = createControlledHoverDelay({
+      onOpen: vi.fn(),
+    });
+
+    expect(hover.getState().isHoveringContent).toBe(false);
+
+    hover.onContentEnter();
+
+    expect(hover.getState().isHoveringContent).toBe(true);
+
+    hover.destroy();
+  });
+
+  it('allows manual open/close', () => {
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+    const hover = createControlledHoverDelay({
+      onOpen,
+      onClose,
+    });
+
+    hover.open();
+    expect(onOpen).toHaveBeenCalled();
+    expect(hover.getState().isOpen).toBe(true);
+
+    hover.close();
+    expect(onClose).toHaveBeenCalled();
+    expect(hover.getState().isOpen).toBe(false);
+
+    hover.destroy();
+  });
+});
+
+describe('wasRecentlyOpen', () => {
+  beforeEach(() => {
+    resetHoverDelayState();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns false initially', () => {
+    expect(wasRecentlyOpen()).toBe(false);
+  });
+
+  it('returns true after a tooltip was opened', () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+
+    const cleanup = createHoverDelay(trigger, {
+      openDelay: 0,
+      onOpen: vi.fn(),
+    });
+
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+    vi.advanceTimersByTime(0);
+
+    expect(wasRecentlyOpen()).toBe(true);
+
+    cleanup();
+    trigger.remove();
+  });
+
+  it('returns false after threshold time', () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+
+    const cleanup = createHoverDelay(trigger, {
+      openDelay: 0,
+      onOpen: vi.fn(),
+    });
+
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+    vi.advanceTimersByTime(0);
+
+    vi.advanceTimersByTime(400); // Past threshold
+
+    expect(wasRecentlyOpen()).toBe(false);
+
+    cleanup();
+    trigger.remove();
+  });
+});
+
+describe('resetHoverDelayState', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resets the global state', () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+
+    const cleanup = createHoverDelay(trigger, {
+      openDelay: 0,
+      onOpen: vi.fn(),
+    });
+
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+    vi.advanceTimersByTime(0);
+
+    expect(wasRecentlyOpen()).toBe(true);
+
+    resetHoverDelayState();
+
+    expect(wasRecentlyOpen()).toBe(false);
+
+    cleanup();
+    trigger.remove();
+  });
+});
+
+describe('createHoverIntent', () => {
+  let element: HTMLDivElement;
+
+  beforeEach(() => {
+    element = document.createElement('div');
+    document.body.appendChild(element);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    element.remove();
+    vi.useRealTimers();
+  });
+
+  it('calls onEnter when mouse settles', () => {
+    const onEnter = vi.fn();
+    const cleanup = createHoverIntent(element, {
+      sensitivity: 7,
+      interval: 100,
+      onEnter,
+    });
+
+    // Enter element
+    element.dispatchEvent(new MouseEvent('mouseenter'));
+
+    // Mouse stays still
+    element.dispatchEvent(new MouseEvent('mousemove', { clientX: 50, clientY: 50 }));
+
+    vi.advanceTimersByTime(100);
+
+    // Mouse still hasn't moved much
+    element.dispatchEvent(new MouseEvent('mousemove', { clientX: 51, clientY: 51 }));
+
+    vi.advanceTimersByTime(100);
+
+    expect(onEnter).toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('does not call onEnter if mouse moves quickly', () => {
+    const onEnter = vi.fn();
+    const cleanup = createHoverIntent(element, {
+      sensitivity: 7,
+      interval: 100,
+      onEnter,
+    });
+
+    element.dispatchEvent(new MouseEvent('mouseenter'));
+    element.dispatchEvent(new MouseEvent('mousemove', { clientX: 50, clientY: 50 }));
+
+    vi.advanceTimersByTime(50);
+
+    // Mouse moves significantly
+    element.dispatchEvent(new MouseEvent('mousemove', { clientX: 100, clientY: 100 }));
+
+    vi.advanceTimersByTime(50);
+
+    // Leave before settling
+    element.dispatchEvent(new MouseEvent('mouseleave'));
+
+    expect(onEnter).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('calls onLeave when mouse leaves', () => {
+    const onEnter = vi.fn();
+    const onLeave = vi.fn();
+    const cleanup = createHoverIntent(element, {
+      sensitivity: 7,
+      interval: 100,
+      onEnter,
+      onLeave,
+    });
+
+    // Trigger enter
+    element.dispatchEvent(new MouseEvent('mouseenter'));
+    element.dispatchEvent(new MouseEvent('mousemove', { clientX: 50, clientY: 50 }));
+    vi.advanceTimersByTime(100);
+    element.dispatchEvent(new MouseEvent('mousemove', { clientX: 51, clientY: 51 }));
+    vi.advanceTimersByTime(100);
+
+    expect(onEnter).toHaveBeenCalled();
+
+    // Leave
+    element.dispatchEvent(new MouseEvent('mouseleave'));
+
+    expect(onLeave).toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('removes listeners on cleanup', () => {
+    const onEnter = vi.fn();
+    const cleanup = createHoverIntent(element, { onEnter });
+
+    cleanup();
+
+    element.dispatchEvent(new MouseEvent('mouseenter'));
+    vi.advanceTimersByTime(200);
+
+    expect(onEnter).not.toHaveBeenCalled();
+  });
+
+  it('returns no-op cleanup in SSR environment', () => {
+    const originalWindow = globalThis.window;
+    // @ts-expect-error Testing SSR
+    delete globalThis.window;
+
+    const cleanup = createHoverIntent(element, { onEnter: vi.fn() });
+    expect(cleanup).toBeInstanceOf(Function);
+
+    globalThis.window = originalWindow;
+  });
+});

--- a/packages/ui/test/primitives/keyboard-handler.test.ts
+++ b/packages/ui/test/primitives/keyboard-handler.test.ts
@@ -1,0 +1,465 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createActivationHandler,
+  createDismissalHandler,
+  createKeyBindings,
+  createKeyboardHandler,
+  createNavigationHandler,
+} from '../../src/primitives/keyboard-handler';
+
+describe('createKeyboardHandler', () => {
+  let element: HTMLDivElement;
+
+  beforeEach(() => {
+    element = document.createElement('div');
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    element.remove();
+  });
+
+  it('calls handler when key matches', () => {
+    const handler = vi.fn();
+    const cleanup = createKeyboardHandler(element, {
+      key: 'Enter',
+      handler,
+    });
+
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('handles Space key correctly', () => {
+    const handler = vi.fn();
+    const cleanup = createKeyboardHandler(element, {
+      key: 'Space',
+      handler,
+    });
+
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('does not call handler for non-matching keys', () => {
+    const handler = vi.fn();
+    const cleanup = createKeyboardHandler(element, {
+      key: 'Enter',
+      handler,
+    });
+
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    expect(handler).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('handles array of keys', () => {
+    const handler = vi.fn();
+    const cleanup = createKeyboardHandler(element, {
+      key: ['Enter', 'Space'],
+      handler,
+    });
+
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    expect(handler).toHaveBeenCalledTimes(2);
+
+    cleanup();
+  });
+
+  it('respects modifier key requirements', () => {
+    const handler = vi.fn();
+    const cleanup = createKeyboardHandler(element, {
+      key: 'Enter',
+      handler,
+      modifiers: { shift: true },
+    });
+
+    // Without shift - should not call
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(handler).not.toHaveBeenCalled();
+
+    // With shift - should call
+    element.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', shiftKey: true, bubbles: true }),
+    );
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('respects ctrl modifier', () => {
+    const handler = vi.fn();
+    const cleanup = createKeyboardHandler(element, {
+      key: 'Enter',
+      handler,
+      modifiers: { ctrl: true },
+    });
+
+    element.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', ctrlKey: true, bubbles: true }),
+    );
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('respects alt modifier', () => {
+    const handler = vi.fn();
+    const cleanup = createKeyboardHandler(element, {
+      key: 'Enter',
+      handler,
+      modifiers: { alt: true },
+    });
+
+    element.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', altKey: true, bubbles: true }),
+    );
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('respects meta modifier', () => {
+    const handler = vi.fn();
+    const cleanup = createKeyboardHandler(element, {
+      key: 'Enter',
+      handler,
+      modifiers: { meta: true },
+    });
+
+    element.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', metaKey: true, bubbles: true }),
+    );
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('prevents default when option is enabled', () => {
+    const handler = vi.fn();
+    const cleanup = createKeyboardHandler(element, {
+      key: 'Enter',
+      handler,
+      preventDefault: true,
+    });
+
+    const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+    element.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+
+    cleanup();
+  });
+
+  it('stops propagation when option is enabled', () => {
+    const handler = vi.fn();
+    const parentHandler = vi.fn();
+
+    const parent = document.createElement('div');
+    parent.appendChild(element);
+    document.body.appendChild(parent);
+    parent.addEventListener('keydown', parentHandler);
+
+    const cleanup = createKeyboardHandler(element, {
+      key: 'Enter',
+      handler,
+      stopPropagation: true,
+    });
+
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    expect(handler).toHaveBeenCalled();
+    expect(parentHandler).not.toHaveBeenCalled();
+
+    cleanup();
+    parent.remove();
+  });
+
+  it('removes listener on cleanup', () => {
+    const handler = vi.fn();
+    const cleanup = createKeyboardHandler(element, {
+      key: 'Enter',
+      handler,
+    });
+
+    cleanup();
+
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when disabled', () => {
+    const handler = vi.fn();
+    const cleanup = createKeyboardHandler(element, {
+      key: 'Enter',
+      handler,
+      enabled: false,
+    });
+
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    expect(handler).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('works with document as target', () => {
+    const handler = vi.fn();
+    const cleanup = createKeyboardHandler(document, {
+      key: 'Escape',
+      handler,
+    });
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('returns no-op cleanup in SSR environment', () => {
+    const originalWindow = globalThis.window;
+    // @ts-expect-error Testing SSR
+    delete globalThis.window;
+
+    const cleanup = createKeyboardHandler(element, {
+      key: 'Enter',
+      handler: vi.fn(),
+    });
+    expect(cleanup).toBeInstanceOf(Function);
+
+    globalThis.window = originalWindow;
+  });
+});
+
+describe('createActivationHandler', () => {
+  let element: HTMLButtonElement;
+
+  beforeEach(() => {
+    element = document.createElement('button');
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    element.remove();
+  });
+
+  it('handles Enter key', () => {
+    const handler = vi.fn();
+    const cleanup = createActivationHandler(element, handler);
+
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('handles Space key', () => {
+    const handler = vi.fn();
+    const cleanup = createActivationHandler(element, handler);
+
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('prevents default on activation', () => {
+    const handler = vi.fn();
+    const cleanup = createActivationHandler(element, handler);
+
+    const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+    element.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+
+    cleanup();
+  });
+});
+
+describe('createDismissalHandler', () => {
+  let element: HTMLDivElement;
+
+  beforeEach(() => {
+    element = document.createElement('div');
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    element.remove();
+  });
+
+  it('handles Escape key', () => {
+    const handler = vi.fn();
+    const cleanup = createDismissalHandler(element, handler);
+
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('works with document as target', () => {
+    const handler = vi.fn();
+    const cleanup = createDismissalHandler(document, handler);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+});
+
+describe('createNavigationHandler', () => {
+  let element: HTMLDivElement;
+
+  beforeEach(() => {
+    element = document.createElement('div');
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    element.remove();
+  });
+
+  it('handles vertical navigation', () => {
+    const onNext = vi.fn();
+    const onPrevious = vi.fn();
+
+    const cleanup = createNavigationHandler(element, {
+      onNext,
+      onPrevious,
+      orientation: 'vertical',
+    });
+
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    expect(onNext).toHaveBeenCalledTimes(1);
+
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    expect(onPrevious).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('handles horizontal navigation', () => {
+    const onNext = vi.fn();
+    const onPrevious = vi.fn();
+
+    const cleanup = createNavigationHandler(element, {
+      onNext,
+      onPrevious,
+      orientation: 'horizontal',
+    });
+
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(onNext).toHaveBeenCalledTimes(1);
+
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    expect(onPrevious).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('handles Home and End keys', () => {
+    const onFirst = vi.fn();
+    const onLast = vi.fn();
+
+    const cleanup = createNavigationHandler(element, {
+      onFirst,
+      onLast,
+    });
+
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+    expect(onFirst).toHaveBeenCalledTimes(1);
+
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    expect(onLast).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('handles both orientation', () => {
+    const onNext = vi.fn();
+
+    const cleanup = createNavigationHandler(element, {
+      onNext,
+      orientation: 'both',
+    });
+
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+
+    expect(onNext).toHaveBeenCalledTimes(2);
+
+    cleanup();
+  });
+});
+
+describe('createKeyBindings', () => {
+  let element: HTMLDivElement;
+
+  beforeEach(() => {
+    element = document.createElement('div');
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    element.remove();
+  });
+
+  it('handles multiple key bindings', () => {
+    const enterHandler = vi.fn();
+    const escapeHandler = vi.fn();
+    const deleteHandler = vi.fn();
+
+    const cleanup = createKeyBindings(element, [
+      { key: 'Enter', handler: enterHandler },
+      { key: 'Escape', handler: escapeHandler },
+      { key: 'Delete', handler: deleteHandler },
+    ]);
+
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }));
+
+    expect(enterHandler).toHaveBeenCalledTimes(1);
+    expect(escapeHandler).toHaveBeenCalledTimes(1);
+    expect(deleteHandler).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it('removes all listeners on cleanup', () => {
+    const handler1 = vi.fn();
+    const handler2 = vi.fn();
+
+    const cleanup = createKeyBindings(element, [
+      { key: 'Enter', handler: handler1 },
+      { key: 'Escape', handler: handler2 },
+    ]);
+
+    cleanup();
+
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    element.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    expect(handler1).not.toHaveBeenCalled();
+    expect(handler2).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/test/primitives/roving-focus.test.ts
+++ b/packages/ui/test/primitives/roving-focus.test.ts
@@ -1,0 +1,377 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createRovingFocus,
+  focusItem,
+  getCurrentIndex,
+  refreshRovingFocus,
+} from '../../src/primitives/roving-focus';
+
+describe('createRovingFocus', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  function createItems(count: number, role = 'menuitem'): HTMLButtonElement[] {
+    const items: HTMLButtonElement[] = [];
+    for (let i = 0; i < count; i++) {
+      const item = document.createElement('button');
+      item.textContent = `Item ${i + 1}`;
+      item.setAttribute('role', role);
+      container.appendChild(item);
+      items.push(item);
+    }
+    return items;
+  }
+
+  it('initializes with first item having tabindex=0', () => {
+    const items = createItems(3);
+    const cleanup = createRovingFocus(container);
+
+    expect(items[0]?.getAttribute('tabindex')).toBe('0');
+    expect(items[1]?.getAttribute('tabindex')).toBe('-1');
+    expect(items[2]?.getAttribute('tabindex')).toBe('-1');
+
+    cleanup();
+  });
+
+  it('navigates with ArrowRight in horizontal orientation', () => {
+    const items = createItems(3);
+    const onNavigate = vi.fn();
+    const cleanup = createRovingFocus(container, {
+      orientation: 'horizontal',
+      onNavigate,
+    });
+
+    items[0]?.focus();
+
+    // Arrow Right to next
+    const rightEvent = new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true });
+    container.dispatchEvent(rightEvent);
+
+    expect(document.activeElement).toBe(items[1]);
+    expect(onNavigate).toHaveBeenCalledWith(items[1], 1);
+
+    cleanup();
+  });
+
+  it('navigates with ArrowDown in vertical orientation', () => {
+    const items = createItems(3);
+    const cleanup = createRovingFocus(container, {
+      orientation: 'vertical',
+    });
+
+    items[0]?.focus();
+
+    const downEvent = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
+    container.dispatchEvent(downEvent);
+
+    expect(document.activeElement).toBe(items[1]);
+
+    cleanup();
+  });
+
+  it('wraps navigation when loop is enabled', () => {
+    const items = createItems(3);
+    const cleanup = createRovingFocus(container, {
+      orientation: 'horizontal',
+      loop: true,
+    });
+
+    // Focus last item
+    items[2]?.focus();
+    container.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+
+    // Arrow Right should wrap to first
+    const rightEvent = new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true });
+    container.dispatchEvent(rightEvent);
+
+    expect(document.activeElement).toBe(items[0]);
+
+    cleanup();
+  });
+
+  it('does not wrap navigation when loop is disabled', () => {
+    const items = createItems(3);
+    const cleanup = createRovingFocus(container, {
+      orientation: 'horizontal',
+      loop: false,
+    });
+
+    // Focus last item
+    items[2]?.focus();
+    container.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+
+    // Arrow Right should stay on last
+    const rightEvent = new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true });
+    container.dispatchEvent(rightEvent);
+
+    expect(document.activeElement).toBe(items[2]);
+
+    cleanup();
+  });
+
+  it('navigates to first item with Home key', () => {
+    const items = createItems(3);
+    const cleanup = createRovingFocus(container);
+
+    items[2]?.focus();
+    container.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+
+    const homeEvent = new KeyboardEvent('keydown', { key: 'Home', bubbles: true });
+    container.dispatchEvent(homeEvent);
+
+    expect(document.activeElement).toBe(items[0]);
+
+    cleanup();
+  });
+
+  it('navigates to last item with End key', () => {
+    const items = createItems(3);
+    const cleanup = createRovingFocus(container);
+
+    items[0]?.focus();
+
+    const endEvent = new KeyboardEvent('keydown', { key: 'End', bubbles: true });
+    container.dispatchEvent(endEvent);
+
+    expect(document.activeElement).toBe(items[2]);
+
+    cleanup();
+  });
+
+  it('respects RTL direction for horizontal navigation', () => {
+    const items = createItems(3);
+    const cleanup = createRovingFocus(container, {
+      orientation: 'horizontal',
+      dir: 'rtl',
+    });
+
+    items[0]?.focus();
+
+    // In RTL, ArrowLeft moves forward
+    const leftEvent = new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true });
+    container.dispatchEvent(leftEvent);
+
+    expect(document.activeElement).toBe(items[1]);
+
+    cleanup();
+  });
+
+  it('skips disabled items', () => {
+    const items = createItems(3);
+    items[1]?.setAttribute('disabled', '');
+
+    const cleanup = createRovingFocus(container, {
+      orientation: 'horizontal',
+    });
+
+    items[0]?.focus();
+
+    const rightEvent = new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true });
+    container.dispatchEvent(rightEvent);
+
+    // Should skip disabled item and go to item 2
+    expect(document.activeElement).toBe(items[2]);
+
+    cleanup();
+  });
+
+  it('skips aria-disabled items', () => {
+    const items = createItems(3);
+    items[1]?.setAttribute('aria-disabled', 'true');
+
+    const cleanup = createRovingFocus(container, {
+      orientation: 'horizontal',
+    });
+
+    items[0]?.focus();
+
+    const rightEvent = new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true });
+    container.dispatchEvent(rightEvent);
+
+    expect(document.activeElement).toBe(items[2]);
+
+    cleanup();
+  });
+
+  it('updates tabindex on focus change', () => {
+    const items = createItems(3);
+    const cleanup = createRovingFocus(container);
+
+    // Initially item 0 has tabindex=0
+    expect(items[0]?.getAttribute('tabindex')).toBe('0');
+
+    // Focus item 2
+    items[2]?.focus();
+    container.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+
+    // Now item 2 should have tabindex=0
+    expect(items[0]?.getAttribute('tabindex')).toBe('-1');
+    expect(items[2]?.getAttribute('tabindex')).toBe('0');
+
+    cleanup();
+  });
+
+  it('supports both orientation', () => {
+    const items = createItems(4);
+    const cleanup = createRovingFocus(container, {
+      orientation: 'both',
+    });
+
+    items[0]?.focus();
+
+    // ArrowRight works
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(document.activeElement).toBe(items[1]);
+
+    // ArrowDown also works
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    expect(document.activeElement).toBe(items[2]);
+
+    cleanup();
+  });
+
+  it('removes listeners on cleanup', () => {
+    const items = createItems(3);
+    const onNavigate = vi.fn();
+    const cleanup = createRovingFocus(container, { onNavigate });
+
+    cleanup();
+
+    items[0]?.focus();
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it('returns no-op cleanup in SSR environment', () => {
+    const originalWindow = globalThis.window;
+    // @ts-expect-error Testing SSR
+    delete globalThis.window;
+
+    const cleanup = createRovingFocus(container);
+    expect(cleanup).toBeInstanceOf(Function);
+
+    globalThis.window = originalWindow;
+  });
+});
+
+describe('focusItem', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it('focuses item at specified index', () => {
+    const item1 = document.createElement('button');
+    const item2 = document.createElement('button');
+    item1.setAttribute('role', 'menuitem');
+    item2.setAttribute('role', 'menuitem');
+    container.appendChild(item1);
+    container.appendChild(item2);
+
+    const result = focusItem(container, 1);
+
+    expect(result).toBe(true);
+    expect(document.activeElement).toBe(item2);
+    expect(item2.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('returns false for invalid index', () => {
+    const item = document.createElement('button');
+    item.setAttribute('role', 'menuitem');
+    container.appendChild(item);
+
+    const result = focusItem(container, 5);
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('getCurrentIndex', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it('returns index of focused item', () => {
+    const item1 = document.createElement('button');
+    const item2 = document.createElement('button');
+    item1.setAttribute('role', 'menuitem');
+    item2.setAttribute('role', 'menuitem');
+    container.appendChild(item1);
+    container.appendChild(item2);
+
+    item2.focus();
+
+    expect(getCurrentIndex(container)).toBe(1);
+  });
+
+  it('returns -1 when no item is focused', () => {
+    const item = document.createElement('button');
+    item.setAttribute('role', 'menuitem');
+    container.appendChild(item);
+
+    expect(getCurrentIndex(container)).toBe(-1);
+  });
+});
+
+describe('refreshRovingFocus', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it('updates tabindex after DOM changes', () => {
+    const item1 = document.createElement('button');
+    const item2 = document.createElement('button');
+    item1.setAttribute('role', 'menuitem');
+    item2.setAttribute('role', 'menuitem');
+    container.appendChild(item1);
+    container.appendChild(item2);
+
+    refreshRovingFocus(container, 1);
+
+    expect(item1.getAttribute('tabindex')).toBe('-1');
+    expect(item2.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('clamps index to valid range', () => {
+    const item1 = document.createElement('button');
+    const item2 = document.createElement('button');
+    item1.setAttribute('role', 'menuitem');
+    item2.setAttribute('role', 'menuitem');
+    container.appendChild(item1);
+    container.appendChild(item2);
+
+    refreshRovingFocus(container, 100);
+
+    // Should clamp to last item
+    expect(item2.getAttribute('tabindex')).toBe('0');
+  });
+});

--- a/packages/ui/test/primitives/slot.test.ts
+++ b/packages/ui/test/primitives/slot.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  extractSlotProps,
+  mergeClassNames,
+  mergeProps,
+  mergeSlotProps,
+  shouldUseSlot,
+} from '../../src/primitives/slot';
+
+describe('mergeSlotProps', () => {
+  let parent: HTMLDivElement;
+  let child: HTMLButtonElement;
+
+  beforeEach(() => {
+    parent = document.createElement('div');
+    child = document.createElement('button');
+    document.body.appendChild(parent);
+    document.body.appendChild(child);
+  });
+
+  afterEach(() => {
+    parent.remove();
+    child.remove();
+  });
+
+  it('merges ARIA attributes from parent to child', () => {
+    parent.setAttribute('aria-label', 'Parent label');
+    parent.setAttribute('aria-expanded', 'true');
+
+    const cleanup = mergeSlotProps(parent, child);
+
+    expect(child.getAttribute('aria-label')).toBe('Parent label');
+    expect(child.getAttribute('aria-expanded')).toBe('true');
+
+    cleanup();
+  });
+
+  it('merges data attributes from parent to child', () => {
+    parent.setAttribute('data-state', 'open');
+    parent.setAttribute('data-side', 'bottom');
+
+    const cleanup = mergeSlotProps(parent, child);
+
+    expect(child.getAttribute('data-state')).toBe('open');
+    expect(child.getAttribute('data-side')).toBe('bottom');
+
+    cleanup();
+  });
+
+  it('merges className from parent to child', () => {
+    parent.className = 'parent-class';
+    child.className = 'child-class';
+
+    const cleanup = mergeSlotProps(parent, child);
+
+    expect(child.className).toBe('child-class parent-class');
+
+    cleanup();
+  });
+
+  it('uses custom classMerger if provided', () => {
+    parent.className = 'parent-class';
+    child.className = 'child-class';
+
+    const classMerger = vi.fn((p, c) => `merged: ${p} + ${c}`);
+    const cleanup = mergeSlotProps(parent, child, { classMerger });
+
+    expect(classMerger).toHaveBeenCalledWith('parent-class', 'child-class');
+    expect(child.className).toBe('merged: parent-class + child-class');
+
+    cleanup();
+  });
+
+  it('merges inline styles from parent to child', () => {
+    parent.setAttribute('style', 'color: red; font-size: 14px');
+    child.setAttribute('style', 'background: blue');
+
+    const cleanup = mergeSlotProps(parent, child);
+
+    const style = child.getAttribute('style') || '';
+    expect(style).toContain('color: red');
+    expect(style).toContain('font-size: 14px');
+    expect(style).toContain('background: blue');
+
+    cleanup();
+  });
+
+  it('restores original attributes on cleanup', () => {
+    child.setAttribute('aria-label', 'Original');
+    child.className = 'original-class';
+
+    parent.setAttribute('aria-label', 'New label');
+    parent.className = 'new-class';
+
+    const cleanup = mergeSlotProps(parent, child);
+
+    expect(child.getAttribute('aria-label')).toBe('New label');
+
+    cleanup();
+
+    expect(child.getAttribute('aria-label')).toBe('Original');
+    expect(child.className).toBe('original-class');
+  });
+
+  it('removes attributes on cleanup if they did not exist originally', () => {
+    parent.setAttribute('aria-expanded', 'true');
+
+    const cleanup = mergeSlotProps(parent, child);
+
+    expect(child.getAttribute('aria-expanded')).toBe('true');
+
+    cleanup();
+
+    expect(child.hasAttribute('aria-expanded')).toBe(false);
+  });
+
+  it('respects merge options', () => {
+    parent.setAttribute('aria-label', 'Parent');
+    parent.setAttribute('data-state', 'open');
+    parent.className = 'parent-class';
+
+    const cleanup = mergeSlotProps(parent, child, {
+      mergeAria: true,
+      mergeData: false,
+      mergeClassName: false,
+    });
+
+    expect(child.getAttribute('aria-label')).toBe('Parent');
+    expect(child.hasAttribute('data-state')).toBe(false);
+    expect(child.className).toBe('');
+
+    cleanup();
+  });
+
+  it('handles role attribute', () => {
+    parent.setAttribute('role', 'button');
+
+    const cleanup = mergeSlotProps(parent, child);
+
+    expect(child.getAttribute('role')).toBe('button');
+
+    cleanup();
+  });
+
+  it('returns no-op cleanup in SSR environment', () => {
+    const originalWindow = globalThis.window;
+    // @ts-expect-error Testing SSR
+    delete globalThis.window;
+
+    const cleanup = mergeSlotProps(parent, child);
+    expect(cleanup).toBeInstanceOf(Function);
+
+    globalThis.window = originalWindow;
+  });
+});
+
+describe('extractSlotProps', () => {
+  it('extracts all attributes from element', () => {
+    const element = document.createElement('button');
+    element.setAttribute('aria-label', 'Test');
+    element.setAttribute('data-state', 'open');
+    element.className = 'test-class';
+
+    const props = extractSlotProps(element);
+
+    expect(props['aria-label']).toBe('Test');
+    expect(props['data-state']).toBe('open');
+    expect(props.class).toBe('test-class');
+  });
+
+  it('returns empty object in SSR environment', () => {
+    const originalWindow = globalThis.window;
+    // @ts-expect-error Testing SSR
+    delete globalThis.window;
+
+    const element = document.createElement('button');
+    const props = extractSlotProps(element);
+    expect(props).toEqual({});
+
+    globalThis.window = originalWindow;
+  });
+});
+
+describe('shouldUseSlot', () => {
+  it('returns true when asChild is true', () => {
+    expect(shouldUseSlot(true)).toBe(true);
+  });
+
+  it('returns false when asChild is false', () => {
+    expect(shouldUseSlot(false)).toBe(false);
+  });
+
+  it('returns false when asChild is undefined', () => {
+    expect(shouldUseSlot(undefined)).toBe(false);
+  });
+});
+
+describe('mergeClassNames', () => {
+  it('merges two class name strings', () => {
+    const result = mergeClassNames('parent-class', 'child-class');
+    expect(result).toBe('parent-class child-class');
+  });
+
+  it('deduplicates classes', () => {
+    const result = mergeClassNames('shared-class other', 'shared-class different');
+    expect(result).toBe('shared-class other different');
+  });
+
+  it('handles empty strings', () => {
+    expect(mergeClassNames('', 'child')).toBe('child');
+    expect(mergeClassNames('parent', '')).toBe('parent');
+    expect(mergeClassNames('', '')).toBe('');
+  });
+
+  it('handles multiple spaces', () => {
+    const result = mergeClassNames('one  two', 'three   four');
+    expect(result).toBe('one two three four');
+  });
+});
+
+describe('mergeProps', () => {
+  it('merges className strings', () => {
+    const result = mergeProps({ className: 'parent' }, { className: 'child' });
+    expect(result.className).toBe('parent child');
+  });
+
+  it('uses custom classMerger for className', () => {
+    const classMerger = (a: string, b: string) => `${b}-${a}`;
+    const result = mergeProps({ className: 'parent' }, { className: 'child' }, { classMerger });
+    expect(result.className).toBe('child-parent');
+  });
+
+  it('merges style objects', () => {
+    const result = mergeProps(
+      { style: { color: 'red', fontSize: '14px' } },
+      { style: { color: 'blue', background: 'white' } },
+    );
+    expect(result.style).toEqual({
+      color: 'blue', // Child overrides parent
+      fontSize: '14px',
+      background: 'white',
+    });
+  });
+
+  it('composes event handlers', () => {
+    const parentHandler = vi.fn();
+    const childHandler = vi.fn();
+
+    const result = mergeProps({ onClick: parentHandler }, { onClick: childHandler });
+
+    (result.onClick as (...args: unknown[]) => void)('arg');
+
+    expect(childHandler).toHaveBeenCalledWith('arg');
+    expect(parentHandler).toHaveBeenCalledWith('arg');
+    expect(childHandler).toHaveBeenCalledBefore(parentHandler);
+  });
+
+  it('child values override parent for other props', () => {
+    const result = mergeProps({ id: 'parent-id', 'aria-label': 'parent' }, { id: 'child-id' });
+    expect(result.id).toBe('child-id');
+    expect(result['aria-label']).toBe('parent');
+  });
+});

--- a/packages/ui/test/primitives/sr-announcer.test.ts
+++ b/packages/ui/test/primitives/sr-announcer.test.ts
@@ -1,0 +1,347 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  announceToScreenReader,
+  clearAllAnnouncers,
+  createAnnouncer,
+  createAssertiveAnnouncer,
+  createPoliteAnnouncer,
+  createQueuedAnnouncer,
+  getAnnouncerCount,
+} from '../../src/primitives/sr-announcer';
+
+describe('createAnnouncer', () => {
+  beforeEach(() => {
+    clearAllAnnouncers();
+  });
+
+  afterEach(() => {
+    clearAllAnnouncers();
+  });
+
+  it('creates a live region element', () => {
+    const announcer = createAnnouncer();
+    const element = announcer.getElement();
+
+    expect(element).not.toBeNull();
+    expect(element?.getAttribute('aria-live')).toBe('polite');
+    expect(element?.getAttribute('aria-atomic')).toBe('true');
+    expect(element?.getAttribute('role')).toBe('status');
+
+    announcer.destroy();
+  });
+
+  it('uses polite by default', () => {
+    const announcer = createAnnouncer();
+    const element = announcer.getElement();
+
+    expect(element?.getAttribute('aria-live')).toBe('polite');
+
+    announcer.destroy();
+  });
+
+  it('uses assertive when specified', () => {
+    const announcer = createAnnouncer({ politeness: 'assertive' });
+    const element = announcer.getElement();
+
+    expect(element?.getAttribute('aria-live')).toBe('assertive');
+
+    announcer.destroy();
+  });
+
+  it('sets role based on politeness', () => {
+    const politeAnnouncer = createAnnouncer({ politeness: 'polite' });
+    expect(politeAnnouncer.getElement()?.getAttribute('role')).toBe('status');
+    politeAnnouncer.destroy();
+
+    clearAllAnnouncers();
+
+    const assertiveAnnouncer = createAnnouncer({ politeness: 'assertive' });
+    expect(assertiveAnnouncer.getElement()?.getAttribute('role')).toBe('alert');
+    assertiveAnnouncer.destroy();
+  });
+
+  it('allows custom role', () => {
+    const announcer = createAnnouncer({ role: 'log' });
+    const element = announcer.getElement();
+
+    expect(element?.getAttribute('role')).toBe('log');
+
+    announcer.destroy();
+  });
+
+  it('announces messages', async () => {
+    const announcer = createAnnouncer({ clearAfterAnnounce: false });
+    const element = announcer.getElement();
+
+    announcer.announce('Test message');
+
+    // Wait for requestAnimationFrame
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    expect(element?.textContent).toBe('Test message');
+
+    announcer.destroy();
+  });
+
+  it('clears messages after timeout', async () => {
+    vi.useFakeTimers();
+
+    const announcer = createAnnouncer({
+      clearAfterAnnounce: true,
+      clearTimeout: 100,
+    });
+    const element = announcer.getElement();
+
+    announcer.announce('Test message');
+
+    // Wait for requestAnimationFrame
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(element?.textContent).toBe('Test message');
+
+    // Wait for clear timeout
+    vi.advanceTimersByTime(100);
+
+    expect(element?.textContent).toBe('');
+
+    announcer.destroy();
+    vi.useRealTimers();
+  });
+
+  it('clears current message', async () => {
+    const announcer = createAnnouncer({ clearAfterAnnounce: false });
+    const element = announcer.getElement();
+
+    announcer.announce('Test message');
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    expect(element?.textContent).toBe('Test message');
+
+    announcer.clear();
+
+    expect(element?.textContent).toBe('');
+
+    announcer.destroy();
+  });
+
+  it('removes live region on destroy', () => {
+    const announcer = createAnnouncer();
+    const element = announcer.getElement();
+
+    expect(document.body.contains(element)).toBe(true);
+
+    announcer.destroy();
+
+    expect(document.body.contains(element)).toBe(false);
+  });
+
+  it('reuses existing announcer with same settings', () => {
+    const announcer1 = createAnnouncer({ politeness: 'polite' });
+    const announcer2 = createAnnouncer({ politeness: 'polite' });
+
+    expect(announcer1).toBe(announcer2);
+    expect(getAnnouncerCount()).toBe(1);
+
+    announcer1.destroy();
+  });
+
+  it('creates separate announcers for different settings', () => {
+    const polite = createAnnouncer({ politeness: 'polite' });
+    const assertive = createAnnouncer({ politeness: 'assertive' });
+
+    expect(polite).not.toBe(assertive);
+    expect(getAnnouncerCount()).toBe(2);
+
+    polite.destroy();
+    assertive.destroy();
+  });
+
+  it('visually hides the live region', () => {
+    const announcer = createAnnouncer();
+    const element = announcer.getElement();
+
+    expect(element?.style.position).toBe('absolute');
+    expect(element?.style.width).toBe('1px');
+    expect(element?.style.height).toBe('1px');
+    expect(element?.style.overflow).toBe('hidden');
+
+    announcer.destroy();
+  });
+
+  it('appends to custom container', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const announcer = createAnnouncer({ container });
+    const element = announcer.getElement();
+
+    expect(container.contains(element)).toBe(true);
+
+    announcer.destroy();
+    container.remove();
+  });
+
+  it('returns no-op in SSR environment', () => {
+    const originalWindow = globalThis.window;
+    // @ts-expect-error Testing SSR
+    delete globalThis.window;
+
+    const announcer = createAnnouncer();
+
+    expect(announcer.announce).toBeInstanceOf(Function);
+    expect(announcer.clear).toBeInstanceOf(Function);
+    expect(announcer.destroy).toBeInstanceOf(Function);
+    expect(announcer.getElement()).toBeNull();
+
+    globalThis.window = originalWindow;
+  });
+});
+
+describe('announceToScreenReader', () => {
+  beforeEach(() => {
+    clearAllAnnouncers();
+  });
+
+  afterEach(() => {
+    clearAllAnnouncers();
+  });
+
+  it('announces with polite by default', async () => {
+    announceToScreenReader('Test message');
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    const liveRegion = document.querySelector('[data-sr-announcer="polite"]');
+    expect(liveRegion?.textContent).toBe('Test message');
+  });
+
+  it('announces with assertive when specified', async () => {
+    announceToScreenReader('Urgent message', 'assertive');
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    const liveRegion = document.querySelector('[data-sr-announcer="assertive"]');
+    expect(liveRegion?.textContent).toBe('Urgent message');
+  });
+});
+
+describe('createPoliteAnnouncer', () => {
+  beforeEach(() => {
+    clearAllAnnouncers();
+  });
+
+  afterEach(() => {
+    clearAllAnnouncers();
+  });
+
+  it('creates announcer with polite politeness', () => {
+    const announcer = createPoliteAnnouncer();
+    const element = announcer.getElement();
+
+    expect(element?.getAttribute('aria-live')).toBe('polite');
+
+    announcer.destroy();
+  });
+});
+
+describe('createAssertiveAnnouncer', () => {
+  beforeEach(() => {
+    clearAllAnnouncers();
+  });
+
+  afterEach(() => {
+    clearAllAnnouncers();
+  });
+
+  it('creates announcer with assertive politeness', () => {
+    const announcer = createAssertiveAnnouncer();
+    const element = announcer.getElement();
+
+    expect(element?.getAttribute('aria-live')).toBe('assertive');
+    expect(element?.getAttribute('role')).toBe('alert');
+
+    announcer.destroy();
+  });
+});
+
+describe('createQueuedAnnouncer', () => {
+  beforeEach(() => {
+    clearAllAnnouncers();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    clearAllAnnouncers();
+    vi.useRealTimers();
+  });
+
+  it('queues multiple messages', async () => {
+    const announcer = createQueuedAnnouncer({ delay: 100 });
+
+    announcer.announce('Message 1');
+    announcer.announce('Message 2');
+    announcer.announce('Message 3');
+
+    expect(announcer.queue).toHaveLength(2); // First is being processed
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(announcer.queue).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(announcer.queue).toHaveLength(0);
+
+    announcer.destroy();
+  });
+
+  it('clears queue on clear()', () => {
+    const announcer = createQueuedAnnouncer({ delay: 100 });
+
+    announcer.announce('Message 1');
+    announcer.announce('Message 2');
+
+    announcer.clear();
+
+    expect(announcer.queue).toHaveLength(0);
+
+    announcer.destroy();
+  });
+});
+
+describe('clearAllAnnouncers', () => {
+  it('removes all announcers', () => {
+    createAnnouncer({ politeness: 'polite' });
+    createAnnouncer({ politeness: 'assertive' });
+
+    expect(getAnnouncerCount()).toBe(2);
+
+    clearAllAnnouncers();
+
+    expect(getAnnouncerCount()).toBe(0);
+  });
+});
+
+describe('getAnnouncerCount', () => {
+  beforeEach(() => {
+    clearAllAnnouncers();
+  });
+
+  afterEach(() => {
+    clearAllAnnouncers();
+  });
+
+  it('returns count of active announcers', () => {
+    expect(getAnnouncerCount()).toBe(0);
+
+    const announcer1 = createAnnouncer({ politeness: 'polite' });
+    expect(getAnnouncerCount()).toBe(1);
+
+    const announcer2 = createAnnouncer({ politeness: 'assertive' });
+    expect(getAnnouncerCount()).toBe(2);
+
+    announcer1.destroy();
+    expect(getAnnouncerCount()).toBe(1);
+
+    announcer2.destroy();
+    expect(getAnnouncerCount()).toBe(0);
+  });
+});

--- a/packages/ui/test/primitives/typeahead.test.ts
+++ b/packages/ui/test/primitives/typeahead.test.ts
@@ -1,0 +1,465 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createControlledTypeahead,
+  createTypeahead,
+  highlightMatch,
+} from '../../src/primitives/typeahead';
+
+describe('createTypeahead', () => {
+  let container: HTMLDivElement;
+  let items: HTMLDivElement[];
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    items = [];
+
+    // Create items
+    const labels = ['Apple', 'Banana', 'Cherry', 'Date', 'Elderberry'];
+    for (const label of labels) {
+      const item = document.createElement('div');
+      item.textContent = label;
+      item.setAttribute('role', 'option');
+      container.appendChild(item);
+      items.push(item);
+    }
+
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it('focuses matching item on keypress', () => {
+    const onMatch = vi.fn();
+    const cleanup = createTypeahead(container, {
+      getItems: () => items,
+      onMatch,
+    });
+
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'b', bubbles: true }));
+
+    expect(onMatch).toHaveBeenCalledWith(items[1], 1); // Banana
+
+    cleanup();
+  });
+
+  it('matches from start by default', () => {
+    const onMatch = vi.fn();
+    const cleanup = createTypeahead(container, {
+      getItems: () => items,
+      onMatch,
+    });
+
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+
+    expect(onMatch).toHaveBeenCalledWith(items[0], 0); // Apple, not Banana
+
+    cleanup();
+  });
+
+  it('accumulates search string', () => {
+    const onMatch = vi.fn();
+    const cleanup = createTypeahead(container, {
+      getItems: () => items,
+      onMatch,
+    });
+
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'c', bubbles: true }));
+    expect(onMatch).toHaveBeenCalledWith(items[2], 2); // Cherry
+
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'h', bubbles: true }));
+    // Still matches Cherry with "ch"
+    expect(onMatch).toHaveBeenLastCalledWith(items[2], 2);
+
+    cleanup();
+  });
+
+  it('resets search string after timeout', () => {
+    vi.useFakeTimers();
+
+    const onMatch = vi.fn();
+    const cleanup = createTypeahead(container, {
+      getItems: () => items,
+      onMatch,
+      timeout: 500,
+    });
+
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+    expect(onMatch).toHaveBeenCalledWith(items[0], 0); // Apple
+
+    vi.advanceTimersByTime(600);
+
+    // After timeout, 'b' should match Banana, not "ab" which wouldn't match
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'b', bubbles: true }));
+    expect(onMatch).toHaveBeenCalledWith(items[1], 1); // Banana
+
+    cleanup();
+  });
+
+  it('calls onNoMatch when no item matches', () => {
+    const onMatch = vi.fn();
+    const onNoMatch = vi.fn();
+    const cleanup = createTypeahead(container, {
+      getItems: () => items,
+      onMatch,
+      onNoMatch,
+    });
+
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', bubbles: true }));
+
+    expect(onMatch).not.toHaveBeenCalled();
+    expect(onNoMatch).toHaveBeenCalledWith('z');
+
+    cleanup();
+  });
+
+  it('is case insensitive by default', () => {
+    const onMatch = vi.fn();
+    const cleanup = createTypeahead(container, {
+      getItems: () => items,
+      onMatch,
+    });
+
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'A', bubbles: true }));
+
+    expect(onMatch).toHaveBeenCalledWith(items[0], 0); // Apple
+
+    cleanup();
+  });
+
+  it('can be case sensitive', () => {
+    const onMatch = vi.fn();
+    const onNoMatch = vi.fn();
+    const cleanup = createTypeahead(container, {
+      getItems: () => items,
+      onMatch,
+      onNoMatch,
+      caseSensitive: true,
+    });
+
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+
+    // 'a' should not match 'Apple' when case sensitive
+    expect(onNoMatch).toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('can match anywhere in text', () => {
+    const onMatch = vi.fn();
+    const cleanup = createTypeahead(container, {
+      getItems: () => items,
+      onMatch,
+      matchFromStart: false,
+    });
+
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'n', bubbles: true }));
+
+    // 'n' matches 'Banana' (contains n)
+    expect(onMatch).toHaveBeenCalledWith(items[1], 1);
+
+    cleanup();
+  });
+
+  it('uses custom getItemText function', () => {
+    // Add data-label attributes
+    items.forEach((item, i) => {
+      item.setAttribute('data-label', ['One', 'Two', 'Three', 'Four', 'Five'][i] || '');
+    });
+
+    const onMatch = vi.fn();
+    const cleanup = createTypeahead(container, {
+      getItems: () => items,
+      getItemText: (item) => item.getAttribute('data-label') || '',
+      onMatch,
+    });
+
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 't', bubbles: true }));
+
+    expect(onMatch).toHaveBeenCalledWith(items[1], 1); // "Two"
+
+    cleanup();
+  });
+
+  it('skips disabled items', () => {
+    items[0]?.setAttribute('disabled', '');
+
+    const onMatch = vi.fn();
+    const cleanup = createTypeahead(container, {
+      getItems: () => items,
+      onMatch,
+    });
+
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+
+    // Should not match Apple (disabled)
+    expect(onMatch).not.toHaveBeenCalledWith(items[0], 0);
+
+    cleanup();
+  });
+
+  it('skips aria-disabled items', () => {
+    items[0]?.setAttribute('aria-disabled', 'true');
+
+    const onMatch = vi.fn();
+    const cleanup = createTypeahead(container, {
+      getItems: () => items,
+      onMatch,
+    });
+
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+
+    expect(onMatch).not.toHaveBeenCalledWith(items[0], 0);
+
+    cleanup();
+  });
+
+  it('ignores modifier keys', () => {
+    const onMatch = vi.fn();
+    const cleanup = createTypeahead(container, {
+      getItems: () => items,
+      onMatch,
+    });
+
+    container.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'a', ctrlKey: true, bubbles: true }),
+    );
+    container.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'a', altKey: true, bubbles: true }),
+    );
+    container.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'a', metaKey: true, bubbles: true }),
+    );
+
+    expect(onMatch).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('ignores special keys', () => {
+    const onMatch = vi.fn();
+    const cleanup = createTypeahead(container, {
+      getItems: () => items,
+      onMatch,
+    });
+
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+
+    expect(onMatch).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('ignores space at start of search', () => {
+    const onMatch = vi.fn();
+    const cleanup = createTypeahead(container, {
+      getItems: () => items,
+      onMatch,
+    });
+
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+
+    expect(onMatch).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('removes listener on cleanup', () => {
+    const onMatch = vi.fn();
+    const cleanup = createTypeahead(container, {
+      getItems: () => items,
+      onMatch,
+    });
+
+    cleanup();
+
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+
+    expect(onMatch).not.toHaveBeenCalled();
+  });
+
+  it('returns no-op cleanup when disabled', () => {
+    const onMatch = vi.fn();
+    const cleanup = createTypeahead(container, {
+      getItems: () => items,
+      onMatch,
+      enabled: false,
+    });
+
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+
+    expect(onMatch).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('returns no-op cleanup in SSR environment', () => {
+    const originalWindow = globalThis.window;
+    // @ts-expect-error Testing SSR
+    delete globalThis.window;
+
+    const cleanup = createTypeahead(container, {
+      getItems: () => items,
+      onMatch: vi.fn(),
+    });
+    expect(cleanup).toBeInstanceOf(Function);
+
+    globalThis.window = originalWindow;
+  });
+});
+
+describe('createControlledTypeahead', () => {
+  let items: HTMLDivElement[];
+
+  beforeEach(() => {
+    items = [];
+    const labels = ['Apple', 'Banana', 'Cherry'];
+    for (const label of labels) {
+      const item = document.createElement('div');
+      item.textContent = label;
+      items.push(item);
+    }
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns handler and state functions', () => {
+    const typeahead = createControlledTypeahead({
+      getItems: () => items,
+    });
+
+    expect(typeahead.handleKeyDown).toBeInstanceOf(Function);
+    expect(typeahead.reset).toBeInstanceOf(Function);
+    expect(typeahead.getState).toBeInstanceOf(Function);
+  });
+
+  it('tracks search state', () => {
+    const typeahead = createControlledTypeahead({
+      getItems: () => items,
+    });
+
+    expect(typeahead.getState().searchString).toBe('');
+    expect(typeahead.getState().isActive).toBe(false);
+
+    typeahead.handleKeyDown(new KeyboardEvent('keydown', { key: 'a' }));
+
+    expect(typeahead.getState().searchString).toBe('a');
+    expect(typeahead.getState().isActive).toBe(true);
+  });
+
+  it('resets state', () => {
+    vi.useFakeTimers();
+
+    const typeahead = createControlledTypeahead({
+      getItems: () => items,
+    });
+
+    typeahead.handleKeyDown(new KeyboardEvent('keydown', { key: 'a' }));
+    expect(typeahead.getState().searchString).toBe('a');
+
+    typeahead.reset();
+
+    expect(typeahead.getState().searchString).toBe('');
+    expect(typeahead.getState().isActive).toBe(false);
+  });
+
+  it('calls onMatch callback', () => {
+    const onMatch = vi.fn();
+    const typeahead = createControlledTypeahead({
+      getItems: () => items,
+      onMatch,
+    });
+
+    typeahead.handleKeyDown(new KeyboardEvent('keydown', { key: 'b' }));
+
+    expect(onMatch).toHaveBeenCalledWith(items[1], 1);
+  });
+});
+
+describe('highlightMatch', () => {
+  let element: HTMLDivElement;
+
+  beforeEach(() => {
+    element = document.createElement('div');
+    element.textContent = 'Hello World';
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    element.remove();
+  });
+
+  it('wraps matching text in mark element', () => {
+    const cleanup = highlightMatch(element, 'World');
+
+    expect(element.innerHTML).toContain('<mark');
+    expect(element.innerHTML).toContain('World');
+    expect(element.innerHTML).toContain('</mark>');
+
+    cleanup();
+  });
+
+  it('applies custom highlight class', () => {
+    const cleanup = highlightMatch(element, 'Hello', {
+      highlightClass: 'custom-highlight',
+    });
+
+    expect(element.innerHTML).toContain('class="custom-highlight"');
+
+    cleanup();
+  });
+
+  it('restores original HTML on cleanup', () => {
+    const originalHTML = element.innerHTML;
+    const cleanup = highlightMatch(element, 'World');
+
+    expect(element.innerHTML).not.toBe(originalHTML);
+
+    cleanup();
+
+    expect(element.innerHTML).toBe(originalHTML);
+  });
+
+  it('returns no-op when no match found', () => {
+    const originalHTML = element.innerHTML;
+    const cleanup = highlightMatch(element, 'xyz');
+
+    expect(element.innerHTML).toBe(originalHTML);
+
+    cleanup();
+  });
+
+  it('is case insensitive by default', () => {
+    const cleanup = highlightMatch(element, 'hello');
+
+    expect(element.innerHTML).toContain('<mark');
+
+    cleanup();
+  });
+
+  it('can be case sensitive', () => {
+    const cleanup = highlightMatch(element, 'hello', { caseSensitive: true });
+
+    // 'hello' should not match 'Hello'
+    expect(element.innerHTML).not.toContain('<mark');
+
+    cleanup();
+  });
+
+  it('returns no-op in SSR environment', () => {
+    const originalWindow = globalThis.window;
+    // @ts-expect-error Testing SSR
+    delete globalThis.window;
+
+    const cleanup = highlightMatch(element, 'World');
+    expect(cleanup).toBeInstanceOf(Function);
+
+    globalThis.window = originalWindow;
+  });
+});


### PR DESCRIPTION
## Summary
- Add 9 headless accessibility primitives for building shadcn-compatible components
- All primitives are SSR-safe, return cleanup functions, and have full test coverage

### Critical Priority
- **roving-focus**: Arrow key navigation + roving tabindex for menus, tabs, radio groups
- **slot**: Prop merging for `asChild` pattern (ARIA, classes, events, styles)
- **keyboard-handler**: Type-safe keyboard events with modifier support

### High Priority
- **dismissable-layer**: Unified outside click + escape + focus detection with layer stacking
- **aria-manager**: Type-safe ARIA attribute setter with validation
- **sr-announcer**: Screen reader live region announcements (polite/assertive)

### Medium Priority
- **collision-detector**: Floating positioning with viewport collision detection
- **typeahead**: Type-to-search with configurable timeout
- **hover-delay**: Show/hide delays for tooltips with global coordination

## Test plan
- [x] All 260 tests pass
- [x] TypeScript strict mode passes
- [x] Lint passes
- [x] SSR safety verified (all primitives check for window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)