### PR TITLE
feat(composites): add built-in rule stubs

### DIFF
--- a/packages/composites/src/built-in-rules/credentials.ts
+++ b/packages/composites/src/built-in-rules/credentials.ts
@@ -1,0 +1,4 @@
+import { z } from 'zod';
+import { email } from './email';
+
+export const credentials = z.object({ email, password: z.string().min(8) });

--- a/packages/composites/src/built-in-rules/email.ts
+++ b/packages/composites/src/built-in-rules/email.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod';
+
+export const email = z.string().email();

--- a/packages/composites/src/built-in-rules/index.ts
+++ b/packages/composites/src/built-in-rules/index.ts
@@ -1,0 +1,5 @@
+export { credentials } from './credentials';
+export { email } from './email';
+export { password } from './password';
+export { required } from './required';
+export { url } from './url';

--- a/packages/composites/src/built-in-rules/password.ts
+++ b/packages/composites/src/built-in-rules/password.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod';
+
+export const password = z.string().min(8);

--- a/packages/composites/src/built-in-rules/required.ts
+++ b/packages/composites/src/built-in-rules/required.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod';
+
+export const required = z.string().min(1);

--- a/packages/composites/src/built-in-rules/url.ts
+++ b/packages/composites/src/built-in-rules/url.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod';
+
+export const url = z.string().url();

--- a/packages/composites/src/index.ts
+++ b/packages/composites/src/index.ts
@@ -7,6 +7,13 @@
  */
 
 export { toBridgeItem, toBridgeItems } from './bridge';
+export {
+  credentials,
+  email,
+  password,
+  required,
+  url,
+} from './built-in-rules/index';
 export type { LoadResult } from './loader';
 export { loadComposites } from './loader';
 export type {

--- a/packages/composites/test/built-in-rules.test.ts
+++ b/packages/composites/test/built-in-rules.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { credentials, email, password, required, url } from '../src/built-in-rules';
+
+describe('email rule', () => {
+  it('accepts valid email', () => {
+    expect(email.parse('user@example.com')).toBe('user@example.com');
+  });
+  it('rejects invalid email', () => {
+    expect(() => email.parse('not-an-email')).toThrow();
+  });
+});
+
+describe('password rule', () => {
+  it('accepts password with 8+ chars', () => {
+    expect(password.parse('12345678')).toBe('12345678');
+  });
+  it('rejects short password', () => {
+    expect(() => password.parse('short')).toThrow();
+  });
+});
+
+describe('required rule', () => {
+  it('accepts non-empty string', () => {
+    expect(required.parse('hello')).toBe('hello');
+  });
+  it('rejects empty string', () => {
+    expect(() => required.parse('')).toThrow();
+  });
+});
+
+describe('url rule', () => {
+  it('accepts valid URL', () => {
+    expect(url.parse('https://example.com')).toBe('https://example.com');
+  });
+  it('rejects invalid URL', () => {
+    expect(() => url.parse('not a url')).toThrow();
+  });
+});
+
+describe('credentials rule', () => {
+  it('accepts valid credentials', () => {
+    const data = { email: 'user@example.com', password: 'longpassword' };
+    expect(credentials.parse(data)).toEqual(data);
+  });
+  it('rejects invalid email in credentials', () => {
+    expect(() => credentials.parse({ email: 'bad', password: 'longpassword' })).toThrow();
+  });
+  it('rejects short password in credentials', () => {
+    expect(() => credentials.parse({ email: 'user@example.com', password: 'short' })).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 5 built-in Zod schema rules: `email`, `password`, `required`, `url`, `credentials`
- Each rule is a single named Zod export for registry distribution
- `credentials` composes `email` + password validation
- Exported from `@rafters/composites` barrel
- 11 unit tests covering valid/invalid parsing for each rule

Closes #902

## Test plan
- [x] All 11 rule stub tests pass
- [x] All 93 composites tests pass
- [x] TypeScript compiles with no errors
- [ ] `pnpm preflight` passes

Generated with [Claude Code](https://claude.com/claude-code)