### PR TITLE
feat(ui): add drawer component

### DIFF
--- a/packages/ui/src/components/ui/drawer.tsx
+++ b/packages/ui/src/components/ui/drawer.tsx
@@ -1,0 +1,629 @@
+/**
+ * Mobile-friendly drawer component with touch gestures and drag-to-dismiss
+ *
+ * @cognitive-load 4/10 - Lower cognitive load than dialogs; familiar mobile pattern
+ * @attention-economics Partial attention capture: content slides up from edge, main context preserved
+ * @trust-building Easy dismissal via drag gesture, overlay tap, or escape; natural mobile interaction
+ * @accessibility Focus trap within drawer, escape key closes, proper ARIA dialog role, touch-friendly targets
+ * @semantic-meaning Supplementary content: action sheets, bottom menus, quick selections on mobile
+ *
+ * @usage-patterns
+ * DO: Use for mobile action sheets, quick selections, confirmations
+ * DO: Use bottom side for mobile-first experiences
+ * DO: Keep content minimal and action-focused
+ * DO: Provide visible drag handle for touch affordance
+ * DO: Support both touch drag and click dismissal
+ * NEVER: Complex multi-step forms (use full page or Dialog)
+ * NEVER: Primary navigation (use Sheet with side="left")
+ * NEVER: Content requiring sustained attention
+ *
+ * @example
+ * ```tsx
+ * <Drawer>
+ *   <Drawer.Trigger asChild>
+ *     <Button>Open Drawer</Button>
+ *   </Drawer.Trigger>
+ *   <Drawer.Portal>
+ *     <Drawer.Overlay />
+ *     <Drawer.Content>
+ *       <Drawer.Header>
+ *         <Drawer.Title>Actions</Drawer.Title>
+ *         <Drawer.Description>Select an action</Drawer.Description>
+ *       </Drawer.Header>
+ *       <div>Drawer content here</div>
+ *       <Drawer.Footer>
+ *         <Drawer.Close asChild>
+ *           <Button variant="outline">Cancel</Button>
+ *         </Drawer.Close>
+ *       </Drawer.Footer>
+ *     </Drawer.Content>
+ *   </Drawer.Portal>
+ * </Drawer>
+ * ```
+ */
+
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import classy from '../../primitives/classy';
+import {
+  getDialogAriaProps,
+  getOverlayAriaProps,
+  getTriggerAriaProps,
+} from '../../primitives/dialog-aria';
+import { onEscapeKeyDown } from '../../primitives/escape-keydown';
+import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap';
+import { onPointerDownOutside } from '../../primitives/outside-click';
+import { getPortalContainer } from '../../primitives/portal';
+import { mergeProps } from '../../primitives/slot';
+
+// Context for sharing drawer state
+interface DrawerContextValue {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  contentId: string;
+  titleId: string;
+  descriptionId: string;
+  modal: boolean;
+  side: DrawerSide;
+}
+
+type DrawerSide = 'top' | 'right' | 'bottom' | 'left';
+
+const DrawerContext = React.createContext<DrawerContextValue | null>(null);
+
+function useDrawerContext() {
+  const context = React.useContext(DrawerContext);
+  if (!context) {
+    throw new Error('Drawer components must be used within Drawer.Root');
+  }
+  return context;
+}
+
+// ==================== Drawer.Root ====================
+
+export interface DrawerProps {
+  children: React.ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  modal?: boolean;
+  /** The edge from which the drawer slides in. Defaults to "bottom" for mobile-first UX */
+  side?: DrawerSide;
+}
+
+export function Drawer({
+  children,
+  open: controlledOpen,
+  defaultOpen = false,
+  onOpenChange,
+  modal = true,
+  side = 'bottom',
+}: DrawerProps) {
+  // Uncontrolled state
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+
+  // Determine if controlled
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : uncontrolledOpen;
+
+  const handleOpenChange = React.useCallback(
+    (newOpen: boolean) => {
+      if (!isControlled) {
+        setUncontrolledOpen(newOpen);
+      }
+      onOpenChange?.(newOpen);
+    },
+    [isControlled, onOpenChange],
+  );
+
+  // Generate stable IDs for ARIA relationships using React 19 useId
+  const id = React.useId();
+  const contentId = `drawer-content-${id}`;
+  const titleId = `drawer-title-${id}`;
+  const descriptionId = `drawer-description-${id}`;
+
+  const contextValue = React.useMemo(
+    () => ({
+      open,
+      onOpenChange: handleOpenChange,
+      contentId,
+      titleId,
+      descriptionId,
+      modal,
+      side,
+    }),
+    [open, handleOpenChange, contentId, titleId, descriptionId, modal, side],
+  );
+
+  return <DrawerContext.Provider value={contextValue}>{children}</DrawerContext.Provider>;
+}
+
+// ==================== Drawer.Trigger ====================
+
+export interface DrawerTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+}
+
+export function DrawerTrigger({ asChild, onClick, children, ...props }: DrawerTriggerProps) {
+  const { open, onOpenChange, contentId } = useDrawerContext();
+
+  const ariaProps = getTriggerAriaProps({ open, controlsId: contentId });
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    onOpenChange(!open);
+  };
+
+  if (asChild && React.isValidElement(children)) {
+    const childProps = children.props as Record<string, unknown>;
+    const mergedProps = mergeProps({ ...ariaProps, onClick: handleClick }, childProps);
+    return React.cloneElement(children, mergedProps as React.Attributes);
+  }
+
+  return (
+    <button type="button" onClick={handleClick} {...ariaProps} {...props}>
+      {children}
+    </button>
+  );
+}
+
+// ==================== Drawer.Portal ====================
+
+export interface DrawerPortalProps {
+  children: React.ReactNode;
+  container?: HTMLElement | null;
+  forceMount?: boolean;
+}
+
+export function DrawerPortal({ children, container, forceMount }: DrawerPortalProps) {
+  const { open } = useDrawerContext();
+  const [mounted, setMounted] = React.useState(false);
+
+  // Wait for client-side hydration
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const portalContainer = getPortalContainer(
+    container !== undefined ? { container, enabled: true } : { enabled: true },
+  );
+
+  const shouldRender = forceMount || open;
+
+  if (!shouldRender || !mounted || !portalContainer) {
+    return null;
+  }
+
+  return createPortal(children, portalContainer);
+}
+
+// ==================== Drawer.Overlay ====================
+
+export interface DrawerOverlayProps extends React.HTMLAttributes<HTMLDivElement> {
+  asChild?: boolean;
+  forceMount?: boolean;
+}
+
+export function DrawerOverlay({ asChild, forceMount, className, ...props }: DrawerOverlayProps) {
+  const { open } = useDrawerContext();
+
+  const ariaProps = getOverlayAriaProps({ open });
+
+  const shouldRender = forceMount || open;
+
+  if (!shouldRender) {
+    return null;
+  }
+
+  const overlayProps = {
+    ...ariaProps,
+    className: classy(
+      'fixed inset-0 z-depth-overlay bg-black/80',
+      'data-[state=open]:animate-in data-[state=closed]:animate-out',
+      'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    ),
+    ...props,
+  };
+
+  if (asChild && React.isValidElement(props.children)) {
+    return React.cloneElement(props.children, overlayProps as Partial<unknown>);
+  }
+
+  return <div {...overlayProps} />;
+}
+
+// ==================== Drawer.Content ====================
+
+export interface DrawerContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  asChild?: boolean;
+  forceMount?: boolean;
+  onOpenAutoFocus?: (event: Event) => void;
+  onCloseAutoFocus?: (event: Event) => void;
+  onEscapeKeyDown?: (event: KeyboardEvent) => void;
+  onPointerDownOutside?: (event: PointerEvent | TouchEvent) => void;
+  onInteractOutside?: (event: Event) => void;
+  /** Threshold in pixels for drag-to-dismiss. Defaults to 100. */
+  dismissThreshold?: number;
+  /** Enable drag-to-dismiss gesture. Defaults to true. */
+  draggable?: boolean;
+}
+
+const sideVariants = {
+  top: 'inset-x-0 top-0 border-b rounded-b-lg data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
+  bottom:
+    'inset-x-0 bottom-0 border-t rounded-t-lg data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+  left: 'inset-y-0 left-0 h-full w-3/4 max-w-sm border-r rounded-r-lg data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left',
+  right:
+    'inset-y-0 right-0 h-full w-3/4 max-w-sm border-l rounded-l-lg data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right',
+} as const;
+
+// Drag handle indicator based on side
+const handleVariants = {
+  top: 'mx-auto mt-auto mb-4 h-1.5 w-24 rounded-full bg-muted',
+  bottom: 'mx-auto mb-auto mt-4 h-1.5 w-24 rounded-full bg-muted',
+  left: 'my-auto ml-auto mr-4 w-1.5 h-24 rounded-full bg-muted',
+  right: 'my-auto mr-auto ml-4 w-1.5 h-24 rounded-full bg-muted',
+} as const;
+
+export function DrawerContent({
+  asChild,
+  forceMount,
+  onOpenAutoFocus,
+  onCloseAutoFocus,
+  onEscapeKeyDown: onEscapeKeyDownProp,
+  onPointerDownOutside: onPointerDownOutsideProp,
+  onInteractOutside,
+  dismissThreshold = 100,
+  draggable = true,
+  className,
+  children,
+  ...props
+}: DrawerContentProps) {
+  const { open, onOpenChange, contentId, titleId, descriptionId, modal, side } = useDrawerContext();
+  const contentRef = React.useRef<HTMLDivElement>(null);
+
+  // Drag state for touch gestures
+  const [dragOffset, setDragOffset] = React.useState(0);
+  const [isDragging, setIsDragging] = React.useState(false);
+  const dragStartRef = React.useRef<{ x: number; y: number } | null>(null);
+
+  // Focus trap
+  React.useEffect(() => {
+    if (!open || !modal || !contentRef.current) return;
+
+    const cleanup = createFocusTrap(contentRef.current);
+    return cleanup;
+  }, [open, modal]);
+
+  // Body scroll lock
+  React.useEffect(() => {
+    if (!open || !modal) return;
+
+    const cleanup = preventBodyScroll();
+    return cleanup;
+  }, [open, modal]);
+
+  // Escape key handler
+  React.useEffect(() => {
+    if (!open) return;
+
+    const cleanup = onEscapeKeyDown((event) => {
+      onEscapeKeyDownProp?.(event);
+      if (!event.defaultPrevented) {
+        onOpenChange(false);
+      }
+    });
+
+    return cleanup;
+  }, [open, onOpenChange, onEscapeKeyDownProp]);
+
+  // Outside click handler
+  React.useEffect(() => {
+    if (!open || !modal || !contentRef.current) return;
+
+    const cleanup = onPointerDownOutside(contentRef.current, (event) => {
+      onPointerDownOutsideProp?.(event);
+      onInteractOutside?.(event as unknown as Event);
+
+      if (!event.defaultPrevented) {
+        onOpenChange(false);
+      }
+    });
+
+    return cleanup;
+  }, [open, modal, onOpenChange, onPointerDownOutsideProp, onInteractOutside]);
+
+  // Touch gesture handlers for drag-to-dismiss
+  const handleTouchStart = React.useCallback(
+    (event: React.TouchEvent) => {
+      if (!draggable) return;
+      const touch = event.touches[0];
+      if (!touch) return;
+      dragStartRef.current = { x: touch.clientX, y: touch.clientY };
+      setIsDragging(true);
+    },
+    [draggable],
+  );
+
+  const handleTouchMove = React.useCallback(
+    (event: React.TouchEvent) => {
+      if (!draggable || !dragStartRef.current) return;
+      const touch = event.touches[0];
+      if (!touch) return;
+
+      let offset = 0;
+      if (side === 'bottom') {
+        offset = Math.max(0, touch.clientY - dragStartRef.current.y);
+      } else if (side === 'top') {
+        offset = Math.max(0, dragStartRef.current.y - touch.clientY);
+      } else if (side === 'right') {
+        offset = Math.max(0, touch.clientX - dragStartRef.current.x);
+      } else if (side === 'left') {
+        offset = Math.max(0, dragStartRef.current.x - touch.clientX);
+      }
+
+      setDragOffset(offset);
+    },
+    [draggable, side],
+  );
+
+  const handleTouchEnd = React.useCallback(() => {
+    if (!draggable) return;
+    setIsDragging(false);
+
+    if (dragOffset >= dismissThreshold) {
+      onOpenChange(false);
+    }
+
+    setDragOffset(0);
+    dragStartRef.current = null;
+  }, [draggable, dragOffset, dismissThreshold, onOpenChange]);
+
+  // Mouse drag handlers for desktop testing
+  const handleMouseDown = React.useCallback(
+    (event: React.MouseEvent) => {
+      if (!draggable) return;
+      // Only start drag from handle area
+      const target = event.target as HTMLElement;
+      if (!target.closest('[data-drawer-handle]')) return;
+
+      dragStartRef.current = { x: event.clientX, y: event.clientY };
+      setIsDragging(true);
+    },
+    [draggable],
+  );
+
+  React.useEffect(() => {
+    if (!isDragging || !draggable) return;
+
+    const handleMouseMove = (event: MouseEvent) => {
+      if (!dragStartRef.current) return;
+
+      let offset = 0;
+      if (side === 'bottom') {
+        offset = Math.max(0, event.clientY - dragStartRef.current.y);
+      } else if (side === 'top') {
+        offset = Math.max(0, dragStartRef.current.y - event.clientY);
+      } else if (side === 'right') {
+        offset = Math.max(0, event.clientX - dragStartRef.current.x);
+      } else if (side === 'left') {
+        offset = Math.max(0, dragStartRef.current.x - event.clientX);
+      }
+
+      setDragOffset(offset);
+    };
+
+    const handleMouseUp = () => {
+      setIsDragging(false);
+
+      if (dragOffset >= dismissThreshold) {
+        onOpenChange(false);
+      }
+
+      setDragOffset(0);
+      dragStartRef.current = null;
+    };
+
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [isDragging, draggable, side, dragOffset, dismissThreshold, onOpenChange]);
+
+  const ariaProps = getDialogAriaProps({
+    open,
+    labelId: titleId,
+    descriptionId,
+    modal,
+  });
+
+  const shouldRender = forceMount || open;
+
+  if (!shouldRender) {
+    return null;
+  }
+
+  // Calculate transform based on drag offset
+  const getTransformStyle = (): React.CSSProperties => {
+    if (!isDragging && dragOffset === 0) return {};
+
+    const transforms: Record<DrawerSide, string> = {
+      bottom: `translateY(${dragOffset}px)`,
+      top: `translateY(-${dragOffset}px)`,
+      right: `translateX(${dragOffset}px)`,
+      left: `translateX(-${dragOffset}px)`,
+    };
+
+    return {
+      transform: transforms[side],
+      transition: isDragging ? 'none' : undefined,
+    };
+  };
+
+  const contentClassName = classy(
+    'fixed z-depth-modal flex flex-col bg-background shadow-lg',
+    'data-[state=open]:animate-in data-[state=closed]:animate-out',
+    'data-[state=open]:duration-300 data-[state=closed]:duration-200',
+    sideVariants[side],
+    className,
+  );
+
+  const contentProps = {
+    ref: contentRef,
+    id: contentId,
+    ...ariaProps,
+    className: contentClassName,
+    style: getTransformStyle(),
+    onTouchStart: handleTouchStart,
+    onTouchMove: handleTouchMove,
+    onTouchEnd: handleTouchEnd,
+    onMouseDown: handleMouseDown,
+    ...props,
+  } as React.HTMLAttributes<HTMLDivElement> & { ref?: React.Ref<HTMLDivElement> };
+
+  // Render handle at appropriate position
+  const renderHandle = () => {
+    if (!draggable) return null;
+    const isVertical = side === 'top' || side === 'bottom';
+    return (
+      <div
+        data-drawer-handle=""
+        className={classy(
+          'shrink-0 cursor-grab touch-none active:cursor-grabbing',
+          isVertical ? 'flex justify-center py-2' : 'flex items-center px-2',
+        )}
+        aria-hidden="true"
+      >
+        <div className={handleVariants[side]} />
+      </div>
+    );
+  };
+
+  if (asChild && React.isValidElement(children)) {
+    return React.cloneElement(children, contentProps as Partial<unknown>);
+  }
+
+  return (
+    <div {...contentProps}>
+      {(side === 'bottom' || side === 'right') && renderHandle()}
+      <div className="flex-1 overflow-auto p-6">{children}</div>
+      {(side === 'top' || side === 'left') && renderHandle()}
+    </div>
+  );
+}
+
+// ==================== Drawer.Header ====================
+
+export interface DrawerHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function DrawerHeader({ className, ...props }: DrawerHeaderProps) {
+  return (
+    <div
+      className={classy('flex flex-col gap-1.5 text-center sm:text-left', className)}
+      {...props}
+    />
+  );
+}
+
+// ==================== Drawer.Footer ====================
+
+export interface DrawerFooterProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function DrawerFooter({ className, ...props }: DrawerFooterProps) {
+  return (
+    <div
+      className={classy('mt-auto flex flex-col gap-2 pt-4', className)}
+      {...props}
+    />
+  );
+}
+
+// ==================== Drawer.Title ====================
+
+export interface DrawerTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  asChild?: boolean;
+}
+
+export function DrawerTitle({ asChild, className, ...props }: DrawerTitleProps) {
+  const { titleId } = useDrawerContext();
+
+  const titleProps = {
+    id: titleId,
+    className: classy('text-lg font-semibold text-foreground', className),
+    ...props,
+  };
+
+  if (asChild && React.isValidElement(props.children)) {
+    return React.cloneElement(props.children, titleProps as Partial<unknown>);
+  }
+
+  return <h2 {...titleProps} />;
+}
+
+// ==================== Drawer.Description ====================
+
+export interface DrawerDescriptionProps extends React.HTMLAttributes<HTMLParagraphElement> {
+  asChild?: boolean;
+}
+
+export function DrawerDescription({ asChild, className, ...props }: DrawerDescriptionProps) {
+  const { descriptionId } = useDrawerContext();
+
+  const descriptionProps = {
+    id: descriptionId,
+    className: classy('text-sm text-muted-foreground', className),
+    ...props,
+  };
+
+  if (asChild && React.isValidElement(props.children)) {
+    return React.cloneElement(props.children, descriptionProps as Partial<unknown>);
+  }
+
+  return <p {...descriptionProps} />;
+}
+
+// ==================== Drawer.Close ====================
+
+export interface DrawerCloseProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+}
+
+export function DrawerClose({ asChild, onClick, children, ...props }: DrawerCloseProps) {
+  const { onOpenChange } = useDrawerContext();
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    onOpenChange(false);
+  };
+
+  if (asChild && React.isValidElement(children)) {
+    const childProps = children.props as Record<string, unknown>;
+    const mergedProps = mergeProps({ onClick: handleClick }, childProps);
+    return React.cloneElement(children, mergedProps as React.Attributes);
+  }
+
+  return (
+    <button type="button" onClick={handleClick} {...props}>
+      {children}
+    </button>
+  );
+}
+
+// ==================== Namespaced Export (shadcn style) ====================
+
+Drawer.Trigger = DrawerTrigger;
+Drawer.Portal = DrawerPortal;
+Drawer.Overlay = DrawerOverlay;
+Drawer.Content = DrawerContent;
+Drawer.Header = DrawerHeader;
+Drawer.Footer = DrawerFooter;
+Drawer.Title = DrawerTitle;
+Drawer.Description = DrawerDescription;
+Drawer.Close = DrawerClose;
+
+// Re-export root as DrawerRoot alias for shadcn compatibility
+export { Drawer as DrawerRoot };

