### PR TITLE
fix(ui): export fuzzyScore from typeahead primitive

### DIFF
--- a/packages/ui/src/primitives/typeahead.ts
+++ b/packages/ui/src/primitives/typeahead.ts
@@ -21,6 +21,52 @@
 
 import type { CleanupFunction } from './types';
 
+/**
+ * Compute a fuzzy match score between a query and a target string.
+ *
+ * Scoring heuristics:
+ * - +2 for each consecutive matching character
+ * - +3 bonus for matching at the start of a word (after space, hyphen, or start of string)
+ * - +1 base point per matched character
+ *
+ * Case insensitive. Empty query matches everything (returns 1).
+ * Query longer than target returns 0.
+ *
+ * @param query - The search query
+ * @param target - The string to match against
+ * @returns A non-negative score; 0 means no match
+ */
+export function fuzzyScore(query: string, target: string): number {
+  if (query.length === 0) return 1;
+  if (query.length > target.length) return 0;
+
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+
+  let score = 0;
+  let qi = 0;
+  let prevMatchIndex = -2; // -2 so first match is never "consecutive"
+
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) {
+      score += 1; // base point
+      // consecutive bonus
+      if (ti === prevMatchIndex + 1) {
+        score += 2;
+      }
+      // start-of-word bonus
+      if (ti === 0 || t[ti - 1] === ' ' || t[ti - 1] === '-') {
+        score += 3;
+      }
+      prevMatchIndex = ti;
+      qi++;
+    }
+  }
+
+  // All query characters must be found
+  return qi === q.length ? score : 0;
+}
+
 export interface TypeaheadOptions {
   /**
    * Function to get searchable items

--- a/packages/ui/test/primitives/typeahead.test.ts
+++ b/packages/ui/test/primitives/typeahead.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createControlledTypeahead,
   createTypeahead,
+  fuzzyScore,
   highlightMatch,
 } from '../../src/primitives/typeahead';
 
@@ -461,5 +462,57 @@ describe('highlightMatch', () => {
     expect(cleanup).toBeInstanceOf(Function);
 
     globalThis.window = originalWindow;
+  });
+});
+
+describe('fuzzyScore', () => {
+  it('returns 1 for empty query', () => {
+    expect(fuzzyScore('', 'anything')).toBe(1);
+  });
+
+  it('returns 0 when query is longer than target', () => {
+    expect(fuzzyScore('longquery', 'short')).toBe(0);
+  });
+
+  it('returns 0 when query characters are not found in order', () => {
+    expect(fuzzyScore('zxy', 'abc')).toBe(0);
+  });
+
+  it('scores exact match at start higher than match in middle', () => {
+    const startScore = fuzzyScore('app', 'Apple');
+    const middleScore = fuzzyScore('app', 'Snapper');
+    expect(startScore).toBeGreaterThan(middleScore);
+  });
+
+  it('is case insensitive', () => {
+    expect(fuzzyScore('APP', 'apple')).toBe(fuzzyScore('app', 'Apple'));
+  });
+
+  it('awards consecutive character bonus', () => {
+    // "ab" in "abc" (consecutive) should score higher than "ab" in "axb" (non-consecutive)
+    const consecutive = fuzzyScore('ab', 'abc');
+    const nonConsecutive = fuzzyScore('ab', 'axb');
+    expect(consecutive).toBeGreaterThan(nonConsecutive);
+  });
+
+  it('awards start-of-word bonus', () => {
+    // "b" at start of word "bar" should score higher than "b" in middle of "abc"
+    const wordStart = fuzzyScore('b', 'foo bar');
+    const wordMiddle = fuzzyScore('b', 'abc');
+    expect(wordStart).toBeGreaterThan(wordMiddle);
+  });
+
+  it('handles hyphenated words', () => {
+    // "b" after hyphen should get start-of-word bonus
+    const score = fuzzyScore('b', 'foo-bar');
+    expect(score).toBeGreaterThan(0);
+  });
+
+  it('returns positive score for valid partial match', () => {
+    expect(fuzzyScore('btn', 'button')).toBeGreaterThan(0);
+  });
+
+  it('returns 0 when not all query characters found', () => {
+    expect(fuzzyScore('xyz', 'hello')).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- Add fuzzyScore function to the typeahead primitive (packages/ui/src/primitives/typeahead.ts)
- Fixes composites registry tests that import fuzzyScore from @rafters/ui/primitives/typeahead
- Includes comprehensive tests covering empty queries, case insensitivity, consecutive/start-of-word bonuses, and edge cases

## Test plan
- [x] pnpm --filter=@rafters/ui test passes (3024 tests, 139 files)
- [x] pnpm preflight passes
- [ ] pnpm --filter=@rafters/composites test passes (composites package not yet on main; will verify after merge with composites branch)

Generated with [Claude Code](https://claude.com/claude-code)