### PR TITLE
feat(ui): add useHistory hook for undo/redo state management (R-301)

### DIFF
--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -3,7 +3,6 @@
  * @module hooks
  */
 
-// R-301: useHistory - not yet implemented
 // R-302: useClipboard - not yet implemented
 // R-303: useDragDrop - not yet implemented
 // R-304: useCommandPalette - not yet implemented
@@ -11,3 +10,7 @@
 // R-300: useBlockSelection
 export { useBlockSelection } from './use-block-selection';
 export type { UseBlockSelectionOptions, UseBlockSelectionReturn } from './use-block-selection';
+
+// R-301: useHistory
+export { useHistory } from './use-history';
+export type { UseHistoryOptions, UseHistoryReturn } from './use-history';

--- a/packages/ui/src/hooks/use-history.ts
+++ b/packages/ui/src/hooks/use-history.ts
@@ -1,0 +1,202 @@
+/**
+ * React hook for undo/redo history management
+ *
+ * Wraps the createHistory primitive with React state management
+ * for automatic re-renders on state changes.
+ *
+ * @example
+ * ```tsx
+ * function Editor() {
+ *   const { state, push, undo, redo, batch, clear } = useHistory({
+ *     initialState: '',
+ *     limit: 50,
+ *   });
+ *
+ *   return (
+ *     <div>
+ *       <input
+ *         value={state.current}
+ *         onChange={(e) => push(e.target.value)}
+ *       />
+ *       <button onClick={undo} disabled={!state.canUndo}>Undo</button>
+ *       <button onClick={redo} disabled={!state.canRedo}>Redo</button>
+ *       <button onClick={clear}>Clear</button>
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import { type History, type HistoryState, createHistory } from '../primitives/history';
+
+export interface UseHistoryOptions<T> {
+  /**
+   * Initial state for the history
+   */
+  initialState: T;
+
+  /**
+   * Maximum number of history entries
+   * Oldest entries are dropped when exceeded
+   * @default 100
+   */
+  limit?: number;
+
+  /**
+   * Equality function to skip duplicate states
+   * If returns true, push is skipped
+   */
+  isEqual?: (a: T, b: T) => boolean;
+}
+
+export interface UseHistoryReturn<T> {
+  /**
+   * Current history state including current value and undo/redo availability
+   */
+  state: HistoryState<T>;
+
+  /**
+   * Push a new state to history
+   * Triggers re-render with updated state
+   */
+  push: (state: T) => void;
+
+  /**
+   * Undo to previous state
+   * Returns previous state or null if at beginning
+   * Triggers re-render with updated state
+   */
+  undo: () => T | null;
+
+  /**
+   * Redo to next state
+   * Returns next state or null if at end
+   * Triggers re-render with updated state
+   */
+  redo: () => T | null;
+
+  /**
+   * Batch multiple push calls into single undo step
+   * Only the final state is recorded
+   * Triggers single re-render after batch completes
+   */
+  batch: (fn: () => void) => void;
+
+  /**
+   * Reset history to initial state only
+   * Triggers re-render with initial state
+   */
+  clear: () => void;
+}
+
+/**
+ * React hook for undo/redo history management
+ *
+ * @param options - Configuration options for the history
+ * @returns History state and control functions with stable references
+ *
+ * @example
+ * ```tsx
+ * // Basic usage
+ * const { state, push, undo, redo } = useHistory({
+ *   initialState: { count: 0 },
+ * });
+ *
+ * // With limit and equality check
+ * const { state, push, undo, redo } = useHistory({
+ *   initialState: '',
+ *   limit: 50,
+ *   isEqual: (a, b) => a === b,
+ * });
+ *
+ * // Batch operations
+ * const { batch, push } = useHistory({ initialState: [] });
+ * batch(() => {
+ *   push([...items, 'a']);
+ *   push([...items, 'a', 'b']);
+ *   push([...items, 'a', 'b', 'c']);
+ * });
+ * // Only one undo step recorded
+ * ```
+ */
+export function useHistory<T>(options: UseHistoryOptions<T>): UseHistoryReturn<T> {
+  // Store history controller in ref to persist across renders
+  const historyRef = useRef<History<T> | null>(null);
+
+  // Initialize history controller once
+  if (historyRef.current === null) {
+    historyRef.current = createHistory(options);
+  }
+
+  // State to trigger re-renders when history changes
+  const [historyState, setHistoryState] = useState<HistoryState<T>>(() =>
+    historyRef.current!.getState(),
+  );
+
+  // Update React state from history controller
+  const syncState = useCallback(() => {
+    if (historyRef.current) {
+      setHistoryState(historyRef.current.getState());
+    }
+  }, []);
+
+  // Push a new state to history
+  const push = useCallback(
+    (state: T): void => {
+      if (historyRef.current) {
+        historyRef.current.push(state);
+        syncState();
+      }
+    },
+    [syncState],
+  );
+
+  // Undo to previous state
+  const undo = useCallback((): T | null => {
+    if (historyRef.current) {
+      const result = historyRef.current.undo();
+      syncState();
+      return result;
+    }
+    return null;
+  }, [syncState]);
+
+  // Redo to next state
+  const redo = useCallback((): T | null => {
+    if (historyRef.current) {
+      const result = historyRef.current.redo();
+      syncState();
+      return result;
+    }
+    return null;
+  }, [syncState]);
+
+  // Batch multiple push calls into single undo step
+  const batch = useCallback(
+    (fn: () => void): void => {
+      if (historyRef.current) {
+        historyRef.current.batch(fn);
+        syncState();
+      }
+    },
+    [syncState],
+  );
+
+  // Reset history to initial state
+  const clear = useCallback((): void => {
+    if (historyRef.current) {
+      historyRef.current.clear();
+      syncState();
+    }
+  }, [syncState]);
+
+  return {
+    state: historyState,
+    push,
+    undo,
+    redo,
+    batch,
+    clear,
+  };
+}

