### PR TITLE
feat(ui): add useBlockSelection hook for block-based editor selection

### DIFF
--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -3,9 +3,11 @@
  * @module hooks
  */
 
-// Hooks will be exported here as they are implemented
+// R-301: useHistory - not yet implemented
+// R-302: useClipboard - not yet implemented
+// R-303: useDragDrop - not yet implemented
+// R-304: useCommandPalette - not yet implemented
+
 // R-300: useBlockSelection
-// R-301: useHistory
-// R-302: useClipboard
-// R-303: useDragDrop
-// R-304: useCommandPalette
+export { useBlockSelection } from './use-block-selection';
+export type { UseBlockSelectionOptions, UseBlockSelectionReturn } from './use-block-selection';

--- a/packages/ui/src/hooks/use-block-selection.ts
+++ b/packages/ui/src/hooks/use-block-selection.ts
@@ -1,0 +1,249 @@
+/**
+ * React hook for block selection in editors
+ * Wraps the createBlockSelection primitive with React lifecycle management
+ * @module hooks/use-block-selection
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  type BlockSelectionController,
+  type BlockSelectionState,
+  createBlockSelection,
+} from '../primitives/selection';
+
+/**
+ * Options for the useBlockSelection hook
+ */
+export interface UseBlockSelectionOptions {
+  /**
+   * Function to get current block elements
+   * Called dynamically to handle DOM changes
+   */
+  getBlocks: () => HTMLElement[];
+
+  /**
+   * Callback fired when selection changes
+   */
+  onSelectionChange?: (selected: Set<string>) => void;
+
+  /**
+   * Whether multiple blocks can be selected
+   * @default true
+   */
+  multiSelect?: boolean;
+}
+
+/**
+ * Return type for the useBlockSelection hook
+ */
+export interface UseBlockSelectionReturn {
+  /**
+   * Ref callback to attach to the container element
+   * When element is set, creates the controller
+   * When element is detached (null), cleans up
+   */
+  ref: React.RefCallback<HTMLElement>;
+
+  /**
+   * Current selection state
+   * Updates when selection changes
+   */
+  state: BlockSelectionState;
+
+  /**
+   * Select a single block
+   * @param id Block ID to select
+   * @param additive If true, add to selection instead of replacing
+   */
+  select: (id: string, additive?: boolean) => void;
+
+  /**
+   * Select a range of blocks between two IDs (inclusive)
+   * @param fromId Start block ID
+   * @param toId End block ID
+   */
+  selectRange: (fromId: string, toId: string) => void;
+
+  /**
+   * Select all blocks
+   */
+  selectAll: () => void;
+
+  /**
+   * Clear all selection
+   */
+  clear: () => void;
+}
+
+/**
+ * Initial empty state for SSR and before container is attached
+ */
+const INITIAL_STATE: BlockSelectionState = {
+  selected: new Set<string>(),
+  anchor: null,
+  focus: null,
+};
+
+/**
+ * React hook for block selection behavior
+ * Wraps createBlockSelection primitive with React lifecycle management
+ *
+ * Features:
+ * - SSR safe: checks for window before creating controller
+ * - StrictMode compatible: handles double-mount cleanup properly
+ * - Ref callback pattern: creates/cleans up controller on mount/unmount
+ * - Stable function references: uses useCallback for all methods
+ *
+ * @example
+ * ```tsx
+ * function Editor() {
+ *   const { ref, state, select, clear } = useBlockSelection({
+ *     getBlocks: () => Array.from(
+ *       document.querySelectorAll('[data-block-id]')
+ *     ) as HTMLElement[],
+ *     onSelectionChange: (selected) => {
+ *       console.log('Selected blocks:', selected);
+ *     },
+ *   });
+ *
+ *   return (
+ *     <div ref={ref}>
+ *       <div data-block-id="block-1">Block 1</div>
+ *       <div data-block-id="block-2">Block 2</div>
+ *       <div data-block-id="block-3">Block 3</div>
+ *       <p>Selected: {state.selected.size} blocks</p>
+ *       <button onClick={clear}>Clear</button>
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export function useBlockSelection(options: UseBlockSelectionOptions): UseBlockSelectionReturn {
+  const { getBlocks, onSelectionChange, multiSelect = true } = options;
+
+  // Store controller in a ref to persist across renders
+  const controllerRef = useRef<BlockSelectionController | null>(null);
+
+  // Store the container element to manage lifecycle with useEffect
+  const elementRef = useRef<HTMLElement | null>(null);
+
+  // Store options in refs to avoid recreating controller on option changes
+  const getBlocksRef = useRef(getBlocks);
+  const onSelectionChangeRef = useRef(onSelectionChange);
+  const multiSelectRef = useRef(multiSelect);
+
+  // Keep refs up to date
+  useEffect(() => {
+    getBlocksRef.current = getBlocks;
+  }, [getBlocks]);
+
+  useEffect(() => {
+    onSelectionChangeRef.current = onSelectionChange;
+  }, [onSelectionChange]);
+
+  useEffect(() => {
+    multiSelectRef.current = multiSelect;
+  }, [multiSelect]);
+
+  // Track current selection state for React updates
+  const [state, setState] = useState<BlockSelectionState>(INITIAL_STATE);
+
+  /**
+   * Internal function to create the controller
+   * Uses refs to access current options without triggering re-creation
+   */
+  const createController = useCallback((element: HTMLElement) => {
+    // SSR guard
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    // Cleanup existing controller
+    if (controllerRef.current) {
+      controllerRef.current.cleanup();
+      controllerRef.current = null;
+    }
+
+    // Create new controller with handler that uses refs
+    controllerRef.current = createBlockSelection({
+      container: element,
+      getBlocks: () => getBlocksRef.current(),
+      onSelectionChange: (selected: Set<string>) => {
+        // Update React state to trigger re-render
+        const controller = controllerRef.current;
+        if (controller) {
+          setState(controller.getState());
+        }
+        // Call user callback via ref
+        onSelectionChangeRef.current?.(selected);
+      },
+      multiSelect: multiSelectRef.current,
+    });
+
+    // Initialize state from controller
+    setState(controllerRef.current.getState());
+  }, []);
+
+  /**
+   * Ref callback that manages controller lifecycle
+   * Creates controller when element is attached
+   * Cleans up when element is detached
+   */
+  const ref = useCallback(
+    (element: HTMLElement | null) => {
+      elementRef.current = element;
+
+      // Cleanup existing controller
+      if (controllerRef.current) {
+        controllerRef.current.cleanup();
+        controllerRef.current = null;
+      }
+
+      // Create new controller if element is provided
+      if (element !== null) {
+        createController(element);
+      } else {
+        // Reset to initial state when element is detached
+        setState(INITIAL_STATE);
+      }
+    },
+    [createController],
+  );
+
+  /**
+   * Select a single block
+   */
+  const select = useCallback((id: string, additive?: boolean) => {
+    controllerRef.current?.select(id, additive);
+  }, []);
+
+  /**
+   * Select a range of blocks
+   */
+  const selectRange = useCallback((fromId: string, toId: string) => {
+    controllerRef.current?.selectRange(fromId, toId);
+  }, []);
+
+  /**
+   * Select all blocks
+   */
+  const selectAll = useCallback(() => {
+    controllerRef.current?.selectAll();
+  }, []);
+
+  /**
+   * Clear all selection
+   */
+  const clear = useCallback(() => {
+    controllerRef.current?.clear();
+  }, []);
+
+  return {
+    ref,
+    state,
+    select,
+    selectRange,
+    selectAll,
+    clear,
+  };
+}

