### PR TITLE
feat(ui): add clipboard primitive (R-004)

### DIFF
--- a/packages/ui/src/primitives/clipboard.ts
+++ b/packages/ui/src/primitives/clipboard.ts
@@ -1,0 +1,255 @@
+/**
+ * Clipboard primitive for copy/cut/paste operations
+ * Client-only, returns cleanup function
+ * SSR-safe: checks for window existence
+ */
+
+import type { CleanupFunction } from './types';
+
+/**
+ * Data structure for clipboard content
+ */
+export interface ClipboardData {
+  text?: string;
+  html?: string;
+  custom?: unknown;
+}
+
+/**
+ * Options for creating a clipboard manager
+ */
+export interface ClipboardOptions {
+  container: HTMLElement;
+  customMimeType?: string;
+  onPaste?: (data: ClipboardData) => void;
+  onCopy?: (data: ClipboardData) => void;
+  onCut?: (data: ClipboardData) => void;
+}
+
+/**
+ * Return type for createClipboard
+ */
+export interface ClipboardManager {
+  write: (data: ClipboardData) => Promise<void>;
+  read: () => Promise<ClipboardData>;
+  cleanup: CleanupFunction;
+}
+
+/**
+ * Parse clipboard data from a ClipboardEvent or Navigator Clipboard API
+ */
+async function parseClipboardData(
+  clipboardData: DataTransfer | null,
+  customMimeType?: string,
+): Promise<ClipboardData> {
+  const result: ClipboardData = {};
+
+  if (!clipboardData) {
+    return result;
+  }
+
+  // Get text content
+  const text = clipboardData.getData('text/plain');
+  if (text) {
+    result.text = text;
+  }
+
+  // Get HTML content
+  const html = clipboardData.getData('text/html');
+  if (html) {
+    result.html = html;
+  }
+
+  // Get custom content if mime type is specified
+  if (customMimeType) {
+    const customData = clipboardData.getData(customMimeType);
+    if (customData) {
+      try {
+        result.custom = JSON.parse(customData);
+      } catch {
+        // If parsing fails, store as string
+        result.custom = customData;
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Create a clipboard manager for an element
+ * Provides read/write operations and event callbacks for copy/cut/paste
+ *
+ * @example
+ * const { write, read, cleanup } = createClipboard({
+ *   container: editorElement,
+ *   customMimeType: 'application/x-rafters-blocks',
+ *   onPaste: (data) => console.log('Pasted:', data),
+ *   onCopy: (data) => console.log('Copied:', data),
+ *   onCut: (data) => console.log('Cut:', data),
+ * });
+ *
+ * // Write to clipboard
+ * await write({ text: 'Hello', custom: { blocks: [...] } });
+ *
+ * // Read from clipboard
+ * const data = await read();
+ *
+ * // Cleanup when done
+ * cleanup();
+ */
+export function createClipboard(options: ClipboardOptions): ClipboardManager {
+  const { container, customMimeType, onPaste, onCopy, onCut } = options;
+
+  // SSR guard
+  if (typeof window === 'undefined') {
+    return {
+      write: async () => {},
+      read: async () => ({}),
+      cleanup: () => {},
+    };
+  }
+
+  const handlePaste = async (event: ClipboardEvent) => {
+    if (!onPaste) return;
+
+    const data = await parseClipboardData(event.clipboardData, customMimeType);
+    onPaste(data);
+  };
+
+  const handleCopy = async (event: ClipboardEvent) => {
+    if (!onCopy) return;
+
+    const data = await parseClipboardData(event.clipboardData, customMimeType);
+    onCopy(data);
+  };
+
+  const handleCut = async (event: ClipboardEvent) => {
+    if (!onCut) return;
+
+    const data = await parseClipboardData(event.clipboardData, customMimeType);
+    onCut(data);
+  };
+
+  // Add event listeners
+  container.addEventListener('paste', handlePaste);
+  container.addEventListener('copy', handleCopy);
+  container.addEventListener('cut', handleCut);
+
+  /**
+   * Write data to the clipboard
+   * Uses the modern Clipboard API with fallback for custom MIME types
+   */
+  const write = async (data: ClipboardData): Promise<void> => {
+    try {
+      // Build clipboard items
+      const items: Record<string, Blob> = {};
+
+      if (data.text) {
+        items['text/plain'] = new Blob([data.text], { type: 'text/plain' });
+      }
+
+      if (data.html) {
+        items['text/html'] = new Blob([data.html], { type: 'text/html' });
+      }
+
+      if (data.custom !== undefined && customMimeType) {
+        const customString =
+          typeof data.custom === 'string' ? data.custom : JSON.stringify(data.custom);
+        items[customMimeType] = new Blob([customString], { type: customMimeType });
+      }
+
+      // If we have any items, write them to clipboard
+      if (Object.keys(items).length > 0) {
+        try {
+          // Try to write with all MIME types
+          const clipboardItem = new ClipboardItem(items);
+          await navigator.clipboard.write([clipboardItem]);
+        } catch {
+          // Custom MIME types may not be supported, fallback to text only
+          if (data.text) {
+            await navigator.clipboard.writeText(data.text);
+          }
+        }
+      }
+    } catch {
+      // Handle permission denied or other errors gracefully
+      // Do not throw - caller can check clipboard state if needed
+    }
+  };
+
+  /**
+   * Read data from the clipboard
+   * Returns empty ClipboardData if clipboard is empty or permission denied
+   */
+  const read = async (): Promise<ClipboardData> => {
+    const result: ClipboardData = {};
+
+    try {
+      // Try to read all clipboard items
+      const items = await navigator.clipboard.read();
+
+      for (const item of items) {
+        // Read text/plain
+        if (item.types.includes('text/plain')) {
+          try {
+            const blob = await item.getType('text/plain');
+            result.text = await blob.text();
+          } catch {
+            // Type not available, skip
+          }
+        }
+
+        // Read text/html
+        if (item.types.includes('text/html')) {
+          try {
+            const blob = await item.getType('text/html');
+            result.html = await blob.text();
+          } catch {
+            // Type not available, skip
+          }
+        }
+
+        // Read custom MIME type
+        if (customMimeType && item.types.includes(customMimeType)) {
+          try {
+            const blob = await item.getType(customMimeType);
+            const customString = await blob.text();
+            try {
+              result.custom = JSON.parse(customString);
+            } catch {
+              result.custom = customString;
+            }
+          } catch {
+            // Type not available, skip
+          }
+        }
+      }
+    } catch {
+      // Permission denied or clipboard empty - return empty result
+      // Try fallback to readText for basic text content
+      try {
+        const text = await navigator.clipboard.readText();
+        if (text) {
+          result.text = text;
+        }
+      } catch {
+        // Still failed, return empty result
+      }
+    }
+
+    return result;
+  };
+
+  const cleanup: CleanupFunction = () => {
+    container.removeEventListener('paste', handlePaste);
+    container.removeEventListener('copy', handleCopy);
+    container.removeEventListener('cut', handleCut);
+  };
+
+  return {
+    write,
+    read,
+    cleanup,
+  };
+}

--- a/packages/ui/test/primitives/clipboard.test.ts
+++ b/packages/ui/test/primitives/clipboard.test.ts
@@ -1,0 +1,452 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createClipboard } from '../../src/primitives/clipboard';
+
+// Mock navigator.clipboard
+const mockClipboardWrite = vi.fn();
+const mockClipboardWriteText = vi.fn();
+const mockClipboardRead = vi.fn();
+const mockClipboardReadText = vi.fn();
+
+beforeEach(() => {
+  // Reset mocks
+  mockClipboardWrite.mockReset();
+  mockClipboardWriteText.mockReset();
+  mockClipboardRead.mockReset();
+  mockClipboardReadText.mockReset();
+
+  // Setup navigator.clipboard mock
+  Object.defineProperty(navigator, 'clipboard', {
+    value: {
+      write: mockClipboardWrite,
+      writeText: mockClipboardWriteText,
+      read: mockClipboardRead,
+      readText: mockClipboardReadText,
+    },
+    writable: true,
+    configurable: true,
+  });
+});
+
+/**
+ * Helper to create a ClipboardEvent with mocked clipboardData
+ * since test environments don't support the clipboardData constructor option
+ */
+function createClipboardEvent(
+  type: 'paste' | 'copy' | 'cut',
+  data: Record<string, string>,
+): ClipboardEvent {
+  const event = new ClipboardEvent(type, { bubbles: true, cancelable: true });
+
+  // Create a mock DataTransfer-like object
+  const mockDataTransfer = {
+    getData: (mimeType: string) => data[mimeType] ?? '',
+    setData: vi.fn(),
+    types: Object.keys(data),
+    items: [],
+    files: new DataTransfer().files,
+    dropEffect: 'none' as const,
+    effectAllowed: 'uninitialized' as const,
+    clearData: vi.fn(),
+    setDragImage: vi.fn(),
+  };
+
+  // Override clipboardData on the event
+  Object.defineProperty(event, 'clipboardData', {
+    value: mockDataTransfer,
+    writable: false,
+    configurable: true,
+  });
+
+  return event;
+}
+
+describe('createClipboard', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('writes text to clipboard', async () => {
+    mockClipboardWrite.mockResolvedValue(undefined);
+
+    const { write, cleanup } = createClipboard({ container });
+
+    await write({ text: 'Hello, World!' });
+
+    expect(mockClipboardWrite).toHaveBeenCalledTimes(1);
+    const clipboardItem = mockClipboardWrite.mock.calls[0][0][0];
+    expect(clipboardItem).toBeInstanceOf(ClipboardItem);
+
+    cleanup();
+  });
+
+  it('reads text from clipboard', async () => {
+    const mockBlob = new Blob(['Test content'], { type: 'text/plain' });
+    mockClipboardRead.mockResolvedValue([
+      {
+        types: ['text/plain'],
+        getType: vi.fn().mockResolvedValue(mockBlob),
+      },
+    ]);
+
+    const { read, cleanup } = createClipboard({ container });
+
+    const data = await read();
+
+    expect(data.text).toBe('Test content');
+
+    cleanup();
+  });
+
+  it('writes custom format to clipboard', async () => {
+    mockClipboardWrite.mockResolvedValue(undefined);
+
+    const customMimeType = 'application/x-rafters-blocks';
+    const { write, cleanup } = createClipboard({
+      container,
+      customMimeType,
+    });
+
+    const customData = { blocks: [{ id: '1', type: 'paragraph' }] };
+    await write({ text: 'Plain text', custom: customData });
+
+    expect(mockClipboardWrite).toHaveBeenCalledTimes(1);
+    const clipboardItem = mockClipboardWrite.mock.calls[0][0][0];
+    expect(clipboardItem).toBeInstanceOf(ClipboardItem);
+
+    cleanup();
+  });
+
+  it('fires onPaste callback on paste event', async () => {
+    const onPaste = vi.fn();
+    const { cleanup } = createClipboard({
+      container,
+      onPaste,
+    });
+
+    const pasteEvent = createClipboardEvent('paste', {
+      'text/plain': 'Pasted text',
+      'text/html': '<p>Pasted HTML</p>',
+    });
+
+    container.dispatchEvent(pasteEvent);
+
+    // Wait for async handler to complete
+    await vi.waitFor(() => {
+      expect(onPaste).toHaveBeenCalledTimes(1);
+    });
+    expect(onPaste).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Pasted text',
+        html: '<p>Pasted HTML</p>',
+      }),
+    );
+
+    cleanup();
+  });
+
+  it('fires onCopy callback on copy event', async () => {
+    const onCopy = vi.fn();
+    const { cleanup } = createClipboard({
+      container,
+      onCopy,
+    });
+
+    const copyEvent = createClipboardEvent('copy', {
+      'text/plain': 'Copied text',
+    });
+
+    container.dispatchEvent(copyEvent);
+
+    // Wait for async handler to complete
+    await vi.waitFor(() => {
+      expect(onCopy).toHaveBeenCalledTimes(1);
+    });
+    expect(onCopy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Copied text',
+      }),
+    );
+
+    cleanup();
+  });
+
+  it('fires onCut callback on cut event', async () => {
+    const onCut = vi.fn();
+    const { cleanup } = createClipboard({
+      container,
+      onCut,
+    });
+
+    const cutEvent = createClipboardEvent('cut', {
+      'text/plain': 'Cut text',
+    });
+
+    container.dispatchEvent(cutEvent);
+
+    // Wait for async handler to complete
+    await vi.waitFor(() => {
+      expect(onCut).toHaveBeenCalledTimes(1);
+    });
+    expect(onCut).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Cut text',
+      }),
+    );
+
+    cleanup();
+  });
+
+  it('handles permission denied gracefully', async () => {
+    mockClipboardWrite.mockRejectedValue(new DOMException('Permission denied'));
+    mockClipboardRead.mockRejectedValue(new DOMException('Permission denied'));
+    mockClipboardReadText.mockRejectedValue(new DOMException('Permission denied'));
+
+    const { write, read, cleanup } = createClipboard({ container });
+
+    // Should not throw
+    await expect(write({ text: 'Test' })).resolves.toBeUndefined();
+
+    // Should return empty data
+    const data = await read();
+    expect(data).toEqual({});
+
+    cleanup();
+  });
+
+  it('cleans up event listeners', async () => {
+    const onPaste = vi.fn();
+    const onCopy = vi.fn();
+    const onCut = vi.fn();
+
+    const { cleanup } = createClipboard({
+      container,
+      onPaste,
+      onCopy,
+      onCut,
+    });
+
+    // Cleanup removes listeners
+    cleanup();
+
+    // Dispatch events after cleanup
+    container.dispatchEvent(createClipboardEvent('paste', { 'text/plain': 'test' }));
+    container.dispatchEvent(createClipboardEvent('copy', { 'text/plain': 'test' }));
+    container.dispatchEvent(createClipboardEvent('cut', { 'text/plain': 'test' }));
+
+    // Give time for any potential async handlers
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // None of the callbacks should have been called after cleanup
+    expect(onPaste).not.toHaveBeenCalled();
+    expect(onCopy).not.toHaveBeenCalled();
+    expect(onCut).not.toHaveBeenCalled();
+  });
+
+  it('returns no-op in SSR environment', () => {
+    const originalWindow = globalThis.window;
+    // @ts-expect-error Testing SSR
+    delete globalThis.window;
+
+    const result = createClipboard({ container });
+
+    expect(result.cleanup).toBeInstanceOf(Function);
+    expect(result.write).toBeInstanceOf(Function);
+    expect(result.read).toBeInstanceOf(Function);
+
+    // Should not throw
+    result.cleanup();
+
+    globalThis.window = originalWindow;
+  });
+
+  it('parses custom MIME type as JSON', async () => {
+    const customMimeType = 'application/x-rafters-blocks';
+    const onPaste = vi.fn();
+    const { cleanup } = createClipboard({
+      container,
+      customMimeType,
+      onPaste,
+    });
+
+    const customData = { blocks: [{ id: '1' }] };
+    const pasteEvent = createClipboardEvent('paste', {
+      'text/plain': 'Plain text',
+      [customMimeType]: JSON.stringify(customData),
+    });
+
+    container.dispatchEvent(pasteEvent);
+
+    // Wait for async handler to complete
+    await vi.waitFor(() => {
+      expect(onPaste).toHaveBeenCalledTimes(1);
+    });
+    expect(onPaste).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Plain text',
+        custom: customData,
+      }),
+    );
+
+    cleanup();
+  });
+
+  it('falls back to text-only when custom MIME type write fails', async () => {
+    // First call with ClipboardItem fails, second call with writeText succeeds
+    mockClipboardWrite.mockRejectedValue(new DOMException('Unsupported MIME type'));
+    mockClipboardWriteText.mockResolvedValue(undefined);
+
+    const customMimeType = 'application/x-rafters-blocks';
+    const { write, cleanup } = createClipboard({
+      container,
+      customMimeType,
+    });
+
+    await write({ text: 'Fallback text', custom: { blocks: [] } });
+
+    expect(mockClipboardWriteText).toHaveBeenCalledWith('Fallback text');
+
+    cleanup();
+  });
+
+  it('handles empty clipboard gracefully', async () => {
+    mockClipboardRead.mockResolvedValue([]);
+
+    const { read, cleanup } = createClipboard({ container });
+
+    const data = await read();
+
+    expect(data).toEqual({});
+
+    cleanup();
+  });
+
+  it('reads HTML content from clipboard', async () => {
+    const textBlob = new Blob(['Plain text'], { type: 'text/plain' });
+    const htmlBlob = new Blob(['<p>Rich text</p>'], { type: 'text/html' });
+
+    mockClipboardRead.mockResolvedValue([
+      {
+        types: ['text/plain', 'text/html'],
+        getType: vi.fn((type: string) => {
+          if (type === 'text/plain') return Promise.resolve(textBlob);
+          if (type === 'text/html') return Promise.resolve(htmlBlob);
+          return Promise.reject(new Error('Unknown type'));
+        }),
+      },
+    ]);
+
+    const { read, cleanup } = createClipboard({ container });
+
+    const data = await read();
+
+    expect(data.text).toBe('Plain text');
+    expect(data.html).toBe('<p>Rich text</p>');
+
+    cleanup();
+  });
+
+  it('reads custom MIME type from clipboard', async () => {
+    const customMimeType = 'application/x-rafters-blocks';
+    const customData = { blocks: [{ id: '1', type: 'heading' }] };
+    const customBlob = new Blob([JSON.stringify(customData)], { type: customMimeType });
+
+    mockClipboardRead.mockResolvedValue([
+      {
+        types: [customMimeType],
+        getType: vi.fn().mockResolvedValue(customBlob),
+      },
+    ]);
+
+    const { read, cleanup } = createClipboard({
+      container,
+      customMimeType,
+    });
+
+    const data = await read();
+
+    expect(data.custom).toEqual(customData);
+
+    cleanup();
+  });
+
+  it('falls back to readText when read() fails', async () => {
+    mockClipboardRead.mockRejectedValue(new DOMException('Not supported'));
+    mockClipboardReadText.mockResolvedValue('Fallback text content');
+
+    const { read, cleanup } = createClipboard({ container });
+
+    const data = await read();
+
+    expect(data.text).toBe('Fallback text content');
+
+    cleanup();
+  });
+
+  it('handles null clipboardData gracefully', async () => {
+    const onPaste = vi.fn();
+    const { cleanup } = createClipboard({
+      container,
+      onPaste,
+    });
+
+    // Create event without clipboardData (simulates edge case)
+    const event = new ClipboardEvent('paste', { bubbles: true });
+    container.dispatchEvent(event);
+
+    // Wait for async handler to complete
+    await vi.waitFor(() => {
+      expect(onPaste).toHaveBeenCalledTimes(1);
+    });
+    expect(onPaste).toHaveBeenCalledWith({});
+
+    cleanup();
+  });
+
+  it('handles non-JSON custom data as string', async () => {
+    const customMimeType = 'application/x-rafters-blocks';
+    const onPaste = vi.fn();
+    const { cleanup } = createClipboard({
+      container,
+      customMimeType,
+      onPaste,
+    });
+
+    // Custom data that is not valid JSON
+    const pasteEvent = createClipboardEvent('paste', {
+      [customMimeType]: 'not valid json',
+    });
+
+    container.dispatchEvent(pasteEvent);
+
+    // Wait for async handler to complete
+    await vi.waitFor(() => {
+      expect(onPaste).toHaveBeenCalledTimes(1);
+    });
+    expect(onPaste).toHaveBeenCalledWith(
+      expect.objectContaining({
+        custom: 'not valid json',
+      }),
+    );
+
+    cleanup();
+  });
+
+  it('writes HTML content to clipboard', async () => {
+    mockClipboardWrite.mockResolvedValue(undefined);
+
+    const { write, cleanup } = createClipboard({ container });
+
+    await write({ html: '<p>Hello</p>' });
+
+    expect(mockClipboardWrite).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+});


### PR DESCRIPTION
## Summary
- Implements the clipboard primitive for Editor v1 (Issue #608)
- Creates `createClipboard()` factory function with SSR guard
- Supports text, HTML, and custom MIME types
- Event callbacks for paste/copy/cut operations
- Graceful fallback when permissions denied or APIs unavailable
- Includes comprehensive test suite with 18 tests

## Changes
- `packages/ui/src/primitives/clipboard.ts` - Clipboard primitive implementation
- `packages/ui/test/primitives/clipboard.test.ts` - Test suite

## Test plan
- [x] All 18 unit tests pass
- [x] Biome lint check passes
- [x] TypeScript compiles without errors

Closes #608

---
Generated with [Claude Code](https://claude.ai/code)