### PR TITLE
fix: remove registry-url to stop .npmrc blocking OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24.12
-          registry-url: "https://registry.npmjs.org"
 
       - name: Install latest npm for OIDC
         run: npm install -g npm@latest
@@ -74,5 +73,3 @@ jobs:
 
       - name: Publish to npm
         run: pnpm changeset publish
-        env:
-          NODE_AUTH_TOKEN: ""


### PR DESCRIPTION
## Summary
`setup-node` with `registry-url` writes an `.npmrc` with `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`. Even when `NODE_AUTH_TOKEN` is empty, npm sees that config and tries token auth instead of OIDC.

Removing `registry-url` entirely prevents the `.npmrc` from being created. OIDC trusted publishing doesn't need it -- npm detects OIDC automatically.

## Test plan
- [ ] Release workflow publishes rafters@0.0.9 via OIDC