### PR TITLE
feat(ui): export EditorBlock and EditorControls from package root

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "exports": {
+    ".": "./src/index.ts",
     "./primitives/*": "./src/primitives/*.ts",
     "./components/*": "./src/components/*.tsx",
     "./hooks/*": "./src/hooks/*.ts",

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @rafters/ui package root
+ *
+ * Re-exports core types that composites and external consumers import
+ * from the package root rather than deep paths.
+ */
+
+export type { EditorBlock, EditorControls } from './components/ui/editor.js';


### PR DESCRIPTION
## Summary
- Create `packages/ui/src/index.ts` barrel export with `EditorBlock` and `EditorControls` type re-exports.
- Add `".": "./src/index.ts"` as the root export entry in `@rafters/ui` package.json.
- Enables composites and external consumers to import core editor types from `@rafters/ui` instead of deep paths.

Closes #846

## Test plan
- [ ] Verify `import type { EditorBlock, EditorControls } from '@rafters/ui'` resolves correctly
- [ ] Verify existing deep-path imports still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>