### PR TITLE
feat(studio): add Vite plugin for WebSocket token updates

### DIFF
--- a/packages/design-tokens/test/playground.ts
+++ b/packages/design-tokens/test/playground.ts
@@ -1,11 +1,12 @@
 /**
- * Playground - Watch registry changes cascade through JSON and CSS
+ * Playground - Explore rich token values (ColorReference, ColorValue)
  *
  * Run with: pnpm exec tsx test/playground.ts
  */
 
 import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import type { ColorReference, Token } from '@rafters/shared';
 import { registryToTailwind } from '../src/exporters/tailwind.js';
 import { NodePersistenceAdapter } from '../src/persistence/node-adapter.js';
 import { TokenRegistry } from '../src/registry.js';
@@ -15,86 +16,83 @@ const RAFTERS_DIR = join(PROJECT_ROOT, '.rafters');
 const OUTPUT_DIR = join(RAFTERS_DIR, 'output');
 
 async function main() {
-  console.log('\n=== Registry Playground ===\n');
+  console.log('\n=== Registry Playground - Rich Token Values ===\n');
 
   // Load tokens
   const adapter = new NodePersistenceAdapter(PROJECT_ROOT);
   const tokens = await adapter.load();
-  console.log(`Loaded ${tokens.length} tokens from .rafters/tokens/`);
+  console.log(`Loaded ${tokens.length} tokens`);
 
-  // Create registry with dependency graph populated
   const registry = new TokenRegistry(tokens);
   registry.setAdapter(adapter);
 
-  // Show initial state
+  // --- Explore different value types ---
+
+  console.log('\n--- Token Value Types ---');
+
+  // 1. String value (spacing, simple colors)
   const spacingBase = registry.get('spacing-base');
-  const spacing4 = registry.get('spacing-4');
+  console.log(`\nspacing-base (string):`);
+  console.log(`  value: ${spacingBase?.value}`);
+  console.log(`  type: ${typeof spacingBase?.value}`);
+
+  // 2. ColorReference value (semantic tokens)
   const primary = registry.get('primary');
-
-  console.log('\n--- Initial Token State ---');
-  console.log(`spacing-base: ${spacingBase?.value}`);
-  console.log(`spacing-4: ${spacing4?.value}`);
-  console.log(`primary: ${JSON.stringify(primary?.value)}`);
-
-  // Show dependency graph
-  console.log('\n--- Dependency Graph ---');
-  const spacingBaseDependents = registry.getDependents('spacing-base');
-  console.log(`spacing-base has ${spacingBaseDependents.length} dependents:`);
-  console.log(
-    `  ${spacingBaseDependents.slice(0, 8).join(', ')}${spacingBaseDependents.length > 8 ? '...' : ''}`,
-  );
-
-  const spacing4Deps = registry.getDependencies('spacing-4');
-  console.log(`spacing-4 depends on: ${spacing4Deps.join(', ') || 'nothing'}`);
-  console.log(`spacing-4 rule: ${spacing4?.generationRule}`);
-
-  // Set up change callback for CSS export
-  let changeCount = 0;
-  registry.setChangeCallback(async (event) => {
-    changeCount++;
-    if (event.type === 'token-changed') {
-      console.log(`  [${changeCount}] ${event.tokenName}: ${event.oldValue} -> ${event.newValue}`);
-    }
-  });
-
-  // Test cascade: change spacing-base
-  console.log('\n--- Testing Cascade ---');
-  console.log('Changing spacing-base from 0.25rem to 0.3rem...');
-  const originalBase = spacingBase?.value;
-  await registry.set('spacing-base', '0.3rem');
-
-  // Show cascaded changes
-  const newSpacing4 = registry.get('spacing-4');
-  const newSpacing8 = registry.get('spacing-8');
-  console.log(`\nAfter cascade:`);
-  console.log(`  spacing-4: ${newSpacing4?.value}`);
-  console.log(`  spacing-8: ${newSpacing8?.value}`);
-
-  // Check persistence
-  const spacingJson = await readFile(join(RAFTERS_DIR, 'tokens/spacing.rafters.json'), 'utf-8');
-  const spacingData = JSON.parse(spacingJson);
-  const savedBase = spacingData.tokens.find((t: { name: string }) => t.name === 'spacing-base');
-  const savedS4 = spacingData.tokens.find((t: { name: string }) => t.name === 'spacing-4');
-  console.log(`\nIn spacing.rafters.json:`);
-  console.log(`  spacing-base: ${savedBase?.value}`);
-  console.log(`  spacing-4: ${savedS4?.value}`);
-
-  // Restore original value
-  console.log('\n--- Restoring ---');
-  console.log(`Restoring spacing-base to ${originalBase}...`);
-  if (originalBase) {
-    await registry.set('spacing-base', originalBase);
+  console.log(`\nprimary (ColorReference):`);
+  console.log(`  value: ${JSON.stringify(primary?.value)}`);
+  if (primary?.value && typeof primary.value === 'object' && 'family' in primary.value) {
+    const ref = primary.value as ColorReference;
+    console.log(`  family: ${ref.family}`);
+    console.log(`  position: ${ref.position}`);
+    console.log(`  -> resolves to: ${ref.family}-${ref.position}`);
   }
 
-  // Generate CSS to show the output format
+  // 3. Check destructive (another semantic)
+  const destructive = registry.get('destructive');
+  console.log(`\ndestructive (ColorReference):`);
+  console.log(`  value: ${JSON.stringify(destructive?.value)}`);
+
+  // --- Test setting a ColorReference ---
+
+  console.log('\n--- Setting ColorReference ---');
+  const originalPrimary = primary?.value;
+
+  // Change primary to point to a different color family/position
+  const newPrimaryRef: ColorReference = { family: 'neutral', position: '700' };
+  console.log(
+    `Changing primary from ${JSON.stringify(originalPrimary)} to ${JSON.stringify(newPrimaryRef)}`,
+  );
+
+  await registry.set('primary', newPrimaryRef);
+
+  // Verify the change
+  const updatedPrimary = registry.get('primary');
+  console.log(`\nAfter set():`);
+  console.log(`  primary.value: ${JSON.stringify(updatedPrimary?.value)}`);
+
+  // Check persistence
+  const semanticJson = await readFile(join(RAFTERS_DIR, 'tokens/semantic.rafters.json'), 'utf-8');
+  const semanticData = JSON.parse(semanticJson);
+  const savedPrimary = semanticData.tokens.find((t: Token) => t.name === 'primary');
+  console.log(`\nIn semantic.rafters.json:`);
+  console.log(`  primary.value: ${JSON.stringify(savedPrimary?.value)}`);
+
+  // --- Restore ---
+  console.log('\n--- Restoring ---');
+  if (originalPrimary) {
+    await registry.set('primary', originalPrimary);
+    console.log(`Restored primary to: ${JSON.stringify(originalPrimary)}`);
+  }
+
+  // --- Generate CSS to see how ColorReferences resolve ---
+  console.log('\n--- CSS Output ---');
   const css = registryToTailwind(registry, { includeImport: true });
   await writeFile(join(OUTPUT_DIR, 'playground.css'), css);
-  console.log(`\nGenerated ${OUTPUT_DIR}/playground.css (${Math.round(css.length / 1024)}KB)`);
 
-  // Show a snippet of the CSS
-  const spacingVars = css.match(/--spacing-[^:]+:[^;]+;/g)?.slice(0, 5) || [];
-  console.log('\nCSS snippet (spacing variables):');
-  for (const v of spacingVars) {
+  // Find primary-related CSS
+  const primaryCss = css.match(/--primary[^;]*;/g)?.slice(0, 3) || [];
+  console.log('Primary CSS variables:');
+  for (const v of primaryCss) {
     console.log(`  ${v}`);
   }
 

--- a/packages/studio/src/api/index.ts
+++ b/packages/studio/src/api/index.ts
@@ -1,0 +1,92 @@
+/**
+ * Client-side token API for Studio
+ *
+ * Uses Vite's HMR WebSocket for instant updates.
+ *
+ * Two-phase color selection:
+ * 1. setToken({ name, value, persist: false }) - instant feedback, no disk write
+ * 2. setToken({ name, value }) - complete data, persists to disk
+ */
+
+import type { Token } from '@rafters/shared';
+
+interface SetTokenOptions {
+  name: string;
+  value: Token['value'];
+  persist?: boolean; // default true - set false for instant feedback
+}
+
+type UpdateResult = { ok: true; name: string; persisted: boolean } | { ok: false; error: string };
+
+const TOKEN_UPDATE_TIMEOUT_MS = 10_000;
+
+/**
+ * Check if HMR is fully available (not just partially defined)
+ */
+function isHmrAvailable(): boolean {
+  return Boolean(
+    import.meta.hot &&
+      typeof import.meta.hot.on === 'function' &&
+      typeof import.meta.hot.off === 'function' &&
+      typeof import.meta.hot.send === 'function',
+  );
+}
+
+/**
+ * Send a token update to the Vite plugin.
+ *
+ * @param options.persist - Set to false for instant feedback without disk write.
+ *                          Default true persists to .rafters/tokens/*.json
+ */
+export function setToken(options: SetTokenOptions): Promise<UpdateResult> {
+  return new Promise((resolve) => {
+    if (!isHmrAvailable()) {
+      console.warn('[rafters] setToken called but HMR is not available');
+      resolve({ ok: false, error: 'HMR not available' });
+      return;
+    }
+
+    // biome-ignore lint/style/noNonNullAssertion: checked by isHmrAvailable
+    const hot = import.meta.hot!;
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    const cleanup = () => {
+      clearTimeout(timeoutId);
+      hot.off('rafters:token-updated', handler);
+    };
+
+    const handler = (result: UpdateResult) => {
+      // Match response to our request by name, or accept any error
+      if ((result.ok && result.name === options.name) || !result.ok) {
+        cleanup();
+        resolve(result);
+      }
+    };
+
+    // Timeout after 10 seconds
+    timeoutId = setTimeout(() => {
+      cleanup();
+      resolve({ ok: false, error: `Token update timed out after ${TOKEN_UPDATE_TIMEOUT_MS}ms` });
+    }, TOKEN_UPDATE_TIMEOUT_MS);
+
+    hot.on('rafters:token-updated', handler);
+    hot.send('rafters:set-token', options);
+  });
+}
+
+/**
+ * Listen for CSS updates (for UI feedback).
+ */
+export function onCssUpdated(callback: () => void): () => void {
+  if (!isHmrAvailable()) {
+    if (import.meta.env?.DEV) {
+      console.warn('[rafters] onCssUpdated called but HMR is not available');
+    }
+    return () => {};
+  }
+
+  // biome-ignore lint/style/noNonNullAssertion: checked by isHmrAvailable
+  const hot = import.meta.hot!;
+  hot.on('rafters:css-updated', callback);
+  return () => hot.off('rafters:css-updated', callback);
+}

--- a/packages/studio/src/api/vite-plugin.ts
+++ b/packages/studio/src/api/vite-plugin.ts
@@ -1,0 +1,113 @@
+/**
+ * Studio Vite Plugin - WebSocket bridge to TokenRegistry
+ *
+ * Handles two-phase color selection:
+ * 1. Instant: color-utils data saved immediately (CSS updates, user sees changes)
+ * 2. Complete: API enrichment arrives, save complete ColorValue to disk
+ *
+ * Use `persist: false` for instant feedback without disk write.
+ * Use `persist: true` (default) when enrichment is complete.
+ */
+
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { NodePersistenceAdapter, registryToVars, TokenRegistry } from '@rafters/design-tokens';
+import { ColorReferenceSchema, ColorValueSchema } from '@rafters/shared';
+import type { Plugin, ViteDevServer } from 'vite';
+import { z } from 'zod';
+
+const projectPath = process.env.RAFTERS_PROJECT_PATH || process.cwd();
+const outputPath = join(projectPath, '.rafters', 'output', 'rafters.vars.css');
+
+// Zod schema for incoming WebSocket messages
+const SetTokenMessageSchema = z.object({
+  name: z.string().min(1),
+  value: z.union([z.string(), ColorValueSchema, ColorReferenceSchema]),
+  persist: z.boolean().optional(),
+});
+
+export function studioApiPlugin(): Plugin {
+  let registry: TokenRegistry;
+  let initialized = false;
+
+  return {
+    name: 'rafters-studio-api',
+
+    async configureServer(server: ViteDevServer) {
+      // Initialize registry from persistence
+      try {
+        const adapter = new NodePersistenceAdapter(projectPath);
+        const tokens = await adapter.load();
+        registry = new TokenRegistry(tokens);
+        registry.setAdapter(adapter);
+        initialized = true;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.log(`[rafters] Failed to initialize: ${message}`);
+        if (message.includes('ENOENT')) {
+          console.log(`[rafters] No project found at ${projectPath}. Run 'rafters init' first.`);
+        }
+        // Create empty registry as fallback
+        registry = new TokenRegistry([]);
+        initialized = false;
+      }
+
+      // Change callback: regenerate CSS for HMR
+      registry.setChangeCallback(async () => {
+        try {
+          await writeFile(outputPath, registryToVars(registry));
+          server.ws.send({ type: 'custom', event: 'rafters:css-updated' });
+        } catch (error) {
+          console.log(`[rafters] CSS regeneration failed: ${error}`);
+        }
+      });
+
+      // Listen for token updates from client
+      server.ws.on('rafters:set-token', async (rawData: unknown, client) => {
+        // Validate incoming message
+        const parsed = SetTokenMessageSchema.safeParse(rawData);
+        if (!parsed.success) {
+          client.send('rafters:token-updated', {
+            ok: false,
+            error: `Invalid message: ${parsed.error.message}`,
+          });
+          return;
+        }
+
+        const data = parsed.data;
+        const shouldPersist = data.persist !== false;
+
+        try {
+          if (shouldPersist) {
+            // Full save: update + cascade + persist (callback handles CSS)
+            await registry.set(data.name, data.value);
+          } else {
+            // Instant feedback: update in-memory only (callback handles CSS)
+            registry.updateToken(data.name, data.value);
+          }
+          client.send('rafters:token-updated', {
+            ok: true,
+            name: data.name,
+            persisted: shouldPersist,
+          });
+        } catch (error) {
+          console.log(`[rafters] Token update failed for "${data.name}": ${error}`);
+          client.send('rafters:token-updated', { ok: false, error: String(error) });
+        }
+      });
+
+      // Endpoint to get current tokens (REST fallback)
+      server.middlewares.use('/api/tokens', (_req, res) => {
+        try {
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ tokens: registry.list(), initialized }));
+        } catch (error) {
+          console.log(`[rafters] Failed to list tokens: ${error}`);
+          res.statusCode = 500;
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ error: 'Failed to retrieve tokens' }));
+        }
+      });
+    },
+  };
+}

