### PR TITLE
feat(ui): add card component

### DIFF
--- a/packages/ui/src/components/ui/card.tsx
+++ b/packages/ui/src/components/ui/card.tsx
@@ -1,0 +1,131 @@
+/**
+ * Flexible container component for grouping related content with semantic structure
+ *
+ * @cognitive-load 2/10 - Simple container with clear boundaries and minimal cognitive overhead
+ * @attention-economics Neutral container: Content drives attention, elevation hierarchy for interactive states
+ * @trust-building Consistent spacing, predictable interaction patterns, clear content boundaries
+ * @accessibility Proper heading structure, landmark roles, keyboard navigation for interactive cards
+ * @semantic-meaning Structural roles: article=standalone content, section=grouped content, aside=supplementary information
+ *
+ * @usage-patterns
+ * DO: Group related information with clear visual boundaries
+ * DO: Create interactive cards with hover states and focus management
+ * DO: Establish information hierarchy with header, content, actions
+ * DO: Implement responsive scaling with consistent proportions
+ * NEVER: Use decorative containers without semantic purpose
+ * NEVER: Nest cards within cards
+ * NEVER: Use Card for layout (use Grid/Container instead)
+ *
+ * @example
+ * ```tsx
+ * // Standalone content - use article
+ * <Card as="article">
+ *   <CardHeader>
+ *     <CardTitle>Blog Post Title</CardTitle>
+ *     <CardDescription>Published Jan 2025</CardDescription>
+ *   </CardHeader>
+ *   <CardContent>Post excerpt...</CardContent>
+ * </Card>
+ *
+ * // Interactive card - product listing
+ * <Card interactive>
+ *   <CardHeader>
+ *     <CardTitle>Product Name</CardTitle>
+ *   </CardHeader>
+ *   <CardContent>$99.00</CardContent>
+ *   <CardFooter>
+ *     <Button>Add to Cart</Button>
+ *   </CardFooter>
+ * </Card>
+ *
+ * // Supplementary content - use aside
+ * <Card as="aside">
+ *   <CardHeader>
+ *     <CardTitle>Related Links</CardTitle>
+ *   </CardHeader>
+ *   <CardContent>...</CardContent>
+ * </Card>
+ * ```
+ */
+import * as React from 'react';
+import classy from '../../primitives/classy';
+
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  as?: 'div' | 'article' | 'section' | 'aside';
+  interactive?: boolean;
+}
+
+export const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ as: Component = 'div', interactive, className, ...props }, ref) => {
+    const base = 'bg-card text-card-foreground border border-card-border rounded-lg shadow-sm';
+
+    const interactiveStyles = interactive
+      ? 'hover:bg-card-hover hover:shadow-md transition-shadow duration-normal motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+      : '';
+
+    const cls = classy(base, interactiveStyles, className);
+
+    return <Component ref={ref} className={cls} tabIndex={interactive ? 0 : undefined} {...props} />;
+  },
+);
+
+Card.displayName = 'Card';
+
+export interface CardHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const CardHeader = React.forwardRef<HTMLDivElement, CardHeaderProps>(
+  ({ className, ...props }, ref) => {
+    const cls = classy('flex flex-col gap-1.5 p-6', className);
+    return <div ref={ref} className={cls} {...props} />;
+  },
+);
+
+CardHeader.displayName = 'CardHeader';
+
+export interface CardTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+}
+
+export const CardTitle = React.forwardRef<HTMLHeadingElement, CardTitleProps>(
+  ({ as: Component = 'h3', className, ...props }, ref) => {
+    const cls = classy('text-2xl font-semibold leading-none tracking-tight', className);
+    return <Component ref={ref} className={cls} {...props} />;
+  },
+);
+
+CardTitle.displayName = 'CardTitle';
+
+export interface CardDescriptionProps extends React.HTMLAttributes<HTMLParagraphElement> {}
+
+export const CardDescription = React.forwardRef<HTMLParagraphElement, CardDescriptionProps>(
+  ({ className, ...props }, ref) => {
+    const cls = classy('text-sm text-muted-foreground', className);
+    return <p ref={ref} className={cls} {...props} />;
+  },
+);
+
+CardDescription.displayName = 'CardDescription';
+
+export interface CardContentProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const CardContent = React.forwardRef<HTMLDivElement, CardContentProps>(
+  ({ className, ...props }, ref) => {
+    const cls = classy('p-6 pt-0', className);
+    return <div ref={ref} className={cls} {...props} />;
+  },
+);
+
+CardContent.displayName = 'CardContent';
+
+export interface CardFooterProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const CardFooter = React.forwardRef<HTMLDivElement, CardFooterProps>(
+  ({ className, ...props }, ref) => {
+    const cls = classy('flex items-center p-6 pt-0', className);
+    return <div ref={ref} className={cls} {...props} />;
+  },
+);
+
+CardFooter.displayName = 'CardFooter';
+
+export default Card;

