### PR TITLE
feat(ui): add input-group component

### DIFF
--- a/packages/ui/src/components/ui/input-group.tsx
+++ b/packages/ui/src/components/ui/input-group.tsx
@@ -1,0 +1,155 @@
+/**
+ * InputGroup combines an input with visual addons (icons, buttons, text) for enhanced form UX
+ *
+ * @cognitive-load 4/10 - Composite input control with clear addon boundaries and input focus
+ * @attention-economics Visual hierarchy: addons=contextual, input=primary focus. Addons should clarify input purpose without competing for attention
+ * @trust-building Clear boundaries between addons and input, consistent sizing, proper focus management across the group
+ * @accessibility Focus ring wraps entire group, addons support aria-label for screen readers, keyboard navigation preserved
+ * @semantic-meaning Start addons=prefixes (currency symbols, icons), end addons=suffixes (units, action buttons)
+ *
+ * @usage-patterns
+ * DO: Use start addon for input type indicators (search icon, currency symbol)
+ * DO: Use end addon for units, clear buttons, or submit actions
+ * DO: Keep addons visually lightweight to not overshadow input
+ * DO: Ensure addons have proper accessibility labels when using icons
+ * NEVER: Use addons without semantic meaning
+ * NEVER: Place primary actions in addons (use a separate button instead)
+ * NEVER: Nest input groups
+ *
+ * @example
+ * ```tsx
+ * // Search input with icon
+ * <InputGroup>
+ *   <InputGroupAddon position="start">
+ *     <SearchIcon aria-hidden />
+ *   </InputGroupAddon>
+ *   <Input placeholder="Search..." aria-label="Search" />
+ * </InputGroup>
+ *
+ * // Price input with currency and unit
+ * <InputGroup>
+ *   <InputGroupAddon position="start">$</InputGroupAddon>
+ *   <Input type="number" placeholder="0.00" />
+ *   <InputGroupAddon position="end">USD</InputGroupAddon>
+ * </InputGroup>
+ *
+ * // Input with button addon
+ * <InputGroup>
+ *   <Input placeholder="Enter code" />
+ *   <InputGroupAddon position="end">
+ *     <Button size="sm" variant="ghost">Apply</Button>
+ *   </InputGroupAddon>
+ * </InputGroup>
+ * ```
+ */
+import * as React from 'react';
+import classy from '../../primitives/classy';
+
+export interface InputGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Size variant matching Input component sizing
+   */
+  size?: 'default' | 'sm' | 'lg';
+  /**
+   * Disabled state for the entire group
+   */
+  disabled?: boolean;
+}
+
+const sizeClasses: Record<string, string> = {
+  default: 'h-10',
+  sm: 'h-9 text-sm',
+  lg: 'h-11',
+};
+
+export const InputGroup = React.forwardRef<HTMLDivElement, InputGroupProps>(
+  ({ size = 'default', disabled, className, children, ...props }, ref) => {
+    const base =
+      'flex items-center w-full rounded-md border border-input bg-background ' +
+      'ring-offset-background ' +
+      'focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2';
+
+    const cls = classy(base, sizeClasses[size] ?? sizeClasses.default, disabled && 'opacity-50 cursor-not-allowed', className);
+
+    return (
+      <div
+        ref={ref}
+        className={cls}
+        data-disabled={disabled || undefined}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+InputGroup.displayName = 'InputGroup';
+
+export interface InputGroupAddonProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Position of the addon relative to the input
+   */
+  position: 'start' | 'end';
+  /**
+   * Addon variant affects background and border styling
+   */
+  variant?: 'default' | 'filled';
+}
+
+export const InputGroupAddon = React.forwardRef<HTMLDivElement, InputGroupAddonProps>(
+  ({ position, variant = 'default', className, ...props }, ref) => {
+    const base =
+      'flex items-center justify-center shrink-0 text-muted-foreground';
+
+    const positionStyles = position === 'start' ? 'border-r border-input' : 'border-l border-input';
+
+    const variantStyles =
+      variant === 'filled'
+        ? 'bg-muted px-3'
+        : 'bg-transparent px-3';
+
+    const cls = classy(base, positionStyles, variantStyles, className);
+
+    return <div ref={ref} className={cls} data-position={position} {...props} />;
+  },
+);
+
+InputGroupAddon.displayName = 'InputGroupAddon';
+
+export interface InputGroupInputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+/**
+ * Input element styled specifically for use within InputGroup.
+ * Removes borders and focus ring since the group handles those.
+ */
+export const InputGroupInput = React.forwardRef<HTMLInputElement, InputGroupInputProps>(
+  ({ className, type = 'text', disabled, ...props }, ref) => {
+    const base =
+      'flex-1 h-full w-full bg-transparent px-3 py-2 text-sm ' +
+      'placeholder:text-muted-foreground ' +
+      'focus:outline-none ' +
+      'disabled:cursor-not-allowed disabled:opacity-50';
+
+    // Remove border radius from internal input (group handles it)
+    // First/last child handling done via CSS selectors would require runtime checks
+    // Keep it simple: the input takes full internal width
+
+    const cls = classy(base, className);
+
+    return (
+      <input
+        type={type}
+        className={cls}
+        ref={ref}
+        disabled={disabled}
+        aria-disabled={disabled ? 'true' : undefined}
+        {...props}
+      />
+    );
+  },
+);
+
+InputGroupInput.displayName = 'InputGroupInput';
+
+export default InputGroup;

--- a/packages/ui/test/components/input-group.a11y.tsx
+++ b/packages/ui/test/components/input-group.a11y.tsx
@@ -1,0 +1,254 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from '../../src/components/ui/input-group';
+
+describe('InputGroup - Accessibility', () => {
+  it('has no accessibility violations with aria-label', async () => {
+    const { container } = render(
+      <InputGroup>
+        <InputGroupInput aria-label="Username" />
+      </InputGroup>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no accessibility violations with associated label', async () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="email-input">Email address</label>
+        <InputGroup>
+          <InputGroupInput id="email-input" type="email" />
+        </InputGroup>
+      </div>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with start addon', async () => {
+    const { container } = render(
+      <InputGroup>
+        <InputGroupAddon position="start" aria-hidden="true">
+          $
+        </InputGroupAddon>
+        <InputGroupInput aria-label="Amount in dollars" />
+      </InputGroup>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with end addon', async () => {
+    const { container } = render(
+      <InputGroup>
+        <InputGroupInput aria-label="Price" />
+        <InputGroupAddon position="end" aria-hidden="true">
+          USD
+        </InputGroupAddon>
+      </InputGroup>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with both addons', async () => {
+    const { container } = render(
+      <InputGroup>
+        <InputGroupAddon position="start" aria-hidden="true">
+          $
+        </InputGroupAddon>
+        <InputGroupInput aria-label="Price in USD" placeholder="0.00" />
+        <InputGroupAddon position="end" aria-hidden="true">
+          USD
+        </InputGroupAddon>
+      </InputGroup>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with icon addon', async () => {
+    const SearchIcon = () => (
+      <svg aria-hidden="true" width="16" height="16" viewBox="0 0 16 16">
+        <circle cx="7" cy="7" r="5" stroke="currentColor" fill="none" />
+        <line x1="11" y1="11" x2="14" y2="14" stroke="currentColor" />
+      </svg>
+    );
+
+    const { container } = render(
+      <InputGroup>
+        <InputGroupAddon position="start">
+          <SearchIcon />
+        </InputGroupAddon>
+        <InputGroupInput aria-label="Search" placeholder="Search..." />
+      </InputGroup>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with button addon', async () => {
+    const { container } = render(
+      <InputGroup>
+        <InputGroupInput aria-label="Discount code" placeholder="Enter code" />
+        <InputGroupAddon position="end">
+          <button type="button">Apply</button>
+        </InputGroupAddon>
+      </InputGroup>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations when disabled', async () => {
+    const { container } = render(
+      <InputGroup disabled>
+        <InputGroupAddon position="start" aria-hidden="true">
+          $
+        </InputGroupAddon>
+        <InputGroupInput aria-label="Disabled amount" disabled />
+      </InputGroup>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations when required', async () => {
+    const { container } = render(
+      <InputGroup>
+        <InputGroupAddon position="start" aria-hidden="true">
+          $
+        </InputGroupAddon>
+        <InputGroupInput aria-label="Required amount" required />
+      </InputGroup>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has visible focus indicator on input', () => {
+    render(
+      <InputGroup data-testid="group">
+        <InputGroupInput aria-label="Focus test" />
+      </InputGroup>,
+    );
+    const group = screen.getByTestId('group');
+    expect(group).toHaveClass('focus-within:ring-2');
+  });
+
+  it('sets aria-disabled on input when disabled', () => {
+    render(
+      <InputGroup>
+        <InputGroupInput disabled aria-label="Disabled" />
+      </InputGroup>,
+    );
+    expect(screen.getByRole('textbox')).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('supports aria-describedby for error messages', async () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="amount">Amount</label>
+        <InputGroup>
+          <InputGroupAddon position="start" aria-hidden="true">
+            $
+          </InputGroupAddon>
+          <InputGroupInput
+            id="amount"
+            aria-invalid="true"
+            aria-describedby="amount-error"
+          />
+        </InputGroup>
+        <span id="amount-error">Amount must be greater than 0</span>
+      </div>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with placeholder', async () => {
+    const { container } = render(
+      <InputGroup>
+        <InputGroupInput aria-label="Search" placeholder="Search..." />
+      </InputGroup>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with filled variant addon', async () => {
+    const { container } = render(
+      <InputGroup>
+        <InputGroupAddon position="start" variant="filled" aria-hidden="true">
+          https://
+        </InputGroupAddon>
+        <InputGroupInput aria-label="Website URL" placeholder="example.com" />
+      </InputGroup>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with different sizes', async () => {
+    const sizes = ['default', 'sm', 'lg'] as const;
+    for (const size of sizes) {
+      const { container } = render(
+        <InputGroup size={size}>
+          <InputGroupAddon position="start" aria-hidden="true">
+            $
+          </InputGroupAddon>
+          <InputGroupInput aria-label={`Amount (${size} size)`} />
+        </InputGroup>,
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    }
+  });
+});
+
+describe('InputGroupAddon - Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <InputGroupAddon position="start" aria-hidden="true">
+        $
+      </InputGroupAddon>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('supports aria-label for descriptive addons', async () => {
+    const { container } = render(
+      <InputGroupAddon position="start" aria-label="Currency symbol">
+        $
+      </InputGroupAddon>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('InputGroupInput - Accessibility', () => {
+  it('has no accessibility violations with aria-label', async () => {
+    const { container } = render(<InputGroupInput aria-label="Test input" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with associated label', async () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="test-input">Test Label</label>
+        <InputGroupInput id="test-input" />
+      </div>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/ui/test/components/input-group.test.tsx
+++ b/packages/ui/test/components/input-group.test.tsx
@@ -1,0 +1,415 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from '../../src/components/ui/input-group';
+
+describe('InputGroup', () => {
+  it('renders with default props', () => {
+    render(
+      <InputGroup data-testid="input-group">
+        <InputGroupInput aria-label="Test input" />
+      </InputGroup>,
+    );
+    const group = screen.getByTestId('input-group');
+    expect(group).toBeInTheDocument();
+    expect(group.tagName).toBe('DIV');
+  });
+
+  it('applies base styles', () => {
+    const { container } = render(
+      <InputGroup>
+        <InputGroupInput aria-label="Test" />
+      </InputGroup>,
+    );
+    const group = container.firstChild;
+    expect(group).toHaveClass('flex');
+    expect(group).toHaveClass('items-center');
+    expect(group).toHaveClass('w-full');
+    expect(group).toHaveClass('rounded-md');
+    expect(group).toHaveClass('border');
+    expect(group).toHaveClass('border-input');
+    expect(group).toHaveClass('bg-background');
+  });
+
+  it('applies focus-within ring styles', () => {
+    const { container } = render(
+      <InputGroup>
+        <InputGroupInput aria-label="Test" />
+      </InputGroup>,
+    );
+    const group = container.firstChild;
+    expect(group).toHaveClass('focus-within:ring-2');
+    expect(group).toHaveClass('focus-within:ring-ring');
+    expect(group).toHaveClass('focus-within:ring-offset-2');
+  });
+
+  it('applies default size styles', () => {
+    const { container } = render(
+      <InputGroup>
+        <InputGroupInput aria-label="Test" />
+      </InputGroup>,
+    );
+    expect(container.firstChild).toHaveClass('h-10');
+  });
+
+  it('applies sm size styles', () => {
+    const { container } = render(
+      <InputGroup size="sm">
+        <InputGroupInput aria-label="Test" />
+      </InputGroup>,
+    );
+    expect(container.firstChild).toHaveClass('h-9');
+    expect(container.firstChild).toHaveClass('text-sm');
+  });
+
+  it('applies lg size styles', () => {
+    const { container } = render(
+      <InputGroup size="lg">
+        <InputGroupInput aria-label="Test" />
+      </InputGroup>,
+    );
+    expect(container.firstChild).toHaveClass('h-11');
+  });
+
+  it('applies disabled state', () => {
+    render(
+      <InputGroup disabled data-testid="input-group">
+        <InputGroupInput aria-label="Test" />
+      </InputGroup>,
+    );
+    const group = screen.getByTestId('input-group');
+    expect(group).toHaveClass('opacity-50');
+    expect(group).toHaveClass('cursor-not-allowed');
+    expect(group).toHaveAttribute('data-disabled', 'true');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(
+      <InputGroup className="custom-class">
+        <InputGroupInput aria-label="Test" />
+      </InputGroup>,
+    );
+    expect(container.firstChild).toHaveClass('custom-class');
+    expect(container.firstChild).toHaveClass('flex');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <InputGroup ref={ref}>
+        <InputGroupInput aria-label="Test" />
+      </InputGroup>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('passes through HTML attributes', () => {
+    render(
+      <InputGroup data-testid="group" aria-label="Input group" id="my-group">
+        <InputGroupInput aria-label="Test" />
+      </InputGroup>,
+    );
+    const group = screen.getByTestId('group');
+    expect(group).toHaveAttribute('aria-label', 'Input group');
+    expect(group).toHaveAttribute('id', 'my-group');
+  });
+});
+
+describe('InputGroupAddon', () => {
+  it('renders with start position', () => {
+    const { container } = render(
+      <InputGroupAddon position="start" data-testid="addon">
+        $
+      </InputGroupAddon>,
+    );
+    const addon = container.firstChild;
+    expect(addon).toHaveClass('border-r');
+    expect(addon).toHaveClass('border-input');
+    expect(addon).toHaveAttribute('data-position', 'start');
+  });
+
+  it('renders with end position', () => {
+    const { container } = render(
+      <InputGroupAddon position="end" data-testid="addon">
+        USD
+      </InputGroupAddon>,
+    );
+    const addon = container.firstChild;
+    expect(addon).toHaveClass('border-l');
+    expect(addon).toHaveClass('border-input');
+    expect(addon).toHaveAttribute('data-position', 'end');
+  });
+
+  it('applies base styles', () => {
+    const { container } = render(<InputGroupAddon position="start">$</InputGroupAddon>);
+    const addon = container.firstChild;
+    expect(addon).toHaveClass('flex');
+    expect(addon).toHaveClass('items-center');
+    expect(addon).toHaveClass('justify-center');
+    expect(addon).toHaveClass('shrink-0');
+    expect(addon).toHaveClass('text-muted-foreground');
+  });
+
+  it('applies default variant styles', () => {
+    const { container } = render(<InputGroupAddon position="start">$</InputGroupAddon>);
+    expect(container.firstChild).toHaveClass('bg-transparent');
+    expect(container.firstChild).toHaveClass('px-3');
+  });
+
+  it('applies filled variant styles', () => {
+    const { container } = render(
+      <InputGroupAddon position="start" variant="filled">
+        $
+      </InputGroupAddon>,
+    );
+    expect(container.firstChild).toHaveClass('bg-muted');
+    expect(container.firstChild).toHaveClass('px-3');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(
+      <InputGroupAddon position="start" className="custom-addon">
+        $
+      </InputGroupAddon>,
+    );
+    expect(container.firstChild).toHaveClass('custom-addon');
+    expect(container.firstChild).toHaveClass('flex');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <InputGroupAddon position="start" ref={ref}>
+        $
+      </InputGroupAddon>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('passes through HTML attributes', () => {
+    render(
+      <InputGroupAddon position="start" data-testid="addon" aria-label="Currency">
+        $
+      </InputGroupAddon>,
+    );
+    const addon = screen.getByTestId('addon');
+    expect(addon).toHaveAttribute('aria-label', 'Currency');
+  });
+});
+
+describe('InputGroupInput', () => {
+  it('renders with default props', () => {
+    render(<InputGroupInput aria-label="Test input" />);
+    const input = screen.getByRole('textbox');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('type', 'text');
+  });
+
+  it('applies base styles', () => {
+    render(<InputGroupInput aria-label="Test" />);
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveClass('flex-1');
+    expect(input).toHaveClass('h-full');
+    expect(input).toHaveClass('w-full');
+    expect(input).toHaveClass('bg-transparent');
+    expect(input).toHaveClass('px-3');
+    expect(input).toHaveClass('py-2');
+    expect(input).toHaveClass('text-sm');
+  });
+
+  it('renders with different input types', () => {
+    const { rerender } = render(<InputGroupInput type="email" aria-label="Email" />);
+    expect(screen.getByRole('textbox')).toHaveAttribute('type', 'email');
+
+    rerender(<InputGroupInput type="password" aria-label="Password" />);
+    expect(screen.getByLabelText('Password')).toHaveAttribute('type', 'password');
+  });
+
+  it('handles disabled state', () => {
+    render(<InputGroupInput disabled aria-label="Disabled input" />);
+    const input = screen.getByRole('textbox');
+    expect(input).toBeDisabled();
+    expect(input).toHaveAttribute('aria-disabled', 'true');
+    expect(input).toHaveClass('disabled:opacity-50');
+    expect(input).toHaveClass('disabled:cursor-not-allowed');
+  });
+
+  it('handles onChange events', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(<InputGroupInput onChange={handleChange} aria-label="Test" />);
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, 'hello');
+
+    expect(handleChange).toHaveBeenCalled();
+    expect(input).toHaveValue('hello');
+  });
+
+  it('displays placeholder text', () => {
+    render(<InputGroupInput placeholder="Enter text..." aria-label="Test" />);
+    expect(screen.getByPlaceholderText('Enter text...')).toBeInTheDocument();
+  });
+
+  it('supports controlled value', () => {
+    const { rerender } = render(
+      <InputGroupInput value="initial" onChange={() => {}} aria-label="Test" />,
+    );
+    expect(screen.getByRole('textbox')).toHaveValue('initial');
+
+    rerender(<InputGroupInput value="updated" onChange={() => {}} aria-label="Test" />);
+    expect(screen.getByRole('textbox')).toHaveValue('updated');
+  });
+
+  it('merges custom className', () => {
+    render(<InputGroupInput className="custom-input" aria-label="Test" />);
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveClass('custom-input');
+    expect(input).toHaveClass('flex-1');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLInputElement>();
+    render(<InputGroupInput ref={ref} aria-label="Test" />);
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+  });
+
+  it('passes through HTML attributes', () => {
+    render(
+      <InputGroupInput
+        aria-label="Test"
+        name="test-input"
+        id="test-id"
+        maxLength={10}
+        required
+      />,
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('name', 'test-input');
+    expect(input).toHaveAttribute('id', 'test-id');
+    expect(input).toHaveAttribute('maxLength', '10');
+    expect(input).toBeRequired();
+  });
+});
+
+describe('InputGroup composition', () => {
+  it('renders complete group with start addon', () => {
+    render(
+      <InputGroup data-testid="group">
+        <InputGroupAddon position="start" data-testid="addon">
+          $
+        </InputGroupAddon>
+        <InputGroupInput aria-label="Amount" data-testid="input" />
+      </InputGroup>,
+    );
+
+    expect(screen.getByTestId('group')).toBeInTheDocument();
+    expect(screen.getByTestId('addon')).toHaveTextContent('$');
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('renders complete group with end addon', () => {
+    render(
+      <InputGroup data-testid="group">
+        <InputGroupInput aria-label="Amount" />
+        <InputGroupAddon position="end" data-testid="addon">
+          USD
+        </InputGroupAddon>
+      </InputGroup>,
+    );
+
+    expect(screen.getByTestId('group')).toBeInTheDocument();
+    expect(screen.getByTestId('addon')).toHaveTextContent('USD');
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('renders complete group with both addons', () => {
+    render(
+      <InputGroup data-testid="group">
+        <InputGroupAddon position="start" data-testid="start-addon">
+          $
+        </InputGroupAddon>
+        <InputGroupInput aria-label="Price" placeholder="0.00" />
+        <InputGroupAddon position="end" data-testid="end-addon">
+          USD
+        </InputGroupAddon>
+      </InputGroup>,
+    );
+
+    expect(screen.getByTestId('group')).toBeInTheDocument();
+    expect(screen.getByTestId('start-addon')).toHaveTextContent('$');
+    expect(screen.getByTestId('end-addon')).toHaveTextContent('USD');
+    expect(screen.getByPlaceholderText('0.00')).toBeInTheDocument();
+  });
+
+  it('renders with icon in addon', () => {
+    const SearchIcon = () => (
+      <svg data-testid="search-icon" aria-hidden="true" />
+    );
+
+    render(
+      <InputGroup>
+        <InputGroupAddon position="start">
+          <SearchIcon />
+        </InputGroupAddon>
+        <InputGroupInput aria-label="Search" placeholder="Search..." />
+      </InputGroup>,
+    );
+
+    expect(screen.getByTestId('search-icon')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search...')).toBeInTheDocument();
+  });
+
+  it('renders with button in addon', () => {
+    render(
+      <InputGroup>
+        <InputGroupInput aria-label="Code" placeholder="Enter code" />
+        <InputGroupAddon position="end">
+          <button type="button">Apply</button>
+        </InputGroupAddon>
+      </InputGroup>,
+    );
+
+    expect(screen.getByPlaceholderText('Enter code')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeInTheDocument();
+  });
+
+  it('handles focus across the group', async () => {
+    const user = userEvent.setup();
+    render(
+      <InputGroup data-testid="group">
+        <InputGroupAddon position="start">$</InputGroupAddon>
+        <InputGroupInput aria-label="Amount" />
+      </InputGroup>,
+    );
+
+    const input = screen.getByRole('textbox');
+    await user.click(input);
+
+    expect(input).toHaveFocus();
+  });
+
+  it('preserves input functionality within group', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    render(
+      <InputGroup>
+        <InputGroupAddon position="start">$</InputGroupAddon>
+        <InputGroupInput aria-label="Amount" onChange={handleChange} />
+        <InputGroupAddon position="end">USD</InputGroupAddon>
+      </InputGroup>,
+    );
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, '100');
+
+    expect(handleChange).toHaveBeenCalled();
+    expect(input).toHaveValue('100');
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `input-group` component with shadcn API parity.

### Features
- JSDoc intelligence blocks (@cognitive-load, @attention-economics, etc.)
- Unit tests
- Accessibility support (ARIA, keyboard navigation)
- Design token compliance (no arbitrary values)

## Test plan
- [x] Component tests pass
- [ ] Manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)