### PR TITLE
feat(cli): add --update and --update-all flags to rafters add

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -22,6 +22,8 @@ import type { RaftersConfig } from './init.js';
 export interface AddOptions {
   list?: boolean;
   overwrite?: boolean;
+  update?: boolean;
+  updateAll?: boolean;
   registryUrl?: string;
   agent?: boolean;
 }
@@ -63,6 +65,16 @@ async function loadConfig(cwd: string): Promise<RaftersConfig | null> {
 async function saveConfig(cwd: string, config: RaftersConfig): Promise<void> {
   const paths = getRaftersPaths(cwd);
   await writeFile(paths.config, JSON.stringify(config, null, 2));
+}
+
+/**
+ * Get all installed component and primitive names from config.
+ * Returns a combined, deduplicated list.
+ */
+export function getInstalledNames(config: RaftersConfig | null): string[] {
+  if (!config?.installed) return [];
+  const names = new Set([...config.installed.components, ...config.installed.primitives]);
+  return [...names].sort();
 }
 
 /**
@@ -291,9 +303,10 @@ export async function installComponent(
 /**
  * Add one or more components to the project
  */
-export async function add(components: string[], options: AddOptions): Promise<void> {
+export async function add(componentArgs: string[], options: AddOptions): Promise<void> {
   setAgentMode(options.agent ?? false);
 
+  let components = componentArgs;
   const client = new RegistryClient(options.registryUrl);
 
   // Handle --list option
@@ -324,6 +337,32 @@ export async function add(components: string[], options: AddOptions): Promise<vo
 
   // Load project config for path mappings
   const config = await loadConfig(cwd);
+
+  // --update is a clearer alias for --overwrite
+  if (options.update) {
+    options.overwrite = true;
+  }
+
+  // --update-all: re-fetch all installed components (takes precedence over --update)
+  if (options.updateAll) {
+    options.overwrite = true;
+
+    if (!config) {
+      error("No rafters config found. Run 'rafters init' first.");
+      process.exitCode = 1;
+      return;
+    }
+
+    const installedNames = getInstalledNames(config);
+    if (installedNames.length === 0) {
+      error("No installed components found. Use 'rafters add <component>' to install first.");
+      process.exitCode = 1;
+      return;
+    }
+
+    // Replace CLI args with installed list
+    components = installedNames;
+  }
 
   // Validate that at least one component is specified
   if (components.length === 0) {
@@ -463,11 +502,12 @@ export async function add(components: string[], options: AddOptions): Promise<vo
   if (skipped.length > 0 && installed.length === 0) {
     log({
       event: 'add:hint',
-      message: 'Some components were skipped. Use --overwrite to replace existing files.',
+      message:
+        'Some components were skipped. Use --update to re-fetch, or --update-all to refresh everything.',
       skipped,
     });
     // Fail if nothing was installed and components were skipped (already exist)
-    error('Component already exists. Use --overwrite to replace.');
+    error('Component already exists. Use --update to re-fetch from registry.');
     process.exitCode = 1;
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,6 +33,8 @@ program
   .argument('[components...]', 'Component names to add')
   .option('--list', 'List available components')
   .option('--overwrite', 'Overwrite existing component files')
+  .option('--update', 'Re-fetch named components from registry')
+  .option('--update-all', 'Re-fetch all installed components from registry')
   .option('--registry-url <url>', 'Custom registry URL')
   .option('--agent', 'Output JSON for machine consumption')
   .action(withErrorHandler(add));

--- a/packages/cli/test/commands/add.test.ts
+++ b/packages/cli/test/commands/add.test.ts
@@ -12,6 +12,7 @@ import { zocker } from 'zocker';
 import { z } from 'zod';
 import {
   collectDependencies,
+  getInstalledNames,
   isAlreadyInstalled,
   trackInstalled,
   transformFileContent,
@@ -386,5 +387,63 @@ describe('registry fixtures', () => {
     for (const fixture of fixtures) {
       expect(() => RegistryItemSchema.parse(fixture)).not.toThrow();
     }
+  });
+});
+
+describe('getInstalledNames', () => {
+  const baseConfig: RaftersConfig = {
+    framework: 'react-router',
+    componentsPath: 'components/ui',
+    primitivesPath: 'lib/primitives',
+    cssPath: null,
+    shadcn: false,
+    exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
+    installed: {
+      components: ['button', 'card'],
+      primitives: ['classy'],
+    },
+  };
+
+  it('returns combined components and primitives', () => {
+    const names = getInstalledNames(baseConfig);
+    expect(names).toContain('button');
+    expect(names).toContain('card');
+    expect(names).toContain('classy');
+    expect(names).toHaveLength(3);
+  });
+
+  it('returns sorted names', () => {
+    const names = getInstalledNames(baseConfig);
+    const sorted = [...names].sort();
+    expect(names).toEqual(sorted);
+  });
+
+  it('deduplicates names that appear in both lists', () => {
+    const config: RaftersConfig = {
+      ...baseConfig,
+      installed: {
+        components: ['classy'],
+        primitives: ['classy'],
+      },
+    };
+    const names = getInstalledNames(config);
+    expect(names).toEqual(['classy']);
+  });
+
+  it('returns empty array when config is null', () => {
+    expect(getInstalledNames(null)).toEqual([]);
+  });
+
+  it('returns empty array when installed field is missing', () => {
+    const config: RaftersConfig = { ...baseConfig, installed: undefined };
+    expect(getInstalledNames(config)).toEqual([]);
+  });
+
+  it('returns empty array when both lists are empty', () => {
+    const config: RaftersConfig = {
+      ...baseConfig,
+      installed: { components: [], primitives: [] },
+    };
+    expect(getInstalledNames(config)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Adds `--update` flag as a clearer-intent alias for `--overwrite` (re-fetch named components from registry)
- Adds `--update-all` flag to re-fetch all installed components from the config's installed list
- Adds `getInstalledNames()` helper that combines and deduplicates components + primitives
- Updates hint messages to reference the new flags

Closes #775

## Test plan
- [ ] 6 new unit tests for `getInstalledNames` (combined output, sorting, deduplication, null config, missing installed, empty lists)
- [ ] All 202 existing CLI tests still pass
- [ ] Preflight green

🤖 Generated with [Claude Code](https://claude.com/claude-code)