### PR TITLE
feat(ui): add Typography component

### DIFF
--- a/packages/ui/src/components/ui/typography.tsx
+++ b/packages/ui/src/components/ui/typography.tsx
@@ -1,0 +1,263 @@
+/**
+ * Typography primitives for consistent text styling and hierarchy
+ *
+ * @cognitive-load 2/10 - Familiar text patterns with clear visual hierarchy
+ * @attention-economics Hierarchy guides reading: H1=page title (one per page), H2=sections, H3=subsections, body text flows naturally
+ * @trust-building Consistent typography builds readability and professionalism
+ * @accessibility Proper heading hierarchy for screen readers; sufficient contrast ratios
+ * @semantic-meaning Element mapping: H1-H4=document structure, P=body content, Lead=introductions, Muted=secondary info, Code=technical content
+ *
+ * @usage-patterns
+ * DO: Use H1 once per page for main title
+ * DO: Follow heading hierarchy (H1 -> H2 -> H3, never skip)
+ * DO: Use Lead for introductory paragraphs
+ * DO: Use Muted for supplementary information
+ * NEVER: Skip heading levels (H1 -> H3)
+ * NEVER: Use headings for styling only (use CSS instead)
+ * NEVER: Use multiple H1s on a single page
+ *
+ * @example
+ * ```tsx
+ * // Page structure
+ * <H1>Page Title</H1>
+ * <Lead>This is an introduction to the page content.</Lead>
+ *
+ * <H2>Section Title</H2>
+ * <P>Body paragraph with standard styling.</P>
+ *
+ * <H3>Subsection</H3>
+ * <P>More content here.</P>
+ * <Muted>Last updated: Jan 2025</Muted>
+ *
+ * // Code example
+ * <P>Use the <Code>useState</Code> hook for local state.</P>
+ *
+ * // Blockquote
+ * <Blockquote>
+ *   "Design is not just what it looks like. Design is how it works."
+ * </Blockquote>
+ * ```
+ */
+import * as React from 'react';
+import classy from '../../primitives/classy';
+
+// Typography variant classes using semantic design tokens
+const typographyClasses = {
+  h1: 'scroll-m-20 text-4xl font-bold tracking-tight lg:text-5xl text-foreground',
+  h2: 'scroll-m-20 text-3xl font-semibold tracking-tight text-foreground',
+  h3: 'scroll-m-20 text-2xl font-semibold tracking-tight text-foreground',
+  h4: 'scroll-m-20 text-xl font-semibold tracking-tight text-foreground',
+  p: 'leading-7 text-foreground',
+  lead: 'text-xl text-muted-foreground',
+  large: 'text-lg font-semibold text-foreground',
+  small: 'text-sm font-medium leading-none text-foreground',
+  muted: 'text-sm text-muted-foreground',
+  code: 'rounded bg-muted px-1 py-0.5 font-mono text-sm text-foreground',
+  blockquote: 'mt-6 border-l-2 border-border pl-6 italic text-foreground',
+} as const;
+
+export interface TypographyProps extends React.HTMLAttributes<HTMLElement> {
+  /** Override the default HTML element */
+  as?: React.ElementType;
+}
+
+/**
+ * H1 - Primary page heading
+ * Use once per page for the main title
+ */
+export const H1 = React.forwardRef<HTMLHeadingElement, TypographyProps>(
+  ({ as, className, ...props }, ref) => {
+    const Component = as ?? 'h1';
+    return (
+      <Component
+        ref={ref as React.Ref<HTMLHeadingElement>}
+        className={classy(typographyClasses.h1, className)}
+        {...props}
+      />
+    );
+  },
+);
+H1.displayName = 'H1';
+
+/**
+ * H2 - Section heading
+ * Use for major sections within the page
+ */
+export const H2 = React.forwardRef<HTMLHeadingElement, TypographyProps>(
+  ({ as, className, ...props }, ref) => {
+    const Component = as ?? 'h2';
+    return (
+      <Component
+        ref={ref as React.Ref<HTMLHeadingElement>}
+        className={classy(typographyClasses.h2, className)}
+        {...props}
+      />
+    );
+  },
+);
+H2.displayName = 'H2';
+
+/**
+ * H3 - Subsection heading
+ * Use for subsections within H2 sections
+ */
+export const H3 = React.forwardRef<HTMLHeadingElement, TypographyProps>(
+  ({ as, className, ...props }, ref) => {
+    const Component = as ?? 'h3';
+    return (
+      <Component
+        ref={ref as React.Ref<HTMLHeadingElement>}
+        className={classy(typographyClasses.h3, className)}
+        {...props}
+      />
+    );
+  },
+);
+H3.displayName = 'H3';
+
+/**
+ * H4 - Minor heading
+ * Use for smaller subsections or grouped content
+ */
+export const H4 = React.forwardRef<HTMLHeadingElement, TypographyProps>(
+  ({ as, className, ...props }, ref) => {
+    const Component = as ?? 'h4';
+    return (
+      <Component
+        ref={ref as React.Ref<HTMLHeadingElement>}
+        className={classy(typographyClasses.h4, className)}
+        {...props}
+      />
+    );
+  },
+);
+H4.displayName = 'H4';
+
+/**
+ * P - Body paragraph
+ * Standard paragraph text with proper line height
+ */
+export const P = React.forwardRef<HTMLParagraphElement, TypographyProps>(
+  ({ as, className, ...props }, ref) => {
+    const Component = as ?? 'p';
+    return (
+      <Component
+        ref={ref as React.Ref<HTMLParagraphElement>}
+        className={classy(typographyClasses.p, className)}
+        {...props}
+      />
+    );
+  },
+);
+P.displayName = 'P';
+
+/**
+ * Lead - Introductory paragraph
+ * Larger, muted text for page or section introductions
+ */
+export const Lead = React.forwardRef<HTMLParagraphElement, TypographyProps>(
+  ({ as, className, ...props }, ref) => {
+    const Component = as ?? 'p';
+    return (
+      <Component
+        ref={ref as React.Ref<HTMLParagraphElement>}
+        className={classy(typographyClasses.lead, className)}
+        {...props}
+      />
+    );
+  },
+);
+Lead.displayName = 'Lead';
+
+/**
+ * Large - Emphasized text
+ * Larger, semibold text for emphasis
+ */
+export const Large = React.forwardRef<HTMLDivElement, TypographyProps>(
+  ({ as, className, ...props }, ref) => {
+    const Component = as ?? 'div';
+    return (
+      <Component
+        ref={ref as React.Ref<HTMLDivElement>}
+        className={classy(typographyClasses.large, className)}
+        {...props}
+      />
+    );
+  },
+);
+Large.displayName = 'Large';
+
+/**
+ * Small - Smaller text
+ * For fine print, captions, or supporting text
+ */
+export const Small = React.forwardRef<HTMLElement, TypographyProps>(
+  ({ as, className, ...props }, ref) => {
+    const Component = as ?? 'small';
+    return (
+      <Component
+        ref={ref as React.Ref<HTMLElement>}
+        className={classy(typographyClasses.small, className)}
+        {...props}
+      />
+    );
+  },
+);
+Small.displayName = 'Small';
+
+/**
+ * Muted - Secondary text
+ * De-emphasized text for metadata or supplementary info
+ */
+export const Muted = React.forwardRef<HTMLParagraphElement, TypographyProps>(
+  ({ as, className, ...props }, ref) => {
+    const Component = as ?? 'p';
+    return (
+      <Component
+        ref={ref as React.Ref<HTMLParagraphElement>}
+        className={classy(typographyClasses.muted, className)}
+        {...props}
+      />
+    );
+  },
+);
+Muted.displayName = 'Muted';
+
+/**
+ * Code - Inline code
+ * Monospace text for code snippets, commands, or technical terms
+ */
+export const Code = React.forwardRef<HTMLElement, TypographyProps>(
+  ({ as, className, ...props }, ref) => {
+    const Component = as ?? 'code';
+    return (
+      <Component
+        ref={ref as React.Ref<HTMLElement>}
+        className={classy(typographyClasses.code, className)}
+        {...props}
+      />
+    );
+  },
+);
+Code.displayName = 'Code';
+
+/**
+ * Blockquote - Block quotation
+ * For quotations or callouts with left border emphasis
+ */
+export const Blockquote = React.forwardRef<HTMLQuoteElement, TypographyProps>(
+  ({ as, className, ...props }, ref) => {
+    const Component = as ?? 'blockquote';
+    return (
+      <Component
+        ref={ref as React.Ref<HTMLQuoteElement>}
+        className={classy(typographyClasses.blockquote, className)}
+        {...props}
+      />
+    );
+  },
+);
+Blockquote.displayName = 'Blockquote';
+
+// Export typography classes for direct use
+export { typographyClasses };

