### PR TITLE
docs(ui): clarify block CRUD ownership in block-handler and editor

### DIFF
--- a/packages/ui/src/components/ui/editor.tsx
+++ b/packages/ui/src/components/ui/editor.tsx
@@ -59,6 +59,15 @@ import { Container } from './container';
 // Types
 // ============================================================================
 
+/**
+ * A single block in the Editor's content tree.
+ *
+ * Composites consume this type to render and interact with blocks.
+ * Import it from the package root:
+ * ```ts
+ * import type { EditorBlock } from '@rafters/ui';
+ * ```
+ */
 export interface EditorBlock {
   id: string;
   type: string;
@@ -118,16 +127,44 @@ export interface BlockRenderContext {
   isFocused: boolean;
 }
 
-/** Imperative handle exposed via ref */
+/**
+ * Imperative handle exposed via ref -- the block mutation API.
+ *
+ * EditorControls is the single owner of all block CRUD operations:
+ * addBlock, removeBlocks, moveBlock, and updateBlock. The block-handler
+ * primitive manages selection, focus, undo/redo, and clipboard but
+ * never initiates mutations. Composites and external consumers should
+ * acquire this handle via `React.useRef<EditorControls>()` and call
+ * these methods to modify the block tree.
+ *
+ * @see block-handler (`primitives/block-handler.ts`) for selection/focus/history state
+ *
+ * @example
+ * ```tsx
+ * const editorRef = React.useRef<EditorControls>(null);
+ * <Editor ref={editorRef} />
+ * // Later:
+ * editorRef.current?.addBlock({ id: crypto.randomUUID(), type: 'text', content: '' });
+ * ```
+ */
 export interface EditorControls {
+  /** Insert a block at the given index (or append if omitted) */
   addBlock: (block: EditorBlock, index?: number) => void;
+  /** Remove blocks by their IDs */
   removeBlocks: (ids: Set<string>) => void;
+  /** Move a block to a new position */
   moveBlock: (id: string, toIndex: number) => void;
+  /** Partially update a block's properties (id is preserved) */
   updateBlock: (id: string, updates: Partial<EditorBlock>) => void;
+  /** Undo the last mutation (delegated to block-handler history) */
   undo: () => void;
+  /** Redo the last undone mutation (delegated to block-handler history) */
   redo: () => void;
+  /** Select all blocks */
   selectAll: () => void;
+  /** Clear selection */
   clearSelection: () => void;
+  /** Move focus to the editor canvas */
   focus: () => void;
 }
 

--- a/packages/ui/src/primitives/block-handler.ts
+++ b/packages/ui/src/primitives/block-handler.ts
@@ -6,6 +6,17 @@
  * multiple leaf primitives. The block handler wires selection, focus, history,
  * and clipboard into a single coherent API for block-based editors.
  *
+ * IMPORTANT -- Block CRUD ownership:
+ * block-handler does NOT manage block creation, deletion, reordering, or content
+ * updates. It manages **selection state**, **focus**, **undo/redo history**, and
+ * **clipboard** only. All block mutations (addBlock, removeBlocks, moveBlock,
+ * updateBlock) are owned by the Editor component's imperative controls
+ * ({@link EditorControls} in `components/ui/editor.tsx`). block-handler receives
+ * block changes via the `$blocks` atom and `onBlocksChange` callback, but it
+ * never initiates mutations itself.
+ *
+ * @see {@link EditorControls} in `components/ui/editor.tsx` for the block mutation API
+ *
  * @registry-name block-handler
  * @registry-version 0.1.0
  * @registry-status published
@@ -28,6 +39,7 @@
  * DO: Call destroy() on cleanup to tear down all child primitives
  * NEVER: Import block-canvas or block-wrapper directly when block-handler is available
  * NEVER: Mutate the atom value directly -- use the provided action functions
+ * NEVER: Use block-handler for block CRUD -- use EditorControls (via Editor ref) instead
  *
  * @example
  * ```ts


### PR DESCRIPTION
## Summary
- Add JSDoc to `block-handler.ts` documenting that it manages selection, focus, undo/redo, and clipboard -- but never initiates block mutations
- Add JSDoc to `EditorBlock` interface clarifying its role as the content tree node type
- Expand `EditorControls` JSDoc to document it as the single owner of all block CRUD operations, with method-level documentation and usage example

## Test plan
- [x] No functional changes -- JSDoc only
- [x] Verify `pnpm typecheck` passes (no interface signature changes)

Closes #844

🤖 Generated with [Claude Code](https://claude.com/claude-code)