### PR TITLE
feat(ui): add block selection primitive (R-001)

### DIFF
--- a/packages/ui/src/primitives/selection.ts
+++ b/packages/ui/src/primitives/selection.ts
@@ -1,0 +1,336 @@
+/**
+ * Block Selection primitive
+ * Manages selection state for block-based editors
+ * Supports single, additive, and range selection patterns
+ *
+ * SSR-safe: checks for window existence
+ */
+
+import type { CleanupFunction } from './types';
+
+/**
+ * Options for block selection behavior
+ */
+export interface BlockSelectionOptions {
+  /**
+   * Container element holding the blocks
+   */
+  container: HTMLElement;
+
+  /**
+   * Function to get current block elements
+   * Called dynamically to handle DOM changes
+   */
+  getBlocks: () => HTMLElement[];
+
+  /**
+   * Callback fired when selection changes
+   */
+  onSelectionChange?: (selected: Set<string>) => void;
+
+  /**
+   * Whether multiple blocks can be selected
+   * @default true
+   */
+  multiSelect?: boolean;
+}
+
+/**
+ * Current selection state
+ */
+export interface BlockSelectionState {
+  /**
+   * Set of selected block IDs
+   */
+  selected: Set<string>;
+
+  /**
+   * ID of the anchor block (start of range selection)
+   */
+  anchor: string | null;
+
+  /**
+   * ID of the focus block (end of range selection)
+   */
+  focus: string | null;
+}
+
+/**
+ * Block selection controller interface
+ */
+export interface BlockSelectionController {
+  /**
+   * Get current selection state
+   */
+  getState: () => BlockSelectionState;
+
+  /**
+   * Select a single block
+   * @param id Block ID to select
+   * @param additive If true, add to selection instead of replacing
+   */
+  select: (id: string, additive?: boolean) => void;
+
+  /**
+   * Select a range of blocks between two IDs (inclusive)
+   * @param fromId Start block ID
+   * @param toId End block ID
+   */
+  selectRange: (fromId: string, toId: string) => void;
+
+  /**
+   * Select all blocks
+   */
+  selectAll: () => void;
+
+  /**
+   * Clear all selection
+   */
+  clear: () => void;
+
+  /**
+   * Cleanup function to remove event listeners
+   */
+  cleanup: CleanupFunction;
+}
+
+/**
+ * Get block ID from element
+ * Blocks are identified by data-block-id attribute
+ */
+function getBlockId(element: HTMLElement): string | null {
+  return element.getAttribute('data-block-id');
+}
+
+/**
+ * Get all block IDs from elements
+ */
+function getBlockIds(blocks: HTMLElement[]): string[] {
+  const ids: string[] = [];
+  for (const block of blocks) {
+    const id = getBlockId(block);
+    if (id !== null) {
+      ids.push(id);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Create block selection behavior for a container
+ * Returns controller object with selection methods
+ *
+ * @example
+ * ```typescript
+ * const selection = createBlockSelection({
+ *   container: editorElement,
+ *   getBlocks: () => Array.from(editorElement.querySelectorAll('[data-block-id]')),
+ *   onSelectionChange: (selected) => {
+ *     // Update UI based on selection
+ *   },
+ *   multiSelect: true,
+ * });
+ *
+ * // Select a single block
+ * selection.select('block-1');
+ *
+ * // Add to selection
+ * selection.select('block-2', true);
+ *
+ * // Select range
+ * selection.selectRange('block-1', 'block-5');
+ *
+ * // Clear selection
+ * selection.clear();
+ *
+ * // Cleanup when done
+ * selection.cleanup();
+ * ```
+ */
+export function createBlockSelection(options: BlockSelectionOptions): BlockSelectionController {
+  // SSR guard
+  if (typeof window === 'undefined') {
+    const emptyState: BlockSelectionState = {
+      selected: new Set(),
+      anchor: null,
+      focus: null,
+    };
+    return {
+      getState: () => emptyState,
+      select: () => {},
+      selectRange: () => {},
+      selectAll: () => {},
+      clear: () => {},
+      cleanup: () => {},
+    };
+  }
+
+  const { container, getBlocks, onSelectionChange, multiSelect = true } = options;
+
+  // Internal state
+  const state: BlockSelectionState = {
+    selected: new Set(),
+    anchor: null,
+    focus: null,
+  };
+
+  /**
+   * Notify listeners of selection change
+   */
+  function notifyChange(): void {
+    onSelectionChange?.(new Set(state.selected));
+  }
+
+  /**
+   * Select a single block, optionally adding to existing selection
+   */
+  function select(id: string, additive = false): void {
+    if (!multiSelect) {
+      // Single select mode: always replace
+      state.selected.clear();
+      state.selected.add(id);
+      state.anchor = id;
+      state.focus = id;
+    } else if (additive) {
+      // Additive: toggle the block in selection
+      if (state.selected.has(id)) {
+        state.selected.delete(id);
+        // Update anchor/focus if we removed them
+        if (state.anchor === id) {
+          state.anchor = state.selected.size > 0 ? (Array.from(state.selected)[0] ?? null) : null;
+        }
+        if (state.focus === id) {
+          state.focus = state.anchor;
+        }
+      } else {
+        state.selected.add(id);
+        state.focus = id;
+        if (state.anchor === null) {
+          state.anchor = id;
+        }
+      }
+    } else {
+      // Non-additive: replace selection
+      state.selected.clear();
+      state.selected.add(id);
+      state.anchor = id;
+      state.focus = id;
+    }
+    notifyChange();
+  }
+
+  /**
+   * Select all blocks between fromId and toId (inclusive)
+   */
+  function selectRange(fromId: string, toId: string): void {
+    const blocks = getBlocks();
+    const blockIds = getBlockIds(blocks);
+
+    const fromIndex = blockIds.indexOf(fromId);
+    const toIndex = blockIds.indexOf(toId);
+
+    if (fromIndex === -1 || toIndex === -1) {
+      // One or both IDs not found, do nothing
+      return;
+    }
+
+    const startIndex = Math.min(fromIndex, toIndex);
+    const endIndex = Math.max(fromIndex, toIndex);
+
+    state.selected.clear();
+    for (let i = startIndex; i <= endIndex; i++) {
+      const id = blockIds[i];
+      if (id !== undefined) {
+        state.selected.add(id);
+      }
+    }
+
+    state.anchor = fromId;
+    state.focus = toId;
+    notifyChange();
+  }
+
+  /**
+   * Select all blocks
+   */
+  function selectAll(): void {
+    const blocks = getBlocks();
+    const blockIds = getBlockIds(blocks);
+
+    state.selected.clear();
+    for (const id of blockIds) {
+      state.selected.add(id);
+    }
+
+    state.anchor = blockIds[0] ?? null;
+    state.focus = blockIds[blockIds.length - 1] ?? null;
+    notifyChange();
+  }
+
+  /**
+   * Clear all selection
+   */
+  function clear(): void {
+    if (state.selected.size === 0 && state.anchor === null && state.focus === null) {
+      // No change needed
+      return;
+    }
+    state.selected.clear();
+    state.anchor = null;
+    state.focus = null;
+    notifyChange();
+  }
+
+  /**
+   * Get current state (returns a copy to prevent external mutation)
+   */
+  function getState(): BlockSelectionState {
+    return {
+      selected: new Set(state.selected),
+      anchor: state.anchor,
+      focus: state.focus,
+    };
+  }
+
+  // Event handlers for click-based selection
+  function handleClick(event: MouseEvent): void {
+    const target = event.target as HTMLElement;
+    const blockElement = target.closest('[data-block-id]') as HTMLElement | null;
+
+    if (!blockElement || !container.contains(blockElement)) {
+      return;
+    }
+
+    const id = getBlockId(blockElement);
+    if (id === null) {
+      return;
+    }
+
+    const isAdditive = multiSelect && (event.ctrlKey || event.metaKey);
+    const anchor = state.anchor;
+    const isRange = multiSelect && event.shiftKey && anchor !== null;
+
+    if (isRange) {
+      selectRange(anchor, id);
+    } else {
+      select(id, isAdditive);
+    }
+  }
+
+  // Add event listeners
+  container.addEventListener('click', handleClick);
+
+  // Cleanup function
+  function cleanup(): void {
+    container.removeEventListener('click', handleClick);
+  }
+
+  return {
+    getState,
+    select,
+    selectRange,
+    selectAll,
+    clear,
+    cleanup,
+  };
+}

--- a/packages/ui/test/primitives/selection.test.ts
+++ b/packages/ui/test/primitives/selection.test.ts
@@ -1,0 +1,499 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createBlockSelection } from '../../src/primitives/selection';
+
+describe('createBlockSelection', () => {
+  let container: HTMLDivElement;
+  let blocks: HTMLDivElement[];
+
+  function createBlock(id: string): HTMLDivElement {
+    const block = document.createElement('div');
+    block.setAttribute('data-block-id', id);
+    block.textContent = `Block ${id}`;
+    return block;
+  }
+
+  function getBlocks(): HTMLElement[] {
+    return Array.from(container.querySelectorAll('[data-block-id]'));
+  }
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    blocks = [
+      createBlock('block-1'),
+      createBlock('block-2'),
+      createBlock('block-3'),
+      createBlock('block-4'),
+      createBlock('block-5'),
+    ];
+    for (const block of blocks) {
+      container.appendChild(block);
+    }
+    document.body.appendChild(container);
+  });
+
+  describe('single block selection', () => {
+    it('selects a single block', () => {
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+      });
+
+      selection.select('block-2');
+
+      const state = selection.getState();
+      expect(state.selected.has('block-2')).toBe(true);
+      expect(state.selected.size).toBe(1);
+      expect(state.anchor).toBe('block-2');
+      expect(state.focus).toBe('block-2');
+
+      selection.cleanup();
+    });
+
+    it('clears previous selection when selecting without additive flag', () => {
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+      });
+
+      selection.select('block-1');
+      selection.select('block-3');
+
+      const state = selection.getState();
+      expect(state.selected.has('block-1')).toBe(false);
+      expect(state.selected.has('block-3')).toBe(true);
+      expect(state.selected.size).toBe(1);
+
+      selection.cleanup();
+    });
+  });
+
+  describe('additive selection', () => {
+    it('adds to selection when additive is true', () => {
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+      });
+
+      selection.select('block-1');
+      selection.select('block-3', true);
+
+      const state = selection.getState();
+      expect(state.selected.has('block-1')).toBe(true);
+      expect(state.selected.has('block-3')).toBe(true);
+      expect(state.selected.size).toBe(2);
+
+      selection.cleanup();
+    });
+
+    it('toggles selection when additive and already selected', () => {
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+      });
+
+      selection.select('block-1');
+      selection.select('block-2', true);
+      selection.select('block-1', true);
+
+      const state = selection.getState();
+      expect(state.selected.has('block-1')).toBe(false);
+      expect(state.selected.has('block-2')).toBe(true);
+      expect(state.selected.size).toBe(1);
+
+      selection.cleanup();
+    });
+  });
+
+  describe('range selection', () => {
+    it('selects all blocks between two IDs inclusive', () => {
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+      });
+
+      selection.selectRange('block-2', 'block-4');
+
+      const state = selection.getState();
+      expect(state.selected.has('block-1')).toBe(false);
+      expect(state.selected.has('block-2')).toBe(true);
+      expect(state.selected.has('block-3')).toBe(true);
+      expect(state.selected.has('block-4')).toBe(true);
+      expect(state.selected.has('block-5')).toBe(false);
+      expect(state.selected.size).toBe(3);
+      expect(state.anchor).toBe('block-2');
+      expect(state.focus).toBe('block-4');
+
+      selection.cleanup();
+    });
+
+    it('handles reverse range (toId before fromId)', () => {
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+      });
+
+      selection.selectRange('block-4', 'block-2');
+
+      const state = selection.getState();
+      expect(state.selected.has('block-2')).toBe(true);
+      expect(state.selected.has('block-3')).toBe(true);
+      expect(state.selected.has('block-4')).toBe(true);
+      expect(state.selected.size).toBe(3);
+
+      selection.cleanup();
+    });
+
+    it('does nothing if fromId is not found', () => {
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+      });
+
+      selection.select('block-1');
+      selection.selectRange('nonexistent', 'block-3');
+
+      const state = selection.getState();
+      expect(state.selected.has('block-1')).toBe(true);
+      expect(state.selected.size).toBe(1);
+
+      selection.cleanup();
+    });
+
+    it('does nothing if toId is not found', () => {
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+      });
+
+      selection.select('block-1');
+      selection.selectRange('block-2', 'nonexistent');
+
+      const state = selection.getState();
+      expect(state.selected.has('block-1')).toBe(true);
+      expect(state.selected.size).toBe(1);
+
+      selection.cleanup();
+    });
+  });
+
+  describe('selectAll', () => {
+    it('selects all blocks', () => {
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+      });
+
+      selection.selectAll();
+
+      const state = selection.getState();
+      expect(state.selected.size).toBe(5);
+      expect(state.selected.has('block-1')).toBe(true);
+      expect(state.selected.has('block-2')).toBe(true);
+      expect(state.selected.has('block-3')).toBe(true);
+      expect(state.selected.has('block-4')).toBe(true);
+      expect(state.selected.has('block-5')).toBe(true);
+      expect(state.anchor).toBe('block-1');
+      expect(state.focus).toBe('block-5');
+
+      selection.cleanup();
+    });
+
+    it('handles empty container', () => {
+      // Remove all children using DOM methods
+      while (container.firstChild) {
+        container.removeChild(container.firstChild);
+      }
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+      });
+
+      selection.selectAll();
+
+      const state = selection.getState();
+      expect(state.selected.size).toBe(0);
+      expect(state.anchor).toBe(null);
+      expect(state.focus).toBe(null);
+
+      selection.cleanup();
+    });
+  });
+
+  describe('clear', () => {
+    it('clears all selection', () => {
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+      });
+
+      selection.selectAll();
+      selection.clear();
+
+      const state = selection.getState();
+      expect(state.selected.size).toBe(0);
+      expect(state.anchor).toBe(null);
+      expect(state.focus).toBe(null);
+
+      selection.cleanup();
+    });
+
+    it('handles already empty selection', () => {
+      const onChange = vi.fn();
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+        onSelectionChange: onChange,
+      });
+
+      selection.clear();
+
+      // Should not call onChange when nothing changes
+      expect(onChange).not.toHaveBeenCalled();
+
+      selection.cleanup();
+    });
+  });
+
+  describe('onSelectionChange callback', () => {
+    it('fires on select', () => {
+      const onChange = vi.fn();
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+        onSelectionChange: onChange,
+      });
+
+      selection.select('block-1');
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(new Set(['block-1']));
+
+      selection.cleanup();
+    });
+
+    it('fires on additive select', () => {
+      const onChange = vi.fn();
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+        onSelectionChange: onChange,
+      });
+
+      selection.select('block-1');
+      selection.select('block-2', true);
+
+      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenLastCalledWith(new Set(['block-1', 'block-2']));
+
+      selection.cleanup();
+    });
+
+    it('fires on selectRange', () => {
+      const onChange = vi.fn();
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+        onSelectionChange: onChange,
+      });
+
+      selection.selectRange('block-1', 'block-3');
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(new Set(['block-1', 'block-2', 'block-3']));
+
+      selection.cleanup();
+    });
+
+    it('fires on selectAll', () => {
+      const onChange = vi.fn();
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+        onSelectionChange: onChange,
+      });
+
+      selection.selectAll();
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(
+        new Set(['block-1', 'block-2', 'block-3', 'block-4', 'block-5']),
+      );
+
+      selection.cleanup();
+    });
+
+    it('fires on clear', () => {
+      const onChange = vi.fn();
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+        onSelectionChange: onChange,
+      });
+
+      selection.select('block-1');
+      selection.clear();
+
+      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenLastCalledWith(new Set());
+
+      selection.cleanup();
+    });
+
+    it('receives a copy of the set to prevent mutation', () => {
+      let capturedSet: Set<string> | null = null;
+      const onChange = (selected: Set<string>) => {
+        capturedSet = selected;
+      };
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+        onSelectionChange: onChange,
+      });
+
+      selection.select('block-1');
+
+      // Mutate the captured set
+      capturedSet?.add('mutated');
+
+      // Internal state should not be affected
+      const state = selection.getState();
+      expect(state.selected.has('mutated')).toBe(false);
+
+      selection.cleanup();
+    });
+  });
+
+  describe('multiSelect option', () => {
+    it('when false, always replaces selection', () => {
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+        multiSelect: false,
+      });
+
+      selection.select('block-1');
+      selection.select('block-2', true); // additive flag ignored
+
+      const state = selection.getState();
+      expect(state.selected.size).toBe(1);
+      expect(state.selected.has('block-2')).toBe(true);
+
+      selection.cleanup();
+    });
+  });
+
+  describe('getState', () => {
+    it('returns a copy of state to prevent mutation', () => {
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+      });
+
+      selection.select('block-1');
+      const state1 = selection.getState();
+
+      // Mutate the returned state
+      state1.selected.add('hacked');
+
+      // Internal state should not be affected
+      const state2 = selection.getState();
+      expect(state2.selected.has('hacked')).toBe(false);
+      expect(state2.selected.size).toBe(1);
+
+      selection.cleanup();
+    });
+  });
+
+  describe('cleanup', () => {
+    it('removes event listeners', () => {
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+      });
+
+      selection.cleanup();
+
+      // After cleanup, clicking should not select
+      const clickEvent = new MouseEvent('click', { bubbles: true });
+      blocks[0]?.dispatchEvent(clickEvent);
+
+      const state = selection.getState();
+      expect(state.selected.size).toBe(0);
+    });
+  });
+
+  describe('click handling', () => {
+    it('selects block on click', () => {
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+      });
+
+      const clickEvent = new MouseEvent('click', { bubbles: true });
+      blocks[1]?.dispatchEvent(clickEvent);
+
+      const state = selection.getState();
+      expect(state.selected.has('block-2')).toBe(true);
+      expect(state.selected.size).toBe(1);
+
+      selection.cleanup();
+    });
+
+    it('handles Ctrl+click for additive selection', () => {
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+      });
+
+      const click1 = new MouseEvent('click', { bubbles: true });
+      blocks[0]?.dispatchEvent(click1);
+
+      const click2 = new MouseEvent('click', { bubbles: true, ctrlKey: true });
+      blocks[2]?.dispatchEvent(click2);
+
+      const state = selection.getState();
+      expect(state.selected.has('block-1')).toBe(true);
+      expect(state.selected.has('block-3')).toBe(true);
+      expect(state.selected.size).toBe(2);
+
+      selection.cleanup();
+    });
+
+    it('handles Shift+click for range selection', () => {
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+      });
+
+      const click1 = new MouseEvent('click', { bubbles: true });
+      blocks[0]?.dispatchEvent(click1);
+
+      const click2 = new MouseEvent('click', { bubbles: true, shiftKey: true });
+      blocks[3]?.dispatchEvent(click2);
+
+      const state = selection.getState();
+      expect(state.selected.has('block-1')).toBe(true);
+      expect(state.selected.has('block-2')).toBe(true);
+      expect(state.selected.has('block-3')).toBe(true);
+      expect(state.selected.has('block-4')).toBe(true);
+      expect(state.selected.size).toBe(4);
+
+      selection.cleanup();
+    });
+
+    it('ignores clicks outside blocks', () => {
+      const selection = createBlockSelection({
+        container,
+        getBlocks,
+      });
+
+      const clickEvent = new MouseEvent('click', { bubbles: true });
+      container.dispatchEvent(clickEvent);
+
+      const state = selection.getState();
+      expect(state.selected.size).toBe(0);
+
+      selection.cleanup();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements the block selection primitive for Editor v1 (Issue #605)
- Creates `createBlockSelection()` factory function with SSR guard
- Supports single selection, additive selection (Ctrl/Cmd+click), and range selection (Shift+click)
- Uses `data-block-id` attribute for block identification
- Includes comprehensive test suite with 25 tests

## Changes
- `packages/ui/src/primitives/selection.ts` - Selection primitive implementation
- `packages/ui/test/primitives/selection.test.ts` - Test suite

## Test plan
- [x] All 25 unit tests pass
- [x] Biome lint check passes
- [x] TypeScript compiles without errors

Closes #605

---
Generated with [Claude Code](https://claude.ai/code)