### PR TITLE
feat(studio): semantic done state and why editing (#692, #721)

### DIFF
--- a/packages/studio/src/components/first-run/SemanticChoices.tsx
+++ b/packages/studio/src/components/first-run/SemanticChoices.tsx
@@ -8,31 +8,73 @@
 
 import { useCallback, useMemo, useState } from 'react';
 import { useStudioDispatch, useStudioState } from '../../context/StudioContext';
+import { generateColorScale } from '../../lib/color-scale';
 import { useTokenMutation } from '../../lib/query';
 import { generateSemanticSuggestions } from '../../lib/semantic-suggestions';
 import { SEMANTIC_INTENTS, type SemanticIntent } from '../../types';
 import { type OKLCH, oklchToHex } from '../../utils/color-conversion';
+import { ColorScale } from '../shared/ColorScale';
 import { WhyGate } from '../shared/WhyGate';
 
 interface SemanticChoicesProps {
   onComplete: () => void;
 }
 
+/** Done state: shows chosen color prominently with its generated scale */
+function SemanticDone({ intent, color }: { intent: SemanticIntent; color: OKLCH }) {
+  const scale = useMemo(() => generateColorScale(color), [color]);
+
+  let hex: string;
+  try {
+    hex = oklchToHex(color);
+  } catch {
+    hex = '#808080';
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      {/* Chosen color box */}
+      <div
+        className="shrink-0 rounded-xl"
+        style={{ width: 48, height: 48, backgroundColor: hex }}
+        title={intent}
+      />
+      {/* Generated scale */}
+      <ColorScale scale={scale} size={24} />
+      {/* Done indicator */}
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 20 20"
+        fill="none"
+        className="shrink-0 text-green-600"
+        role="img"
+        aria-label={`${intent} complete`}
+      >
+        <path
+          d="M16.7 5.3a1 1 0 010 1.4l-8 8a1 1 0 01-1.4 0l-4-4a1 1 0 111.4-1.4L8 12.6l7.3-7.3a1 1 0 011.4 0z"
+          fill="currentColor"
+        />
+      </svg>
+    </div>
+  );
+}
+
 function SemanticRow({
   intent,
   suggestions,
   onPick,
-  completed,
+  chosenColor,
 }: {
   intent: SemanticIntent;
   suggestions: OKLCH[];
   onPick: (intent: SemanticIntent, color: OKLCH) => void;
-  completed: boolean;
+  chosenColor: OKLCH | null;
 }) {
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
 
-  if (completed) {
-    return null; // Will be replaced by done state
+  if (chosenColor) {
+    return <SemanticDone intent={intent} color={chosenColor} />;
   }
 
   return (
@@ -81,6 +123,9 @@ export function SemanticChoices({ onComplete }: SemanticChoicesProps) {
   const { completedSemantics, primaryColor } = useStudioState();
   const tokenMutation = useTokenMutation();
 
+  // Track chosen colors for displaying done state
+  const [chosenColors, setChosenColors] = useState<Partial<Record<SemanticIntent, OKLCH>>>({});
+
   // Compute suggestions for all intents based on primary color
   const suggestionsByIntent = useMemo(() => {
     const primary: OKLCH = primaryColor ?? { l: 0.55, c: 0.15, h: 260 };
@@ -90,6 +135,7 @@ export function SemanticChoices({ onComplete }: SemanticChoicesProps) {
     }
     return result;
   }, [primaryColor]);
+
   const [pendingIntent, setPendingIntent] = useState<{
     intent: SemanticIntent;
     color: OKLCH;
@@ -103,6 +149,10 @@ export function SemanticChoices({ onComplete }: SemanticChoicesProps) {
     (reason: string) => {
       if (!pendingIntent) return;
       const { intent, color } = pendingIntent;
+
+      // Store chosen color for done state display
+      setChosenColors((prev) => ({ ...prev, [intent]: color }));
+
       dispatch({ type: 'COMPLETE_SEMANTIC', intent });
       tokenMutation.mutate({
         namespace: 'semantic',
@@ -138,7 +188,7 @@ export function SemanticChoices({ onComplete }: SemanticChoicesProps) {
           intent={intent}
           suggestions={suggestionsByIntent[intent] ?? []}
           onPick={handlePick}
-          completed={completedSemantics.has(intent)}
+          chosenColor={chosenColors[intent] ?? null}
         />
       ))}
     </div>

--- a/packages/studio/src/components/shared/WhyGate.tsx
+++ b/packages/studio/src/components/shared/WhyGate.tsx
@@ -12,10 +12,16 @@ interface WhyGateProps {
   onCommit: (reason: string) => void;
   context?: string;
   intelligenceHints?: string[];
+  initialValue?: string;
 }
 
-export function WhyGate({ onCommit, context = 'primary', intelligenceHints }: WhyGateProps) {
-  const [reason, setReason] = useState('');
+export function WhyGate({
+  onCommit,
+  context = 'primary',
+  intelligenceHints,
+  initialValue = '',
+}: WhyGateProps) {
+  const [reason, setReason] = useState(initialValue);
   const [showEnforcement, setShowEnforcement] = useState(false);
 
   const handleSubmit = useCallback(() => {

--- a/packages/studio/src/components/workspaces/ColorWorkspace.tsx
+++ b/packages/studio/src/components/workspaces/ColorWorkspace.tsx
@@ -117,6 +117,21 @@ export function ColorWorkspace() {
     [menuTarget, tokenMutation, handleClose],
   );
 
+  const handleReasonEdit = useCallback(
+    (reason: string) => {
+      if (!menuTarget) return;
+      // Update reason without changing value
+      tokenMutation.mutate({
+        namespace: menuTarget.namespace,
+        name: menuTarget.name,
+        value: menuTarget.value,
+        reason,
+      });
+      handleClose();
+    },
+    [menuTarget, tokenMutation, handleClose],
+  );
+
   const colorTokens = (data?.tokens.color || []).filter(isColorToken);
   const semanticTokens = (data?.tokens.semantic || []).filter(isColorToken);
 
@@ -180,7 +195,9 @@ export function ColorWorkspace() {
           onClose={handleClose}
           color={menuColor}
           tokenName={menuTarget.name}
+          existingReason={menuTarget.userOverride?.reason}
           onCommit={handleCommit}
+          onReasonEdit={handleReasonEdit}
         />
       )}
     </div>

--- a/packages/studio/src/lib/color-scale.ts
+++ b/packages/studio/src/lib/color-scale.ts
@@ -1,0 +1,22 @@
+/**
+ * Color Scale Generation
+ *
+ * Generates 11-position lightness scale from a base OKLCH color.
+ * Positions: 50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950
+ */
+
+import type { OKLCH } from '../utils/color-conversion';
+
+const SCALE_POSITIONS = [0.97, 0.93, 0.85, 0.75, 0.65, 0.55, 0.45, 0.35, 0.25, 0.18, 0.12];
+
+/**
+ * Generate an 11-position lightness scale from a base color.
+ * The 500 position uses the base color's lightness; others interpolate.
+ */
+export function generateColorScale(base: OKLCH): OKLCH[] {
+  return SCALE_POSITIONS.map((l, i) => ({
+    l: i === 5 ? base.l : l,
+    c: base.c,
+    h: base.h,
+  }));
+}


### PR DESCRIPTION
## Summary
- Add `SemanticDone` component showing chosen color + 11-position lightness scale + checkmark after semantic color selection
- Add `color-scale.ts` for generating lightness scales from base OKLCH color (50-950 positions)
- Add why editing to `ColorContextMenu` - displays existing reason with "Edit reasoning..." option
- Add `initialValue` prop to `WhyGate` for pre-filling when editing existing reasons

## Test plan
- [ ] Complete first-run semantic selection, verify chosen colors display with scale and checkmark
- [ ] Right-click a color token that has an existing reason, verify reason displays
- [ ] Click "Edit reasoning..." and verify WhyGate pre-fills with existing reason
- [ ] Submit edited reason and verify it updates

Closes #692, closes #721

Generated with [Claude Code](https://claude.ai/claude-code)