--- a/packages/ui/test/components/drawer.a11y.tsx
+++ b/packages/ui/test/components/drawer.a11y.tsx
@@ -1,0 +1,471 @@
+/**
+ * Drawer component accessibility tests
+ * Tests ARIA attributes, focus management, and keyboard navigation
+ */
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerTitle,
+  DrawerTrigger,
+} from '../../src/components/ui/drawer';
+
+describe('Drawer - Accessibility', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it('has no accessibility violations when open', async () => {
+    const { container } = render(
+      <Drawer defaultOpen>
+        <DrawerTrigger>Open</DrawerTrigger>
+        <DrawerPortal>
+          <DrawerOverlay />
+          <DrawerContent>
+            <DrawerHeader>
+              <DrawerTitle>Drawer Title</DrawerTitle>
+              <DrawerDescription>Drawer description text</DrawerDescription>
+            </DrawerHeader>
+            <p>Drawer content goes here</p>
+            <DrawerFooter>
+              <DrawerClose>Close</DrawerClose>
+            </DrawerFooter>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no accessibility violations when closed', async () => {
+    const { container } = render(
+      <Drawer>
+        <DrawerTrigger>Open Drawer</DrawerTrigger>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Title</DrawerTitle>
+            <DrawerDescription>Description</DrawerDescription>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has correct role="dialog"', async () => {
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Title</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+
+  it('has aria-modal="true" for modal drawers', async () => {
+    render(
+      <Drawer defaultOpen modal>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Modal Drawer</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+    });
+  });
+
+  it('has aria-labelledby pointing to title', async () => {
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>My Title</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      const dialog = screen.getByRole('dialog');
+      const titleId = dialog.getAttribute('aria-labelledby');
+      expect(titleId).toBeTruthy();
+
+      const title = document.getElementById(titleId as string);
+      expect(title).toHaveTextContent('My Title');
+    });
+  });
+
+  it('has aria-describedby pointing to description', async () => {
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Title</DrawerTitle>
+            <DrawerDescription>My description text</DrawerDescription>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      const dialog = screen.getByRole('dialog');
+      const descriptionId = dialog.getAttribute('aria-describedby');
+      expect(descriptionId).toBeTruthy();
+
+      const description = document.getElementById(descriptionId as string);
+      expect(description).toHaveTextContent('My description text');
+    });
+  });
+
+  it('trigger has correct aria-expanded attribute', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Drawer>
+        <DrawerTrigger>Open</DrawerTrigger>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Title</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Open' });
+
+    // Initially closed
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    // Open drawer
+    await user.click(trigger);
+
+    await waitFor(() => {
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+
+  it('trigger has aria-haspopup="dialog"', () => {
+    render(
+      <Drawer>
+        <DrawerTrigger>Open</DrawerTrigger>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Title</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Open' });
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+  });
+
+  it('trigger has aria-controls pointing to drawer content', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Drawer>
+        <DrawerTrigger>Open</DrawerTrigger>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Title</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Open' });
+    const controlsId = trigger.getAttribute('aria-controls');
+    expect(controlsId).toBeTruthy();
+
+    await user.click(trigger);
+
+    await waitFor(() => {
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('id', controlsId);
+    });
+  });
+
+  it('focuses first focusable element when opened', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Drawer>
+        <DrawerTrigger>Open</DrawerTrigger>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Title</DrawerTitle>
+            <button type="button">First Button</button>
+            <button type="button">Second Button</button>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+
+    await waitFor(() => {
+      // First focusable element should have focus
+      expect(screen.getByRole('button', { name: 'First Button' })).toHaveFocus();
+    });
+  });
+
+  it('traps focus within drawer', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Focus Trap Test</DrawerTitle>
+            <button type="button">First</button>
+            <button type="button">Second</button>
+            <button type="button">Third</button>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'First' })).toHaveFocus();
+    });
+
+    // Tab through all elements
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'Second' })).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'Third' })).toHaveFocus();
+
+    // Tab should wrap to first
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'First' })).toHaveFocus();
+  });
+
+  it('supports Shift+Tab for reverse focus navigation', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Reverse Navigation Test</DrawerTitle>
+            <button type="button">First</button>
+            <button type="button">Second</button>
+            <button type="button">Third</button>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'First' })).toHaveFocus();
+    });
+
+    // Shift+Tab should wrap to last
+    await user.keyboard('{Shift>}{Tab}{/Shift}');
+    expect(screen.getByRole('button', { name: 'Third' })).toHaveFocus();
+
+    await user.keyboard('{Shift>}{Tab}{/Shift}');
+    expect(screen.getByRole('button', { name: 'Second' })).toHaveFocus();
+  });
+
+  it('closes on Escape key press', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Escape Test</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('returns focus to trigger on close', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Drawer>
+        <DrawerTrigger>Open</DrawerTrigger>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Focus Return Test</DrawerTitle>
+            <DrawerClose data-testid="close-btn">Close</DrawerClose>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Open' });
+    await user.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('close-btn'));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      expect(trigger).toHaveFocus();
+    });
+  });
+
+  it('has data-state attribute for open/closed states', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Drawer>
+        <DrawerTrigger>Open</DrawerTrigger>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>State Test</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Open' });
+    expect(trigger).toHaveAttribute('data-state', 'closed');
+
+    await user.click(trigger);
+
+    await waitFor(() => {
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('data-state', 'open');
+      expect(trigger).toHaveAttribute('data-state', 'open');
+    });
+  });
+
+  it('overlay has aria-hidden="true"', async () => {
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerOverlay data-testid="overlay" />
+          <DrawerContent>
+            <DrawerTitle>Overlay Test</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      const overlay = screen.getByTestId('overlay');
+      expect(overlay).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  it('works correctly with all side variants', async () => {
+    const sides: Array<'top' | 'right' | 'bottom' | 'left'> = ['top', 'right', 'bottom', 'left'];
+
+    for (const side of sides) {
+      cleanup();
+
+      const { container } = render(
+        <Drawer defaultOpen side={side}>
+          <DrawerPortal>
+            <DrawerContent>
+              <DrawerTitle>{side} Drawer</DrawerTitle>
+              <DrawerDescription>Description for {side}</DrawerDescription>
+            </DrawerContent>
+          </DrawerPortal>
+        </Drawer>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    }
+  });
+
+  it('drag handle has aria-hidden for screen readers', async () => {
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Drag Handle A11y</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      const handle = document.querySelector('[data-drawer-handle]');
+      expect(handle).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  it('maintains focus within drawer when clicking drag handle', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Drag Handle Focus</DrawerTitle>
+            <button type="button">Focusable</button>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Focusable')).toBeInTheDocument();
+    });
+
+    // Click on the handle area
+    const handle = document.querySelector('[data-drawer-handle]');
+    if (handle) {
+      await user.click(handle);
+    }
+
+    // Focus should still be trapped within drawer
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'Focusable' })).toHaveFocus();
+  });
+});

