### PR TITLE
fix: rewrite release workflow to match kelex OIDC pattern

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,15 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [
-    "@rafters/chrome",
-    "@rafters/color-utils",
-    "@rafters/composites",
-    "@rafters/math-utils",
-    "@rafters/studio",
-    "@rafters/ui",
-    "rafters-api",
-    "demo",
-    "rafters-website"
-  ]
+  "ignore": []
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,19 +2,21 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  release:
-    name: Release
+  version:
+    name: Version
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
+    outputs:
+      hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,14 +33,44 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Clean .npmrc for OIDC
-        run: rm -f .npmrc
-
-      - name: Create Release PR or Publish
+      - name: Create release PR or detect merged version
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm run version
-          publish: pnpm release
+          title: "chore: version packages"
+          commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish
+    needs: version
+    if: needs.version.outputs.hasChangesets == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.12
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install latest npm for OIDC
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build CLI
+        run: pnpm --filter=rafters build
+
+      - name: Publish to npm
+        run: pnpm changeset publish


### PR DESCRIPTION
## Summary
Rewrites the release workflow based on the working kelex pattern.

**Previous approach (broken):** Single job, ignore list for changesets config. Failed because changesets validates the entire dependency graph and rejects ignored packages that are transitive deps of non-ignored packages.

**New approach (kelex pattern):**
- Two jobs: `version` (creates release PR) and `publish` (npm OIDC)
- Empty ignore list -- all non-CLI packages are `private: true`, so changesets skips them automatically
- Publish job has `id-token: write` for OIDC, installs latest npm (>=11.5.1)
- Version job only needs `contents: write` + `pull-requests: write`

## Test plan
- [ ] Merge triggers version job
- [ ] No pending changesets -> publish job runs
- [ ] OIDC auth succeeds
- [ ] `rafters@0.0.9` appears on npm