### PR TITLE
feat(ui): add breadcrumb component

### DIFF
--- a/packages/ui/src/components/ui/breadcrumb.tsx
+++ b/packages/ui/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,231 @@
+/**
+ * Hierarchical navigation component for wayfinding
+ *
+ * @cognitive-load 2/10 - Optimized for peripheral navigation aid with minimal cognitive overhead
+ * @attention-economics Tertiary support: Never competes with primary content, provides spatial context only
+ * @trust-building Low trust routine navigation with predictable, reliable wayfinding patterns
+ * @accessibility Complete ARIA support with aria-current="page", aria-hidden separators, and keyboard navigation
+ * @semantic-meaning Wayfinding system with spatial context and navigation hierarchy indication
+ *
+ * @usage-patterns
+ * DO: Provide spatial context and navigation hierarchy
+ * DO: Use clear current page indication with aria-current="page"
+ * DO: Implement truncation strategies for long paths (Miller's Law: 7+/-2 items)
+ * DO: Configure separators with proper accessibility attributes
+ * NEVER: Use for primary actions or main navigation
+ * NEVER: Show breadcrumbs on homepage (nothing to navigate back to)
+ * NEVER: Make current page clickable
+ *
+ * @example
+ * ```tsx
+ * // Basic breadcrumb
+ * <Breadcrumb>
+ *   <BreadcrumbList>
+ *     <BreadcrumbItem>
+ *       <BreadcrumbLink href="/">Home</BreadcrumbLink>
+ *     </BreadcrumbItem>
+ *     <BreadcrumbSeparator />
+ *     <BreadcrumbItem>
+ *       <BreadcrumbLink href="/products">Products</BreadcrumbLink>
+ *     </BreadcrumbItem>
+ *     <BreadcrumbSeparator />
+ *     <BreadcrumbItem>
+ *       <BreadcrumbPage>Widget</BreadcrumbPage>
+ *     </BreadcrumbItem>
+ *   </BreadcrumbList>
+ * </Breadcrumb>
+ *
+ * // With truncation for deep paths
+ * <Breadcrumb>
+ *   <BreadcrumbList>
+ *     <BreadcrumbItem>
+ *       <BreadcrumbLink href="/">Home</BreadcrumbLink>
+ *     </BreadcrumbItem>
+ *     <BreadcrumbSeparator />
+ *     <BreadcrumbItem>
+ *       <BreadcrumbEllipsis />
+ *     </BreadcrumbItem>
+ *     <BreadcrumbSeparator />
+ *     <BreadcrumbItem>
+ *       <BreadcrumbPage>Current Page</BreadcrumbPage>
+ *     </BreadcrumbItem>
+ *   </BreadcrumbList>
+ * </Breadcrumb>
+ *
+ * // With router Link (asChild)
+ * <BreadcrumbLink asChild>
+ *   <Link to="/products">Products</Link>
+ * </BreadcrumbLink>
+ * ```
+ */
+import * as React from 'react';
+import classy from '../../primitives/classy';
+import { mergeProps } from '../../primitives/slot';
+
+export interface BreadcrumbProps extends React.ComponentPropsWithoutRef<'nav'> {
+  separator?: React.ReactNode;
+}
+
+export const Breadcrumb = React.forwardRef<HTMLElement, BreadcrumbProps>(
+  ({ className, ...props }, ref) => (
+    <nav ref={ref} aria-label="Breadcrumb" className={classy(className)} {...props} />
+  ),
+);
+Breadcrumb.displayName = 'Breadcrumb';
+
+export interface BreadcrumbListProps extends React.ComponentPropsWithoutRef<'ol'> {}
+
+export const BreadcrumbList = React.forwardRef<HTMLOListElement, BreadcrumbListProps>(
+  ({ className, ...props }, ref) => (
+    <ol
+      ref={ref}
+      className={classy(
+        'flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-2.5',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+BreadcrumbList.displayName = 'BreadcrumbList';
+
+export interface BreadcrumbItemProps extends React.ComponentPropsWithoutRef<'li'> {}
+
+export const BreadcrumbItem = React.forwardRef<HTMLLIElement, BreadcrumbItemProps>(
+  ({ className, ...props }, ref) => (
+    <li ref={ref} className={classy('inline-flex items-center gap-1.5', className)} {...props} />
+  ),
+);
+BreadcrumbItem.displayName = 'BreadcrumbItem';
+
+export interface BreadcrumbLinkProps extends React.ComponentPropsWithoutRef<'a'> {
+  asChild?: boolean;
+}
+
+export const BreadcrumbLink = React.forwardRef<HTMLAnchorElement, BreadcrumbLinkProps>(
+  ({ asChild, className, children, ...props }, ref) => {
+    const cls = classy('transition-colors hover:text-foreground', className);
+
+    if (asChild && React.isValidElement(children)) {
+      const child = children as React.ReactElement<
+        Record<string, unknown>,
+        string | React.JSXElementConstructor<unknown>
+      >;
+      const childPropsTyped = child.props as Record<string, unknown>;
+
+      const parentProps = {
+        ref,
+        className: cls,
+        ...props,
+      };
+
+      const mergedProps = mergeProps(
+        parentProps as Parameters<typeof mergeProps>[0],
+        childPropsTyped,
+      );
+
+      return React.cloneElement(child, mergedProps as Partial<Record<string, unknown>>);
+    }
+
+    return (
+      <a ref={ref} className={cls} {...props}>
+        {children}
+      </a>
+    );
+  },
+);
+BreadcrumbLink.displayName = 'BreadcrumbLink';
+
+export interface BreadcrumbPageProps extends React.ComponentPropsWithoutRef<'span'> {}
+
+export const BreadcrumbPage = React.forwardRef<HTMLSpanElement, BreadcrumbPageProps>(
+  ({ className, ...props }, ref) => (
+    <span
+      ref={ref}
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={classy('font-normal text-foreground', className)}
+      {...props}
+    />
+  ),
+);
+BreadcrumbPage.displayName = 'BreadcrumbPage';
+
+export interface BreadcrumbSeparatorProps extends React.ComponentPropsWithoutRef<'li'> {}
+
+export const BreadcrumbSeparator = React.forwardRef<HTMLLIElement, BreadcrumbSeparatorProps>(
+  ({ children, className, ...props }, ref) => (
+    <li
+      ref={ref}
+      role="presentation"
+      aria-hidden="true"
+      className={classy('[&>svg]:size-3.5', className)}
+      {...props}
+    >
+      {children ?? <ChevronRight />}
+    </li>
+  ),
+);
+BreadcrumbSeparator.displayName = 'BreadcrumbSeparator';
+
+export interface BreadcrumbEllipsisProps extends React.ComponentPropsWithoutRef<'span'> {}
+
+export const BreadcrumbEllipsis = React.forwardRef<HTMLSpanElement, BreadcrumbEllipsisProps>(
+  ({ className, ...props }, ref) => (
+    <span
+      ref={ref}
+      role="presentation"
+      aria-hidden="true"
+      className={classy('flex h-9 w-9 items-center justify-center', className)}
+      {...props}
+    >
+      <MoreHorizontal className="h-4 w-4" />
+      <span className="sr-only">More</span>
+    </span>
+  ),
+);
+BreadcrumbEllipsis.displayName = 'BreadcrumbEllipsis';
+
+// Internal icon components to avoid external dependencies
+function ChevronRight({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="m9 18 6-6-6-6" />
+    </svg>
+  );
+}
+
+function MoreHorizontal({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="1" />
+      <circle cx="19" cy="12" r="1" />
+      <circle cx="5" cy="12" r="1" />
+    </svg>
+  );
+}

--- a/packages/ui/test/components/breadcrumb.a11y.tsx
+++ b/packages/ui/test/components/breadcrumb.a11y.tsx
@@ -1,0 +1,242 @@
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import {
+  Breadcrumb,
+  BreadcrumbEllipsis,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '../../src/components/ui/breadcrumb';
+
+describe('Breadcrumb - Accessibility', () => {
+  it('has no accessibility violations with proper structure', async () => {
+    const { container } = render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/products">Products</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Widget</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with current page indication', async () => {
+    const { container } = render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Current Page</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has aria-current="page" on current item', () => {
+    const { container } = render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Current Page</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const currentPage = container.querySelector('[aria-current="page"]');
+    expect(currentPage).toBeInTheDocument();
+    expect(currentPage).toHaveTextContent('Current Page');
+  });
+
+  it('separators are hidden from screen readers', () => {
+    const { container } = render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Current</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const separators = container.querySelectorAll('[aria-hidden="true"]');
+    expect(separators.length).toBeGreaterThan(0);
+  });
+
+  it('has no violations with ellipsis for truncation', async () => {
+    const { container } = render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbEllipsis />
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Current</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('ellipsis is hidden from screen readers', () => {
+    const { container } = render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbEllipsis />
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const ellipsis = container.querySelector('[aria-hidden="true"]');
+    expect(ellipsis).toBeInTheDocument();
+  });
+
+  it('has no violations with custom separator', async () => {
+    const { container } = render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator>/</BreadcrumbSeparator>
+          <BreadcrumbItem>
+            <BreadcrumbPage>Current</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with asChild links', async () => {
+    const CustomLink = React.forwardRef<HTMLAnchorElement, { to: string; children: React.ReactNode }>(
+      ({ to, children, ...props }, ref) => (
+        <a ref={ref} href={to} {...props}>
+          {children}
+        </a>
+      ),
+    );
+    CustomLink.displayName = 'CustomLink';
+
+    const { container } = render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <CustomLink to="/">Home</CustomLink>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Current</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('nav element has correct aria-label', () => {
+    const { container } = render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbPage>Home</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const nav = container.querySelector('nav');
+    expect(nav).toHaveAttribute('aria-label', 'Breadcrumb');
+  });
+
+  it('uses proper semantic structure with ol', () => {
+    const { container } = render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Current</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const nav = container.querySelector('nav');
+    const ol = nav?.querySelector('ol');
+    const lis = ol?.querySelectorAll('li');
+    
+    expect(nav).toBeInTheDocument();
+    expect(ol).toBeInTheDocument();
+    expect(lis?.length).toBeGreaterThan(0);
+  });
+
+  it('has no violations with long breadcrumb trail', async () => {
+    const { container } = render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/category">Category</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/category/subcategory">Subcategory</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/category/subcategory/item">Item</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Details</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/ui/test/components/breadcrumb.test.tsx
+++ b/packages/ui/test/components/breadcrumb.test.tsx
@@ -1,0 +1,685 @@
+import { render, screen } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+import {
+  Breadcrumb,
+  BreadcrumbEllipsis,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '../../src/components/ui/breadcrumb';
+
+describe('Breadcrumb', () => {
+  it('renders as nav element', () => {
+    render(
+      <Breadcrumb data-testid="breadcrumb">
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbPage>Home</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const nav = screen.getByTestId('breadcrumb');
+    expect(nav.tagName).toBe('NAV');
+  });
+
+  it('has aria-label="Breadcrumb"', () => {
+    render(
+      <Breadcrumb data-testid="breadcrumb">
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbPage>Home</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(screen.getByTestId('breadcrumb')).toHaveAttribute('aria-label', 'Breadcrumb');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(
+      <Breadcrumb className="custom-class">
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbPage>Home</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+
+  it('forwards ref', () => {
+    const ref = React.createRef<HTMLElement>();
+    render(
+      <Breadcrumb ref={ref}>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbPage>Home</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+    expect(ref.current?.tagName).toBe('NAV');
+  });
+});
+
+describe('BreadcrumbList', () => {
+  it('renders as ol element', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList data-testid="list">
+          <BreadcrumbItem>
+            <BreadcrumbPage>Home</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const list = screen.getByTestId('list');
+    expect(list.tagName).toBe('OL');
+  });
+
+  it('has proper base classes', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList data-testid="list">
+          <BreadcrumbItem>
+            <BreadcrumbPage>Home</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const list = screen.getByTestId('list');
+    expect(list).toHaveClass('flex');
+    expect(list).toHaveClass('flex-wrap');
+    expect(list).toHaveClass('items-center');
+    expect(list).toHaveClass('text-sm');
+    expect(list).toHaveClass('text-muted-foreground');
+  });
+
+  it('merges custom className', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList data-testid="list" className="custom-class">
+          <BreadcrumbItem>
+            <BreadcrumbPage>Home</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(screen.getByTestId('list')).toHaveClass('custom-class');
+  });
+
+  it('forwards ref', () => {
+    const ref = React.createRef<HTMLOListElement>();
+    render(
+      <Breadcrumb>
+        <BreadcrumbList ref={ref}>
+          <BreadcrumbItem>
+            <BreadcrumbPage>Home</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLOListElement);
+  });
+});
+
+describe('BreadcrumbItem', () => {
+  it('renders as li element', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem data-testid="item">
+            <BreadcrumbPage>Home</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const item = screen.getByTestId('item');
+    expect(item.tagName).toBe('LI');
+  });
+
+  it('has proper base classes', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem data-testid="item">
+            <BreadcrumbPage>Home</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const item = screen.getByTestId('item');
+    expect(item).toHaveClass('inline-flex');
+    expect(item).toHaveClass('items-center');
+  });
+
+  it('merges custom className', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem data-testid="item" className="custom-class">
+            <BreadcrumbPage>Home</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(screen.getByTestId('item')).toHaveClass('custom-class');
+  });
+
+  it('forwards ref', () => {
+    const ref = React.createRef<HTMLLIElement>();
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem ref={ref}>
+            <BreadcrumbPage>Home</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLLIElement);
+  });
+});
+
+describe('BreadcrumbLink', () => {
+  it('renders as anchor element', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/" data-testid="link">
+              Home
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const link = screen.getByTestId('link');
+    expect(link.tagName).toBe('A');
+  });
+
+  it('has proper base classes', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/" data-testid="link">
+              Home
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const link = screen.getByTestId('link');
+    expect(link).toHaveClass('transition-colors');
+    expect(link).toHaveClass('hover:text-foreground');
+  });
+
+  it('merges custom className', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/" data-testid="link" className="custom-class">
+              Home
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(screen.getByTestId('link')).toHaveClass('custom-class');
+  });
+
+  it('passes through href attribute', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/products" data-testid="link">
+              Products
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(screen.getByTestId('link')).toHaveAttribute('href', '/products');
+  });
+
+  it('forwards ref', () => {
+    const ref = React.createRef<HTMLAnchorElement>();
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink ref={ref} href="/">
+              Home
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLAnchorElement);
+  });
+
+  it('supports asChild prop for custom link components', () => {
+    const CustomLink = React.forwardRef<HTMLAnchorElement, { to: string; children: React.ReactNode }>(
+      ({ to, children, ...props }, ref) => (
+        <a ref={ref} href={to} {...props}>
+          {children}
+        </a>
+      ),
+    );
+    CustomLink.displayName = 'CustomLink';
+
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild data-testid="link">
+              <CustomLink to="/products">Products</CustomLink>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const link = screen.getByText('Products');
+    expect(link).toHaveAttribute('href', '/products');
+    expect(link).toHaveClass('transition-colors');
+  });
+});
+
+describe('BreadcrumbPage', () => {
+  it('renders as span element', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbPage data-testid="page">Current</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const page = screen.getByTestId('page');
+    expect(page.tagName).toBe('SPAN');
+  });
+
+  it('has aria-current="page"', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbPage data-testid="page">Current</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(screen.getByTestId('page')).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('has aria-disabled="true"', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbPage data-testid="page">Current</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(screen.getByTestId('page')).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('has role="link"', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbPage data-testid="page">Current</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(screen.getByTestId('page')).toHaveAttribute('role', 'link');
+  });
+
+  it('has proper base classes', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbPage data-testid="page">Current</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const page = screen.getByTestId('page');
+    expect(page).toHaveClass('font-normal');
+    expect(page).toHaveClass('text-foreground');
+  });
+
+  it('merges custom className', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbPage data-testid="page" className="custom-class">
+              Current
+            </BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(screen.getByTestId('page')).toHaveClass('custom-class');
+  });
+
+  it('forwards ref', () => {
+    const ref = React.createRef<HTMLSpanElement>();
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbPage ref={ref}>Current</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+  });
+});
+
+describe('BreadcrumbSeparator', () => {
+  it('renders as li element', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator data-testid="separator" />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Current</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const separator = screen.getByTestId('separator');
+    expect(separator.tagName).toBe('LI');
+  });
+
+  it('has aria-hidden="true"', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator data-testid="separator" />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Current</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(screen.getByTestId('separator')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('has role="presentation"', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator data-testid="separator" />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Current</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(screen.getByTestId('separator')).toHaveAttribute('role', 'presentation');
+  });
+
+  it('renders default chevron icon when no children', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator data-testid="separator" />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Current</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const separator = screen.getByTestId('separator');
+    const svg = separator.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('renders custom children when provided', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator data-testid="separator">/</BreadcrumbSeparator>
+          <BreadcrumbItem>
+            <BreadcrumbPage>Current</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(screen.getByTestId('separator')).toHaveTextContent('/');
+  });
+
+  it('merges custom className', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator data-testid="separator" className="custom-class" />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Current</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(screen.getByTestId('separator')).toHaveClass('custom-class');
+  });
+
+  it('forwards ref', () => {
+    const ref = React.createRef<HTMLLIElement>();
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator ref={ref} />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Current</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLLIElement);
+  });
+});
+
+describe('BreadcrumbEllipsis', () => {
+  it('renders as span element', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbEllipsis data-testid="ellipsis" />
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const ellipsis = screen.getByTestId('ellipsis');
+    expect(ellipsis.tagName).toBe('SPAN');
+  });
+
+  it('has aria-hidden="true"', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbEllipsis data-testid="ellipsis" />
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(screen.getByTestId('ellipsis')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('has role="presentation"', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbEllipsis data-testid="ellipsis" />
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(screen.getByTestId('ellipsis')).toHaveAttribute('role', 'presentation');
+  });
+
+  it('has screen reader text', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbEllipsis data-testid="ellipsis" />
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(screen.getByText('More')).toHaveClass('sr-only');
+  });
+
+  it('has proper base classes', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbEllipsis data-testid="ellipsis" />
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const ellipsis = screen.getByTestId('ellipsis');
+    expect(ellipsis).toHaveClass('flex');
+    expect(ellipsis).toHaveClass('h-9');
+    expect(ellipsis).toHaveClass('w-9');
+    expect(ellipsis).toHaveClass('items-center');
+    expect(ellipsis).toHaveClass('justify-center');
+  });
+
+  it('merges custom className', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbEllipsis data-testid="ellipsis" className="custom-class" />
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(screen.getByTestId('ellipsis')).toHaveClass('custom-class');
+  });
+
+  it('forwards ref', () => {
+    const ref = React.createRef<HTMLSpanElement>();
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbEllipsis ref={ref} />
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+  });
+
+  it('renders ellipsis icon', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbEllipsis data-testid="ellipsis" />
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+    const ellipsis = screen.getByTestId('ellipsis');
+    const svg = ellipsis.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+});
+
+describe('Breadcrumb - Full integration', () => {
+  it('renders a complete breadcrumb trail', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/products">Products</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Widget</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+
+    expect(screen.getByText('Home')).toBeInTheDocument();
+    expect(screen.getByText('Products')).toBeInTheDocument();
+    expect(screen.getByText('Widget')).toBeInTheDocument();
+    expect(screen.getByText('Widget')).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('renders with ellipsis for truncation', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbEllipsis />
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Current</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>,
+    );
+
+    expect(screen.getByText('Home')).toBeInTheDocument();
+    expect(screen.getByText('More')).toBeInTheDocument(); // sr-only text
+    expect(screen.getByText('Current')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `breadcrumb` component with shadcn API parity.

### Features
- JSDoc intelligence blocks (@cognitive-load, @attention-economics, etc.)
- Unit tests
- Accessibility support (ARIA, keyboard navigation)
- Design token compliance (no arbitrary values)

## Test plan
- [x] Component tests pass
- [ ] Manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)