### PR TITLE
feat(ui): add navigation-menu component

### DIFF
--- a/packages/ui/src/components/ui/navigation-menu.tsx
+++ b/packages/ui/src/components/ui/navigation-menu.tsx
@@ -1,0 +1,755 @@
+/**
+ * Navigation menu component for site-level navigation with expandable sections
+ *
+ * @cognitive-load 5/10 - Navigation requires scanning and decision-making but with predictable patterns
+ * @attention-economics Primary navigation: visible structure, expandable sections reveal content on demand
+ * @trust-building Predictable hover/click behavior, clear visual indicators, smooth transitions
+ * @accessibility Full keyboard support (arrows, escape), proper ARIA navigation role, focus management
+ * @semantic-meaning Site navigation with expandable sections for mega-menu style content organization
+ *
+ * @usage-patterns
+ * DO: Use for primary site navigation with grouped content
+ * DO: Keep top-level items to 7 or fewer (Miller's Law)
+ * DO: Provide clear visual indicator for active/current item
+ * DO: Ensure content panels are logically organized
+ * DO: Support both hover and click interactions for accessibility
+ * NEVER: Use for contextual actions (use DropdownMenu instead)
+ * NEVER: Nest more than 2 levels deep
+ * NEVER: Hide critical navigation behind expandable sections only
+ *
+ * @example
+ * ```tsx
+ * <NavigationMenu>
+ *   <NavigationMenu.List>
+ *     <NavigationMenu.Item>
+ *       <NavigationMenu.Trigger>Products</NavigationMenu.Trigger>
+ *       <NavigationMenu.Content>
+ *         <NavigationMenu.Link href="/products/widgets">Widgets</NavigationMenu.Link>
+ *         <NavigationMenu.Link href="/products/gadgets">Gadgets</NavigationMenu.Link>
+ *       </NavigationMenu.Content>
+ *     </NavigationMenu.Item>
+ *     <NavigationMenu.Item>
+ *       <NavigationMenu.Link href="/about">About</NavigationMenu.Link>
+ *     </NavigationMenu.Item>
+ *   </NavigationMenu.List>
+ *   <NavigationMenu.Viewport />
+ * </NavigationMenu>
+ * ```
+ */
+
+import * as React from 'react';
+import classy from '../../primitives/classy';
+import { onEscapeKeyDown } from '../../primitives/escape-keydown';
+import { onPointerDownOutside } from '../../primitives/outside-click';
+import { mergeProps } from '../../primitives/slot';
+
+// ==================== Types ====================
+
+interface NavigationMenuContextValue {
+  value: string;
+  onValueChange: (value: string) => void;
+  baseId: string;
+  orientation: 'horizontal' | 'vertical';
+  delayDuration: number;
+  skipDelayDuration: number;
+  viewportRef: React.RefObject<HTMLDivElement | null>;
+  triggerRefs: React.MutableRefObject<Map<string, HTMLButtonElement | null>>;
+  contentRefs: React.MutableRefObject<Map<string, HTMLDivElement | null>>;
+}
+
+interface NavigationMenuItemContextValue {
+  value: string;
+  triggerRef: React.RefObject<HTMLButtonElement | null>;
+  contentRef: React.RefObject<HTMLDivElement | null>;
+  isActive: boolean;
+}
+
+// ==================== Contexts ====================
+
+const NavigationMenuContext = React.createContext<NavigationMenuContextValue | null>(null);
+const NavigationMenuItemContext = React.createContext<NavigationMenuItemContextValue | null>(null);
+
+function useNavigationMenuContext() {
+  const context = React.useContext(NavigationMenuContext);
+  if (!context) {
+    throw new Error('NavigationMenu components must be used within NavigationMenu');
+  }
+  return context;
+}
+
+function useNavigationMenuItemContext() {
+  const context = React.useContext(NavigationMenuItemContext);
+  if (!context) {
+    throw new Error('NavigationMenuTrigger/Content must be used within NavigationMenuItem');
+  }
+  return context;
+}
+
+// ==================== NavigationMenu (Root) ====================
+
+export interface NavigationMenuProps extends React.HTMLAttributes<HTMLElement> {
+  /** Controlled value - the item currently open */
+  value?: string;
+  /** Default value for uncontrolled usage */
+  defaultValue?: string;
+  /** Callback when value changes */
+  onValueChange?: (value: string) => void;
+  /** Orientation of the menu */
+  orientation?: 'horizontal' | 'vertical';
+  /** Delay before opening on hover (ms) */
+  delayDuration?: number;
+  /** Delay between moving from one item to another (ms) */
+  skipDelayDuration?: number;
+}
+
+export function NavigationMenu({
+  value: controlledValue,
+  defaultValue = '',
+  onValueChange,
+  orientation = 'horizontal',
+  delayDuration = 200,
+  skipDelayDuration = 300,
+  className,
+  children,
+  ...props
+}: NavigationMenuProps) {
+  const [uncontrolledValue, setUncontrolledValue] = React.useState(defaultValue);
+
+  const isControlled = controlledValue !== undefined;
+  const value = isControlled ? controlledValue : uncontrolledValue;
+
+  const handleValueChange = React.useCallback(
+    (newValue: string) => {
+      if (!isControlled) {
+        setUncontrolledValue(newValue);
+      }
+      onValueChange?.(newValue);
+    },
+    [isControlled, onValueChange],
+  );
+
+  const baseId = React.useId();
+  const viewportRef = React.useRef<HTMLDivElement | null>(null);
+  const triggerRefs = React.useRef<Map<string, HTMLButtonElement | null>>(new Map());
+  const contentRefs = React.useRef<Map<string, HTMLDivElement | null>>(new Map());
+
+  // Close on escape
+  React.useEffect(() => {
+    if (!value) return;
+
+    const cleanup = onEscapeKeyDown((event) => {
+      if (!event.defaultPrevented) {
+        handleValueChange('');
+        // Focus the trigger that was open
+        const trigger = triggerRefs.current.get(value);
+        trigger?.focus();
+      }
+    });
+
+    return cleanup;
+  }, [value, handleValueChange]);
+
+  // Close on outside click
+  React.useEffect(() => {
+    if (!value || !viewportRef.current) return;
+
+    const cleanup = onPointerDownOutside(viewportRef.current, (event) => {
+      // Check if click was on any trigger
+      let clickedOnTrigger = false;
+      for (const trigger of triggerRefs.current.values()) {
+        if (trigger?.contains(event.target as Node)) {
+          clickedOnTrigger = true;
+          break;
+        }
+      }
+
+      if (!clickedOnTrigger && !event.defaultPrevented) {
+        handleValueChange('');
+      }
+    });
+
+    return cleanup;
+  }, [value, handleValueChange]);
+
+  const contextValue = React.useMemo(
+    () => ({
+      value,
+      onValueChange: handleValueChange,
+      baseId,
+      orientation,
+      delayDuration,
+      skipDelayDuration,
+      viewportRef,
+      triggerRefs,
+      contentRefs,
+    }),
+    [value, handleValueChange, baseId, orientation, delayDuration, skipDelayDuration],
+  );
+
+  return (
+    <NavigationMenuContext.Provider value={contextValue}>
+      <nav
+        aria-label="Main navigation"
+        data-orientation={orientation}
+        className={classy('relative z-10 flex max-w-max flex-1 items-center justify-center', className)}
+        {...props}
+      >
+        {children}
+      </nav>
+    </NavigationMenuContext.Provider>
+  );
+}
+
+NavigationMenu.displayName = 'NavigationMenu';
+
+// ==================== NavigationMenuList ====================
+
+export interface NavigationMenuListProps extends React.HTMLAttributes<HTMLUListElement> {}
+
+export const NavigationMenuList = React.forwardRef<HTMLUListElement, NavigationMenuListProps>(
+  ({ className, ...props }, ref) => {
+    const { orientation } = useNavigationMenuContext();
+
+    return (
+      <ul
+        ref={ref}
+        data-orientation={orientation}
+        className={classy(
+          'group flex flex-1 list-none items-center justify-center gap-1',
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+
+NavigationMenuList.displayName = 'NavigationMenuList';
+
+// ==================== NavigationMenuItem ====================
+
+export interface NavigationMenuItemProps extends React.HTMLAttributes<HTMLLIElement> {
+  /** Unique value for this item */
+  value?: string;
+}
+
+export const NavigationMenuItem = React.forwardRef<HTMLLIElement, NavigationMenuItemProps>(
+  ({ value: propValue, className, children, ...props }, ref) => {
+    const context = useNavigationMenuContext();
+    const generatedId = React.useId();
+    const value = propValue ?? generatedId;
+
+    const triggerRef = React.useRef<HTMLButtonElement | null>(null);
+    const contentRef = React.useRef<HTMLDivElement | null>(null);
+
+    const isActive = context.value === value;
+
+    const itemContextValue = React.useMemo(
+      () => ({
+        value,
+        triggerRef,
+        contentRef,
+        isActive,
+      }),
+      [value, isActive],
+    );
+
+    return (
+      <NavigationMenuItemContext.Provider value={itemContextValue}>
+        <li ref={ref} className={classy('relative', className)} {...props}>
+          {children}
+        </li>
+      </NavigationMenuItemContext.Provider>
+    );
+  },
+);
+
+NavigationMenuItem.displayName = 'NavigationMenuItem';
+
+// ==================== NavigationMenuTrigger ====================
+
+export interface NavigationMenuTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const NavigationMenuTrigger = React.forwardRef<HTMLButtonElement, NavigationMenuTriggerProps>(
+  ({ className, children, onPointerEnter, onPointerLeave, onClick, onKeyDown, ...props }, ref) => {
+    const context = useNavigationMenuContext();
+    const itemContext = useNavigationMenuItemContext();
+    const openTimerRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+    const closeTimerRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+    const { value, onValueChange, baseId, delayDuration, triggerRefs } = context;
+    const { value: itemValue, isActive } = itemContext;
+
+    // Compose refs
+    const composedRef = React.useCallback(
+      (node: HTMLButtonElement | null) => {
+        if (typeof ref === 'function') {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+        itemContext.triggerRef.current = node;
+        triggerRefs.current.set(itemValue, node);
+      },
+      [ref, itemContext.triggerRef, triggerRefs, itemValue],
+    );
+
+    // Clear timers on unmount
+    React.useEffect(() => {
+      return () => {
+        if (openTimerRef.current) clearTimeout(openTimerRef.current);
+        if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+      };
+    }, []);
+
+    const handlePointerEnter = (event: React.PointerEvent<HTMLButtonElement>) => {
+      onPointerEnter?.(event);
+
+      if (closeTimerRef.current) {
+        clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = undefined;
+      }
+
+      // If already open somewhere, switch immediately
+      if (value && value !== itemValue) {
+        onValueChange(itemValue);
+      } else if (!isActive) {
+        openTimerRef.current = setTimeout(() => {
+          onValueChange(itemValue);
+        }, delayDuration);
+      }
+    };
+
+    const handlePointerLeave = (event: React.PointerEvent<HTMLButtonElement>) => {
+      onPointerLeave?.(event);
+
+      if (openTimerRef.current) {
+        clearTimeout(openTimerRef.current);
+        openTimerRef.current = undefined;
+      }
+
+      // Don't close immediately - let the content handle hover
+      closeTimerRef.current = setTimeout(() => {
+        if (isActive) {
+          onValueChange('');
+        }
+      }, delayDuration);
+    };
+
+    const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+
+      // Toggle on click
+      if (isActive) {
+        onValueChange('');
+      } else {
+        onValueChange(itemValue);
+      }
+    };
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+      onKeyDown?.(event);
+
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        if (isActive) {
+          onValueChange('');
+        } else {
+          onValueChange(itemValue);
+        }
+      }
+
+      // Arrow down opens the menu
+      if (event.key === 'ArrowDown' && !isActive) {
+        event.preventDefault();
+        onValueChange(itemValue);
+      }
+    };
+
+    const triggerId = `${baseId}-trigger-${itemValue}`;
+    const contentId = `${baseId}-content-${itemValue}`;
+
+    return (
+      <button
+        ref={composedRef}
+        id={triggerId}
+        type="button"
+        aria-expanded={isActive}
+        aria-controls={contentId}
+        aria-haspopup="menu"
+        data-state={isActive ? 'open' : 'closed'}
+        className={classy(
+          'group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2',
+          'text-sm font-medium transition-colors',
+          'hover:bg-accent hover:text-accent-foreground',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+          'disabled:pointer-events-none disabled:opacity-50',
+          isActive && 'bg-accent-subtle',
+          className,
+        )}
+        onPointerEnter={handlePointerEnter}
+        onPointerLeave={handlePointerLeave}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        {...props}
+      >
+        {children}
+        <ChevronDown
+          className={classy(
+            'ml-1 h-3 w-3 transition-transform duration-200',
+          )}
+          style={{ transform: isActive ? 'rotate(180deg)' : undefined }}
+          aria-hidden="true"
+        />
+      </button>
+    );
+  },
+);
+
+NavigationMenuTrigger.displayName = 'NavigationMenuTrigger';
+
+// ==================== NavigationMenuContent ====================
+
+export interface NavigationMenuContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Force mount the content (for animations) */
+  forceMount?: boolean;
+}
+
+export const NavigationMenuContent = React.forwardRef<HTMLDivElement, NavigationMenuContentProps>(
+  ({ forceMount, className, onPointerEnter, onPointerLeave, children, ...props }, ref) => {
+    const context = useNavigationMenuContext();
+    const itemContext = useNavigationMenuItemContext();
+    const closeTimerRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+    const { onValueChange, baseId, delayDuration, contentRefs } = context;
+    const { value: itemValue, isActive } = itemContext;
+
+    // Compose refs
+    const composedRef = React.useCallback(
+      (node: HTMLDivElement | null) => {
+        if (typeof ref === 'function') {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+        itemContext.contentRef.current = node;
+        contentRefs.current.set(itemValue, node);
+      },
+      [ref, itemContext.contentRef, contentRefs, itemValue],
+    );
+
+    // Clear timers on unmount
+    React.useEffect(() => {
+      return () => {
+        if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+      };
+    }, []);
+
+    const handlePointerEnter = (event: React.PointerEvent<HTMLDivElement>) => {
+      onPointerEnter?.(event);
+
+      if (closeTimerRef.current) {
+        clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = undefined;
+      }
+    };
+
+    const handlePointerLeave = (event: React.PointerEvent<HTMLDivElement>) => {
+      onPointerLeave?.(event);
+
+      closeTimerRef.current = setTimeout(() => {
+        onValueChange('');
+      }, delayDuration);
+    };
+
+    const contentId = `${baseId}-content-${itemValue}`;
+    const triggerId = `${baseId}-trigger-${itemValue}`;
+
+    const shouldRender = forceMount || isActive;
+
+    if (!shouldRender) {
+      return null;
+    }
+
+    return (
+      <div
+        ref={composedRef}
+        id={contentId}
+        aria-labelledby={triggerId}
+        data-state={isActive ? 'open' : 'closed'}
+        className={classy(
+          'left-0 top-0 w-full',
+          isActive && 'animate-in fade-in-0 zoom-in-95',
+          className,
+        )}
+        style={{ position: 'absolute' }}
+        onPointerEnter={handlePointerEnter}
+        onPointerLeave={handlePointerLeave}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+NavigationMenuContent.displayName = 'NavigationMenuContent';
+
+// ==================== NavigationMenuLink ====================
+
+export interface NavigationMenuLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  /** Render as child element (asChild pattern) */
+  asChild?: boolean;
+  /** Whether this link is currently active */
+  active?: boolean;
+}
+
+export const NavigationMenuLink = React.forwardRef<HTMLAnchorElement, NavigationMenuLinkProps>(
+  ({ asChild, active, className, children, ...props }, ref) => {
+    const context = React.useContext(NavigationMenuContext);
+
+    const handleSelect = React.useCallback(() => {
+      // Close menu after selection
+      context?.onValueChange('');
+    }, [context]);
+
+    const cls = classy(
+      'block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors',
+      'hover:bg-accent hover:text-accent-foreground',
+      'focus-visible:bg-accent focus-visible:text-accent-foreground',
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      active && 'bg-accent-subtle',
+      className,
+    );
+
+    if (asChild && React.isValidElement(children)) {
+      const child = children as React.ReactElement<
+        Record<string, unknown>,
+        string | React.JSXElementConstructor<unknown>
+      >;
+      const childPropsTyped = child.props as Record<string, unknown>;
+
+      const parentProps = {
+        ref,
+        className: cls,
+        onClick: handleSelect,
+        'data-active': active || undefined,
+        ...props,
+      };
+
+      const mergedProps = mergeProps(
+        parentProps as Parameters<typeof mergeProps>[0],
+        childPropsTyped,
+      );
+
+      return React.cloneElement(child, mergedProps as Partial<Record<string, unknown>>);
+    }
+
+    return (
+      <a
+        ref={ref}
+        className={cls}
+        data-active={active || undefined}
+        onClick={handleSelect}
+        {...props}
+      >
+        {children}
+      </a>
+    );
+  },
+);
+
+NavigationMenuLink.displayName = 'NavigationMenuLink';
+
+// ==================== NavigationMenuViewport ====================
+
+export interface NavigationMenuViewportProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Force mount the viewport (for animations) */
+  forceMount?: boolean;
+}
+
+export const NavigationMenuViewport = React.forwardRef<HTMLDivElement, NavigationMenuViewportProps>(
+  ({ forceMount, className, ...props }, ref) => {
+    const context = useNavigationMenuContext();
+    const { value, viewportRef, contentRefs } = context;
+
+    // Compose refs
+    const composedRef = React.useCallback(
+      (node: HTMLDivElement | null) => {
+        if (typeof ref === 'function') {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+        viewportRef.current = node;
+      },
+      [ref, viewportRef],
+    );
+
+    const isOpen = Boolean(value);
+    const shouldRender = forceMount || isOpen;
+
+    // Get the active content for sizing
+    const activeContent = value ? contentRefs.current.get(value) : null;
+    const [size, setSize] = React.useState({ width: 0, height: 0 });
+
+    React.useEffect(() => {
+      if (activeContent) {
+        setSize({
+          width: activeContent.offsetWidth,
+          height: activeContent.offsetHeight,
+        });
+      }
+    }, [activeContent, value]);
+
+    if (!shouldRender) {
+      return null;
+    }
+
+    return (
+      <div className="left-0 top-full flex justify-center" style={{ position: 'absolute' }}>
+        <div
+          ref={composedRef}
+          data-state={isOpen ? 'open' : 'closed'}
+          className={classy(
+            'mt-1.5 h-min w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg',
+            'origin-top-center',
+            isOpen && 'animate-in fade-in-0 zoom-in-95',
+            className,
+          )}
+          style={{
+            position: 'relative',
+            width: size.width || undefined,
+            height: size.height || undefined,
+          }}
+          {...props}
+        >
+          {/* Render all contents but only show active one */}
+          {Array.from(contentRefs.current.entries()).map(([itemValue, content]) => {
+            if (!content) return null;
+            const contentIsActive = value === itemValue;
+            return (
+              <div
+                key={itemValue}
+                data-state={contentIsActive ? 'open' : 'closed'}
+                style={{ display: contentIsActive ? 'block' : 'none' }}
+              >
+                {/* Content is rendered in NavigationMenuContent, this just positions it */}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  },
+);
+
+NavigationMenuViewport.displayName = 'NavigationMenuViewport';
+
+// ==================== NavigationMenuIndicator ====================
+
+export interface NavigationMenuIndicatorProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Force mount the indicator (for animations) */
+  forceMount?: boolean;
+}
+
+export const NavigationMenuIndicator = React.forwardRef<HTMLDivElement, NavigationMenuIndicatorProps>(
+  ({ forceMount, className, ...props }, ref) => {
+    const context = useNavigationMenuContext();
+    const { value, triggerRefs } = context;
+
+    const [position, setPosition] = React.useState({ left: 0, width: 0 });
+    const isVisible = Boolean(value);
+
+    // Update position based on active trigger
+    React.useEffect(() => {
+      if (value) {
+        const trigger = triggerRefs.current.get(value);
+        if (trigger) {
+          const rect = trigger.getBoundingClientRect();
+          const parentRect = trigger.parentElement?.getBoundingClientRect();
+          if (parentRect) {
+            setPosition({
+              left: rect.left - parentRect.left,
+              width: rect.width,
+            });
+          }
+        }
+      }
+    }, [value, triggerRefs]);
+
+    const shouldRender = forceMount || isVisible;
+
+    if (!shouldRender) {
+      return null;
+    }
+
+    return (
+      <div
+        ref={ref}
+        data-state={isVisible ? 'visible' : 'hidden'}
+        className={classy(
+          'bottom-0 z-10 flex h-2.5 items-end justify-center overflow-hidden',
+          'transition-transform duration-200',
+          isVisible && 'animate-in fade-in',
+          className,
+        )}
+        style={{
+          position: 'absolute',
+          left: position.left,
+          width: position.width,
+        }}
+        aria-hidden="true"
+        {...props}
+      >
+        <div
+          className="top-full h-2 w-2 rotate-45 rounded-tl-sm bg-border shadow-md"
+          style={{ position: 'relative' }}
+        />
+      </div>
+    );
+  },
+);
+
+NavigationMenuIndicator.displayName = 'NavigationMenuIndicator';
+
+// ==================== Internal Icons ====================
+
+function ChevronDown({
+  className,
+  style,
+}: {
+  className?: string;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      style={style}
+    >
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}
+
+// ==================== Namespaced Export ====================
+
+NavigationMenu.List = NavigationMenuList;
+NavigationMenu.Item = NavigationMenuItem;
+NavigationMenu.Trigger = NavigationMenuTrigger;
+NavigationMenu.Content = NavigationMenuContent;
+NavigationMenu.Link = NavigationMenuLink;
+NavigationMenu.Viewport = NavigationMenuViewport;
+NavigationMenu.Indicator = NavigationMenuIndicator;
+
+// Re-export root as NavigationMenuRoot alias for compatibility
+export { NavigationMenu as NavigationMenuRoot };

--- a/packages/ui/test/components/navigation-menu.a11y.tsx
+++ b/packages/ui/test/components/navigation-menu.a11y.tsx
@@ -1,0 +1,511 @@
+/**
+ * NavigationMenu component accessibility tests
+ * Tests ARIA attributes, focus management, and keyboard navigation
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import {
+  NavigationMenu,
+  NavigationMenuContent,
+  NavigationMenuIndicator,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+  NavigationMenuTrigger,
+  NavigationMenuViewport,
+} from '../../src/components/ui/navigation-menu';
+
+describe('NavigationMenu - Accessibility', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('has no accessibility violations when closed', async () => {
+    const { container } = render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products/widgets">Widgets</NavigationMenuLink>
+              <NavigationMenuLink href="/products/gadgets">Gadgets</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+          <NavigationMenuItem value="services">
+            <NavigationMenuTrigger>Services</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/services/consulting">Consulting</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+          <NavigationMenuItem>
+            <NavigationMenuLink href="/about">About</NavigationMenuLink>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no accessibility violations when open', async () => {
+    const { container } = render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products/widgets">Widgets</NavigationMenuLink>
+              <NavigationMenuLink href="/products/gadgets">Gadgets</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+          <NavigationMenuItem value="services">
+            <NavigationMenuTrigger>Services</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/services/consulting">Consulting</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no accessibility violations with viewport', async () => {
+    const { container } = render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Products Link</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+        <NavigationMenuViewport />
+      </NavigationMenu>,
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has correct navigation landmark role', () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem>
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const nav = screen.getByRole('navigation');
+    expect(nav).toBeInTheDocument();
+  });
+
+  it('has accessible name on navigation', () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem>
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const nav = screen.getByRole('navigation');
+    expect(nav).toHaveAttribute('aria-label', 'Main navigation');
+  });
+
+  it('trigger has correct aria-expanded when closed', () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Link</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /Products/i });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('trigger has correct aria-expanded when open', () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Link</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /Products/i });
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('trigger has aria-haspopup="menu"', () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem>
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /Products/i });
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+  });
+
+  it('trigger has aria-controls pointing to content', () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent data-testid="content">
+              <NavigationMenuLink href="/products">Link</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /Products/i });
+    const content = screen.getByTestId('content');
+    const controlsId = trigger.getAttribute('aria-controls');
+
+    expect(controlsId).toBeTruthy();
+    expect(content).toHaveAttribute('id', controlsId);
+  });
+
+  it('content has aria-labelledby pointing to trigger', () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent data-testid="content">
+              <NavigationMenuLink href="/products">Link</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /Products/i });
+    const content = screen.getByTestId('content');
+
+    expect(content).toHaveAttribute('aria-labelledby', trigger.id);
+  });
+
+  it('links are accessible', () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products/widgets">Widgets</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const link = screen.getByRole('link', { name: 'Widgets' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/products/widgets');
+  });
+
+  it('supports keyboard navigation with Enter key', () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Link</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /Products/i });
+    trigger.focus();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('supports keyboard navigation with Space key', () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Link</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /Products/i });
+    trigger.focus();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.keyDown(trigger, { key: ' ' });
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('supports keyboard navigation with ArrowDown key', () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Link</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /Products/i });
+    trigger.focus();
+
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('closes on Escape key', () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Link</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /Products/i });
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('returns focus to trigger on Escape', async () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Link</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /Products/i });
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(trigger).toHaveFocus();
+    });
+  });
+
+  it('has data-state attribute for state indication', () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Link</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /Products/i });
+    expect(trigger).toHaveAttribute('data-state', 'closed');
+
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('data-state', 'open');
+  });
+
+  it('indicator has aria-hidden for screen readers', () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Link</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+        <NavigationMenuIndicator data-testid="indicator" />
+      </NavigationMenu>,
+    );
+
+    const indicator = screen.getByTestId('indicator');
+    expect(indicator).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('active link shows active state', () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products/widgets" active>
+                Widgets
+              </NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const link = screen.getByRole('link', { name: 'Widgets' });
+    expect(link).toHaveAttribute('data-active');
+  });
+
+  it('supports data-orientation attribute', () => {
+    render(
+      <NavigationMenu orientation="vertical" data-testid="nav">
+        <NavigationMenuList data-testid="list">
+          <NavigationMenuItem>
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const nav = screen.getByTestId('nav');
+    const list = screen.getByTestId('list');
+
+    expect(nav).toHaveAttribute('data-orientation', 'vertical');
+    expect(list).toHaveAttribute('data-orientation', 'vertical');
+  });
+
+  it('button type is explicitly set', () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem>
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /Products/i });
+    expect(trigger).toHaveAttribute('type', 'button');
+  });
+
+  it('multiple triggers work independently', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Products Link</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+          <NavigationMenuItem value="services">
+            <NavigationMenuTrigger>Services</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/services">Services Link</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const productsTrigger = screen.getByRole('button', { name: /Products/i });
+    const servicesTrigger = screen.getByRole('button', { name: /Services/i });
+
+    // Both start closed
+    expect(productsTrigger).toHaveAttribute('aria-expanded', 'false');
+    expect(servicesTrigger).toHaveAttribute('aria-expanded', 'false');
+
+    // Open products
+    await user.click(productsTrigger);
+    expect(productsTrigger).toHaveAttribute('aria-expanded', 'true');
+    expect(servicesTrigger).toHaveAttribute('aria-expanded', 'false');
+
+    // Open services (closes products)
+    await user.click(servicesTrigger);
+    expect(productsTrigger).toHaveAttribute('aria-expanded', 'false');
+    expect(servicesTrigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('viewport has proper data-state', () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Link</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+        <NavigationMenuViewport data-testid="viewport" />
+      </NavigationMenu>,
+    );
+
+    const viewport = screen.getByTestId('viewport');
+    expect(viewport).toHaveAttribute('data-state', 'open');
+  });
+});

--- a/packages/ui/test/components/navigation-menu.test.tsx
+++ b/packages/ui/test/components/navigation-menu.test.tsx
@@ -1,0 +1,933 @@
+/**
+ * NavigationMenu component tests
+ * Tests SSR, hydration, interactions, and navigation semantics
+ */
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { renderToString } from 'react-dom/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  NavigationMenu,
+  NavigationMenuContent,
+  NavigationMenuIndicator,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+  NavigationMenuTrigger,
+  NavigationMenuViewport,
+} from '../../src/components/ui/navigation-menu';
+
+describe('NavigationMenu - SSR Safety', () => {
+  it('should render on server without errors', () => {
+    const html = renderToString(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem>
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products/widgets">Widgets</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    expect(html).toBeTruthy();
+    expect(html).toContain('Products');
+  });
+
+  it('should not render content when closed on server', () => {
+    const html = renderToString(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem>
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Server Content</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    expect(html).not.toContain('Server Content');
+  });
+});
+
+describe('NavigationMenu - Client Hydration', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should hydrate and render correctly on client', async () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Hydrated Content</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    expect(screen.getByText('Hydrated Content')).toBeInTheDocument();
+  });
+
+  it('should maintain state after hydration', async () => {
+    const { rerender } = render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Content</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    expect(screen.getByText('Content')).toBeInTheDocument();
+
+    rerender(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Content</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+});
+
+describe('NavigationMenu - Basic Interactions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('should open on trigger click', async () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    expect(screen.queryByText('Widget')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Products'));
+
+    expect(screen.getByText('Widget')).toBeInTheDocument();
+  });
+
+  it('should close on trigger click when open', async () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    expect(screen.getByText('Widget')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Products'));
+
+    expect(screen.queryByText('Widget')).not.toBeInTheDocument();
+  });
+
+  it('should open on hover after delay', async () => {
+    render(
+      <NavigationMenu delayDuration={200}>
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    expect(screen.queryByText('Widget')).not.toBeInTheDocument();
+
+    fireEvent.pointerEnter(screen.getByText('Products'));
+
+    // Not immediately visible
+    expect(screen.queryByText('Widget')).not.toBeInTheDocument();
+
+    // Advance timer past delay
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
+    expect(screen.getByText('Widget')).toBeInTheDocument();
+  });
+
+  it('should close on Escape key', async () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    expect(screen.getByText('Widget')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(screen.queryByText('Widget')).not.toBeInTheDocument();
+  });
+
+  it('should switch between items immediately when open', async () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Products Content</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+          <NavigationMenuItem value="services">
+            <NavigationMenuTrigger>Services</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/services">Services Content</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    expect(screen.getByText('Products Content')).toBeInTheDocument();
+    expect(screen.queryByText('Services Content')).not.toBeInTheDocument();
+
+    // Hover over services trigger - should switch immediately since menu is open
+    fireEvent.pointerEnter(screen.getByText('Services'));
+
+    expect(screen.queryByText('Products Content')).not.toBeInTheDocument();
+    expect(screen.getByText('Services Content')).toBeInTheDocument();
+  });
+});
+
+describe('NavigationMenu - Controlled Mode', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should work in controlled mode', async () => {
+    const onValueChange = vi.fn();
+
+    const ControlledNav = () => {
+      const [value, setValue] = React.useState('');
+
+      return (
+        <NavigationMenu
+          value={value}
+          onValueChange={(newValue) => {
+            setValue(newValue);
+            onValueChange(newValue);
+          }}
+        >
+          <NavigationMenuList>
+            <NavigationMenuItem value="products">
+              <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+              <NavigationMenuContent>
+                <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+              </NavigationMenuContent>
+            </NavigationMenuItem>
+          </NavigationMenuList>
+        </NavigationMenu>
+      );
+    };
+
+    render(<ControlledNav />);
+
+    expect(screen.queryByText('Widget')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Products'));
+
+    expect(screen.getByText('Widget')).toBeInTheDocument();
+    expect(onValueChange).toHaveBeenCalledWith('products');
+
+    fireEvent.click(screen.getByText('Products'));
+
+    expect(screen.queryByText('Widget')).not.toBeInTheDocument();
+    expect(onValueChange).toHaveBeenCalledWith('');
+  });
+});
+
+describe('NavigationMenu - Keyboard Navigation', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should open on Enter key', async () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByText('Products');
+    trigger.focus();
+
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+
+    expect(screen.getByText('Widget')).toBeInTheDocument();
+  });
+
+  it('should open on Space key', async () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByText('Products');
+    trigger.focus();
+
+    fireEvent.keyDown(trigger, { key: ' ' });
+
+    expect(screen.getByText('Widget')).toBeInTheDocument();
+  });
+
+  it('should open on ArrowDown key', async () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByText('Products');
+    trigger.focus();
+
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+
+    expect(screen.getByText('Widget')).toBeInTheDocument();
+  });
+
+  it('should close on Enter when open', async () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    expect(screen.getByText('Widget')).toBeInTheDocument();
+
+    const trigger = screen.getByText('Products');
+    trigger.focus();
+
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+
+    expect(screen.queryByText('Widget')).not.toBeInTheDocument();
+  });
+});
+
+describe('NavigationMenu - ARIA Attributes', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should have correct aria-label on nav', () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem>
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const nav = screen.getByRole('navigation');
+    expect(nav).toHaveAttribute('aria-label', 'Main navigation');
+  });
+
+  it('trigger should have aria-expanded attribute', () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /Products/i });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('trigger should have aria-haspopup="menu"', () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem>
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /Products/i });
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+  });
+
+  it('trigger should have aria-controls pointing to content', () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent data-testid="content">
+              <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /Products/i });
+    const contentId = trigger.getAttribute('aria-controls');
+
+    expect(contentId).toBeTruthy();
+
+    const content = screen.getByTestId('content');
+    expect(content).toHaveAttribute('id', contentId);
+  });
+
+  it('content should have aria-labelledby pointing to trigger', () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent data-testid="content">
+              <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /Products/i });
+    const content = screen.getByTestId('content');
+
+    expect(content).toHaveAttribute('aria-labelledby', trigger.id);
+  });
+});
+
+describe('NavigationMenu - Links', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should render links correctly', () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products/widgets">Widgets</NavigationMenuLink>
+              <NavigationMenuLink href="/products/gadgets">Gadgets</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const widgetsLink = screen.getByRole('link', { name: 'Widgets' });
+    const gadgetsLink = screen.getByRole('link', { name: 'Gadgets' });
+
+    expect(widgetsLink).toHaveAttribute('href', '/products/widgets');
+    expect(gadgetsLink).toHaveAttribute('href', '/products/gadgets');
+  });
+
+  it('should support asChild pattern for custom links', () => {
+    const CustomLink = React.forwardRef<HTMLAnchorElement, { to: string; children: React.ReactNode }>(
+      ({ to, children, ...props }, ref) => (
+        <a ref={ref} href={to} data-custom {...props}>
+          {children}
+        </a>
+      ),
+    );
+    CustomLink.displayName = 'CustomLink';
+
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink asChild>
+                <CustomLink to="/products/widgets">Widgets</CustomLink>
+              </NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const link = screen.getByRole('link', { name: 'Widgets' });
+    expect(link).toHaveAttribute('href', '/products/widgets');
+    expect(link).toHaveAttribute('data-custom');
+  });
+
+  it('should show active state on link', () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products/widgets" active>
+                Active Link
+              </NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const link = screen.getByRole('link', { name: 'Active Link' });
+    expect(link).toHaveAttribute('data-active');
+  });
+});
+
+describe('NavigationMenu - Data Attributes', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should have data-state attribute on trigger', () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /Products/i });
+    expect(trigger).toHaveAttribute('data-state', 'closed');
+
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('data-state', 'open');
+  });
+
+  it('should have data-state attribute on content', () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent data-testid="content">
+              <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const content = screen.getByTestId('content');
+    expect(content).toHaveAttribute('data-state', 'open');
+  });
+
+  it('should have data-orientation on root and list', () => {
+    render(
+      <NavigationMenu data-testid="nav">
+        <NavigationMenuList data-testid="list">
+          <NavigationMenuItem>
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const nav = screen.getByTestId('nav');
+    const list = screen.getByTestId('list');
+
+    expect(nav).toHaveAttribute('data-orientation', 'horizontal');
+    expect(list).toHaveAttribute('data-orientation', 'horizontal');
+  });
+
+  it('should support vertical orientation', () => {
+    render(
+      <NavigationMenu orientation="vertical" data-testid="nav">
+        <NavigationMenuList data-testid="list">
+          <NavigationMenuItem>
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const nav = screen.getByTestId('nav');
+    const list = screen.getByTestId('list');
+
+    expect(nav).toHaveAttribute('data-orientation', 'vertical');
+    expect(list).toHaveAttribute('data-orientation', 'vertical');
+  });
+});
+
+describe('NavigationMenu - Viewport', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should render viewport when open', () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+        <NavigationMenuViewport data-testid="viewport" />
+      </NavigationMenu>,
+    );
+
+    expect(screen.getByTestId('viewport')).toBeInTheDocument();
+  });
+
+  it('should not render viewport when closed', () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+        <NavigationMenuViewport data-testid="viewport" />
+      </NavigationMenu>,
+    );
+
+    expect(screen.queryByTestId('viewport')).not.toBeInTheDocument();
+  });
+
+  it('should render viewport with forceMount', () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+        <NavigationMenuViewport forceMount data-testid="viewport" />
+      </NavigationMenu>,
+    );
+
+    expect(screen.getByTestId('viewport')).toBeInTheDocument();
+  });
+});
+
+describe('NavigationMenu - Indicator', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should render indicator when open', () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+        <NavigationMenuIndicator data-testid="indicator" />
+      </NavigationMenu>,
+    );
+
+    expect(screen.getByTestId('indicator')).toBeInTheDocument();
+  });
+
+  it('should not render indicator when closed', () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+        <NavigationMenuIndicator data-testid="indicator" />
+      </NavigationMenu>,
+    );
+
+    expect(screen.queryByTestId('indicator')).not.toBeInTheDocument();
+  });
+
+  it('indicator should have aria-hidden', () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+        <NavigationMenuIndicator data-testid="indicator" />
+      </NavigationMenu>,
+    );
+
+    const indicator = screen.getByTestId('indicator');
+    expect(indicator).toHaveAttribute('aria-hidden', 'true');
+  });
+});
+
+describe('NavigationMenu - Multiple Items', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should only show one content at a time', () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Products Content</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+          <NavigationMenuItem value="services">
+            <NavigationMenuTrigger>Services</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/services">Services Content</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    expect(screen.getByText('Products Content')).toBeInTheDocument();
+    expect(screen.queryByText('Services Content')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Services/i }));
+
+    expect(screen.queryByText('Products Content')).not.toBeInTheDocument();
+    expect(screen.getByText('Services Content')).toBeInTheDocument();
+  });
+
+  it('should allow simple links without content', () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Content</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+          <NavigationMenuItem>
+            <NavigationMenuLink href="/about">About</NavigationMenuLink>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const aboutLink = screen.getByRole('link', { name: 'About' });
+    expect(aboutLink).toHaveAttribute('href', '/about');
+  });
+});
+
+describe('NavigationMenu - Custom className', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should merge custom className on root', () => {
+    render(
+      <NavigationMenu className="custom-nav" data-testid="nav">
+        <NavigationMenuList>
+          <NavigationMenuItem>
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const nav = screen.getByTestId('nav');
+    expect(nav).toHaveClass('custom-nav');
+  });
+
+  it('should merge custom className on trigger', () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem>
+            <NavigationMenuTrigger className="custom-trigger">Products</NavigationMenuTrigger>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /Products/i });
+    expect(trigger).toHaveClass('custom-trigger');
+  });
+
+  it('should merge custom className on content', () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent className="custom-content" data-testid="content">
+              <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const content = screen.getByTestId('content');
+    expect(content).toHaveClass('custom-content');
+  });
+
+  it('should merge custom className on link', () => {
+    render(
+      <NavigationMenu defaultValue="products">
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products" className="custom-link">
+                Widget
+              </NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const link = screen.getByRole('link', { name: 'Widget' });
+    expect(link).toHaveClass('custom-link');
+  });
+});
+
+describe('NavigationMenu - Focus Management', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should return focus to trigger on Escape', async () => {
+    render(
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem value="products">
+            <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink href="/products">Widget</NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /Products/i });
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    expect(screen.getByText('Widget')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Widget')).not.toBeInTheDocument();
+      expect(trigger).toHaveFocus();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `navigation-menu` component with shadcn API parity.

### Features
- JSDoc intelligence blocks (@cognitive-load, @attention-economics, etc.)
- Unit tests
- Accessibility support (ARIA, keyboard navigation)
- Design token compliance (no arbitrary values)

## Test plan
- [x] Component tests pass
- [ ] Manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)