--- a/packages/studio/src/vite-env.d.ts
+++ b/packages/studio/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/studio/test/api/client-api.test.ts
+++ b/packages/studio/test/api/client-api.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Client API Unit Tests
+ *
+ * Tests the client API types and constants.
+ * HMR-dependent behavior is tested via manual dev server testing
+ * since import.meta.hot cannot be reliably mocked in Vitest.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+describe('Client API', () => {
+  describe('module exports', () => {
+    it('exports setToken function', async () => {
+      const module = await import('../../src/api/index');
+      expect(typeof module.setToken).toBe('function');
+    });
+
+    it('exports onCssUpdated function', async () => {
+      const module = await import('../../src/api/index');
+      expect(typeof module.onCssUpdated).toBe('function');
+    });
+  });
+
+  describe('setToken without HMR', () => {
+    it('returns error result when HMR not available', async () => {
+      // In test environment, import.meta.hot is undefined
+      const { setToken } = await import('../../src/api/index');
+
+      const result = await setToken({ name: 'primary', value: 'red' });
+
+      expect(result).toEqual({ ok: false, error: 'HMR not available' });
+    });
+
+    it('handles ColorReference value type', async () => {
+      const { setToken } = await import('../../src/api/index');
+
+      const result = await setToken({
+        name: 'primary',
+        value: { family: 'neutral', position: '500' },
+      });
+
+      // Without HMR, still returns error but accepts the value type
+      expect(result.ok).toBe(false);
+    });
+
+    it('accepts persist option', async () => {
+      const { setToken } = await import('../../src/api/index');
+
+      // These should not throw - type checking
+      const result1 = await setToken({ name: 'test', value: 'red', persist: true });
+      const result2 = await setToken({ name: 'test', value: 'red', persist: false });
+
+      expect(result1.ok).toBe(false);
+      expect(result2.ok).toBe(false);
+    });
+  });
+
+  describe('onCssUpdated without HMR', () => {
+    it('returns cleanup function even without HMR', async () => {
+      const { onCssUpdated } = await import('../../src/api/index');
+
+      const cleanup = onCssUpdated(() => {});
+
+      expect(typeof cleanup).toBe('function');
+      // Should not throw when called
+      expect(() => cleanup()).not.toThrow();
+    });
+  });
+
+  describe('UpdateResult type', () => {
+    it('success result has expected shape', () => {
+      const success = { ok: true as const, name: 'primary', persisted: true };
+
+      expect(success.ok).toBe(true);
+      expect(success.name).toBe('primary');
+      expect(success.persisted).toBe(true);
+    });
+
+    it('error result has expected shape', () => {
+      const error = { ok: false as const, error: 'Something went wrong' };
+
+      expect(error.ok).toBe(false);
+      expect(error.error).toBe('Something went wrong');
+    });
+  });
+});

