### PR TITLE
feat(ui): add command component

### DIFF
--- a/packages/ui/src/components/ui/command.tsx
+++ b/packages/ui/src/components/ui/command.tsx
@@ -1,0 +1,520 @@
+/**
+ * Command component for keyboard-driven command palettes and search interfaces
+ *
+ * @cognitive-load 6/10 - Command-based interface; requires learning shortcuts but fast once known
+ * @attention-economics High initial attention, low ongoing: power users benefit from muscle memory
+ * @trust-building Immediate search feedback, keyboard navigable, clear action consequences
+ * @accessibility Full keyboard navigation, ARIA combobox pattern, screen reader announcements
+ * @semantic-meaning Command execution: quick actions, navigation, search, command palettes
+ *
+ * @usage-patterns
+ * DO: Use for power-user features and keyboard shortcuts
+ * DO: Provide instant search/filter feedback
+ * DO: Group related commands logically
+ * DO: Support both mouse and keyboard navigation
+ * DO: Show keyboard shortcut hints
+ * NEVER: Use for simple forms or data entry
+ * NEVER: Require mouse-only interaction
+ * NEVER: Hide without clear dismissal method
+ *
+ * @example
+ * ```tsx
+ * <Command>
+ *   <Command.Input placeholder="Type a command or search..." />
+ *   <Command.List>
+ *     <Command.Empty>No results found.</Command.Empty>
+ *     <Command.Group heading="Suggestions">
+ *       <Command.Item onSelect={() => {}}>Calendar</Command.Item>
+ *       <Command.Item onSelect={() => {}}>Search</Command.Item>
+ *     </Command.Group>
+ *   </Command.List>
+ * </Command>
+ * ```
+ */
+
+import * as React from 'react';
+import classy from '../../primitives/classy';
+
+// ==================== Context ====================
+
+interface CommandContextValue {
+  value: string;
+  onValueChange: (value: string) => void;
+  selectedValue: string;
+  onSelect: (value: string) => void;
+  activeIndex: number;
+  setActiveIndex: (index: number) => void;
+  items: string[];
+  registerItem: (value: string) => void;
+  unregisterItem: (value: string) => void;
+  listId: string;
+  inputId: string;
+  getItemId: (value: string) => string;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+}
+
+const CommandContext = React.createContext<CommandContextValue | null>(null);
+
+function useCommandContext() {
+  const context = React.useContext(CommandContext);
+  if (!context) {
+    throw new Error('Command components must be used within Command');
+  }
+  return context;
+}
+
+// ==================== Command (Root) ====================
+
+export interface CommandProps extends React.HTMLAttributes<HTMLDivElement> {
+  value?: string;
+  onValueChange?: (value: string) => void;
+  filter?: (value: string, search: string) => boolean;
+  loop?: boolean;
+}
+
+export function Command({
+  value: controlledValue,
+  onValueChange,
+  filter,
+  loop = false,
+  className,
+  children,
+  ...props
+}: CommandProps) {
+  // Search input value
+  const [uncontrolledValue, setUncontrolledValue] = React.useState('');
+  const isControlled = controlledValue !== undefined;
+  const value = isControlled ? controlledValue : uncontrolledValue;
+
+  // Selected/highlighted item
+  const [selectedValue, setSelectedValue] = React.useState('');
+  const [activeIndex, setActiveIndex] = React.useState(-1);
+
+  // Registered items
+  const [items, setItems] = React.useState<string[]>([]);
+
+  // Refs
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+
+  // IDs
+  const id = React.useId();
+  const listId = `command-list-${id}`;
+  const inputId = `command-input-${id}`;
+
+  const handleValueChange = React.useCallback(
+    (newValue: string) => {
+      if (!isControlled) {
+        setUncontrolledValue(newValue);
+      }
+      onValueChange?.(newValue);
+      // Reset active index when search changes
+      setActiveIndex(-1);
+    },
+    [isControlled, onValueChange],
+  );
+
+  const handleSelect = React.useCallback((itemValue: string) => {
+    setSelectedValue(itemValue);
+  }, []);
+
+  const registerItem = React.useCallback((itemValue: string) => {
+    setItems((prev) => {
+      if (prev.includes(itemValue)) return prev;
+      return [...prev, itemValue];
+    });
+  }, []);
+
+  const unregisterItem = React.useCallback((itemValue: string) => {
+    setItems((prev) => prev.filter((v) => v !== itemValue));
+  }, []);
+
+  const getItemId = React.useCallback(
+    (itemValue: string) => `${listId}-item-${itemValue.replace(/\s+/g, '-')}`,
+    [listId],
+  );
+
+  const contextValue = React.useMemo<CommandContextValue>(
+    () => ({
+      value,
+      onValueChange: handleValueChange,
+      selectedValue,
+      onSelect: handleSelect,
+      activeIndex,
+      setActiveIndex,
+      items,
+      registerItem,
+      unregisterItem,
+      listId,
+      inputId,
+      getItemId,
+      inputRef,
+    }),
+    [
+      value,
+      handleValueChange,
+      selectedValue,
+      handleSelect,
+      activeIndex,
+      items,
+      registerItem,
+      unregisterItem,
+      listId,
+      inputId,
+      getItemId,
+    ],
+  );
+
+  return (
+    <CommandContext.Provider value={contextValue}>
+      <div
+        data-command=""
+        className={classy(
+          'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </CommandContext.Provider>
+  );
+}
+
+// ==================== CommandDialog ====================
+
+export interface CommandDialogProps extends React.HTMLAttributes<HTMLDivElement> {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function CommandDialog({
+  open,
+  onOpenChange,
+  className,
+  children,
+  ...props
+}: CommandDialogProps) {
+  // Handle escape to close
+  React.useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onOpenChange?.(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, onOpenChange]);
+
+  if (!open) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-50 bg-black/80"
+        onClick={() => onOpenChange?.(false)}
+      />
+      {/* Dialog */}
+      <div
+        data-command-dialog=""
+        className={classy(
+          'fixed left-1/2 top-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2',
+          'rounded-lg border bg-popover shadow-lg',
+          className,
+        )}
+        {...props}
+      >
+        <Command className="[&_[data-command-input-wrapper]]:border-b">{children}</Command>
+      </div>
+    </>
+  );
+}
+
+// ==================== CommandInput ====================
+
+export interface CommandInputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'> {}
+
+export function CommandInput({ className, onKeyDown, ...props }: CommandInputProps) {
+  const { value, onValueChange, activeIndex, setActiveIndex, items, onSelect, listId, inputId, getItemId, inputRef } =
+    useCommandContext();
+
+  // Get visible items (for keyboard navigation)
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    onKeyDown?.(e);
+    if (e.defaultPrevented) return;
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setActiveIndex(Math.min(activeIndex + 1, items.length - 1));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setActiveIndex(Math.max(activeIndex - 1, 0));
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          onSelect(items[activeIndex]);
+        }
+        break;
+      case 'Home':
+        e.preventDefault();
+        setActiveIndex(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        setActiveIndex(items.length - 1);
+        break;
+    }
+  };
+
+  const activeItemId = activeIndex >= 0 && items[activeIndex] ? getItemId(items[activeIndex]) : undefined;
+
+  return (
+    <div data-command-input-wrapper="" className="flex items-center border-b px-3">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="mr-2 shrink-0 opacity-50"
+      >
+        <circle cx="11" cy="11" r="8" />
+        <path d="m21 21-4.3-4.3" />
+      </svg>
+      <input
+        ref={inputRef}
+        id={inputId}
+        type="text"
+        role="combobox"
+        aria-autocomplete="list"
+        aria-expanded="true"
+        aria-controls={listId}
+        aria-activedescendant={activeItemId}
+        autoComplete="off"
+        autoCorrect="off"
+        spellCheck="false"
+        value={value}
+        onChange={(e) => onValueChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        data-command-input=""
+        className={classy(
+          'flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none',
+          'placeholder:text-muted-foreground',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+// ==================== CommandList ====================
+
+export interface CommandListProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function CommandList({ className, children, ...props }: CommandListProps) {
+  const { listId } = useCommandContext();
+
+  return (
+    <div
+      id={listId}
+      role="listbox"
+      data-command-list=""
+      className={classy('max-h-80 overflow-y-auto overflow-x-hidden', className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+// ==================== CommandEmpty ====================
+
+export interface CommandEmptyProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function CommandEmpty({ className, children, ...props }: CommandEmptyProps) {
+  const { items, value } = useCommandContext();
+
+  // Calculate visible items (those that match the search)
+  const visibleItems = React.useMemo(() => {
+    if (!value) return items;
+    const lower = value.toLowerCase();
+    return items.filter((item) => item.toLowerCase().includes(lower));
+  }, [items, value]);
+
+  // Only show when there are no visible items and there's a search value
+  if (visibleItems.length > 0 || !value) return null;
+
+  return (
+    <div
+      data-command-empty=""
+      className={classy('py-6 text-center text-sm', className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+// ==================== CommandGroup ====================
+
+export interface CommandGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+  heading?: string;
+}
+
+export function CommandGroup({ heading, className, children, ...props }: CommandGroupProps) {
+  const headingId = React.useId();
+
+  return (
+    <div
+      role="group"
+      aria-labelledby={heading ? headingId : undefined}
+      data-command-group=""
+      className={classy('overflow-hidden p-1 text-foreground', className)}
+      {...props}
+    >
+      {heading && (
+        <div
+          id={headingId}
+          data-command-group-heading=""
+          className="px-2 py-1.5 text-xs font-medium text-muted-foreground"
+        >
+          {heading}
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}
+
+// ==================== CommandItem ====================
+
+export interface CommandItemProps extends React.HTMLAttributes<HTMLDivElement> {
+  value?: string;
+  disabled?: boolean;
+  onSelect?: (value: string) => void;
+}
+
+export function CommandItem({
+  value: itemValue,
+  disabled = false,
+  onSelect,
+  className,
+  children,
+  ...props
+}: CommandItemProps) {
+  const { value: searchValue, activeIndex, setActiveIndex, items, registerItem, unregisterItem, getItemId, onSelect: contextOnSelect } =
+    useCommandContext();
+
+  // Use children text as value if not provided
+  const computedValue = itemValue ?? (typeof children === 'string' ? children : '');
+
+  // Register item
+  React.useEffect(() => {
+    if (!disabled) {
+      registerItem(computedValue);
+      return () => unregisterItem(computedValue);
+    }
+  }, [computedValue, disabled, registerItem, unregisterItem]);
+
+  // Filter check
+  const isFiltered = React.useMemo(() => {
+    if (!searchValue) return false;
+    const lower = searchValue.toLowerCase();
+    return !computedValue.toLowerCase().includes(lower);
+  }, [searchValue, computedValue]);
+
+  // Don't render if filtered out
+  if (isFiltered) return null;
+
+  // Find index
+  const index = items.indexOf(computedValue);
+  const isActive = index === activeIndex;
+
+  const handleClick = () => {
+    if (!disabled) {
+      onSelect?.(computedValue);
+      contextOnSelect(computedValue);
+    }
+  };
+
+  const handleMouseEnter = () => {
+    if (!disabled) {
+      setActiveIndex(index);
+    }
+  };
+
+  return (
+    <div
+      id={getItemId(computedValue)}
+      role="option"
+      aria-selected={isActive}
+      aria-disabled={disabled}
+      data-command-item=""
+      data-value={computedValue}
+      data-selected={isActive || undefined}
+      data-disabled={disabled || undefined}
+      onClick={handleClick}
+      onMouseEnter={handleMouseEnter}
+      className={classy(
+        'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none',
+        'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        'data-[selected]:bg-accent data-[selected]:text-accent-foreground',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+// ==================== CommandSeparator ====================
+
+export interface CommandSeparatorProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function CommandSeparator({ className, ...props }: CommandSeparatorProps) {
+  return (
+    <div
+      data-command-separator=""
+      className={classy('-mx-1 h-px bg-border', className)}
+      {...props}
+    />
+  );
+}
+
+// ==================== CommandShortcut ====================
+
+export interface CommandShortcutProps extends React.HTMLAttributes<HTMLSpanElement> {}
+
+export function CommandShortcut({ className, ...props }: CommandShortcutProps) {
+  return (
+    <span
+      data-command-shortcut=""
+      className={classy('ml-auto text-xs tracking-widest text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+// ==================== Namespaced Export ====================
+
+Command.Dialog = CommandDialog;
+Command.Input = CommandInput;
+Command.List = CommandList;
+Command.Empty = CommandEmpty;
+Command.Group = CommandGroup;
+Command.Item = CommandItem;
+Command.Separator = CommandSeparator;
+Command.Shortcut = CommandShortcut;

--- a/packages/ui/test/components/command.test.tsx
+++ b/packages/ui/test/components/command.test.tsx
@@ -1,0 +1,455 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import * as React from 'react';
+import {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandSeparator,
+  CommandShortcut,
+} from '../../src/components/ui/command';
+
+const TestCommand = ({
+  value,
+  onValueChange,
+}: {
+  value?: string;
+  onValueChange?: (value: string) => void;
+}) => (
+  <Command value={value} onValueChange={onValueChange} data-testid="command">
+    <CommandInput placeholder="Type a command..." data-testid="input" />
+    <CommandList data-testid="list">
+      <CommandEmpty>No results found.</CommandEmpty>
+      <CommandGroup heading="Suggestions" data-testid="group">
+        <CommandItem value="calendar" data-testid="item-calendar">
+          Calendar
+          <CommandShortcut data-testid="shortcut">Cmd+C</CommandShortcut>
+        </CommandItem>
+        <CommandItem value="search" data-testid="item-search">
+          Search
+        </CommandItem>
+        <CommandSeparator data-testid="separator" />
+        <CommandItem value="settings" disabled data-testid="item-settings">
+          Settings
+        </CommandItem>
+      </CommandGroup>
+    </CommandList>
+  </Command>
+);
+
+describe('Command - Basic Rendering', () => {
+  it('should render command with input and list', () => {
+    render(<TestCommand />);
+
+    expect(screen.getByTestId('command')).toBeInTheDocument();
+    expect(screen.getByTestId('input')).toBeInTheDocument();
+    expect(screen.getByTestId('list')).toBeInTheDocument();
+  });
+
+  it('should render group with heading', () => {
+    render(<TestCommand />);
+
+    expect(screen.getByText('Suggestions')).toBeInTheDocument();
+    expect(screen.getByTestId('group')).toBeInTheDocument();
+  });
+
+  it('should render items', () => {
+    render(<TestCommand />);
+
+    expect(screen.getByTestId('item-calendar')).toHaveTextContent('Calendar');
+    expect(screen.getByTestId('item-search')).toHaveTextContent('Search');
+  });
+
+  it('should render with namespaced components', () => {
+    render(
+      <Command data-testid="command">
+        <Command.Input placeholder="Search..." data-testid="input" />
+        <Command.List data-testid="list">
+          <Command.Empty>No results.</Command.Empty>
+          <Command.Group heading="Actions">
+            <Command.Item value="action1">
+              Action 1
+              <Command.Shortcut>Cmd+1</Command.Shortcut>
+            </Command.Item>
+            <Command.Separator />
+            <Command.Item value="action2">Action 2</Command.Item>
+          </Command.Group>
+        </Command.List>
+      </Command>,
+    );
+
+    expect(screen.getByTestId('command')).toBeInTheDocument();
+    expect(screen.getByTestId('input')).toBeInTheDocument();
+    expect(screen.getByTestId('list')).toBeInTheDocument();
+  });
+});
+
+describe('Command - ARIA Attributes', () => {
+  it('should have combobox role on input', () => {
+    render(<TestCommand />);
+
+    expect(screen.getByTestId('input')).toHaveAttribute('role', 'combobox');
+  });
+
+  it('should have aria-autocomplete list', () => {
+    render(<TestCommand />);
+
+    expect(screen.getByTestId('input')).toHaveAttribute('aria-autocomplete', 'list');
+  });
+
+  it('should have listbox role on list', () => {
+    render(<TestCommand />);
+
+    expect(screen.getByTestId('list')).toHaveAttribute('role', 'listbox');
+  });
+
+  it('should have option role on items', () => {
+    render(<TestCommand />);
+
+    expect(screen.getAllByRole('option')).toHaveLength(3);
+  });
+
+  it('should have group role on groups', () => {
+    render(<TestCommand />);
+
+    expect(screen.getByRole('group')).toBeInTheDocument();
+  });
+
+  it('should have aria-labelledby for group with heading', () => {
+    render(<TestCommand />);
+
+    const group = screen.getByRole('group');
+    expect(group).toHaveAttribute('aria-labelledby');
+  });
+});
+
+describe('Command - Search Filtering', () => {
+  it('should call onValueChange when typing', () => {
+    const handleValueChange = vi.fn();
+    render(<TestCommand onValueChange={handleValueChange} />);
+
+    const input = screen.getByTestId('input');
+    fireEvent.change(input, { target: { value: 'cal' } });
+
+    expect(handleValueChange).toHaveBeenCalledWith('cal');
+  });
+
+  it('should filter items based on search', () => {
+    render(<TestCommand value="cal" />);
+
+    // Only Calendar should be visible
+    expect(screen.getByTestId('item-calendar')).toBeInTheDocument();
+    expect(screen.queryByTestId('item-search')).not.toBeInTheDocument();
+  });
+
+  it('should show empty state when no matches', () => {
+    render(<TestCommand value="xyz" />);
+
+    expect(screen.getByText('No results found.')).toBeInTheDocument();
+  });
+
+  it('should not show empty state when matches exist', () => {
+    render(<TestCommand value="cal" />);
+
+    expect(screen.queryByText('No results found.')).not.toBeInTheDocument();
+  });
+});
+
+describe('Command - Keyboard Navigation', () => {
+  it('should navigate down with ArrowDown', () => {
+    render(<TestCommand />);
+
+    const input = screen.getByTestId('input');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    const calendarItem = screen.getByTestId('item-calendar');
+    expect(calendarItem).toHaveAttribute('data-selected', 'true');
+  });
+
+  it('should navigate up with ArrowUp', () => {
+    render(<TestCommand />);
+
+    const input = screen.getByTestId('input');
+
+    // Navigate down twice, then up once
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+
+    const calendarItem = screen.getByTestId('item-calendar');
+    expect(calendarItem).toHaveAttribute('data-selected', 'true');
+  });
+
+  it('should navigate to first with Home', () => {
+    render(<TestCommand />);
+
+    const input = screen.getByTestId('input');
+
+    // Navigate down twice, then Home
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Home' });
+
+    const calendarItem = screen.getByTestId('item-calendar');
+    expect(calendarItem).toHaveAttribute('data-selected', 'true');
+  });
+
+  it('should navigate to last with End', () => {
+    render(<TestCommand />);
+
+    const input = screen.getByTestId('input');
+    fireEvent.keyDown(input, { key: 'End' });
+
+    // Settings is disabled so not registered - search is the last enabled item
+    const searchItem = screen.getByTestId('item-search');
+    expect(searchItem).toHaveAttribute('data-selected', 'true');
+  });
+});
+
+describe('Command - Selection', () => {
+  it('should call onSelect when item clicked', () => {
+    const handleSelect = vi.fn();
+    render(
+      <Command>
+        <CommandInput />
+        <CommandList>
+          <CommandItem value="test" onSelect={handleSelect}>
+            Test
+          </CommandItem>
+        </CommandList>
+      </Command>,
+    );
+
+    fireEvent.click(screen.getByText('Test'));
+
+    expect(handleSelect).toHaveBeenCalledWith('test');
+  });
+
+  it('should not select disabled items', () => {
+    const handleSelect = vi.fn();
+    render(
+      <Command>
+        <CommandInput />
+        <CommandList>
+          <CommandItem value="test" disabled onSelect={handleSelect}>
+            Test
+          </CommandItem>
+        </CommandList>
+      </Command>,
+    );
+
+    fireEvent.click(screen.getByText('Test'));
+
+    expect(handleSelect).not.toHaveBeenCalled();
+  });
+});
+
+describe('Command - Mouse Interaction', () => {
+  it('should highlight item on mouse enter', () => {
+    render(<TestCommand />);
+
+    const searchItem = screen.getByTestId('item-search');
+    fireEvent.mouseEnter(searchItem);
+
+    expect(searchItem).toHaveAttribute('data-selected', 'true');
+  });
+});
+
+describe('Command - Disabled State', () => {
+  it('should mark disabled items', () => {
+    render(<TestCommand />);
+
+    const settingsItem = screen.getByTestId('item-settings');
+    expect(settingsItem).toHaveAttribute('aria-disabled', 'true');
+    expect(settingsItem).toHaveAttribute('data-disabled', 'true');
+  });
+});
+
+describe('Command - Separator', () => {
+  it('should render separator', () => {
+    render(<TestCommand />);
+
+    expect(screen.getByTestId('separator')).toBeInTheDocument();
+    expect(screen.getByTestId('separator')).toHaveAttribute('data-command-separator');
+  });
+});
+
+describe('Command - Shortcut', () => {
+  it('should render shortcut', () => {
+    render(<TestCommand />);
+
+    expect(screen.getByTestId('shortcut')).toHaveTextContent('Cmd+C');
+    expect(screen.getByTestId('shortcut')).toHaveAttribute('data-command-shortcut');
+  });
+});
+
+describe('Command - Dialog', () => {
+  it('should not render when closed', () => {
+    render(
+      <CommandDialog open={false} data-testid="dialog">
+        <CommandInput />
+        <CommandList>
+          <CommandItem value="test">Test</CommandItem>
+        </CommandList>
+      </CommandDialog>,
+    );
+
+    expect(screen.queryByTestId('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should render when open', () => {
+    render(
+      <CommandDialog open data-testid="dialog">
+        <CommandInput />
+        <CommandList>
+          <CommandItem value="test">Test</CommandItem>
+        </CommandList>
+      </CommandDialog>,
+    );
+
+    expect(screen.getByTestId('dialog')).toBeInTheDocument();
+  });
+
+  it('should call onOpenChange when escape pressed', () => {
+    const handleOpenChange = vi.fn();
+    render(
+      <CommandDialog open onOpenChange={handleOpenChange}>
+        <CommandInput />
+        <CommandList>
+          <CommandItem value="test">Test</CommandItem>
+        </CommandList>
+      </CommandDialog>,
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(handleOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('should call onOpenChange when backdrop clicked', () => {
+    const handleOpenChange = vi.fn();
+    render(
+      <CommandDialog open onOpenChange={handleOpenChange}>
+        <CommandInput />
+        <CommandList>
+          <CommandItem value="test">Test</CommandItem>
+        </CommandList>
+      </CommandDialog>,
+    );
+
+    // Click the backdrop (first child with inset-0 class)
+    const backdrop = document.querySelector('.fixed.inset-0');
+    if (backdrop) {
+      fireEvent.click(backdrop);
+    }
+
+    expect(handleOpenChange).toHaveBeenCalledWith(false);
+  });
+});
+
+describe('Command - Data Attributes', () => {
+  it('should set data-command on root', () => {
+    render(<TestCommand />);
+
+    expect(screen.getByTestId('command')).toHaveAttribute('data-command');
+  });
+
+  it('should set data-command-input on input', () => {
+    render(<TestCommand />);
+
+    expect(screen.getByTestId('input')).toHaveAttribute('data-command-input');
+  });
+
+  it('should set data-command-list on list', () => {
+    render(<TestCommand />);
+
+    expect(screen.getByTestId('list')).toHaveAttribute('data-command-list');
+  });
+
+  it('should set data-command-group on groups', () => {
+    render(<TestCommand />);
+
+    expect(screen.getByTestId('group')).toHaveAttribute('data-command-group');
+  });
+
+  it('should set data-command-item on items', () => {
+    render(<TestCommand />);
+
+    expect(screen.getByTestId('item-calendar')).toHaveAttribute('data-command-item');
+  });
+
+  it('should set data-value on items', () => {
+    render(<TestCommand />);
+
+    expect(screen.getByTestId('item-calendar')).toHaveAttribute('data-value', 'calendar');
+  });
+});
+
+describe('Command - Custom className', () => {
+  it('should merge custom className on command', () => {
+    render(
+      <Command className="custom-command" data-testid="command">
+        <CommandInput />
+        <CommandList>
+          <CommandItem value="test">Test</CommandItem>
+        </CommandList>
+      </Command>,
+    );
+
+    expect(screen.getByTestId('command').className).toContain('custom-command');
+  });
+
+  it('should merge custom className on input', () => {
+    render(
+      <Command>
+        <CommandInput className="custom-input" data-testid="input" />
+        <CommandList>
+          <CommandItem value="test">Test</CommandItem>
+        </CommandList>
+      </Command>,
+    );
+
+    expect(screen.getByTestId('input').className).toContain('custom-input');
+  });
+
+  it('should merge custom className on list', () => {
+    render(
+      <Command>
+        <CommandInput />
+        <CommandList className="custom-list" data-testid="list">
+          <CommandItem value="test">Test</CommandItem>
+        </CommandList>
+      </Command>,
+    );
+
+    expect(screen.getByTestId('list').className).toContain('custom-list');
+  });
+
+  it('should merge custom className on item', () => {
+    render(
+      <Command>
+        <CommandInput />
+        <CommandList>
+          <CommandItem value="test" className="custom-item" data-testid="item">
+            Test
+          </CommandItem>
+        </CommandList>
+      </Command>,
+    );
+
+    expect(screen.getByTestId('item').className).toContain('custom-item');
+  });
+});
+
+describe('Command - Input Search Icon', () => {
+  it('should render search icon', () => {
+    render(<TestCommand />);
+
+    const inputWrapper = document.querySelector('[data-command-input-wrapper]');
+    expect(inputWrapper?.querySelector('svg')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `command` component with shadcn API parity.

### Features
- JSDoc intelligence blocks (@cognitive-load, @attention-economics, etc.)
- Unit tests
- Accessibility support (ARIA, keyboard navigation)
- Design token compliance (no arbitrary values)

## Test plan
- [x] Component tests pass
- [ ] Manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)