### PR TITLE
docs(ui): clarify drop zone position-awareness in drag-drop

### DIFF
--- a/packages/ui/src/primitives/drag-drop.ts
+++ b/packages/ui/src/primitives/drag-drop.ts
@@ -735,7 +735,17 @@ export function createDraggable(options: DraggableOptions): DraggableControls {
 // =============================================================================
 
 /**
- * Create a drop zone that accepts draggable items
+ * Create a drop zone that accepts draggable items.
+ *
+ * NOTE: The `onDrop` callback receives the dragged data and drop effect but
+ * does NOT provide position coordinates (clientX/clientY). This is by design:
+ * createDropZone answers "was something dropped here?" but not "where exactly
+ * within the zone?" For position-aware drop handling (e.g., inserting a block
+ * between existing blocks based on cursor position), use the canvas-drop-zone
+ * primitive (`primitives/canvas-drop-zone.ts`) which calculates insertion
+ * indices from cursor proximity to existing block boundaries.
+ *
+ * @see canvas-drop-zone (`primitives/canvas-drop-zone.ts`) for position-aware drop targeting
  *
  * @example
  * ```typescript


### PR DESCRIPTION
## Summary
- Add JSDoc documentation to `createDropZone` in the drag-drop primitive clarifying position-awareness limitations
- Explain that `createDropZone` answers "was something dropped here?" but not "where exactly within the zone?"
- Point to the `canvas-drop-zone` primitive for position-aware drop targeting

Closes #845

## Test plan
- [ ] Verify no functional changes in drag-drop.ts (JSDoc only)
- [ ] Confirm existing drag-drop tests still pass

Generated with [Claude Code](https://claude.com/claude-code)