### PR TITLE
fix: ignore all non-CLI packages in changeset config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,17 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [
+    "@rafters/chrome",
+    "@rafters/color-utils",
+    "@rafters/composites",
+    "@rafters/design-tokens",
+    "@rafters/math-utils",
+    "@rafters/shared",
+    "@rafters/studio",
+    "@rafters/ui",
+    "rafters-api",
+    "rafters-website",
+    "demo"
+  ]
 }

--- a/apps/website/CHANGELOG.md
+++ b/apps/website/CHANGELOG.md
@@ -1,8 +1,0 @@
-# rafters-website
-
-## 0.0.2
-
-### Patch Changes
-
-- Updated dependencies [a50a8ae]
-  - rafters@0.0.10

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -2,7 +2,7 @@
   "name": "rafters-website",
   "private": true,
   "type": "module",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",


### PR DESCRIPTION
## Summary
- Adds every non-CLI package to `.changeset/config.json` ignore list
- Removes accidental `apps/website/CHANGELOG.md` 
- Resets website version back to 0.0.1

Only `rafters` (the CLI) is published to npm. All other packages are private workspace-only and should never be versioned or changelogged by changesets.

## Test plan
- [ ] Merge, then verify next changeset release PR only touches `packages/cli/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)