--- a/packages/ui/test/hooks/use-block-selection.test.tsx
+++ b/packages/ui/test/hooks/use-block-selection.test.tsx
@@ -1,0 +1,429 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StrictMode, useEffect, useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { useBlockSelection } from '../../src/hooks/use-block-selection';
+
+/**
+ * Test component that uses useBlockSelection hook
+ */
+function TestEditor({
+  onSelectionChange,
+  multiSelect = true,
+}: {
+  onSelectionChange?: (selected: Set<string>) => void;
+  multiSelect?: boolean;
+}) {
+  const { ref, state, select, selectRange, selectAll, clear } = useBlockSelection({
+    getBlocks: () =>
+      Array.from(document.querySelectorAll('[data-block-id]')) as HTMLElement[],
+    onSelectionChange,
+    multiSelect,
+  });
+
+  return (
+    <div ref={ref} data-testid="container">
+      <div data-block-id="block-1">Block 1</div>
+      <div data-block-id="block-2">Block 2</div>
+      <div data-block-id="block-3">Block 3</div>
+      <div data-testid="selected-count">{state.selected.size}</div>
+      <div data-testid="anchor">{state.anchor ?? 'null'}</div>
+      <div data-testid="focus">{state.focus ?? 'null'}</div>
+      <button type="button" data-testid="select-1" onClick={() => select('block-1')}>
+        Select 1
+      </button>
+      <button type="button" data-testid="select-2-additive" onClick={() => select('block-2', true)}>
+        Select 2 Additive
+      </button>
+      <button
+        type="button"
+        data-testid="select-range"
+        onClick={() => selectRange('block-1', 'block-3')}
+      >
+        Select Range
+      </button>
+      <button type="button" data-testid="select-all" onClick={selectAll}>
+        Select All
+      </button>
+      <button type="button" data-testid="clear" onClick={clear}>
+        Clear
+      </button>
+    </div>
+  );
+}
+
+describe('useBlockSelection', () => {
+  describe('ref callback', () => {
+    it('returns a ref callback', () => {
+      let capturedRef: React.RefCallback<HTMLElement> | null = null;
+
+      function CaptureRef() {
+        const { ref } = useBlockSelection({
+          getBlocks: () => [],
+        });
+        capturedRef = ref;
+        return null;
+      }
+
+      render(<CaptureRef />);
+
+      expect(typeof capturedRef).toBe('function');
+    });
+
+    it('creates controller when ref is attached', () => {
+      render(<TestEditor />);
+
+      // Verify container is rendered and accessible
+      const container = screen.getByTestId('container');
+      expect(container).toBeInTheDocument();
+
+      // Initial state should be empty
+      expect(screen.getByTestId('selected-count')).toHaveTextContent('0');
+    });
+
+    it('cleans up when ref is detached', async () => {
+      const onSelectionChange = vi.fn();
+
+      function ToggleEditor() {
+        const [show, setShow] = useState(true);
+
+        return (
+          <div>
+            {show && <TestEditor onSelectionChange={onSelectionChange} />}
+            <button type="button" data-testid="toggle" onClick={() => setShow(false)}>
+              Toggle
+            </button>
+          </div>
+        );
+      }
+
+      const user = userEvent.setup();
+      render(<ToggleEditor />);
+
+      // Select a block first
+      await user.click(screen.getByTestId('select-1'));
+      expect(onSelectionChange).toHaveBeenCalledWith(new Set(['block-1']));
+
+      // Reset mock to track post-unmount calls
+      onSelectionChange.mockClear();
+
+      // Unmount the editor
+      await user.click(screen.getByTestId('toggle'));
+
+      // The container should be gone
+      expect(screen.queryByTestId('container')).not.toBeInTheDocument();
+
+      // No selection changes should happen after unmount
+      expect(onSelectionChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('selection methods', () => {
+    it('select() selects a single block', async () => {
+      const user = userEvent.setup();
+      render(<TestEditor />);
+
+      await user.click(screen.getByTestId('select-1'));
+
+      expect(screen.getByTestId('selected-count')).toHaveTextContent('1');
+      expect(screen.getByTestId('anchor')).toHaveTextContent('block-1');
+      expect(screen.getByTestId('focus')).toHaveTextContent('block-1');
+    });
+
+    it('select() with additive adds to selection', async () => {
+      const user = userEvent.setup();
+      render(<TestEditor />);
+
+      await user.click(screen.getByTestId('select-1'));
+      await user.click(screen.getByTestId('select-2-additive'));
+
+      expect(screen.getByTestId('selected-count')).toHaveTextContent('2');
+    });
+
+    it('selectRange() selects multiple blocks', async () => {
+      const user = userEvent.setup();
+      render(<TestEditor />);
+
+      await user.click(screen.getByTestId('select-range'));
+
+      expect(screen.getByTestId('selected-count')).toHaveTextContent('3');
+      expect(screen.getByTestId('anchor')).toHaveTextContent('block-1');
+      expect(screen.getByTestId('focus')).toHaveTextContent('block-3');
+    });
+
+    it('selectAll() selects all blocks', async () => {
+      const user = userEvent.setup();
+      render(<TestEditor />);
+
+      await user.click(screen.getByTestId('select-all'));
+
+      expect(screen.getByTestId('selected-count')).toHaveTextContent('3');
+    });
+
+    it('clear() removes all selection', async () => {
+      const user = userEvent.setup();
+      render(<TestEditor />);
+
+      await user.click(screen.getByTestId('select-all'));
+      expect(screen.getByTestId('selected-count')).toHaveTextContent('3');
+
+      await user.click(screen.getByTestId('clear'));
+
+      expect(screen.getByTestId('selected-count')).toHaveTextContent('0');
+      expect(screen.getByTestId('anchor')).toHaveTextContent('null');
+      expect(screen.getByTestId('focus')).toHaveTextContent('null');
+    });
+  });
+
+  describe('state updates', () => {
+    it('updates state when selection changes', async () => {
+      const user = userEvent.setup();
+      render(<TestEditor />);
+
+      // Initial state
+      expect(screen.getByTestId('selected-count')).toHaveTextContent('0');
+
+      // After selection
+      await user.click(screen.getByTestId('select-1'));
+      expect(screen.getByTestId('selected-count')).toHaveTextContent('1');
+
+      // After additional selection
+      await user.click(screen.getByTestId('select-2-additive'));
+      expect(screen.getByTestId('selected-count')).toHaveTextContent('2');
+
+      // After clear
+      await user.click(screen.getByTestId('clear'));
+      expect(screen.getByTestId('selected-count')).toHaveTextContent('0');
+    });
+
+    it('calls onSelectionChange callback', async () => {
+      const onSelectionChange = vi.fn();
+      const user = userEvent.setup();
+      render(<TestEditor onSelectionChange={onSelectionChange} />);
+
+      await user.click(screen.getByTestId('select-1'));
+
+      expect(onSelectionChange).toHaveBeenCalledWith(new Set(['block-1']));
+    });
+
+    it('calls onSelectionChange with updated set on additive selection', async () => {
+      const onSelectionChange = vi.fn();
+      const user = userEvent.setup();
+      render(<TestEditor onSelectionChange={onSelectionChange} />);
+
+      await user.click(screen.getByTestId('select-1'));
+      await user.click(screen.getByTestId('select-2-additive'));
+
+      expect(onSelectionChange).toHaveBeenLastCalledWith(new Set(['block-1', 'block-2']));
+    });
+  });
+
+  describe('multiSelect option', () => {
+    it('replaces selection when multiSelect is false', async () => {
+      const user = userEvent.setup();
+      render(<TestEditor multiSelect={false} />);
+
+      await user.click(screen.getByTestId('select-1'));
+      await user.click(screen.getByTestId('select-2-additive'));
+
+      // Even with additive flag, should replace in single-select mode
+      expect(screen.getByTestId('selected-count')).toHaveTextContent('1');
+    });
+  });
+
+  describe('StrictMode compatibility', () => {
+    it('handles StrictMode double-mount correctly', async () => {
+      const onSelectionChange = vi.fn();
+
+      function StrictModeEditor() {
+        return (
+          <StrictMode>
+            <TestEditor onSelectionChange={onSelectionChange} />
+          </StrictMode>
+        );
+      }
+
+      const user = userEvent.setup();
+      render(<StrictModeEditor />);
+
+      // Should work correctly after StrictMode remount
+      await user.click(screen.getByTestId('select-1'));
+
+      expect(screen.getByTestId('selected-count')).toHaveTextContent('1');
+      expect(onSelectionChange).toHaveBeenCalledWith(new Set(['block-1']));
+    });
+
+    it('cleans up properly on StrictMode remount', () => {
+      // Track how many times the controller would be created
+      // We verify this by checking that selection works after remount
+      const onSelectionChange = vi.fn();
+
+      function TrackingEditor() {
+        const { ref, state } = useBlockSelection({
+          getBlocks: () =>
+            Array.from(document.querySelectorAll('[data-block-id]')) as HTMLElement[],
+          onSelectionChange,
+        });
+
+        return (
+          <div ref={ref} data-testid="container">
+            <div data-block-id="block-1">Block 1</div>
+            <div data-testid="count">{state.selected.size}</div>
+          </div>
+        );
+      }
+
+      render(
+        <StrictMode>
+          <TrackingEditor />
+        </StrictMode>,
+      );
+
+      // Verify the component rendered correctly after StrictMode remount
+      expect(screen.getByTestId('container')).toBeInTheDocument();
+      expect(screen.getByTestId('count')).toHaveTextContent('0');
+    });
+  });
+
+  describe('SSR safety', () => {
+    it('returns initial empty state before container is attached', () => {
+      function CheckInitialState() {
+        const { state } = useBlockSelection({
+          getBlocks: () => [],
+        });
+
+        return (
+          <div>
+            <div data-testid="size">{state.selected.size}</div>
+            <div data-testid="anchor">{state.anchor ?? 'null'}</div>
+            <div data-testid="focus">{state.focus ?? 'null'}</div>
+          </div>
+        );
+      }
+
+      render(<CheckInitialState />);
+
+      expect(screen.getByTestId('size')).toHaveTextContent('0');
+      expect(screen.getByTestId('anchor')).toHaveTextContent('null');
+      expect(screen.getByTestId('focus')).toHaveTextContent('null');
+    });
+
+    it('methods are no-ops before container is attached', () => {
+      function NoContainerComponent() {
+        const { state, select, selectRange, selectAll, clear } = useBlockSelection({
+          getBlocks: () => [],
+        });
+
+        // Call methods without attaching ref
+        useEffect(() => {
+          select('block-1');
+          selectRange('block-1', 'block-3');
+          selectAll();
+          clear();
+        }, [select, selectRange, selectAll, clear]);
+
+        return <div data-testid="size">{state.selected.size}</div>;
+      }
+
+      // Should not throw
+      render(<NoContainerComponent />);
+
+      // State should remain empty since no container was attached
+      expect(screen.getByTestId('size')).toHaveTextContent('0');
+    });
+  });
+
+  describe('click-based selection', () => {
+    it('selects block on click within container', async () => {
+      const user = userEvent.setup();
+      render(<TestEditor />);
+
+      // Click directly on a block
+      const block = screen.getByText('Block 2');
+      await user.click(block);
+
+      expect(screen.getByTestId('selected-count')).toHaveTextContent('1');
+    });
+
+    it('handles Ctrl+click for additive selection', async () => {
+      const user = userEvent.setup();
+      render(<TestEditor />);
+
+      // Click first block
+      await user.click(screen.getByText('Block 1'));
+
+      // Ctrl+click second block
+      await user.keyboard('{Control>}');
+      await user.click(screen.getByText('Block 2'));
+      await user.keyboard('{/Control}');
+
+      expect(screen.getByTestId('selected-count')).toHaveTextContent('2');
+    });
+
+    it('handles Shift+click for range selection', async () => {
+      const user = userEvent.setup();
+      render(<TestEditor />);
+
+      // Click first block
+      await user.click(screen.getByText('Block 1'));
+
+      // Shift+click third block
+      await user.keyboard('{Shift>}');
+      await user.click(screen.getByText('Block 3'));
+      await user.keyboard('{/Shift}');
+
+      expect(screen.getByTestId('selected-count')).toHaveTextContent('3');
+    });
+  });
+
+  describe('stable function references', () => {
+    it('maintains stable references across renders', async () => {
+      const references: {
+        select: (id: string, additive?: boolean) => void;
+        selectRange: (fromId: string, toId: string) => void;
+        selectAll: () => void;
+        clear: () => void;
+      }[] = [];
+
+      function CaptureReferences() {
+        const { ref, select, selectRange, selectAll, clear } = useBlockSelection({
+          getBlocks: () => [],
+        });
+
+        // Only capture on the first mount and after explicit rerender
+        useEffect(() => {
+          references.push({ select, selectRange, selectAll, clear });
+        });
+
+        const [, setCounter] = useState(0);
+
+        return (
+          <div ref={ref}>
+            <button type="button" data-testid="rerender" onClick={() => setCounter((c) => c + 1)}>
+              Rerender
+            </button>
+          </div>
+        );
+      }
+
+      const user = userEvent.setup();
+      render(<CaptureReferences />);
+
+      // Trigger a rerender via user interaction
+      await user.click(screen.getByTestId('rerender'));
+
+      // Compare references - should have at least 2 captures
+      expect(references.length).toBeGreaterThanOrEqual(2);
+
+      // Get last two references
+      const lastRef = references[references.length - 1];
+      const prevRef = references[references.length - 2];
+
+      // select, selectRange, selectAll, clear should be stable (useCallback with empty deps)
+      expect(prevRef?.select).toBe(lastRef?.select);
+      expect(prevRef?.selectRange).toBe(lastRef?.selectRange);
+      expect(prevRef?.selectAll).toBe(lastRef?.selectAll);
+      expect(prevRef?.clear).toBe(lastRef?.clear);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implement `useBlockSelection` React hook that wraps the `createBlockSelection` primitive
- Ref callback pattern for clean container mount/unmount handling
- SSR safe (checks for window before creating controller)
- StrictMode compatible (handles double-mount cleanup properly)
- Stable function references via `useCallback` for performance
- State updates on selection change trigger React re-renders

## Test plan
- [x] Unit tests for ref callback (creates controller, cleans up)
- [x] Unit tests for selection methods (select, selectRange, selectAll, clear)
- [x] Unit tests for state updates and callbacks
- [x] Unit tests for StrictMode compatibility
- [x] Unit tests for SSR safety
- [x] Unit tests for click-based selection
- [x] Unit tests for stable function references

Closes #623

Generated with [Claude Code](https://claude.ai/code)