### PR TITLE
feat(ui): add item component

### DIFF
--- a/packages/ui/src/components/ui/item.tsx
+++ b/packages/ui/src/components/ui/item.tsx
@@ -1,0 +1,173 @@
+/**
+ * Generic list item component for menus, lists, and selection interfaces
+ *
+ * @cognitive-load 3/10 - Familiar list pattern with clear visual states and predictable behavior
+ * @attention-economics Secondary selection: Selected state draws focus, disabled reduces prominence. Icon slot provides visual anchoring for quick scanning.
+ * @trust-building Consistent hover/focus/selected states build predictable interaction patterns. Clear disabled state prevents user confusion.
+ * @accessibility Proper aria-selected for selection, aria-disabled for disabled state, keyboard navigation support, focus-visible for keyboard users
+ * @semantic-meaning Building block for: menu items (navigation/actions), list items (content/data), option items (selection interfaces)
+ *
+ * @usage-patterns
+ * DO: Use as building block for menu items, list items, selection options
+ * DO: Include icons on the left for quick visual scanning
+ * DO: Add description for secondary information or context
+ * DO: Use selected state for current/active items in navigation
+ * DO: Use disabled state for unavailable options with clear visual feedback
+ * NEVER: Use for primary actions (use Button instead)
+ * NEVER: Nest interactive elements within Item
+ * NEVER: Use Item without a container (list, menu, etc.)
+ *
+ * @example
+ * ```tsx
+ * // Basic list item
+ * <Item>Settings</Item>
+ *
+ * // With icon and description
+ * <Item
+ *   icon={<UserIcon className="h-4 w-4" />}
+ *   description="Manage your account settings"
+ * >
+ *   Profile
+ * </Item>
+ *
+ * // Selected state for navigation
+ * <Item selected icon={<HomeIcon className="h-4 w-4" />}>
+ *   Dashboard
+ * </Item>
+ *
+ * // Disabled option
+ * <Item disabled icon={<LockIcon className="h-4 w-4" />}>
+ *   Admin Panel
+ * </Item>
+ *
+ * // Interactive item with handler
+ * <Item onClick={handleSelect} icon={<SettingsIcon className="h-4 w-4" />}>
+ *   Settings
+ * </Item>
+ * ```
+ */
+import * as React from 'react';
+import classy from '../../primitives/classy';
+
+export interface ItemProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Icon element displayed before the item content */
+  icon?: React.ReactNode;
+  /** Secondary description text displayed below the main content */
+  description?: React.ReactNode;
+  /** Whether the item is in a selected/active state */
+  selected?: boolean;
+  /** Whether the item is disabled and non-interactive */
+  disabled?: boolean;
+  /** Visual size variant */
+  size?: 'default' | 'sm' | 'lg';
+}
+
+const sizeClasses: Record<string, string> = {
+  default: 'px-3 py-2 text-sm',
+  sm: 'px-2 py-1.5 text-xs',
+  lg: 'px-4 py-3 text-base',
+};
+
+export const Item = React.forwardRef<HTMLDivElement, ItemProps>(
+  (
+    {
+      icon,
+      description,
+      selected = false,
+      disabled = false,
+      size = 'default',
+      className,
+      children,
+      onClick,
+      onKeyDown,
+      ...props
+    },
+    ref,
+  ) => {
+    const base =
+      'flex items-center gap-3 rounded-md cursor-default select-none outline-none';
+
+    // State styles following design token patterns
+    const stateStyles = disabled
+      ? 'opacity-50 pointer-events-none text-muted-foreground'
+      : selected
+        ? 'bg-accent text-accent-foreground'
+        : 'text-foreground hover:bg-accent hover:text-accent-foreground';
+
+    // Focus styles for keyboard navigation
+    const focusStyles =
+      'focus-visible:bg-accent focus-visible:text-accent-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1';
+
+    // Motion with reduced motion support
+    const motionStyles =
+      'transition-colors duration-fast motion-reduce:transition-none';
+
+    const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+      if (disabled) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+      onClick?.(event);
+    };
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (disabled) return;
+
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        // Simulate click for keyboard activation
+        const clickEvent = new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+        });
+        event.currentTarget.dispatchEvent(clickEvent);
+      }
+      onKeyDown?.(event);
+    };
+
+    const cls = classy(
+      base,
+      sizeClasses[size] ?? sizeClasses.default,
+      stateStyles,
+      focusStyles,
+      motionStyles,
+      className,
+    );
+
+    return (
+      <div
+        ref={ref}
+        role="option"
+        tabIndex={disabled ? undefined : 0}
+        aria-selected={selected}
+        aria-disabled={disabled || undefined}
+        data-selected={selected ? '' : undefined}
+        data-disabled={disabled ? '' : undefined}
+        className={cls}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        {...props}
+      >
+        {icon && (
+          <span className="shrink-0 text-current" aria-hidden="true">
+            {icon}
+          </span>
+        )}
+        <span className="flex min-w-0 flex-1 flex-col">
+          <span className="truncate">{children}</span>
+          {description && (
+            <span className="truncate text-muted-foreground text-xs mt-0.5">
+              {description}
+            </span>
+          )}
+        </span>
+      </div>
+    );
+  },
+);
+
+Item.displayName = 'Item';
+
+export default Item;

