### PR TITLE
fix(website): remove docs link and exclude @rafters/* from deps

### DIFF
--- a/apps/website/src/components/Footer.astro
+++ b/apps/website/src/components/Footer.astro
@@ -15,9 +15,6 @@ const _currentYear = new Date().getFullYear();
       <a href="https://github.com/real-handy/rafters" class="underline hover:no-underline">
         GitHub
       </a>
-      <a href="/docs" class="underline hover:no-underline">
-        Docs
-      </a>
       <a href="/registry" class="underline hover:no-underline">
         Registry
       </a>

--- a/apps/website/src/lib/registry/componentService.ts
+++ b/apps/website/src/lib/registry/componentService.ts
@@ -95,12 +95,18 @@ const FRAMEWORK_VERSIONS: Record<string, string> = {
 const EXCLUDED_DEPS = new Set(['react/jsx-runtime', '@types/react', '@types/react-dom']);
 
 /**
+ * Prefixes to exclude (internal packages)
+ */
+const EXCLUDED_PREFIXES = ['@rafters/'];
+
+/**
  * Add versions to dependencies
  * Framework deps get minimum versions, others passed through (for now)
  */
 function versionDeps(deps: string[]): string[] {
   return deps
     .filter((dep) => !EXCLUDED_DEPS.has(dep))
+    .filter((dep) => !EXCLUDED_PREFIXES.some((prefix) => dep.startsWith(prefix)))
     .map((dep) => {
       const version = FRAMEWORK_VERSIONS[dep];
       return version ? `${dep}@${version}` : dep;


### PR DESCRIPTION
## Summary
- Remove docs link from footer (not implemented yet)
- Exclude @rafters/* packages from registry dependencies (was causing install failures)

## Test plan
- [ ] Verify footer no longer shows docs link
- [ ] Verify `rafters add button` no longer tries to install `@rafters/ui`

Generated with [Claude Code](https://claude.com/claude-code)