### PR TITLE
feat(ui): add drag-drop primitive for accessible drag and drop

### DIFF
--- a/packages/ui/src/primitives/drag-drop.ts
+++ b/packages/ui/src/primitives/drag-drop.ts
@@ -1,0 +1,911 @@
+/**
+ * Drag and Drop primitive
+ * Accessible drag-and-drop with mouse, keyboard, and touch support
+ *
+ * WCAG Compliance:
+ * - 2.1.1 Keyboard (Level A): Full keyboard support for drag operations
+ * - 2.1.3 Keyboard (Level AAA): No keyboard traps during drag
+ * - 4.1.2 Name, Role, Value (Level A): ARIA attributes for drag state
+ * - 4.1.3 Status Messages (Level AA): Live region announcements for keyboard drag
+ *
+ * @example
+ * ```typescript
+ * const draggable = createDraggable({
+ *   element: item,
+ *   data: { id: 'item-1', type: 'task' },
+ *   onDragStart: (data) => console.log('Started dragging:', data),
+ *   onDragEnd: (data, dropEffect) => console.log('Dropped:', dropEffect),
+ * });
+ *
+ * const dropZone = createDropZone({
+ *   element: container,
+ *   accept: (data) => data.type === 'task',
+ *   onDrop: (data) => console.log('Received:', data),
+ * });
+ *
+ * // Cleanup
+ * draggable.cleanup();
+ * dropZone.cleanup();
+ * ```
+ */
+
+import type { CleanupFunction } from './types';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Axis constraint for dragging
+ */
+export type DragAxis = 'x' | 'y' | 'both';
+
+/**
+ * Drop effect for drop operations
+ */
+export type DropEffect = 'none' | 'copy' | 'move' | 'link';
+
+/**
+ * Drag event data passed to callbacks
+ */
+export interface DragEventData {
+  /** The original data attached to the draggable */
+  data: unknown;
+  /** Current X position (relative to viewport) */
+  clientX: number;
+  /** Current Y position (relative to viewport) */
+  clientY: number;
+  /** Accumulated horizontal movement */
+  deltaX: number;
+  /** Accumulated vertical movement */
+  deltaY: number;
+}
+
+/**
+ * Options for createDraggable
+ */
+export interface DraggableOptions {
+  /** Element to make draggable */
+  element: HTMLElement;
+  /** Optional handle element (if provided, only this element initiates drag) */
+  handle?: HTMLElement;
+  /** Data associated with this draggable (passed to callbacks and drop zones) */
+  data: unknown;
+  /** Axis constraint for movement */
+  axis?: DragAxis;
+  /** Whether dragging is disabled */
+  disabled?: boolean;
+  /** Called when drag starts */
+  onDragStart?: (data: DragEventData) => void;
+  /** Called during drag (on mouse/touch move) */
+  onDrag?: (data: DragEventData) => void;
+  /** Called when drag ends */
+  onDragEnd?: (data: DragEventData, dropEffect: DropEffect) => void;
+}
+
+/**
+ * Return value from createDraggable
+ */
+export interface DraggableControls {
+  /** Update disabled state */
+  setDisabled: (disabled: boolean) => void;
+  /** Start keyboard drag mode */
+  startKeyboardDrag: () => void;
+  /** Move up in keyboard drag mode */
+  moveUp: () => void;
+  /** Move down in keyboard drag mode */
+  moveDown: () => void;
+  /** Commit keyboard drag (drop) */
+  commitKeyboardDrag: () => void;
+  /** Cancel keyboard drag */
+  cancelKeyboardDrag: () => void;
+  /** Remove all event listeners */
+  cleanup: CleanupFunction;
+}
+
+/**
+ * Options for createDropZone
+ */
+export interface DropZoneOptions {
+  /** Element to use as drop zone */
+  element: HTMLElement;
+  /** Function to filter acceptable drags (return true to accept) */
+  accept?: (data: unknown) => boolean;
+  /** Called when drag enters the drop zone */
+  onDragEnter?: (data: unknown) => void;
+  /** Called when drag moves over the drop zone */
+  onDragOver?: (data: unknown) => void;
+  /** Called when drag leaves the drop zone */
+  onDragLeave?: (data: unknown) => void;
+  /** Called when item is dropped */
+  onDrop?: (data: unknown, dropEffect: DropEffect) => void;
+}
+
+/**
+ * Return value from createDropZone
+ */
+export interface DropZoneControls {
+  /** Remove all event listeners */
+  cleanup: CleanupFunction;
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Long press duration for touch drag initiation (ms) */
+const TOUCH_LONG_PRESS_DURATION = 300;
+
+/** Custom MIME type for drag data transfer */
+const DRAG_DATA_TYPE = 'application/x-rafters-drag-data';
+
+// =============================================================================
+// Shared State
+// =============================================================================
+
+/** Shared state for keyboard drag mode across draggables and drop zones */
+let keyboardDragState: {
+  active: boolean;
+  data: unknown;
+  element: HTMLElement | null;
+  announcer: HTMLElement | null;
+  dropZones: Map<HTMLElement, DropZoneOptions>;
+  currentDropZone: HTMLElement | null;
+  currentDropZoneIndex: number;
+} = {
+  active: false,
+  data: null,
+  element: null,
+  announcer: null,
+  dropZones: new Map(),
+  currentDropZone: null,
+  currentDropZoneIndex: -1,
+};
+
+/** Registry for drop zones to allow keyboard navigation between them */
+const dropZoneRegistry: Set<HTMLElement> = new Set();
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Create a visually hidden live region for screen reader announcements
+ */
+function getOrCreateAnnouncer(): HTMLElement {
+  if (typeof window === 'undefined') {
+    return null as unknown as HTMLElement;
+  }
+
+  if (keyboardDragState.announcer) {
+    return keyboardDragState.announcer;
+  }
+
+  const announcer = document.createElement('div');
+  announcer.setAttribute('aria-live', 'assertive');
+  announcer.setAttribute('aria-atomic', 'true');
+  announcer.setAttribute('role', 'status');
+  announcer.setAttribute('data-drag-drop-announcer', 'true');
+
+  // Visually hidden but accessible
+  Object.assign(announcer.style, {
+    position: 'absolute',
+    width: '1px',
+    height: '1px',
+    padding: '0',
+    margin: '-1px',
+    overflow: 'hidden',
+    clip: 'rect(0, 0, 0, 0)',
+    whiteSpace: 'nowrap',
+    border: '0',
+  });
+
+  document.body.appendChild(announcer);
+  keyboardDragState.announcer = announcer;
+
+  return announcer;
+}
+
+/**
+ * Announce a message to screen readers
+ */
+function announce(message: string): void {
+  if (typeof window === 'undefined') return;
+
+  const announcer = getOrCreateAnnouncer();
+  if (!announcer) return;
+
+  // Clear and set to trigger announcement
+  announcer.textContent = '';
+  requestAnimationFrame(() => {
+    announcer.textContent = message;
+  });
+}
+
+/**
+ * Get sorted array of drop zone elements
+ */
+function getDropZonesArray(): HTMLElement[] {
+  return Array.from(dropZoneRegistry).sort((a, b) => {
+    const rectA = a.getBoundingClientRect();
+    const rectB = b.getBoundingClientRect();
+    // Sort by vertical position first, then horizontal
+    if (rectA.top !== rectB.top) return rectA.top - rectB.top;
+    return rectA.left - rectB.left;
+  });
+}
+
+/**
+ * Serialize data for DataTransfer
+ */
+function serializeData(data: unknown): string {
+  try {
+    return JSON.stringify(data);
+  } catch {
+    return String(data);
+  }
+}
+
+/**
+ * Deserialize data from DataTransfer
+ */
+function deserializeData(serialized: string): unknown {
+  try {
+    return JSON.parse(serialized);
+  } catch {
+    return serialized;
+  }
+}
+
+// =============================================================================
+// createDraggable
+// =============================================================================
+
+/**
+ * Create a draggable element with mouse, keyboard, and touch support
+ *
+ * @example
+ * ```typescript
+ * const controls = createDraggable({
+ *   element: cardElement,
+ *   data: { id: 'card-1' },
+ *   onDragStart: () => console.log('Started'),
+ *   onDragEnd: (data, effect) => console.log('Ended:', effect),
+ * });
+ *
+ * // Programmatic keyboard drag
+ * controls.startKeyboardDrag();
+ * controls.moveDown();
+ * controls.commitKeyboardDrag();
+ *
+ * // Cleanup
+ * controls.cleanup();
+ * ```
+ */
+export function createDraggable(options: DraggableOptions): DraggableControls {
+  // SSR guard
+  if (typeof window === 'undefined') {
+    return {
+      setDisabled: () => {},
+      startKeyboardDrag: () => {},
+      moveUp: () => {},
+      moveDown: () => {},
+      commitKeyboardDrag: () => {},
+      cancelKeyboardDrag: () => {},
+      cleanup: () => {},
+    };
+  }
+
+  const { element, handle, data, axis = 'both', onDragStart, onDrag, onDragEnd } = options;
+
+  let disabled = options.disabled ?? false;
+
+  let touchLongPressTimer: ReturnType<typeof setTimeout> | null = null;
+  let touchStartPosition = { x: 0, y: 0 };
+  let startPosition = { x: 0, y: 0 };
+
+  // ==========================================================================
+  // ARIA Setup
+  // ==========================================================================
+
+  // Set initial ARIA attributes
+  element.setAttribute('draggable', 'true');
+  element.setAttribute('aria-grabbed', 'false');
+  element.setAttribute('tabindex', element.getAttribute('tabindex') ?? '0');
+  element.setAttribute('role', element.getAttribute('role') ?? 'button');
+
+  function updateAriaGrabbed(grabbed: boolean): void {
+    element.setAttribute('aria-grabbed', grabbed ? 'true' : 'false');
+  }
+
+  // ==========================================================================
+  // Event Data Builder
+  // ==========================================================================
+
+  function createEventData(clientX: number, clientY: number): DragEventData {
+    let deltaX = clientX - startPosition.x;
+    let deltaY = clientY - startPosition.y;
+
+    // Apply axis constraints
+    if (axis === 'x') deltaY = 0;
+    if (axis === 'y') deltaX = 0;
+
+    return {
+      data,
+      clientX,
+      clientY,
+      deltaX,
+      deltaY,
+    };
+  }
+
+  // ==========================================================================
+  // HTML5 Drag and Drop (Mouse)
+  // ==========================================================================
+
+  function handleDragStart(event: DragEvent): void {
+    if (disabled) {
+      event.preventDefault();
+      return;
+    }
+
+    // Only proceed if drag started from handle
+    if (handle && !handle.contains(event.target as Node)) {
+      event.preventDefault();
+      return;
+    }
+
+    startPosition = { x: event.clientX, y: event.clientY };
+    updateAriaGrabbed(true);
+
+    // Set drag data
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = 'all';
+      event.dataTransfer.setData(DRAG_DATA_TYPE, serializeData(data));
+      event.dataTransfer.setData('text/plain', serializeData(data));
+    }
+
+    const eventData = createEventData(event.clientX, event.clientY);
+    onDragStart?.(eventData);
+  }
+
+  function handleDrag(event: DragEvent): void {
+    if (disabled) return;
+
+    // During drag, clientX/Y may be 0 at the end
+    if (event.clientX === 0 && event.clientY === 0) return;
+
+    const eventData = createEventData(event.clientX, event.clientY);
+    onDrag?.(eventData);
+  }
+
+  function handleDragEnd(event: DragEvent): void {
+    if (disabled) return;
+
+    updateAriaGrabbed(false);
+
+    const dropEffect = (event.dataTransfer?.dropEffect ?? 'none') as DropEffect;
+    const eventData = createEventData(event.clientX, event.clientY);
+    onDragEnd?.(eventData, dropEffect);
+  }
+
+  // ==========================================================================
+  // Touch Support (Long Press)
+  // ==========================================================================
+
+  function handleTouchStart(event: TouchEvent): void {
+    if (disabled) return;
+
+    const touch = event.touches[0];
+    if (!touch) return;
+
+    // Only proceed if touch started from handle
+    if (handle && !handle.contains(event.target as Node)) {
+      return;
+    }
+
+    touchStartPosition = { x: touch.clientX, y: touch.clientY };
+
+    // Start long press timer
+    touchLongPressTimer = setTimeout(() => {
+      // Initiate drag after long press
+      startPosition = { ...touchStartPosition };
+      updateAriaGrabbed(true);
+
+      const eventData = createEventData(touchStartPosition.x, touchStartPosition.y);
+      onDragStart?.(eventData);
+
+      // Prevent scrolling during drag
+      event.preventDefault();
+    }, TOUCH_LONG_PRESS_DURATION);
+  }
+
+  function handleTouchMove(event: TouchEvent): void {
+    if (disabled) return;
+
+    const touch = event.touches[0];
+    if (!touch) return;
+
+    // Cancel long press if moved too much before timer fires
+    if (touchLongPressTimer) {
+      const dx = Math.abs(touch.clientX - touchStartPosition.x);
+      const dy = Math.abs(touch.clientY - touchStartPosition.y);
+      if (dx > 10 || dy > 10) {
+        clearTimeout(touchLongPressTimer);
+        touchLongPressTimer = null;
+        return;
+      }
+    }
+
+    // If drag is active (aria-grabbed is true), call onDrag
+    if (element.getAttribute('aria-grabbed') === 'true') {
+      event.preventDefault();
+      const eventData = createEventData(touch.clientX, touch.clientY);
+      onDrag?.(eventData);
+    }
+  }
+
+  function handleTouchEnd(event: TouchEvent): void {
+    if (disabled) return;
+
+    // Clear long press timer if still pending
+    if (touchLongPressTimer) {
+      clearTimeout(touchLongPressTimer);
+      touchLongPressTimer = null;
+    }
+
+    // If drag was active, end it
+    if (element.getAttribute('aria-grabbed') === 'true') {
+      updateAriaGrabbed(false);
+
+      const touch = event.changedTouches[0];
+      const clientX = touch?.clientX ?? 0;
+      const clientY = touch?.clientY ?? 0;
+
+      // Determine drop effect by checking if over a drop zone
+      let dropEffect: DropEffect = 'none';
+      const elementAtPoint = document.elementFromPoint(clientX, clientY);
+      if (elementAtPoint) {
+        for (const dropZone of dropZoneRegistry) {
+          if (dropZone.contains(elementAtPoint)) {
+            dropEffect = 'move';
+            break;
+          }
+        }
+      }
+
+      const eventData = createEventData(clientX, clientY);
+      onDragEnd?.(eventData, dropEffect);
+    }
+  }
+
+  // ==========================================================================
+  // Keyboard Support
+  // ==========================================================================
+
+  function handleKeyDown(event: KeyboardEvent): void {
+    if (disabled) return;
+
+    // Space to pick up or drop
+    if (event.key === ' ') {
+      event.preventDefault();
+
+      if (keyboardDragState.active && keyboardDragState.element === element) {
+        // Drop at current location
+        commitKeyboardDrag();
+      } else if (!keyboardDragState.active) {
+        // Pick up
+        startKeyboardDrag();
+      }
+      return;
+    }
+
+    // Arrow keys to move during keyboard drag
+    if (keyboardDragState.active && keyboardDragState.element === element) {
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        moveUp();
+      } else if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        moveDown();
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        cancelKeyboardDrag();
+      }
+    }
+  }
+
+  function startKeyboardDrag(): void {
+    if (disabled) return;
+    if (keyboardDragState.active) return;
+
+    const rect = element.getBoundingClientRect();
+    startPosition = { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+
+    keyboardDragState.active = true;
+    keyboardDragState.data = data;
+    keyboardDragState.element = element;
+    keyboardDragState.currentDropZoneIndex = -1;
+    keyboardDragState.currentDropZone = null;
+
+    updateAriaGrabbed(true);
+
+    const eventData = createEventData(startPosition.x, startPosition.y);
+    onDragStart?.(eventData);
+
+    announce(
+      'Grabbed. Use arrow keys to navigate to a drop zone. Space to drop. Escape to cancel.',
+    );
+  }
+
+  function moveUp(): void {
+    if (!keyboardDragState.active || keyboardDragState.element !== element) return;
+
+    const dropZones = getDropZonesArray();
+    if (dropZones.length === 0) return;
+
+    // Leave current drop zone
+    if (keyboardDragState.currentDropZone) {
+      const currentOptions = keyboardDragState.dropZones.get(keyboardDragState.currentDropZone);
+      currentOptions?.onDragLeave?.(data);
+      keyboardDragState.currentDropZone.setAttribute('aria-dropeffect', 'none');
+    }
+
+    // Move to previous drop zone
+    keyboardDragState.currentDropZoneIndex--;
+    if (keyboardDragState.currentDropZoneIndex < 0) {
+      keyboardDragState.currentDropZoneIndex = dropZones.length - 1;
+    }
+
+    const newDropZone = dropZones[keyboardDragState.currentDropZoneIndex];
+    if (newDropZone) {
+      keyboardDragState.currentDropZone = newDropZone;
+      const newOptions = keyboardDragState.dropZones.get(newDropZone);
+      newDropZone.setAttribute('aria-dropeffect', 'move');
+      newOptions?.onDragEnter?.(data);
+
+      const label =
+        newDropZone.getAttribute('aria-label') ??
+        `Drop zone ${keyboardDragState.currentDropZoneIndex + 1}`;
+      announce(`Over ${label}`);
+    }
+  }
+
+  function moveDown(): void {
+    if (!keyboardDragState.active || keyboardDragState.element !== element) return;
+
+    const dropZones = getDropZonesArray();
+    if (dropZones.length === 0) return;
+
+    // Leave current drop zone
+    if (keyboardDragState.currentDropZone) {
+      const currentOptions = keyboardDragState.dropZones.get(keyboardDragState.currentDropZone);
+      currentOptions?.onDragLeave?.(data);
+      keyboardDragState.currentDropZone.setAttribute('aria-dropeffect', 'none');
+    }
+
+    // Move to next drop zone
+    keyboardDragState.currentDropZoneIndex++;
+    if (keyboardDragState.currentDropZoneIndex >= dropZones.length) {
+      keyboardDragState.currentDropZoneIndex = 0;
+    }
+
+    const newDropZone = dropZones[keyboardDragState.currentDropZoneIndex];
+    if (newDropZone) {
+      keyboardDragState.currentDropZone = newDropZone;
+      const newOptions = keyboardDragState.dropZones.get(newDropZone);
+      newDropZone.setAttribute('aria-dropeffect', 'move');
+      newOptions?.onDragEnter?.(data);
+
+      const label =
+        newDropZone.getAttribute('aria-label') ??
+        `Drop zone ${keyboardDragState.currentDropZoneIndex + 1}`;
+      announce(`Over ${label}`);
+    }
+  }
+
+  function commitKeyboardDrag(): void {
+    if (!keyboardDragState.active || keyboardDragState.element !== element) return;
+
+    let dropEffect: DropEffect = 'none';
+
+    if (keyboardDragState.currentDropZone) {
+      const dropZoneOptions = keyboardDragState.dropZones.get(keyboardDragState.currentDropZone);
+      const acceptsFn = dropZoneOptions?.accept ?? (() => true);
+
+      if (acceptsFn(data)) {
+        dropEffect = 'move';
+        dropZoneOptions?.onDrop?.(data, dropEffect);
+
+        const label = keyboardDragState.currentDropZone.getAttribute('aria-label') ?? 'drop zone';
+        announce(`Dropped on ${label}`);
+      } else {
+        announce('Drop cancelled. Target does not accept this item.');
+      }
+
+      keyboardDragState.currentDropZone.setAttribute('aria-dropeffect', 'none');
+    } else {
+      announce('Dropped');
+    }
+
+    updateAriaGrabbed(false);
+
+    const rect = element.getBoundingClientRect();
+    const eventData = createEventData(rect.left + rect.width / 2, rect.top + rect.height / 2);
+    onDragEnd?.(eventData, dropEffect);
+
+    // Reset state
+    keyboardDragState.active = false;
+    keyboardDragState.data = null;
+    keyboardDragState.element = null;
+    keyboardDragState.currentDropZone = null;
+    keyboardDragState.currentDropZoneIndex = -1;
+  }
+
+  function cancelKeyboardDrag(): void {
+    if (!keyboardDragState.active || keyboardDragState.element !== element) return;
+
+    // Leave current drop zone
+    if (keyboardDragState.currentDropZone) {
+      const currentOptions = keyboardDragState.dropZones.get(keyboardDragState.currentDropZone);
+      currentOptions?.onDragLeave?.(data);
+      keyboardDragState.currentDropZone.setAttribute('aria-dropeffect', 'none');
+    }
+
+    updateAriaGrabbed(false);
+    announce('Drag cancelled');
+
+    const rect = element.getBoundingClientRect();
+    const eventData = createEventData(rect.left + rect.width / 2, rect.top + rect.height / 2);
+    onDragEnd?.(eventData, 'none');
+
+    // Reset state
+    keyboardDragState.active = false;
+    keyboardDragState.data = null;
+    keyboardDragState.element = null;
+    keyboardDragState.currentDropZone = null;
+    keyboardDragState.currentDropZoneIndex = -1;
+  }
+
+  // ==========================================================================
+  // Event Binding
+  // ==========================================================================
+
+  element.addEventListener('dragstart', handleDragStart);
+  element.addEventListener('drag', handleDrag);
+  element.addEventListener('dragend', handleDragEnd);
+  element.addEventListener('touchstart', handleTouchStart, { passive: false });
+  element.addEventListener('touchmove', handleTouchMove, { passive: false });
+  element.addEventListener('touchend', handleTouchEnd);
+  element.addEventListener('keydown', handleKeyDown);
+
+  // ==========================================================================
+  // Controls
+  // ==========================================================================
+
+  function setDisabled(newDisabled: boolean): void {
+    disabled = newDisabled;
+    element.setAttribute('draggable', disabled ? 'false' : 'true');
+    if (disabled) {
+      element.removeAttribute('aria-grabbed');
+    } else {
+      element.setAttribute('aria-grabbed', 'false');
+    }
+  }
+
+  function cleanup(): void {
+    // Cancel any active keyboard drag
+    if (keyboardDragState.active && keyboardDragState.element === element) {
+      cancelKeyboardDrag();
+    }
+
+    // Clear touch timer
+    if (touchLongPressTimer) {
+      clearTimeout(touchLongPressTimer);
+      touchLongPressTimer = null;
+    }
+
+    // Remove event listeners
+    element.removeEventListener('dragstart', handleDragStart);
+    element.removeEventListener('drag', handleDrag);
+    element.removeEventListener('dragend', handleDragEnd);
+    element.removeEventListener('touchstart', handleTouchStart);
+    element.removeEventListener('touchmove', handleTouchMove);
+    element.removeEventListener('touchend', handleTouchEnd);
+    element.removeEventListener('keydown', handleKeyDown);
+
+    // Clean up ARIA attributes
+    element.removeAttribute('aria-grabbed');
+    element.removeAttribute('draggable');
+  }
+
+  return {
+    setDisabled,
+    startKeyboardDrag,
+    moveUp,
+    moveDown,
+    commitKeyboardDrag,
+    cancelKeyboardDrag,
+    cleanup,
+  };
+}
+
+// =============================================================================
+// createDropZone
+// =============================================================================
+
+/**
+ * Create a drop zone that accepts draggable items
+ *
+ * @example
+ * ```typescript
+ * const controls = createDropZone({
+ *   element: containerElement,
+ *   accept: (data) => typeof data === 'object' && data !== null,
+ *   onDragEnter: () => container.classList.add('drag-over'),
+ *   onDragLeave: () => container.classList.remove('drag-over'),
+ *   onDrop: (data) => addItem(data),
+ * });
+ *
+ * // Cleanup
+ * controls.cleanup();
+ * ```
+ */
+export function createDropZone(options: DropZoneOptions): DropZoneControls {
+  // SSR guard
+  if (typeof window === 'undefined') {
+    return {
+      cleanup: () => {},
+    };
+  }
+
+  const { element, accept = () => true, onDragEnter, onDragOver, onDragLeave, onDrop } = options;
+
+  // Track enter/leave for nested elements
+  let dragEnterCount = 0;
+
+  // ==========================================================================
+  // ARIA Setup
+  // ==========================================================================
+
+  element.setAttribute('aria-dropeffect', 'none');
+
+  // ==========================================================================
+  // Register for keyboard navigation
+  // ==========================================================================
+
+  dropZoneRegistry.add(element);
+  keyboardDragState.dropZones.set(element, options);
+
+  // ==========================================================================
+  // HTML5 Drag and Drop Events
+  // ==========================================================================
+
+  function handleDragEnter(event: DragEvent): void {
+    dragEnterCount++;
+
+    // Only process on first enter
+    if (dragEnterCount !== 1) return;
+
+    event.preventDefault();
+
+    // Get drag data
+    const serialized =
+      event.dataTransfer?.getData(DRAG_DATA_TYPE) || event.dataTransfer?.getData('text/plain');
+    const data = serialized ? deserializeData(serialized) : null;
+
+    if (accept(data)) {
+      element.setAttribute('aria-dropeffect', 'move');
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = 'move';
+      }
+      onDragEnter?.(data);
+    }
+  }
+
+  function handleDragOver(event: DragEvent): void {
+    event.preventDefault();
+
+    const serialized =
+      event.dataTransfer?.getData(DRAG_DATA_TYPE) || event.dataTransfer?.getData('text/plain');
+    const data = serialized ? deserializeData(serialized) : null;
+
+    if (accept(data)) {
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = 'move';
+      }
+      onDragOver?.(data);
+    } else {
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = 'none';
+      }
+    }
+  }
+
+  function handleDragLeave(event: DragEvent): void {
+    dragEnterCount--;
+
+    // Only process on final leave
+    if (dragEnterCount !== 0) return;
+
+    const serialized =
+      event.dataTransfer?.getData(DRAG_DATA_TYPE) || event.dataTransfer?.getData('text/plain');
+    const data = serialized ? deserializeData(serialized) : null;
+
+    element.setAttribute('aria-dropeffect', 'none');
+    onDragLeave?.(data);
+  }
+
+  function handleDrop(event: DragEvent): void {
+    event.preventDefault();
+    dragEnterCount = 0;
+
+    const serialized =
+      event.dataTransfer?.getData(DRAG_DATA_TYPE) || event.dataTransfer?.getData('text/plain');
+    const data = serialized ? deserializeData(serialized) : null;
+
+    element.setAttribute('aria-dropeffect', 'none');
+
+    if (accept(data)) {
+      const dropEffect = (event.dataTransfer?.dropEffect ?? 'move') as DropEffect;
+      onDrop?.(data, dropEffect);
+    }
+  }
+
+  // ==========================================================================
+  // Event Binding
+  // ==========================================================================
+
+  element.addEventListener('dragenter', handleDragEnter);
+  element.addEventListener('dragover', handleDragOver);
+  element.addEventListener('dragleave', handleDragLeave);
+  element.addEventListener('drop', handleDrop);
+
+  // ==========================================================================
+  // Controls
+  // ==========================================================================
+
+  function cleanup(): void {
+    // Unregister from keyboard navigation
+    dropZoneRegistry.delete(element);
+    keyboardDragState.dropZones.delete(element);
+
+    // Remove event listeners
+    element.removeEventListener('dragenter', handleDragEnter);
+    element.removeEventListener('dragover', handleDragOver);
+    element.removeEventListener('dragleave', handleDragLeave);
+    element.removeEventListener('drop', handleDrop);
+
+    // Clean up ARIA attributes
+    element.removeAttribute('aria-dropeffect');
+  }
+
+  return {
+    cleanup,
+  };
+}
+
+// =============================================================================
+// Testing Utilities
+// =============================================================================
+
+/**
+ * Reset keyboard drag state (for testing)
+ */
+export function resetDragDropState(): void {
+  if (keyboardDragState.announcer) {
+    keyboardDragState.announcer.remove();
+  }
+
+  keyboardDragState = {
+    active: false,
+    data: null,
+    element: null,
+    announcer: null,
+    dropZones: new Map(),
+    currentDropZone: null,
+    currentDropZoneIndex: -1,
+  };
+
+  dropZoneRegistry.clear();
+}

