### PR TITLE
feat(composites): add built-in typography composites

### DIFF
--- a/packages/composites/src/typography/blockquote.composite.json
+++ b/packages/composites/src/typography/blockquote.composite.json
@@ -1,19 +1,19 @@
 {
-	"manifest": {
-		"id": "blockquote",
-		"name": "Blockquote",
-		"category": "typography",
-		"description": "Quoted text block",
-		"keywords": ["quote", "citation", "pullquote"],
-		"cognitiveLoad": 1
-	},
-	"input": [],
-	"output": [],
-	"blocks": [
-		{
-			"id": "1",
-			"type": "blockquote",
-			"content": ""
-		}
-	]
+  "manifest": {
+    "id": "blockquote",
+    "name": "Blockquote",
+    "category": "typography",
+    "description": "Quoted text block",
+    "keywords": ["quote", "citation", "pullquote"],
+    "cognitiveLoad": 1
+  },
+  "input": [],
+  "output": [],
+  "blocks": [
+    {
+      "id": "1",
+      "type": "blockquote",
+      "content": ""
+    }
+  ]
 }

--- a/packages/composites/src/typography/heading.composite.json
+++ b/packages/composites/src/typography/heading.composite.json
@@ -1,20 +1,20 @@
 {
-	"manifest": {
-		"id": "heading",
-		"name": "Heading",
-		"category": "typography",
-		"description": "Section heading with configurable level",
-		"keywords": ["title", "h1", "h2", "h3", "h4", "h5", "h6"],
-		"cognitiveLoad": 1
-	},
-	"input": [],
-	"output": [],
-	"blocks": [
-		{
-			"id": "1",
-			"type": "heading",
-			"content": "Heading",
-			"meta": { "level": 2 }
-		}
-	]
+  "manifest": {
+    "id": "heading",
+    "name": "Heading",
+    "category": "typography",
+    "description": "Section heading with configurable level",
+    "keywords": ["title", "h1", "h2", "h3", "h4", "h5", "h6"],
+    "cognitiveLoad": 1
+  },
+  "input": [],
+  "output": [],
+  "blocks": [
+    {
+      "id": "1",
+      "type": "heading",
+      "content": "Heading",
+      "meta": { "level": 2 }
+    }
+  ]
 }

--- a/packages/composites/src/typography/list.composite.json
+++ b/packages/composites/src/typography/list.composite.json
@@ -1,20 +1,20 @@
 {
-	"manifest": {
-		"id": "list",
-		"name": "List",
-		"category": "typography",
-		"description": "Ordered or unordered list",
-		"keywords": ["ul", "ol", "bullet", "numbered"],
-		"cognitiveLoad": 2
-	},
-	"input": [],
-	"output": [],
-	"blocks": [
-		{
-			"id": "1",
-			"type": "list",
-			"content": ["Item 1", "Item 2"],
-			"meta": { "ordered": false }
-		}
-	]
+  "manifest": {
+    "id": "list",
+    "name": "List",
+    "category": "typography",
+    "description": "Ordered or unordered list",
+    "keywords": ["ul", "ol", "bullet", "numbered"],
+    "cognitiveLoad": 2
+  },
+  "input": [],
+  "output": [],
+  "blocks": [
+    {
+      "id": "1",
+      "type": "list",
+      "content": ["Item 1", "Item 2"],
+      "meta": { "ordered": false }
+    }
+  ]
 }

--- a/packages/composites/src/typography/paragraph.composite.json
+++ b/packages/composites/src/typography/paragraph.composite.json
@@ -1,19 +1,19 @@
 {
-	"manifest": {
-		"id": "paragraph",
-		"name": "Paragraph",
-		"category": "typography",
-		"description": "Body text paragraph",
-		"keywords": ["text", "body", "p"],
-		"cognitiveLoad": 1
-	},
-	"input": [],
-	"output": [],
-	"blocks": [
-		{
-			"id": "1",
-			"type": "text",
-			"content": ""
-		}
-	]
+  "manifest": {
+    "id": "paragraph",
+    "name": "Paragraph",
+    "category": "typography",
+    "description": "Body text paragraph",
+    "keywords": ["text", "body", "p"],
+    "cognitiveLoad": 1
+  },
+  "input": [],
+  "output": [],
+  "blocks": [
+    {
+      "id": "1",
+      "type": "text",
+      "content": ""
+    }
+  ]
 }

