### PR TITLE
fix(ui): ensure 44x44px minimum target size for editor controls (#651)

### DIFF
--- a/packages/ui/src/components/editor/BlockSidebar.tsx
+++ b/packages/ui/src/components/editor/BlockSidebar.tsx
@@ -497,7 +497,7 @@ export function BlockSidebar({
         {onCollapse && (
           <button
             type="button"
-            className="p-3 hover:bg-muted transition-colors flex-shrink-0"
+            className="min-h-11 min-w-11 p-3 hover:bg-muted transition-colors flex-shrink-0"
             onClick={handleCollapseToggle}
             aria-label="Expand sidebar"
           >
@@ -577,7 +577,7 @@ export function BlockSidebar({
         {onCollapse && (
           <button
             type="button"
-            className="p-1.5 rounded hover:bg-muted transition-colors"
+            className="min-h-11 min-w-11 p-1.5 rounded hover:bg-muted transition-colors"
             onClick={handleCollapseToggle}
             aria-label="Collapse sidebar"
           >

--- a/packages/ui/src/components/editor/BlockWrapper.tsx
+++ b/packages/ui/src/components/editor/BlockWrapper.tsx
@@ -237,7 +237,7 @@ export function BlockWrapper({
   const handleClasses = classy(
     'absolute left-0 top-1/2 -translate-y-1/2 -translate-x-full',
     'flex items-center justify-center',
-    'w-6 h-8 mr-1',
+    'min-h-11 min-w-11 mr-1',
     'text-muted-foreground hover:text-foreground',
     'cursor-grab active:cursor-grabbing',
     'opacity-0 transition-opacity duration-150',
@@ -248,7 +248,7 @@ export function BlockWrapper({
   const menuButtonClasses = classy(
     'absolute right-0 top-1/2 -translate-y-1/2 translate-x-full',
     'flex items-center justify-center',
-    'w-6 h-6 ml-1',
+    'min-h-11 min-w-11 ml-1',
     'rounded hover:bg-muted',
     'text-muted-foreground hover:text-foreground',
     'opacity-0 transition-opacity duration-150',

--- a/packages/ui/src/components/editor/EditorToolbar.tsx
+++ b/packages/ui/src/components/editor/EditorToolbar.tsx
@@ -248,7 +248,7 @@ function ToolbarButton({ onClick, disabled, label, shortcut, children }: Toolbar
           disabled={disabled}
           aria-label={label}
           aria-disabled={disabled ? 'true' : undefined}
-          className="h-8 w-8"
+          className="h-11 w-11"
         >
           {children}
         </Button>

--- a/packages/ui/src/components/editor/InlineToolbar.tsx
+++ b/packages/ui/src/components/editor/InlineToolbar.tsx
@@ -408,7 +408,7 @@ function FormatButton({ config, isActive, onClick }: FormatButtonProps): React.J
           onClick={onClick}
           aria-pressed={isActive}
           data-testid={`format-${config.format}`}
-          className="h-8 w-8"
+          className="h-11 w-11"
         >
           {config.icon}
           <span className="sr-only">{config.label}</span>
@@ -598,7 +598,7 @@ export function InlineToolbar({
                   size="icon"
                   aria-pressed={isLinkActive}
                   data-testid="format-link"
-                  className="h-8 w-8"
+                  className="h-11 w-11"
                 >
                   <LinkIcon />
                   <span className="sr-only">Link</span>
@@ -627,7 +627,7 @@ export function InlineToolbar({
                 size="icon"
                 onClick={handleUnlinkClick}
                 data-testid="unlink-button"
-                className="h-8 w-8"
+                className="h-11 w-11"
               >
                 <UnlinkIcon />
                 <span className="sr-only">Remove link</span>


### PR DESCRIPTION
## Summary
- Update all interactive elements in editor components to meet WCAG 2.5.5 Target Size (Enhanced) requirement of 44x44 CSS pixels minimum
- Affected components: BlockSidebar, BlockWrapper, InlineToolbar, EditorToolbar

## Test plan
- [ ] Verify all buttons/controls in editor components measure at least 44x44 CSS pixels
- [ ] Test touch interactions on mobile/tablet devices
- [ ] Run accessibility audit to confirm compliance

Closes #651

Generated with [Claude Code](https://claude.ai/code)