### PR TITLE
feat(ui): add hover-card component

### DIFF
--- a/packages/ui/src/components/ui/hover-card.tsx
+++ b/packages/ui/src/components/ui/hover-card.tsx
@@ -1,0 +1,573 @@
+/**
+ * HoverCard component for rich preview content on hover
+ *
+ * @cognitive-load 3/10 - Contextual preview that supplements rather than replaces visible content
+ * @attention-economics Glanceable enrichment: provides additional context without requiring action
+ * @trust-building Predictable reveal timing, stable positioning, non-disruptive appearance
+ * @accessibility Focus management, keyboard triggerable via focus, escape to dismiss, role="dialog" with aria-describedby
+ * @semantic-meaning Rich preview: profile cards, link previews, contextual details that enhance understanding
+ *
+ * @usage-patterns
+ * DO: Show supplementary information like user profiles, link previews, or contextual details
+ * DO: Use appropriate delays to prevent accidental triggers (openDelay >= 500ms recommended)
+ * DO: Keep content focused and scannable - users glance, not read
+ * DO: Position intelligently to avoid viewport edges
+ * NEVER: Essential information that should always be visible
+ * NEVER: Interactive forms or multi-step workflows (use Popover instead)
+ * NEVER: Time-sensitive content that disappears before user can read it
+ *
+ * @example
+ * ```tsx
+ * <HoverCard>
+ *   <HoverCard.Trigger asChild>
+ *     <a href="/user/john">@john</a>
+ *   </HoverCard.Trigger>
+ *   <HoverCard.Content>
+ *     <div className="flex gap-4">
+ *       <Avatar src="/john.jpg" />
+ *       <div>
+ *         <h4>John Doe</h4>
+ *         <p>Software Engineer</p>
+ *       </div>
+ *     </div>
+ *   </HoverCard.Content>
+ * </HoverCard>
+ * ```
+ */
+
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import classy from '../../primitives/classy';
+import { type CollisionOptions, computePosition } from '../../primitives/collision-detector';
+import { onEscapeKeyDown } from '../../primitives/escape-keydown';
+import { getPortalContainer } from '../../primitives/portal';
+import type { Align, Side } from '../../primitives/types';
+
+// ==================== Global state for skip delay ====================
+
+let globalOpenTimestamp = 0;
+const SKIP_DELAY_THRESHOLD = 300;
+
+function shouldSkipOpenDelay(): boolean {
+  const timeSinceLastOpen = Date.now() - globalOpenTimestamp;
+  return timeSinceLastOpen < SKIP_DELAY_THRESHOLD;
+}
+
+/**
+ * Reset global hover delay state - for testing
+ */
+export function resetHoverCardState(): void {
+  globalOpenTimestamp = 0;
+}
+
+// ==================== HoverCard Context ====================
+
+interface HoverCardContextValue {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  triggerRef: React.RefObject<HTMLElement | null>;
+  contentId: string;
+  openDelay: number;
+  closeDelay: number;
+  // Shared hover state management
+  isHoveringTrigger: React.MutableRefObject<boolean>;
+  isHoveringContent: React.MutableRefObject<boolean>;
+  isFocused: React.MutableRefObject<boolean>;
+  openTimeoutRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>;
+  closeTimeoutRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>;
+}
+
+const HoverCardContext = React.createContext<HoverCardContextValue | null>(null);
+
+function useHoverCardContext() {
+  const context = React.useContext(HoverCardContext);
+  if (!context) {
+    throw new Error('HoverCard components must be used within HoverCard');
+  }
+  return context;
+}
+
+// ==================== HoverCard (Root) ====================
+
+export interface HoverCardProps {
+  /**
+   * Controlled open state
+   */
+  open?: boolean;
+
+  /**
+   * Default open state for uncontrolled usage
+   */
+  defaultOpen?: boolean;
+
+  /**
+   * Callback when open state changes
+   */
+  onOpenChange?: (open: boolean) => void;
+
+  /**
+   * Delay in ms before showing content
+   * @default 700
+   */
+  openDelay?: number;
+
+  /**
+   * Delay in ms before hiding content after mouse leaves
+   * @default 300
+   */
+  closeDelay?: number;
+
+  children: React.ReactNode;
+}
+
+export function HoverCard({
+  open: controlledOpen,
+  defaultOpen = false,
+  onOpenChange,
+  openDelay = 700,
+  closeDelay = 300,
+  children,
+}: HoverCardProps) {
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : uncontrolledOpen;
+
+  const handleOpenChange = React.useCallback(
+    (newOpen: boolean) => {
+      if (newOpen) {
+        globalOpenTimestamp = Date.now();
+      }
+      if (!isControlled) {
+        setUncontrolledOpen(newOpen);
+      }
+      onOpenChange?.(newOpen);
+    },
+    [isControlled, onOpenChange],
+  );
+
+  const triggerRef = React.useRef<HTMLElement | null>(null);
+  const id = React.useId();
+  const contentId = `hover-card-content-${id}`;
+
+  // Shared hover state refs
+  const isHoveringTrigger = React.useRef(false);
+  const isHoveringContent = React.useRef(false);
+  const isFocused = React.useRef(false);
+  const openTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const closeTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Cleanup timeouts on unmount
+  React.useEffect(() => {
+    return () => {
+      if (openTimeoutRef.current) {
+        clearTimeout(openTimeoutRef.current);
+      }
+      if (closeTimeoutRef.current) {
+        clearTimeout(closeTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const contextValue = React.useMemo(
+    () => ({
+      open,
+      onOpenChange: handleOpenChange,
+      triggerRef,
+      contentId,
+      openDelay,
+      closeDelay,
+      isHoveringTrigger,
+      isHoveringContent,
+      isFocused,
+      openTimeoutRef,
+      closeTimeoutRef,
+    }),
+    [open, handleOpenChange, contentId, openDelay, closeDelay],
+  );
+
+  return <HoverCardContext.Provider value={contextValue}>{children}</HoverCardContext.Provider>;
+}
+
+// ==================== HoverCardTrigger ====================
+
+export interface HoverCardTriggerProps extends React.HTMLAttributes<HTMLElement> {
+  /**
+   * Render as child element instead of default anchor
+   */
+  asChild?: boolean;
+}
+
+export function HoverCardTrigger({ asChild, children, ...props }: HoverCardTriggerProps) {
+  const {
+    open,
+    onOpenChange,
+    triggerRef,
+    contentId,
+    openDelay,
+    closeDelay,
+    isHoveringTrigger,
+    isHoveringContent,
+    isFocused,
+    openTimeoutRef,
+    closeTimeoutRef,
+  } = useHoverCardContext();
+
+  const internalRef = React.useRef<HTMLAnchorElement>(null);
+
+  // Sync the triggerRef
+  React.useEffect(() => {
+    if (internalRef.current) {
+      (triggerRef as React.MutableRefObject<HTMLElement | null>).current = internalRef.current;
+    }
+  }, [triggerRef]);
+
+  const scheduleOpen = React.useCallback(() => {
+    // Cancel any pending close
+    if (closeTimeoutRef.current) {
+      clearTimeout(closeTimeoutRef.current);
+      closeTimeoutRef.current = null;
+    }
+
+    // If already open or opening, do nothing
+    if (open || openTimeoutRef.current) {
+      return;
+    }
+
+    const delay = shouldSkipOpenDelay() ? 0 : openDelay;
+
+    if (delay === 0) {
+      onOpenChange(true);
+    } else {
+      openTimeoutRef.current = setTimeout(() => {
+        openTimeoutRef.current = null;
+        onOpenChange(true);
+      }, delay);
+    }
+  }, [open, openDelay, onOpenChange, openTimeoutRef, closeTimeoutRef]);
+
+  const scheduleClose = React.useCallback(() => {
+    // Cancel any pending open
+    if (openTimeoutRef.current) {
+      clearTimeout(openTimeoutRef.current);
+      openTimeoutRef.current = null;
+    }
+
+    // If already closed or closing, do nothing
+    if (!open || closeTimeoutRef.current) {
+      return;
+    }
+
+    if (closeDelay === 0) {
+      onOpenChange(false);
+    } else {
+      closeTimeoutRef.current = setTimeout(() => {
+        closeTimeoutRef.current = null;
+        // Only close if still not hovering anything
+        if (!isHoveringTrigger.current && !isHoveringContent.current && !isFocused.current) {
+          onOpenChange(false);
+        }
+      }, closeDelay);
+    }
+  }, [open, closeDelay, onOpenChange, openTimeoutRef, closeTimeoutRef, isHoveringTrigger, isHoveringContent, isFocused]);
+
+  const updateState = React.useCallback(() => {
+    const shouldBeOpen = isHoveringTrigger.current || isHoveringContent.current || isFocused.current;
+    if (shouldBeOpen) {
+      scheduleOpen();
+    } else {
+      scheduleClose();
+    }
+  }, [scheduleOpen, scheduleClose, isHoveringTrigger, isHoveringContent, isFocused]);
+
+  const handleMouseEnter = React.useCallback(() => {
+    isHoveringTrigger.current = true;
+    updateState();
+  }, [updateState, isHoveringTrigger]);
+
+  const handleMouseLeave = React.useCallback(() => {
+    isHoveringTrigger.current = false;
+    updateState();
+  }, [updateState, isHoveringTrigger]);
+
+  const handleFocus = React.useCallback(() => {
+    isFocused.current = true;
+    updateState();
+  }, [updateState, isFocused]);
+
+  const handleBlur = React.useCallback(() => {
+    isFocused.current = false;
+    updateState();
+  }, [updateState, isFocused]);
+
+  const triggerProps = {
+    ref: internalRef,
+    'aria-describedby': open ? contentId : undefined,
+    'data-state': open ? 'open' : 'closed',
+    onMouseEnter: handleMouseEnter,
+    onMouseLeave: handleMouseLeave,
+    onFocus: handleFocus,
+    onBlur: handleBlur,
+    ...props,
+  };
+
+  if (asChild && React.isValidElement(children)) {
+    return React.cloneElement(children, {
+      ...triggerProps,
+      ref: internalRef,
+    } as Partial<unknown>);
+  }
+
+  return (
+    <a {...triggerProps}>
+      {children}
+    </a>
+  );
+}
+
+// ==================== HoverCardPortal ====================
+
+export interface HoverCardPortalProps {
+  children: React.ReactNode;
+  /**
+   * Custom container for the portal
+   */
+  container?: HTMLElement | null;
+  /**
+   * Force mount the portal content even when closed
+   */
+  forceMount?: boolean;
+}
+
+export function HoverCardPortal({ children, container, forceMount }: HoverCardPortalProps) {
+  const { open } = useHoverCardContext();
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const portalContainer = getPortalContainer(
+    container !== undefined ? { container, enabled: true } : { enabled: true },
+  );
+
+  const shouldRender = forceMount || open;
+
+  if (!shouldRender || !mounted || !portalContainer) {
+    return null;
+  }
+
+  return createPortal(children, portalContainer);
+}
+
+// ==================== HoverCardContent ====================
+
+export interface HoverCardContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Preferred side for positioning
+   * @default 'bottom'
+   */
+  side?: Side;
+
+  /**
+   * Alignment along the side
+   * @default 'center'
+   */
+  align?: Align;
+
+  /**
+   * Offset from the trigger element
+   * @default 4
+   */
+  sideOffset?: number;
+
+  /**
+   * Offset along the alignment axis
+   * @default 0
+   */
+  alignOffset?: number;
+
+  /**
+   * Render as child element
+   */
+  asChild?: boolean;
+
+  /**
+   * Force mount even when closed
+   */
+  forceMount?: boolean;
+
+  /**
+   * Handler for escape key press
+   */
+  onEscapeKeyDown?: (event: KeyboardEvent) => void;
+}
+
+export function HoverCardContent({
+  side = 'bottom',
+  align = 'center',
+  sideOffset = 4,
+  alignOffset = 0,
+  asChild,
+  forceMount,
+  className,
+  children,
+  onEscapeKeyDown: onEscapeKeyDownProp,
+  ...props
+}: HoverCardContentProps) {
+  const {
+    open,
+    onOpenChange,
+    triggerRef,
+    contentId,
+    closeDelay,
+    isHoveringTrigger,
+    isHoveringContent,
+    isFocused,
+    openTimeoutRef,
+    closeTimeoutRef,
+  } = useHoverCardContext();
+  const contentRef = React.useRef<HTMLDivElement>(null);
+  const [position, setPosition] = React.useState({ x: 0, y: 0 });
+  const [actualSide, setActualSide] = React.useState(side);
+  const [actualAlign, setActualAlign] = React.useState(align);
+
+  // Update position when hover card opens or trigger moves
+  React.useEffect(() => {
+    if (!open || !triggerRef.current || !contentRef.current) {
+      return;
+    }
+
+    const updatePosition = () => {
+      if (!triggerRef.current || !contentRef.current) return;
+
+      const options: CollisionOptions = {
+        side,
+        align,
+        sideOffset,
+        alignOffset,
+        avoidCollisions: true,
+      };
+
+      const result = computePosition(triggerRef.current, contentRef.current, options);
+      setPosition({ x: result.x, y: result.y });
+      setActualSide(result.side);
+      setActualAlign(result.align);
+    };
+
+    // Initial position
+    updatePosition();
+
+    // Update on scroll/resize
+    window.addEventListener('scroll', updatePosition, { capture: true, passive: true });
+    window.addEventListener('resize', updatePosition, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', updatePosition, { capture: true });
+      window.removeEventListener('resize', updatePosition);
+    };
+  }, [open, side, align, sideOffset, alignOffset, triggerRef]);
+
+  // Escape key handler
+  React.useEffect(() => {
+    if (!open) return;
+
+    const cleanup = onEscapeKeyDown((event) => {
+      onEscapeKeyDownProp?.(event);
+      if (!event.defaultPrevented) {
+        onOpenChange(false);
+      }
+    });
+
+    return cleanup;
+  }, [open, onOpenChange, onEscapeKeyDownProp]);
+
+  // Handle hovering over content - keeps card open
+  const handleContentMouseEnter = React.useCallback(() => {
+    isHoveringContent.current = true;
+    // Cancel any pending close
+    if (closeTimeoutRef.current) {
+      clearTimeout(closeTimeoutRef.current);
+      closeTimeoutRef.current = null;
+    }
+  }, [isHoveringContent, closeTimeoutRef]);
+
+  const handleContentMouseLeave = React.useCallback(() => {
+    isHoveringContent.current = false;
+    // Cancel any pending open
+    if (openTimeoutRef.current) {
+      clearTimeout(openTimeoutRef.current);
+      openTimeoutRef.current = null;
+    }
+    // Schedule close with delay
+    if (!open || closeTimeoutRef.current) {
+      return;
+    }
+    if (closeDelay === 0) {
+      // Only close if not hovering trigger or focused
+      if (!isHoveringTrigger.current && !isFocused.current) {
+        onOpenChange(false);
+      }
+    } else {
+      closeTimeoutRef.current = setTimeout(() => {
+        closeTimeoutRef.current = null;
+        // Only close if still not hovering anything
+        if (!isHoveringTrigger.current && !isHoveringContent.current && !isFocused.current) {
+          onOpenChange(false);
+        }
+      }, closeDelay);
+    }
+  }, [closeDelay, onOpenChange, isHoveringContent, isHoveringTrigger, isFocused, openTimeoutRef, closeTimeoutRef, open]);
+
+  const shouldRender = forceMount || open;
+
+  if (!shouldRender) {
+    return null;
+  }
+
+  const contentClassName = classy(
+    'z-depth-popover w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-lg outline-none',
+    'data-[state=open]:animate-in data-[state=closed]:animate-out',
+    'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+    'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+    'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2',
+    'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+    className,
+  );
+
+  const style: React.CSSProperties = {
+    position: 'fixed',
+    left: 0,
+    top: 0,
+    transform: `translate(${Math.round(position.x)}px, ${Math.round(position.y)}px)`,
+  };
+
+  const contentProps = {
+    ref: contentRef,
+    id: contentId,
+    role: 'dialog' as const,
+    'data-state': open ? 'open' : 'closed',
+    'data-side': actualSide,
+    'data-align': actualAlign,
+    className: contentClassName,
+    style,
+    onMouseEnter: handleContentMouseEnter,
+    onMouseLeave: handleContentMouseLeave,
+    ...props,
+  };
+
+  if (asChild && React.isValidElement(children)) {
+    return React.cloneElement(children, contentProps as Partial<unknown>);
+  }
+
+  return <div {...contentProps}>{children}</div>;
+}
+
+// ==================== Namespaced Export (shadcn style) ====================
+
+HoverCard.Trigger = HoverCardTrigger;
+HoverCard.Portal = HoverCardPortal;
+HoverCard.Content = HoverCardContent;
+
+// Re-export individual components for direct import
+export { HoverCard as HoverCardRoot };

--- a/packages/ui/test/components/hover-card.a11y.tsx
+++ b/packages/ui/test/components/hover-card.a11y.tsx
@@ -1,0 +1,414 @@
+/**
+ * HoverCard component accessibility tests
+ * Tests ARIA attributes, keyboard navigation, and screen reader support
+ */
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { axe } from 'vitest-axe';
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardPortal,
+  HoverCardTrigger,
+  resetHoverCardState,
+} from '../../src/components/ui/hover-card';
+
+describe('HoverCard - Accessibility', () => {
+  beforeEach(() => {
+    cleanup();
+    resetHoverCardState();
+  });
+
+  it('has no accessibility violations when closed', async () => {
+    const { container } = render(
+      <HoverCard>
+        <HoverCardTrigger>@johndoe</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>User profile information</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no accessibility violations when open', async () => {
+    const { container } = render(
+      <HoverCard open>
+        <HoverCardTrigger>@johndoe</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>User profile information</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has correct role="dialog" on content', async () => {
+    render(
+      <HoverCard open>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Hover card content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toBeInTheDocument();
+      expect(dialog).toHaveTextContent('Hover card content');
+    });
+  });
+
+  it('links trigger to hover card with aria-describedby when open', async () => {
+    render(
+      <HoverCard open>
+        <HoverCardTrigger>Described trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Description text</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      const trigger = screen.getByText('Described trigger');
+      const dialog = screen.getByRole('dialog');
+
+      const describedById = trigger.getAttribute('aria-describedby');
+      expect(describedById).toBeTruthy();
+      expect(dialog).toHaveAttribute('id', describedById);
+    });
+  });
+
+  it('removes aria-describedby when hover card closes', async () => {
+    const TestComponent = () => {
+      const [open, setOpen] = React.useState(true);
+      return (
+        <HoverCard open={open} onOpenChange={setOpen}>
+          <HoverCardTrigger>Trigger</HoverCardTrigger>
+          <HoverCardPortal>
+            <HoverCardContent>Content</HoverCardContent>
+          </HoverCardPortal>
+          <button type="button" onClick={() => setOpen(false)}>
+            Close
+          </button>
+        </HoverCard>
+      );
+    };
+
+    render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    const trigger = screen.getByText('Trigger');
+    expect(trigger).toHaveAttribute('aria-describedby');
+
+    fireEvent.click(screen.getByText('Close'));
+
+    await waitFor(() => {
+      expect(trigger).not.toHaveAttribute('aria-describedby');
+    });
+  });
+
+  it('shows hover card on keyboard focus', async () => {
+    vi.useFakeTimers();
+
+    render(
+      <HoverCard openDelay={0}>
+        <HoverCardTrigger>Focusable trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Keyboard accessible</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    const trigger = screen.getByText('Focusable trigger');
+
+    // Initially no hover card
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    // Focus the trigger
+    fireEvent.focus(trigger);
+
+    await act(async () => {
+      vi.advanceTimersByTime(10);
+    });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Keyboard accessible')).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it('hides hover card on blur', async () => {
+    vi.useFakeTimers();
+
+    render(
+      <HoverCard openDelay={0} closeDelay={0}>
+        <HoverCardTrigger>Focusable trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Keyboard accessible</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    const trigger = screen.getByText('Focusable trigger');
+
+    // Focus to show
+    fireEvent.focus(trigger);
+
+    await act(async () => {
+      vi.advanceTimersByTime(10);
+    });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    // Blur to hide
+    fireEvent.blur(trigger);
+
+    await act(async () => {
+      vi.advanceTimersByTime(10);
+    });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it('trigger has correct data-state attribute', async () => {
+    vi.useFakeTimers();
+
+    render(
+      <HoverCard openDelay={0}>
+        <HoverCardTrigger>State trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    const trigger = screen.getByText('State trigger');
+
+    // Initially closed
+    expect(trigger).toHaveAttribute('data-state', 'closed');
+
+    // Focus to open
+    fireEvent.focus(trigger);
+
+    await act(async () => {
+      vi.advanceTimersByTime(10);
+    });
+
+    expect(trigger).toHaveAttribute('data-state', 'open');
+
+    vi.useRealTimers();
+  });
+
+  it('content has correct data-state attribute', async () => {
+    render(
+      <HoverCard open>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Content with state</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('data-state', 'open');
+    });
+  });
+
+  it('supports screen reader announcements via role="dialog"', async () => {
+    render(
+      <HoverCard open>
+        <HoverCardTrigger>User link with preview</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>This user is a software engineer at Acme Corp</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      // Screen readers will announce the dialog content when the trigger is focused
+      // because of the aria-describedby relationship
+      const trigger = screen.getByText('User link with preview');
+      const dialog = screen.getByRole('dialog');
+
+      expect(trigger.getAttribute('aria-describedby')).toBe(dialog.id);
+      expect(dialog).toHaveTextContent('This user is a software engineer at Acme Corp');
+    });
+  });
+
+  it('trigger remains focusable', () => {
+    render(
+      <HoverCard>
+        <HoverCardTrigger>Focusable</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    const trigger = screen.getByText('Focusable');
+
+    // Anchor should be focusable by default
+    expect(trigger.tagName).toBe('A');
+    expect(trigger).not.toHaveAttribute('tabindex', '-1');
+  });
+
+  it('asChild trigger maintains focusability', () => {
+    render(
+      <HoverCard>
+        <HoverCardTrigger asChild>
+          <a href="/profile">Profile link</a>
+        </HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>User profile preview</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    const trigger = screen.getByText('Profile link');
+
+    // Link should be focusable
+    expect(trigger.tagName).toBe('A');
+    expect(trigger).toHaveAttribute('href', '/profile');
+  });
+
+  it('works with tab navigation', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <HoverCard openDelay={0}>
+        <button type="button">Before</button>
+        <HoverCardTrigger>Hover card trigger</HoverCardTrigger>
+        <button type="button">After</button>
+        <HoverCardPortal>
+          <HoverCardContent>Hover card content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    const beforeButton = screen.getByText('Before');
+    const trigger = screen.getByText('Hover card trigger');
+    const afterButton = screen.getByText('After');
+
+    // Start at before button
+    beforeButton.focus();
+    expect(beforeButton).toHaveFocus();
+
+    // Tab to hover card trigger
+    await user.tab();
+    expect(trigger).toHaveFocus();
+
+    // Hover card should appear on focus
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    // Tab to after button (hover card should close)
+    await user.tab();
+    expect(afterButton).toHaveFocus();
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('has data-side and data-align for CSS styling hooks', async () => {
+    render(
+      <HoverCard open>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent side="bottom" align="start">
+            Positioned hover card
+          </HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('data-side');
+      expect(dialog).toHaveAttribute('data-align');
+    });
+  });
+
+  it('closes on Escape key', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <HoverCard open>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Dismissable content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('content does not trap focus like modal dialogs', async () => {
+    render(
+      <HoverCard open>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>
+            Non-modal content
+            <button type="button">Inside button</button>
+          </HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      const dialog = screen.getByRole('dialog');
+      // HoverCard should not have aria-modal since it's non-modal
+      expect(dialog).not.toHaveAttribute('aria-modal', 'true');
+    });
+  });
+
+  it('hover card content is semantically linked to trigger', async () => {
+    render(
+      <HoverCard open>
+        <HoverCardTrigger data-testid="trigger">@username</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent data-testid="content">Profile information</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      const trigger = screen.getByTestId('trigger');
+      const content = screen.getByTestId('content');
+
+      // Trigger should reference content
+      const describedBy = trigger.getAttribute('aria-describedby');
+      expect(describedBy).toBe(content.id);
+    });
+  });
+});

--- a/packages/ui/test/components/hover-card.test.tsx
+++ b/packages/ui/test/components/hover-card.test.tsx
@@ -1,0 +1,838 @@
+/**
+ * HoverCard component tests
+ * Tests SSR, hydration, interactions, and hover behavior
+ */
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { renderToString } from 'react-dom/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardPortal,
+  HoverCardTrigger,
+  resetHoverCardState,
+} from '../../src/components/ui/hover-card';
+
+describe('HoverCard - SSR Safety', () => {
+  it('should render on server without errors', () => {
+    const html = renderToString(
+      <HoverCard>
+        <HoverCardTrigger>@johndoe</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>User profile content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    expect(html).toBeTruthy();
+    expect(html).toContain('@johndoe');
+  });
+
+  it('should not render portal content on server', () => {
+    const html = renderToString(
+      <HoverCard open>
+        <HoverCardTrigger>Hover me</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Server Content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    // Portal content should not be in SSR output
+    expect(html).not.toContain('Server Content');
+  });
+});
+
+describe('HoverCard - Client Hydration', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it('should hydrate and render portal content on client when open', async () => {
+    render(
+      <HoverCard open>
+        <HoverCardTrigger>Hover me</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Hydrated Content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Hydrated Content')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('HoverCard - Basic Interactions', () => {
+  beforeEach(() => {
+    cleanup();
+    resetHoverCardState();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should show hover card on hover after delay', async () => {
+    render(
+      <HoverCard openDelay={700}>
+        <HoverCardTrigger>@username</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Profile preview</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    const trigger = screen.getByText('@username');
+
+    // Initially closed
+    expect(screen.queryByText('Profile preview')).not.toBeInTheDocument();
+
+    // Hover over trigger
+    fireEvent.mouseEnter(trigger);
+
+    // Still closed before delay
+    expect(screen.queryByText('Profile preview')).not.toBeInTheDocument();
+
+    // Fast-forward past delay
+    await act(async () => {
+      vi.advanceTimersByTime(700);
+    });
+
+    // Should be open now
+    expect(screen.getByText('Profile preview')).toBeInTheDocument();
+  });
+
+  it('should hide hover card on mouse leave', async () => {
+    render(
+      <HoverCard openDelay={0} closeDelay={0}>
+        <HoverCardTrigger>@username</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Profile preview</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    const trigger = screen.getByText('@username');
+
+    // Hover to open
+    fireEvent.mouseEnter(trigger);
+
+    await act(async () => {
+      vi.advanceTimersByTime(10);
+    });
+
+    expect(screen.getByText('Profile preview')).toBeInTheDocument();
+
+    // Mouse leave
+    fireEvent.mouseLeave(trigger);
+
+    await act(async () => {
+      vi.advanceTimersByTime(10);
+    });
+
+    // Should close
+    expect(screen.queryByText('Profile preview')).not.toBeInTheDocument();
+  });
+
+  it('should show hover card on focus', async () => {
+    render(
+      <HoverCard openDelay={0}>
+        <HoverCardTrigger>Focus me</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Hover card on focus</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    const trigger = screen.getByText('Focus me');
+
+    // Focus trigger
+    fireEvent.focus(trigger);
+
+    await act(async () => {
+      vi.advanceTimersByTime(10);
+    });
+
+    expect(screen.getByText('Hover card on focus')).toBeInTheDocument();
+  });
+
+  it('should hide hover card on blur', async () => {
+    render(
+      <HoverCard openDelay={0} closeDelay={0}>
+        <HoverCardTrigger>Focus me</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Hover card on focus</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    const trigger = screen.getByText('Focus me');
+
+    // Focus to open
+    fireEvent.focus(trigger);
+
+    await act(async () => {
+      vi.advanceTimersByTime(10);
+    });
+
+    expect(screen.getByText('Hover card on focus')).toBeInTheDocument();
+
+    // Blur to close
+    fireEvent.blur(trigger);
+
+    await act(async () => {
+      vi.advanceTimersByTime(10);
+    });
+
+    expect(screen.queryByText('Hover card on focus')).not.toBeInTheDocument();
+  });
+
+  it('should keep open when hovering over content', async () => {
+    render(
+      <HoverCard openDelay={0} closeDelay={100}>
+        <HoverCardTrigger>@username</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent data-testid="content">Profile preview</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    const trigger = screen.getByText('@username');
+
+    // Hover to open
+    fireEvent.mouseEnter(trigger);
+
+    await act(async () => {
+      vi.advanceTimersByTime(10);
+    });
+
+    expect(screen.getByText('Profile preview')).toBeInTheDocument();
+
+    // Leave trigger but enter content
+    fireEvent.mouseLeave(trigger);
+    const content = screen.getByTestId('content');
+    fireEvent.mouseEnter(content);
+
+    // Wait past close delay
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+
+    // Should still be open because hovering content
+    expect(screen.getByText('Profile preview')).toBeInTheDocument();
+  });
+
+  it('should close when leaving content', async () => {
+    render(
+      <HoverCard openDelay={0} closeDelay={50}>
+        <HoverCardTrigger>@username</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent data-testid="content">Profile preview</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    const trigger = screen.getByText('@username');
+
+    // Hover to open
+    fireEvent.mouseEnter(trigger);
+
+    await act(async () => {
+      vi.advanceTimersByTime(10);
+    });
+
+    expect(screen.getByText('Profile preview')).toBeInTheDocument();
+
+    // Leave trigger and enter content
+    fireEvent.mouseLeave(trigger);
+    const content = screen.getByTestId('content');
+    fireEvent.mouseEnter(content);
+
+    // Now leave content
+    fireEvent.mouseLeave(content);
+
+    // Wait for close delay
+    await act(async () => {
+      vi.advanceTimersByTime(50);
+    });
+
+    // Should close
+    expect(screen.queryByText('Profile preview')).not.toBeInTheDocument();
+  });
+});
+
+describe('HoverCard - Controlled Mode', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it('should work in controlled mode', async () => {
+    const onOpenChange = vi.fn();
+
+    const ControlledHoverCard = () => {
+      const [open, setOpen] = React.useState(false);
+
+      return (
+        <HoverCard
+          open={open}
+          onOpenChange={(newOpen) => {
+            setOpen(newOpen);
+            onOpenChange(newOpen);
+          }}
+        >
+          <HoverCardTrigger>Controlled</HoverCardTrigger>
+          <HoverCardPortal>
+            <HoverCardContent>Controlled hover card</HoverCardContent>
+          </HoverCardPortal>
+          <button type="button" onClick={() => setOpen(true)}>
+            Open externally
+          </button>
+        </HoverCard>
+      );
+    };
+
+    render(<ControlledHoverCard />);
+
+    // Initially closed
+    expect(screen.queryByText('Controlled hover card')).not.toBeInTheDocument();
+
+    // Open via external button
+    fireEvent.click(screen.getByText('Open externally'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Controlled hover card')).toBeInTheDocument();
+    });
+  });
+
+  it('should respect defaultOpen prop', async () => {
+    render(
+      <HoverCard defaultOpen>
+        <HoverCardTrigger>Default open</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Already visible</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Already visible')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('HoverCard - Delay Configuration', () => {
+  beforeEach(() => {
+    cleanup();
+    resetHoverCardState();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should use custom openDelay', async () => {
+    render(
+      <HoverCard openDelay={100}>
+        <HoverCardTrigger>Custom delay</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    const trigger = screen.getByText('Custom delay');
+    fireEvent.mouseEnter(trigger);
+
+    // Not visible at 50ms
+    await act(async () => {
+      vi.advanceTimersByTime(50);
+    });
+    expect(screen.queryByText('Content')).not.toBeInTheDocument();
+
+    // Visible at 100ms
+    await act(async () => {
+      vi.advanceTimersByTime(50);
+    });
+
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+
+  it('should use custom closeDelay', async () => {
+    render(
+      <HoverCard openDelay={0} closeDelay={200}>
+        <HoverCardTrigger>Custom close delay</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    const trigger = screen.getByText('Custom close delay');
+
+    // Open
+    fireEvent.mouseEnter(trigger);
+    await act(async () => {
+      vi.advanceTimersByTime(10);
+    });
+    expect(screen.getByText('Content')).toBeInTheDocument();
+
+    // Leave trigger
+    fireEvent.mouseLeave(trigger);
+
+    // Still visible at 100ms
+    await act(async () => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(screen.getByText('Content')).toBeInTheDocument();
+
+    // Closed at 200ms
+    await act(async () => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(screen.queryByText('Content')).not.toBeInTheDocument();
+  });
+
+  it('should skip open delay when recently opened another hover card', async () => {
+    const { rerender } = render(
+      <HoverCard openDelay={700} closeDelay={0}>
+        <HoverCardTrigger data-testid="trigger1">First</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>First content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    const trigger1 = screen.getByTestId('trigger1');
+
+    // Open first hover card (wait full delay)
+    fireEvent.mouseEnter(trigger1);
+    await act(async () => {
+      vi.advanceTimersByTime(700);
+    });
+    expect(screen.getByText('First content')).toBeInTheDocument();
+
+    // Close it
+    fireEvent.mouseLeave(trigger1);
+    await act(async () => {
+      vi.advanceTimersByTime(10);
+    });
+    expect(screen.queryByText('First content')).not.toBeInTheDocument();
+
+    // Render second hover card
+    rerender(
+      <HoverCard openDelay={700} closeDelay={0}>
+        <HoverCardTrigger data-testid="trigger2">Second</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Second content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    const trigger2 = screen.getByTestId('trigger2');
+
+    // Hover second - should open immediately due to skip delay
+    fireEvent.mouseEnter(trigger2);
+    await act(async () => {
+      vi.advanceTimersByTime(10);
+    });
+
+    // Should open without waiting 700ms
+    expect(screen.getByText('Second content')).toBeInTheDocument();
+  });
+});
+
+describe('HoverCard - Content Positioning', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('should position content with correct data attributes', async () => {
+    render(
+      <HoverCard open>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent side="bottom" align="center">
+            Positioned content
+          </HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      const content = screen.getByRole('dialog');
+      expect(content).toBeInTheDocument();
+      expect(content).toHaveAttribute('data-state', 'open');
+    });
+  });
+
+  it('should support different side options', async () => {
+    const { rerender } = render(
+      <HoverCard open>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent side="top">Top content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    rerender(
+      <HoverCard open>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent side="right">Right content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Right content')).toBeInTheDocument();
+    });
+  });
+
+  it('should have data-side and data-align attributes', async () => {
+    render(
+      <HoverCard open>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent side="bottom" align="start">
+            Content
+          </HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      const content = screen.getByRole('dialog');
+      expect(content).toHaveAttribute('data-side');
+      expect(content).toHaveAttribute('data-align');
+    });
+  });
+});
+
+describe('HoverCard - ARIA Attributes', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('should have role="dialog" on content', async () => {
+    render(
+      <HoverCard open>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Accessible content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+
+  it('should link trigger to content with aria-describedby when open', async () => {
+    render(
+      <HoverCard open>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Linked content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      const trigger = screen.getByText('Trigger');
+      const content = screen.getByRole('dialog');
+
+      expect(trigger).toHaveAttribute('aria-describedby', content.id);
+    });
+  });
+
+  it('should not have aria-describedby when closed', () => {
+    render(
+      <HoverCard>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Hidden content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    const trigger = screen.getByText('Trigger');
+    expect(trigger).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('should have data-state attribute on trigger', async () => {
+    render(
+      <HoverCard openDelay={0} closeDelay={0}>
+        <HoverCardTrigger>State trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    const trigger = screen.getByText('State trigger');
+
+    // Initially closed
+    expect(trigger).toHaveAttribute('data-state', 'closed');
+
+    // Hover to open
+    await userEvent.hover(trigger);
+
+    await waitFor(() => {
+      expect(trigger).toHaveAttribute('data-state', 'open');
+    });
+  });
+});
+
+describe('HoverCard - Escape Key', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('should close on escape key', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <HoverCard defaultOpen>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should call onEscapeKeyDown handler', async () => {
+    const user = userEvent.setup();
+    const onEscapeKeyDown = vi.fn();
+
+    render(
+      <HoverCard defaultOpen>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent onEscapeKeyDown={onEscapeKeyDown}>Content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    await user.keyboard('{Escape}');
+
+    expect(onEscapeKeyDown).toHaveBeenCalled();
+  });
+
+  it('should prevent close when onEscapeKeyDown calls preventDefault', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <HoverCard defaultOpen>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent
+            onEscapeKeyDown={(event) => {
+              event.preventDefault();
+            }}
+          >
+            Content
+          </HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    await user.keyboard('{Escape}');
+
+    // Should still be open
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});
+
+describe('HoverCard - asChild Pattern', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('should support asChild on trigger', async () => {
+    render(
+      <HoverCard openDelay={0} closeDelay={0}>
+        <HoverCardTrigger asChild>
+          <a href="/user/john">@johndoe</a>
+        </HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent>Profile preview</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    const trigger = screen.getByText('@johndoe');
+    expect(trigger.tagName).toBe('A');
+    expect(trigger).toHaveAttribute('href', '/user/john');
+
+    await userEvent.hover(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByText('Profile preview')).toBeInTheDocument();
+    });
+  });
+
+  it('should support asChild on content', async () => {
+    render(
+      <HoverCard open>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent asChild>
+            <article data-testid="custom-content">Custom content element</article>
+          </HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      const content = screen.getByTestId('custom-content');
+      expect(content.tagName).toBe('ARTICLE');
+      expect(content).toHaveAttribute('role', 'dialog');
+    });
+  });
+});
+
+describe('HoverCard - Custom className', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('should merge custom className with default styles', async () => {
+    render(
+      <HoverCard open>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent className="custom-hover-card-class">Styled content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      const content = screen.getByRole('dialog');
+      expect(content).toHaveClass('custom-hover-card-class');
+      expect(content).toHaveClass('rounded-md');
+    });
+  });
+});
+
+describe('HoverCard - Multiple HoverCards', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('should handle multiple hover cards independently', async () => {
+    render(
+      <>
+        <HoverCard openDelay={0} closeDelay={0}>
+          <HoverCardTrigger>First trigger</HoverCardTrigger>
+          <HoverCardPortal>
+            <HoverCardContent>First content</HoverCardContent>
+          </HoverCardPortal>
+        </HoverCard>
+        <HoverCard openDelay={0} closeDelay={0}>
+          <HoverCardTrigger>Second trigger</HoverCardTrigger>
+          <HoverCardPortal>
+            <HoverCardContent>Second content</HoverCardContent>
+          </HoverCardPortal>
+        </HoverCard>
+      </>,
+    );
+
+    const firstTrigger = screen.getByText('First trigger');
+    const secondTrigger = screen.getByText('Second trigger');
+
+    // Hover first
+    await userEvent.hover(firstTrigger);
+
+    await waitFor(() => {
+      expect(screen.getByText('First content')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Second content')).not.toBeInTheDocument();
+
+    // Leave first, hover second
+    await userEvent.unhover(firstTrigger);
+    await userEvent.hover(secondTrigger);
+
+    await waitFor(() => {
+      expect(screen.getByText('Second content')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('First content')).not.toBeInTheDocument();
+  });
+});
+
+describe('HoverCard - forceMount', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('should render content when forceMount is true even when closed', async () => {
+    render(
+      <HoverCard>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardPortal forceMount>
+          <HoverCardContent forceMount>Force mounted content</HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Force mounted content')).toBeInTheDocument();
+    });
+  });
+
+  it('should have data-state=closed when force mounted but not open', async () => {
+    render(
+      <HoverCard>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardPortal forceMount>
+          <HoverCardContent forceMount data-testid="content">
+            Content
+          </HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>,
+    );
+
+    await waitFor(() => {
+      const content = screen.getByTestId('content');
+      expect(content).toHaveAttribute('data-state', 'closed');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `hover-card` component with shadcn API parity.

### Features
- JSDoc intelligence blocks (@cognitive-load, @attention-economics, etc.)
- Unit tests
- Accessibility support (ARIA, keyboard navigation)
- Design token compliance (no arbitrary values)

## Test plan
- [x] Component tests pass
- [ ] Manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)