--- a/packages/ui/test/components/typography.a11y.tsx
+++ b/packages/ui/test/components/typography.a11y.tsx
@@ -1,0 +1,265 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import {
+  Blockquote,
+  Code,
+  H1,
+  H2,
+  H3,
+  H4,
+  Large,
+  Lead,
+  Muted,
+  P,
+  Small,
+} from '../../src/components/ui/typography';
+
+describe('H1 - Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(<H1>Page Title</H1>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with custom as prop', async () => {
+    const { container } = render(<H1 as="div">Styled as Heading</H1>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('H2 - Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(<H2>Section Title</H2>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('H3 - Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(<H3>Subsection Title</H3>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('H4 - Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(<H4>Minor Heading</H4>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('P - Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(<P>This is a paragraph of text.</P>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with links inside', async () => {
+    const { container } = render(
+      <P>
+        Read more at <a href="#docs">documentation</a>.
+      </P>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('Lead - Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(<Lead>Introduction to the page content.</Lead>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('Large - Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(<Large>Emphasized text</Large>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('Small - Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(<Small>Fine print text</Small>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('Muted - Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(<Muted>Secondary information</Muted>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('Code - Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(<Code>const x = 1</Code>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations inside paragraph', async () => {
+    const { container } = render(
+      <P>
+        Use the <Code>useState</Code> hook for local state.
+      </P>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('Blockquote - Accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <Blockquote>Design is not just what it looks like. Design is how it works.</Blockquote>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with citation', async () => {
+    const { container } = render(
+      <figure>
+        <Blockquote>Design is not just what it looks like. Design is how it works.</Blockquote>
+        <figcaption>
+          <cite>Steve Jobs</cite>
+        </figcaption>
+      </figure>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('Typography - Heading hierarchy', () => {
+  it('has no violations with proper heading hierarchy', async () => {
+    const { container } = render(
+      <article>
+        <H1>Page Title</H1>
+        <Lead>Introduction paragraph.</Lead>
+        <H2>Section 1</H2>
+        <P>Content for section 1.</P>
+        <H3>Subsection 1.1</H3>
+        <P>Content for subsection 1.1.</P>
+        <H2>Section 2</H2>
+        <P>Content for section 2.</P>
+      </article>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with all heading levels', async () => {
+    const { container } = render(
+      <main>
+        <H1>Main Title</H1>
+        <H2>Section</H2>
+        <H3>Subsection</H3>
+        <H4>Minor Heading</H4>
+        <P>Paragraph content.</P>
+      </main>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('Typography - Complete page structure', () => {
+  it('has no violations in a complete page structure', async () => {
+    const { container } = render(
+      <main>
+        <article>
+          <header>
+            <H1>Article Title</H1>
+            <Lead>This is an introduction to the article content.</Lead>
+            <Muted>Published: January 2025</Muted>
+          </header>
+
+          <section>
+            <H2>First Section</H2>
+            <P>
+              This is a body paragraph with standard styling. It includes <Code>inline code</Code>{' '}
+              for technical terms.
+            </P>
+
+            <H3>Subsection</H3>
+            <P>More content here with detailed information.</P>
+
+            <Blockquote>A quote that emphasizes an important point from the article.</Blockquote>
+          </section>
+
+          <section>
+            <H2>Second Section</H2>
+            <Large>An emphasized statement</Large>
+            <P>Regular paragraph following the emphasis.</P>
+            <Small>A note in smaller text.</Small>
+          </section>
+
+          <footer>
+            <Muted>Last updated: January 2025</Muted>
+          </footer>
+        </article>
+      </main>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('Typography - With interactive elements', () => {
+  it('has no violations with links and buttons', async () => {
+    const { container } = render(
+      <article>
+        <H1>Interactive Content</H1>
+        <P>
+          Visit our <a href="#docs">documentation</a> for more information.
+        </P>
+        <P>
+          <button type="button">Click here</button> to learn more.
+        </P>
+      </article>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('Typography - With ARIA attributes', () => {
+  it('has no violations with aria-labelledby', async () => {
+    const { container } = render(
+      <section aria-labelledby="section-title">
+        <H2 id="section-title">Section with ARIA</H2>
+        <P>Content describing the section.</P>
+      </section>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with aria-describedby', async () => {
+    const { container } = render(
+      <div>
+        <H3 id="feature-title">Feature Name</H3>
+        <P id="feature-desc">Description of the feature.</P>
+        <button type="button" aria-labelledby="feature-title" aria-describedby="feature-desc">
+          Enable Feature
+        </button>
+      </div>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/ui/test/components/typography.test.tsx
+++ b/packages/ui/test/components/typography.test.tsx
@@ -1,0 +1,511 @@
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import { describe, expect, it } from 'vitest';
+import {
+  Blockquote,
+  Code,
+  H1,
+  H2,
+  H3,
+  H4,
+  Large,
+  Lead,
+  Muted,
+  P,
+  Small,
+  typographyClasses,
+} from '../../src/components/ui/typography';
+
+describe('H1', () => {
+  it('renders as h1 by default', () => {
+    render(<H1 data-testid="h1">Heading 1</H1>);
+    const heading = screen.getByTestId('h1');
+    expect(heading.tagName).toBe('H1');
+  });
+
+  it('applies correct styles', () => {
+    const { container } = render(<H1>Heading</H1>);
+    const h1 = container.firstChild;
+    expect(h1).toHaveClass('text-4xl');
+    expect(h1).toHaveClass('font-bold');
+    expect(h1).toHaveClass('tracking-tight');
+    expect(h1).toHaveClass('scroll-m-20');
+    expect(h1).toHaveClass('lg:text-5xl');
+    expect(h1).toHaveClass('text-foreground');
+  });
+
+  it('renders as custom element via as prop', () => {
+    render(
+      <H1 as="span" data-testid="h1">
+        Styled as H1
+      </H1>,
+    );
+    const element = screen.getByTestId('h1');
+    expect(element.tagName).toBe('SPAN');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<H1 className="custom-class">Heading</H1>);
+    expect(container.firstChild).toHaveClass('custom-class');
+    expect(container.firstChild).toHaveClass('text-4xl');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLHeadingElement>();
+    render(<H1 ref={ref}>Heading</H1>);
+    expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
+  });
+
+  it('passes through HTML attributes', () => {
+    render(
+      <H1 data-testid="h1" id="main-title">
+        Title
+      </H1>,
+    );
+    expect(screen.getByTestId('h1')).toHaveAttribute('id', 'main-title');
+  });
+});
+
+describe('H2', () => {
+  it('renders as h2 by default', () => {
+    render(<H2 data-testid="h2">Heading 2</H2>);
+    const heading = screen.getByTestId('h2');
+    expect(heading.tagName).toBe('H2');
+  });
+
+  it('applies correct styles', () => {
+    const { container } = render(<H2>Heading</H2>);
+    const h2 = container.firstChild;
+    expect(h2).toHaveClass('text-3xl');
+    expect(h2).toHaveClass('font-semibold');
+    expect(h2).toHaveClass('tracking-tight');
+    expect(h2).toHaveClass('scroll-m-20');
+    expect(h2).toHaveClass('text-foreground');
+  });
+
+  it('renders as custom element via as prop', () => {
+    render(
+      <H2 as="div" data-testid="h2">
+        Styled as H2
+      </H2>,
+    );
+    const element = screen.getByTestId('h2');
+    expect(element.tagName).toBe('DIV');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<H2 className="custom-class">Heading</H2>);
+    expect(container.firstChild).toHaveClass('custom-class');
+    expect(container.firstChild).toHaveClass('text-3xl');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLHeadingElement>();
+    render(<H2 ref={ref}>Heading</H2>);
+    expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
+  });
+});
+
+describe('H3', () => {
+  it('renders as h3 by default', () => {
+    render(<H3 data-testid="h3">Heading 3</H3>);
+    const heading = screen.getByTestId('h3');
+    expect(heading.tagName).toBe('H3');
+  });
+
+  it('applies correct styles', () => {
+    const { container } = render(<H3>Heading</H3>);
+    const h3 = container.firstChild;
+    expect(h3).toHaveClass('text-2xl');
+    expect(h3).toHaveClass('font-semibold');
+    expect(h3).toHaveClass('tracking-tight');
+    expect(h3).toHaveClass('scroll-m-20');
+    expect(h3).toHaveClass('text-foreground');
+  });
+
+  it('renders as custom element via as prop', () => {
+    render(
+      <H3 as="span" data-testid="h3">
+        Styled as H3
+      </H3>,
+    );
+    const element = screen.getByTestId('h3');
+    expect(element.tagName).toBe('SPAN');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<H3 className="custom-class">Heading</H3>);
+    expect(container.firstChild).toHaveClass('custom-class');
+    expect(container.firstChild).toHaveClass('text-2xl');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLHeadingElement>();
+    render(<H3 ref={ref}>Heading</H3>);
+    expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
+  });
+});
+
+describe('H4', () => {
+  it('renders as h4 by default', () => {
+    render(<H4 data-testid="h4">Heading 4</H4>);
+    const heading = screen.getByTestId('h4');
+    expect(heading.tagName).toBe('H4');
+  });
+
+  it('applies correct styles', () => {
+    const { container } = render(<H4>Heading</H4>);
+    const h4 = container.firstChild;
+    expect(h4).toHaveClass('text-xl');
+    expect(h4).toHaveClass('font-semibold');
+    expect(h4).toHaveClass('tracking-tight');
+    expect(h4).toHaveClass('scroll-m-20');
+    expect(h4).toHaveClass('text-foreground');
+  });
+
+  it('renders as custom element via as prop', () => {
+    render(
+      <H4 as="div" data-testid="h4">
+        Styled as H4
+      </H4>,
+    );
+    const element = screen.getByTestId('h4');
+    expect(element.tagName).toBe('DIV');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<H4 className="custom-class">Heading</H4>);
+    expect(container.firstChild).toHaveClass('custom-class');
+    expect(container.firstChild).toHaveClass('text-xl');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLHeadingElement>();
+    render(<H4 ref={ref}>Heading</H4>);
+    expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
+  });
+});
+
+describe('P', () => {
+  it('renders as p by default', () => {
+    render(<P data-testid="p">Paragraph text</P>);
+    const para = screen.getByTestId('p');
+    expect(para.tagName).toBe('P');
+  });
+
+  it('applies correct styles', () => {
+    const { container } = render(<P>Paragraph</P>);
+    const p = container.firstChild;
+    expect(p).toHaveClass('leading-7');
+    expect(p).toHaveClass('text-foreground');
+  });
+
+  it('renders as custom element via as prop', () => {
+    render(
+      <P as="span" data-testid="p">
+        Styled as P
+      </P>,
+    );
+    const element = screen.getByTestId('p');
+    expect(element.tagName).toBe('SPAN');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<P className="custom-class">Paragraph</P>);
+    expect(container.firstChild).toHaveClass('custom-class');
+    expect(container.firstChild).toHaveClass('leading-7');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLParagraphElement>();
+    render(<P ref={ref}>Paragraph</P>);
+    expect(ref.current).toBeInstanceOf(HTMLParagraphElement);
+  });
+});
+
+describe('Lead', () => {
+  it('renders as p by default', () => {
+    render(<Lead data-testid="lead">Lead paragraph</Lead>);
+    const lead = screen.getByTestId('lead');
+    expect(lead.tagName).toBe('P');
+  });
+
+  it('applies correct styles', () => {
+    const { container } = render(<Lead>Lead</Lead>);
+    const lead = container.firstChild;
+    expect(lead).toHaveClass('text-xl');
+    expect(lead).toHaveClass('text-muted-foreground');
+  });
+
+  it('renders as custom element via as prop', () => {
+    render(
+      <Lead as="div" data-testid="lead">
+        Styled as Lead
+      </Lead>,
+    );
+    const element = screen.getByTestId('lead');
+    expect(element.tagName).toBe('DIV');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<Lead className="custom-class">Lead</Lead>);
+    expect(container.firstChild).toHaveClass('custom-class');
+    expect(container.firstChild).toHaveClass('text-xl');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLParagraphElement>();
+    render(<Lead ref={ref}>Lead</Lead>);
+    expect(ref.current).toBeInstanceOf(HTMLParagraphElement);
+  });
+});
+
+describe('Large', () => {
+  it('renders as div by default', () => {
+    render(<Large data-testid="large">Large text</Large>);
+    const large = screen.getByTestId('large');
+    expect(large.tagName).toBe('DIV');
+  });
+
+  it('applies correct styles', () => {
+    const { container } = render(<Large>Large</Large>);
+    const large = container.firstChild;
+    expect(large).toHaveClass('text-lg');
+    expect(large).toHaveClass('font-semibold');
+    expect(large).toHaveClass('text-foreground');
+  });
+
+  it('renders as custom element via as prop', () => {
+    render(
+      <Large as="span" data-testid="large">
+        Styled as Large
+      </Large>,
+    );
+    const element = screen.getByTestId('large');
+    expect(element.tagName).toBe('SPAN');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<Large className="custom-class">Large</Large>);
+    expect(container.firstChild).toHaveClass('custom-class');
+    expect(container.firstChild).toHaveClass('text-lg');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(<Large ref={ref}>Large</Large>);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+});
+
+describe('Small', () => {
+  it('renders as small by default', () => {
+    render(<Small data-testid="small">Small text</Small>);
+    const small = screen.getByTestId('small');
+    expect(small.tagName).toBe('SMALL');
+  });
+
+  it('applies correct styles', () => {
+    const { container } = render(<Small>Small</Small>);
+    const small = container.firstChild;
+    expect(small).toHaveClass('text-sm');
+    expect(small).toHaveClass('font-medium');
+    expect(small).toHaveClass('leading-none');
+    expect(small).toHaveClass('text-foreground');
+  });
+
+  it('renders as custom element via as prop', () => {
+    render(
+      <Small as="span" data-testid="small">
+        Styled as Small
+      </Small>,
+    );
+    const element = screen.getByTestId('small');
+    expect(element.tagName).toBe('SPAN');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<Small className="custom-class">Small</Small>);
+    expect(container.firstChild).toHaveClass('custom-class');
+    expect(container.firstChild).toHaveClass('text-sm');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLElement>();
+    render(<Small ref={ref}>Small</Small>);
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+  });
+});
+
+describe('Muted', () => {
+  it('renders as p by default', () => {
+    render(<Muted data-testid="muted">Muted text</Muted>);
+    const muted = screen.getByTestId('muted');
+    expect(muted.tagName).toBe('P');
+  });
+
+  it('applies correct styles', () => {
+    const { container } = render(<Muted>Muted</Muted>);
+    const muted = container.firstChild;
+    expect(muted).toHaveClass('text-sm');
+    expect(muted).toHaveClass('text-muted-foreground');
+  });
+
+  it('renders as custom element via as prop', () => {
+    render(
+      <Muted as="span" data-testid="muted">
+        Styled as Muted
+      </Muted>,
+    );
+    const element = screen.getByTestId('muted');
+    expect(element.tagName).toBe('SPAN');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<Muted className="custom-class">Muted</Muted>);
+    expect(container.firstChild).toHaveClass('custom-class');
+    expect(container.firstChild).toHaveClass('text-sm');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLParagraphElement>();
+    render(<Muted ref={ref}>Muted</Muted>);
+    expect(ref.current).toBeInstanceOf(HTMLParagraphElement);
+  });
+});
+
+describe('Code', () => {
+  it('renders as code by default', () => {
+    render(<Code data-testid="code">const x = 1</Code>);
+    const code = screen.getByTestId('code');
+    expect(code.tagName).toBe('CODE');
+  });
+
+  it('applies correct styles', () => {
+    const { container } = render(<Code>code</Code>);
+    const code = container.firstChild;
+    expect(code).toHaveClass('rounded');
+    expect(code).toHaveClass('bg-muted');
+    expect(code).toHaveClass('px-1');
+    expect(code).toHaveClass('py-0.5');
+    expect(code).toHaveClass('font-mono');
+    expect(code).toHaveClass('text-sm');
+    expect(code).toHaveClass('text-foreground');
+  });
+
+  it('renders as custom element via as prop', () => {
+    render(
+      <Code as="span" data-testid="code">
+        Styled as Code
+      </Code>,
+    );
+    const element = screen.getByTestId('code');
+    expect(element.tagName).toBe('SPAN');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<Code className="custom-class">code</Code>);
+    expect(container.firstChild).toHaveClass('custom-class');
+    expect(container.firstChild).toHaveClass('font-mono');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLElement>();
+    render(<Code ref={ref}>code</Code>);
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+  });
+});
+
+describe('Blockquote', () => {
+  it('renders as blockquote by default', () => {
+    render(<Blockquote data-testid="quote">Quote text</Blockquote>);
+    const quote = screen.getByTestId('quote');
+    expect(quote.tagName).toBe('BLOCKQUOTE');
+  });
+
+  it('applies correct styles', () => {
+    const { container } = render(<Blockquote>Quote</Blockquote>);
+    const quote = container.firstChild;
+    expect(quote).toHaveClass('mt-6');
+    expect(quote).toHaveClass('border-l-2');
+    expect(quote).toHaveClass('border-border');
+    expect(quote).toHaveClass('pl-6');
+    expect(quote).toHaveClass('italic');
+    expect(quote).toHaveClass('text-foreground');
+  });
+
+  it('renders as custom element via as prop', () => {
+    render(
+      <Blockquote as="div" data-testid="quote">
+        Styled as Blockquote
+      </Blockquote>,
+    );
+    const element = screen.getByTestId('quote');
+    expect(element.tagName).toBe('DIV');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<Blockquote className="custom-class">Quote</Blockquote>);
+    expect(container.firstChild).toHaveClass('custom-class');
+    expect(container.firstChild).toHaveClass('italic');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLQuoteElement>();
+    render(<Blockquote ref={ref}>Quote</Blockquote>);
+    expect(ref.current).toBeInstanceOf(HTMLQuoteElement);
+  });
+});
+
+describe('typographyClasses', () => {
+  it('exports all typography class strings', () => {
+    expect(typographyClasses).toHaveProperty('h1');
+    expect(typographyClasses).toHaveProperty('h2');
+    expect(typographyClasses).toHaveProperty('h3');
+    expect(typographyClasses).toHaveProperty('h4');
+    expect(typographyClasses).toHaveProperty('p');
+    expect(typographyClasses).toHaveProperty('lead');
+    expect(typographyClasses).toHaveProperty('large');
+    expect(typographyClasses).toHaveProperty('small');
+    expect(typographyClasses).toHaveProperty('muted');
+    expect(typographyClasses).toHaveProperty('code');
+    expect(typographyClasses).toHaveProperty('blockquote');
+  });
+
+  it('h1 class includes expected values', () => {
+    expect(typographyClasses.h1).toContain('text-4xl');
+    expect(typographyClasses.h1).toContain('font-bold');
+  });
+
+  it('code class includes font-mono', () => {
+    expect(typographyClasses.code).toContain('font-mono');
+  });
+});
+
+describe('Typography composition', () => {
+  it('renders a complete page structure', () => {
+    render(
+      <article>
+        <H1 data-testid="h1">Page Title</H1>
+        <Lead data-testid="lead">Introduction paragraph.</Lead>
+        <H2 data-testid="h2">Section Title</H2>
+        <P data-testid="p">Body paragraph with standard styling.</P>
+        <H3 data-testid="h3">Subsection</H3>
+        <P>
+          Use the <Code data-testid="code">useState</Code> hook.
+        </P>
+        <Blockquote data-testid="quote">Design is how it works.</Blockquote>
+        <Muted data-testid="muted">Last updated: Jan 2025</Muted>
+      </article>,
+    );
+
+    expect(screen.getByTestId('h1')).toHaveTextContent('Page Title');
+    expect(screen.getByTestId('lead')).toHaveTextContent('Introduction paragraph.');
+    expect(screen.getByTestId('h2')).toHaveTextContent('Section Title');
+    expect(screen.getByTestId('p')).toHaveTextContent('Body paragraph with standard styling.');
+    expect(screen.getByTestId('h3')).toHaveTextContent('Subsection');
+    expect(screen.getByTestId('code')).toHaveTextContent('useState');
+    expect(screen.getByTestId('quote')).toHaveTextContent('Design is how it works.');
+    expect(screen.getByTestId('muted')).toHaveTextContent('Last updated: Jan 2025');
+  });
+});


### PR DESCRIPTION
## Summary
- Semantic typography with heading levels
- Custom element via 'as' prop
- Size and weight variants

## Test Plan
- [x] Unit tests passing
- [x] Accessibility tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)