--- a/packages/ui/test/components/item.a11y.tsx
+++ b/packages/ui/test/components/item.a11y.tsx
@@ -1,0 +1,172 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import { Item } from '../../src/components/ui/item';
+
+describe('Item - Accessibility', () => {
+  it('has no accessibility violations with default props', async () => {
+    const { container } = render(
+      <div role="listbox" aria-label="Options">
+        <Item>Default Item</Item>
+      </div>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with icon', async () => {
+    const { container } = render(
+      <div role="listbox" aria-label="Options">
+        <Item icon={<span>Icon</span>}>Item with Icon</Item>
+      </div>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with description', async () => {
+    const { container } = render(
+      <div role="listbox" aria-label="Options">
+        <Item description="Secondary information">Item with Description</Item>
+      </div>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with icon and description', async () => {
+    const { container } = render(
+      <div role="listbox" aria-label="Options">
+        <Item icon={<span>Icon</span>} description="Description text">
+          Complete Item
+        </Item>
+      </div>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations when selected', async () => {
+    const { container } = render(
+      <div role="listbox" aria-label="Options">
+        <Item selected>Selected Item</Item>
+      </div>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations when disabled', async () => {
+    const { container } = render(
+      <div role="listbox" aria-label="Options">
+        <Item disabled>Disabled Item</Item>
+      </div>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with all sizes', async () => {
+    const sizes = ['sm', 'default', 'lg'] as const;
+    for (const size of sizes) {
+      const { container } = render(
+        <div role="listbox" aria-label="Options">
+          <Item size={size}>{size} Item</Item>
+        </div>,
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    }
+  });
+
+  it('has no violations in a complete list context', async () => {
+    const { container } = render(
+      <div role="listbox" aria-label="Navigation options">
+        <Item selected icon={<span>Home</span>}>
+          Dashboard
+        </Item>
+        <Item icon={<span>User</span>} description="Manage your profile">
+          Profile
+        </Item>
+        <Item icon={<span>Gear</span>}>
+          Settings
+        </Item>
+        <Item disabled icon={<span>Lock</span>}>
+          Admin Panel
+        </Item>
+      </div>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with multiple selected items (multi-select)', async () => {
+    const { container } = render(
+      <div role="listbox" aria-label="Select items" aria-multiselectable="true">
+        <Item selected>Selected 1</Item>
+        <Item selected>Selected 2</Item>
+        <Item>Not Selected</Item>
+      </div>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with custom aria attributes', async () => {
+    const { container } = render(
+      <div role="listbox" aria-label="Options">
+        <Item aria-label="Custom label" aria-describedby="description">
+          Item
+        </Item>
+        <p id="description">Additional description for screen readers</p>
+      </div>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations in menu context', async () => {
+    const { container } = render(
+      // biome-ignore lint/a11y/useSemanticElements: role="menu" is correct for menu context per WAI-ARIA APG
+      <div role="menu" aria-label="Actions">
+        <Item role="menuitem">Edit</Item>
+        <Item role="menuitem">Duplicate</Item>
+        <Item role="menuitem" disabled>Delete</Item>
+      </div>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations when combined with different states', async () => {
+    const { container } = render(
+      <div role="listbox" aria-label="Complex options">
+        <Item size="sm">Small</Item>
+        <Item size="default" selected>Default Selected</Item>
+        <Item size="lg" disabled>Large Disabled</Item>
+        <Item
+          size="default"
+          icon={<span>Icon</span>}
+          description="Has everything"
+          selected
+        >
+          Complete
+        </Item>
+      </div>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has proper focus management', async () => {
+    const { container } = render(
+      <div role="listbox" aria-label="Focusable items">
+        <Item>Focusable 1</Item>
+        <Item>Focusable 2</Item>
+        <Item disabled>Not Focusable</Item>
+      </div>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/ui/test/components/item.test.tsx
+++ b/packages/ui/test/components/item.test.tsx
@@ -1,0 +1,214 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { Item } from '../../src/components/ui/item';
+
+describe('Item', () => {
+  it('renders with default props', () => {
+    render(<Item>Settings</Item>);
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+    const item = screen.getByRole('option');
+    expect(item).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('renders with icon slot', () => {
+    render(
+      <Item icon={<span data-testid="icon">Icon</span>}>
+        With Icon
+      </Item>,
+    );
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+    expect(screen.getByText('With Icon')).toBeInTheDocument();
+  });
+
+  it('renders with description', () => {
+    render(
+      <Item description="Secondary text">
+        Primary Text
+      </Item>,
+    );
+    expect(screen.getByText('Primary Text')).toBeInTheDocument();
+    expect(screen.getByText('Secondary text')).toBeInTheDocument();
+  });
+
+  it('renders with icon and description', () => {
+    render(
+      <Item
+        icon={<span data-testid="icon">Icon</span>}
+        description="Description here"
+      >
+        Label
+      </Item>,
+    );
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+    expect(screen.getByText('Label')).toBeInTheDocument();
+    expect(screen.getByText('Description here')).toBeInTheDocument();
+  });
+
+  it('applies selected state correctly', () => {
+    render(<Item selected>Selected Item</Item>);
+    const item = screen.getByRole('option');
+    expect(item).toHaveAttribute('aria-selected', 'true');
+    expect(item).toHaveAttribute('data-selected', '');
+    expect(item.className).toContain('bg-accent');
+  });
+
+  it('applies disabled state correctly', () => {
+    render(<Item disabled>Disabled Item</Item>);
+    const item = screen.getByRole('option');
+    expect(item).toHaveAttribute('aria-disabled', 'true');
+    expect(item).toHaveAttribute('data-disabled', '');
+    expect(item.className).toContain('opacity-50');
+    expect(item.className).toContain('pointer-events-none');
+    expect(item).not.toHaveAttribute('tabIndex');
+  });
+
+  it('applies size variants correctly', () => {
+    render(
+      <div>
+        <Item size="sm">Small</Item>
+        <Item size="default">Default</Item>
+        <Item size="lg">Large</Item>
+      </div>,
+    );
+
+    expect(screen.getByText('Small').parentElement?.parentElement?.className).toContain('text-xs');
+    expect(screen.getByText('Default').parentElement?.parentElement?.className).toContain('text-sm');
+    expect(screen.getByText('Large').parentElement?.parentElement?.className).toContain('text-base');
+  });
+
+  it('forwards onClick handler', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(<Item onClick={handleClick}>Clickable</Item>);
+    await user.click(screen.getByRole('option'));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClick when disabled', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(
+      <Item disabled onClick={handleClick}>
+        Disabled
+      </Item>,
+    );
+
+    // pointer-events-none prevents click, but we test the handler logic anyway
+    const item = screen.getByRole('option');
+    // Force click through code since pointer-events-none blocks userEvent
+    item.click();
+
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('handles keyboard navigation with Enter', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(<Item onClick={handleClick}>Keyboard Item</Item>);
+    const item = screen.getByRole('option');
+
+    item.focus();
+    await user.keyboard('{Enter}');
+
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('handles keyboard navigation with Space', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(<Item onClick={handleClick}>Keyboard Item</Item>);
+    const item = screen.getByRole('option');
+
+    item.focus();
+    await user.keyboard(' ');
+
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('does not handle keyboard when disabled', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(
+      <Item disabled onClick={handleClick}>
+        Disabled
+      </Item>,
+    );
+
+    // Cannot focus disabled items (no tabIndex)
+    expect(screen.getByRole('option')).not.toHaveAttribute('tabIndex');
+  });
+
+  it('is focusable when not disabled', () => {
+    render(<Item>Focusable</Item>);
+    const item = screen.getByRole('option');
+    expect(item).toHaveAttribute('tabIndex', '0');
+  });
+
+  it('applies custom className', () => {
+    render(<Item className="custom-class">Custom</Item>);
+    const item = screen.getByRole('option');
+    expect(item.className).toContain('custom-class');
+  });
+
+  it('forwards additional HTML attributes', () => {
+    render(<Item data-testid="my-item" id="item-1">With Attrs</Item>);
+    const item = screen.getByTestId('my-item');
+    expect(item).toHaveAttribute('id', 'item-1');
+  });
+
+  it('forwards ref correctly', () => {
+    const ref = vi.fn();
+    render(<Item ref={ref}>Ref Test</Item>);
+    expect(ref).toHaveBeenCalled();
+    expect(ref.mock.calls[0][0]).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('includes hover state classes', () => {
+    render(<Item>Hover Test</Item>);
+    const item = screen.getByRole('option');
+    expect(item.className).toContain('hover:bg-accent');
+  });
+
+  it('includes focus-visible state classes', () => {
+    render(<Item>Focus Test</Item>);
+    const item = screen.getByRole('option');
+    expect(item.className).toContain('focus-visible:ring-2');
+    expect(item.className).toContain('focus-visible:ring-ring');
+  });
+
+  it('includes motion transition classes with reduced motion support', () => {
+    render(<Item>Motion Test</Item>);
+    const item = screen.getByRole('option');
+    expect(item.className).toContain('transition-colors');
+    expect(item.className).toContain('motion-reduce:transition-none');
+  });
+
+  it('hides icon from screen readers', () => {
+    render(
+      <Item icon={<span>Icon</span>}>With Icon</Item>,
+    );
+    const iconContainer = screen.getByText('Icon').parentElement;
+    expect(iconContainer).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('truncates long text', () => {
+    render(
+      <Item description="Very long description that should be truncated">
+        Very long label that should be truncated
+      </Item>,
+    );
+
+    const label = screen.getByText('Very long label that should be truncated');
+    expect(label.className).toContain('truncate');
+
+    const description = screen.getByText('Very long description that should be truncated');
+    expect(description.className).toContain('truncate');
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `item` component with shadcn API parity.

### Features
- JSDoc intelligence blocks (@cognitive-load, @attention-economics, etc.)
- Unit tests
- Accessibility support (ARIA, keyboard navigation)
- Design token compliance (no arbitrary values)

## Test plan
- [x] Component tests pass
- [ ] Manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)