### PR TITLE
feat(ui): add empty component

### DIFF
--- a/packages/ui/src/components/ui/empty.tsx
+++ b/packages/ui/src/components/ui/empty.tsx
@@ -1,0 +1,148 @@
+/**
+ * Empty state display for when there's no content to show
+ *
+ * @cognitive-load 2/10 - Simple informational display with clear next steps
+ * @attention-economics Supportive element: Fills void without demanding attention, guides to action
+ * @trust-building Honest communication about empty state builds trust; actionable guidance reduces frustration
+ * @accessibility Clear heading hierarchy; actionable elements are keyboard accessible
+ * @semantic-meaning State communication: empty search results, no items yet, cleared list, filtered to nothing
+ *
+ * @usage-patterns
+ * DO: Provide actionable next steps when possible
+ * DO: Explain why the state is empty (no results, no items yet, etc.)
+ * DO: Use appropriate illustrations to soften the empty state
+ * DO: Match tone to context (playful for personal apps, professional for business)
+ * NEVER: Leave empty states blank
+ * NEVER: Use generic "No data" without context
+ * NEVER: Make users feel like something is broken
+ *
+ * @example
+ * ```tsx
+ * // Empty search results
+ * <Empty>
+ *   <EmptyIcon>
+ *     <SearchIcon />
+ *   </EmptyIcon>
+ *   <EmptyTitle>No results found</EmptyTitle>
+ *   <EmptyDescription>
+ *     Try adjusting your search terms or filters.
+ *   </EmptyDescription>
+ *   <EmptyAction>
+ *     <Button variant="outline" onClick={clearFilters}>
+ *       Clear filters
+ *     </Button>
+ *   </EmptyAction>
+ * </Empty>
+ *
+ * // Empty list (first time)
+ * <Empty>
+ *   <EmptyIcon>
+ *     <FolderIcon />
+ *   </EmptyIcon>
+ *   <EmptyTitle>No projects yet</EmptyTitle>
+ *   <EmptyDescription>
+ *     Create your first project to get started.
+ *   </EmptyDescription>
+ *   <EmptyAction>
+ *     <Button>Create project</Button>
+ *   </EmptyAction>
+ * </Empty>
+ *
+ * // Informational only (no action)
+ * <Empty>
+ *   <EmptyIcon>
+ *     <InboxIcon />
+ *   </EmptyIcon>
+ *   <EmptyTitle>All caught up!</EmptyTitle>
+ *   <EmptyDescription>
+ *     No new notifications.
+ *   </EmptyDescription>
+ * </Empty>
+ * ```
+ */
+import * as React from 'react';
+import classy from '../../primitives/classy';
+
+export interface EmptyProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export interface EmptyIconProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export interface EmptyTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {}
+
+export interface EmptyDescriptionProps extends React.HTMLAttributes<HTMLParagraphElement> {}
+
+export interface EmptyActionProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const Empty = React.forwardRef<HTMLDivElement, EmptyProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={classy(
+          'flex flex-col items-center justify-center py-12 text-center',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+Empty.displayName = 'Empty';
+
+export const EmptyIcon = React.forwardRef<HTMLDivElement, EmptyIconProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={classy('mb-4 text-muted-foreground [&>svg]:h-12 [&>svg]:w-12', className)}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+EmptyIcon.displayName = 'EmptyIcon';
+
+export const EmptyTitle = React.forwardRef<HTMLHeadingElement, EmptyTitleProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <h3
+        ref={ref}
+        className={classy('mb-2 text-lg font-semibold text-foreground', className)}
+        {...props}
+      >
+        {children}
+      </h3>
+    );
+  },
+);
+EmptyTitle.displayName = 'EmptyTitle';
+
+export const EmptyDescription = React.forwardRef<HTMLParagraphElement, EmptyDescriptionProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <p
+        ref={ref}
+        className={classy('mb-4 max-w-sm text-sm text-muted-foreground', className)}
+        {...props}
+      >
+        {children}
+      </p>
+    );
+  },
+);
+EmptyDescription.displayName = 'EmptyDescription';
+
+export const EmptyAction = React.forwardRef<HTMLDivElement, EmptyActionProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <div ref={ref} className={classy('mt-2', className)} {...props}>
+        {children}
+      </div>
+    );
+  },
+);
+EmptyAction.displayName = 'EmptyAction';

