### PR TITLE
feat(ui): add gap prop to Container for vertical flow

### DIFF
--- a/packages/ui/src/components/ui/container.tsx
+++ b/packages/ui/src/components/ui/container.tsx
@@ -52,6 +52,12 @@ export interface ContainerProps extends React.HTMLAttributes<HTMLElement> {
   padding?: '0' | '1' | '2' | '3' | '4' | '5' | '6' | '8' | '10' | '12' | '16' | '20' | '24';
 
   /**
+   * Vertical flow gap between children using Tailwind spacing scale
+   * Applies flex flex-col gap-{n} to create a vertical stack with consistent spacing
+   */
+  gap?: '0' | '1' | '2' | '3' | '4' | '5' | '6' | '8' | '10' | '12' | '16' | '20' | '24';
+
+  /**
    * Enable container queries on this element
    * Children can use @container queries to respond to this container's size
    * @default true
@@ -120,6 +126,22 @@ const paddingClasses: Record<string, string> = {
   '16': 'p-16',
   '20': 'p-20',
   '24': 'p-24',
+};
+
+const gapClasses: Record<string, string> = {
+  '0': 'flex flex-col gap-0',
+  '1': 'flex flex-col gap-1',
+  '2': 'flex flex-col gap-2',
+  '3': 'flex flex-col gap-3',
+  '4': 'flex flex-col gap-4',
+  '5': 'flex flex-col gap-5',
+  '6': 'flex flex-col gap-6',
+  '8': 'flex flex-col gap-8',
+  '10': 'flex flex-col gap-10',
+  '12': 'flex flex-col gap-12',
+  '16': 'flex flex-col gap-16',
+  '20': 'flex flex-col gap-20',
+  '24': 'flex flex-col gap-24',
 };
 
 // Article typography - the magic for readable content
@@ -191,6 +213,7 @@ export const Container = React.forwardRef<HTMLElement, ContainerProps>(
       as: Element = 'div',
       size,
       padding,
+      gap,
       query = true,
       queryName,
       editable,
@@ -223,6 +246,9 @@ export const Container = React.forwardRef<HTMLElement, ContainerProps>(
 
       // Padding
       padding && paddingClasses[padding],
+
+      // Vertical flow with gap
+      gap && gapClasses[gap],
 
       // Background (R-202)
       background && backgroundClasses[background],

--- a/packages/ui/test/components/container.test.tsx
+++ b/packages/ui/test/components/container.test.tsx
@@ -1,0 +1,63 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Container } from '../../src/components/ui/container';
+
+describe('Container', () => {
+  describe('gap prop', () => {
+    it('applies flex flex-col and gap class when gap is set', () => {
+      const { container } = render(<Container gap="6">content</Container>);
+      const el = container.firstElementChild!;
+      expect(el.className).toContain('flex');
+      expect(el.className).toContain('flex-col');
+      expect(el.className).toContain('gap-6');
+    });
+
+    it('does not apply flex or gap classes when gap is not set', () => {
+      const { container } = render(<Container>content</Container>);
+      const el = container.firstElementChild!;
+      expect(el.className).not.toContain('flex-col');
+      expect(el.className).not.toContain('gap-');
+    });
+
+    it('works with gap="0"', () => {
+      const { container } = render(<Container gap="0">content</Container>);
+      const el = container.firstElementChild!;
+      expect(el.className).toContain('flex');
+      expect(el.className).toContain('flex-col');
+      expect(el.className).toContain('gap-0');
+    });
+
+    it('combines with padding', () => {
+      const { container } = render(
+        <Container padding="4" gap="6">
+          content
+        </Container>,
+      );
+      const el = container.firstElementChild!;
+      expect(el.className).toContain('p-4');
+      expect(el.className).toContain('gap-6');
+    });
+
+    it('combines with size', () => {
+      const { container } = render(
+        <Container size="sm" gap="8">
+          content
+        </Container>,
+      );
+      const el = container.firstElementChild!;
+      expect(el.className).toContain('max-w-sm');
+      expect(el.className).toContain('gap-8');
+    });
+
+    it('combines with className', () => {
+      const { container } = render(
+        <Container gap="4" className="custom-class">
+          content
+        </Container>,
+      );
+      const el = container.firstElementChild!;
+      expect(el.className).toContain('gap-4');
+      expect(el.className).toContain('custom-class');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `gap` prop to Container component using same spacing scale as `padding`
- When set, applies `flex flex-col gap-{n}` for vertical stacking with consistent spacing
- Eliminates need for `className="flex flex-col gap-6"` workarounds

## Test plan
- [x] 6 unit tests covering gap application, gap="0", combinations with padding/size/className, and absence when unset
- [x] Preflight passes clean

Closes #772

Generated with [Claude Code](https://claude.com/claude-code)