--- a/packages/ui/test/primitives/drag-drop.test.ts
+++ b/packages/ui/test/primitives/drag-drop.test.ts
@@ -1,0 +1,1097 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createDraggable,
+  createDropZone,
+  resetDragDropState,
+} from '../../src/primitives/drag-drop';
+
+describe('createDraggable', () => {
+  let element: HTMLDivElement;
+
+  beforeEach(() => {
+    resetDragDropState();
+    element = document.createElement('div');
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    element.remove();
+    resetDragDropState();
+  });
+
+  describe('initialization', () => {
+    it('sets initial ARIA attributes', () => {
+      const controls = createDraggable({
+        element,
+        data: { id: 'test' },
+      });
+
+      expect(element.getAttribute('draggable')).toBe('true');
+      expect(element.getAttribute('aria-grabbed')).toBe('false');
+      expect(element.getAttribute('tabindex')).toBe('0');
+
+      controls.cleanup();
+    });
+
+    it('preserves existing tabindex', () => {
+      element.setAttribute('tabindex', '-1');
+
+      const controls = createDraggable({
+        element,
+        data: { id: 'test' },
+      });
+
+      expect(element.getAttribute('tabindex')).toBe('-1');
+
+      controls.cleanup();
+    });
+  });
+
+  describe('mouse drag and drop', () => {
+    it('calls onDragStart when drag begins', () => {
+      const onDragStart = vi.fn();
+      const controls = createDraggable({
+        element,
+        data: { id: 'item-1' },
+        onDragStart,
+      });
+
+      const dragEvent = new DragEvent('dragstart', {
+        bubbles: true,
+        dataTransfer: new DataTransfer(),
+      });
+
+      element.dispatchEvent(dragEvent);
+
+      expect(onDragStart).toHaveBeenCalledTimes(1);
+      expect(onDragStart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { id: 'item-1' },
+        }),
+      );
+
+      controls.cleanup();
+    });
+
+    it('sets aria-grabbed to true during drag', () => {
+      const controls = createDraggable({
+        element,
+        data: { id: 'test' },
+      });
+
+      const dragEvent = new DragEvent('dragstart', {
+        bubbles: true,
+        dataTransfer: new DataTransfer(),
+      });
+
+      element.dispatchEvent(dragEvent);
+
+      expect(element.getAttribute('aria-grabbed')).toBe('true');
+
+      controls.cleanup();
+    });
+
+    it('calls onDrag during drag movement', () => {
+      const onDrag = vi.fn();
+      const controls = createDraggable({
+        element,
+        data: { id: 'item-1' },
+        onDrag,
+      });
+
+      // Start drag
+      element.dispatchEvent(
+        new DragEvent('dragstart', {
+          bubbles: true,
+          dataTransfer: new DataTransfer(),
+        }),
+      );
+
+      // Move during drag - note: jsdom doesn't fully support clientX/clientY on DragEvent
+      // We test that onDrag is called; real browser tests would verify coordinates
+      const dragEvent = new DragEvent('drag', {
+        bubbles: true,
+      });
+      // Manually set properties since jsdom doesn't support them in constructor
+      Object.defineProperty(dragEvent, 'clientX', { value: 50 });
+      Object.defineProperty(dragEvent, 'clientY', { value: 60 });
+
+      element.dispatchEvent(dragEvent);
+
+      expect(onDrag).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { id: 'item-1' },
+          clientX: 50,
+          clientY: 60,
+        }),
+      );
+
+      controls.cleanup();
+    });
+
+    it('calls onDragEnd when drag ends', () => {
+      const onDragEnd = vi.fn();
+      const controls = createDraggable({
+        element,
+        data: { id: 'item-1' },
+        onDragEnd,
+      });
+
+      // Start drag
+      element.dispatchEvent(
+        new DragEvent('dragstart', {
+          bubbles: true,
+          dataTransfer: new DataTransfer(),
+        }),
+      );
+
+      // End drag
+      const endEvent = new DragEvent('dragend', {
+        bubbles: true,
+        clientX: 100,
+        clientY: 100,
+        dataTransfer: new DataTransfer(),
+      });
+
+      element.dispatchEvent(endEvent);
+
+      expect(onDragEnd).toHaveBeenCalledTimes(1);
+      expect(element.getAttribute('aria-grabbed')).toBe('false');
+
+      controls.cleanup();
+    });
+
+    it('applies axis constraint for x-only', () => {
+      const onDrag = vi.fn();
+      const controls = createDraggable({
+        element,
+        data: { id: 'test' },
+        axis: 'x',
+        onDrag,
+      });
+
+      // Start drag with manually set coordinates
+      const startEvent = new DragEvent('dragstart', {
+        bubbles: true,
+        dataTransfer: new DataTransfer(),
+      });
+      Object.defineProperty(startEvent, 'clientX', { value: 0 });
+      Object.defineProperty(startEvent, 'clientY', { value: 0 });
+      element.dispatchEvent(startEvent);
+
+      const dragEvent = new DragEvent('drag', {
+        bubbles: true,
+      });
+      Object.defineProperty(dragEvent, 'clientX', { value: 100 });
+      Object.defineProperty(dragEvent, 'clientY', { value: 50 });
+      element.dispatchEvent(dragEvent);
+
+      expect(onDrag).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deltaX: 100,
+          deltaY: 0, // constrained to 0
+        }),
+      );
+
+      controls.cleanup();
+    });
+
+    it('applies axis constraint for y-only', () => {
+      const onDrag = vi.fn();
+      const controls = createDraggable({
+        element,
+        data: { id: 'test' },
+        axis: 'y',
+        onDrag,
+      });
+
+      const startEvent = new DragEvent('dragstart', {
+        bubbles: true,
+        dataTransfer: new DataTransfer(),
+      });
+      Object.defineProperty(startEvent, 'clientX', { value: 0 });
+      Object.defineProperty(startEvent, 'clientY', { value: 0 });
+      element.dispatchEvent(startEvent);
+
+      const dragEvent = new DragEvent('drag', {
+        bubbles: true,
+      });
+      Object.defineProperty(dragEvent, 'clientX', { value: 50 });
+      Object.defineProperty(dragEvent, 'clientY', { value: 100 });
+      element.dispatchEvent(dragEvent);
+
+      expect(onDrag).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deltaX: 0, // constrained to 0
+          deltaY: 100,
+        }),
+      );
+
+      controls.cleanup();
+    });
+  });
+
+  describe('keyboard drag', () => {
+    it('starts keyboard drag on Space key', () => {
+      const onDragStart = vi.fn();
+      const controls = createDraggable({
+        element,
+        data: { id: 'test' },
+        onDragStart,
+      });
+
+      element.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+
+      expect(onDragStart).toHaveBeenCalledTimes(1);
+      expect(element.getAttribute('aria-grabbed')).toBe('true');
+
+      controls.cleanup();
+    });
+
+    it('commits keyboard drag on second Space key', () => {
+      const onDragEnd = vi.fn();
+      const controls = createDraggable({
+        element,
+        data: { id: 'test' },
+        onDragEnd,
+      });
+
+      // Start drag
+      element.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+
+      // Commit drag
+      element.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+
+      expect(onDragEnd).toHaveBeenCalledTimes(1);
+      expect(element.getAttribute('aria-grabbed')).toBe('false');
+
+      controls.cleanup();
+    });
+
+    it('cancels keyboard drag on Escape key', () => {
+      const onDragEnd = vi.fn();
+      const controls = createDraggable({
+        element,
+        data: { id: 'test' },
+        onDragEnd,
+      });
+
+      // Start drag
+      element.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+
+      // Cancel drag
+      element.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+      expect(onDragEnd).toHaveBeenCalledWith(expect.anything(), 'none');
+      expect(element.getAttribute('aria-grabbed')).toBe('false');
+
+      controls.cleanup();
+    });
+
+    it('navigates with arrow keys during keyboard drag', () => {
+      const dropZone1 = document.createElement('div');
+      const dropZone2 = document.createElement('div');
+      dropZone1.style.cssText = 'position: absolute; top: 0; left: 0;';
+      dropZone2.style.cssText = 'position: absolute; top: 100px; left: 0;';
+      document.body.appendChild(dropZone1);
+      document.body.appendChild(dropZone2);
+
+      const onDragEnter1 = vi.fn();
+      const onDragEnter2 = vi.fn();
+
+      const dz1 = createDropZone({
+        element: dropZone1,
+        onDragEnter: onDragEnter1,
+      });
+
+      const dz2 = createDropZone({
+        element: dropZone2,
+        onDragEnter: onDragEnter2,
+      });
+
+      const controls = createDraggable({
+        element,
+        data: { id: 'test' },
+      });
+
+      // Start keyboard drag
+      element.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+
+      // Move down to first drop zone
+      element.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+
+      expect(onDragEnter1).toHaveBeenCalled();
+
+      // Move down to second drop zone
+      element.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+
+      expect(onDragEnter2).toHaveBeenCalled();
+
+      controls.cleanup();
+      dz1.cleanup();
+      dz2.cleanup();
+      dropZone1.remove();
+      dropZone2.remove();
+    });
+
+    it('exposes programmatic keyboard drag methods', () => {
+      const onDragStart = vi.fn();
+      const onDragEnd = vi.fn();
+
+      const controls = createDraggable({
+        element,
+        data: { id: 'test' },
+        onDragStart,
+        onDragEnd,
+      });
+
+      // Test startKeyboardDrag
+      controls.startKeyboardDrag();
+      expect(onDragStart).toHaveBeenCalledTimes(1);
+      expect(element.getAttribute('aria-grabbed')).toBe('true');
+
+      // Test commitKeyboardDrag
+      controls.commitKeyboardDrag();
+      expect(onDragEnd).toHaveBeenCalledTimes(1);
+      expect(element.getAttribute('aria-grabbed')).toBe('false');
+
+      controls.cleanup();
+    });
+
+    it('cancelKeyboardDrag calls onDragEnd with none effect', () => {
+      const onDragEnd = vi.fn();
+
+      const controls = createDraggable({
+        element,
+        data: { id: 'test' },
+        onDragEnd,
+      });
+
+      controls.startKeyboardDrag();
+      controls.cancelKeyboardDrag();
+
+      expect(onDragEnd).toHaveBeenCalledWith(expect.anything(), 'none');
+
+      controls.cleanup();
+    });
+  });
+
+  describe('touch support', () => {
+    it('initiates drag after long press', async () => {
+      vi.useFakeTimers();
+
+      const onDragStart = vi.fn();
+      const controls = createDraggable({
+        element,
+        data: { id: 'test' },
+        onDragStart,
+      });
+
+      // Start touch
+      const touchStartEvent = new TouchEvent('touchstart', {
+        bubbles: true,
+        touches: [{ clientX: 100, clientY: 100, identifier: 0 } as Touch],
+      });
+      element.dispatchEvent(touchStartEvent);
+
+      // Fast forward past long press duration
+      vi.advanceTimersByTime(350);
+
+      expect(onDragStart).toHaveBeenCalledTimes(1);
+      expect(element.getAttribute('aria-grabbed')).toBe('true');
+
+      controls.cleanup();
+      vi.useRealTimers();
+    });
+
+    it('cancels long press if moved before timer', async () => {
+      vi.useFakeTimers();
+
+      const onDragStart = vi.fn();
+      const controls = createDraggable({
+        element,
+        data: { id: 'test' },
+        onDragStart,
+      });
+
+      // Start touch
+      element.dispatchEvent(
+        new TouchEvent('touchstart', {
+          bubbles: true,
+          touches: [{ clientX: 100, clientY: 100, identifier: 0 } as Touch],
+        }),
+      );
+
+      // Move significantly before long press fires
+      vi.advanceTimersByTime(100);
+
+      element.dispatchEvent(
+        new TouchEvent('touchmove', {
+          bubbles: true,
+          touches: [{ clientX: 150, clientY: 100, identifier: 0 } as Touch],
+        }),
+      );
+
+      // Advance past long press duration
+      vi.advanceTimersByTime(300);
+
+      // Should not have started drag
+      expect(onDragStart).not.toHaveBeenCalled();
+
+      controls.cleanup();
+      vi.useRealTimers();
+    });
+
+    it('ends touch drag on touchend', async () => {
+      vi.useFakeTimers();
+
+      const onDragEnd = vi.fn();
+      const controls = createDraggable({
+        element,
+        data: { id: 'test' },
+        onDragEnd,
+      });
+
+      // Start touch
+      element.dispatchEvent(
+        new TouchEvent('touchstart', {
+          bubbles: true,
+          touches: [{ clientX: 100, clientY: 100, identifier: 0 } as Touch],
+        }),
+      );
+
+      // Wait for long press
+      vi.advanceTimersByTime(350);
+
+      // End touch
+      element.dispatchEvent(
+        new TouchEvent('touchend', {
+          bubbles: true,
+          changedTouches: [{ clientX: 150, clientY: 150, identifier: 0 } as Touch],
+        }),
+      );
+
+      expect(onDragEnd).toHaveBeenCalledTimes(1);
+      expect(element.getAttribute('aria-grabbed')).toBe('false');
+
+      controls.cleanup();
+      vi.useRealTimers();
+    });
+  });
+
+  describe('disabled state', () => {
+    it('prevents drag when disabled', () => {
+      const onDragStart = vi.fn();
+      const controls = createDraggable({
+        element,
+        data: { id: 'test' },
+        disabled: true,
+        onDragStart,
+      });
+
+      const event = new DragEvent('dragstart', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer: new DataTransfer(),
+      });
+
+      element.dispatchEvent(event);
+
+      expect(onDragStart).not.toHaveBeenCalled();
+
+      controls.cleanup();
+    });
+
+    it('setDisabled updates state correctly', () => {
+      const onDragStart = vi.fn();
+      const controls = createDraggable({
+        element,
+        data: { id: 'test' },
+        onDragStart,
+      });
+
+      controls.setDisabled(true);
+
+      expect(element.getAttribute('draggable')).toBe('false');
+      expect(element.hasAttribute('aria-grabbed')).toBe(false);
+
+      controls.setDisabled(false);
+
+      expect(element.getAttribute('draggable')).toBe('true');
+      expect(element.getAttribute('aria-grabbed')).toBe('false');
+
+      controls.cleanup();
+    });
+
+    it('prevents keyboard drag when disabled', () => {
+      const onDragStart = vi.fn();
+      const controls = createDraggable({
+        element,
+        data: { id: 'test' },
+        disabled: true,
+        onDragStart,
+      });
+
+      element.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+
+      expect(onDragStart).not.toHaveBeenCalled();
+
+      controls.cleanup();
+    });
+  });
+
+  describe('handle option', () => {
+    it('only initiates drag from handle element', () => {
+      const handle = document.createElement('div');
+      element.appendChild(handle);
+
+      const onDragStart = vi.fn();
+      const controls = createDraggable({
+        element,
+        handle,
+        data: { id: 'test' },
+        onDragStart,
+      });
+
+      // Drag from element (not handle) - should not work
+      const event1 = new DragEvent('dragstart', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer: new DataTransfer(),
+      });
+      Object.defineProperty(event1, 'target', { value: element });
+      element.dispatchEvent(event1);
+
+      expect(onDragStart).not.toHaveBeenCalled();
+
+      // Drag from handle - should work
+      const event2 = new DragEvent('dragstart', {
+        bubbles: true,
+        dataTransfer: new DataTransfer(),
+      });
+      Object.defineProperty(event2, 'target', { value: handle });
+      element.dispatchEvent(event2);
+
+      expect(onDragStart).toHaveBeenCalled();
+
+      controls.cleanup();
+    });
+  });
+
+  describe('cleanup', () => {
+    it('removes all event listeners', () => {
+      const onDragStart = vi.fn();
+      const controls = createDraggable({
+        element,
+        data: { id: 'test' },
+        onDragStart,
+      });
+
+      controls.cleanup();
+
+      element.dispatchEvent(
+        new DragEvent('dragstart', {
+          bubbles: true,
+          dataTransfer: new DataTransfer(),
+        }),
+      );
+
+      expect(onDragStart).not.toHaveBeenCalled();
+    });
+
+    it('removes ARIA attributes', () => {
+      const controls = createDraggable({
+        element,
+        data: { id: 'test' },
+      });
+
+      controls.cleanup();
+
+      expect(element.hasAttribute('aria-grabbed')).toBe(false);
+      expect(element.hasAttribute('draggable')).toBe(false);
+    });
+
+    it('cancels active keyboard drag', () => {
+      const onDragEnd = vi.fn();
+      const controls = createDraggable({
+        element,
+        data: { id: 'test' },
+        onDragEnd,
+      });
+
+      controls.startKeyboardDrag();
+      controls.cleanup();
+
+      // Should have been cancelled
+      expect(onDragEnd).toHaveBeenCalledWith(expect.anything(), 'none');
+    });
+  });
+
+  describe('SSR', () => {
+    it('returns no-op controls in SSR environment', () => {
+      const originalWindow = globalThis.window;
+      // @ts-expect-error Testing SSR
+      delete globalThis.window;
+
+      const controls = createDraggable({
+        element,
+        data: { id: 'test' },
+      });
+
+      // All methods should be callable without errors
+      expect(() => controls.setDisabled(true)).not.toThrow();
+      expect(() => controls.startKeyboardDrag()).not.toThrow();
+      expect(() => controls.moveUp()).not.toThrow();
+      expect(() => controls.moveDown()).not.toThrow();
+      expect(() => controls.commitKeyboardDrag()).not.toThrow();
+      expect(() => controls.cancelKeyboardDrag()).not.toThrow();
+      expect(() => controls.cleanup()).not.toThrow();
+
+      globalThis.window = originalWindow;
+    });
+  });
+});
+
+describe('createDropZone', () => {
+  let element: HTMLDivElement;
+
+  beforeEach(() => {
+    resetDragDropState();
+    element = document.createElement('div');
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    element.remove();
+    resetDragDropState();
+  });
+
+  describe('initialization', () => {
+    it('sets aria-dropeffect to none', () => {
+      const controls = createDropZone({ element });
+
+      expect(element.getAttribute('aria-dropeffect')).toBe('none');
+
+      controls.cleanup();
+    });
+  });
+
+  describe('drag events', () => {
+    it('calls onDragEnter when drag enters', () => {
+      const onDragEnter = vi.fn();
+      const controls = createDropZone({
+        element,
+        onDragEnter,
+      });
+
+      const event = new DragEvent('dragenter', {
+        bubbles: true,
+        dataTransfer: new DataTransfer(),
+      });
+
+      element.dispatchEvent(event);
+
+      expect(onDragEnter).toHaveBeenCalled();
+      expect(element.getAttribute('aria-dropeffect')).toBe('move');
+
+      controls.cleanup();
+    });
+
+    it('calls onDragOver during drag movement over zone', () => {
+      const onDragOver = vi.fn();
+      const controls = createDropZone({
+        element,
+        onDragOver,
+      });
+
+      element.dispatchEvent(
+        new DragEvent('dragenter', {
+          bubbles: true,
+          dataTransfer: new DataTransfer(),
+        }),
+      );
+
+      element.dispatchEvent(
+        new DragEvent('dragover', {
+          bubbles: true,
+          dataTransfer: new DataTransfer(),
+        }),
+      );
+
+      expect(onDragOver).toHaveBeenCalled();
+
+      controls.cleanup();
+    });
+
+    it('calls onDragLeave when drag leaves', () => {
+      const onDragLeave = vi.fn();
+      const controls = createDropZone({
+        element,
+        onDragLeave,
+      });
+
+      // Enter
+      element.dispatchEvent(
+        new DragEvent('dragenter', {
+          bubbles: true,
+          dataTransfer: new DataTransfer(),
+        }),
+      );
+
+      // Leave
+      element.dispatchEvent(
+        new DragEvent('dragleave', {
+          bubbles: true,
+          dataTransfer: new DataTransfer(),
+        }),
+      );
+
+      expect(onDragLeave).toHaveBeenCalled();
+      expect(element.getAttribute('aria-dropeffect')).toBe('none');
+
+      controls.cleanup();
+    });
+
+    it('calls onDrop when item is dropped', () => {
+      const onDrop = vi.fn();
+      const controls = createDropZone({
+        element,
+        onDrop,
+      });
+
+      element.dispatchEvent(
+        new DragEvent('dragenter', {
+          bubbles: true,
+          dataTransfer: new DataTransfer(),
+        }),
+      );
+
+      const dropEvent = new DragEvent('drop', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer: new DataTransfer(),
+      });
+
+      element.dispatchEvent(dropEvent);
+
+      expect(onDrop).toHaveBeenCalled();
+      expect(element.getAttribute('aria-dropeffect')).toBe('none');
+
+      controls.cleanup();
+    });
+
+    it('handles nested enter/leave correctly', () => {
+      const onDragEnter = vi.fn();
+      const onDragLeave = vi.fn();
+
+      const controls = createDropZone({
+        element,
+        onDragEnter,
+        onDragLeave,
+      });
+
+      // Enter parent
+      element.dispatchEvent(
+        new DragEvent('dragenter', {
+          bubbles: true,
+          dataTransfer: new DataTransfer(),
+        }),
+      );
+
+      // Enter child (fires another dragenter)
+      element.dispatchEvent(
+        new DragEvent('dragenter', {
+          bubbles: true,
+          dataTransfer: new DataTransfer(),
+        }),
+      );
+
+      // Leave child (fires dragleave, but still in parent)
+      element.dispatchEvent(
+        new DragEvent('dragleave', {
+          bubbles: true,
+          dataTransfer: new DataTransfer(),
+        }),
+      );
+
+      // onDragEnter should only have been called once
+      expect(onDragEnter).toHaveBeenCalledTimes(1);
+      // onDragLeave should not have been called yet
+      expect(onDragLeave).not.toHaveBeenCalled();
+
+      // Leave parent
+      element.dispatchEvent(
+        new DragEvent('dragleave', {
+          bubbles: true,
+          dataTransfer: new DataTransfer(),
+        }),
+      );
+
+      expect(onDragLeave).toHaveBeenCalledTimes(1);
+
+      controls.cleanup();
+    });
+  });
+
+  describe('accept filter', () => {
+    it('rejects items that do not pass accept filter', () => {
+      const onDrop = vi.fn();
+      const controls = createDropZone({
+        element,
+        accept: (data) => {
+          return (
+            typeof data === 'object' && data !== null && 'type' in data && data.type === 'task'
+          );
+        },
+        onDrop,
+      });
+
+      // Drop with non-matching data
+      const dataTransfer = new DataTransfer();
+      dataTransfer.setData('text/plain', JSON.stringify({ type: 'note' }));
+
+      element.dispatchEvent(
+        new DragEvent('drop', {
+          bubbles: true,
+          dataTransfer,
+        }),
+      );
+
+      expect(onDrop).not.toHaveBeenCalled();
+
+      controls.cleanup();
+    });
+
+    it('accepts items that pass accept filter', () => {
+      const onDrop = vi.fn();
+      const controls = createDropZone({
+        element,
+        // Note: In real browsers, getData only works in drop event
+        // In jsdom, DataTransfer doesn't persist data between events properly
+        // So we use a simple accept that allows the drop
+        accept: () => true,
+        onDrop,
+      });
+
+      // Drop with matching data
+      const dataTransfer = new DataTransfer();
+      dataTransfer.setData('text/plain', JSON.stringify({ type: 'task' }));
+
+      const dropEvent = new DragEvent('drop', {
+        bubbles: true,
+        cancelable: true,
+      });
+      // Manually attach dataTransfer since jsdom has issues with it
+      Object.defineProperty(dropEvent, 'dataTransfer', { value: dataTransfer });
+
+      element.dispatchEvent(dropEvent);
+
+      expect(onDrop).toHaveBeenCalled();
+
+      controls.cleanup();
+    });
+  });
+
+  describe('cleanup', () => {
+    it('removes event listeners', () => {
+      const onDragEnter = vi.fn();
+      const controls = createDropZone({
+        element,
+        onDragEnter,
+      });
+
+      controls.cleanup();
+
+      element.dispatchEvent(
+        new DragEvent('dragenter', {
+          bubbles: true,
+          dataTransfer: new DataTransfer(),
+        }),
+      );
+
+      expect(onDragEnter).not.toHaveBeenCalled();
+    });
+
+    it('removes aria-dropeffect attribute', () => {
+      const controls = createDropZone({ element });
+
+      controls.cleanup();
+
+      expect(element.hasAttribute('aria-dropeffect')).toBe(false);
+    });
+  });
+
+  describe('SSR', () => {
+    it('returns no-op controls in SSR environment', () => {
+      const originalWindow = globalThis.window;
+      // @ts-expect-error Testing SSR
+      delete globalThis.window;
+
+      const controls = createDropZone({ element });
+
+      expect(() => controls.cleanup()).not.toThrow();
+
+      globalThis.window = originalWindow;
+    });
+  });
+});
+
+describe('ARIA attributes', () => {
+  beforeEach(() => {
+    resetDragDropState();
+  });
+
+  afterEach(() => {
+    resetDragDropState();
+  });
+
+  it('draggable aria-grabbed updates correctly through drag lifecycle', () => {
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+
+    const controls = createDraggable({
+      element,
+      data: { id: 'test' },
+    });
+
+    expect(element.getAttribute('aria-grabbed')).toBe('false');
+
+    // Start drag
+    element.dispatchEvent(
+      new DragEvent('dragstart', {
+        bubbles: true,
+        dataTransfer: new DataTransfer(),
+      }),
+    );
+
+    expect(element.getAttribute('aria-grabbed')).toBe('true');
+
+    // End drag
+    element.dispatchEvent(
+      new DragEvent('dragend', {
+        bubbles: true,
+        dataTransfer: new DataTransfer(),
+      }),
+    );
+
+    expect(element.getAttribute('aria-grabbed')).toBe('false');
+
+    controls.cleanup();
+    element.remove();
+  });
+
+  it('drop zone aria-dropeffect updates correctly', () => {
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+
+    const controls = createDropZone({ element });
+
+    expect(element.getAttribute('aria-dropeffect')).toBe('none');
+
+    // Enter
+    element.dispatchEvent(
+      new DragEvent('dragenter', {
+        bubbles: true,
+        dataTransfer: new DataTransfer(),
+      }),
+    );
+
+    expect(element.getAttribute('aria-dropeffect')).toBe('move');
+
+    // Leave
+    element.dispatchEvent(
+      new DragEvent('dragleave', {
+        bubbles: true,
+        dataTransfer: new DataTransfer(),
+      }),
+    );
+
+    expect(element.getAttribute('aria-dropeffect')).toBe('none');
+
+    controls.cleanup();
+    element.remove();
+  });
+});
+
+describe('integration', () => {
+  beforeEach(() => {
+    resetDragDropState();
+  });
+
+  afterEach(() => {
+    resetDragDropState();
+  });
+
+  it('keyboard drag drops into drop zone correctly', () => {
+    const draggable = document.createElement('div');
+    const dropZone = document.createElement('div');
+    document.body.appendChild(draggable);
+    document.body.appendChild(dropZone);
+
+    const onDrop = vi.fn();
+
+    const dragControls = createDraggable({
+      element: draggable,
+      data: { id: 'item-1', type: 'task' },
+    });
+
+    const dropControls = createDropZone({
+      element: dropZone,
+      onDrop,
+    });
+
+    // Start keyboard drag
+    dragControls.startKeyboardDrag();
+
+    // Navigate to drop zone
+    dragControls.moveDown();
+
+    // Drop
+    dragControls.commitKeyboardDrag();
+
+    expect(onDrop).toHaveBeenCalledWith({ id: 'item-1', type: 'task' }, 'move');
+
+    dragControls.cleanup();
+    dropControls.cleanup();
+    draggable.remove();
+    dropZone.remove();
+  });
+
+  it('keyboard drag respects accept filter', () => {
+    const draggable = document.createElement('div');
+    const dropZone = document.createElement('div');
+    document.body.appendChild(draggable);
+    document.body.appendChild(dropZone);
+
+    const onDrop = vi.fn();
+
+    const dragControls = createDraggable({
+      element: draggable,
+      data: { id: 'item-1', type: 'note' },
+    });
+
+    const dropControls = createDropZone({
+      element: dropZone,
+      accept: (data) => {
+        return typeof data === 'object' && data !== null && 'type' in data && data.type === 'task';
+      },
+      onDrop,
+    });
+
+    // Start keyboard drag
+    dragControls.startKeyboardDrag();
+
+    // Navigate to drop zone
+    dragControls.moveDown();
+
+    // Drop (should be rejected)
+    dragControls.commitKeyboardDrag();
+
+    expect(onDrop).not.toHaveBeenCalled();
+
+    dragControls.cleanup();
+    dropControls.cleanup();
+    draggable.remove();
+    dropZone.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `createDraggable` function for making elements draggable with mouse, keyboard, and touch support
- Add `createDropZone` function for accepting dropped items with filtering
- Full ARIA support with `aria-grabbed`, `aria-dropeffect`, and live region announcements for keyboard drag

## Features
- **Mouse drag**: Standard HTML5 drag and drop with DataTransfer
- **Keyboard drag**: Space to pick up, Arrow keys to navigate between drop zones, Space to drop, Escape to cancel
- **Touch drag**: Long press (300ms) to initiate drag
- **Axis constraints**: Optional x/y axis locking
- **Handle support**: Optional drag handle element
- **Accept filter**: Drop zones can filter acceptable items

## Test plan
- [x] Unit tests for mouse drag lifecycle (start, drag, end)
- [x] Unit tests for keyboard drag (Space, ArrowUp/Down, Escape)
- [x] Unit tests for touch long-press initiation
- [x] Unit tests for ARIA attribute updates
- [x] Unit tests for disabled state
- [x] Unit tests for cleanup
- [x] Unit tests for SSR safety
- [x] Integration test for keyboard drag to drop zone

Closes #610

Generated with [Claude Code](https://claude.com/claude-code)