--- a/packages/studio/test/api/vite-plugin.test.ts
+++ b/packages/studio/test/api/vite-plugin.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Vite Plugin Unit Tests
+ *
+ * Tests plugin factory, Zod validation, and error handling.
+ * Integration with actual Vite server is tested manually.
+ */
+
+import { ColorReferenceSchema, ColorValueSchema } from '@rafters/shared';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { studioApiPlugin } from '../../src/api/vite-plugin';
+
+// Replicate the schema from vite-plugin.ts to test validation logic
+const SetTokenMessageSchema = z.object({
+  name: z.string().min(1),
+  value: z.union([z.string(), ColorValueSchema, ColorReferenceSchema]),
+  persist: z.boolean().optional(),
+});
+
+describe('studioApiPlugin', () => {
+  describe('plugin factory', () => {
+    it('exports a function', () => {
+      expect(typeof studioApiPlugin).toBe('function');
+    });
+
+    it('returns plugin with correct name', () => {
+      const plugin = studioApiPlugin();
+      expect(plugin.name).toBe('rafters-studio-api');
+    });
+
+    it('has configureServer hook', () => {
+      const plugin = studioApiPlugin();
+      expect(typeof plugin.configureServer).toBe('function');
+    });
+  });
+
+  describe('SetTokenMessageSchema validation', () => {
+    it('accepts valid string value', () => {
+      const result = SetTokenMessageSchema.safeParse({
+        name: 'primary',
+        value: 'oklch(0.5 0.2 250)',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts valid ColorReference value', () => {
+      const result = SetTokenMessageSchema.safeParse({
+        name: 'primary',
+        value: { family: 'neutral', position: '500' },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts persist: true', () => {
+      const result = SetTokenMessageSchema.safeParse({
+        name: 'primary',
+        value: 'red',
+        persist: true,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.persist).toBe(true);
+      }
+    });
+
+    it('accepts persist: false', () => {
+      const result = SetTokenMessageSchema.safeParse({
+        name: 'primary',
+        value: 'red',
+        persist: false,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.persist).toBe(false);
+      }
+    });
+
+    it('defaults persist to undefined when not provided', () => {
+      const result = SetTokenMessageSchema.safeParse({
+        name: 'primary',
+        value: 'red',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.persist).toBeUndefined();
+      }
+    });
+
+    it('rejects empty name', () => {
+      const result = SetTokenMessageSchema.safeParse({
+        name: '',
+        value: 'red',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects missing name', () => {
+      const result = SetTokenMessageSchema.safeParse({
+        value: 'red',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects missing value', () => {
+      const result = SetTokenMessageSchema.safeParse({
+        name: 'primary',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects null value', () => {
+      const result = SetTokenMessageSchema.safeParse({
+        name: 'primary',
+        value: null,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects invalid ColorReference (missing family)', () => {
+      const result = SetTokenMessageSchema.safeParse({
+        name: 'primary',
+        value: { position: '500' },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects invalid ColorReference (missing position)', () => {
+      const result = SetTokenMessageSchema.safeParse({
+        name: 'primary',
+        value: { family: 'neutral' },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects non-string persist', () => {
+      const result = SetTokenMessageSchema.safeParse({
+        name: 'primary',
+        value: 'red',
+        persist: 'true',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects completely invalid payload', () => {
+      const result = SetTokenMessageSchema.safeParse('not an object');
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects array payload', () => {
+      const result = SetTokenMessageSchema.safeParse([{ name: 'test', value: 'red' }]);
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/packages/studio/test/setup.ts
+++ b/packages/studio/test/setup.ts
@@ -1,0 +1,5 @@
+/**
+ * Vitest setup for Studio tests
+ */
+
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary

- Add minimal Vite plugin (~55 lines) that bridges Studio UI to TokenRegistry
- Initialize registry from persistence at dev server start
- Vite custom events receive Token updates, call `registry.set()`
- Registry handles cascade, persistence, CSS regeneration automatically
- Change callback writes `rafters.vars.css` for instant HMR

## Architecture

The plugin is intentionally thin - all intelligence lives in the registry:

```
Client (setToken) --> Vite WS --> registry.set(name, value)
                                       |
                                       v
                              cascade dependents
                              persist to disk
                              trigger change callback
                                       |
                                       v
                              write rafters.vars.css
                              send 'rafters:css-updated'
                                       |
                                       v
                              Vite HMR picks up CSS
```

## Files

- `src/api/vite-plugin.ts` - Server-side Vite plugin
- `src/api/index.ts` - Client-side API (setToken, onCssUpdated)
- `test/api/vite-plugin.test.ts` - Basic plugin structure tests
- `test/setup.ts` - Vitest setup file

## Test plan

- [x] Plugin factory returns correct structure
- [x] Preflight passes
- [ ] Manual: Start studio with `pnpm dev:standalone`, verify WebSocket connection
- [ ] Manual: Token update cascades and CSS regenerates

Generated with [Claude Code](https://claude.com/claude-code)