### PR TITLE
feat(ui): add date-picker component

### DIFF
--- a/packages/ui/src/components/ui/date-picker.tsx
+++ b/packages/ui/src/components/ui/date-picker.tsx
@@ -1,0 +1,274 @@
+/**
+ * DatePicker component combining popover trigger with calendar selection
+ *
+ * @cognitive-load 5/10 - Familiar pattern; click button, see calendar, pick date
+ * @attention-economics Medium attention: viewing calendar grid, selecting date
+ * @trust-building Clear date display, predictable calendar behavior, keyboard accessible
+ * @accessibility Full keyboard navigation, ARIA expanded states, screen reader announcements
+ * @semantic-meaning Date selection: scheduling, booking, form input
+ *
+ * @usage-patterns
+ * DO: Use for single date or date range selection
+ * DO: Display selected date clearly in trigger
+ * DO: Support keyboard navigation in calendar
+ * DO: Provide clear empty state placeholder
+ * NEVER: Use for time-only selection (use TimePicker)
+ * NEVER: Hide the calendar close affordance
+ * NEVER: Require multiple clicks to select a date
+ *
+ * @example
+ * ```tsx
+ * <DatePicker
+ *   value={date}
+ *   onValueChange={setDate}
+ *   placeholder="Pick a date"
+ * />
+ * ```
+ */
+
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import classy from '../../primitives/classy';
+import { computePosition } from '../../primitives/collision-detector';
+import { onEscapeKeyDown } from '../../primitives/escape-keydown';
+import { onPointerDownOutside } from '../../primitives/outside-click';
+import { getPortalContainer } from '../../primitives/portal';
+import { Calendar, type CalendarProps } from './calendar';
+
+// ==================== Types ====================
+
+type DatePickerMode = 'single' | 'range';
+
+interface DateRange {
+  from: Date | undefined;
+  to: Date | undefined;
+}
+
+// ==================== DatePicker ====================
+
+export interface DatePickerProps<T extends DatePickerMode = 'single'>
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'value' | 'onChange'> {
+  mode?: T;
+  value?: T extends 'single' ? Date | undefined : DateRange | undefined;
+  onValueChange?: T extends 'single'
+    ? (date: Date | undefined) => void
+    : (range: DateRange | undefined) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  calendarProps?: Omit<CalendarProps<T extends 'single' ? 'single' : 'range'>, 'mode' | 'selected' | 'onSelect'>;
+  formatDate?: (date: Date) => string;
+  formatRange?: (range: DateRange) => string;
+}
+
+export function DatePicker<T extends DatePickerMode = 'single'>({
+  mode = 'single' as T,
+  value,
+  onValueChange,
+  placeholder = 'Pick a date',
+  disabled = false,
+  calendarProps,
+  formatDate = defaultFormatDate,
+  formatRange = defaultFormatRange,
+  className,
+  ...props
+}: DatePickerProps<T>) {
+  const [open, setOpen] = React.useState(false);
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const contentRef = React.useRef<HTMLDivElement>(null);
+  const [mounted, setMounted] = React.useState(false);
+  const [position, setPosition] = React.useState({ x: 0, y: 0 });
+
+  const id = React.useId();
+  const contentId = `datepicker-content-${id}`;
+
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Position the popover
+  React.useEffect(() => {
+    if (!open || !triggerRef.current || !contentRef.current) return;
+
+    const updatePosition = () => {
+      const anchor = triggerRef.current;
+      const floating = contentRef.current;
+
+      if (!anchor || !floating) return;
+
+      const result = computePosition(anchor, floating, {
+        side: 'bottom',
+        align: 'start',
+        sideOffset: 4,
+        avoidCollisions: true,
+      });
+
+      setPosition({ x: result.x, y: result.y });
+    };
+
+    const frame = requestAnimationFrame(updatePosition);
+    window.addEventListener('scroll', updatePosition, { capture: true, passive: true });
+    window.addEventListener('resize', updatePosition, { passive: true });
+
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener('scroll', updatePosition, { capture: true });
+      window.removeEventListener('resize', updatePosition);
+    };
+  }, [open]);
+
+  // Escape key handler
+  React.useEffect(() => {
+    if (!open) return;
+
+    return onEscapeKeyDown(() => {
+      setOpen(false);
+      triggerRef.current?.focus();
+    });
+  }, [open]);
+
+  // Outside click handler
+  React.useEffect(() => {
+    if (!open || !contentRef.current) return;
+
+    return onPointerDownOutside(contentRef.current, (event) => {
+      const target = event.target as Node;
+      if (triggerRef.current?.contains(target)) return;
+
+      setOpen(false);
+    });
+  }, [open]);
+
+  // Handle date selection
+  const handleSelect = React.useCallback(
+    (selected: Date | DateRange | undefined) => {
+      if (mode === 'single') {
+        (onValueChange as (date: Date | undefined) => void)?.(selected as Date | undefined);
+        setOpen(false);
+      } else {
+        const range = selected as DateRange | undefined;
+        (onValueChange as (range: DateRange | undefined) => void)?.(range);
+        // Close when range is complete
+        if (range?.from && range?.to) {
+          setOpen(false);
+        }
+      }
+    },
+    [mode, onValueChange],
+  );
+
+  // Format display value
+  const displayValue = React.useMemo(() => {
+    if (mode === 'single') {
+      const date = value as Date | undefined;
+      return date ? formatDate(date) : placeholder;
+    } else {
+      const range = value as DateRange | undefined;
+      if (!range?.from) return placeholder;
+      return formatRange(range);
+    }
+  }, [mode, value, placeholder, formatDate, formatRange]);
+
+  const hasValue = mode === 'single' ? !!value : !!(value as DateRange)?.from;
+
+  const portalContainer = mounted ? getPortalContainer({ enabled: true }) : null;
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        disabled={disabled}
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        aria-controls={contentId}
+        aria-haspopup="dialog"
+        data-state={open ? 'open' : 'closed'}
+        data-datepicker-trigger=""
+        className={classy(
+          'flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm',
+          'shadow-sm ring-offset-background',
+          'focus:outline-none focus:ring-1 focus:ring-ring',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          !hasValue && 'text-muted-foreground',
+          className,
+        )}
+        {...props}
+      >
+        <span className="truncate">{displayValue}</span>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="ml-2 shrink-0 opacity-50"
+        >
+          <path d="M8 2v4" />
+          <path d="M16 2v4" />
+          <rect width="18" height="18" x="3" y="4" rx="2" />
+          <path d="M3 10h18" />
+        </svg>
+      </button>
+
+      {open && mounted && portalContainer && createPortal(
+        <div
+          ref={contentRef}
+          id={contentId}
+          role="dialog"
+          aria-modal="true"
+          data-state="open"
+          data-datepicker-content=""
+          className={classy(
+            'z-50 rounded-md border bg-popover p-0 text-popover-foreground shadow-md',
+            'data-[state=open]:animate-in data-[state=closed]:animate-out',
+            'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+            'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+          )}
+          style={{
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            transform: `translate(${Math.round(position.x)}px, ${Math.round(position.y)}px)`,
+          }}
+        >
+          <Calendar
+            mode={mode === 'single' ? 'single' : 'range'}
+            selected={value as Date | DateRange | undefined}
+            onSelect={handleSelect as CalendarProps['onSelect']}
+            defaultMonth={
+              mode === 'single'
+                ? (value as Date) || new Date()
+                : (value as DateRange)?.from || new Date()
+            }
+            {...calendarProps}
+          />
+        </div>,
+        portalContainer,
+      )}
+    </>
+  );
+}
+
+// ==================== Date Formatting Utilities ====================
+
+function defaultFormatDate(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function defaultFormatRange(range: DateRange): string {
+  if (!range.from) return '';
+  if (!range.to) return defaultFormatDate(range.from);
+  return `${defaultFormatDate(range.from)} - ${defaultFormatDate(range.to)}`;
+}
+
+// ==================== Display Name ====================
+
+DatePicker.displayName = 'DatePicker';

--- a/packages/ui/test/components/date-picker.test.tsx
+++ b/packages/ui/test/components/date-picker.test.tsx
@@ -1,0 +1,275 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import * as React from 'react';
+import { DatePicker } from '../../src/components/ui/date-picker';
+
+describe('DatePicker - Basic Rendering', () => {
+  it('should render trigger button', () => {
+    render(<DatePicker data-testid="trigger" />);
+
+    expect(screen.getByTestId('trigger')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('should display placeholder when no value', () => {
+    render(<DatePicker placeholder="Select date" />);
+
+    expect(screen.getByText('Select date')).toBeInTheDocument();
+  });
+
+  it('should display default placeholder', () => {
+    render(<DatePicker />);
+
+    expect(screen.getByText('Pick a date')).toBeInTheDocument();
+  });
+
+  it('should render calendar icon', () => {
+    render(<DatePicker />);
+
+    expect(document.querySelector('svg')).toBeInTheDocument();
+  });
+});
+
+describe('DatePicker - Value Display', () => {
+  it('should display formatted date when value is set', () => {
+    const date = new Date(2024, 5, 15); // June 15, 2024
+    render(<DatePicker value={date} />);
+
+    expect(screen.getByText('Jun 15, 2024')).toBeInTheDocument();
+  });
+
+  it('should use custom formatDate function', () => {
+    const date = new Date(2024, 5, 15);
+    const formatDate = (d: Date) => d.toISOString().split('T')[0];
+    render(<DatePicker value={date} formatDate={formatDate} />);
+
+    expect(screen.getByText('2024-06-15')).toBeInTheDocument();
+  });
+
+  it('should display range when mode is range', () => {
+    const range = { from: new Date(2024, 5, 10), to: new Date(2024, 5, 20) };
+    render(<DatePicker mode="range" value={range} />);
+
+    expect(screen.getByText(/Jun 10, 2024.*Jun 20, 2024/)).toBeInTheDocument();
+  });
+
+  it('should display partial range', () => {
+    const range = { from: new Date(2024, 5, 10), to: undefined };
+    render(<DatePicker mode="range" value={range} />);
+
+    expect(screen.getByText('Jun 10, 2024')).toBeInTheDocument();
+  });
+});
+
+describe('DatePicker - Open/Close', () => {
+  it('should open calendar when clicked', () => {
+    render(<DatePicker data-testid="trigger" />);
+
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('should close calendar when clicked again', () => {
+    render(<DatePicker data-testid="trigger" />);
+
+    const trigger = screen.getByTestId('trigger');
+    fireEvent.click(trigger);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    fireEvent.click(trigger);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should set aria-expanded when open', () => {
+    render(<DatePicker data-testid="trigger" />);
+
+    const trigger = screen.getByTestId('trigger');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+});
+
+describe('DatePicker - Selection', () => {
+  it('should call onValueChange when date selected', () => {
+    const handleValueChange = vi.fn();
+    render(
+      <DatePicker
+        onValueChange={handleValueChange}
+        calendarProps={{ defaultMonth: new Date(2024, 5, 1) }}
+        data-testid="trigger"
+      />,
+    );
+
+    // Open calendar
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    // Find and click a date
+    const dayButtons = screen.getAllByRole('button');
+    const day15 = dayButtons.find((btn) => btn.textContent === '15' && !btn.hasAttribute('data-outside'));
+    expect(day15).toBeDefined();
+    fireEvent.click(day15!);
+
+    expect(handleValueChange).toHaveBeenCalledWith(expect.any(Date));
+  });
+
+  it('should close after single date selection', () => {
+    render(
+      <DatePicker
+        calendarProps={{ defaultMonth: new Date(2024, 5, 1) }}
+        data-testid="trigger"
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    // Select a date
+    const dayButtons = screen.getAllByRole('button');
+    const day15 = dayButtons.find((btn) => btn.textContent === '15' && !btn.hasAttribute('data-outside'));
+    fireEvent.click(day15!);
+
+    // Calendar should be closed
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should stay open after first range selection', () => {
+    render(
+      <DatePicker
+        mode="range"
+        calendarProps={{ defaultMonth: new Date(2024, 5, 1) }}
+        data-testid="trigger"
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    // Select first date
+    const dayButtons = screen.getAllByRole('button');
+    const day10 = dayButtons.find((btn) => btn.textContent === '10' && !btn.hasAttribute('data-outside'));
+    fireEvent.click(day10!);
+
+    // Calendar should still be open
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});
+
+describe('DatePicker - Disabled State', () => {
+  it('should disable trigger when disabled', () => {
+    render(<DatePicker disabled data-testid="trigger" />);
+
+    expect(screen.getByTestId('trigger')).toBeDisabled();
+  });
+
+  it('should not open when disabled', () => {
+    render(<DatePicker disabled data-testid="trigger" />);
+
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should apply opacity when disabled', () => {
+    render(<DatePicker disabled data-testid="trigger" />);
+
+    expect(screen.getByTestId('trigger').className).toContain('opacity-50');
+  });
+});
+
+describe('DatePicker - ARIA Attributes', () => {
+  it('should have aria-haspopup dialog', () => {
+    render(<DatePicker data-testid="trigger" />);
+
+    expect(screen.getByTestId('trigger')).toHaveAttribute('aria-haspopup', 'dialog');
+  });
+
+  it('should have aria-controls', () => {
+    render(<DatePicker data-testid="trigger" />);
+
+    const trigger = screen.getByTestId('trigger');
+    expect(trigger).toHaveAttribute('aria-controls');
+  });
+
+  it('should have aria-modal on dialog', () => {
+    render(<DatePicker data-testid="trigger" />);
+
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
+  });
+});
+
+describe('DatePicker - Data Attributes', () => {
+  it('should set data-datepicker-trigger on trigger', () => {
+    render(<DatePicker data-testid="trigger" />);
+
+    expect(screen.getByTestId('trigger')).toHaveAttribute('data-datepicker-trigger');
+  });
+
+  it('should set data-state on trigger', () => {
+    render(<DatePicker data-testid="trigger" />);
+
+    const trigger = screen.getByTestId('trigger');
+    expect(trigger).toHaveAttribute('data-state', 'closed');
+
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('data-state', 'open');
+  });
+
+  it('should set data-datepicker-content on content', () => {
+    render(<DatePicker data-testid="trigger" />);
+
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    expect(screen.getByRole('dialog')).toHaveAttribute('data-datepicker-content');
+  });
+});
+
+describe('DatePicker - Custom className', () => {
+  it('should merge custom className on trigger', () => {
+    render(<DatePicker className="custom-trigger" data-testid="trigger" />);
+
+    expect(screen.getByTestId('trigger').className).toContain('custom-trigger');
+  });
+});
+
+describe('DatePicker - Calendar Props', () => {
+  it('should pass calendarProps to Calendar', () => {
+    const date = new Date(2024, 5, 15);
+    render(
+      <DatePicker
+        value={date}
+        calendarProps={{
+          disabled: (d) => d.getDate() === 10,
+        }}
+        data-testid="trigger"
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    // Find the 10th day - should be disabled
+    const dayButtons = screen.getAllByRole('button');
+    const day10 = dayButtons.find((btn) => btn.textContent === '10' && !btn.hasAttribute('data-outside'));
+    expect(day10).toBeDisabled();
+  });
+});
+
+describe('DatePicker - Placeholder Style', () => {
+  it('should apply muted style when no value', () => {
+    render(<DatePicker data-testid="trigger" />);
+
+    expect(screen.getByTestId('trigger').className).toContain('text-muted-foreground');
+  });
+
+  it('should not apply muted style when value is set', () => {
+    render(<DatePicker value={new Date()} data-testid="trigger" />);
+
+    expect(screen.getByTestId('trigger').className).not.toContain('text-muted-foreground');
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `date-picker` component with shadcn API parity.

### Features
- JSDoc intelligence blocks (@cognitive-load, @attention-economics, etc.)
- Unit tests
- Accessibility support (ARIA, keyboard navigation)
- Design token compliance (no arbitrary values)

## Test plan
- [x] Component tests pass
- [ ] Manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)