### PR TITLE
feat(ui): add color picker types to primitives

### DIFF
--- a/packages/ui/src/primitives/types.ts
+++ b/packages/ui/src/primitives/types.ts
@@ -231,3 +231,47 @@ export interface FormatDefinition {
   attributes?: Record<string, string>;
   class?: string;
 }
+
+// =============================================================================
+// Color Picker Types
+// =============================================================================
+
+/** Normalized 2D coordinate within a surface, both axes 0-1 */
+export interface NormalizedPoint {
+  /** Horizontal position, 0 = left edge, 1 = right edge */
+  left: number;
+  /** Vertical position, 0 = top edge, 1 = bottom edge */
+  top: number;
+}
+
+/** Keyboard movement delta (additive offset applied to a NormalizedPoint) */
+export interface MoveDelta {
+  /** Horizontal delta, positive = rightward */
+  dLeft: number;
+  /** Vertical delta, positive = downward */
+  dTop: number;
+}
+
+/**
+ * Dimension mode for the interactive primitive.
+ * '1d-horizontal' - only left axis is active (top locked to 0)
+ * '1d-vertical' - only top axis is active (left locked to 0)
+ * '2d' - both axes are active
+ */
+export type InteractiveMode = '1d-horizontal' | '1d-vertical' | '2d';
+
+/** OKLCH color triplet without alpha */
+export interface OklchColor {
+  /** Lightness, 0 (black) to 1 (white) */
+  l: number;
+  /** Chroma, 0 (gray) to ~0.4 (most vivid in sRGB) -- no theoretical max */
+  c: number;
+  /** Hue angle in degrees, 0 to 360 (circular: 0 and 360 are equivalent) */
+  h: number;
+}
+
+/** OKLCH color triplet with optional alpha */
+export interface OklchColorAlpha extends OklchColor {
+  /** Opacity, 0 (transparent) to 1 (opaque). Omit for fully opaque. */
+  alpha?: number;
+}

--- a/packages/ui/test/primitives/types.test.ts
+++ b/packages/ui/test/primitives/types.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  InteractiveMode,
+  MoveDelta,
+  NormalizedPoint,
+  OklchColor,
+  OklchColorAlpha,
+} from '../../src/primitives/types';
+
+describe('Color Picker Types', () => {
+  it('NormalizedPoint holds left and top coordinates', () => {
+    const point: NormalizedPoint = { left: 0.5, top: 0.3 };
+    expect(Object.keys(point).sort()).toEqual(['left', 'top']);
+  });
+
+  it('MoveDelta holds dLeft and dTop offsets', () => {
+    const delta: MoveDelta = { dLeft: 0.01, dTop: -0.01 };
+    expect(Object.keys(delta).sort()).toEqual(['dLeft', 'dTop']);
+  });
+
+  it('InteractiveMode accepts all three literals', () => {
+    const modes: InteractiveMode[] = ['1d-horizontal', '1d-vertical', '2d'];
+    expect(modes).toHaveLength(3);
+  });
+
+  it('OklchColor holds l, c, h channels', () => {
+    const color: OklchColor = { l: 0.7, c: 0.15, h: 250 };
+    expect(Object.keys(color).sort()).toEqual(['c', 'h', 'l']);
+  });
+
+  it('OklchColorAlpha extends OklchColor with optional alpha', () => {
+    const opaque: OklchColorAlpha = { l: 0.7, c: 0.15, h: 250 };
+    expect(opaque.alpha).toBeUndefined();
+
+    const translucent: OklchColorAlpha = { l: 0.7, c: 0.15, h: 250, alpha: 0.8 };
+    expect(translucent.alpha).toBe(0.8);
+  });
+});


### PR DESCRIPTION
Closes #786

## Summary
- Add 5 color picker types to `packages/ui/src/primitives/types.ts`: `NormalizedPoint`, `MoveDelta`, `InteractiveMode`, `OklchColor`, `OklchColorAlpha`
- JSDoc annotations with range constraints (lightness 0-1, hue 0-360 circular, chroma ~0.4 no theoretical max)
- Structural tests verifying type shape

## Test plan
- [x] `pnpm --filter=@rafters/ui test --run types` (5 tests pass)
- [x] `pnpm --filter=@rafters/ui typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)