--- a/packages/composites/test/typography.test.ts
+++ b/packages/composites/test/typography.test.ts
@@ -15,46 +15,46 @@ const TYPOGRAPHY_DIR = join(__dirname, '../src/typography');
 const TYPOGRAPHY_NAMES = ['heading', 'paragraph', 'blockquote', 'list'] as const;
 
 function loadTypography(name: string) {
-	const raw = readFileSync(join(TYPOGRAPHY_DIR, `${name}.composite.json`), 'utf-8');
-	return CompositeFileSchema.parse(JSON.parse(raw));
+  const raw = readFileSync(join(TYPOGRAPHY_DIR, `${name}.composite.json`), 'utf-8');
+  return CompositeFileSchema.parse(JSON.parse(raw));
 }
 
 describe('typography composites', () => {
-	for (const name of TYPOGRAPHY_NAMES) {
-		it(`${name}.composite.json validates against CompositeFileSchema`, () => {
-			expect(() => loadTypography(name)).not.toThrow();
-		});
-	}
+  for (const name of TYPOGRAPHY_NAMES) {
+    it(`${name}.composite.json validates against CompositeFileSchema`, () => {
+      expect(() => loadTypography(name)).not.toThrow();
+    });
+  }
 
-	it('heading has level meta', () => {
-		const heading = loadTypography('heading');
-		expect(heading.blocks[0].meta?.level).toBe(2);
-	});
+  it('heading has level meta', () => {
+    const heading = loadTypography('heading');
+    expect(heading.blocks[0].meta?.level).toBe(2);
+  });
 
-	it('list has ordered meta', () => {
-		const list = loadTypography('list');
-		expect(list.blocks[0].meta?.ordered).toBe(false);
-	});
+  it('list has ordered meta', () => {
+    const list = loadTypography('list');
+    expect(list.blocks[0].meta?.ordered).toBe(false);
+  });
 
-	it('all typography composites have no I/O rules', () => {
-		for (const name of TYPOGRAPHY_NAMES) {
-			const composite = loadTypography(name);
-			expect(composite.input).toEqual([]);
-			expect(composite.output).toEqual([]);
-		}
-	});
+  it('all typography composites have no I/O rules', () => {
+    for (const name of TYPOGRAPHY_NAMES) {
+      const composite = loadTypography(name);
+      expect(composite.input).toEqual([]);
+      expect(composite.output).toEqual([]);
+    }
+  });
 
-	it('all typography composites are category "typography"', () => {
-		for (const name of TYPOGRAPHY_NAMES) {
-			const composite = loadTypography(name);
-			expect(composite.manifest.category).toBe('typography');
-		}
-	});
+  it('all typography composites are category "typography"', () => {
+    for (const name of TYPOGRAPHY_NAMES) {
+      const composite = loadTypography(name);
+      expect(composite.manifest.category).toBe('typography');
+    }
+  });
 
-	it('all typography composites have exactly one block', () => {
-		for (const name of TYPOGRAPHY_NAMES) {
-			const composite = loadTypography(name);
-			expect(composite.blocks).toHaveLength(1);
-		}
-	});
+  it('all typography composites have exactly one block', () => {
+    for (const name of TYPOGRAPHY_NAMES) {
+      const composite = loadTypography(name);
+      expect(composite.blocks).toHaveLength(1);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Add four typography `.composite.json` files: heading, paragraph, blockquote, list
- All validate against `CompositeFileSchema` with no I/O rules
- Tests cover schema validation, meta fields, category, and block count

Closes #897

## Test plan
- [x] All four files pass `CompositeFileSchema.parse()`
- [x] Heading has `meta.level: 2`
- [x] List has `meta.ordered: false`
- [x] No I/O rules on any typography composite
- [x] `pnpm --filter=@rafters/composites test` passes (102 tests)

Generated with [Claude Code](https://claude.com/claude-code)