### PR TITLE
feat(ui): add command palette primitive with fuzzy search (R-007)

### DIFF
--- a/packages/ui/src/primitives/command-palette.ts
+++ b/packages/ui/src/primitives/command-palette.ts
@@ -1,0 +1,572 @@
+/**
+ * Command Palette primitive
+ * Slash-triggered command palette with fuzzy search and keyboard navigation
+ *
+ * WCAG Compliance:
+ * - 2.1.1 Keyboard (Level A): Full keyboard navigation available
+ * - 2.1.2 No Keyboard Trap (Level A): Escape dismisses palette
+ * - 2.4.3 Focus Order (Level A): Logical focus order with arrow keys
+ *
+ * @example
+ * ```typescript
+ * const palette = createCommandPalette({
+ *   container: document.getElementById('editor'),
+ *   commands: [
+ *     { id: 'bold', label: 'Bold', action: () => toggleBold() },
+ *     { id: 'italic', label: 'Italic', action: () => toggleItalic() },
+ *   ],
+ *   onOpen: () => console.log('Palette opened'),
+ *   onClose: () => console.log('Palette closed'),
+ * });
+ * ```
+ */
+
+import type { CleanupFunction, Command } from './types';
+
+/**
+ * Result of fuzzy matching a query against text
+ */
+export interface FuzzyMatchResult {
+  /** Whether the query matches the text */
+  matches: boolean;
+  /** Score for ranking (higher is better) */
+  score: number;
+  /** Indices of matched characters for highlighting */
+  indices: number[];
+}
+
+/**
+ * Options for creating a command palette
+ */
+export interface CommandPaletteOptions {
+  /** Container element to attach keyboard listener to */
+  container: HTMLElement;
+  /** Trigger character (default '/') */
+  trigger?: string;
+  /** Available commands */
+  commands: Command[];
+  /** Callback when palette opens */
+  onOpen?: () => void;
+  /** Callback when palette closes */
+  onClose?: () => void;
+  /** Callback when selection changes */
+  onSelect?: (command: Command, index: number) => void;
+  /** Callback when command is executed */
+  onExecute?: (command: Command) => void;
+}
+
+/**
+ * Current state of the command palette
+ */
+export interface CommandPaletteState {
+  /** Whether the palette is open */
+  isOpen: boolean;
+  /** Current search query */
+  query: string;
+  /** Commands filtered by current query */
+  filteredCommands: Command[];
+  /** Index of currently selected command */
+  selectedIndex: number;
+}
+
+/**
+ * Command palette controller interface
+ */
+export interface CommandPaletteController {
+  /** Get current state */
+  getState: () => CommandPaletteState;
+  /** Open the palette */
+  open: () => void;
+  /** Close the palette */
+  close: () => void;
+  /** Update available commands */
+  setCommands: (commands: Command[]) => void;
+  /** Update search query and filter commands */
+  setQuery: (query: string) => void;
+  /** Select next command */
+  selectNext: () => void;
+  /** Select previous command */
+  selectPrevious: () => void;
+  /** Select first command */
+  selectFirst: () => void;
+  /** Select last command */
+  selectLast: () => void;
+  /** Execute currently selected command */
+  execute: () => void;
+  /** Cleanup event listeners */
+  cleanup: CleanupFunction;
+}
+
+/**
+ * Fuzzy match a query against text
+ *
+ * Scores matches based on:
+ * - Exact match: highest score
+ * - Prefix match: high score
+ * - Consecutive character matches: bonus
+ * - Character found: base score
+ *
+ * @example
+ * ```typescript
+ * const result = fuzzyMatch('Bold Text', 'bt');
+ * // { matches: true, score: X, indices: [0, 5] }
+ *
+ * const exact = fuzzyMatch('Bold', 'bold');
+ * // { matches: true, score: high, indices: [0, 1, 2, 3] }
+ * ```
+ */
+export function fuzzyMatch(text: string, query: string): FuzzyMatchResult {
+  if (!query) {
+    return { matches: true, score: 0, indices: [] };
+  }
+
+  const lowerText = text.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+
+  // Exact match (case-insensitive) gets highest score
+  if (lowerText === lowerQuery) {
+    const indices: number[] = [];
+    for (let i = 0; i < text.length; i++) {
+      indices.push(i);
+    }
+    return { matches: true, score: 1000, indices };
+  }
+
+  // Check if query is a substring (case-insensitive)
+  const substringIndex = lowerText.indexOf(lowerQuery);
+  if (substringIndex !== -1) {
+    const indices: number[] = [];
+    for (let i = 0; i < query.length; i++) {
+      indices.push(substringIndex + i);
+    }
+    // Prefix match gets higher score than substring elsewhere
+    const prefixBonus = substringIndex === 0 ? 500 : 0;
+    return { matches: true, score: 800 + prefixBonus, indices };
+  }
+
+  // Fuzzy character-by-character matching
+  const indices: number[] = [];
+  let score = 0;
+  let textIndex = 0;
+  let lastMatchIndex = -1;
+  let consecutiveBonus = 0;
+
+  for (let queryIndex = 0; queryIndex < lowerQuery.length; queryIndex++) {
+    const queryChar = lowerQuery[queryIndex];
+    let found = false;
+
+    while (textIndex < lowerText.length) {
+      if (lowerText[textIndex] === queryChar) {
+        indices.push(textIndex);
+        found = true;
+
+        // Consecutive match bonus
+        if (lastMatchIndex === textIndex - 1) {
+          consecutiveBonus += 10;
+        }
+
+        // Start of word bonus (after space or at beginning)
+        if (textIndex === 0 || text[textIndex - 1] === ' ') {
+          score += 20;
+        }
+
+        lastMatchIndex = textIndex;
+        textIndex++;
+        break;
+      }
+      textIndex++;
+    }
+
+    if (!found) {
+      return { matches: false, score: 0, indices: [] };
+    }
+  }
+
+  // Base score for each matched character plus bonuses
+  score += indices.length * 10 + consecutiveBonus;
+
+  return { matches: true, score, indices };
+}
+
+/**
+ * Score and filter commands based on query
+ */
+function filterCommands(commands: Command[], query: string): Command[] {
+  if (!query) {
+    return commands;
+  }
+
+  const scored: Array<{ command: Command; score: number }> = [];
+
+  for (const command of commands) {
+    // Match against label
+    const labelMatch = fuzzyMatch(command.label, query);
+    let bestScore = labelMatch.score;
+
+    // Match against description
+    if (command.description) {
+      const descMatch = fuzzyMatch(command.description, query);
+      if (descMatch.matches && descMatch.score > bestScore) {
+        bestScore = descMatch.score;
+      }
+    }
+
+    // Match against keywords
+    if (command.keywords) {
+      for (const keyword of command.keywords) {
+        const keywordMatch = fuzzyMatch(keyword, query);
+        if (keywordMatch.matches && keywordMatch.score > bestScore) {
+          bestScore = keywordMatch.score;
+        }
+      }
+    }
+
+    if (labelMatch.matches || bestScore > 0) {
+      scored.push({ command, score: bestScore });
+    }
+  }
+
+  // Sort by score descending
+  scored.sort((a, b) => b.score - a.score);
+
+  return scored.map((item) => item.command);
+}
+
+/**
+ * Check if trigger character should activate palette
+ * Only activates at start of line or after whitespace
+ */
+function shouldTrigger(container: HTMLElement, trigger: string, key: string): boolean {
+  if (key !== trigger) {
+    return false;
+  }
+
+  // Check selection position in contenteditable or input
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) {
+    return false;
+  }
+
+  const range = selection.getRangeAt(0);
+  if (!range.collapsed) {
+    return false;
+  }
+
+  const node = range.startContainer;
+  const offset = range.startOffset;
+
+  // At start of text node
+  if (offset === 0) {
+    // Check if this is start of container or previous is a block/whitespace
+    if (node === container || node.parentNode === container) {
+      return true;
+    }
+
+    // Check previous sibling or parent context
+    const parentElement = node.parentElement;
+    if (parentElement) {
+      const previousSibling = node.previousSibling;
+      if (!previousSibling) {
+        return true;
+      }
+      // Previous sibling is a block element (br, p, div, etc.)
+      if (
+        previousSibling.nodeType === Node.ELEMENT_NODE &&
+        (previousSibling as HTMLElement).tagName.match(/^(BR|P|DIV|LI|H[1-6])$/i)
+      ) {
+        return true;
+      }
+    }
+
+    return true;
+  }
+
+  // Check character before cursor
+  if (node.nodeType === Node.TEXT_NODE) {
+    const textContent = node.textContent || '';
+    const charBefore = textContent[offset - 1];
+    // Trigger after whitespace or at start
+    if (charBefore === ' ' || charBefore === '\t' || charBefore === '\n') {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Create a command palette with fuzzy search and keyboard navigation
+ *
+ * @example
+ * ```typescript
+ * const palette = createCommandPalette({
+ *   container: editorElement,
+ *   trigger: '/',
+ *   commands: [
+ *     { id: 'heading', label: 'Heading', keywords: ['h1', 'title'], action: insertHeading },
+ *     { id: 'bold', label: 'Bold', shortcut: 'Cmd+B', action: toggleBold },
+ *   ],
+ *   onOpen: () => showPaletteUI(),
+ *   onClose: () => hidePaletteUI(),
+ *   onSelect: (cmd, idx) => highlightItem(idx),
+ *   onExecute: (cmd) => console.log('Executed:', cmd.id),
+ * });
+ *
+ * // Programmatic control
+ * palette.open();
+ * palette.setQuery('head');
+ * palette.selectNext();
+ * palette.execute();
+ *
+ * // Cleanup
+ * palette.cleanup();
+ * ```
+ */
+export function createCommandPalette(options: CommandPaletteOptions): CommandPaletteController {
+  // SSR guard
+  if (typeof window === 'undefined') {
+    const noopState: CommandPaletteState = {
+      isOpen: false,
+      query: '',
+      filteredCommands: [],
+      selectedIndex: -1,
+    };
+    return {
+      getState: () => noopState,
+      open: () => {},
+      close: () => {},
+      setCommands: () => {},
+      setQuery: () => {},
+      selectNext: () => {},
+      selectPrevious: () => {},
+      selectFirst: () => {},
+      selectLast: () => {},
+      execute: () => {},
+      cleanup: () => {},
+    };
+  }
+
+  const { container, trigger = '/', onOpen, onClose, onSelect, onExecute } = options;
+
+  // Internal state
+  let commands = [...options.commands];
+  let isOpen = false;
+  let query = '';
+  let filteredCommands: Command[] = [];
+  let selectedIndex = -1;
+
+  /**
+   * Get current state
+   */
+  const getState = (): CommandPaletteState => ({
+    isOpen,
+    query,
+    filteredCommands,
+    selectedIndex,
+  });
+
+  /**
+   * Update filtered commands and selection
+   */
+  const updateFiltered = () => {
+    filteredCommands = filterCommands(commands, query);
+    if (filteredCommands.length > 0 && selectedIndex === -1) {
+      selectedIndex = 0;
+      const selected = filteredCommands[selectedIndex];
+      if (selected) {
+        onSelect?.(selected, selectedIndex);
+      }
+    } else if (filteredCommands.length === 0) {
+      selectedIndex = -1;
+    } else if (selectedIndex >= filteredCommands.length) {
+      selectedIndex = filteredCommands.length - 1;
+      const selected = filteredCommands[selectedIndex];
+      if (selected) {
+        onSelect?.(selected, selectedIndex);
+      }
+    }
+  };
+
+  /**
+   * Open the palette
+   */
+  const open = () => {
+    if (isOpen) return;
+    isOpen = true;
+    query = '';
+    filteredCommands = [...commands];
+    selectedIndex = filteredCommands.length > 0 ? 0 : -1;
+    onOpen?.();
+    if (selectedIndex >= 0) {
+      const selected = filteredCommands[selectedIndex];
+      if (selected) {
+        onSelect?.(selected, selectedIndex);
+      }
+    }
+  };
+
+  /**
+   * Close the palette
+   */
+  const close = () => {
+    if (!isOpen) return;
+    isOpen = false;
+    query = '';
+    filteredCommands = [];
+    selectedIndex = -1;
+    onClose?.();
+  };
+
+  /**
+   * Update available commands
+   */
+  const setCommands = (newCommands: Command[]) => {
+    commands = [...newCommands];
+    if (isOpen) {
+      updateFiltered();
+    }
+  };
+
+  /**
+   * Update search query
+   */
+  const setQuery = (newQuery: string) => {
+    query = newQuery;
+    updateFiltered();
+  };
+
+  /**
+   * Select next command
+   */
+  const selectNext = () => {
+    if (filteredCommands.length === 0) return;
+    selectedIndex = (selectedIndex + 1) % filteredCommands.length;
+    const selected = filteredCommands[selectedIndex];
+    if (selected) {
+      onSelect?.(selected, selectedIndex);
+    }
+  };
+
+  /**
+   * Select previous command
+   */
+  const selectPrevious = () => {
+    if (filteredCommands.length === 0) return;
+    selectedIndex = selectedIndex <= 0 ? filteredCommands.length - 1 : selectedIndex - 1;
+    const selected = filteredCommands[selectedIndex];
+    if (selected) {
+      onSelect?.(selected, selectedIndex);
+    }
+  };
+
+  /**
+   * Select first command
+   */
+  const selectFirst = () => {
+    if (filteredCommands.length === 0) return;
+    selectedIndex = 0;
+    const selected = filteredCommands[selectedIndex];
+    if (selected) {
+      onSelect?.(selected, selectedIndex);
+    }
+  };
+
+  /**
+   * Select last command
+   */
+  const selectLast = () => {
+    if (filteredCommands.length === 0) return;
+    selectedIndex = filteredCommands.length - 1;
+    const selected = filteredCommands[selectedIndex];
+    if (selected) {
+      onSelect?.(selected, selectedIndex);
+    }
+  };
+
+  /**
+   * Execute currently selected command
+   */
+  const execute = () => {
+    if (selectedIndex < 0 || selectedIndex >= filteredCommands.length) return;
+    const command = filteredCommands[selectedIndex];
+    if (command) {
+      close();
+      command.action();
+      onExecute?.(command);
+    }
+  };
+
+  /**
+   * Handle keydown events
+   */
+  const handleKeyDown = (event: KeyboardEvent) => {
+    const { key } = event;
+
+    // Check for trigger when palette is closed
+    if (!isOpen) {
+      if (shouldTrigger(container, trigger, key)) {
+        event.preventDefault();
+        open();
+      }
+      return;
+    }
+
+    // Handle palette navigation
+    switch (key) {
+      case 'Escape':
+        event.preventDefault();
+        close();
+        break;
+
+      case 'ArrowDown':
+        event.preventDefault();
+        selectNext();
+        break;
+
+      case 'ArrowUp':
+        event.preventDefault();
+        selectPrevious();
+        break;
+
+      case 'Enter':
+        event.preventDefault();
+        execute();
+        break;
+
+      case 'Home':
+        event.preventDefault();
+        selectFirst();
+        break;
+
+      case 'End':
+        event.preventDefault();
+        selectLast();
+        break;
+    }
+  };
+
+  // Attach event listener
+  container.addEventListener('keydown', handleKeyDown);
+
+  /**
+   * Cleanup function
+   */
+  const cleanup: CleanupFunction = () => {
+    container.removeEventListener('keydown', handleKeyDown);
+    close();
+  };
+
+  return {
+    getState,
+    open,
+    close,
+    setCommands,
+    setQuery,
+    selectNext,
+    selectPrevious,
+    selectFirst,
+    selectLast,
+    execute,
+    cleanup,
+  };
+}

--- a/packages/ui/test/primitives/command-palette.test.ts
+++ b/packages/ui/test/primitives/command-palette.test.ts
@@ -1,0 +1,713 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createCommandPalette, fuzzyMatch } from '../../src/primitives/command-palette';
+import type { Command } from '../../src/primitives/types';
+
+describe('fuzzyMatch', () => {
+  describe('exact matching', () => {
+    it('returns highest score for exact case-insensitive match', () => {
+      const result = fuzzyMatch('Bold', 'bold');
+      expect(result.matches).toBe(true);
+      expect(result.score).toBe(1000);
+      expect(result.indices).toEqual([0, 1, 2, 3]);
+    });
+
+    it('returns highest score for exact case-sensitive match', () => {
+      const result = fuzzyMatch('Bold', 'Bold');
+      expect(result.matches).toBe(true);
+      expect(result.score).toBe(1000);
+      expect(result.indices).toEqual([0, 1, 2, 3]);
+    });
+  });
+
+  describe('substring matching', () => {
+    it('scores prefix matches higher than substring elsewhere', () => {
+      const prefixResult = fuzzyMatch('Bold Text', 'bold');
+      const substringResult = fuzzyMatch('Make Bold', 'bold');
+
+      expect(prefixResult.matches).toBe(true);
+      expect(substringResult.matches).toBe(true);
+      expect(prefixResult.score).toBeGreaterThan(substringResult.score);
+    });
+
+    it('returns correct indices for substring match', () => {
+      const result = fuzzyMatch('Add Bold', 'bold');
+      expect(result.matches).toBe(true);
+      expect(result.indices).toEqual([4, 5, 6, 7]);
+    });
+
+    it('returns correct indices for prefix match', () => {
+      const result = fuzzyMatch('Bold Text', 'bold');
+      expect(result.matches).toBe(true);
+      expect(result.indices).toEqual([0, 1, 2, 3]);
+    });
+  });
+
+  describe('fuzzy character matching', () => {
+    it('matches non-consecutive characters', () => {
+      const result = fuzzyMatch('Bold Text', 'bt');
+      expect(result.matches).toBe(true);
+      expect(result.indices).toEqual([0, 5]);
+    });
+
+    it('matches characters spread across text', () => {
+      const result = fuzzyMatch('Insert Heading', 'ih');
+      expect(result.matches).toBe(true);
+      expect(result.indices).toEqual([0, 7]);
+    });
+
+    it('gives bonus for consecutive matches', () => {
+      const consecutiveResult = fuzzyMatch('Bold', 'bo');
+      const spreadResult = fuzzyMatch('B o l d', 'bo');
+
+      expect(consecutiveResult.matches).toBe(true);
+      expect(spreadResult.matches).toBe(true);
+      // Consecutive should score higher due to bonus
+      expect(consecutiveResult.score).toBeGreaterThan(spreadResult.score);
+    });
+
+    it('gives bonus for word boundary matches', () => {
+      const wordStartResult = fuzzyMatch('Bold Text', 'bt');
+      // Both B and T are at word boundaries
+      expect(wordStartResult.matches).toBe(true);
+      expect(wordStartResult.score).toBeGreaterThan(0);
+    });
+  });
+
+  describe('non-matching cases', () => {
+    it('returns no match when characters not found', () => {
+      const result = fuzzyMatch('Bold', 'xyz');
+      expect(result.matches).toBe(false);
+      expect(result.score).toBe(0);
+      expect(result.indices).toEqual([]);
+    });
+
+    it('returns no match when characters in wrong order', () => {
+      const result = fuzzyMatch('Bold', 'db');
+      expect(result.matches).toBe(false);
+      expect(result.score).toBe(0);
+      expect(result.indices).toEqual([]);
+    });
+
+    it('returns no match when not all characters found', () => {
+      const result = fuzzyMatch('Bold', 'boldy');
+      expect(result.matches).toBe(false);
+      expect(result.score).toBe(0);
+      expect(result.indices).toEqual([]);
+    });
+  });
+
+  describe('empty query', () => {
+    it('matches everything with empty query', () => {
+      const result = fuzzyMatch('Bold Text', '');
+      expect(result.matches).toBe(true);
+      expect(result.score).toBe(0);
+      expect(result.indices).toEqual([]);
+    });
+  });
+
+  describe('case insensitivity', () => {
+    it('matches regardless of case', () => {
+      const lowerResult = fuzzyMatch('BOLD', 'bold');
+      const upperResult = fuzzyMatch('bold', 'BOLD');
+      const mixedResult = fuzzyMatch('BoLd', 'bOlD');
+
+      expect(lowerResult.matches).toBe(true);
+      expect(upperResult.matches).toBe(true);
+      expect(mixedResult.matches).toBe(true);
+    });
+  });
+});
+
+describe('createCommandPalette', () => {
+  let container: HTMLDivElement;
+  let commands: Command[];
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.setAttribute('contenteditable', 'true');
+    document.body.appendChild(container);
+
+    commands = [
+      { id: 'bold', label: 'Bold', description: 'Make text bold', action: vi.fn() },
+      { id: 'italic', label: 'Italic', keywords: ['emphasis'], action: vi.fn() },
+      { id: 'heading', label: 'Heading 1', keywords: ['h1', 'title'], action: vi.fn() },
+      { id: 'link', label: 'Insert Link', description: 'Add hyperlink', action: vi.fn() },
+    ];
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  describe('opening and closing', () => {
+    it('starts in closed state', () => {
+      const palette = createCommandPalette({ container, commands });
+      expect(palette.getState().isOpen).toBe(false);
+      palette.cleanup();
+    });
+
+    it('opens programmatically', () => {
+      const onOpen = vi.fn();
+      const palette = createCommandPalette({ container, commands, onOpen });
+
+      palette.open();
+
+      expect(palette.getState().isOpen).toBe(true);
+      expect(onOpen).toHaveBeenCalledTimes(1);
+      palette.cleanup();
+    });
+
+    it('closes programmatically', () => {
+      const onClose = vi.fn();
+      const palette = createCommandPalette({ container, commands, onClose });
+
+      palette.open();
+      palette.close();
+
+      expect(palette.getState().isOpen).toBe(false);
+      expect(onClose).toHaveBeenCalledTimes(1);
+      palette.cleanup();
+    });
+
+    it('does not call onOpen if already open', () => {
+      const onOpen = vi.fn();
+      const palette = createCommandPalette({ container, commands, onOpen });
+
+      palette.open();
+      palette.open();
+
+      expect(onOpen).toHaveBeenCalledTimes(1);
+      palette.cleanup();
+    });
+
+    it('does not call onClose if already closed', () => {
+      const onClose = vi.fn();
+      const palette = createCommandPalette({ container, commands, onClose });
+
+      palette.close();
+
+      expect(onClose).not.toHaveBeenCalled();
+      palette.cleanup();
+    });
+
+    it('initializes with all commands when opened', () => {
+      const palette = createCommandPalette({ container, commands });
+
+      palette.open();
+
+      expect(palette.getState().filteredCommands).toHaveLength(4);
+      expect(palette.getState().selectedIndex).toBe(0);
+      palette.cleanup();
+    });
+
+    it('resets query when opened', () => {
+      const palette = createCommandPalette({ container, commands });
+
+      palette.open();
+      palette.setQuery('bold');
+      palette.close();
+      palette.open();
+
+      expect(palette.getState().query).toBe('');
+      palette.cleanup();
+    });
+  });
+
+  describe('keyboard trigger detection', () => {
+    it('opens on trigger at start of text', () => {
+      const onOpen = vi.fn();
+      const palette = createCommandPalette({ container, commands, onOpen });
+
+      // Set up selection at start
+      container.textContent = '';
+      container.focus();
+      const range = document.createRange();
+      range.setStart(container, 0);
+      range.collapse(true);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+
+      container.dispatchEvent(new KeyboardEvent('keydown', { key: '/', bubbles: true }));
+
+      expect(onOpen).toHaveBeenCalled();
+      palette.cleanup();
+    });
+
+    it('opens on trigger after whitespace', () => {
+      const onOpen = vi.fn();
+      const palette = createCommandPalette({ container, commands, onOpen });
+
+      // Set up text with cursor after space
+      container.textContent = 'Hello ';
+      container.focus();
+      const textNode = container.firstChild;
+      if (textNode) {
+        const range = document.createRange();
+        range.setStart(textNode, 6);
+        range.collapse(true);
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      }
+
+      container.dispatchEvent(new KeyboardEvent('keydown', { key: '/', bubbles: true }));
+
+      expect(onOpen).toHaveBeenCalled();
+      palette.cleanup();
+    });
+
+    it('does not open trigger mid-word', () => {
+      const onOpen = vi.fn();
+      const palette = createCommandPalette({ container, commands, onOpen });
+
+      // Set up text with cursor mid-word
+      container.textContent = 'Hello';
+      container.focus();
+      const textNode = container.firstChild;
+      if (textNode) {
+        const range = document.createRange();
+        range.setStart(textNode, 3);
+        range.collapse(true);
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      }
+
+      container.dispatchEvent(new KeyboardEvent('keydown', { key: '/', bubbles: true }));
+
+      expect(onOpen).not.toHaveBeenCalled();
+      palette.cleanup();
+    });
+
+    it('uses custom trigger character', () => {
+      const onOpen = vi.fn();
+      const palette = createCommandPalette({ container, commands, trigger: '@', onOpen });
+
+      container.textContent = '';
+      container.focus();
+      const range = document.createRange();
+      range.setStart(container, 0);
+      range.collapse(true);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+
+      // Default trigger should not work
+      container.dispatchEvent(new KeyboardEvent('keydown', { key: '/', bubbles: true }));
+      expect(onOpen).not.toHaveBeenCalled();
+
+      // Custom trigger should work
+      container.dispatchEvent(new KeyboardEvent('keydown', { key: '@', bubbles: true }));
+      expect(onOpen).toHaveBeenCalled();
+
+      palette.cleanup();
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    it('closes on Escape', () => {
+      const onClose = vi.fn();
+      const palette = createCommandPalette({ container, commands, onClose });
+
+      palette.open();
+      container.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+      expect(palette.getState().isOpen).toBe(false);
+      expect(onClose).toHaveBeenCalled();
+      palette.cleanup();
+    });
+
+    it('selects next on ArrowDown', () => {
+      const onSelect = vi.fn();
+      const palette = createCommandPalette({ container, commands, onSelect });
+
+      palette.open();
+      onSelect.mockClear();
+
+      container.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+
+      expect(palette.getState().selectedIndex).toBe(1);
+      expect(onSelect).toHaveBeenCalledWith(commands[1], 1);
+      palette.cleanup();
+    });
+
+    it('selects previous on ArrowUp', () => {
+      const onSelect = vi.fn();
+      const palette = createCommandPalette({ container, commands, onSelect });
+
+      palette.open();
+      palette.selectNext(); // Move to index 1
+      onSelect.mockClear();
+
+      container.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+
+      expect(palette.getState().selectedIndex).toBe(0);
+      expect(onSelect).toHaveBeenCalledWith(commands[0], 0);
+      palette.cleanup();
+    });
+
+    it('wraps from last to first on ArrowDown', () => {
+      const palette = createCommandPalette({ container, commands });
+
+      palette.open();
+      palette.selectLast();
+
+      container.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+
+      expect(palette.getState().selectedIndex).toBe(0);
+      palette.cleanup();
+    });
+
+    it('wraps from first to last on ArrowUp', () => {
+      const palette = createCommandPalette({ container, commands });
+
+      palette.open();
+
+      container.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+
+      expect(palette.getState().selectedIndex).toBe(3);
+      palette.cleanup();
+    });
+
+    it('executes on Enter', () => {
+      const onExecute = vi.fn();
+      const palette = createCommandPalette({ container, commands, onExecute });
+
+      palette.open();
+      container.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+      expect(commands[0]?.action).toHaveBeenCalled();
+      expect(onExecute).toHaveBeenCalledWith(commands[0]);
+      expect(palette.getState().isOpen).toBe(false);
+      palette.cleanup();
+    });
+
+    it('selects first on Home', () => {
+      const palette = createCommandPalette({ container, commands });
+
+      palette.open();
+      palette.selectLast();
+
+      container.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+
+      expect(palette.getState().selectedIndex).toBe(0);
+      palette.cleanup();
+    });
+
+    it('selects last on End', () => {
+      const palette = createCommandPalette({ container, commands });
+
+      palette.open();
+
+      container.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+
+      expect(palette.getState().selectedIndex).toBe(3);
+      palette.cleanup();
+    });
+
+    it('ignores navigation keys when closed', () => {
+      const palette = createCommandPalette({ container, commands });
+
+      container.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+      container.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+      container.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+      expect(palette.getState().isOpen).toBe(false);
+      palette.cleanup();
+    });
+  });
+
+  describe('command filtering', () => {
+    it('filters commands by label', () => {
+      const palette = createCommandPalette({ container, commands });
+
+      palette.open();
+      palette.setQuery('bold');
+
+      expect(palette.getState().filteredCommands).toHaveLength(1);
+      expect(palette.getState().filteredCommands[0]?.id).toBe('bold');
+      palette.cleanup();
+    });
+
+    it('filters commands by description', () => {
+      const palette = createCommandPalette({ container, commands });
+
+      palette.open();
+      palette.setQuery('hyperlink');
+
+      expect(palette.getState().filteredCommands).toHaveLength(1);
+      expect(palette.getState().filteredCommands[0]?.id).toBe('link');
+      palette.cleanup();
+    });
+
+    it('filters commands by keywords', () => {
+      const palette = createCommandPalette({ container, commands });
+
+      palette.open();
+      palette.setQuery('h1');
+
+      expect(palette.getState().filteredCommands).toHaveLength(1);
+      expect(palette.getState().filteredCommands[0]?.id).toBe('heading');
+      palette.cleanup();
+    });
+
+    it('shows all commands with empty query', () => {
+      const palette = createCommandPalette({ container, commands });
+
+      palette.open();
+      palette.setQuery('');
+
+      expect(palette.getState().filteredCommands).toHaveLength(4);
+      palette.cleanup();
+    });
+
+    it('shows no commands when none match', () => {
+      const palette = createCommandPalette({ container, commands });
+
+      palette.open();
+      palette.setQuery('zzzzz');
+
+      expect(palette.getState().filteredCommands).toHaveLength(0);
+      expect(palette.getState().selectedIndex).toBe(-1);
+      palette.cleanup();
+    });
+
+    it('adjusts selection when filter reduces list', () => {
+      const palette = createCommandPalette({ container, commands });
+
+      palette.open();
+      palette.selectLast(); // index 3
+      palette.setQuery('bold');
+
+      // Should adjust to valid index
+      expect(palette.getState().selectedIndex).toBe(0);
+      palette.cleanup();
+    });
+  });
+
+  describe('programmatic navigation', () => {
+    it('selectNext wraps around', () => {
+      const palette = createCommandPalette({ container, commands });
+
+      palette.open();
+      palette.selectNext();
+      palette.selectNext();
+      palette.selectNext();
+      palette.selectNext();
+
+      expect(palette.getState().selectedIndex).toBe(0);
+      palette.cleanup();
+    });
+
+    it('selectPrevious wraps around', () => {
+      const palette = createCommandPalette({ container, commands });
+
+      palette.open();
+      palette.selectPrevious();
+
+      expect(palette.getState().selectedIndex).toBe(3);
+      palette.cleanup();
+    });
+
+    it('selectFirst sets index to 0', () => {
+      const palette = createCommandPalette({ container, commands });
+
+      palette.open();
+      palette.selectLast();
+      palette.selectFirst();
+
+      expect(palette.getState().selectedIndex).toBe(0);
+      palette.cleanup();
+    });
+
+    it('selectLast sets index to last', () => {
+      const palette = createCommandPalette({ container, commands });
+
+      palette.open();
+      palette.selectLast();
+
+      expect(palette.getState().selectedIndex).toBe(3);
+      palette.cleanup();
+    });
+
+    it('navigation no-ops with empty commands', () => {
+      const palette = createCommandPalette({ container, commands: [] });
+
+      palette.open();
+      palette.selectNext();
+      palette.selectPrevious();
+      palette.selectFirst();
+      palette.selectLast();
+
+      expect(palette.getState().selectedIndex).toBe(-1);
+      palette.cleanup();
+    });
+  });
+
+  describe('execute', () => {
+    it('calls command action and closes palette', () => {
+      const onExecute = vi.fn();
+      const palette = createCommandPalette({ container, commands, onExecute });
+
+      palette.open();
+      palette.execute();
+
+      expect(commands[0]?.action).toHaveBeenCalled();
+      expect(onExecute).toHaveBeenCalledWith(commands[0]);
+      expect(palette.getState().isOpen).toBe(false);
+      palette.cleanup();
+    });
+
+    it('executes selected command', () => {
+      const palette = createCommandPalette({ container, commands });
+
+      palette.open();
+      palette.selectNext(); // Select second command
+      palette.execute();
+
+      expect(commands[0]?.action).not.toHaveBeenCalled();
+      expect(commands[1]?.action).toHaveBeenCalled();
+      palette.cleanup();
+    });
+
+    it('no-ops when no command selected', () => {
+      const onExecute = vi.fn();
+      const palette = createCommandPalette({ container, commands: [], onExecute });
+
+      palette.open();
+      palette.execute();
+
+      expect(onExecute).not.toHaveBeenCalled();
+      palette.cleanup();
+    });
+  });
+
+  describe('setCommands', () => {
+    it('updates available commands', () => {
+      const palette = createCommandPalette({ container, commands });
+      const newCommands: Command[] = [{ id: 'new', label: 'New Command', action: vi.fn() }];
+
+      palette.open();
+      palette.setCommands(newCommands);
+
+      expect(palette.getState().filteredCommands).toHaveLength(1);
+      expect(palette.getState().filteredCommands[0]?.id).toBe('new');
+      palette.cleanup();
+    });
+
+    it('applies current filter to new commands', () => {
+      const palette = createCommandPalette({ container, commands });
+      const newCommands: Command[] = [
+        { id: 'bold', label: 'Bold', action: vi.fn() },
+        { id: 'other', label: 'Other', action: vi.fn() },
+      ];
+
+      palette.open();
+      palette.setQuery('bold');
+      palette.setCommands(newCommands);
+
+      expect(palette.getState().filteredCommands).toHaveLength(1);
+      expect(palette.getState().filteredCommands[0]?.id).toBe('bold');
+      palette.cleanup();
+    });
+  });
+
+  describe('cleanup', () => {
+    it('removes event listeners', () => {
+      const onOpen = vi.fn();
+      const palette = createCommandPalette({ container, commands, onOpen });
+
+      palette.cleanup();
+
+      // Set up selection to allow trigger
+      container.textContent = '';
+      container.focus();
+      const range = document.createRange();
+      range.setStart(container, 0);
+      range.collapse(true);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+
+      container.dispatchEvent(new KeyboardEvent('keydown', { key: '/', bubbles: true }));
+
+      expect(onOpen).not.toHaveBeenCalled();
+    });
+
+    it('closes palette on cleanup', () => {
+      const onClose = vi.fn();
+      const palette = createCommandPalette({ container, commands, onClose });
+
+      palette.open();
+      palette.cleanup();
+
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('SSR safety', () => {
+    it('returns no-op controller in SSR environment', () => {
+      const originalWindow = globalThis.window;
+      // @ts-expect-error Testing SSR
+      delete globalThis.window;
+
+      const palette = createCommandPalette({ container, commands });
+
+      expect(palette.getState().isOpen).toBe(false);
+      expect(palette.getState().filteredCommands).toEqual([]);
+
+      // All methods should be no-ops
+      palette.open();
+      expect(palette.getState().isOpen).toBe(false);
+
+      palette.close();
+      palette.setCommands([]);
+      palette.setQuery('test');
+      palette.selectNext();
+      palette.selectPrevious();
+      palette.selectFirst();
+      palette.selectLast();
+      palette.execute();
+      palette.cleanup();
+
+      globalThis.window = originalWindow;
+    });
+  });
+
+  describe('callbacks', () => {
+    it('calls onSelect when selection changes', () => {
+      const onSelect = vi.fn();
+      const palette = createCommandPalette({ container, commands, onSelect });
+
+      palette.open();
+
+      // Called on open with first command selected
+      expect(onSelect).toHaveBeenCalledWith(commands[0], 0);
+
+      onSelect.mockClear();
+      palette.selectNext();
+      expect(onSelect).toHaveBeenCalledWith(commands[1], 1);
+
+      palette.cleanup();
+    });
+
+    it('calls onSelect when filtering changes selection to different command', () => {
+      const onSelect = vi.fn();
+      const palette = createCommandPalette({ container, commands, onSelect });
+
+      palette.open();
+      // Initially at index 0 with Bold selected
+      palette.selectLast(); // Move to last
+      onSelect.mockClear();
+
+      // Filter to only show italic - selection should adjust
+      palette.setQuery('italic');
+
+      // Selected index should be 0 (first in filtered list)
+      expect(palette.getState().selectedIndex).toBe(0);
+      expect(palette.getState().filteredCommands[0]?.id).toBe('italic');
+      palette.cleanup();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `createCommandPalette` function for slash-triggered command palette with fuzzy search and keyboard navigation
- Add `fuzzyMatch` function with score-based matching for command filtering
- Trigger detection at line start or after whitespace in contenteditable
- Full keyboard navigation: ArrowUp/Down, Home/End, Enter to execute, Escape to close
- Filter commands by label, description, and keywords
- SSR-safe implementation with no-op controller in server environments

## Test plan

- [x] Run `pnpm --filter=@rafters/ui test command-palette` - 55 tests passing
- [ ] Verify fuzzyMatch scoring: exact > prefix > substring > fuzzy
- [ ] Test trigger only fires at line start or after whitespace
- [ ] Verify keyboard navigation wraps correctly
- [ ] Test execute closes palette and runs command action
- [ ] Verify SSR returns no-op controller

Closes #611

Generated with [Claude Code](https://claude.ai/code)