### PR TITLE
fix(color-utils): use brightness-based luminosity words

### DIFF
--- a/apps/api/test/routes/color/color.test.ts
+++ b/apps/api/test/routes/color/color.test.ts
@@ -153,32 +153,32 @@ describe('Color Routes', () => {
       });
 
       it('generates deterministic three-word color names', async () => {
-        // Test violet (hue 260) - bone (L=0.7), honest (C=0.15, medium density), violet (H=260, no expanded hub)
+        // Test violet (hue 260) - pale (L=0.7), honest (C=0.15, medium density), violet (H=260, no expanded hub)
         const violetRes = await SELF.fetch('http://localhost/color/0.700-0.150-260?adhoc=true');
         const violetJson = await violetRes.json();
-        expect(violetJson.color.name).toBe('bone-honest-violet');
+        expect(violetJson.color.name).toBe('pale-honest-violet');
 
         // Test red (hue 10) - uses expanded hub with semantic sub-selection
         const redRes = await SELF.fetch('http://localhost/color/0.500-0.200-10?adhoc=true');
         const redJson = await redRes.json();
-        expect(redJson.color.name).toBe('silver-bold-warning-red');
+        expect(redJson.color.name).toBe('balanced-bold-warning-red');
 
-        // Test low chroma - silver (L=0.5), whisper (C=0.02, achromatic), arctic (H=180, no expanded hub)
+        // Test low chroma - balanced (L=0.5), whisper (C=0.02, achromatic), arctic (H=180, no expanded hub)
         const lowChromaRes = await SELF.fetch('http://localhost/color/0.500-0.020-180?adhoc=true');
         const lowChromaJson = await lowChromaRes.json();
-        expect(lowChromaJson.color.name).toBe('silver-whisper-arctic');
+        expect(lowChromaJson.color.name).toBe('balanced-whisper-arctic');
       });
 
       it('varies luminosity word by lightness', async () => {
-        // Test light (lightness 0.85) - ivory (L=0.85), honest (C=0.15), violet (H=260)
+        // Test light (lightness 0.85) - faint (L=0.85), honest (C=0.15), violet (H=260)
         const lightRes = await SELF.fetch('http://localhost/color/0.850-0.150-260?adhoc=true');
         const lightJson = await lightRes.json();
-        expect(lightJson.color.name).toBe('ivory-honest-violet');
+        expect(lightJson.color.name).toBe('faint-honest-violet');
 
-        // Test dark (lightness 0.20) - slate (L=0.2), honest (C=0.15), violet (H=260)
+        // Test dark (lightness 0.20) - deep (L=0.2), honest (C=0.15), violet (H=260)
         const darkRes = await SELF.fetch('http://localhost/color/0.200-0.150-260?adhoc=true');
         const darkJson = await darkRes.json();
-        expect(darkJson.color.name).toBe('slate-honest-violet');
+        expect(darkJson.color.name).toBe('deep-honest-violet');
       });
     });
   });

--- a/packages/color-utils/src/naming/generator.ts
+++ b/packages/color-utils/src/naming/generator.ts
@@ -5,7 +5,7 @@
  * Uses temperature and perceptual weight to select appropriate word variants.
  *
  * Format: {luminosity}-{intensity}-{material}
- * Examples: "slate-bold-cobalt", "ivory-soft-sage", "obsidian-whisper"
+ * Examples: "deep-bold-cobalt", "faint-soft-sage", "shadow-whisper"
  *
  * Two-tier system:
  * 1. Expanded hubs: Rich semantic word banks for Red, Green, Blue (more coming)
@@ -28,14 +28,14 @@ const ACHROMATIC_THRESHOLD = 0.02;
  * Generate a deterministic color name from OKLCH values
  *
  * The name is composed of up to three hyphenated words:
- * - Luminosity: describes the lightness (obsidian, slate, ivory, snow, etc.)
+ * - Luminosity: describes the lightness (shadow, deep, balanced, pale, brilliant, etc.)
  * - Intensity: describes the chroma/saturation (whisper, bold, fierce, etc.)
  * - Material: describes the hue (ember, sapphire, sage, etc.)
  *
  * Achromatic colors (chroma < 0.02) omit the material word.
  *
  * @param oklch - The color in OKLCH format
