### PR TITLE
fix(ui): use accent-foreground for container article headings

### DIFF
--- a/packages/ui/src/components/ui/container.tsx
+++ b/packages/ui/src/components/ui/container.tsx
@@ -130,10 +130,10 @@ const articleTypography = [
   '[&_p:last-child]:mb-0',
 
   // Headings
-  '[&_h1]:text-4xl [&_h1]:font-bold [&_h1]:tracking-tight [&_h1]:mb-4 [&_h1]:mt-0',
-  '[&_h2]:text-3xl [&_h2]:font-semibold [&_h2]:tracking-tight [&_h2]:mb-3 [&_h2]:mt-8 [&_h2]:first:mt-0',
-  '[&_h3]:text-2xl [&_h3]:font-semibold [&_h3]:mb-2 [&_h3]:mt-6',
-  '[&_h4]:text-xl [&_h4]:font-semibold [&_h4]:mb-2 [&_h4]:mt-4',
+  '[&_h1]:text-4xl [&_h1]:font-bold [&_h1]:tracking-tight [&_h1]:mb-4 [&_h1]:mt-0 [&_h1]:text-accent-foreground',
+  '[&_h2]:text-3xl [&_h2]:font-semibold [&_h2]:tracking-tight [&_h2]:mb-3 [&_h2]:mt-8 [&_h2]:first:mt-0 [&_h2]:text-accent-foreground',
+  '[&_h3]:text-2xl [&_h3]:font-semibold [&_h3]:mb-2 [&_h3]:mt-6 [&_h3]:text-accent-foreground',
+  '[&_h4]:text-xl [&_h4]:font-semibold [&_h4]:mb-2 [&_h4]:mt-4 [&_h4]:text-accent-foreground',
 
   // Lists
   '[&_ul]:list-disc [&_ul]:pl-6 [&_ul]:mb-4',


### PR DESCRIPTION
## Summary

- Fixes #760 -- Container article headings used `text-accent` (neutral-100, a near-white background token) which fails WCAG contrast
- Adds `text-accent-foreground` (neutral-900) to h1-h4 selectors in `articleTypography` so headings are readable

## Test plan

- [ ] Visual check: render a Container with `variant="article"` and confirm headings are dark text on light background
- [ ] Verify no regressions in other Container variants

Generated with [Claude Code](https://claude.com/claude-code)