### PR TITLE
feat(cli): add installed tracking to RaftersConfig and rafters add

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -10,6 +10,7 @@ import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { RegistryClient } from '../registry/client.js';
 import type { RegistryItem } from '../registry/types.js';
+import { DEFAULT_EXPORTS } from '../utils/exports.js';
 import { getRaftersPaths } from '../utils/paths.js';
 import { error, log, setAgentMode } from '../utils/ui.js';
 import { updateDependencies } from '../utils/update-dependencies.js';
@@ -51,6 +52,48 @@ async function loadConfig(cwd: string): Promise<RaftersConfig | null> {
     }
     return null;
   }
+}
+
+/**
+ * Save config back to .rafters/config.rafters.json
+ */
+async function saveConfig(cwd: string, config: RaftersConfig): Promise<void> {
+  const paths = getRaftersPaths(cwd);
+  await writeFile(paths.config, JSON.stringify(config, null, 2));
+}
+
+/**
+ * Check if an item is already tracked in the installed list
+ */
+export function isAlreadyInstalled(config: RaftersConfig | null, item: RegistryItem): boolean {
+  if (!config?.installed) return false;
+  if (item.type === 'registry:ui') {
+    return config.installed.components.includes(item.name);
+  }
+  return config.installed.primitives.includes(item.name);
+}
+
+/**
+ * Update the installed list in config with newly installed items.
+ * Deduplicates and sorts alphabetically.
+ */
+export function trackInstalled(config: RaftersConfig, items: RegistryItem[]): void {
+  if (!config.installed) {
+    config.installed = { components: [], primitives: [] };
+  }
+  for (const item of items) {
+    if (item.type === 'registry:ui') {
+      if (!config.installed.components.includes(item.name)) {
+        config.installed.components.push(item.name);
+      }
+    } else {
+      if (!config.installed.primitives.includes(item.name)) {
+        config.installed.primitives.push(item.name);
+      }
+    }
+  }
+  config.installed.components.sort();
+  config.installed.primitives.sort();
 }
 
 /**
@@ -312,13 +355,26 @@ export async function add(components: string[], options: AddOptions): Promise<vo
   // Install all resolved items
   const installed: string[] = [];
   const skipped: string[] = [];
+  const installedItems: RegistryItem[] = [];
 
   for (const item of allItems) {
+    // Skip items already tracked in config (unless --overwrite)
+    if (!options.overwrite && isAlreadyInstalled(config, item)) {
+      log({
+        event: 'add:skip',
+        component: item.name,
+        reason: 'already installed',
+      });
+      skipped.push(item.name);
+      continue;
+    }
+
     try {
       const result = await installItem(cwd, item, options, config);
 
       if (result.installed) {
         installed.push(item.name);
+        installedItems.push(item);
         log({
           event: 'add:installed',
           component: item.name,
@@ -362,6 +418,25 @@ export async function add(components: string[], options: AddOptions): Promise<vo
       });
       // Don't fail the whole command - files are already written
     }
+  }
+
+  // Update config with installed items
+  if (installedItems.length > 0 && config) {
+    trackInstalled(config, installedItems);
+    await saveConfig(cwd, config);
+  } else if (installedItems.length > 0 && !config) {
+    // No config file yet -- create minimal installed tracking
+    const newConfig: RaftersConfig = {
+      framework: 'unknown' as RaftersConfig['framework'],
+      componentsPath: 'components/ui',
+      primitivesPath: 'lib/primitives',
+      cssPath: null,
+      shadcn: false,
+      exports: DEFAULT_EXPORTS,
+      installed: { components: [], primitives: [] },
+    };
+    trackInstalled(newConfig, installedItems);
+    await saveConfig(cwd, newConfig);
   }
 
   // Summary

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -90,6 +90,11 @@ export interface RaftersConfig {
   shadcn: boolean;
   /** Export format selections */
   exports: ExportConfig;