--- a/packages/ui/test/hooks/use-history.test.tsx
+++ b/packages/ui/test/hooks/use-history.test.tsx
@@ -1,0 +1,423 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useHistory } from "../../src/hooks/use-history";
+
+describe("useHistory", () => {
+  describe("initial state", () => {
+    it("returns initial state", () => {
+      const { result } = renderHook(() =>
+        useHistory({ initialState: "initial" }),
+      );
+
+      expect(result.current.state.current).toBe("initial");
+      expect(result.current.state.canUndo).toBe(false);
+      expect(result.current.state.canRedo).toBe(false);
+      expect(result.current.state.undoCount).toBe(0);
+      expect(result.current.state.redoCount).toBe(0);
+    });
+
+    it("works with object initial state", () => {
+      const initialState = { count: 0, name: "test" };
+      const { result } = renderHook(() => useHistory({ initialState }));
+
+      expect(result.current.state.current).toEqual(initialState);
+    });
+
+    it("works with array initial state", () => {
+      const initialState = [1, 2, 3];
+      const { result } = renderHook(() => useHistory({ initialState }));
+
+      expect(result.current.state.current).toEqual(initialState);
+    });
+  });
+
+  describe("push", () => {
+    it("updates state and triggers re-render", () => {
+      const { result } = renderHook(() => useHistory({ initialState: 0 }));
+
+      act(() => {
+        result.current.push(1);
+      });
+
+      expect(result.current.state.current).toBe(1);
+      expect(result.current.state.canUndo).toBe(true);
+      expect(result.current.state.undoCount).toBe(1);
+    });
+
+    it("skips duplicate states when isEqual is provided", () => {
+      const { result } = renderHook(() =>
+        useHistory({
+          initialState: { x: 0 },
+          isEqual: (a, b) => a.x === b.x,
+        }),
+      );
+
+      act(() => {
+        result.current.push({ x: 0 });
+      });
+
+      expect(result.current.state.undoCount).toBe(0);
+      expect(result.current.state.canUndo).toBe(false);
+    });
+
+    it("clears redo stack after push", () => {
+      const { result } = renderHook(() => useHistory({ initialState: 0 }));
+
+      act(() => {
+        result.current.push(1);
+        result.current.push(2);
+      });
+
+      act(() => {
+        result.current.undo();
+      });
+
+      expect(result.current.state.canRedo).toBe(true);
+
+      act(() => {
+        result.current.push(3);
+      });
+
+      expect(result.current.state.canRedo).toBe(false);
+      expect(result.current.state.redoCount).toBe(0);
+    });
+  });
+
+  describe("undo/redo", () => {
+    it("navigates history correctly", () => {
+      const { result } = renderHook(() => useHistory({ initialState: 0 }));
+
+      act(() => {
+        result.current.push(1);
+        result.current.push(2);
+        result.current.push(3);
+      });
+
+      expect(result.current.state.current).toBe(3);
+      expect(result.current.state.undoCount).toBe(3);
+
+      act(() => {
+        const prev = result.current.undo();
+        expect(prev).toBe(2);
+      });
+
+      expect(result.current.state.current).toBe(2);
+      expect(result.current.state.canUndo).toBe(true);
+      expect(result.current.state.canRedo).toBe(true);
+
+      act(() => {
+        const next = result.current.redo();
+        expect(next).toBe(3);
+      });
+
+      expect(result.current.state.current).toBe(3);
+    });
+
+    it("returns null when at beginning for undo", () => {
+      const { result } = renderHook(() => useHistory({ initialState: 0 }));
+
+      act(() => {
+        const prev = result.current.undo();
+        expect(prev).toBeNull();
+      });
+
+      expect(result.current.state.current).toBe(0);
+    });
+
+    it("returns null when at end for redo", () => {
+      const { result } = renderHook(() => useHistory({ initialState: 0 }));
+
+      act(() => {
+        const next = result.current.redo();
+        expect(next).toBeNull();
+      });
+
+      expect(result.current.state.current).toBe(0);
+    });
+
+    it("can undo all the way to initial state", () => {
+      const { result } = renderHook(() => useHistory({ initialState: 0 }));
+
+      act(() => {
+        result.current.push(1);
+        result.current.push(2);
+        result.current.push(3);
+      });
+
+      act(() => {
+        result.current.undo();
+        result.current.undo();
+        result.current.undo();
+      });
+
+      expect(result.current.state.current).toBe(0);
+      expect(result.current.state.canUndo).toBe(false);
+      expect(result.current.state.canRedo).toBe(true);
+      expect(result.current.state.redoCount).toBe(3);
+    });
+  });
+
+  describe("batch", () => {
+    it("groups multiple changes into single undo step", () => {
+      const { result } = renderHook(() =>
+        useHistory({ initialState: [] as string[] }),
+      );
+
+      act(() => {
+        result.current.batch(() => {
+          result.current.push(["a"]);
+          result.current.push(["a", "b"]);
+          result.current.push(["a", "b", "c"]);
+        });
+      });
+
+      expect(result.current.state.current).toEqual(["a", "b", "c"]);
+      expect(result.current.state.undoCount).toBe(1);
+
+      act(() => {
+        result.current.undo();
+      });
+
+      expect(result.current.state.current).toEqual([]);
+    });
+
+    it("handles nested batches", () => {
+      const { result } = renderHook(() => useHistory({ initialState: 0 }));
+
+      act(() => {
+        result.current.batch(() => {
+          result.current.push(1);
+          result.current.batch(() => {
+            result.current.push(2);
+            result.current.push(3);
+          });
+          result.current.push(4);
+        });
+      });
+
+      expect(result.current.state.current).toBe(4);
+      expect(result.current.state.undoCount).toBe(1);
+    });
+
+    it("does not record if state unchanged during batch", () => {
+      const { result } = renderHook(() =>
+        useHistory({
+          initialState: { x: 0 },
+          isEqual: (a, b) => a.x === b.x,
+        }),
+      );
+
+      act(() => {
+        result.current.batch(() => {
+          result.current.push({ x: 1 });
+          result.current.push({ x: 0 });
+        });
+      });
+
+      expect(result.current.state.undoCount).toBe(0);
+    });
+  });
+
+  describe("clear", () => {
+    it("resets to initial state", () => {
+      const { result } = renderHook(() => useHistory({ initialState: 0 }));
+
+      act(() => {
+        result.current.push(1);
+        result.current.push(2);
+        result.current.push(3);
+      });
+
+      expect(result.current.state.current).toBe(3);
+      expect(result.current.state.undoCount).toBe(3);
+
+      act(() => {
+        result.current.clear();
+      });
+
+      expect(result.current.state.current).toBe(0);
+      expect(result.current.state.canUndo).toBe(false);
+      expect(result.current.state.canRedo).toBe(false);
+      expect(result.current.state.undoCount).toBe(0);
+      expect(result.current.state.redoCount).toBe(0);
+    });
+
+    it("clears redo stack as well", () => {
+      const { result } = renderHook(() => useHistory({ initialState: 0 }));
+
+      act(() => {
+        result.current.push(1);
+        result.current.push(2);
+      });
+
+      act(() => {
+        result.current.undo();
+      });
+
+      expect(result.current.state.canRedo).toBe(true);
+
+      act(() => {
+        result.current.clear();
+      });
+
+      expect(result.current.state.canRedo).toBe(false);
+    });
+  });
+
+  describe("stable function references", () => {
+    it("maintains stable references across renders", () => {
+      const { result, rerender } = renderHook(() =>
+        useHistory({ initialState: 0 }),
+      );
+
+      const initialPush = result.current.push;
+      const initialUndo = result.current.undo;
+      const initialRedo = result.current.redo;
+      const initialBatch = result.current.batch;
+      const initialClear = result.current.clear;
+
+      rerender();
+
+      expect(result.current.push).toBe(initialPush);
+      expect(result.current.undo).toBe(initialUndo);
+      expect(result.current.redo).toBe(initialRedo);
+      expect(result.current.batch).toBe(initialBatch);
+      expect(result.current.clear).toBe(initialClear);
+    });
+
+    it("maintains stable references after state changes", () => {
+      const { result } = renderHook(() => useHistory({ initialState: 0 }));
+
+      const initialPush = result.current.push;
+      const initialUndo = result.current.undo;
+
+      act(() => {
+        result.current.push(1);
+      });
+
+      expect(result.current.push).toBe(initialPush);
+      expect(result.current.undo).toBe(initialUndo);
+
+      act(() => {
+        result.current.undo();
+      });
+
+      expect(result.current.push).toBe(initialPush);
+      expect(result.current.undo).toBe(initialUndo);
+    });
+  });
+
+  describe("generic types", () => {
+    it("works with complex object types", () => {
+      interface EditorState {
+        blocks: Array<{ id: string; content: string }>;
+        selection: { start: number; end: number } | null;
+      }
+
+      const initialState: EditorState = {
+        blocks: [],
+        selection: null,
+      };
+
+      const { result } = renderHook(() => useHistory({ initialState }));
+
+      act(() => {
+        result.current.push({
+          blocks: [{ id: "1", content: "Hello" }],
+          selection: { start: 0, end: 5 },
+        });
+      });
+
+      expect(result.current.state.current.blocks).toHaveLength(1);
+      expect(result.current.state.current.selection).toEqual({
+        start: 0,
+        end: 5,
+      });
+    });
+
+    it("works with union types", () => {
+      type Status = "idle" | "loading" | "success" | "error";
+
+      const { result } = renderHook(() =>
+        useHistory<Status>({ initialState: "idle" }),
+      );
+
+      act(() => {
+        result.current.push("loading");
+      });
+
+      expect(result.current.state.current).toBe("loading");
+
+      act(() => {
+        result.current.push("success");
+      });
+
+      expect(result.current.state.current).toBe("success");
+
+      act(() => {
+        result.current.undo();
+      });
+
+      expect(result.current.state.current).toBe("loading");
+    });
+
+    it("preserves type safety for isEqual callback", () => {
+      interface Point {
+        x: number;
+        y: number;
+      }
+
+      const { result } = renderHook(() =>
+        useHistory<Point>({
+          initialState: { x: 0, y: 0 },
+          isEqual: (a, b) => a.x === b.x && a.y === b.y,
+        }),
+      );
+
+      act(() => {
+        result.current.push({ x: 1, y: 1 });
+      });
+
+      expect(result.current.state.current).toEqual({ x: 1, y: 1 });
+
+      act(() => {
+        result.current.push({ x: 1, y: 1 });
+      });
+
+      // Should not add duplicate
+      expect(result.current.state.undoCount).toBe(1);
+    });
+  });
+
+  describe("limit option", () => {
+    it("respects limit and drops oldest entries", () => {
+      const { result } = renderHook(() =>
+        useHistory({
+          initialState: 0,
+          limit: 3,
+        }),
+      );
+
+      act(() => {
+        result.current.push(1);
+        result.current.push(2);
+        result.current.push(3);
+        result.current.push(4);
+        result.current.push(5);
+      });
+
+      expect(result.current.state.current).toBe(5);
+      expect(result.current.state.undoCount).toBe(3);
+
+      act(() => {
+        result.current.undo();
+        result.current.undo();
+        result.current.undo();
+      });
+
+      // Should only go back 3 steps (to state 2, not 0 or 1)
+      expect(result.current.state.current).toBe(2);
+      expect(result.current.state.canUndo).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `useHistory` React hook wrapping the `createHistory` primitive from `packages/ui/src/primitives/history.ts`
- Provides React state management with automatic re-renders when history changes
- Uses `useRef` to store history controller, `useState` for render triggers, and `useCallback` for stable function references
- Supports generic types with configurable `limit` and `isEqual` options
- SSR safe (no DOM dependencies)

## Changes

- Added `packages/ui/src/hooks/use-history.ts` with full TypeScript types
- Added comprehensive test suite at `packages/ui/test/hooks/use-history.test.tsx` (21 tests)
- Updated `packages/ui/src/hooks/index.ts` to export the hook and types

## API

```typescript
interface UseHistoryOptions<T> {
  initialState: T;
  limit?: number;
  isEqual?: (a: T, b: T) => boolean;
}

interface UseHistoryReturn<T> {
  state: HistoryState<T>;
  push: (state: T) => void;
  undo: () => T | null;
  redo: () => T | null;
  batch: (fn: () => void) => void;
  clear: () => void;
}
```

## Test plan

- [x] Returns initial state correctly
- [x] push() updates state and triggers re-render
- [x] undo()/redo() navigate history with correct return values
- [x] batch() groups changes into single undo step
- [x] clear() resets to initial state
- [x] Stable function references maintained across renders
- [x] Works with complex generic types (objects, arrays, unions)
- [x] Respects limit option and isEqual callback
- [x] All 21 tests passing

Closes #624

Generated with [Claude Code](https://claude.ai/code)