### PR TITLE
feat(ui): add nanostores as composition primitive dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,11 @@ pnpm update -r
 - Tailwind v4 integration with CSS variables
 - shadcn drop-in compatibility: Overlay components include Portal/Overlay internally
 
+#### Primitive Categories
+- **Leaf primitives**: Zero external dependencies, callback injection for state. Examples: block-canvas, keyboard-handler, focus-trap, escape-keydown, drag-drop, history, clipboard.
+- **Composition primitives**: Orchestrate multiple leaf primitives with shared reactive state via nanostores atoms. Examples: block-handler, color-picker. Registry type remains `registry:primitive`.
+- **Rule**: Only composition primitives may import nanostores. Leaf primitives must remain zero-dep.
+
 ### Environment Requirements
 - Node.js >= 24.12.0
 - pnpm >= 10.25.0

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -45,5 +45,8 @@
     "vitest": "catalog:",
     "vitest-axe": "catalog:",
     "zod": "catalog:"
+  },
+  "dependencies": {
+    "nanostores": "^1.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -542,6 +542,9 @@ importers:
 
   packages/ui:
     dependencies:
+      nanostores:
+        specifier: ^1.1.0
+        version: 1.1.0
       vue:
         specifier: ^3.4.0
         version: 3.5.22(typescript@5.9.3)
@@ -4408,6 +4411,10 @@ packages:
     resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
     engines: {node: ^18 || >=20}
     hasBin: true
+
+  nanostores@1.1.0:
+    resolution: {integrity: sha512-yJBmDJr18xy47dbNVlHcgdPrulSn1nhSE6Ns9vTG+Nx9VPT6iV1MD6aQFp/t52zpf82FhLLTXAXr30NuCnxvwA==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
@@ -10045,6 +10052,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   nanoid@5.1.5: {}
+
+  nanostores@1.1.0: {}
 
   negotiator@1.0.0: {}
 


### PR DESCRIPTION
## Summary
- Adds `nanostores` (~1KB, zero transitive deps) as production dependency in `packages/ui`
- Documents leaf vs composition primitive rule in CLAUDE.md
- Verified no existing leaf primitives import nanostores

Closes #809

## Test plan
- [x] `pnpm build` passes
- [x] No existing leaf primitives import nanostores
- [x] `nanostores` listed in packages/ui/package.json dependencies

Generated with [Claude Code](https://claude.com/claude-code)