### PR TITLE
fix(ui): prefix unused PopoverContent params for oxlint compat

### DIFF
--- a/packages/ui/src/components/ui/popover.tsx
+++ b/packages/ui/src/components/ui/popover.tsx
@@ -182,14 +182,14 @@ export interface PopoverContentProps extends React.HTMLAttributes<HTMLDivElement
 }
 
 export function PopoverContent({
-  asChild,
+  asChild: _asChild,
   forceMount,
   side = 'bottom',
   align = 'center',
   sideOffset = 4,
   alignOffset = 0,
-  onOpenAutoFocus,
-  onCloseAutoFocus,
+  onOpenAutoFocus: _onOpenAutoFocus,
+  onCloseAutoFocus: _onCloseAutoFocus,
   onEscapeKeyDown,
   onPointerDownOutside,
   onInteractOutside,


### PR DESCRIPTION
## Summary
- Prefix 3 unused destructured params (`asChild`, `onOpenAutoFocus`, `onCloseAutoFocus`) with `_` in `PopoverContent`
- These are part of the shadcn API surface but handled internally by `Float.Content`
- Fixes `eslint(no-unused-vars)` errors when generated components are linted with oxlint

Closes #754

## Test plan
- [x] `pnpm --filter=@rafters/ui typecheck` passes

Generated with [Claude Code](https://claude.ai/code)