### PR TITLE
feat(ui): add createTextSelection primitive for contenteditable (R-002)

### DIFF
--- a/packages/ui/src/primitives/selection.ts
+++ b/packages/ui/src/primitives/selection.ts
@@ -1,12 +1,10 @@
 /**
- * Block Selection primitive
- * Manages selection state for block-based editors
- * Supports single, additive, and range selection patterns
- *
+ * Selection primitives for editors
+ * Includes block selection for block-based editors and text selection for contenteditable
  * SSR-safe: checks for window existence
  */
 
-import type { CleanupFunction } from './types';
+import type { CleanupFunction, SelectionRange } from './types';
 
 /**
  * Options for block selection behavior
@@ -331,6 +329,332 @@ export function createBlockSelection(options: BlockSelectionOptions): BlockSelec
     selectRange,
     selectAll,
     clear,
+    cleanup,
+  };
+}
+
+// =============================================================================
+// Text Selection Primitive
+// =============================================================================
+
+/**
+ * Options for text selection behavior
+ */
+export interface TextSelectionOptions {
+  /**
+   * Container element (typically contenteditable) that bounds the selection
+   */
+  container: HTMLElement;
+
+  /**
+   * Callback fired when selection changes within the container
+   */
+  onSelectionChange?: (range: SelectionRange | null) => void;
+}
+
+/**
+ * Text selection controller interface
+ */
+export interface TextSelectionController {
+  /**
+   * Get current selection range within container
+   * Returns null if no selection or selection is outside container
+   */
+  getRange: () => SelectionRange | null;
+
+  /**
+   * Set selection range programmatically
+   * @param range The range to set
+   */
+  setRange: (range: SelectionRange) => void;
+
+  /**
+   * Collapse selection to start or end
+   * @param toStart If true, collapse to start; otherwise collapse to end
+   */
+  collapse: (toStart?: boolean) => void;
+
+  /**
+   * Expand selection to include complete words
+   */
+  expandByWord: () => void;
+
+  /**
+   * Expand selection to include complete lines
+   */
+  expandByLine: () => void;
+
+  /**
+   * Cleanup function to remove event listeners
+   */
+  cleanup: CleanupFunction;
+}
+
+/**
+ * Check if a node is inside a container
+ */
+function isNodeInContainer(node: Node | null, container: HTMLElement): boolean {
+  if (!node) return false;
+  return container.contains(node);
+}
+
+/**
+ * Convert browser Selection to SelectionRange
+ * Returns null if selection is not within container
+ */
+function selectionToRange(selection: Selection, container: HTMLElement): SelectionRange | null {
+  if (selection.rangeCount === 0) {
+    return null;
+  }
+
+  const range = selection.getRangeAt(0);
+  const startNode = range.startContainer;
+  const endNode = range.endContainer;
+
+  // Check if selection is within container
+  if (!isNodeInContainer(startNode, container) || !isNodeInContainer(endNode, container)) {
+    return null;
+  }
+
+  return {
+    startNode,
+    startOffset: range.startOffset,
+    endNode,
+    endOffset: range.endOffset,
+    collapsed: range.collapsed,
+  };
+}
+
+/**
+ * Create text selection behavior for a contenteditable container
+ * Wraps browser Selection API with container-scoped operations
+ *
+ * @example
+ * ```typescript
+ * const textSelection = createTextSelection({
+ *   container: contentEditableElement,
+ *   onSelectionChange: (range) => {
+ *     if (range) {
+ *       console.log('Selection changed:', range.collapsed ? 'cursor' : 'range');
+ *     }
+ *   },
+ * });
+ *
+ * // Get current selection
+ * const range = textSelection.getRange();
+ *
+ * // Expand to word boundaries
+ * textSelection.expandByWord();
+ *
+ * // Collapse to start
+ * textSelection.collapse(true);
+ *
+ * // Cleanup when done
+ * textSelection.cleanup();
+ * ```
+ */
+export function createTextSelection(options: TextSelectionOptions): TextSelectionController {
+  // SSR guard
+  if (typeof window === 'undefined') {
+    return {
+      getRange: () => null,
+      setRange: () => {},
+      collapse: () => {},
+      expandByWord: () => {},
+      expandByLine: () => {},
+      cleanup: () => {},
+    };
+  }
+
+  const { container, onSelectionChange } = options;
+
+  /**
+   * Get current selection range within container
+   */
+  function getRange(): SelectionRange | null {
+    const selection = window.getSelection();
+    if (!selection) {
+      return null;
+    }
+    return selectionToRange(selection, container);
+  }
+
+  /**
+   * Set selection range programmatically
+   */
+  function setRange(selectionRange: SelectionRange): void {
+    const selection = window.getSelection();
+    if (!selection) {
+      return;
+    }
+
+    // Verify nodes are in container
+    if (
+      !isNodeInContainer(selectionRange.startNode, container) ||
+      !isNodeInContainer(selectionRange.endNode, container)
+    ) {
+      return;
+    }
+
+    const range = document.createRange();
+    range.setStart(selectionRange.startNode, selectionRange.startOffset);
+    range.setEnd(selectionRange.endNode, selectionRange.endOffset);
+
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+
+  /**
+   * Collapse selection to start or end
+   */
+  function collapse(toStart = true): void {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) {
+      return;
+    }
+
+    const currentRange = selectionToRange(selection, container);
+    if (!currentRange) {
+      return;
+    }
+
+    if (toStart) {
+      selection.collapseToStart();
+    } else {
+      selection.collapseToEnd();
+    }
+  }
+
+  /**
+   * Expand selection to word boundaries
+   */
+  function expandByWord(): void {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) {
+      return;
+    }
+
+    const currentRange = selectionToRange(selection, container);
+    if (!currentRange) {
+      return;
+    }
+
+    // Use modify to expand to word boundaries
+    // Note: modify is not standard but widely supported
+    if ('modify' in selection && typeof selection.modify === 'function') {
+      // If collapsed, first expand in both directions
+      if (currentRange.collapsed) {
+        selection.modify('move', 'backward', 'word');
+        selection.modify('extend', 'forward', 'word');
+      } else {
+        // For existing selection, expand both ends to word boundaries
+        const anchorNode = selection.anchorNode;
+        const anchorOffset = selection.anchorOffset;
+
+        // Collapse to start and move backward to word start
+        selection.collapseToStart();
+        selection.modify('move', 'backward', 'word');
+        const wordStart = {
+          node: selection.anchorNode,
+          offset: selection.anchorOffset,
+        };
+
+        // Go to end and move forward to word end
+        selection.collapse(anchorNode, anchorOffset);
+        selection.collapseToEnd();
+        selection.modify('extend', 'forward', 'word');
+
+        // Now set range from word start to current position
+        if (wordStart.node && isNodeInContainer(wordStart.node, container)) {
+          const range = document.createRange();
+          range.setStart(wordStart.node, wordStart.offset);
+          if (selection.focusNode && isNodeInContainer(selection.focusNode, container)) {
+            range.setEnd(selection.focusNode, selection.focusOffset);
+            selection.removeAllRanges();
+            selection.addRange(range);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Expand selection to line boundaries
+   */
+  function expandByLine(): void {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) {
+      return;
+    }
+
+    const currentRange = selectionToRange(selection, container);
+    if (!currentRange) {
+      return;
+    }
+
+    // Use modify to expand to line boundaries
+    if ('modify' in selection && typeof selection.modify === 'function') {
+      if (currentRange.collapsed) {
+        selection.modify('move', 'backward', 'lineboundary');
+        selection.modify('extend', 'forward', 'lineboundary');
+      } else {
+        const anchorNode = selection.anchorNode;
+        const anchorOffset = selection.anchorOffset;
+
+        // Collapse to start and move to line start
+        selection.collapseToStart();
+        selection.modify('move', 'backward', 'lineboundary');
+        const lineStart = {
+          node: selection.anchorNode,
+          offset: selection.anchorOffset,
+        };
+
+        // Go to end and move to line end
+        selection.collapse(anchorNode, anchorOffset);
+        selection.collapseToEnd();
+        selection.modify('extend', 'forward', 'lineboundary');
+
+        // Set range from line start to current position
+        if (lineStart.node && isNodeInContainer(lineStart.node, container)) {
+          const range = document.createRange();
+          range.setStart(lineStart.node, lineStart.offset);
+          if (selection.focusNode && isNodeInContainer(selection.focusNode, container)) {
+            range.setEnd(selection.focusNode, selection.focusOffset);
+            selection.removeAllRanges();
+            selection.addRange(range);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Handle selectionchange events
+   */
+  function handleSelectionChange(): void {
+    if (!onSelectionChange) {
+      return;
+    }
+    const range = getRange();
+    onSelectionChange(range);
+  }
+
+  // Add event listener for selection changes
+  document.addEventListener('selectionchange', handleSelectionChange);
+
+  /**
+   * Cleanup function to remove event listeners
+   */
+  function cleanup(): void {
+    document.removeEventListener('selectionchange', handleSelectionChange);
+  }
+
+  return {
+    getRange,
+    setRange,
+    collapse,
+    expandByWord,
+    expandByLine,
     cleanup,
   };
 }


### PR DESCRIPTION
## Summary

- Implements `createTextSelection` primitive that wraps browser Selection API for contenteditable elements
- Returns container-scoped selection range (null if selection is outside container)
- Provides programmatic selection control: getRange, setRange, collapse, expandByWord, expandByLine
- SSR safe with window existence check
- Full test coverage including edge cases

## Test plan

- [x] Unit tests pass: `pnpm --filter=@rafters/ui test selection`
- [x] getRange returns null when no selection
- [x] getRange returns null when selection outside container
- [x] setRange programmatically sets selection
- [x] collapse to start/end works correctly
- [x] expandByWord/expandByLine handle missing Selection.modify gracefully
- [x] cleanup removes event listeners
- [x] SSR safe (no-op controller when window undefined)

Closes #606

Generated with [Claude Code](https://claude.com/claude-code)