### PR TITLE
feat(ui): implement block-handler composition primitive

### DIFF
--- a/packages/ui/src/primitives/block-handler.ts
+++ b/packages/ui/src/primitives/block-handler.ts
@@ -46,7 +46,7 @@
  * ```
  */
 import { atom, computed } from 'nanostores';
-import type { BlockCanvasBlock, BlockCanvasOptions } from './block-canvas';
+import type { BlockCanvasOptions } from './block-canvas';
 
 // ============================================================================
 // Types
@@ -160,20 +160,14 @@ function isAncestor(startId: string, targetId: string, blockMap: Map<string, Blo
  * Build a Map<string, Block> from an array.
  */
 function buildBlockMap(blocks: Block[]): Map<string, Block> {
-  const map = new Map<string, Block>();
-  for (const block of blocks) {
-    map.set(block.id, block);
-  }
-  return map;
+  return new Map(blocks.map((block) => [block.id, block]));
 }
 
 /**
  * Clamp an index into [0, max].
  */
 function clampIndex(index: number, max: number): number {
-  if (index < 0) return 0;
-  if (index > max) return max;
-  return index;
+  return Math.max(0, Math.min(index, max));
 }
 
 // ============================================================================
@@ -210,18 +204,12 @@ export function createBlockHandler(options?: BlockHandlerOptions): BlockHandlerI
     unsubscribes.push(unsub);
   }
 
-  // -- Notify helper ---------------------------------------------------------
-  function setBlocks(next: Block[]): void {
-    $blocks.set(next);
-  }
-
   // -- Mutations -------------------------------------------------------------
 
   function addBlock(block: Block, index?: number): void {
     const current = $blocks.get();
-    const map = buildBlockMap(current);
 
-    if (map.has(block.id)) {
+    if (current.some((b) => b.id === block.id)) {
       throw new Error(`Block with id '${block.id}' already exists`);
     }
 
@@ -233,7 +221,7 @@ export function createBlockHandler(options?: BlockHandlerOptions): BlockHandlerI
       next.splice(clamped, 0, block);
     }
 
-    setBlocks(next);
+    $blocks.set(next);
   }
 
   function removeBlocks(ids: Set<string>): void {
@@ -243,14 +231,19 @@ export function createBlockHandler(options?: BlockHandlerOptions): BlockHandlerI
     // Collect all IDs to remove (requested + descendants)
     const toRemove = new Set<string>(ids);
     for (const id of ids) {
-      const descendants = collectDescendants(id, map);
-      for (const descendantId of descendants) {
+      for (const descendantId of collectDescendants(id, map)) {
         toRemove.add(descendantId);
       }
     }
 
     // Short-circuit when none of the IDs exist in the current blocks
-    const hasRemovals = [...toRemove].some((id) => map.has(id));
+    let hasRemovals = false;
+    for (const id of toRemove) {
+      if (map.has(id)) {
+        hasRemovals = true;
+        break;
+      }
+    }
     if (!hasRemovals) return;
 
     // Remove children references from surviving parents and clean orphaned parentIds
@@ -275,16 +268,8 @@ export function createBlockHandler(options?: BlockHandlerOptions): BlockHandlerI
 
     // Clean up removed IDs from selection
     const selectedIds = $selectedIds.get();
-    let selectionChanged = false;
-    const newSelection = new Set<string>();
-    for (const id of selectedIds) {
-      if (!toRemove.has(id)) {
-        newSelection.add(id);
-      } else {
-        selectionChanged = true;
-      }
-    }
-    if (selectionChanged) {
+    const newSelection = new Set([...selectedIds].filter((id) => !toRemove.has(id)));
+    if (newSelection.size !== selectedIds.size) {
       $selectedIds.set(newSelection);
     }
 
@@ -294,7 +279,7 @@ export function createBlockHandler(options?: BlockHandlerOptions): BlockHandlerI
       $focusedId.set(null);
     }
 
-    setBlocks(next);
+    $blocks.set(next);
   }
 
   function moveBlock(id: string, toIndex: number): void {
@@ -306,16 +291,10 @@ export function createBlockHandler(options?: BlockHandlerOptions): BlockHandlerI
     }
 
     const next = [...current];
-    const spliced = next.splice(fromIndex, 1);
-    // fromIndex is validated above so splice always returns one element
-    const block = spliced[0];
-    if (!block)
-      throw new Error(`Unexpected: splice at validated index ${fromIndex} returned empty`);
+    const block = next.splice(fromIndex, 1)[0];
+    if (block) next.splice(clampIndex(toIndex, next.length), 0, block);
 
-    const clamped = clampIndex(toIndex, next.length);
-    next.splice(clamped, 0, block);
-
-    setBlocks(next);
+    $blocks.set(next);
   }
 
   function reorderBlocks(fromIndex: number, toIndex: number): void {
@@ -328,15 +307,10 @@ export function createBlockHandler(options?: BlockHandlerOptions): BlockHandlerI
     if (clampedFrom === clampedTo) return;
 
     const next = [...current];
-    const spliced = next.splice(clampedFrom, 1);
-    // clampedFrom is within bounds so splice always returns one element
-    const block = spliced[0];
-    if (!block)
-      throw new Error(`Unexpected: splice at clamped index ${clampedFrom} returned empty`);
+    const block = next.splice(clampedFrom, 1)[0];
+    if (block) next.splice(clampedTo, 0, block);
 
-    next.splice(clampedTo, 0, block);
-
-    setBlocks(next);
+    $blocks.set(next);
   }
 
   function updateBlock(id: string, updates: Partial<Block>): void {
@@ -357,9 +331,9 @@ export function createBlockHandler(options?: BlockHandlerOptions): BlockHandlerI
     if (!existing) return;
 
     const next = [...current];
-    next[index] = { ...existing, ...updates, id: existing.id };
+    next[index] = { ...existing, ...updates, id };
 
-    setBlocks(next);
+    $blocks.set(next);
   }
 
   function nestBlock(childId: string, parentId: string): void {
@@ -376,17 +350,13 @@ export function createBlockHandler(options?: BlockHandlerOptions): BlockHandlerI
       throw new Error(`Block with id '${parentId}' not found`);
     }
 
-    // Circular reference detection: check if parentId is a descendant of childId
-    if (childId === parentId) {
-      throw new Error(`Cannot nest block '${childId}' under '${parentId}': circular reference`);
-    }
-
-    const descendants = collectDescendants(childId, map);
-    if (descendants.has(parentId)) {
-      throw new Error(`Cannot nest block '${childId}' under '${parentId}': circular reference`);
-    }
-
-    if (isAncestor(parentId, childId, map)) {
+    // Circular reference detection: self-nesting, descendant check (children pointers),
+    // and ancestor check (parentId pointers) for robustness with inconsistent trees
+    if (
+      childId === parentId ||
+      collectDescendants(childId, map).has(parentId) ||
+      isAncestor(parentId, childId, map)
+    ) {
       throw new Error(`Cannot nest block '${childId}' under '${parentId}': circular reference`);
     }
 
@@ -423,7 +393,7 @@ export function createBlockHandler(options?: BlockHandlerOptions): BlockHandlerI
       return block;
     });
 
-    setBlocks(next);
+    $blocks.set(next);
   }
 
   function unnestBlock(childId: string): void {
@@ -460,7 +430,7 @@ export function createBlockHandler(options?: BlockHandlerOptions): BlockHandlerI
       return block;
     });
 
-    setBlocks(next);
+    $blocks.set(next);
   }
 
   function setSelection(ids: Set<string>): void {
@@ -475,21 +445,11 @@ export function createBlockHandler(options?: BlockHandlerOptions): BlockHandlerI
 
   function getCanvasCallbacks(): CanvasCallbacks {
     return {
-      getBlocks: (): BlockCanvasBlock[] => {
-        return $blocks.get().map((b) => ({ id: b.id, type: b.type }));
-      },
-      getSelectedIds: (): Set<string> => {
-        return $selectedIds.get();
-      },
-      getFocusedId: (): string | undefined => {
-        return $focusedId.get() ?? undefined;
-      },
-      onSelectionChange: (ids: Set<string>): void => {
-        $selectedIds.set(ids);
-      },
-      onFocusChange: (id: string | null): void => {
-        $focusedId.set(id);
-      },
+      getBlocks: () => $blocks.get().map((b) => ({ id: b.id, type: b.type })),
+      getSelectedIds: () => $selectedIds.get(),
+      getFocusedId: () => $focusedId.get() ?? undefined,
+      onSelectionChange: (ids) => $selectedIds.set(ids),
+      onFocusChange: (id) => $focusedId.set(id),
     };
   }
 

--- a/packages/ui/test/primitives/block-handler.test.ts
+++ b/packages/ui/test/primitives/block-handler.test.ts
@@ -10,6 +10,16 @@ function makeBlock(id: string, overrides?: Partial<Block>): Block {
   return { id, type: 'paragraph', content: `Content for ${id}`, ...overrides };
 }
 
+/** Extract ordered IDs from a handler's block list */
+function blockIds(handler: ReturnType<typeof createBlockHandler>): string[] {
+  return handler.$blocks.get().map((b) => b.id);
+}
+
+/** Find a block by ID in a handler's block list */
+function findBlock(handler: ReturnType<typeof createBlockHandler>, id: string): Block | undefined {
+  return handler.$blocks.get().find((b) => b.id === id);
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -71,8 +81,7 @@ describe('createBlockHandler', () => {
 
       handler.addBlock(makeBlock('b'), 1);
 
-      const ids = handler.$blocks.get().map((b) => b.id);
-      expect(ids).toEqual(['a', 'b', 'c']);
+      expect(blockIds(handler)).toEqual(['a', 'b', 'c']);
     });
 
     it('clamps negative index to 0', () => {
@@ -80,8 +89,7 @@ describe('createBlockHandler', () => {
 
       handler.addBlock(makeBlock('b'), -5);
 
-      const ids = handler.$blocks.get().map((b) => b.id);
-      expect(ids).toEqual(['b', 'a']);
+      expect(blockIds(handler)).toEqual(['b', 'a']);
     });
 
     it('clamps out-of-range index to length', () => {
@@ -89,8 +97,7 @@ describe('createBlockHandler', () => {
 
       handler.addBlock(makeBlock('b'), 999);
 
-      const ids = handler.$blocks.get().map((b) => b.id);
-      expect(ids).toEqual(['a', 'b']);
+      expect(blockIds(handler)).toEqual(['a', 'b']);
     });
 
     it('throws on duplicate ID', () => {
@@ -114,8 +121,7 @@ describe('createBlockHandler', () => {
 
       handler.removeBlocks(new Set(['b']));
 
-      const ids = handler.$blocks.get().map((b) => b.id);
-      expect(ids).toEqual(['a', 'c']);
+      expect(blockIds(handler)).toEqual(['a', 'c']);
     });
 
     it('removes multiple blocks', () => {
@@ -125,8 +131,7 @@ describe('createBlockHandler', () => {
 
       handler.removeBlocks(new Set(['a', 'c']));
 
-      const ids = handler.$blocks.get().map((b) => b.id);
-      expect(ids).toEqual(['b']);
+      expect(blockIds(handler)).toEqual(['b']);
     });
 
     it('cascades removal to nested children', () => {
@@ -142,8 +147,7 @@ describe('createBlockHandler', () => {
 
       handler.removeBlocks(new Set(['parent']));
 
-      const ids = handler.$blocks.get().map((b) => b.id);
-      expect(ids).toEqual(['other']);
+      expect(blockIds(handler)).toEqual(['other']);
     });
 
     it('cleans up children references from surviving parents', () => {
@@ -157,8 +161,7 @@ describe('createBlockHandler', () => {
 
       handler.removeBlocks(new Set(['child1']));
 
-      const parent = handler.$blocks.get().find((b) => b.id === 'parent');
-      expect(parent?.children).toEqual(['child2']);
+      expect(findBlock(handler, 'parent')?.children).toEqual(['child2']);
     });
 
     it('cleans orphaned parentId when parent is removed but child survives', () => {
@@ -175,7 +178,7 @@ describe('createBlockHandler', () => {
       // Remove the parent -- child survives because it is not in parent.children
       handler.removeBlocks(new Set(['parent']));
 
-      const child = handler.$blocks.get().find((b) => b.id === 'child');
+      const child = findBlock(handler, 'child');
       expect(child).toBeDefined();
       expect(child?.parentId).toBeUndefined();
     });
@@ -189,7 +192,6 @@ describe('createBlockHandler', () => {
 
       handler.removeBlocks(new Set(['nonexistent']));
 
-      // onChange should not fire since nothing was actually removed
       expect(onChange).not.toHaveBeenCalled();
     });
 
@@ -238,8 +240,7 @@ describe('createBlockHandler', () => {
 
       handler.moveBlock('a', 2);
 
-      const ids = handler.$blocks.get().map((b) => b.id);
-      expect(ids).toEqual(['b', 'c', 'a']);
+      expect(blockIds(handler)).toEqual(['b', 'c', 'a']);
     });
 
     it('clamps target index to valid range', () => {
@@ -249,8 +250,7 @@ describe('createBlockHandler', () => {
 
       handler.moveBlock('a', 999);
 
-      const ids = handler.$blocks.get().map((b) => b.id);
-      expect(ids).toEqual(['b', 'a']);
+      expect(blockIds(handler)).toEqual(['b', 'a']);
     });
 
     it('throws for unknown block ID', () => {
@@ -276,8 +276,7 @@ describe('createBlockHandler', () => {
 
       handler.reorderBlocks(0, 2);
 
-      const ids = handler.$blocks.get().map((b) => b.id);
-      expect(ids).toEqual(['b', 'c', 'a']);
+      expect(blockIds(handler)).toEqual(['b', 'c', 'a']);
     });
 
     it('clamps out-of-range indices', () => {
@@ -287,8 +286,7 @@ describe('createBlockHandler', () => {
 
       handler.reorderBlocks(-1, 100);
 
-      const ids = handler.$blocks.get().map((b) => b.id);
-      expect(ids).toEqual(['b', 'c', 'a']);
+      expect(blockIds(handler)).toEqual(['b', 'c', 'a']);
     });
 
     it('is a no-op when from and to are the same', () => {
@@ -300,14 +298,12 @@ describe('createBlockHandler', () => {
 
       handler.reorderBlocks(1, 1);
 
-      // Should not have been called since indices are equal
       expect(onChange).not.toHaveBeenCalled();
     });
 
     it('handles empty block list', () => {
       const handler = createBlockHandler();
 
-      // Should not throw
       handler.reorderBlocks(0, 1);
 
       expect(handler.$blocks.get()).toEqual([]);
@@ -385,12 +381,8 @@ describe('createBlockHandler', () => {
 
       handler.nestBlock('child', 'parent');
 
-      const blocks = handler.$blocks.get();
-      const parent = blocks.find((b) => b.id === 'parent');
-      const child = blocks.find((b) => b.id === 'child');
-
-      expect(parent?.children).toEqual(['child']);
-      expect(child?.parentId).toBe('parent');
+      expect(findBlock(handler, 'parent')?.children).toEqual(['child']);
+      expect(findBlock(handler, 'child')?.parentId).toBe('parent');
     });
 
     it('moves a child from one parent to another', () => {
@@ -404,14 +396,9 @@ describe('createBlockHandler', () => {
 
       handler.nestBlock('child', 'parent2');
 
-      const blocks = handler.$blocks.get();
-      const parent1 = blocks.find((b) => b.id === 'parent1');
-      const parent2 = blocks.find((b) => b.id === 'parent2');
-      const child = blocks.find((b) => b.id === 'child');
-
-      expect(parent1?.children).toEqual([]);
-      expect(parent2?.children).toEqual(['child']);
-      expect(child?.parentId).toBe('parent2');
+      expect(findBlock(handler, 'parent1')?.children).toEqual([]);
+      expect(findBlock(handler, 'parent2')?.children).toEqual(['child']);
+      expect(findBlock(handler, 'child')?.parentId).toBe('parent2');
     });
 
     it('throws on self-nesting', () => {
@@ -466,11 +453,9 @@ describe('createBlockHandler', () => {
         ],
       });
 
-      // Nesting again under the same parent should not add a duplicate
       handler.nestBlock('child', 'parent');
 
-      const parent = handler.$blocks.get().find((b) => b.id === 'parent');
-      expect(parent?.children).toEqual(['child']);
+      expect(findBlock(handler, 'parent')?.children).toEqual(['child']);
     });
   });
 
@@ -489,12 +474,8 @@ describe('createBlockHandler', () => {
 
       handler.unnestBlock('child');
 
-      const blocks = handler.$blocks.get();
-      const parent = blocks.find((b) => b.id === 'parent');
-      const child = blocks.find((b) => b.id === 'child');
-
-      expect(parent?.children).toEqual([]);
-      expect(child?.parentId).toBeUndefined();
+      expect(findBlock(handler, 'parent')?.children).toEqual([]);
+      expect(findBlock(handler, 'child')?.parentId).toBeUndefined();
     });
 
     it('is a no-op for top-level blocks', () => {
@@ -506,7 +487,6 @@ describe('createBlockHandler', () => {
 
       handler.unnestBlock('a');
 
-      // Should not trigger a state change
       expect(onChange).not.toHaveBeenCalled();
     });
 
@@ -570,14 +550,11 @@ describe('createBlockHandler', () => {
 
       const callbacks = handler.getCanvasCallbacks();
 
-      // Must have these keys
       expect(callbacks).toHaveProperty('getBlocks');
       expect(callbacks).toHaveProperty('getSelectedIds');
       expect(callbacks).toHaveProperty('getFocusedId');
       expect(callbacks).toHaveProperty('onSelectionChange');
       expect(callbacks).toHaveProperty('onFocusChange');
-
-      // Must NOT have container (that comes from the caller)
       expect(callbacks).not.toHaveProperty('container');
     });
 
@@ -590,7 +567,6 @@ describe('createBlockHandler', () => {
       const blocks = callbacks.getBlocks();
 
       expect(blocks).toEqual([{ id: 'a', type: 'heading' }]);
-      // Should NOT include content or other Block fields
       expect(blocks[0]).not.toHaveProperty('content');
     });
 
@@ -737,7 +713,6 @@ describe('createBlockHandler', () => {
 
       handler.addBlock(makeBlock('a'));
 
-      // onChange should NOT have been called after destroy
       expect(onChange).not.toHaveBeenCalled();
     });
 
@@ -746,8 +721,6 @@ describe('createBlockHandler', () => {
 
       handler.destroy();
       handler.destroy();
-
-      // No error thrown
     });
 
     it('atoms remain readable after destroy', () => {
@@ -757,7 +730,6 @@ describe('createBlockHandler', () => {
 
       handler.destroy();
 
-      // Atoms should still be readable (just not subscribed)
       expect(handler.$blocks.get()).toHaveLength(1);
     });
   });
@@ -830,7 +802,6 @@ describe('createBlockHandler', () => {
         onChange,
       });
 
-      // Both will clamp to 0
       handler.reorderBlocks(0, 0);
       expect(onChange).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary
- Implements `createBlockHandler()` composition primitive using nanostores atoms
- Manages block tree state: CRUD, reordering, nesting/unnesting, selection, focus
- `getCanvasCallbacks()` returns exact shape for `createBlockCanvas()` integration
- Cascading child removal, circular reference detection, index clamping
- Comprehensive test suite (59 tests)

Closes #810
Depends on #812

## Test plan
- [x] All 59 unit tests pass
- [x] TypeScript compiles (no `any` types)
- [x] Biome lint passes
- [x] SSR safe (no DOM access)
- [x] Full `pnpm preflight` passes

Generated with [Claude Code](https://claude.com/claude-code)