### PR TITLE
fix(ui): prefix unused onFocusOutside param in FloatContent

### DIFF
--- a/packages/ui/src/primitives/float.tsx
+++ b/packages/ui/src/primitives/float.tsx
@@ -209,7 +209,7 @@ const FloatContent = React.forwardRef<HTMLDivElement, FloatContentProps>(functio
     disablePortal = false,
     onEscapeKeyDown: onEscapeKeyDownProp,
     onPointerDownOutside: onPointerDownOutsideProp,
-    onFocusOutside,
+    onFocusOutside: _onFocusOutside,
     disableOutsideClick = false,
     disableEscapeKey = false,
     className,


### PR DESCRIPTION
## Summary
- Prefix unused `onFocusOutside` destructured param with `_` in `FloatContent`
- Parameter is part of the API surface but focus-outside dismissal is not yet implemented
- Fixes `eslint(no-unused-vars)` error when generated primitives are linted with oxlint

Closes #755

## Test plan
- [x] `pnpm --filter=@rafters/ui typecheck` passes

Generated with [Claude Code](https://claude.ai/code)