### PR TITLE
fix: clear NODE_AUTH_TOKEN for npm OIDC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,3 +74,5 @@ jobs:
 
       - name: Publish to npm
         run: pnpm changeset publish
+        env:
+          NODE_AUTH_TOKEN: ""


### PR DESCRIPTION
## Summary
setup-node with registry-url sets NODE_AUTH_TOKEN to a placeholder value (actions/setup-node#1440), which prevents npm from falling back to OIDC trusted publishing. Clear it explicitly in the publish step.

## Test plan
- [ ] Release workflow publishes rafters@0.0.9 via OIDC