--- a/packages/ui/test/components/empty.a11y.tsx
+++ b/packages/ui/test/components/empty.a11y.tsx
@@ -1,0 +1,206 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import {
+  Empty,
+  EmptyAction,
+  EmptyDescription,
+  EmptyIcon,
+  EmptyTitle,
+} from '../../src/components/ui/empty';
+
+describe('Empty - Accessibility', () => {
+  it('has no accessibility violations with default props', async () => {
+    const { container } = render(
+      <Empty>
+        <EmptyTitle>No results</EmptyTitle>
+      </Empty>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with complete empty state', async () => {
+    const { container } = render(
+      <Empty>
+        <EmptyIcon aria-hidden="true">
+          <svg viewBox="0 0 24 24" width="48" height="48">
+            <circle cx="12" cy="12" r="10" />
+          </svg>
+        </EmptyIcon>
+        <EmptyTitle>No results found</EmptyTitle>
+        <EmptyDescription>
+          Try adjusting your search terms or filters.
+        </EmptyDescription>
+        <EmptyAction>
+          <button type="button">Clear filters</button>
+        </EmptyAction>
+      </Empty>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations without action (informational only)', async () => {
+    const { container } = render(
+      <Empty>
+        <EmptyIcon aria-hidden="true">
+          <svg viewBox="0 0 24 24" width="48" height="48">
+            <path d="M12 2L2 7v10l10 5 10-5V7z" />
+          </svg>
+        </EmptyIcon>
+        <EmptyTitle>All caught up!</EmptyTitle>
+        <EmptyDescription>No new notifications.</EmptyDescription>
+      </Empty>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with multiple action buttons', async () => {
+    const { container } = render(
+      <Empty>
+        <EmptyTitle>No projects yet</EmptyTitle>
+        <EmptyDescription>Create your first project to get started.</EmptyDescription>
+        <EmptyAction>
+          <button type="button">Create project</button>
+          <button type="button">Import project</button>
+        </EmptyAction>
+      </Empty>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with link action', async () => {
+    const { container } = render(
+      <Empty>
+        <EmptyTitle>Page not found</EmptyTitle>
+        <EmptyDescription>The page you are looking for does not exist.</EmptyDescription>
+        <EmptyAction>
+          <a href="/">Go back home</a>
+        </EmptyAction>
+      </Empty>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with custom aria attributes', async () => {
+    const { container } = render(
+      <Empty role="status" aria-live="polite">
+        <EmptyTitle>Search complete</EmptyTitle>
+        <EmptyDescription>No matches found for your query.</EmptyDescription>
+      </Empty>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations in a list context', async () => {
+    const { container } = render(
+      <div role="list" aria-label="Projects list">
+        <Empty>
+          <EmptyTitle>No projects</EmptyTitle>
+          <EmptyDescription>Create a new project to get started.</EmptyDescription>
+          <EmptyAction>
+            <button type="button">Create project</button>
+          </EmptyAction>
+        </Empty>
+      </div>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with descriptive icon', async () => {
+    const { container } = render(
+      <Empty>
+        <EmptyIcon>
+          <svg
+            viewBox="0 0 24 24"
+            width="48"
+            height="48"
+            role="img"
+            aria-label="Empty inbox"
+          >
+            <rect x="2" y="4" width="20" height="16" rx="2" />
+            <path d="M22 7L12 13L2 7" />
+          </svg>
+        </EmptyIcon>
+        <EmptyTitle>Inbox is empty</EmptyTitle>
+        <EmptyDescription>New messages will appear here.</EmptyDescription>
+      </Empty>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations when used inside a main landmark', async () => {
+    const { container } = render(
+      <main>
+        <h1>Search Results</h1>
+        <Empty>
+          <EmptyTitle>No results</EmptyTitle>
+          <EmptyDescription>Try a different search term.</EmptyDescription>
+        </Empty>
+      </main>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('EmptyIcon - Accessibility', () => {
+  it('has no accessibility violations with decorative icon', async () => {
+    const { container } = render(
+      <EmptyIcon aria-hidden="true">
+        <svg viewBox="0 0 24 24" width="48" height="48">
+          <circle cx="12" cy="12" r="10" />
+        </svg>
+      </EmptyIcon>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('EmptyTitle - Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(<EmptyTitle>Empty State Title</EmptyTitle>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('EmptyDescription - Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <EmptyDescription>Description of the empty state.</EmptyDescription>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('EmptyAction - Accessibility', () => {
+  it('has no accessibility violations with button', async () => {
+    const { container } = render(
+      <EmptyAction>
+        <button type="button">Take Action</button>
+      </EmptyAction>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no accessibility violations with link', async () => {
+    const { container } = render(
+      <EmptyAction>
+        <a href="/create">Create new item</a>
+      </EmptyAction>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/ui/test/components/empty.test.tsx
+++ b/packages/ui/test/components/empty.test.tsx
@@ -1,0 +1,320 @@
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import { describe, expect, it } from 'vitest';
+import {
+  Empty,
+  EmptyAction,
+  EmptyDescription,
+  EmptyIcon,
+  EmptyTitle,
+} from '../../src/components/ui/empty';
+
+describe('Empty', () => {
+  it('renders with default props', () => {
+    render(<Empty data-testid="empty">Empty content</Empty>);
+    const empty = screen.getByTestId('empty');
+    expect(empty).toBeInTheDocument();
+    expect(empty.tagName).toBe('DIV');
+  });
+
+  it('applies base styles', () => {
+    const { container } = render(<Empty>Content</Empty>);
+    const empty = container.firstChild;
+    expect(empty).toHaveClass('flex');
+    expect(empty).toHaveClass('flex-col');
+    expect(empty).toHaveClass('items-center');
+    expect(empty).toHaveClass('justify-center');
+    expect(empty).toHaveClass('py-12');
+    expect(empty).toHaveClass('text-center');
+  });
+
+  it('renders children', () => {
+    render(
+      <Empty>
+        <span data-testid="child">Child content</span>
+      </Empty>,
+    );
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<Empty className="custom-class">Content</Empty>);
+    expect(container.firstChild).toHaveClass('custom-class');
+    expect(container.firstChild).toHaveClass('flex');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(<Empty ref={ref}>Content</Empty>);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('passes through HTML attributes', () => {
+    render(
+      <Empty data-testid="empty" aria-label="Empty state" id="empty-container">
+        Content
+      </Empty>,
+    );
+    const empty = screen.getByTestId('empty');
+    expect(empty).toHaveAttribute('aria-label', 'Empty state');
+    expect(empty).toHaveAttribute('id', 'empty-container');
+  });
+});
+
+describe('EmptyIcon', () => {
+  it('renders with default styles', () => {
+    const { container } = render(
+      <EmptyIcon>
+        <svg data-testid="icon" />
+      </EmptyIcon>,
+    );
+    const icon = container.firstChild;
+    expect(icon).toHaveClass('mb-4');
+    expect(icon).toHaveClass('text-muted-foreground');
+  });
+
+  it('renders children', () => {
+    render(
+      <EmptyIcon>
+        <svg data-testid="icon" />
+      </EmptyIcon>,
+    );
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(
+      <EmptyIcon className="custom-icon">
+        <svg />
+      </EmptyIcon>,
+    );
+    expect(container.firstChild).toHaveClass('custom-icon');
+    expect(container.firstChild).toHaveClass('mb-4');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <EmptyIcon ref={ref}>
+        <svg />
+      </EmptyIcon>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('passes through HTML attributes', () => {
+    render(
+      <EmptyIcon data-testid="icon-container" aria-hidden="true">
+        <svg />
+      </EmptyIcon>,
+    );
+    const icon = screen.getByTestId('icon-container');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+  });
+});
+
+describe('EmptyTitle', () => {
+  it('renders as h3 by default', () => {
+    render(<EmptyTitle data-testid="title">Title</EmptyTitle>);
+    const title = screen.getByTestId('title');
+    expect(title.tagName).toBe('H3');
+  });
+
+  it('applies default styles', () => {
+    const { container } = render(<EmptyTitle>Title</EmptyTitle>);
+    const title = container.firstChild;
+    expect(title).toHaveClass('mb-2');
+    expect(title).toHaveClass('text-lg');
+    expect(title).toHaveClass('font-semibold');
+    expect(title).toHaveClass('text-foreground');
+  });
+
+  it('renders children', () => {
+    render(<EmptyTitle>No results found</EmptyTitle>);
+    expect(screen.getByText('No results found')).toBeInTheDocument();
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<EmptyTitle className="custom-title">Title</EmptyTitle>);
+    expect(container.firstChild).toHaveClass('custom-title');
+    expect(container.firstChild).toHaveClass('text-lg');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLHeadingElement>();
+    render(<EmptyTitle ref={ref}>Title</EmptyTitle>);
+    expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
+  });
+
+  it('passes through HTML attributes', () => {
+    render(
+      <EmptyTitle data-testid="title" id="empty-title">
+        Title
+      </EmptyTitle>,
+    );
+    const title = screen.getByTestId('title');
+    expect(title).toHaveAttribute('id', 'empty-title');
+  });
+});
+
+describe('EmptyDescription', () => {
+  it('renders as paragraph', () => {
+    render(<EmptyDescription data-testid="desc">Description</EmptyDescription>);
+    const desc = screen.getByTestId('desc');
+    expect(desc.tagName).toBe('P');
+  });
+
+  it('applies default styles', () => {
+    const { container } = render(<EmptyDescription>Description</EmptyDescription>);
+    const desc = container.firstChild;
+    expect(desc).toHaveClass('mb-4');
+    expect(desc).toHaveClass('max-w-sm');
+    expect(desc).toHaveClass('text-sm');
+    expect(desc).toHaveClass('text-muted-foreground');
+  });
+
+  it('renders children', () => {
+    render(<EmptyDescription>Try adjusting your search.</EmptyDescription>);
+    expect(screen.getByText('Try adjusting your search.')).toBeInTheDocument();
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(
+      <EmptyDescription className="custom-desc">Description</EmptyDescription>,
+    );
+    expect(container.firstChild).toHaveClass('custom-desc');
+    expect(container.firstChild).toHaveClass('text-sm');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLParagraphElement>();
+    render(<EmptyDescription ref={ref}>Description</EmptyDescription>);
+    expect(ref.current).toBeInstanceOf(HTMLParagraphElement);
+  });
+
+  it('passes through HTML attributes', () => {
+    render(
+      <EmptyDescription data-testid="desc" id="empty-desc">
+        Description
+      </EmptyDescription>,
+    );
+    const desc = screen.getByTestId('desc');
+    expect(desc).toHaveAttribute('id', 'empty-desc');
+  });
+});
+
+describe('EmptyAction', () => {
+  it('renders with default styles', () => {
+    const { container } = render(
+      <EmptyAction>
+        <button type="button">Action</button>
+      </EmptyAction>,
+    );
+    const action = container.firstChild;
+    expect(action).toHaveClass('mt-2');
+  });
+
+  it('renders children', () => {
+    render(
+      <EmptyAction>
+        <button type="button" data-testid="action-button">
+          Create Project
+        </button>
+      </EmptyAction>,
+    );
+    expect(screen.getByTestId('action-button')).toBeInTheDocument();
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(
+      <EmptyAction className="custom-action">
+        <button type="button">Action</button>
+      </EmptyAction>,
+    );
+    expect(container.firstChild).toHaveClass('custom-action');
+    expect(container.firstChild).toHaveClass('mt-2');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <EmptyAction ref={ref}>
+        <button type="button">Action</button>
+      </EmptyAction>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('passes through HTML attributes', () => {
+    render(
+      <EmptyAction data-testid="action" role="group">
+        <button type="button">Action</button>
+      </EmptyAction>,
+    );
+    const action = screen.getByTestId('action');
+    expect(action).toHaveAttribute('role', 'group');
+  });
+});
+
+describe('Empty composition', () => {
+  it('renders a complete empty state with all subcomponents', () => {
+    render(
+      <Empty data-testid="empty">
+        <EmptyIcon data-testid="icon">
+          <svg aria-hidden="true" />
+        </EmptyIcon>
+        <EmptyTitle data-testid="title">No results found</EmptyTitle>
+        <EmptyDescription data-testid="desc">
+          Try adjusting your search terms or filters.
+        </EmptyDescription>
+        <EmptyAction data-testid="action">
+          <button type="button">Clear filters</button>
+        </EmptyAction>
+      </Empty>,
+    );
+
+    expect(screen.getByTestId('empty')).toBeInTheDocument();
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+    expect(screen.getByTestId('title')).toHaveTextContent('No results found');
+    expect(screen.getByTestId('desc')).toHaveTextContent(
+      'Try adjusting your search terms or filters.',
+    );
+    expect(screen.getByTestId('action')).toBeInTheDocument();
+  });
+
+  it('renders without action (informational only)', () => {
+    render(
+      <Empty data-testid="empty">
+        <EmptyIcon>
+          <svg aria-hidden="true" />
+        </EmptyIcon>
+        <EmptyTitle>All caught up!</EmptyTitle>
+        <EmptyDescription>No new notifications.</EmptyDescription>
+      </Empty>,
+    );
+
+    expect(screen.getByTestId('empty')).toBeInTheDocument();
+    expect(screen.getByText('All caught up!')).toBeInTheDocument();
+    expect(screen.getByText('No new notifications.')).toBeInTheDocument();
+  });
+
+  it('renders with multiple action buttons', () => {
+    render(
+      <Empty>
+        <EmptyTitle>No projects yet</EmptyTitle>
+        <EmptyDescription>Create your first project to get started.</EmptyDescription>
+        <EmptyAction>
+          <button type="button" data-testid="primary-action">
+            Create project
+          </button>
+          <button type="button" data-testid="secondary-action">
+            Import project
+          </button>
+        </EmptyAction>
+      </Empty>,
+    );
+
+    expect(screen.getByTestId('primary-action')).toBeInTheDocument();
+    expect(screen.getByTestId('secondary-action')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `empty` component with shadcn API parity.

### Features
- JSDoc intelligence blocks (@cognitive-load, @attention-economics, etc.)
- Unit tests
- Accessibility support (ARIA, keyboard navigation)
- Design token compliance (no arbitrary values)

## Test plan
- [x] Component tests pass
- [ ] Manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)