### PR TITLE
feat(cli): add human-friendly output with --agent flag for JSON

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "website",
+  "name": "rafters-website",
   "private": true,
   "type": "module",
   "version": "0.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "description": "CLI for Rafters design system - scaffold tokens and add components",
   "type": "module",
   "bin": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,6 +22,7 @@ program
   .command('init')
   .description('Initialize .rafters/ with default tokens and config')
   .option('-f, --force', 'Regenerate output files from existing config')
+  .option('--agent', 'Output JSON for machine consumption')
   .action(init);
 
 program
@@ -30,6 +31,7 @@ program
   .argument('<components...>', 'Component names to add')
   .option('--overwrite', 'Overwrite existing component files')
   .option('--registry-url <url>', 'Custom registry URL')
+  .option('--agent', 'Output JSON for machine consumption')
   .action(add);
 
 program.command('mcp').description('Start MCP server for AI agent access (stdio)').action(mcp);

--- a/packages/cli/src/utils/detect.ts
+++ b/packages/cli/src/utils/detect.ts
@@ -7,7 +7,7 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-export type Framework = 'next' | 'vite' | 'remix' | 'astro' | 'unknown';
+export type Framework = 'next' | 'vite' | 'remix' | 'react-router' | 'astro' | 'unknown';
 
 export interface ShadcnConfig {
   tailwind?: {
@@ -60,6 +60,11 @@ export async function detectFramework(cwd: string): Promise<Framework> {
     // Check for frameworks in order of specificity
     if (deps.next) {
       return 'next';
+    }
+
+    // React Router v7 uses react-router package (check before Remix)
+    if (deps['react-router']) {
+      return 'react-router';
     }
 
     // Remix packages all start with @remix-run/

--- a/packages/cli/src/utils/ui.ts
+++ b/packages/cli/src/utils/ui.ts
@@ -1,0 +1,188 @@
+/**
+ * CLI UI utilities
+ *
+ * Pretty output for humans, JSON for agents.
+ */
+
+import ora, { type Ora } from 'ora';
+
+export interface UIContext {
+  agent: boolean;
+  spinner: Ora | null;
+}
+
+const context: UIContext = {
+  agent: false,
+  spinner: null,
+};
+
+export function setAgentMode(agent: boolean): void {
+  context.agent = agent;
+}
+
+export function isAgentMode(): boolean {
+  return context.agent;
+}
+
+/**
+ * Log an event - JSON for agents, pretty for humans
+ */
+export function log(event: Record<string, unknown>): void {
+  if (context.agent) {
+    console.log(JSON.stringify(event));
+    return;
+  }
+
+  // Human-friendly output based on event type
+  const eventType = event.event as string;
+
+  switch (eventType) {
+    // Init events
+    case 'init:start':
+      context.spinner = ora('Initializing rafters...').start();
+      break;
+
+    case 'init:detected':
+      context.spinner?.succeed('Project detected');
+      console.log(`  Framework: ${event.framework}`);
+      console.log(`  Tailwind: v${event.tailwindVersion}`);
+      if (event.hasShadcn) {
+        console.log('  shadcn/ui: detected');
+      }
+      context.spinner = ora('Generating tokens...').start();
+      break;
+
+    case 'init:shadcn_detected': {
+      context.spinner?.info('Found existing shadcn colors');
+      console.log(`  Backed up: ${event.backupPath}`);
+      const colors = event.colorsFound as { light: number; dark: number };
+      console.log(`  Colors: ${colors.light} light, ${colors.dark} dark`);
+      context.spinner = ora('Generating tokens...').start();
+      break;
+    }
+
+    case 'init:generated':
+      context.spinner?.succeed(`Generated ${event.tokenCount} tokens`);
+      context.spinner = ora('Saving registry...').start();
+      break;
+
+    case 'init:registry_saved':
+      context.spinner?.succeed(`Saved ${event.namespaceCount} namespaces`);
+      break;
+
+    case 'init:css_updated':
+      console.log(`  Updated: ${event.cssPath}`);
+      break;
+
+    case 'init:css_not_found':
+      console.log(`\n  Note: ${event.message}`);
+      break;
+
+    case 'init:css_already_imported':
+      console.log(`  CSS already configured: ${event.cssPath}`);
+      break;
+
+    case 'init:regenerate':
+      context.spinner = ora('Regenerating from existing config...').start();
+      break;
+
+    case 'init:loaded':
+      context.spinner?.succeed(`Loaded ${event.tokenCount} tokens`);
+      context.spinner = ora('Generating outputs...').start();
+      break;
+
+    case 'init:colors_imported':
+      console.log(`  Imported ${event.count} existing colors`);
+      break;
+
+    case 'init:complete': {
+      context.spinner?.succeed('Done!');
+      console.log(`\n  Output: ${event.path}`);
+      const outputs = event.outputs as string[];
+      for (const file of outputs) {
+        console.log(`    - ${file}`);
+      }
+      console.log('');
+      break;
+    }
+
+    // Add events
+    case 'add:start': {
+      const components = event.components as string[];
+      context.spinner = ora(`Adding ${components.join(', ')}...`).start();
+      break;
+    }
+
+    case 'add:installed': {
+      context.spinner?.succeed(`Installed ${event.component}`);
+      const files = event.files as string[];
+      for (const file of files) {
+        console.log(`    ${file}`);
+      }
+      context.spinner = ora('Installing...').start();
+      break;
+    }
+
+    case 'add:skip':
+      context.spinner?.warn(`Skipped ${event.component} (already exists)`);
+      context.spinner = ora('Installing...').start();
+      break;
+
+    case 'add:dependencies':
+      if (context.spinner) {
+        context.spinner.text = 'Installing dependencies...';
+      }
+      break;
+
+    case 'add:complete':
+      context.spinner?.succeed(
+        `Added ${event.installed} component${(event.installed as number) !== 1 ? 's' : ''}`,
+      );
+      if ((event.skipped as number) > 0) {
+        console.log(`  Skipped: ${event.skipped} (use --overwrite to replace)`);
+      }
+      console.log('');
+      break;
+
+    case 'add:hint':
+      console.log(`\n  ${event.message}`);
+      break;
+
+    case 'add:warning':
+      console.warn(`  Warning: ${event.message}`);
+      break;
+
+    case 'add:error':
+      context.spinner?.fail(event.message as string);
+      break;
+
+    default:
+      // Fallback for unknown events
+      if (context.spinner) {
+        context.spinner.text = eventType;
+      } else {
+        console.log(event);
+      }
+  }
+}
+
+/**
+ * Log an error
+ */
+export function error(message: string): void {
+  if (context.agent) {
+    console.error(JSON.stringify({ event: 'error', message }));
+    return;
+  }
+
+  context.spinner?.fail(message);
+  context.spinner = null;
+}
+
+/**
+ * Stop spinner on unexpected exit
+ */
+export function cleanup(): void {
+  context.spinner?.stop();
+  context.spinner = null;
+}

--- a/packages/cli/test/commands/add.test.ts
+++ b/packages/cli/test/commands/add.test.ts
@@ -17,43 +17,43 @@ import { generateRandomItems, registryFixtures } from '../fixtures/registry.js';
 describe('transformFileContent', () => {
   it('transforms ../../primitives/ imports to @/lib/primitives/', () => {
     const input = `import classy from '../../primitives/classy';`;
-    const result = transformFileContent(input);
+    const result = transformFileContent(input, null);
     expect(result).toBe(`import classy from '@/lib/primitives/classy';`);
   });
 
   it('transforms ../primitives/ imports to @/lib/primitives/', () => {
     const input = `import { cn } from '../primitives/cn';`;
-    const result = transformFileContent(input);
+    const result = transformFileContent(input, null);
     expect(result).toBe(`import { cn } from '@/lib/primitives/cn';`);
   });
 
   it('transforms ./ component imports to @/components/ui/', () => {
     const input = `import { Button } from './button';`;
-    const result = transformFileContent(input);
+    const result = transformFileContent(input, null);
     expect(result).toBe(`import { Button } from '@/components/ui/button';`);
   });
 
   it('transforms ../ component imports to @/components/ui/', () => {
     const input = `import { Card } from '../card';`;
-    const result = transformFileContent(input);
+    const result = transformFileContent(input, null);
     expect(result).toBe(`import { Card } from '@/components/ui/card';`);
   });
 
   it('transforms ../lib/ imports to @/lib/', () => {
     const input = `import { cn } from '../lib/utils';`;
-    const result = transformFileContent(input);
+    const result = transformFileContent(input, null);
     expect(result).toBe(`import { cn } from '@/lib/utils';`);
   });
 
   it('transforms ../hooks/ imports to @/hooks/', () => {
     const input = `import { useMediaQuery } from '../hooks/use-media-query';`;
-    const result = transformFileContent(input);
+    const result = transformFileContent(input, null);
     expect(result).toBe(`import { useMediaQuery } from '@/hooks/use-media-query';`);
   });
 
   it('does not incorrectly transform ../lib/ as component import', () => {
     const input = `import { cn } from '../lib/utils';`;
-    const result = transformFileContent(input);
+    const result = transformFileContent(input, null);
     // Should NOT be @/components/ui/lib/utils
     expect(result).not.toContain('@/components/ui/lib');
     expect(result).toBe(`import { cn } from '@/lib/utils';`);
@@ -64,7 +64,7 @@ describe('transformFileContent', () => {
 import { Button } from './button';
 import { Card } from '../card';`;
 
-    const result = transformFileContent(input);
+    const result = transformFileContent(input, null);
 
     expect(result).toContain(`from '@/lib/primitives/classy'`);
     expect(result).toContain(`from '@/components/ui/button'`);
@@ -75,7 +75,7 @@ import { Card } from '../card';`;
     const input = `import React from 'react';
 import * as Dialog from '@radix-ui/react-dialog';`;
 
-    const result = transformFileContent(input);
+    const result = transformFileContent(input, null);
 
     expect(result).toContain(`from 'react'`);
     expect(result).toContain(`from '@radix-ui/react-dialog'`);
@@ -83,7 +83,7 @@ import * as Dialog from '@radix-ui/react-dialog';`;
 
   it('handles double quotes', () => {
     const input = `import classy from "../../primitives/classy";`;
-    const result = transformFileContent(input);
+    const result = transformFileContent(input, null);
     expect(result).toBe(`import classy from '@/lib/primitives/classy';`);
   });
 });

--- a/packages/cli/test/utils/detect.test.ts
+++ b/packages/cli/test/utils/detect.test.ts
@@ -46,6 +46,18 @@ describe('detectFramework', () => {
     expect(framework).toBe('vite');
   });
 
+  it('should detect React Router v7', async () => {
+    await writeFile(
+      join(testDir, 'package.json'),
+      JSON.stringify({
+        dependencies: { 'react-router': '^7.0.0', react: '^19.0.0' },
+      }),
+    );
+
+    const framework = await detectFramework(testDir);
+    expect(framework).toBe('react-router');
+  });
+
   it('should detect Remix', async () => {
     await writeFile(
       join(testDir, 'package.json'),


### PR DESCRIPTION
## Summary

- Adds `ui.ts` with `log`/`error` utilities that render differently based on mode
- Humans get ora spinners and pretty formatted output
- Agents get structured JSON events for easy parsing
- Adds `--agent` flag to `add` and `init` commands
- Transforms component/primitive paths based on rafters config

## Test plan

- [x] Tests updated for new behavior
- [ ] Manual test: `rafters init` shows spinners
- [ ] Manual test: `rafters init --agent` outputs JSON
- [ ] Manual test: `rafters add button` shows progress
- [ ] Manual test: `rafters add button --agent` outputs JSON events

Generated with [Claude Code](https://claude.ai/code)