### PR TITLE
feat(ui): add field component

### DIFF
--- a/packages/ui/src/components/ui/field.tsx
+++ b/packages/ui/src/components/ui/field.tsx
@@ -1,0 +1,151 @@
+/**
+ * Form field wrapper that composes Label, input slot, and helper text
+ *
+ * @cognitive-load 3/10 - Familiar form pattern with clear visual hierarchy
+ * @attention-economics Information hierarchy: label=field identity, input=action area, description=guidance, error=requires attention
+ * @trust-building Clear labeling reduces uncertainty, helpful descriptions guide input, non-punitive error messaging
+ * @accessibility Automatic label-input association via htmlFor/id, aria-describedby for helper text, error announcements
+ * @semantic-meaning Field states: default=ready, error=validation failed, disabled=unavailable
+ *
+ * @usage-patterns
+ * DO: Always provide a label for form fields
+ * DO: Use description for format hints or requirements
+ * DO: Use error state with clear, actionable messages
+ * DO: Generate consistent IDs for accessibility associations
+ * NEVER: Leave inputs without associated labels
+ * NEVER: Use error styling without error messages
+ * NEVER: Stack multiple Field components without spacing
+ *
+ * @example
+ * ```tsx
+ * // Basic field with description
+ * <Field label="Email" description="We'll never share your email">
+ *   <Input type="email" />
+ * </Field>
+ *
+ * // Field with error state
+ * <Field label="Password" error="Password must be at least 8 characters">
+ *   <Input type="password" />
+ * </Field>
+ *
+ * // Required field
+ * <Field label="Username" required>
+ *   <Input />
+ * </Field>
+ *
+ * // With custom ID
+ * <Field label="Name" id="user-name">
+ *   <Input />
+ * </Field>
+ * ```
+ */
+import * as React from 'react';
+import classy from '../../primitives/classy';
+import { Label } from './label';
+
+export interface FieldProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Field label text */
+  label: React.ReactNode;
+  /** Optional description/hint text shown below input */
+  description?: React.ReactNode;
+  /** Error message - when provided, field enters error state */
+  error?: React.ReactNode;
+  /** Whether the field is required */
+  required?: boolean;
+  /** Whether the field is disabled */
+  disabled?: boolean;
+  /** Custom ID for the field - used to connect label, input, and descriptions */
+  id?: string;
+  /** The form control (Input, Select, Textarea, etc.) */
+  children: React.ReactNode;
+}
+
+// Simple counter for generating unique IDs
+let fieldIdCounter = 0;
+
+function useFieldId(providedId?: string): string {
+  const generatedId = React.useMemo(() => {
+    if (providedId) return providedId;
+    fieldIdCounter += 1;
+    return `field-${fieldIdCounter}`;
+  }, [providedId]);
+
+  return generatedId;
+}
+
+export const Field = React.forwardRef<HTMLDivElement, FieldProps>(
+  (
+    {
+      className,
+      label,
+      description,
+      error,
+      required,
+      disabled,
+      id: providedId,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const fieldId = useFieldId(providedId);
+    const inputId = fieldId;
+    const descriptionId = description ? `${fieldId}-description` : undefined;
+    const errorId = error ? `${fieldId}-error` : undefined;
+
+    // Determine aria-describedby value
+    const ariaDescribedBy = [errorId, descriptionId].filter(Boolean).join(' ') || undefined;
+
+    // Clone child to inject accessibility props
+    const enhancedChildren = React.Children.map(children, (child) => {
+      if (!React.isValidElement(child)) return child;
+
+      // Type assertion for element props
+      const childProps = child.props as Record<string, unknown>;
+
+      return React.cloneElement(child as React.ReactElement<Record<string, unknown>>, {
+        id: (childProps.id as string | undefined) ?? inputId,
+        'aria-describedby':
+          (childProps['aria-describedby'] as string | undefined) ?? ariaDescribedBy,
+        'aria-invalid': error ? 'true' : undefined,
+        'aria-required': required ? 'true' : undefined,
+        disabled: (childProps.disabled as boolean | undefined) ?? disabled,
+      });
+    });
+
+    const baseClasses = 'flex flex-col gap-2';
+
+    const cls = classy(baseClasses, className);
+
+    return (
+      <div ref={ref} className={cls} {...props}>
+        <Label htmlFor={inputId} className={disabled ? 'opacity-50' : undefined}>
+          {label}
+          {required && (
+            <span className="text-destructive ml-1" aria-hidden="true">
+              *
+            </span>
+          )}
+        </Label>
+
+        {enhancedChildren}
+
+        {description && !error && (
+          <p id={descriptionId} className="text-sm text-muted-foreground">
+            {description}
+          </p>
+        )}
+
+        {error && (
+          <p id={errorId} className="text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+    );
+  },
+);
+
+Field.displayName = 'Field';
+
+export default Field;

--- a/packages/ui/test/components/field.a11y.tsx
+++ b/packages/ui/test/components/field.a11y.tsx
@@ -1,0 +1,251 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import { Field } from '../../src/components/ui/field';
+import { Input } from '../../src/components/ui/input';
+
+describe('Field - Accessibility', () => {
+  it('has no accessibility violations with basic usage', async () => {
+    const { container } = render(
+      <Field label="Email">
+        <Input type="email" />
+      </Field>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with required field', async () => {
+    const { container } = render(
+      <Field label="Username" required>
+        <Input />
+      </Field>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with description', async () => {
+    const { container } = render(
+      <Field label="Password" description="Must be at least 8 characters">
+        <Input type="password" />
+      </Field>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with error state', async () => {
+    const { container } = render(
+      <Field label="Email" error="Invalid email address">
+        <Input type="email" />
+      </Field>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with disabled state', async () => {
+    const { container } = render(
+      <Field label="Disabled Field" disabled>
+        <Input />
+      </Field>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with all features combined', async () => {
+    const { container } = render(
+      <Field
+        label="Full Name"
+        description="Enter your legal name"
+        required
+        id="full-name"
+      >
+        <Input />
+      </Field>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with error and description combined', async () => {
+    const { container } = render(
+      <Field
+        label="Email"
+        description="We will never share your email"
+        error="Please enter a valid email"
+      >
+        <Input type="email" />
+      </Field>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations in a form context', async () => {
+    const { container } = render(
+      <form>
+        <Field label="First Name" required>
+          <Input />
+        </Field>
+        <Field label="Last Name" required>
+          <Input />
+        </Field>
+        <Field label="Email" description="For account recovery">
+          <Input type="email" />
+        </Field>
+        <button type="submit">Submit</button>
+      </form>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with custom ID', async () => {
+    const { container } = render(
+      <Field label="Custom ID Field" id="custom-field-id">
+        <Input />
+      </Field>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with native input element', async () => {
+    const { container } = render(
+      <Field label="Native Input">
+        <input type="text" />
+      </Field>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with textarea', async () => {
+    const { container } = render(
+      <Field label="Comments" description="Optional feedback">
+        <textarea />
+      </Field>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with select element', async () => {
+    const { container } = render(
+      <Field label="Country">
+        <select>
+          <option value="">Select a country</option>
+          <option value="us">United States</option>
+          <option value="uk">United Kingdom</option>
+        </select>
+      </Field>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with password input and error', async () => {
+    const { container } = render(
+      <Field
+        label="Password"
+        description="Must contain uppercase, lowercase, and numbers"
+        error="Password does not meet requirements"
+        required
+      >
+        <Input type="password" />
+      </Field>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with multiple fields in fieldset', async () => {
+    const { container } = render(
+      <fieldset>
+        <legend>Contact Information</legend>
+        <Field label="Phone" description="Including country code">
+          <Input type="tel" />
+        </Field>
+        <Field label="Address">
+          <Input />
+        </Field>
+        <Field label="City" required>
+          <Input />
+        </Field>
+      </fieldset>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with aria attributes on container', async () => {
+    const { container } = render(
+      <Field
+        label="Accessible Field"
+        aria-label="Custom aria label"
+        data-testid="accessible-field"
+      >
+        <Input />
+      </Field>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('Field - Accessibility associations', () => {
+  it('properly associates label with input', async () => {
+    const { container, getByText, getByRole } = render(
+      <Field label="Labeled Input" id="labeled-input">
+        <Input />
+      </Field>,
+    );
+
+    const label = getByText('Labeled Input');
+    const input = getByRole('textbox');
+
+    expect(label).toHaveAttribute('for', 'labeled-input');
+    expect(input).toHaveAttribute('id', 'labeled-input');
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('properly associates description with input', async () => {
+    const { container, getByRole, getByText } = render(
+      <Field label="With Description" description="This is helpful" id="desc-field">
+        <Input />
+      </Field>,
+    );
+
+    const input = getByRole('textbox');
+    const description = getByText('This is helpful');
+
+    expect(input).toHaveAttribute('aria-describedby', 'desc-field-description');
+    expect(description).toHaveAttribute('id', 'desc-field-description');
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('properly associates error with input', async () => {
+    const { container, getByRole } = render(
+      <Field label="With Error" error="This is an error" id="error-field">
+        <Input />
+      </Field>,
+    );
+
+    const input = getByRole('textbox');
+    const error = getByRole('alert');
+
+    expect(input).toHaveAttribute('aria-describedby', 'error-field-error');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(error).toHaveAttribute('id', 'error-field-error');
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/ui/test/components/field.test.tsx
+++ b/packages/ui/test/components/field.test.tsx
@@ -1,0 +1,366 @@
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import { describe, expect, it } from 'vitest';
+import { Field } from '../../src/components/ui/field';
+import { Input } from '../../src/components/ui/input';
+
+describe('Field', () => {
+  it('renders with label and children', () => {
+    render(
+      <Field label="Email">
+        <Input type="email" />
+      </Field>,
+    );
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('renders as a div element', () => {
+    const { container } = render(
+      <Field label="Name">
+        <Input />
+      </Field>,
+    );
+    expect(container.firstChild?.nodeName).toBe('DIV');
+  });
+
+  it('applies base layout classes', () => {
+    const { container } = render(
+      <Field label="Username">
+        <Input />
+      </Field>,
+    );
+    const field = container.firstChild;
+    expect(field).toHaveClass('flex');
+    expect(field).toHaveClass('flex-col');
+    expect(field).toHaveClass('gap-2');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(
+      <Field label="Custom" className="custom-class">
+        <Input />
+      </Field>,
+    );
+    expect(container.firstChild).toHaveClass('custom-class');
+    expect(container.firstChild).toHaveClass('flex');
+  });
+
+  it('forwards ref to container div', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <Field ref={ref} label="With Ref">
+        <Input />
+      </Field>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('passes through HTML attributes', () => {
+    render(
+      <Field data-testid="field" aria-label="Form field" label="Test">
+        <Input />
+      </Field>,
+    );
+    const field = screen.getByTestId('field');
+    expect(field).toHaveAttribute('aria-label', 'Form field');
+  });
+});
+
+describe('Field - Label association', () => {
+  it('associates label with input via generated ID', () => {
+    render(
+      <Field label="Generated ID">
+        <Input />
+      </Field>,
+    );
+    const label = screen.getByText('Generated ID');
+    const input = screen.getByRole('textbox');
+    expect(label).toHaveAttribute('for');
+    expect(input).toHaveAttribute('id', label.getAttribute('for'));
+  });
+
+  it('uses custom ID when provided', () => {
+    render(
+      <Field label="Custom ID" id="my-custom-id">
+        <Input />
+      </Field>,
+    );
+    const label = screen.getByText('Custom ID');
+    const input = screen.getByRole('textbox');
+    expect(label).toHaveAttribute('for', 'my-custom-id');
+    expect(input).toHaveAttribute('id', 'my-custom-id');
+  });
+
+  it('preserves child ID if already set', () => {
+    render(
+      <Field label="Existing ID">
+        <Input id="existing-input-id" />
+      </Field>,
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('id', 'existing-input-id');
+  });
+});
+
+describe('Field - Required state', () => {
+  it('shows required indicator when required prop is true', () => {
+    render(
+      <Field label="Required Field" required>
+        <Input />
+      </Field>,
+    );
+    expect(screen.getByText('*')).toBeInTheDocument();
+  });
+
+  it('hides required indicator with aria-hidden', () => {
+    render(
+      <Field label="Required Field" required>
+        <Input />
+      </Field>,
+    );
+    const asterisk = screen.getByText('*');
+    expect(asterisk).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('applies destructive color to required indicator', () => {
+    render(
+      <Field label="Required Field" required>
+        <Input />
+      </Field>,
+    );
+    const asterisk = screen.getByText('*');
+    expect(asterisk).toHaveClass('text-destructive');
+  });
+
+  it('sets aria-required on input when required', () => {
+    render(
+      <Field label="Required Input" required>
+        <Input />
+      </Field>,
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-required', 'true');
+  });
+
+  it('does not show indicator when not required', () => {
+    render(
+      <Field label="Optional Field">
+        <Input />
+      </Field>,
+    );
+    expect(screen.queryByText('*')).not.toBeInTheDocument();
+  });
+});
+
+describe('Field - Description', () => {
+  it('renders description text', () => {
+    render(
+      <Field label="Email" description="We will never share your email">
+        <Input type="email" />
+      </Field>,
+    );
+    expect(screen.getByText('We will never share your email')).toBeInTheDocument();
+  });
+
+  it('applies muted text styling to description', () => {
+    render(
+      <Field label="Email" description="Help text">
+        <Input />
+      </Field>,
+    );
+    const description = screen.getByText('Help text');
+    expect(description).toHaveClass('text-sm');
+    expect(description).toHaveClass('text-muted-foreground');
+  });
+
+  it('renders description as paragraph', () => {
+    render(
+      <Field label="Email" description="Help text">
+        <Input />
+      </Field>,
+    );
+    const description = screen.getByText('Help text');
+    expect(description.tagName).toBe('P');
+  });
+
+  it('connects input to description via aria-describedby', () => {
+    render(
+      <Field label="Email" description="Format hint" id="email-field">
+        <Input />
+      </Field>,
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-describedby', 'email-field-description');
+  });
+});
+
+describe('Field - Error state', () => {
+  it('renders error message', () => {
+    render(
+      <Field label="Password" error="Password is required">
+        <Input type="password" />
+      </Field>,
+    );
+    expect(screen.getByText('Password is required')).toBeInTheDocument();
+  });
+
+  it('applies destructive styling to error message', () => {
+    render(
+      <Field label="Password" error="Invalid password">
+        <Input />
+      </Field>,
+    );
+    const error = screen.getByText('Invalid password');
+    expect(error).toHaveClass('text-sm');
+    expect(error).toHaveClass('text-destructive');
+  });
+
+  it('renders error as paragraph with role="alert"', () => {
+    render(
+      <Field label="Password" error="Error message">
+        <Input />
+      </Field>,
+    );
+    const error = screen.getByRole('alert');
+    expect(error).toHaveTextContent('Error message');
+    expect(error.tagName).toBe('P');
+  });
+
+  it('sets aria-invalid on input when error is present', () => {
+    render(
+      <Field label="Email" error="Invalid email">
+        <Input />
+      </Field>,
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('connects input to error via aria-describedby', () => {
+    render(
+      <Field label="Email" error="Error text" id="email-field">
+        <Input />
+      </Field>,
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-describedby', 'email-field-error');
+  });
+
+  it('prioritizes error over description in display', () => {
+    render(
+      <Field label="Email" description="Help text" error="Error text">
+        <Input />
+      </Field>,
+    );
+    expect(screen.getByText('Error text')).toBeInTheDocument();
+    expect(screen.queryByText('Help text')).not.toBeInTheDocument();
+  });
+
+  it('includes both error and description in aria-describedby when both exist', () => {
+    render(
+      <Field label="Email" description="Help text" error="Error text" id="email-field">
+        <Input />
+      </Field>,
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute(
+      'aria-describedby',
+      'email-field-error email-field-description',
+    );
+  });
+});
+
+describe('Field - Disabled state', () => {
+  it('passes disabled prop to child input', () => {
+    render(
+      <Field label="Disabled Field" disabled>
+        <Input />
+      </Field>,
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).toBeDisabled();
+  });
+
+  it('applies opacity to label when disabled', () => {
+    render(
+      <Field label="Disabled Field" disabled>
+        <Input />
+      </Field>,
+    );
+    const label = screen.getByText('Disabled Field');
+    expect(label).toHaveClass('opacity-50');
+  });
+
+  it('does not override child disabled prop if already set', () => {
+    render(
+      <Field label="Field">
+        <Input disabled />
+      </Field>,
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).toBeDisabled();
+  });
+});
+
+describe('Field - Multiple children', () => {
+  it('enhances first valid element child', () => {
+    render(
+      <Field label="Multi">
+        <Input data-testid="input" />
+      </Field>,
+    );
+    const input = screen.getByTestId('input');
+    expect(input).toHaveAttribute('id');
+  });
+
+  it('handles non-element children gracefully', () => {
+    render(
+      <Field label="With Text">
+        Some text
+        <Input data-testid="input" />
+      </Field>,
+    );
+    expect(screen.getByTestId('input')).toBeInTheDocument();
+  });
+});
+
+describe('Field - Composition', () => {
+  it('works with different input types', () => {
+    render(
+      <Field label="Password" required error="Too weak">
+        <input type="password" data-testid="password-input" />
+      </Field>,
+    );
+
+    const input = screen.getByTestId('password-input');
+    expect(input).toHaveAttribute('aria-required', 'true');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('renders complete field with all features', () => {
+    render(
+      <Field
+        label="Email Address"
+        description="We will never share your email"
+        required
+        id="complete-field"
+        data-testid="complete-field"
+      >
+        <Input type="email" />
+      </Field>,
+    );
+
+    // Check structure
+    expect(screen.getByTestId('complete-field')).toBeInTheDocument();
+    expect(screen.getByText('Email Address')).toBeInTheDocument();
+    expect(screen.getByText('*')).toBeInTheDocument();
+    expect(screen.getByText('We will never share your email')).toBeInTheDocument();
+
+    // Check associations
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('id', 'complete-field');
+    expect(input).toHaveAttribute('aria-describedby', 'complete-field-description');
+    expect(input).toHaveAttribute('aria-required', 'true');
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `field` component with shadcn API parity.

### Features
- JSDoc intelligence blocks (@cognitive-load, @attention-economics, etc.)
- Unit tests
- Accessibility support (ARIA, keyboard navigation)
- Design token compliance (no arbitrary values)

## Test plan
- [x] Component tests pass
- [ ] Manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)