--- a/packages/ui/test/components/card.a11y.tsx
+++ b/packages/ui/test/components/card.a11y.tsx
@@ -1,0 +1,213 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '../../src/components/ui/card';
+
+describe('Card - Accessibility', () => {
+  it('has no accessibility violations with default props', async () => {
+    const { container } = render(
+      <Card>
+        <CardContent>Card content</CardContent>
+      </Card>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations when rendered as article', async () => {
+    const { container } = render(
+      <Card as="article">
+        <CardHeader>
+          <CardTitle>Blog Post</CardTitle>
+          <CardDescription>Published Jan 2025</CardDescription>
+        </CardHeader>
+        <CardContent>Article content here</CardContent>
+      </Card>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations when rendered as section', async () => {
+    const { container } = render(
+      <Card as="section">
+        <CardHeader>
+          <CardTitle>Section Title</CardTitle>
+        </CardHeader>
+        <CardContent>Section content</CardContent>
+      </Card>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations when rendered as aside', async () => {
+    const { container } = render(
+      <Card as="aside">
+        <CardHeader>
+          <CardTitle>Related Links</CardTitle>
+        </CardHeader>
+        <CardContent>Supplementary content</CardContent>
+      </Card>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with interactive card', async () => {
+    const { container } = render(
+      <Card interactive>
+        <CardHeader>
+          <CardTitle>Interactive Card</CardTitle>
+        </CardHeader>
+        <CardContent>Click to select</CardContent>
+      </Card>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with all subcomponents', async () => {
+    const { container } = render(
+      <Card as="article">
+        <CardHeader>
+          <CardTitle>Complete Card</CardTitle>
+          <CardDescription>With all components</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p>Main content paragraph</p>
+        </CardContent>
+        <CardFooter>
+          <button type="button">Action</button>
+        </CardFooter>
+      </Card>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with different heading levels', async () => {
+    const headingLevels = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
+    for (const level of headingLevels) {
+      const { container } = render(
+        <Card>
+          <CardHeader>
+            <CardTitle as={level}>Heading Level {level}</CardTitle>
+          </CardHeader>
+          <CardContent>Content</CardContent>
+        </Card>,
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    }
+  });
+
+  it('has no violations with aria attributes', async () => {
+    const { container } = render(
+      <Card aria-label="Product card" role="region">
+        <CardHeader>
+          <CardTitle>Product Name</CardTitle>
+          <CardDescription>Product description</CardDescription>
+        </CardHeader>
+        <CardContent>Price and details</CardContent>
+      </Card>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with interactive content inside', async () => {
+    const { container } = render(
+      <Card>
+        <CardHeader>
+          <CardTitle>Form Card</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <label htmlFor="input">Name</label>
+          <input id="input" type="text" />
+        </CardContent>
+        <CardFooter>
+          <button type="submit">Submit</button>
+          <button type="button">Cancel</button>
+        </CardFooter>
+      </Card>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with links inside', async () => {
+    const { container } = render(
+      <Card as="article">
+        <CardHeader>
+          <CardTitle>Article with Links</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p>
+            Read more at <a href="#docs">documentation</a> or{' '}
+            <a href="#api">API reference</a>.
+          </p>
+        </CardContent>
+      </Card>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('CardHeader - Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <CardHeader>
+        <CardTitle>Header Title</CardTitle>
+      </CardHeader>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('CardTitle - Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(<CardTitle>Title Text</CardTitle>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('CardDescription - Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <CardDescription>Description text</CardDescription>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('CardContent - Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(<CardContent>Content here</CardContent>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('CardFooter - Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <CardFooter>
+        <button type="button">Action</button>
+      </CardFooter>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/ui/test/components/card.test.tsx
+++ b/packages/ui/test/components/card.test.tsx
@@ -1,0 +1,254 @@
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import { describe, expect, it } from 'vitest';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '../../src/components/ui/card';
+
+describe('Card', () => {
+  it('renders with default props', () => {
+    render(<Card data-testid="card">Card content</Card>);
+    const card = screen.getByTestId('card');
+    expect(card).toBeInTheDocument();
+    expect(card.tagName).toBe('DIV');
+  });
+
+  it('applies base styles', () => {
+    const { container } = render(<Card>Test</Card>);
+    const card = container.firstChild;
+    expect(card).toHaveClass('bg-card');
+    expect(card).toHaveClass('text-card-foreground');
+    expect(card).toHaveClass('border');
+    expect(card).toHaveClass('border-card-border');
+    expect(card).toHaveClass('rounded-lg');
+    expect(card).toHaveClass('shadow-sm');
+  });
+
+  it('renders as article when as="article"', () => {
+    render(<Card as="article" data-testid="card">Content</Card>);
+    const card = screen.getByTestId('card');
+    expect(card.tagName).toBe('ARTICLE');
+  });
+
+  it('renders as section when as="section"', () => {
+    render(<Card as="section" data-testid="card">Content</Card>);
+    const card = screen.getByTestId('card');
+    expect(card.tagName).toBe('SECTION');
+  });
+
+  it('renders as aside when as="aside"', () => {
+    render(<Card as="aside" data-testid="card">Content</Card>);
+    const card = screen.getByTestId('card');
+    expect(card.tagName).toBe('ASIDE');
+  });
+
+  it('applies interactive styles when interactive prop is true', () => {
+    const { container } = render(<Card interactive>Interactive Card</Card>);
+    const card = container.firstChild;
+    expect(card).toHaveClass('hover:bg-card-hover');
+    expect(card).toHaveClass('hover:shadow-md');
+    expect(card).toHaveClass('transition-shadow');
+    expect(card).toHaveClass('duration-normal');
+    expect(card).toHaveClass('motion-reduce:transition-none');
+    expect(card).toHaveClass('focus-visible:outline-none');
+    expect(card).toHaveClass('focus-visible:ring-2');
+    expect(card).toHaveClass('focus-visible:ring-ring');
+    expect(card).toHaveClass('focus-visible:ring-offset-2');
+  });
+
+  it('adds tabIndex=0 when interactive', () => {
+    render(<Card interactive data-testid="card">Interactive</Card>);
+    const card = screen.getByTestId('card');
+    expect(card).toHaveAttribute('tabIndex', '0');
+  });
+
+  it('does not add tabIndex when not interactive', () => {
+    render(<Card data-testid="card">Static</Card>);
+    const card = screen.getByTestId('card');
+    expect(card).not.toHaveAttribute('tabIndex');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<Card className="custom-class">Test</Card>);
+    expect(container.firstChild).toHaveClass('custom-class');
+    expect(container.firstChild).toHaveClass('bg-card');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(<Card ref={ref}>Content</Card>);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('passes through HTML attributes', () => {
+    render(
+      <Card data-testid="card" aria-label="Card container" id="my-card">
+        Test
+      </Card>,
+    );
+    const card = screen.getByTestId('card');
+    expect(card).toHaveAttribute('aria-label', 'Card container');
+    expect(card).toHaveAttribute('id', 'my-card');
+  });
+});
+
+describe('CardHeader', () => {
+  it('renders with default styles', () => {
+    const { container } = render(<CardHeader>Header</CardHeader>);
+    const header = container.firstChild;
+    expect(header).toHaveClass('flex');
+    expect(header).toHaveClass('flex-col');
+    expect(header).toHaveClass('gap-1.5');
+    expect(header).toHaveClass('p-6');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<CardHeader className="custom">Header</CardHeader>);
+    expect(container.firstChild).toHaveClass('custom');
+    expect(container.firstChild).toHaveClass('flex');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(<CardHeader ref={ref}>Header</CardHeader>);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('passes through HTML attributes', () => {
+    render(<CardHeader data-testid="header" aria-label="Header section">Header</CardHeader>);
+    const header = screen.getByTestId('header');
+    expect(header).toHaveAttribute('aria-label', 'Header section');
+  });
+});
+
+describe('CardTitle', () => {
+  it('renders as h3 by default', () => {
+    render(<CardTitle data-testid="title">Title</CardTitle>);
+    const title = screen.getByTestId('title');
+    expect(title.tagName).toBe('H3');
+  });
+
+  it('renders as specified heading level', () => {
+    render(<CardTitle as="h2" data-testid="title">Title</CardTitle>);
+    const title = screen.getByTestId('title');
+    expect(title.tagName).toBe('H2');
+  });
+
+  it('applies default styles', () => {
+    const { container } = render(<CardTitle>Title</CardTitle>);
+    const title = container.firstChild;
+    expect(title).toHaveClass('text-2xl');
+    expect(title).toHaveClass('font-semibold');
+    expect(title).toHaveClass('leading-none');
+    expect(title).toHaveClass('tracking-tight');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<CardTitle className="custom">Title</CardTitle>);
+    expect(container.firstChild).toHaveClass('custom');
+    expect(container.firstChild).toHaveClass('text-2xl');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLHeadingElement>();
+    render(<CardTitle ref={ref}>Title</CardTitle>);
+    expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
+  });
+});
+
+describe('CardDescription', () => {
+  it('renders as paragraph', () => {
+    render(<CardDescription data-testid="desc">Description</CardDescription>);
+    const desc = screen.getByTestId('desc');
+    expect(desc.tagName).toBe('P');
+  });
+
+  it('applies default styles', () => {
+    const { container } = render(<CardDescription>Description</CardDescription>);
+    const desc = container.firstChild;
+    expect(desc).toHaveClass('text-sm');
+    expect(desc).toHaveClass('text-muted-foreground');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<CardDescription className="custom">Desc</CardDescription>);
+    expect(container.firstChild).toHaveClass('custom');
+    expect(container.firstChild).toHaveClass('text-sm');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLParagraphElement>();
+    render(<CardDescription ref={ref}>Description</CardDescription>);
+    expect(ref.current).toBeInstanceOf(HTMLParagraphElement);
+  });
+});
+
+describe('CardContent', () => {
+  it('renders with default styles', () => {
+    const { container } = render(<CardContent>Content</CardContent>);
+    const content = container.firstChild;
+    expect(content).toHaveClass('p-6');
+    expect(content).toHaveClass('pt-0');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<CardContent className="custom">Content</CardContent>);
+    expect(container.firstChild).toHaveClass('custom');
+    expect(container.firstChild).toHaveClass('p-6');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(<CardContent ref={ref}>Content</CardContent>);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+});
+
+describe('CardFooter', () => {
+  it('renders with default styles', () => {
+    const { container } = render(<CardFooter>Footer</CardFooter>);
+    const footer = container.firstChild;
+    expect(footer).toHaveClass('flex');
+    expect(footer).toHaveClass('items-center');
+    expect(footer).toHaveClass('p-6');
+    expect(footer).toHaveClass('pt-0');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<CardFooter className="custom">Footer</CardFooter>);
+    expect(container.firstChild).toHaveClass('custom');
+    expect(container.firstChild).toHaveClass('flex');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(<CardFooter ref={ref}>Footer</CardFooter>);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+});
+
+describe('Card composition', () => {
+  it('renders a complete card with all subcomponents', () => {
+    render(
+      <Card as="article" data-testid="card">
+        <CardHeader>
+          <CardTitle data-testid="title">Test Title</CardTitle>
+          <CardDescription data-testid="desc">Test Description</CardDescription>
+        </CardHeader>
+        <CardContent data-testid="content">Main content here</CardContent>
+        <CardFooter data-testid="footer">Footer actions</CardFooter>
+      </Card>,
+    );
+
+    expect(screen.getByTestId('card')).toBeInTheDocument();
+    expect(screen.getByTestId('title')).toHaveTextContent('Test Title');
+    expect(screen.getByTestId('desc')).toHaveTextContent('Test Description');
+    expect(screen.getByTestId('content')).toHaveTextContent('Main content here');
+    expect(screen.getByTestId('footer')).toHaveTextContent('Footer actions');
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `card` component with shadcn API parity.

### Features
- JSDoc intelligence blocks (@cognitive-load, @attention-economics, etc.)
- Unit tests
- Accessibility support (ARIA, keyboard navigation)
- Design token compliance (no arbitrary values)

## Test plan
- [x] Component tests pass
- [ ] Manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)