- * @returns A hyphenated color name like "dove-clear-sapphire"
+ * @returns A hyphenated color name like "luminous-clear-sapphire"
  */
 export function generateColorName(oklch: OKLCH): string {
   // Get computed properties for semantic word selection

--- a/packages/color-utils/src/naming/index.ts
+++ b/packages/color-utils/src/naming/index.ts
@@ -9,7 +9,7 @@
  * import { generateColorName } from '@rafters/color-utils';
  *
  * const name = generateColorName({ l: 0.65, c: 0.12, h: 230, alpha: 1 });
- * // Returns: "dove-true-cobalt"
+ * // Returns: "luminous-true-cobalt"
  * ```
  */
 

--- a/packages/color-utils/src/naming/word-banks.ts
+++ b/packages/color-utils/src/naming/word-banks.ts
@@ -2,7 +2,7 @@
  * Word Banks for Deterministic Color Naming
  *
  * Three independent word banks map to OKLCH dimensions:
- * - Luminosity (L): materials/textures describing light levels
+ * - Luminosity (L): brightness-based words describing light levels
  * - Intensity (C): emotions/feelings describing saturation
  * - Material (H): objects/places/nature describing hue
  *
@@ -13,18 +13,21 @@
 /**
  * Luminosity words by lightness bucket (0-1 in 10 steps)
  * Index 0 = darkest (0.0-0.1), Index 9 = lightest (0.9-1.0)
+ *
+ * Uses brightness-based words that describe luminance without implying
+ * grayscale materials, allowing natural composition with chromatic hues.
  */
 export const LUMINOSITY_WORDS: readonly string[] = [
-  'obsidian', // 0.0-0.1: darkest
-  'coal', // 0.1-0.2
-  'slate', // 0.2-0.3
-  'pewter', // 0.3-0.4
-  'stone', // 0.4-0.5
-  'silver', // 0.5-0.6
-  'dove', // 0.6-0.7
-  'bone', // 0.7-0.8
-  'ivory', // 0.8-0.9
-  'snow', // 0.9-1.0: lightest
+  'shadow', // 0.0-0.1: darkest
+  'dark', // 0.1-0.2
+  'deep', // 0.2-0.3
+  'dim', // 0.3-0.4
+  'mid', // 0.4-0.5
+  'balanced', // 0.5-0.6
+  'luminous', // 0.6-0.7
+  'pale', // 0.7-0.8
+  'faint', // 0.8-0.9
+  'brilliant', // 0.9-1.0: lightest
 ] as const;
 
 /**

--- a/packages/color-utils/test/naming.test.ts
+++ b/packages/color-utils/test/naming.test.ts
@@ -187,7 +187,7 @@ describe('generateColorName', () => {
     const name = generateColorName(oklch);
 
     // Format: luminosity-intensity-material (each component may contain hyphens)
-    // Examples: "dove-true-bay-blue", "slate-bold-cobalt", "ivory-soft-sage"
+    // Examples: "luminous-true-lagoon", "deep-bold-cobalt", "faint-soft-sage"
     expect(name).toMatch(/^[a-z]+(-[a-z]+)+$/);
   });
 });


### PR DESCRIPTION
## Summary
- Replace material-based luminosity words that imply grayscale with brightness-based words
- Old: `obsidian, coal, slate, pewter, stone, silver, dove, bone, ivory, snow`
- New: `shadow, dark, deep, dim, mid, balanced, luminous, pale, faint, brilliant`

### Result
| Before | After |
|--------|-------|
| `silver-bold-warning-red` | `balanced-bold-warning-red` |
| `bone-true-strait-blue` | `pale-true-strait-blue` |

## Test plan
- [x] All color-utils naming tests pass
- [x] All API color route tests updated and pass
- [x] Preflight passes

## Breaking Change
Existing cached color names in Vectorize will have stale names. Follow-up required to upsert vectors with new naming scheme.

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)