### PR TITLE
feat(ui): add color-area 2D canvas primitive

### DIFF
--- a/packages/ui/src/primitives/color-area.ts
+++ b/packages/ui/src/primitives/color-area.ts
@@ -27,7 +27,8 @@ export interface ColorAreaOptions {
 
 /**
  * Render the Lightness x Chroma surface onto a canvas.
- * Gracefully handles missing 2D context (SSR, happy-dom).
+ * Gracefully handles getContext('2d') returning null (e.g. happy-dom).
+ * SSR is guarded at the public API boundary (createColorArea/updateColorArea).
  */
 function renderArea(canvas: HTMLCanvasElement, options: ColorAreaOptions): void {
   const ctx = canvas.getContext('2d');
@@ -44,10 +45,13 @@ function renderArea(canvas: HTMLCanvasElement, options: ColorAreaOptions): void 
   canvas.width = width;
   canvas.height = height;
 
+  const maxX = width > 1 ? width - 1 : 1;
+  const maxY = height > 1 ? height - 1 : 1;
+
   for (let x = 0; x < width; x++) {
     for (let y = 0; y < height; y++) {
-      const l = x / width; // 0 (black) at left, 1 (white) at right
-      const c = (1 - y / height) * maxChroma; // maxChroma at top, 0 (gray) at bottom
+      const l = x / maxX; // 0 (black) at left, 1 (white) at right
+      const c = (1 - y / maxY) * maxChroma; // maxChroma at top, 0 (gray) at bottom
 
       if (inSrgb(l, c, hue) || inP3(l, c, hue)) {
         ctx.fillStyle = `oklch(${l} ${c} ${hue})`;

--- a/packages/ui/test/primitives/color-area.test.ts
+++ b/packages/ui/test/primitives/color-area.test.ts
@@ -73,3 +73,19 @@ describe('updateColorArea', () => {
     expect(canvas.getAttribute('aria-label')).toBe('Color area for hue 120 degrees');
   });
 });
+
+describe('SSR safety', () => {
+  it('returns a no-op cleanup when window is undefined', () => {
+    const savedWindow = globalThis.window;
+    // biome-ignore lint/performance/noDelete: SSR simulation
+    delete (globalThis as Record<string, unknown>).window;
+    try {
+      const canvas = {} as HTMLCanvasElement;
+      const cleanup = createColorArea(canvas, { hue: 250 });
+      expect(typeof cleanup).toBe('function');
+      cleanup(); // should not throw
+    } finally {
+      globalThis.window = savedWindow;
+    }
+  });
+});


### PR DESCRIPTION
Closes #789

## Summary
- `createColorArea` / `updateColorArea` render Lightness x Chroma surface at fixed hue
- Two-tier gamut check: sRGB or P3 painted with OKLCH color, outside both painted black
- Per-pixel rendering at physical DPR resolution (no ctx.scale)
- Cleanup restores original ARIA attributes and clears canvas
- 6 tests covering ARIA, cleanup, and attribute restoration

**Stack**: depends on #794

## Test plan
- [x] `pnpm --filter=@rafters/ui test --run color-area` (6 tests pass)
- [x] `pnpm --filter=@rafters/ui typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)