### PR TITLE
feat(ui): add pagination component

### DIFF
--- a/packages/ui/src/components/ui/pagination.tsx
+++ b/packages/ui/src/components/ui/pagination.tsx
@@ -1,0 +1,324 @@
+/**
+ * Navigation component for paginated content
+ *
+ * @cognitive-load 4/10 - Moderate complexity with page calculations, but clear visual patterns
+ * @attention-economics Secondary navigation: Supports content discovery without competing with primary content. Use sparingly at bottom of paginated lists.
+ * @trust-building Predictable navigation patterns build user confidence. Clear current page indication prevents disorientation. Disabled states prevent invalid actions.
+ * @accessibility Complete ARIA support with nav landmark, aria-current="page", aria-label descriptions, and keyboard navigation
+ * @semantic-meaning Page-based navigation system for large data sets. Ellipsis indicates hidden pages. Visual distinction between active and inactive states.
+ *
+ * @usage-patterns
+ * DO: Place at bottom of paginated content for natural flow
+ * DO: Show current page clearly with aria-current="page"
+ * DO: Use ellipsis to truncate large page ranges (7+/-2 items visible)
+ * DO: Disable Previous/Next at boundaries
+ * NEVER: Use pagination for small datasets (prefer infinite scroll or full display)
+ * NEVER: Hide the current page number from users
+ * NEVER: Allow navigation to invalid page numbers
+ *
+ * @example
+ * ```tsx
+ * // Basic composable pagination
+ * <Pagination>
+ *   <PaginationContent>
+ *     <PaginationItem>
+ *       <PaginationPrevious href="/page/1" />
+ *     </PaginationItem>
+ *     <PaginationItem>
+ *       <PaginationLink href="/page/1">1</PaginationLink>
+ *     </PaginationItem>
+ *     <PaginationItem>
+ *       <PaginationLink href="/page/2" isActive>2</PaginationLink>
+ *     </PaginationItem>
+ *     <PaginationItem>
+ *       <PaginationEllipsis />
+ *     </PaginationItem>
+ *     <PaginationItem>
+ *       <PaginationNext href="/page/3" />
+ *     </PaginationItem>
+ *   </PaginationContent>
+ * </Pagination>
+ *
+ * // Button-style pagination (onClick handlers)
+ * <Pagination>
+ *   <PaginationContent>
+ *     <PaginationItem>
+ *       <PaginationPrevious onClick={() => setPage(page - 1)} disabled={page === 1} />
+ *     </PaginationItem>
+ *     <PaginationItem>
+ *       <PaginationLink onClick={() => setPage(1)} isActive={page === 1}>1</PaginationLink>
+ *     </PaginationItem>
+ *     <PaginationItem>
+ *       <PaginationNext onClick={() => setPage(page + 1)} disabled={page === totalPages} />
+ *     </PaginationItem>
+ *   </PaginationContent>
+ * </Pagination>
+ * ```
+ */
+import * as React from 'react';
+import classy from '../../primitives/classy';
+import { mergeProps } from '../../primitives/slot';
+
+export interface PaginationProps extends React.ComponentPropsWithoutRef<'nav'> {}
+
+export const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
+  ({ className, ...props }, ref) => (
+    <nav
+      ref={ref}
+      role="navigation"
+      aria-label="Pagination"
+      className={classy('mx-auto flex w-full justify-center', className)}
+      {...props}
+    />
+  ),
+);
+Pagination.displayName = 'Pagination';
+
+export interface PaginationContentProps extends React.ComponentPropsWithoutRef<'ul'> {}
+
+export const PaginationContent = React.forwardRef<HTMLUListElement, PaginationContentProps>(
+  ({ className, ...props }, ref) => (
+    <ul
+      ref={ref}
+      className={classy('flex flex-row items-center gap-1', className)}
+      {...props}
+    />
+  ),
+);
+PaginationContent.displayName = 'PaginationContent';
+
+export interface PaginationItemProps extends React.ComponentPropsWithoutRef<'li'> {}
+
+export const PaginationItem = React.forwardRef<HTMLLIElement, PaginationItemProps>(
+  ({ className, ...props }, ref) => (
+    <li ref={ref} className={classy(className)} {...props} />
+  ),
+);
+PaginationItem.displayName = 'PaginationItem';
+
+type PaginationLinkElement = HTMLAnchorElement | HTMLButtonElement;
+
+export interface PaginationLinkProps {
+  isActive?: boolean;
+  disabled?: boolean;
+  size?: 'default' | 'sm' | 'lg' | 'icon';
+  asChild?: boolean;
+  href?: string;
+  onClick?: React.MouseEventHandler<PaginationLinkElement>;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+const sizeClasses: Record<string, string> = {
+  default: 'h-10 min-w-10 px-4 py-2',
+  sm: 'h-9 min-w-9 px-3',
+  lg: 'h-11 min-w-11 px-8',
+  icon: 'h-10 w-10',
+};
+
+export const PaginationLink = React.forwardRef<PaginationLinkElement, PaginationLinkProps>(
+  (
+    {
+      isActive,
+      disabled,
+      size = 'icon',
+      asChild,
+      href,
+      onClick,
+      className,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const baseClasses = classy(
+      'inline-flex items-center justify-center rounded-md text-sm font-medium',
+      'transition-colors duration-normal motion-reduce:transition-none',
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      sizeClasses[size] ?? sizeClasses.icon,
+      isActive
+        ? 'bg-primary text-primary-foreground hover:bg-primary-hover'
+        : 'bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground',
+      disabled && 'pointer-events-none opacity-50',
+      className,
+    );
+
+    // Render as button when onClick is provided without href
+    const isButton = onClick && !href;
+
+    if (asChild && React.isValidElement(children)) {
+      const child = children as React.ReactElement<
+        Record<string, unknown>,
+        string | React.JSXElementConstructor<unknown>
+      >;
+      const childPropsTyped = child.props as Record<string, unknown>;
+
+      const parentProps = {
+        ref,
+        className: baseClasses,
+        'aria-current': isActive ? ('page' as const) : undefined,
+        'aria-disabled': disabled ? 'true' : undefined,
+        ...props,
+      };
+
+      const mergedProps = mergeProps(
+        parentProps as Parameters<typeof mergeProps>[0],
+        childPropsTyped,
+      );
+
+      return React.cloneElement(child, mergedProps as Partial<Record<string, unknown>>);
+    }
+
+    if (isButton) {
+      return (
+        <button
+          ref={ref as React.Ref<HTMLButtonElement>}
+          type="button"
+          className={baseClasses}
+          onClick={onClick as React.MouseEventHandler<HTMLButtonElement>}
+          disabled={disabled}
+          aria-current={isActive ? 'page' : undefined}
+          aria-disabled={disabled ? 'true' : undefined}
+          {...props}
+        >
+          {children}
+        </button>
+      );
+    }
+
+    return (
+      <a
+        ref={ref as React.Ref<HTMLAnchorElement>}
+        href={href}
+        className={baseClasses}
+        onClick={onClick as React.MouseEventHandler<HTMLAnchorElement>}
+        aria-current={isActive ? 'page' : undefined}
+        aria-disabled={disabled ? 'true' : undefined}
+        {...props}
+      >
+        {children}
+      </a>
+    );
+  },
+);
+PaginationLink.displayName = 'PaginationLink';
+
+export interface PaginationPreviousProps extends Omit<PaginationLinkProps, 'children'> {
+  label?: string;
+}
+
+export const PaginationPrevious = React.forwardRef<PaginationLinkElement, PaginationPreviousProps>(
+  ({ className, label = 'Previous', ...props }, ref) => (
+    <PaginationLink
+      ref={ref}
+      aria-label="Go to previous page"
+      size="default"
+      className={classy('gap-1 pl-2.5', className)}
+      {...props}
+    >
+      <ChevronLeft className="h-4 w-4" />
+      <span>{label}</span>
+    </PaginationLink>
+  ),
+);
+PaginationPrevious.displayName = 'PaginationPrevious';
+
+export interface PaginationNextProps extends Omit<PaginationLinkProps, 'children'> {
+  label?: string;
+}
+
+export const PaginationNext = React.forwardRef<PaginationLinkElement, PaginationNextProps>(
+  ({ className, label = 'Next', ...props }, ref) => (
+    <PaginationLink
+      ref={ref}
+      aria-label="Go to next page"
+      size="default"
+      className={classy('gap-1 pr-2.5', className)}
+      {...props}
+    >
+      <span>{label}</span>
+      <ChevronRight className="h-4 w-4" />
+    </PaginationLink>
+  ),
+);
+PaginationNext.displayName = 'PaginationNext';
+
+export interface PaginationEllipsisProps extends React.ComponentPropsWithoutRef<'span'> {}
+
+export const PaginationEllipsis = React.forwardRef<HTMLSpanElement, PaginationEllipsisProps>(
+  ({ className, ...props }, ref) => (
+    <span
+      ref={ref}
+      aria-hidden="true"
+      className={classy('flex h-9 w-9 items-center justify-center', className)}
+      {...props}
+    >
+      <MoreHorizontal className="h-4 w-4" />
+      <span className="sr-only">More pages</span>
+    </span>
+  ),
+);
+PaginationEllipsis.displayName = 'PaginationEllipsis';
+
+// Internal icon components to avoid external dependencies
+function ChevronLeft({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  );
+}
+
+function ChevronRight({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="m9 18 6-6-6-6" />
+    </svg>
+  );
+}
+
+function MoreHorizontal({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="1" />
+      <circle cx="19" cy="12" r="1" />
+      <circle cx="5" cy="12" r="1" />
+    </svg>
+  );
+}

--- a/packages/ui/test/components/pagination.a11y.tsx
+++ b/packages/ui/test/components/pagination.a11y.tsx
@@ -1,0 +1,359 @@
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '../../src/components/ui/pagination';
+
+describe('Pagination - Accessibility', () => {
+  it('has no accessibility violations with proper structure', async () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="/page/1" />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/2" isActive>
+              2
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/3">3</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext href="/page/3" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with current page indication', async () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/2" isActive>
+              2
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has aria-current="page" on active link', () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/2" isActive>
+              2
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const currentPage = container.querySelector('[aria-current="page"]');
+    expect(currentPage).toBeInTheDocument();
+    expect(currentPage).toHaveTextContent('2');
+  });
+
+  it('ellipsis is hidden from screen readers', () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationEllipsis />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const ellipsis = container.querySelector('[aria-hidden="true"]');
+    expect(ellipsis).toBeInTheDocument();
+  });
+
+  it('has no violations with ellipsis for truncation', async () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationEllipsis />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/5" isActive>
+              5
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationEllipsis />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/10">10</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('nav element has correct aria-label', () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1" isActive>
+              1
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const nav = container.querySelector('nav');
+    expect(nav).toHaveAttribute('aria-label', 'Pagination');
+    expect(nav).toHaveAttribute('role', 'navigation');
+  });
+
+  it('uses proper semantic structure with ul and li', () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/2" isActive>
+              2
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const nav = container.querySelector('nav');
+    const ul = nav?.querySelector('ul');
+    const lis = ul?.querySelectorAll('li');
+
+    expect(nav).toBeInTheDocument();
+    expect(ul).toBeInTheDocument();
+    expect(lis?.length).toBeGreaterThan(0);
+  });
+
+  it('has no violations with disabled previous button', async () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious onClick={() => {}} disabled />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink onClick={() => {}} isActive>
+              1
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext onClick={() => {}} />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with disabled next button', async () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious onClick={() => {}} />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink onClick={() => {}} isActive>
+              10
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext onClick={() => {}} disabled />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('previous button has descriptive aria-label', () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="/page/1" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const prev = container.querySelector('a');
+    expect(prev).toHaveAttribute('aria-label', 'Go to previous page');
+  });
+
+  it('next button has descriptive aria-label', () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationNext href="/page/2" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const next = container.querySelector('a');
+    expect(next).toHaveAttribute('aria-label', 'Go to next page');
+  });
+
+  it('has no violations with long pagination trail', async () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="/page/4" />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/2">2</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/3">3</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/4">4</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/5" isActive>
+              5
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/6">6</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/7">7</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext href="/page/6" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with asChild links', async () => {
+    const CustomLink = React.forwardRef<HTMLAnchorElement, { to: string; children: React.ReactNode }>(
+      ({ to, children, ...props }, ref) => (
+        <a ref={ref} href={to} {...props}>
+          {children}
+        </a>
+      ),
+    );
+    CustomLink.displayName = 'CustomLink';
+
+    const { container } = render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink asChild>
+              <CustomLink to="/page/1">1</CustomLink>
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink asChild isActive>
+              <CustomLink to="/page/2">2</CustomLink>
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('disabled links have aria-disabled', () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1" disabled>
+              1
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const link = container.querySelector('a');
+    expect(link).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('focus is visible on interactive elements', () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const link = container.querySelector('a');
+    expect(link).toHaveClass('focus-visible:ring-2');
+  });
+
+  it('has no violations when all buttons are disabled at boundaries', async () => {
+    const { container } = render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious onClick={() => {}} disabled />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink onClick={() => {}} isActive>
+              1
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext onClick={() => {}} disabled />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/ui/test/components/pagination.test.tsx
+++ b/packages/ui/test/components/pagination.test.tsx
@@ -1,0 +1,849 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '../../src/components/ui/pagination';
+
+describe('Pagination', () => {
+  it('renders as nav element', () => {
+    render(
+      <Pagination data-testid="pagination">
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const nav = screen.getByTestId('pagination');
+    expect(nav.tagName).toBe('NAV');
+  });
+
+  it('has role="navigation"', () => {
+    render(
+      <Pagination data-testid="pagination">
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('pagination')).toHaveAttribute('role', 'navigation');
+  });
+
+  it('has aria-label="Pagination"', () => {
+    render(
+      <Pagination data-testid="pagination">
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('pagination')).toHaveAttribute('aria-label', 'Pagination');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(
+      <Pagination className="custom-class">
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+
+  it('forwards ref', () => {
+    const ref = React.createRef<HTMLElement>();
+    render(
+      <Pagination ref={ref}>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+    expect(ref.current?.tagName).toBe('NAV');
+  });
+});
+
+describe('PaginationContent', () => {
+  it('renders as ul element', () => {
+    render(
+      <Pagination>
+        <PaginationContent data-testid="content">
+          <PaginationItem>
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const content = screen.getByTestId('content');
+    expect(content.tagName).toBe('UL');
+  });
+
+  it('has proper base classes', () => {
+    render(
+      <Pagination>
+        <PaginationContent data-testid="content">
+          <PaginationItem>
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const content = screen.getByTestId('content');
+    expect(content).toHaveClass('flex');
+    expect(content).toHaveClass('flex-row');
+    expect(content).toHaveClass('items-center');
+    expect(content).toHaveClass('gap-1');
+  });
+
+  it('merges custom className', () => {
+    render(
+      <Pagination>
+        <PaginationContent data-testid="content" className="custom-class">
+          <PaginationItem>
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('content')).toHaveClass('custom-class');
+  });
+
+  it('forwards ref', () => {
+    const ref = React.createRef<HTMLUListElement>();
+    render(
+      <Pagination>
+        <PaginationContent ref={ref}>
+          <PaginationItem>
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLUListElement);
+  });
+});
+
+describe('PaginationItem', () => {
+  it('renders as li element', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem data-testid="item">
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const item = screen.getByTestId('item');
+    expect(item.tagName).toBe('LI');
+  });
+
+  it('merges custom className', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem data-testid="item" className="custom-class">
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('item')).toHaveClass('custom-class');
+  });
+
+  it('forwards ref', () => {
+    const ref = React.createRef<HTMLLIElement>();
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem ref={ref}>
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLLIElement);
+  });
+});
+
+describe('PaginationLink', () => {
+  it('renders as anchor element when href is provided', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1" data-testid="link">
+              1
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const link = screen.getByTestId('link');
+    expect(link.tagName).toBe('A');
+  });
+
+  it('renders as button element when onClick is provided without href', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink onClick={() => {}} data-testid="link">
+              1
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const link = screen.getByTestId('link');
+    expect(link.tagName).toBe('BUTTON');
+  });
+
+  it('has proper base classes', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1" data-testid="link">
+              1
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const link = screen.getByTestId('link');
+    expect(link).toHaveClass('inline-flex');
+    expect(link).toHaveClass('items-center');
+    expect(link).toHaveClass('justify-center');
+    expect(link).toHaveClass('rounded-md');
+  });
+
+  it('passes through href attribute', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/2" data-testid="link">
+              2
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('link')).toHaveAttribute('href', '/page/2');
+  });
+
+  it('sets aria-current="page" when isActive', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1" isActive data-testid="link">
+              1
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('link')).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('does not set aria-current when not active', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1" data-testid="link">
+              1
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('link')).not.toHaveAttribute('aria-current');
+  });
+
+  it('applies active styles when isActive', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1" isActive data-testid="link">
+              1
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const link = screen.getByTestId('link');
+    expect(link).toHaveClass('bg-primary');
+    expect(link).toHaveClass('text-primary-foreground');
+  });
+
+  it('applies inactive styles when not active', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1" data-testid="link">
+              1
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const link = screen.getByTestId('link');
+    expect(link).toHaveClass('bg-transparent');
+    expect(link).toHaveClass('text-foreground');
+  });
+
+  it('handles onClick', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink onClick={handleClick} data-testid="link">
+              1
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    await user.click(screen.getByTestId('link'));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('applies disabled styles when disabled', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1" disabled data-testid="link">
+              1
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const link = screen.getByTestId('link');
+    expect(link).toHaveClass('pointer-events-none');
+    expect(link).toHaveClass('opacity-50');
+  });
+
+  it('sets aria-disabled when disabled', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1" disabled data-testid="link">
+              1
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('link')).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('disables button when disabled', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink onClick={() => {}} disabled data-testid="link">
+              1
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('link')).toBeDisabled();
+  });
+
+  it('applies size classes', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1" size="lg" data-testid="link">
+              1
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const link = screen.getByTestId('link');
+    expect(link).toHaveClass('h-11');
+    expect(link).toHaveClass('min-w-11');
+  });
+
+  it('merges custom className', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="/page/1" className="custom-class" data-testid="link">
+              1
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('link')).toHaveClass('custom-class');
+  });
+
+  it('supports asChild prop for custom link components', () => {
+    const CustomLink = React.forwardRef<HTMLAnchorElement, { to: string; children: React.ReactNode }>(
+      ({ to, children, ...props }, ref) => (
+        <a ref={ref} href={to} {...props}>
+          {children}
+        </a>
+      ),
+    );
+    CustomLink.displayName = 'CustomLink';
+
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink asChild data-testid="link">
+              <CustomLink to="/page/2">2</CustomLink>
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const link = screen.getByText('2');
+    expect(link).toHaveAttribute('href', '/page/2');
+    expect(link).toHaveClass('inline-flex');
+  });
+});
+
+describe('PaginationPrevious', () => {
+  it('renders with default label', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="/page/1" data-testid="prev" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('prev')).toHaveTextContent('Previous');
+  });
+
+  it('renders with custom label', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="/page/1" label="Back" data-testid="prev" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('prev')).toHaveTextContent('Back');
+  });
+
+  it('has aria-label for accessibility', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="/page/1" data-testid="prev" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('prev')).toHaveAttribute('aria-label', 'Go to previous page');
+  });
+
+  it('renders chevron icon', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="/page/1" data-testid="prev" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const svg = screen.getByTestId('prev').querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('handles disabled state', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious onClick={() => {}} disabled data-testid="prev" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('prev')).toBeDisabled();
+  });
+
+  it('merges custom className', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="/page/1" className="custom-class" data-testid="prev" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('prev')).toHaveClass('custom-class');
+  });
+});
+
+describe('PaginationNext', () => {
+  it('renders with default label', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationNext href="/page/2" data-testid="next" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('next')).toHaveTextContent('Next');
+  });
+
+  it('renders with custom label', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationNext href="/page/2" label="Forward" data-testid="next" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('next')).toHaveTextContent('Forward');
+  });
+
+  it('has aria-label for accessibility', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationNext href="/page/2" data-testid="next" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('next')).toHaveAttribute('aria-label', 'Go to next page');
+  });
+
+  it('renders chevron icon', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationNext href="/page/2" data-testid="next" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const svg = screen.getByTestId('next').querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('handles disabled state', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationNext onClick={() => {}} disabled data-testid="next" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('next')).toBeDisabled();
+  });
+
+  it('merges custom className', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationNext href="/page/2" className="custom-class" data-testid="next" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('next')).toHaveClass('custom-class');
+  });
+});
+
+describe('PaginationEllipsis', () => {
+  it('renders as span element', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationEllipsis data-testid="ellipsis" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const ellipsis = screen.getByTestId('ellipsis');
+    expect(ellipsis.tagName).toBe('SPAN');
+  });
+
+  it('has aria-hidden="true"', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationEllipsis data-testid="ellipsis" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('ellipsis')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('has screen reader text', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationEllipsis data-testid="ellipsis" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByText('More pages')).toHaveClass('sr-only');
+  });
+
+  it('has proper base classes', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationEllipsis data-testid="ellipsis" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const ellipsis = screen.getByTestId('ellipsis');
+    expect(ellipsis).toHaveClass('flex');
+    expect(ellipsis).toHaveClass('h-9');
+    expect(ellipsis).toHaveClass('w-9');
+    expect(ellipsis).toHaveClass('items-center');
+    expect(ellipsis).toHaveClass('justify-center');
+  });
+
+  it('renders ellipsis icon', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationEllipsis data-testid="ellipsis" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    const ellipsis = screen.getByTestId('ellipsis');
+    const svg = ellipsis.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('merges custom className', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationEllipsis data-testid="ellipsis" className="custom-class" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(screen.getByTestId('ellipsis')).toHaveClass('custom-class');
+  });
+
+  it('forwards ref', () => {
+    const ref = React.createRef<HTMLSpanElement>();
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationEllipsis ref={ref} />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+  });
+});
+
+describe('Pagination - Full integration', () => {
+  it('renders a complete pagination with links', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="/page/1" />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/2" isActive>
+              2
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/3">3</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext href="/page/3" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+
+    expect(screen.getByText('Previous')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('Next')).toBeInTheDocument();
+    expect(screen.getByText('2')).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('renders with ellipsis for truncation', () => {
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="/page/4" />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationEllipsis />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/5" isActive>
+              5
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationEllipsis />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/10">10</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext href="/page/6" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+    expect(screen.getAllByText('More pages').length).toBe(2);
+  });
+
+  it('renders button-style pagination with onClick handlers', async () => {
+    const user = userEvent.setup();
+    const handlePrev = vi.fn();
+    const handleNext = vi.fn();
+    const handlePage = vi.fn();
+
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious onClick={handlePrev} disabled />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink onClick={() => handlePage(1)} isActive>
+              1
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink onClick={() => handlePage(2)}>2</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext onClick={handleNext} />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+
+    // Previous should be disabled
+    expect(screen.getByText('Previous').closest('button')).toBeDisabled();
+
+    // Click on page 2
+    await user.click(screen.getByText('2'));
+    expect(handlePage).toHaveBeenCalledWith(2);
+
+    // Click next
+    await user.click(screen.getByText('Next'));
+    expect(handleNext).toHaveBeenCalled();
+  });
+
+  it('supports mixed link and button navigation', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="/page/1" />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="/page/1">1</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink onClick={handleClick} isActive>
+              2
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext href="/page/3" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>,
+    );
+
+    // Link-style has href
+    expect(screen.getByText('1')).toHaveAttribute('href', '/page/1');
+
+    // Button-style has onClick
+    await user.click(screen.getByText('2'));
+    expect(handleClick).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `pagination` component with shadcn API parity.

### Features
- JSDoc intelligence blocks (@cognitive-load, @attention-economics, etc.)
- Unit tests
- Accessibility support (ARIA, keyboard navigation)
- Design token compliance (no arbitrary values)

## Test plan
- [x] Component tests pass
- [ ] Manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)