### PR TITLE
fix(ui): prevent Container width collapse with @container in flex contexts

### DIFF
--- a/packages/ui/src/components/ui/container.tsx
+++ b/packages/ui/src/components/ui/container.tsx
@@ -15,6 +15,7 @@
  * DO: Spacing happens inside (padding), not outside (no margins)
  * NEVER: Nest containers unnecessarily
  * NEVER: Use margins for spacing - let parent Grid handle gaps
+ * NEVER: Use @container without w-full in flex/grid contexts (causes width collapse in Tailwind v4)
  *
  * @example
  * ```tsx
@@ -143,8 +144,9 @@ export const Container = React.forwardRef<HTMLElement, ContainerProps>(
     const isArticle = Element === 'article';
 
     const classes = classy(
-      // Container queries
-      query && '@container',
+      // Container queries - w-full prevents width collapse when container-type: inline-size
+      // is applied to flex/grid children (Tailwind v4 behavior)
+      query && '@container w-full',
 
       // Size constraint
       size && sizeClasses[size],


### PR DESCRIPTION
## Summary
- Fixed width collapse issue when Container with `@container` is used inside flex/grid contexts
- Added `w-full` alongside `@container` to ensure proper width calculation
- Documented pattern in JSDoc as a NEVER pattern

## Problem
Tailwind v4's `@container` class applies `container-type: inline-size`, which causes flex children without explicit width to collapse to 0px.

**Before:** Grid with `grid-cols-3` computed to `gridTemplateColumns: 0px 0px 0px`
**After:** Grid properly computes to `gridTemplateColumns: 368px 368px 368px`

## Test plan
- [x] All 1614 unit tests pass
- [x] Verified fix in courses.silvius.me project with Playwright

Generated with [Claude Code](https://claude.ai/code)