### PR TITLE
fix(ui): reclassify primitive refs as @internal-dependencies

### DIFF
--- a/packages/ui/src/primitives/block-wrapper.ts
+++ b/packages/ui/src/primitives/block-wrapper.ts
@@ -24,7 +24,7 @@
  * NEVER: Nest block wrappers
  * NEVER: Add wrapper-level keyboard handlers that conflict with canvas-level navigation
  *
- * @dependencies primitives/drag-drop
+ * @internal-dependencies primitives/drag-drop
  *
  * @example
  * ```ts

--- a/packages/ui/src/primitives/editor-toolbar.ts
+++ b/packages/ui/src/primitives/editor-toolbar.ts
@@ -22,7 +22,7 @@
  * DO: Display shortcut labels from each button's shortcut field
  * NEVER: Hard-code modifier keys -- use modifierKey from the controls
  *
- * @dependencies primitives/history (via consumer-provided getHistory callback)
+ * @internal-dependencies primitives/history (via consumer-provided getHistory callback)
  *
  * @example
  * ```ts


### PR DESCRIPTION
## Summary
- `editor-toolbar.ts` and `block-wrapper.ts` listed sibling primitives under `@dependencies` instead of `@internal-dependencies`
- The registry parser treats `@dependencies` as npm packages, so `primitives/history` and `primitives/drag-drop` were passed to `pnpm add`, causing install failures when running `rafters add editor`
- Changed both to `@internal-dependencies` which the parser correctly excludes from registry output

## Test plan
- [ ] Deploy website to rebuild registry JSON endpoints
- [ ] Run `rafters add editor` in a fresh project - should no longer attempt `pnpm add primitives/history`

🤖 Generated with [Claude Code](https://claude.com/claude-code)