### PR TITLE
feat(composites): add folder loader for .composite.json files

### DIFF
--- a/packages/composites/src/index.ts
+++ b/packages/composites/src/index.ts
@@ -7,6 +7,8 @@
  */
 
 export { toBridgeItem, toBridgeItems } from './bridge';
+export type { LoadResult } from './loader';
+export { loadComposites } from './loader';
 export type {
   AppliedRule,
   CompositeBlock,

--- a/packages/composites/src/loader.ts
+++ b/packages/composites/src/loader.ts
@@ -1,0 +1,66 @@
+/**
+ * Folder loader
+ *
+ * Reads all `.composite.json` files from a directory, validates
+ * them with CompositeFileSchema, and returns valid composites
+ * alongside any errors.
+ */
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { CompositeFile } from './manifest';
+import { CompositeFileSchema } from './manifest';
+
+export interface LoadResult {
+  composites: CompositeFile[];
+  errors: Array<{ path: string; error: string }>;
+}
+
+/**
+ * Read and validate all .composite.json files from a directory.
+ * Invalid files are reported in errors, not thrown.
+ */
+export async function loadComposites(directory: string): Promise<LoadResult> {
+  const composites: CompositeFile[] = [];
+  const errors: LoadResult['errors'] = [];
+
+  let entries: string[];
+  try {
+    entries = await readdir(directory);
+  } catch {
+    return { composites, errors };
+  }
+
+  const files = entries.filter((f) => f.endsWith('.composite.json'));
+
+  for (const file of files) {
+    const filePath = join(directory, file);
+    try {
+      const raw = await readFile(filePath, 'utf-8');
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch (e) {
+        errors.push({
+          path: filePath,
+          error: `Invalid JSON: ${e instanceof Error ? e.message : String(e)}`,
+        });
+        continue;
+      }
+
+      const result = CompositeFileSchema.safeParse(parsed);
+      if (result.success) {
+        composites.push(result.data);
+      } else {
+        errors.push({ path: filePath, error: result.error.message });
+      }
+    } catch (e) {
+      errors.push({
+        path: filePath,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  return { composites, errors };
+}

--- a/packages/composites/test/loader.test.ts
+++ b/packages/composites/test/loader.test.ts
@@ -1,0 +1,99 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadComposites } from '../src/loader';
+
+const tmpDir = join(import.meta.dirname, '__test-composites__');
+
+function writeComposite(name: string, data: unknown): void {
+  writeFileSync(join(tmpDir, `${name}.composite.json`), JSON.stringify(data));
+}
+
+const validComposite = {
+  manifest: {
+    id: 'heading',
+    name: 'Heading',
+    category: 'typography',
+    description: 'A heading block',
+    keywords: [],
+    cognitiveLoad: 1,
+  },
+  blocks: [{ id: '1', type: 'heading', content: 'Hello' }],
+};
+
+beforeEach(() => mkdirSync(tmpDir, { recursive: true }));
+afterEach(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+describe('loadComposites', () => {
+  it('loads valid composite files', async () => {
+    writeComposite('heading', validComposite);
+    const result = await loadComposites(tmpDir);
+    expect(result.composites).toHaveLength(1);
+    expect(result.composites[0].manifest.id).toBe('heading');
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('loads multiple composite files', async () => {
+    writeComposite('heading', validComposite);
+    writeComposite('paragraph', {
+      ...validComposite,
+      manifest: { ...validComposite.manifest, id: 'paragraph', name: 'Paragraph' },
+    });
+    const result = await loadComposites(tmpDir);
+    expect(result.composites).toHaveLength(2);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('reports invalid JSON', async () => {
+    writeFileSync(join(tmpDir, 'bad.composite.json'), '{ invalid json }');
+    const result = await loadComposites(tmpDir);
+    expect(result.composites).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].path).toContain('bad.composite.json');
+    expect(result.errors[0].error).toContain('Invalid JSON');
+  });
+
+  it('reports schema validation failures', async () => {
+    writeComposite('invalid', { manifest: { id: 'x' } });
+    const result = await loadComposites(tmpDir);
+    expect(result.composites).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].path).toContain('invalid.composite.json');
+  });
+
+  it('separates valid and invalid files', async () => {
+    writeComposite('good', validComposite);
+    writeFileSync(join(tmpDir, 'bad.composite.json'), 'not json');
+    const result = await loadComposites(tmpDir);
+    expect(result.composites).toHaveLength(1);
+    expect(result.composites[0].manifest.id).toBe('heading');
+    expect(result.errors).toHaveLength(1);
+  });
+
+  it('ignores non-composite files', async () => {
+    writeFileSync(join(tmpDir, 'readme.txt'), 'not a composite');
+    writeFileSync(join(tmpDir, 'data.json'), '{}');
+    const result = await loadComposites(tmpDir);
+    expect(result.composites).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('returns empty for nonexistent directory', async () => {
+    const result = await loadComposites('/nonexistent/path/to/composites');
+    expect(result.composites).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('returns empty for empty directory', async () => {
+    const result = await loadComposites(tmpDir);
+    expect(result.composites).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('applies schema defaults for input/output', async () => {
+    writeComposite('minimal', validComposite);
+    const result = await loadComposites(tmpDir);
+    expect(result.composites[0].input).toEqual([]);
+    expect(result.composites[0].output).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `loadComposites()` that reads `*.composite.json` files from a directory
- Validates each file with `CompositeFileSchema` (Zod)
- Invalid JSON and schema failures collected in `errors` array, never thrown
- Non-existent and empty directories return empty results gracefully
- Ignores non-composite files in the directory
- 9 unit tests with temp directory setup/teardown

Closes #891

## Test plan
- [x] All 9 loader tests pass
- [x] All 82 composites tests pass  
- [x] TypeScript compiles with no errors
- [ ] `pnpm preflight` passes

Generated with [Claude Code](https://claude.com/claude-code)