--- a/packages/ui/test/components/drawer.test.tsx
+++ b/packages/ui/test/components/drawer.test.tsx
@@ -1,0 +1,890 @@
+/**
+ * Drawer component tests
+ * Tests SSR, hydration, interactions, touch gestures, and side variants
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { renderToString } from 'react-dom/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerTitle,
+  DrawerTrigger,
+} from '../../src/components/ui/drawer';
+
+describe('Drawer - SSR Safety', () => {
+  it('should render on server without errors', () => {
+    const html = renderToString(
+      <Drawer open>
+        <DrawerTrigger>Open</DrawerTrigger>
+        <DrawerPortal>
+          <DrawerOverlay />
+          <DrawerContent>
+            <DrawerTitle>Title</DrawerTitle>
+            <DrawerDescription>Description</DrawerDescription>
+            <DrawerClose>Close</DrawerClose>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    expect(html).toBeTruthy();
+    expect(html).toContain('Open'); // Trigger should render
+  });
+
+  it('should not render portal content on server', () => {
+    const html = renderToString(
+      <Drawer open>
+        <DrawerTrigger>Open</DrawerTrigger>
+        <DrawerPortal>
+          <DrawerOverlay />
+          <DrawerContent>
+            <DrawerTitle>Server Content</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    // Portal content should not be in SSR output
+    expect(html).not.toContain('Server Content');
+  });
+});
+
+describe('Drawer - Client Hydration', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it('should hydrate and render portal content on client', async () => {
+    render(
+      <Drawer open>
+        <DrawerTrigger>Open</DrawerTrigger>
+        <DrawerPortal>
+          <DrawerOverlay />
+          <DrawerContent>
+            <DrawerTitle>Hydrated Content</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Hydrated Content')).toBeInTheDocument();
+    });
+  });
+
+  it('should maintain state after hydration', async () => {
+    const { rerender } = render(
+      <Drawer defaultOpen>
+        <DrawerTrigger>Open</DrawerTrigger>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Title</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Title')).toBeInTheDocument();
+    });
+
+    // Rerender should maintain open state
+    rerender(
+      <Drawer defaultOpen>
+        <DrawerTrigger>Open</DrawerTrigger>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Title</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    expect(screen.getByText('Title')).toBeInTheDocument();
+  });
+});
+
+describe('Drawer - Basic Interactions', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it('should open when trigger is clicked', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Drawer>
+        <DrawerTrigger>Open Drawer</DrawerTrigger>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Drawer Title</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    // Initially closed
+    expect(screen.queryByText('Drawer Title')).not.toBeInTheDocument();
+
+    // Click trigger
+    await user.click(screen.getByText('Open Drawer'));
+
+    // Should open
+    await waitFor(() => {
+      expect(screen.getByText('Drawer Title')).toBeInTheDocument();
+    });
+  });
+
+  it('should close when close button is clicked', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Drawer Title</DrawerTitle>
+            <DrawerClose data-testid="custom-close">Close</DrawerClose>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    // Initially open
+    await waitFor(() => {
+      expect(screen.getByText('Drawer Title')).toBeInTheDocument();
+    });
+
+    // Click close
+    await user.click(screen.getByTestId('custom-close'));
+
+    // Should close
+    await waitFor(() => {
+      expect(screen.queryByText('Drawer Title')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should close on Escape key', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Drawer Title</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Drawer Title')).toBeInTheDocument();
+    });
+
+    // Press Escape
+    await user.keyboard('{Escape}');
+
+    // Should close
+    await waitFor(() => {
+      expect(screen.queryByText('Drawer Title')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should close when clicking outside (modal mode)', async () => {
+    render(
+      <Drawer defaultOpen modal>
+        <DrawerPortal>
+          <DrawerOverlay data-testid="overlay" />
+          <DrawerContent>
+            <DrawerTitle>Drawer Title</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Drawer Title')).toBeInTheDocument();
+    });
+
+    // Click overlay
+    const overlay = screen.getByTestId('overlay');
+    fireEvent.pointerDown(overlay);
+
+    // Should close
+    await waitFor(() => {
+      expect(screen.queryByText('Drawer Title')).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe('Drawer - Controlled Mode', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it('should work in controlled mode', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const ControlledDrawer = () => {
+      const [open, setOpen] = React.useState(false);
+
+      return (
+        <Drawer
+          open={open}
+          onOpenChange={(newOpen) => {
+            setOpen(newOpen);
+            onOpenChange(newOpen);
+          }}
+        >
+          <DrawerTrigger>Open</DrawerTrigger>
+          <DrawerPortal>
+            <DrawerContent>
+              <DrawerTitle>Controlled</DrawerTitle>
+              <DrawerClose data-testid="custom-close">Close</DrawerClose>
+            </DrawerContent>
+          </DrawerPortal>
+        </Drawer>
+      );
+    };
+
+    render(<ControlledDrawer />);
+
+    // Initially closed
+    expect(screen.queryByText('Controlled')).not.toBeInTheDocument();
+
+    // Open
+    await user.click(screen.getByText('Open'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Controlled')).toBeInTheDocument();
+      expect(onOpenChange).toHaveBeenCalledWith(true);
+    });
+
+    // Close
+    await user.click(screen.getByTestId('custom-close'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Controlled')).not.toBeInTheDocument();
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+});
+
+describe('Drawer - Side Variants', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it('should render with bottom side by default', async () => {
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerContent data-testid="drawer-content">
+            <DrawerTitle>Bottom Drawer</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      const content = screen.getByTestId('drawer-content');
+      expect(content).toHaveClass('bottom-0');
+      expect(content).toHaveClass('inset-x-0');
+    });
+  });
+
+  it('should render with top side', async () => {
+    render(
+      <Drawer defaultOpen side="top">
+        <DrawerPortal>
+          <DrawerContent data-testid="drawer-content">
+            <DrawerTitle>Top Drawer</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      const content = screen.getByTestId('drawer-content');
+      expect(content).toHaveClass('top-0');
+      expect(content).toHaveClass('inset-x-0');
+    });
+  });
+
+  it('should render with left side', async () => {
+    render(
+      <Drawer defaultOpen side="left">
+        <DrawerPortal>
+          <DrawerContent data-testid="drawer-content">
+            <DrawerTitle>Left Drawer</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      const content = screen.getByTestId('drawer-content');
+      expect(content).toHaveClass('left-0');
+      expect(content).toHaveClass('inset-y-0');
+    });
+  });
+
+  it('should render with right side', async () => {
+    render(
+      <Drawer defaultOpen side="right">
+        <DrawerPortal>
+          <DrawerContent data-testid="drawer-content">
+            <DrawerTitle>Right Drawer</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      const content = screen.getByTestId('drawer-content');
+      expect(content).toHaveClass('right-0');
+      expect(content).toHaveClass('inset-y-0');
+    });
+  });
+});
+
+describe('Drawer - Touch Gestures', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it('should render drag handle by default', async () => {
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerContent data-testid="drawer-content">
+            <DrawerTitle>Drag Handle</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      const handle = document.querySelector('[data-drawer-handle]');
+      expect(handle).toBeInTheDocument();
+    });
+  });
+
+  it('should not render drag handle when draggable is false', async () => {
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerContent draggable={false} data-testid="drawer-content">
+            <DrawerTitle>No Drag Handle</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('No Drag Handle')).toBeInTheDocument();
+    });
+
+    const handle = document.querySelector('[data-drawer-handle]');
+    expect(handle).not.toBeInTheDocument();
+  });
+
+  it('should handle touch drag to dismiss on bottom drawer', async () => {
+    const onOpenChange = vi.fn();
+
+    render(
+      <Drawer defaultOpen onOpenChange={onOpenChange}>
+        <DrawerPortal>
+          <DrawerContent data-testid="drawer-content" dismissThreshold={50}>
+            <DrawerTitle>Touch Drag</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Touch Drag')).toBeInTheDocument();
+    });
+
+    const content = screen.getByTestId('drawer-content');
+
+    // Simulate touch drag down (beyond threshold)
+    fireEvent.touchStart(content, {
+      touches: [{ clientX: 100, clientY: 100 }],
+    });
+
+    fireEvent.touchMove(content, {
+      touches: [{ clientX: 100, clientY: 200 }],
+    });
+
+    fireEvent.touchEnd(content);
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it('should not dismiss when drag is below threshold', async () => {
+    const onOpenChange = vi.fn();
+
+    render(
+      <Drawer defaultOpen onOpenChange={onOpenChange}>
+        <DrawerPortal>
+          <DrawerContent data-testid="drawer-content" dismissThreshold={100}>
+            <DrawerTitle>Touch Drag</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Touch Drag')).toBeInTheDocument();
+    });
+
+    const content = screen.getByTestId('drawer-content');
+
+    // Simulate small touch drag (below threshold)
+    fireEvent.touchStart(content, {
+      touches: [{ clientX: 100, clientY: 100 }],
+    });
+
+    fireEvent.touchMove(content, {
+      touches: [{ clientX: 100, clientY: 130 }],
+    });
+
+    fireEvent.touchEnd(content);
+
+    // Should not close
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+});
+
+describe('Drawer - ARIA Attributes', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it('should have correct ARIA attributes', async () => {
+    render(
+      <Drawer defaultOpen>
+        <DrawerTrigger>Open</DrawerTrigger>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Title</DrawerTitle>
+            <DrawerDescription>Description</DrawerDescription>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toBeInTheDocument();
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+      expect(dialog).toHaveAttribute('aria-labelledby');
+      expect(dialog).toHaveAttribute('aria-describedby');
+      expect(dialog).toHaveAttribute('data-state', 'open');
+    });
+
+    const trigger = screen.getByText('Open');
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(trigger).toHaveAttribute('aria-controls');
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+  });
+});
+
+describe('Drawer - Focus Management', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it('should trap focus inside drawer', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Focus Trap</DrawerTitle>
+            <button type="button">First</button>
+            <button type="button">Second</button>
+            <DrawerClose data-testid="last-button">Last</DrawerClose>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Focus Trap')).toBeInTheDocument();
+    });
+
+    // Focus trap automatically focuses first focusable element
+    await waitFor(() => {
+      expect(screen.getByText('First')).toHaveFocus();
+    });
+
+    // Tab through elements
+    await user.tab();
+    expect(screen.getByText('Second')).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByTestId('last-button')).toHaveFocus();
+
+    // Tab should wrap back to first
+    await user.tab();
+    expect(screen.getByText('First')).toHaveFocus();
+  });
+});
+
+describe('Drawer - Body Scroll Lock', () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.style.overflow = '';
+    document.body.style.paddingRight = '';
+  });
+
+  afterEach(() => {
+    document.body.style.overflow = '';
+    document.body.style.paddingRight = '';
+  });
+
+  it('should lock body scroll when open', async () => {
+    const { rerender } = render(
+      <Drawer defaultOpen modal>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Scroll Lock</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Scroll Lock')).toBeInTheDocument();
+    });
+
+    // Body scroll should be locked
+    expect(document.body.style.overflow).toBe('hidden');
+
+    // Unmount
+    rerender(<div />);
+
+    // Scroll should be restored
+    await waitFor(() => {
+      expect(document.body.style.overflow).not.toBe('hidden');
+    });
+  });
+});
+
+describe('Drawer - Form Integration', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it('should work with form inside drawer', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    const DrawerWithForm = () => {
+      const [open, setOpen] = React.useState(false);
+
+      return (
+        <Drawer open={open} onOpenChange={setOpen}>
+          <DrawerTrigger>Open Form</DrawerTrigger>
+          <DrawerPortal>
+            <DrawerContent>
+              <DrawerTitle>Form Drawer</DrawerTitle>
+              <form
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  const formData = new FormData(e.currentTarget);
+                  onSubmit(Object.fromEntries(formData));
+                  setOpen(false);
+                }}
+              >
+                <input name="username" placeholder="Username" />
+                <input name="email" type="email" placeholder="Email" />
+                <button type="submit">Submit</button>
+              </form>
+            </DrawerContent>
+          </DrawerPortal>
+        </Drawer>
+      );
+    };
+
+    render(<DrawerWithForm />);
+
+    // Open drawer
+    await user.click(screen.getByText('Open Form'));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Username')).toBeInTheDocument();
+    });
+
+    // Fill form
+    await user.type(screen.getByPlaceholderText('Username'), 'testuser');
+    await user.type(screen.getByPlaceholderText('Email'), 'test@example.com');
+
+    // Submit
+    await user.click(screen.getByText('Submit'));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        username: 'testuser',
+        email: 'test@example.com',
+      });
+      expect(screen.queryByText('Form Drawer')).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe('Drawer - asChild Pattern', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it('should support asChild on trigger', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Drawer>
+        <DrawerTrigger asChild>
+          <a href="#open">Custom Trigger</a>
+        </DrawerTrigger>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Opened</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    const trigger = screen.getByText('Custom Trigger');
+    expect(trigger.tagName).toBe('A');
+    expect(trigger).toHaveAttribute('href', '#open');
+
+    await user.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByText('Opened')).toBeInTheDocument();
+    });
+  });
+
+  it('should support asChild on close', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Title</DrawerTitle>
+            <DrawerClose asChild>
+              <a href="#close">Custom Close</a>
+            </DrawerClose>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Title')).toBeInTheDocument();
+    });
+
+    const closeLink = screen.getByText('Custom Close');
+    expect(closeLink.tagName).toBe('A');
+
+    await user.click(closeLink);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Title')).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe('Drawer - Header and Footer', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it('should render DrawerHeader with correct layout classes', async () => {
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerHeader data-testid="header">
+              <DrawerTitle>Title</DrawerTitle>
+              <DrawerDescription>Description</DrawerDescription>
+            </DrawerHeader>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      const header = screen.getByTestId('header');
+      expect(header).toBeInTheDocument();
+      expect(header).toHaveClass('flex', 'flex-col');
+    });
+  });
+
+  it('should render DrawerFooter with correct layout classes', async () => {
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Title</DrawerTitle>
+            <DrawerFooter data-testid="footer">
+              <button type="button">Cancel</button>
+              <button type="button">Save</button>
+            </DrawerFooter>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      const footer = screen.getByTestId('footer');
+      expect(footer).toBeInTheDocument();
+      expect(footer).toHaveClass('flex', 'flex-col');
+    });
+  });
+
+  it('should allow custom className on Header and Footer', async () => {
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerHeader className="custom-header" data-testid="header">
+              <DrawerTitle>Title</DrawerTitle>
+            </DrawerHeader>
+            <DrawerFooter className="custom-footer" data-testid="footer">
+              <button type="button">Action</button>
+            </DrawerFooter>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('header')).toHaveClass('custom-header');
+      expect(screen.getByTestId('footer')).toHaveClass('custom-footer');
+    });
+  });
+});
+
+describe('Drawer - Title and Description styling', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it('should apply default styles to DrawerTitle', async () => {
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle data-testid="title">Styled Title</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      const title = screen.getByTestId('title');
+      expect(title).toHaveClass('text-lg', 'font-semibold');
+    });
+  });
+
+  it('should apply default styles to DrawerDescription', async () => {
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Title</DrawerTitle>
+            <DrawerDescription data-testid="description">Styled Description</DrawerDescription>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      const description = screen.getByTestId('description');
+      expect(description).toHaveClass('text-sm');
+    });
+  });
+
+  it('should allow custom className on Title and Description', async () => {
+    render(
+      <Drawer defaultOpen>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle className="custom-title" data-testid="title">
+              Title
+            </DrawerTitle>
+            <DrawerDescription className="custom-desc" data-testid="description">
+              Description
+            </DrawerDescription>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('title')).toHaveClass('custom-title');
+      expect(screen.getByTestId('description')).toHaveClass('custom-desc');
+    });
+  });
+});
+
+describe('Drawer - Drag handle position based on side', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it('should position drag handle at top for bottom drawer', async () => {
+    render(
+      <Drawer defaultOpen side="bottom">
+        <DrawerPortal>
+          <DrawerContent data-testid="drawer-content">
+            <DrawerTitle>Bottom Drawer</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      const content = screen.getByTestId('drawer-content');
+      const handle = content.querySelector('[data-drawer-handle]');
+      // Handle should be the first child for bottom drawer
+      expect(content.firstElementChild).toBe(handle);
+    });
+  });
+
+  it('should position drag handle at bottom for top drawer', async () => {
+    render(
+      <Drawer defaultOpen side="top">
+        <DrawerPortal>
+          <DrawerContent data-testid="drawer-content">
+            <DrawerTitle>Top Drawer</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      const content = screen.getByTestId('drawer-content');
+      const handle = content.querySelector('[data-drawer-handle]');
+      // Handle should be the last child for top drawer
+      expect(content.lastElementChild).toBe(handle);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `drawer` component with shadcn API parity.

### Features
- JSDoc intelligence blocks (@cognitive-load, @attention-economics, etc.)
- Unit tests
- Accessibility support (ARIA, keyboard navigation)
- Design token compliance (no arbitrary values)

## Test plan
- [x] Component tests pass
- [ ] Manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)