+  /** Items installed via `rafters add` */
+  installed?: {
+    components: string[];
+    primitives: string[];
+  };
 }
 
 async function findMainCssFile(cwd: string, framework: Framework): Promise<string | null> {
@@ -641,6 +646,10 @@ export async function init(options: InitOptions): Promise<void> {
     cssPath: detectedCssPath,
     shadcn: !!shadcn,
     exports,
+    installed: {
+      components: [],
+      primitives: [],
+    },
   };
   await writeFile(paths.config, JSON.stringify(config, null, 2));
 

--- a/packages/cli/test/commands/add.test.ts
+++ b/packages/cli/test/commands/add.test.ts
@@ -10,7 +10,14 @@
 import { describe, expect, it } from 'vitest';
 import { zocker } from 'zocker';
 import { z } from 'zod';
-import { collectDependencies, transformFileContent } from '../../src/commands/add.js';
+import {
+  collectDependencies,
+  isAlreadyInstalled,
+  trackInstalled,
+  transformFileContent,
+} from '../../src/commands/add.js';
+import type { RaftersConfig } from '../../src/commands/init.js';
+import type { RegistryItem } from '../../src/registry/types.js';
 import { RegistryItemSchema } from '../../src/registry/types.js';
 import { generateRandomItems, registryFixtures } from '../fixtures/registry.js';
 
@@ -132,6 +139,160 @@ describe('collectDependencies', () => {
 
     expect(Array.isArray(result.dependencies)).toBe(true);
     expect(Array.isArray(result.devDependencies)).toBe(true);
+  });
+});
+
+describe('isAlreadyInstalled', () => {
+  const baseConfig: RaftersConfig = {
+    framework: 'react-router',
+    componentsPath: 'components/ui',
+    primitivesPath: 'lib/primitives',
+    cssPath: null,
+    shadcn: false,
+    exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
+    installed: {
+      components: ['button', 'card'],
+      primitives: ['classy'],
+    },
+  };
+
+  it('returns true for installed component', () => {
+    const item: RegistryItem = {
+      name: 'button',
+      type: 'registry:ui',
+      primitives: ['classy'],
+      files: [],
+    };
+    expect(isAlreadyInstalled(baseConfig, item)).toBe(true);
+  });
+
+  it('returns true for installed primitive', () => {
+    const item: RegistryItem = {
+      name: 'classy',
+      type: 'registry:primitive',
+      primitives: [],
+      files: [],
+    };
+    expect(isAlreadyInstalled(baseConfig, item)).toBe(true);
+  });
+
+  it('returns false for uninstalled component', () => {
+    const item: RegistryItem = { name: 'dialog', type: 'registry:ui', primitives: [], files: [] };
+    expect(isAlreadyInstalled(baseConfig, item)).toBe(false);
+  });
+
+  it('returns false when config is null', () => {
+    const item: RegistryItem = { name: 'button', type: 'registry:ui', primitives: [], files: [] };
+    expect(isAlreadyInstalled(null, item)).toBe(false);
+  });
+
+  it('returns false when installed field is missing', () => {
+    const configNoInstalled: RaftersConfig = {
+      ...baseConfig,
+      installed: undefined,
+    };
+    const item: RegistryItem = { name: 'button', type: 'registry:ui', primitives: [], files: [] };
+    expect(isAlreadyInstalled(configNoInstalled, item)).toBe(false);
+  });
+});
+
+describe('trackInstalled', () => {
+  it('adds components to installed list', () => {
+    const config: RaftersConfig = {
+      framework: 'react-router',
+      componentsPath: 'components/ui',
+      primitivesPath: 'lib/primitives',
+      cssPath: null,
+      shadcn: false,
+      exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
+      installed: { components: [], primitives: [] },
+    };
+
+    const items: RegistryItem[] = [registryFixtures.buttonComponent()];
+
+    trackInstalled(config, items);
+
+    expect(config.installed?.components).toContain('button');
+  });
+
+  it('adds primitives to installed list', () => {
+    const config: RaftersConfig = {
+      framework: 'react-router',
+      componentsPath: 'components/ui',
+      primitivesPath: 'lib/primitives',
+      cssPath: null,
+      shadcn: false,
+      exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
+      installed: { components: [], primitives: [] },
+    };
+
+    const items: RegistryItem[] = [registryFixtures.classyPrimitive()];
+
+    trackInstalled(config, items);
+
+    expect(config.installed?.primitives).toContain('classy');
+  });
+
+  it('deduplicates when adding same item twice', () => {
+    const config: RaftersConfig = {
+      framework: 'react-router',
+      componentsPath: 'components/ui',
+      primitivesPath: 'lib/primitives',
+      cssPath: null,
+      shadcn: false,
+      exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
+      installed: { components: ['button'], primitives: ['classy'] },
+    };
+
+    const items: RegistryItem[] = [
+      registryFixtures.buttonComponent(),
+      registryFixtures.classyPrimitive(),
+    ];
+
+    trackInstalled(config, items);
+
+    expect(config.installed?.components.filter((c) => c === 'button')).toHaveLength(1);
+    expect(config.installed?.primitives.filter((p) => p === 'classy')).toHaveLength(1);
+  });
+
+  it('sorts installed lists alphabetically', () => {
+    const config: RaftersConfig = {
+      framework: 'react-router',
+      componentsPath: 'components/ui',
+      primitivesPath: 'lib/primitives',
+      cssPath: null,
+      shadcn: false,
+      exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
+      installed: { components: [], primitives: [] },
+    };
+
+    const items: RegistryItem[] = [
+      registryFixtures.dialogComponent(),
+      registryFixtures.buttonComponent(),
+      registryFixtures.cardComponent(),
+    ];
+
+    trackInstalled(config, items);
+
+    expect(config.installed?.components).toEqual(['button', 'card', 'dialog']);
+  });
+
+  it('initializes installed field when missing', () => {
+    const config: RaftersConfig = {
+      framework: 'react-router',
+      componentsPath: 'components/ui',
+      primitivesPath: 'lib/primitives',
+      cssPath: null,
+      shadcn: false,
+      exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
+    };
+
+    const items: RegistryItem[] = [registryFixtures.buttonComponent()];
+
+    trackInstalled(config, items);
+
+    expect(config.installed).toBeDefined();
+    expect(config.installed?.components).toContain('button');
   });
 });
 


### PR DESCRIPTION
## Summary

- Extend `RaftersConfig` with optional `installed` field tracking components and primitives
- `rafters init` creates config with empty `installed` lists
- `rafters add` appends installed items (deduped, sorted alphabetically)
- Skip already-installed items unless `--overwrite` is passed
- Existing configs without `installed` field parse without error

## Test plan

- [x] `isAlreadyInstalled` returns true for installed items, false for missing/null config
- [x] `trackInstalled` adds to correct list, deduplicates, sorts, initializes missing field
- [x] All existing tests still pass
- [x] `pnpm preflight` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)