### PR TITLE
feat(studio): add GET /api/tokens/:name endpoint

### DIFF
--- a/packages/studio/test/api/vite-plugin.test.ts
+++ b/packages/studio/test/api/vite-plugin.test.ts
@@ -5,16 +5,31 @@
  * Integration with actual Vite server is tested manually.
  */
 
-import { ColorReferenceSchema, ColorValueSchema } from '@rafters/shared';
+import { ColorReferenceSchema, ColorValueSchema, TokenSchema } from '@rafters/shared';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { studioApiPlugin } from '../../src/api/vite-plugin';
 
-// Replicate the schema from vite-plugin.ts to test validation logic
+// Replicate schemas from vite-plugin.ts to test validation logic
 const SetTokenMessageSchema = z.object({
   name: z.string().min(1),
   value: z.union([z.string(), ColorValueSchema, ColorReferenceSchema]),
   persist: z.boolean().optional(),
+});
+
+const TokenResponseSchema = z.object({
+  ok: z.literal(true),
+  token: TokenSchema,
+});
+
+const TokensResponseSchema = z.object({
+  tokens: z.array(TokenSchema),
+  initialized: z.boolean(),
+});
+
+const ErrorResponseSchema = z.object({
+  ok: z.literal(false),
+  error: z.string(),
 });
 
 describe('studioApiPlugin', () => {
@@ -149,6 +164,183 @@ describe('studioApiPlugin', () => {
     it('rejects array payload', () => {
       const result = SetTokenMessageSchema.safeParse([{ name: 'test', value: 'red' }]);
       expect(result.success).toBe(false);
+    });
+  });
+
+  describe('Response schema validation', () => {
+    describe('TokenResponseSchema', () => {
+      it('accepts valid token response', () => {
+        const result = TokenResponseSchema.safeParse({
+          ok: true,
+          token: {
+            name: 'primary',
+            value: { family: 'neutral', position: '500' },
+            category: 'color',
+            namespace: 'semantic',
+          },
+        });
+        expect(result.success).toBe(true);
+      });
+
+      it('rejects response without ok field', () => {
+        const result = TokenResponseSchema.safeParse({
+          token: {
+            name: 'primary',
+            value: 'red',
+            category: 'color',
+            namespace: 'semantic',
+          },
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it('rejects response with ok: false', () => {
+        const result = TokenResponseSchema.safeParse({
+          ok: false,
+          token: {
+            name: 'primary',
+            value: 'red',
+            category: 'color',
+            namespace: 'semantic',
+          },
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it('rejects response with invalid token', () => {
+        const result = TokenResponseSchema.safeParse({
+          ok: true,
+          token: { name: 'primary' }, // missing required fields
+        });
+        expect(result.success).toBe(false);
+      });
+    });
+
+    describe('TokensResponseSchema', () => {
+      it('accepts valid tokens list response', () => {
+        const result = TokensResponseSchema.safeParse({
+          tokens: [
+            {
+              name: 'primary',
+              value: { family: 'neutral', position: '500' },
+              category: 'color',
+              namespace: 'semantic',
+            },
+          ],
+          initialized: true,
+        });
+        expect(result.success).toBe(true);
+      });
+
+      it('accepts empty tokens array', () => {
+        const result = TokensResponseSchema.safeParse({
+          tokens: [],
+          initialized: false,
+        });
+        expect(result.success).toBe(true);
+      });
+
+      it('rejects response without initialized field', () => {
+        const result = TokensResponseSchema.safeParse({
+          tokens: [],
+        });
+        expect(result.success).toBe(false);
+      });
+    });
+
+    describe('ErrorResponseSchema', () => {
+      it('accepts valid error response', () => {
+        const result = ErrorResponseSchema.safeParse({
+          ok: false,
+          error: 'Token not found',
+        });
+        expect(result.success).toBe(true);
+      });
+
+      it('rejects error response with ok: true', () => {
+        const result = ErrorResponseSchema.safeParse({
+          ok: true,
+          error: 'Something went wrong',
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it('rejects error response without error message', () => {
+        const result = ErrorResponseSchema.safeParse({
+          ok: false,
+        });
+        expect(result.success).toBe(false);
+      });
+    });
+  });
+
+  describe('URL parsing logic', () => {
+    // Test the pathname extraction logic used in the middleware
+    function extractPathname(url: string): string {
+      return new URL(url, 'http://localhost').pathname;
+    }
+
+    function extractTokenName(pathname: string): string | null {
+      const match = pathname.match(/^\/api\/tokens\/(.+)$/);
+      return match ? decodeURIComponent(match[1]) : null;
+    }
+
+    describe('pathname extraction', () => {
+      it('extracts pathname from simple URL', () => {
+        expect(extractPathname('/api/tokens')).toBe('/api/tokens');
+      });
+
+      it('strips query string from URL', () => {
+        expect(extractPathname('/api/tokens?foo=bar')).toBe('/api/tokens');
+      });
+
+      it('strips query string from token URL', () => {
+        expect(extractPathname('/api/tokens/primary?foo=bar')).toBe('/api/tokens/primary');
+      });
+
+      it('handles complex query strings', () => {
+        expect(extractPathname('/api/tokens/primary?foo=bar&baz=qux')).toBe('/api/tokens/primary');
+      });
+    });
+
+    describe('token name extraction', () => {
+      it('extracts simple token name', () => {
+        expect(extractTokenName('/api/tokens/primary')).toBe('primary');
+      });
+
+      it('extracts token name with dash', () => {
+        expect(extractTokenName('/api/tokens/primary-500')).toBe('primary-500');
+      });
+
+      it('decodes URL-encoded token name', () => {
+        expect(extractTokenName('/api/tokens/card-foreground')).toBe('card-foreground');
+      });
+
+      it('decodes percent-encoded spaces', () => {
+        expect(extractTokenName('/api/tokens/my%20token')).toBe('my token');
+      });
+
+      it('returns null for /api/tokens (no name)', () => {
+        expect(extractTokenName('/api/tokens')).toBe(null);
+      });
+
+      it('returns null for non-matching paths', () => {
+        expect(extractTokenName('/api/other/primary')).toBe(null);
+      });
+    });
+
+    describe('malformed URL encoding', () => {
+      it('throws on invalid percent encoding', () => {
+        expect(() => decodeURIComponent('%E0%A4%A')).toThrow();
+      });
+
+      it('throws on incomplete percent encoding', () => {
+        expect(() => decodeURIComponent('%')).toThrow();
+      });
+
+      it('throws on invalid UTF-8 sequence', () => {
+        expect(() => decodeURIComponent('%C0%C1')).toThrow();
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add REST endpoint to fetch a specific token by name for right-click editing
- Registry is in memory so lookup is instant
- Refactor middleware to handle both `/api/tokens` and `/api/tokens/:name`

## API

```
GET /api/tokens/:name
```

**Success (200):**
```json
{ "ok": true, "token": { "name": "primary", "value": {...}, ... } }
```

**Not Found (404):**
```json
{ "ok": false, "error": "Token \"foo\" not found" }
```

## Use Case

Right-click on color swatch opens editor with L, C, H sliders. Needs raw token value (not CSS) to populate the sliders.

## Test plan

- [x] Preflight passes
- [ ] Manual: `curl http://localhost:5173/api/tokens/primary`

Generated with [Claude Code](https://claude.com/claude-code)