### PR TITLE
feat(ui): Add PropertyEditor component for schema-driven property editing (R-103)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,7 +25,8 @@
   "peerDependencies": {
     "react": "catalog:",
     "react-dom": "catalog:",
-    "vue": "^3.4.0"
+    "vue": "^3.4.0",
+    "zod": "catalog:"
   },
   "peerDependenciesMeta": {
     "vue": {
@@ -33,6 +34,7 @@
     }
   },
   "devDependencies": {
+    "zod": "catalog:",
     "@hookform/resolvers": "^5.2.2",
     "@testing-library/jest-dom": "catalog:",
     "@testing-library/react": "catalog:",

--- a/packages/ui/src/components/editor/PropertyEditor.tsx
+++ b/packages/ui/src/components/editor/PropertyEditor.tsx
@@ -1,0 +1,582 @@
+/**
+ * Schema-driven property editor for block-based editing
+ *
+ * @cognitive-load 6/10 - Dynamic form generation requires understanding of schema structure
+ * @attention-economics Field types are inferred from Zod schema, reducing manual configuration
+ * @trust-building Inline validation with clear error messages, required field indicators
+ * @accessibility Labels associated with inputs, validation errors announced via aria
+ * @semantic-meaning Schema-driven forms: field types determine input rendering
+ *
+ * @usage-patterns
+ * DO: Use Zod schemas to define block properties
+ * DO: Provide clear field names that convert well to labels
+ * DO: Handle validation errors gracefully
+ * NEVER: Use any types in schema definitions
+ * NEVER: Ignore validation errors from Zod
+ *
+ * @example
+ * ```tsx
+ * const BlockSchema = z.object({
+ *   title: z.string(),
+ *   count: z.number(),
+ *   enabled: z.boolean(),
+ *   variant: z.enum(['primary', 'secondary']),
+ * });
+ *
+ * <PropertyEditor
+ *   schema={BlockSchema}
+ *   values={{ title: 'Hello', count: 5, enabled: true, variant: 'primary' }}
+ *   onChange={(values) => console.log(values)}
+ * />
+ * ```
+ */
+import * as React from 'react';
+import type { ZodObject, ZodRawShape, ZodTypeAny } from 'zod';
+import classy from '../../primitives/classy';
+import { Checkbox } from '../ui/checkbox';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface PropertyEditorProps<T extends ZodRawShape> {
+  /** Zod schema defining the properties */
+  schema: ZodObject<T>;
+  /** Current property values */
+  values: Record<string, unknown>;
+  /** Callback when values change */
+  onChange: (values: Record<string, unknown>) => void;
+  /** Optional block type name for display */
+  blockType?: string;
+  /** Optional title for the editor panel */
+  title?: string;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+interface FieldConfig {
+  key: string;
+  label: string;
+  type: 'string' | 'number' | 'boolean' | 'enum' | 'array' | 'unknown';
+  enumValues: readonly string[] | undefined;
+  isOptional: boolean;
+  description: string | undefined;
+}
+
+interface FieldState {
+  value: unknown;
+  error: string | null;
+  touched: boolean;
+}
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+/**
+ * Convert camelCase to Title Case
+ * e.g., "firstName" -> "First Name"
+ */
+function camelToTitleCase(str: string): string {
+  const result = str.replace(/([A-Z])/g, ' $1');
+  return result.charAt(0).toUpperCase() + result.slice(1);
+}
+
+/**
+ * Get the Zod type name, handling both Zod v3 and v4 APIs
+ * Zod v3: _def.typeName (e.g., "ZodString")
+ * Zod v4: _def.type (e.g., "string")
+ */
+function getZodTypeName(zodType: ZodTypeAny): string {
+  const def = zodType._def as unknown;
+  if (!def || typeof def !== 'object') return 'unknown';
+  const defObj = def as Record<string, unknown>;
+
+  // Zod v4: _def.type is a short string like "string", "number", etc.
+  const typeV4 = defObj.type;
+  if (typeof typeV4 === 'string') return typeV4;
+
+  // Zod v3: _def.typeName is like "ZodString", "ZodNumber", etc.
+  const typeV3 = defObj.typeName;
+  if (typeof typeV3 === 'string') {
+    // Normalize to v4-style: "ZodString" -> "string"
+    return typeV3.replace('Zod', '').toLowerCase();
+  }
+
+  return 'unknown';
+}
+
+/**
+ * Get the inner type, unwrapping optionals and defaults
+ */
+function getInnerType(zodType: ZodTypeAny): ZodTypeAny {
+  const typeName = getZodTypeName(zodType);
+  const def = zodType._def as unknown;
+  const defObj = def && typeof def === 'object' ? (def as Record<string, unknown>) : null;
+
+  if (typeName === 'optional' || typeName === 'nullable') {
+    const innerType = defObj?.innerType as ZodTypeAny | undefined;
+    return innerType ? getInnerType(innerType) : zodType;
+  }
+
+  if (typeName === 'default') {
+    const innerType = defObj?.innerType as ZodTypeAny | undefined;
+    return innerType ? getInnerType(innerType) : zodType;
+  }
+
+  return zodType;
+}
+
+/**
+ * Check if a Zod type is optional
+ */
+function isOptional(zodType: ZodTypeAny): boolean {
+  const typeName = getZodTypeName(zodType);
+  if (typeName === 'optional' || typeName === 'nullable') {
+    return true;
+  }
+  if (typeName === 'default') {
+    return true; // Has a default, so effectively optional
+  }
+  return false;
+}
+
+/**
+ * Determine the field type from a Zod type
+ */
+function getFieldType(
+  zodType: ZodTypeAny,
+): 'string' | 'number' | 'boolean' | 'enum' | 'array' | 'unknown' {
+  const inner = getInnerType(zodType);
+  const typeName = getZodTypeName(inner);
+
+  switch (typeName) {
+    case 'string':
+      return 'string';
+    case 'number':
+      return 'number';
+    case 'boolean':
+      return 'boolean';
+    case 'enum':
+    case 'nativeenum':
+      return 'enum';
+    case 'array':
+      return 'array';
+    default:
+      return 'unknown';
+  }
+}
+
+/**
+ * Get enum values from a Zod enum type
+ */
+function getEnumValues(zodType: ZodTypeAny): readonly string[] | undefined {
+  const inner = getInnerType(zodType);
+  const typeName = getZodTypeName(inner);
+  const def = inner._def as unknown;
+  const defObj = def && typeof def === 'object' ? (def as Record<string, unknown>) : null;
+
+  if (typeName === 'enum') {
+    // Zod v4: _def.entries is an object { value: value }
+    const entries = defObj?.entries as Record<string, string> | undefined;
+    if (entries) {
+      return Object.values(entries);
+    }
+    // Zod v3: _def.values is an array
+    const values = defObj?.values as readonly string[] | undefined;
+    return values;
+  }
+
+  if (typeName === 'nativeenum') {
+    const enumValues = defObj?.values as Record<string, string | number> | undefined;
+    if (enumValues) {
+      return Object.values(enumValues).filter((v): v is string => typeof v === 'string');
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Get description from a Zod type
+ */
+function getDescription(zodType: ZodTypeAny): string | undefined {
+  const def = zodType._def as unknown;
+  const defObj = def && typeof def === 'object' ? (def as Record<string, unknown>) : null;
+  const description = defObj?.description;
+  return typeof description === 'string' ? description : undefined;
+}
+
+/**
+ * Parse schema into field configurations
+ */
+function parseSchema<T extends ZodRawShape>(schema: ZodObject<T>): FieldConfig[] {
+  const shape = schema.shape;
+  const fields: FieldConfig[] = [];
+
+  for (const key of Object.keys(shape)) {
+    const zodType = shape[key] as ZodTypeAny;
+    const fieldType = getFieldType(zodType);
+    const enumValues = fieldType === 'enum' ? getEnumValues(zodType) : undefined;
+
+    fields.push({
+      key,
+      label: camelToTitleCase(key),
+      type: fieldType,
+      enumValues,
+      isOptional: isOptional(zodType),
+      description: getDescription(zodType),
+    });
+  }
+
+  return fields;
+}
+
+/**
+ * Validate a single field value against the schema
+ */
+function validateField<T extends ZodRawShape>(
+  schema: ZodObject<T>,
+  key: string,
+  value: unknown,
+): string | null {
+  const shape = schema.shape;
+  const zodType = shape[key] as ZodTypeAny | undefined;
+
+  if (!zodType) {
+    return null;
+  }
+
+  const result = zodType.safeParse(value);
+  if (result.success) {
+    return null;
+  }
+
+  // Handle both Zod v3 (errors) and Zod v4 (issues) error structures
+  const errorObj = result.error as {
+    issues?: Array<{ message: string }>;
+    errors?: Array<{ message: string }>;
+  };
+  const firstError = errorObj.issues?.[0] ?? errorObj.errors?.[0];
+  return firstError?.message ?? 'Invalid value';
+}
+
+/**
+ * Convert array value to comma-separated string
+ */
+function arrayToString(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.join(', ');
+  }
+  return '';
+}
+
+/**
+ * Parse comma-separated string to array
+ */
+function stringToArray(value: string): string[] {
+  return value
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function PropertyEditor<T extends ZodRawShape>({
+  schema,
+  values,
+  onChange,
+  blockType,
+  title,
+  className,
+}: PropertyEditorProps<T>): React.JSX.Element {
+  // Parse schema into field configurations
+  const fields = React.useMemo(() => parseSchema(schema), [schema]);
+
+  // Track field states (errors and touched)
+  const [fieldStates, setFieldStates] = React.useState<Record<string, FieldState>>(() => {
+    const initialStates: Record<string, FieldState> = {};
+    for (const field of fields) {
+      initialStates[field.key] = {
+        value: values[field.key],
+        error: null,
+        touched: false,
+      };
+    }
+    return initialStates;
+  });
+
+  // Update field states when values prop changes
+  React.useEffect(() => {
+    setFieldStates((prev) => {
+      const updated: Record<string, FieldState> = {};
+      for (const field of fields) {
+        updated[field.key] = {
+          value: values[field.key],
+          error: prev[field.key]?.error ?? null,
+          touched: prev[field.key]?.touched ?? false,
+        };
+      }
+      return updated;
+    });
+  }, [values, fields]);
+
+  // Handle field value change
+  const handleFieldChange = React.useCallback(
+    (key: string, newValue: unknown) => {
+      const updatedValues = { ...values, [key]: newValue };
+      onChange(updatedValues);
+
+      // Clear error on change if field was touched
+      setFieldStates((prev) => ({
+        ...prev,
+        [key]: {
+          ...prev[key],
+          value: newValue,
+          error: null,
+        } as FieldState,
+      }));
+    },
+    [values, onChange],
+  );
+
+  // Handle field blur (validation)
+  const handleFieldBlur = React.useCallback(
+    (key: string) => {
+      const currentValue = values[key];
+      const error = validateField(schema, key, currentValue);
+
+      setFieldStates((prev) => ({
+        ...prev,
+        [key]: {
+          ...prev[key],
+          touched: true,
+          error,
+        } as FieldState,
+      }));
+    },
+    [schema, values],
+  );
+
+  // Render a text input field
+  const renderTextField = (field: FieldConfig): React.JSX.Element => {
+    const state = fieldStates[field.key];
+    const value = values[field.key];
+    const stringValue = typeof value === 'string' ? value : '';
+
+    return (
+      <Input
+        id={`property-${field.key}`}
+        type="text"
+        value={stringValue}
+        onChange={(e) => handleFieldChange(field.key, e.target.value)}
+        onBlur={() => handleFieldBlur(field.key)}
+        variant={state?.error ? 'destructive' : 'default'}
+        aria-invalid={state?.error ? 'true' : undefined}
+        aria-describedby={state?.error ? `property-${field.key}-error` : undefined}
+      />
+    );
+  };
+
+  // Render a number input field
+  const renderNumberField = (field: FieldConfig): React.JSX.Element => {
+    const state = fieldStates[field.key];
+    const value = values[field.key];
+    const numValue = typeof value === 'number' ? value : '';
+
+    return (
+      <Input
+        id={`property-${field.key}`}
+        type="number"
+        value={numValue}
+        onChange={(e) => {
+          const parsed = e.target.value === '' ? undefined : Number(e.target.value);
+          handleFieldChange(field.key, parsed);
+        }}
+        onBlur={() => handleFieldBlur(field.key)}
+        variant={state?.error ? 'destructive' : 'default'}
+        aria-invalid={state?.error ? 'true' : undefined}
+        aria-describedby={state?.error ? `property-${field.key}-error` : undefined}
+      />
+    );
+  };
+
+  // Render a checkbox field
+  const renderCheckboxField = (field: FieldConfig): React.JSX.Element => {
+    const value = values[field.key];
+    const boolValue = typeof value === 'boolean' ? value : false;
+
+    return (
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id={`property-${field.key}`}
+          checked={boolValue}
+          onCheckedChange={(checked) => handleFieldChange(field.key, checked)}
+        />
+        <Label htmlFor={`property-${field.key}`} className="font-normal">
+          {field.label}
+          {!field.isOptional && (
+            <span className="ml-1 text-destructive" aria-hidden="true">
+              *
+            </span>
+          )}
+        </Label>
+      </div>
+    );
+  };
+
+  // Render a select dropdown field
+  const renderEnumField = (field: FieldConfig): React.JSX.Element => {
+    const state = fieldStates[field.key];
+    const value = values[field.key];
+    const stringValue = typeof value === 'string' ? value : '';
+
+    return (
+      <Select
+        value={stringValue}
+        onValueChange={(newValue) => handleFieldChange(field.key, newValue)}
+      >
+        <SelectTrigger
+          id={`property-${field.key}`}
+          aria-invalid={state?.error ? 'true' : undefined}
+          aria-describedby={state?.error ? `property-${field.key}-error` : undefined}
+          onBlur={() => handleFieldBlur(field.key)}
+        >
+          <SelectValue placeholder={`Select ${field.label.toLowerCase()}...`} />
+        </SelectTrigger>
+        <SelectContent>
+          {field.enumValues?.map((option) => (
+            <SelectItem key={option} value={option}>
+              {camelToTitleCase(option)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  };
+
+  // Render an array field (comma-separated input)
+  const renderArrayField = (field: FieldConfig): React.JSX.Element => {
+    const state = fieldStates[field.key];
+    const value = values[field.key];
+    const stringValue = arrayToString(value);
+
+    return (
+      <Input
+        id={`property-${field.key}`}
+        type="text"
+        value={stringValue}
+        placeholder="Comma-separated values"
+        onChange={(e) => {
+          const arrayValue = stringToArray(e.target.value);
+          handleFieldChange(field.key, arrayValue);
+        }}
+        onBlur={() => handleFieldBlur(field.key)}
+        variant={state?.error ? 'destructive' : 'default'}
+        aria-invalid={state?.error ? 'true' : undefined}
+        aria-describedby={state?.error ? `property-${field.key}-error` : undefined}
+      />
+    );
+  };
+
+  // Render an unknown type field (disabled text display)
+  const renderUnknownField = (field: FieldConfig): React.JSX.Element => {
+    const value = values[field.key];
+    const displayValue = value !== undefined && value !== null ? String(value) : '';
+
+    return (
+      <Input
+        id={`property-${field.key}`}
+        type="text"
+        value={displayValue}
+        disabled
+        aria-describedby={`property-${field.key}-hint`}
+      />
+    );
+  };
+
+  // Render a single field based on its type
+  const renderField = (field: FieldConfig): React.JSX.Element => {
+    const state = fieldStates[field.key];
+
+    // Boolean fields have inline label, skip wrapper label
+    if (field.type === 'boolean') {
+      return (
+        <div key={field.key} className="space-y-1">
+          {renderCheckboxField(field)}
+          {state?.error && (
+            <p id={`property-${field.key}-error`} className="text-sm text-destructive" role="alert">
+              {state.error}
+            </p>
+          )}
+        </div>
+      );
+    }
+
+    return (
+      <div key={field.key} className="space-y-2">
+        <Label htmlFor={`property-${field.key}`}>
+          {field.label}
+          {!field.isOptional && (
+            <span className="ml-1 text-destructive" aria-hidden="true">
+              *
+            </span>
+          )}
+        </Label>
+
+        {field.type === 'string' && renderTextField(field)}
+        {field.type === 'number' && renderNumberField(field)}
+        {field.type === 'enum' && renderEnumField(field)}
+        {field.type === 'array' && renderArrayField(field)}
+        {field.type === 'unknown' && (
+          <>
+            {renderUnknownField(field)}
+            <p id={`property-${field.key}-hint`} className="text-xs text-muted-foreground">
+              Unsupported type - read only
+            </p>
+          </>
+        )}
+
+        {field.description && !state?.error && (
+          <p className="text-sm text-muted-foreground">{field.description}</p>
+        )}
+
+        {state?.error && (
+          <p id={`property-${field.key}-error`} className="text-sm text-destructive" role="alert">
+            {state.error}
+          </p>
+        )}
+      </div>
+    );
+  };
+
+  const containerClasses = classy('flex flex-col gap-4', className);
+
+  return (
+    <form
+      className={containerClasses}
+      aria-label={title ?? 'Property editor'}
+      onSubmit={(e) => e.preventDefault()}
+    >
+      {(title ?? blockType) && (
+        <div className="border-b pb-2">
+          <h3 className="text-sm font-semibold text-foreground">
+            {title ?? `${blockType} Properties`}
+          </h3>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-4">{fields.map(renderField)}</div>
+    </form>
+  );
+}
+
+PropertyEditor.displayName = 'PropertyEditor';
+
+export default PropertyEditor;

--- a/packages/ui/src/components/editor/index.ts
+++ b/packages/ui/src/components/editor/index.ts
@@ -3,11 +3,13 @@
  * @module components/editor
  */
 
+// R-103: PropertyEditor - Schema-driven property editor
+export { PropertyEditor, type PropertyEditorProps } from './PropertyEditor';
+
 // Components will be exported here as they are implemented
 // R-100: BlockCanvas
 // R-101: BlockWrapper
 // R-102: BlockSidebar
-// R-103: PropertyEditor
 // R-104: EditorToolbar
 // R-105: CommandPaletteUI
 // R-106: InlineToolbar

--- a/packages/ui/test/components/editor/PropertyEditor.test.tsx
+++ b/packages/ui/test/components/editor/PropertyEditor.test.tsx
@@ -1,0 +1,570 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { PropertyEditor } from '../../../src/components/editor/PropertyEditor';
+
+describe('PropertyEditor', () => {
+  it('generates text field for z.string()', () => {
+    const schema = z.object({
+      title: z.string(),
+    });
+
+    render(<PropertyEditor schema={schema} values={{ title: 'Hello' }} onChange={() => {}} />);
+
+    const input = screen.getByRole('textbox');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue('Hello');
+    expect(input).toHaveAttribute('type', 'text');
+  });
+
+  it('generates number field for z.number()', () => {
+    const schema = z.object({
+      count: z.number(),
+    });
+
+    render(<PropertyEditor schema={schema} values={{ count: 42 }} onChange={() => {}} />);
+
+    const input = screen.getByRole('spinbutton');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue(42);
+    expect(input).toHaveAttribute('type', 'number');
+  });
+
+  it('generates checkbox for z.boolean()', () => {
+    const schema = z.object({
+      enabled: z.boolean(),
+    });
+
+    render(<PropertyEditor schema={schema} values={{ enabled: true }} onChange={() => {}} />);
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('generates select for z.enum()', () => {
+    const schema = z.object({
+      variant: z.enum(['primary', 'secondary', 'destructive']),
+    });
+
+    render(<PropertyEditor schema={schema} values={{ variant: 'primary' }} onChange={() => {}} />);
+
+    const combobox = screen.getByRole('combobox');
+    expect(combobox).toBeInTheDocument();
+  });
+
+  it('shows required indicator for non-optional fields', () => {
+    const schema = z.object({
+      requiredField: z.string(),
+      optionalField: z.string().optional(),
+    });
+
+    render(
+      <PropertyEditor
+        schema={schema}
+        values={{ requiredField: 'test', optionalField: undefined }}
+        onChange={() => {}}
+      />,
+    );
+
+    // Required field should have asterisk
+    expect(screen.getByText('Required Field')).toBeInTheDocument();
+    const asterisks = screen.getAllByText('*');
+    expect(asterisks.length).toBe(1);
+
+    // Check the asterisk is near the required field label
+    const asterisk = asterisks[0];
+    expect(asterisk).toHaveClass('text-destructive');
+    expect(asterisk).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('validates on blur', async () => {
+    const user = userEvent.setup();
+    const schema = z.object({
+      email: z.string().email('Invalid email format'),
+    });
+
+    render(<PropertyEditor schema={schema} values={{ email: 'invalid' }} onChange={() => {}} />);
+
+    const input = screen.getByRole('textbox');
+    await user.click(input);
+    await user.tab(); // Blur the input
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Invalid email format');
+    });
+  });
+
+  it('shows validation errors inline', async () => {
+    const user = userEvent.setup();
+    const schema = z.object({
+      name: z.string().min(3, 'Name must be at least 3 characters'),
+    });
+
+    render(<PropertyEditor schema={schema} values={{ name: 'ab' }} onChange={() => {}} />);
+
+    const input = screen.getByRole('textbox');
+    await user.click(input);
+    await user.tab();
+
+    await waitFor(() => {
+      const errorMessage = screen.getByRole('alert');
+      expect(errorMessage).toHaveTextContent('Name must be at least 3 characters');
+      expect(errorMessage).toHaveClass('text-destructive');
+    });
+  });
+
+  it('calls onChange with updated values', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    const schema = z.object({
+      title: z.string(),
+    });
+
+    // Use a wrapper that updates state to simulate real usage
+    function ControlledEditor() {
+      const [values, setValues] = React.useState({ title: '' });
+      return (
+        <PropertyEditor
+          schema={schema}
+          values={values}
+          onChange={(newValues) => {
+            setValues(newValues as { title: string });
+            handleChange(newValues);
+          }}
+        />
+      );
+    }
+
+    render(<ControlledEditor />);
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, 'World');
+
+    // onChange should be called for each character
+    expect(handleChange).toHaveBeenCalled();
+    // The last call should have the final value
+    const lastCall = handleChange.mock.calls.at(-1);
+    expect(lastCall).toEqual([{ title: 'World' }]);
+  });
+});
+
+describe('PropertyEditor - Field types', () => {
+  it('handles multiple field types in one schema', () => {
+    const schema = z.object({
+      title: z.string(),
+      count: z.number(),
+      enabled: z.boolean(),
+      variant: z.enum(['a', 'b']),
+    });
+
+    render(
+      <PropertyEditor
+        schema={schema}
+        values={{ title: 'Test', count: 10, enabled: false, variant: 'a' }}
+        onChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('handles z.array(z.string()) as comma-separated input', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    const schema = z.object({
+      tags: z.array(z.string()),
+    });
+
+    render(
+      <PropertyEditor schema={schema} values={{ tags: ['one', 'two'] }} onChange={handleChange} />,
+    );
+
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveValue('one, two');
+
+    // Test that onChange is called with parsed array when typing
+    // Since this is a controlled component, each keystroke creates a new parsed array
+    await user.type(input, 'x');
+
+    // The input value becomes "one, twox" which parses to ['one', 'twox']
+    // This verifies the array parsing is working
+    expect(handleChange).toHaveBeenCalled();
+    const lastCall = handleChange.mock.calls.at(-1);
+    expect(lastCall).toEqual([{ tags: ['one', 'twox'] }]);
+  });
+
+  it('renders unknown types as disabled text field', () => {
+    // Using z.object for a nested object which is not directly supported
+    const schema = z.object({
+      data: z.object({ nested: z.string() }),
+    });
+
+    render(
+      <PropertyEditor schema={schema} values={{ data: { nested: 'value' } }} onChange={() => {}} />,
+    );
+
+    const input = screen.getByRole('textbox');
+    expect(input).toBeDisabled();
+    expect(screen.getByText('Unsupported type - read only')).toBeInTheDocument();
+  });
+});
+
+describe('PropertyEditor - Labels', () => {
+  it('converts camelCase to Title Case', () => {
+    const schema = z.object({
+      firstName: z.string(),
+      lastName: z.string(),
+      emailAddress: z.string(),
+    });
+
+    render(
+      <PropertyEditor
+        schema={schema}
+        values={{ firstName: '', lastName: '', emailAddress: '' }}
+        onChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('First Name')).toBeInTheDocument();
+    expect(screen.getByText('Last Name')).toBeInTheDocument();
+    expect(screen.getByText('Email Address')).toBeInTheDocument();
+  });
+
+  it('associates labels with inputs via htmlFor', () => {
+    const schema = z.object({
+      username: z.string(),
+    });
+
+    render(<PropertyEditor schema={schema} values={{ username: '' }} onChange={() => {}} />);
+
+    const label = screen.getByText('Username');
+    const input = screen.getByRole('textbox');
+
+    expect(label).toHaveAttribute('for', 'property-username');
+    expect(input).toHaveAttribute('id', 'property-username');
+  });
+});
+
+describe('PropertyEditor - Optional fields', () => {
+  it('does not show required indicator for optional fields', () => {
+    const schema = z.object({
+      optional: z.string().optional(),
+    });
+
+    render(<PropertyEditor schema={schema} values={{ optional: '' }} onChange={() => {}} />);
+
+    expect(screen.queryByText('*')).not.toBeInTheDocument();
+  });
+
+  it('does not show required indicator for fields with defaults', () => {
+    const schema = z.object({
+      withDefault: z.string().default('default value'),
+    });
+
+    render(
+      <PropertyEditor
+        schema={schema}
+        values={{ withDefault: 'default value' }}
+        onChange={() => {}}
+      />,
+    );
+
+    expect(screen.queryByText('*')).not.toBeInTheDocument();
+  });
+
+  it('does not show required indicator for nullable fields', () => {
+    const schema = z.object({
+      nullable: z.string().nullable(),
+    });
+
+    render(<PropertyEditor schema={schema} values={{ nullable: null }} onChange={() => {}} />);
+
+    expect(screen.queryByText('*')).not.toBeInTheDocument();
+  });
+});
+
+describe('PropertyEditor - Title and blockType', () => {
+  it('displays title when provided', () => {
+    const schema = z.object({
+      field: z.string(),
+    });
+
+    render(
+      <PropertyEditor
+        schema={schema}
+        values={{ field: '' }}
+        onChange={() => {}}
+        title="Custom Title"
+      />,
+    );
+
+    expect(screen.getByText('Custom Title')).toBeInTheDocument();
+  });
+
+  it('displays blockType as title when no title provided', () => {
+    const schema = z.object({
+      field: z.string(),
+    });
+
+    render(
+      <PropertyEditor
+        schema={schema}
+        values={{ field: '' }}
+        onChange={() => {}}
+        blockType="TextBlock"
+      />,
+    );
+
+    expect(screen.getByText('TextBlock Properties')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    const schema = z.object({
+      field: z.string(),
+    });
+
+    const { container } = render(
+      <PropertyEditor
+        schema={schema}
+        values={{ field: '' }}
+        onChange={() => {}}
+        className="custom-editor-class"
+      />,
+    );
+
+    expect(container.firstChild).toHaveClass('custom-editor-class');
+  });
+});
+
+describe('PropertyEditor - Checkbox interactions', () => {
+  it('toggles checkbox on click', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    const schema = z.object({
+      active: z.boolean(),
+    });
+
+    render(<PropertyEditor schema={schema} values={{ active: false }} onChange={handleChange} />);
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toHaveAttribute('aria-checked', 'false');
+
+    await user.click(checkbox);
+
+    expect(handleChange).toHaveBeenCalledWith({ active: true });
+  });
+
+  it('displays label next to checkbox', () => {
+    const schema = z.object({
+      isPublished: z.boolean(),
+    });
+
+    render(<PropertyEditor schema={schema} values={{ isPublished: true }} onChange={() => {}} />);
+
+    // For boolean fields, label is rendered inline
+    const label = screen.getByText('Is Published');
+    expect(label).toBeInTheDocument();
+  });
+});
+
+describe('PropertyEditor - Select interactions', () => {
+  it('opens select and shows options', async () => {
+    const user = userEvent.setup();
+    const schema = z.object({
+      size: z.enum(['small', 'medium', 'large']),
+    });
+
+    render(<PropertyEditor schema={schema} values={{ size: 'medium' }} onChange={() => {}} />);
+
+    const trigger = screen.getByRole('combobox');
+    await user.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+
+    // Check options are displayed with Title Case
+    expect(screen.getByRole('option', { name: 'Small' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Medium' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Large' })).toBeInTheDocument();
+  });
+
+  it('calls onChange when option selected', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    const schema = z.object({
+      color: z.enum(['red', 'blue', 'green']),
+    });
+
+    render(<PropertyEditor schema={schema} values={{ color: 'red' }} onChange={handleChange} />);
+
+    const trigger = screen.getByRole('combobox');
+    await user.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+
+    const blueOption = screen.getByRole('option', { name: 'Blue' });
+    await user.click(blueOption);
+
+    expect(handleChange).toHaveBeenCalledWith({ color: 'blue' });
+  });
+});
+
+describe('PropertyEditor - Number field interactions', () => {
+  it('updates value when typing', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    const schema = z.object({
+      amount: z.number(),
+    });
+
+    // Use a wrapper that updates state to simulate real usage
+    function ControlledEditor() {
+      const [values, setValues] = React.useState<{ amount: number | undefined }>({
+        amount: undefined,
+      });
+      return (
+        <PropertyEditor
+          schema={schema}
+          values={values}
+          onChange={(newValues) => {
+            setValues(newValues as { amount: number | undefined });
+            handleChange(newValues);
+          }}
+        />
+      );
+    }
+
+    render(<ControlledEditor />);
+
+    const input = screen.getByRole('spinbutton');
+    await user.type(input, '123');
+
+    const lastCall = handleChange.mock.calls.at(-1);
+    expect(lastCall).toEqual([{ amount: 123 }]);
+  });
+
+  it('handles empty value as undefined', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    const schema = z.object({
+      amount: z.number().optional(),
+    });
+
+    render(<PropertyEditor schema={schema} values={{ amount: 42 }} onChange={handleChange} />);
+
+    const input = screen.getByRole('spinbutton');
+    await user.clear(input);
+
+    const lastCall = handleChange.mock.calls.at(-1);
+    expect(lastCall).toEqual([{ amount: undefined }]);
+  });
+});
+
+describe('PropertyEditor - Validation', () => {
+  it('clears error when value changes', async () => {
+    const user = userEvent.setup();
+    const schema = z.object({
+      email: z.string().email('Invalid email'),
+    });
+
+    const { rerender } = render(
+      <PropertyEditor schema={schema} values={{ email: 'invalid' }} onChange={() => {}} />,
+    );
+
+    const input = screen.getByRole('textbox');
+    await user.click(input);
+    await user.tab();
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    // Simulate a value change that would come from parent
+    rerender(
+      <PropertyEditor schema={schema} values={{ email: 'valid@email.com' }} onChange={() => {}} />,
+    );
+
+    // Blur again to trigger validation
+    await user.click(input);
+    await user.tab();
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows error state styling on input', async () => {
+    const user = userEvent.setup();
+    const schema = z.object({
+      name: z.string().min(5, 'Too short'),
+    });
+
+    render(<PropertyEditor schema={schema} values={{ name: 'ab' }} onChange={() => {}} />);
+
+    const input = screen.getByRole('textbox');
+    await user.click(input);
+    await user.tab();
+
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-invalid', 'true');
+    });
+  });
+});
+
+describe('PropertyEditor - Accessibility', () => {
+  it('has form role and aria-label', () => {
+    const schema = z.object({
+      field: z.string(),
+    });
+
+    render(
+      <PropertyEditor
+        schema={schema}
+        values={{ field: '' }}
+        onChange={() => {}}
+        title="Settings"
+      />,
+    );
+
+    const form = screen.getByRole('form');
+    expect(form).toHaveAttribute('aria-label', 'Settings');
+  });
+
+  it('uses default aria-label when no title', () => {
+    const schema = z.object({
+      field: z.string(),
+    });
+
+    render(<PropertyEditor schema={schema} values={{ field: '' }} onChange={() => {}} />);
+
+    const form = screen.getByRole('form');
+    expect(form).toHaveAttribute('aria-label', 'Property editor');
+  });
+
+  it('connects error messages via aria-describedby', async () => {
+    const user = userEvent.setup();
+    const schema = z.object({
+      field: z.string().min(1, 'Required'),
+    });
+
+    render(<PropertyEditor schema={schema} values={{ field: '' }} onChange={() => {}} />);
+
+    const input = screen.getByRole('textbox');
+    await user.click(input);
+    await user.tab();
+
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-describedby', 'property-field-error');
+      expect(screen.getByRole('alert')).toHaveAttribute('id', 'property-field-error');
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -558,6 +558,9 @@ importers:
       vitest-axe:
         specifier: 'catalog:'
         version: 1.0.0-pre.5(vitest@3.2.4)
+      zod:
+        specifier: 'catalog:'
+        version: 4.1.12
 
 packages:
 


### PR DESCRIPTION
## Summary

- Implements a schema-driven property editor component that generates form controls from Zod schemas
- Supports string, number, boolean, enum, and array field types with automatic control selection
- Full accessibility support with proper ARIA attributes, labels, and required field indicators

## Implementation Details

The PropertyEditor is a React component that:
- Takes a Zod object schema and generates appropriate form controls
- Uses controlled component pattern with `values` and `onChange` props
- Extracts metadata from Zod schemas (descriptions, enums, optional/required)
- Renders appropriate inputs: text fields, number inputs, checkboxes, select dropdowns, and array editors

## Test Coverage

- 30 passing tests covering all field types and behaviors
- Tests verify controlled component behavior with proper state updates
- Accessibility tests for ARIA attributes and required indicators

## Related Issue

Closes #606 (R-103: PropertyEditor - Schema-driven property editor)

## Test plan

- [x] All 30 unit tests pass
- [x] Preflight passes
- [x] TypeScript compilation succeeds
- [x] Biome linting passes

Generated with [Claude Code](https://claude.ai/claude-code)