### PR TITLE
fix(editor): free-form composite categories with combobox

### DIFF
--- a/apps/demo/src/components/ui/editor.tsx
+++ b/apps/demo/src/components/ui/editor.tsx
@@ -148,15 +148,12 @@ export interface SlashCommand {
   action: (editor: EditorControls) => void;
 }
 
-// SYNC:composite-category - must match CompositeCategorySchema in packages/composites/src/manifest.ts
-export type CompositeCategory = 'typography' | 'layout' | 'form' | 'widget' | 'media';
-
 /** Metadata for saving the current canvas as a composite. */
 export interface SaveCompositeData {
   /** Display name */
   name: string;
-  /** Category */
-  category: CompositeCategory;
+  /** Category (free-form -- existing categories are suggested in the dialog) */
+  category: string;
   /** Description */
   description: string;
   /** Current canvas blocks */
@@ -350,26 +347,24 @@ function EditorToolbarSection({ canUndo, canRedo, onUndo, onRedo }: ToolbarSecti
   );
 }
 
-// SYNC:composite-category
-const COMPOSITE_CATEGORIES = [
-  'typography',
-  'layout',
-  'form',
-  'widget',
-  'media',
-] as const satisfies readonly CompositeCategory[];
-
 interface SaveCompositeDialogProps {
   blocks: EditorBlock[];
+  existingCategories: string[];
   onSave: (data: SaveCompositeData) => void;
   onCancel: () => void;
 }
 
-function SaveCompositeDialog({ blocks, onSave, onCancel }: SaveCompositeDialogProps) {
+function SaveCompositeDialog({
+  blocks,
+  existingCategories,
+  onSave,
+  onCancel,
+}: SaveCompositeDialogProps) {
   const [name, setName] = React.useState('');
-  const [category, setCategory] = React.useState<CompositeCategory>('layout');
+  const [category, setCategory] = React.useState(existingCategories[0] ?? '');
   const [description, setDescription] = React.useState('');
   const [error, setError] = React.useState('');
+  const [showSuggestions, setShowSuggestions] = React.useState(false);
   const nameInputRef = React.useRef<HTMLInputElement>(null);
 
   React.useEffect(() => {
@@ -379,13 +374,18 @@ function SaveCompositeDialog({ blocks, onSave, onCancel }: SaveCompositeDialogPr
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const trimmedName = name.trim();
+    const trimmedCategory = category.trim();
     if (!trimmedName) {
       setError('Name is required');
       return;
     }
+    if (!trimmedCategory) {
+      setError('Category is required');
+      return;
+    }
     onSave({
       name: trimmedName,
-      category,
+      category: trimmedCategory,
       description: description.trim(),
       blocks,
     });
@@ -434,20 +434,61 @@ function SaveCompositeDialog({ blocks, onSave, onCancel }: SaveCompositeDialogPr
           </label>
           <label className={classy('flex flex-col gap-1 text-sm')}>
             Category
-            <select
-              value={category}
-              onChange={(e) => setCategory(e.target.value as CompositeCategory)}
-              className={classy(
-                'rounded-md border border-border bg-background px-3 py-1.5 text-sm',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring',
+            <div className={classy('relative')}>
+              <input
+                type="text"
+                value={category}
+                onChange={(e) => {
+                  setCategory(e.target.value);
+                  setShowSuggestions(true);
+                  setError('');
+                }}
+                onFocus={() => setShowSuggestions(true)}
+                onBlur={() => {
+                  // Delay to allow click on suggestion
+                  setTimeout(() => setShowSuggestions(false), 150);
+                }}
+                placeholder="e.g. form, layout, widget"
+                role="combobox"
+                aria-expanded={showSuggestions && existingCategories.length > 0}
+                aria-autocomplete="list"
+                aria-controls="category-suggestions"
+                className={classy(
+                  'w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring',
+                )}
+              />
+              {showSuggestions && existingCategories.length > 0 && (
+                <div
+                  id="category-suggestions"
+                  role="listbox"
+                  className={classy(
+                    'absolute top-full left-0 z-10 mt-1 w-full rounded-md border border-border bg-background py-1 shadow-md',
+                  )}
+                >
+                  {existingCategories
+                    .filter((c) => c.toLowerCase().includes(category.toLowerCase()))
+                    .map((cat) => (
+                      <button
+                        key={cat}
+                        type="button"
+                        role="option"
+                        aria-selected={cat === category}
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          setCategory(cat);
+                          setShowSuggestions(false);
+                        }}
+                        className={classy(
+                          'w-full px-3 py-1 text-left text-sm hover:bg-accent hover:text-accent-foreground',
+                        )}
+                      >
+                        {cat}
+                      </button>
+                    ))}
+                </div>
               )}
-            >
-              {COMPOSITE_CATEGORIES.map((cat) => (
-                <option key={cat} value={cat}>
-                  {cat.charAt(0).toUpperCase() + cat.slice(1)}
-                </option>
-              ))}
-            </select>
+            </div>
           </label>
           <label className={classy('flex flex-col gap-1 text-sm')}>
             Description
@@ -2190,6 +2231,11 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
         {showSaveDialog && onSaveAsComposite && (
           <SaveCompositeDialog
             blocks={blocks}
+            existingCategories={
+              typeof sidebarRef.current === 'object' && sidebarRef.current
+                ? sidebarRef.current.categories
+                : []
+            }
             onSave={handleSaveComposite}
             onCancel={() => setShowSaveDialog(false)}
           />

--- a/apps/demo/src/lib/primitives/block-context-menu.ts
+++ b/apps/demo/src/lib/primitives/block-context-menu.ts
@@ -14,9 +14,9 @@
  * @registry-type primitive
  */
 
-import { onEscapeKeyDown } from './escape-keydown';
-import { createFocusTrap } from './focus-trap';
-import type { CleanupFunction } from './types';
+import { onEscapeKeyDown } from '@/lib/primitives/escape-keydown';
+import { createFocusTrap } from '@/lib/primitives/focus-trap';
+import type { CleanupFunction } from '@/lib/primitives/types';
 
 // =============================================================================
 // Types

--- a/apps/demo/src/lib/primitives/escape-keydown.ts
+++ b/apps/demo/src/lib/primitives/escape-keydown.ts
@@ -3,7 +3,7 @@
  * Client-only, returns cleanup function
  */
 
-import type { CleanupFunction, EscapeKeyHandler } from './types';
+import type { CleanupFunction, EscapeKeyHandler } from '@/lib/primitives/types';
 
 /**
  * Listen for Escape key and call handler

--- a/apps/demo/src/lib/primitives/focus-trap.ts
+++ b/apps/demo/src/lib/primitives/focus-trap.ts
@@ -4,7 +4,7 @@
  * SSR-safe: checks for window existence
  */
 
-import type { CleanupFunction } from './types';
+import type { CleanupFunction } from '@/lib/primitives/types';
 
 const FOCUSABLE_SELECTOR = [
   'a[href]',

--- a/apps/demo/src/lib/primitives/rule-palette.ts
+++ b/apps/demo/src/lib/primitives/rule-palette.ts
@@ -28,7 +28,7 @@
  * ```
  */
 
-import { fuzzyScore } from './typeahead';
+import { fuzzyScore } from '@/lib/primitives/typeahead';
 
 // =============================================================================
 // Types

--- a/packages/composites/src/manifest.ts
+++ b/packages/composites/src/manifest.ts
@@ -8,8 +8,8 @@
 
 import { z } from 'zod';
 
-/** Categories for composite blocks */
-export const CompositeCategorySchema = z.enum(['typography', 'layout', 'form', 'widget', 'media']);
+/** Category for composite blocks (free-form -- users define their own) */
+export const CompositeCategorySchema = z.string().min(1);
 
 export type CompositeCategory = z.infer<typeof CompositeCategorySchema>;
 

--- a/packages/composites/test/manifest.test.ts
+++ b/packages/composites/test/manifest.test.ts
@@ -77,8 +77,8 @@ describe('CompositeManifestSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('rejects invalid category', () => {
-    const result = CompositeManifestSchema.safeParse({ ...validManifest, category: 'invalid' });
+  it('rejects empty category', () => {
+    const result = CompositeManifestSchema.safeParse({ ...validManifest, category: '' });
     expect(result.success).toBe(false);
   });
 

--- a/packages/ui/src/components/ui/editor.tsx
+++ b/packages/ui/src/components/ui/editor.tsx
@@ -148,15 +148,12 @@ export interface SlashCommand {
   action: (editor: EditorControls) => void;
 }
 
-// SYNC:composite-category - must match CompositeCategorySchema in packages/composites/src/manifest.ts
-export type CompositeCategory = 'typography' | 'layout' | 'form' | 'widget' | 'media';
-
 /** Metadata for saving the current canvas as a composite. */
 export interface SaveCompositeData {
   /** Display name */
   name: string;
-  /** Category */
-  category: CompositeCategory;
+  /** Category (free-form -- existing categories are suggested in the dialog) */
+  category: string;
   /** Description */
   description: string;
   /** Current canvas blocks */
@@ -350,26 +347,24 @@ function EditorToolbarSection({ canUndo, canRedo, onUndo, onRedo }: ToolbarSecti
   );
 }
 
-// SYNC:composite-category
-const COMPOSITE_CATEGORIES = [
-  'typography',
-  'layout',
-  'form',
-  'widget',
-  'media',
-] as const satisfies readonly CompositeCategory[];
-
 interface SaveCompositeDialogProps {
   blocks: EditorBlock[];
+  existingCategories: string[];
   onSave: (data: SaveCompositeData) => void;
   onCancel: () => void;
 }
 
-function SaveCompositeDialog({ blocks, onSave, onCancel }: SaveCompositeDialogProps) {
+function SaveCompositeDialog({
+  blocks,
+  existingCategories,
+  onSave,
+  onCancel,
+}: SaveCompositeDialogProps) {
   const [name, setName] = React.useState('');
-  const [category, setCategory] = React.useState<CompositeCategory>('layout');
+  const [category, setCategory] = React.useState(existingCategories[0] ?? '');
   const [description, setDescription] = React.useState('');
   const [error, setError] = React.useState('');
+  const [showSuggestions, setShowSuggestions] = React.useState(false);
   const nameInputRef = React.useRef<HTMLInputElement>(null);
 
   React.useEffect(() => {
@@ -379,13 +374,18 @@ function SaveCompositeDialog({ blocks, onSave, onCancel }: SaveCompositeDialogPr
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const trimmedName = name.trim();
+    const trimmedCategory = category.trim();
     if (!trimmedName) {
       setError('Name is required');
       return;
     }
+    if (!trimmedCategory) {
+      setError('Category is required');
+      return;
+    }
     onSave({
       name: trimmedName,
-      category,
+      category: trimmedCategory,
       description: description.trim(),
       blocks,
     });
@@ -434,20 +434,61 @@ function SaveCompositeDialog({ blocks, onSave, onCancel }: SaveCompositeDialogPr
           </label>
           <label className={classy('flex flex-col gap-1 text-sm')}>
             Category
-            <select
-              value={category}
-              onChange={(e) => setCategory(e.target.value as CompositeCategory)}
-              className={classy(
-                'rounded-md border border-border bg-background px-3 py-1.5 text-sm',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring',
+            <div className={classy('relative')}>
+              <input
+                type="text"
+                value={category}
+                onChange={(e) => {
+                  setCategory(e.target.value);
+                  setShowSuggestions(true);
+                  setError('');
+                }}
+                onFocus={() => setShowSuggestions(true)}
+                onBlur={() => {
+                  // Delay to allow click on suggestion
+                  setTimeout(() => setShowSuggestions(false), 150);
+                }}
+                placeholder="e.g. form, layout, widget"
+                role="combobox"
+                aria-expanded={showSuggestions && existingCategories.length > 0}
+                aria-autocomplete="list"
+                aria-controls="category-suggestions"
+                className={classy(
+                  'w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring',
+                )}
+              />
+              {showSuggestions && existingCategories.length > 0 && (
+                <div
+                  id="category-suggestions"
+                  role="listbox"
+                  className={classy(
+                    'absolute top-full left-0 z-10 mt-1 w-full rounded-md border border-border bg-background py-1 shadow-md',
+                  )}
+                >
+                  {existingCategories
+                    .filter((c) => c.toLowerCase().includes(category.toLowerCase()))
+                    .map((cat) => (
+                      <button
+                        key={cat}
+                        type="button"
+                        role="option"
+                        aria-selected={cat === category}
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          setCategory(cat);
+                          setShowSuggestions(false);
+                        }}
+                        className={classy(
+                          'w-full px-3 py-1 text-left text-sm hover:bg-accent hover:text-accent-foreground',
+                        )}
+                      >
+                        {cat}
+                      </button>
+                    ))}
+                </div>
               )}
-            >
-              {COMPOSITE_CATEGORIES.map((cat) => (
-                <option key={cat} value={cat}>
-                  {cat.charAt(0).toUpperCase() + cat.slice(1)}
-                </option>
-              ))}
-            </select>
+            </div>
           </label>
           <label className={classy('flex flex-col gap-1 text-sm')}>
             Description
@@ -2190,6 +2231,11 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
         {showSaveDialog && onSaveAsComposite && (
           <SaveCompositeDialog
             blocks={blocks}
+            existingCategories={
+              typeof sidebarRef.current === 'object' && sidebarRef.current
+                ? sidebarRef.current.categories
+                : []
+            }
             onSave={handleSaveComposite}
             onCancel={() => setShowSaveDialog(false)}
           />

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -7,7 +7,6 @@
 
 export type {
   AppliedRule,
-  CompositeCategory,
   EditorBlock,
   EditorControls,
   EditorRulePaletteConfig,

--- a/packages/ui/test/components/editor.test.tsx
+++ b/packages/ui/test/components/editor.test.tsx
@@ -378,6 +378,7 @@ describe('Editor', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Save as Composite' }));
 
       fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Login Form' } });
+      fireEvent.change(screen.getByRole('combobox'), { target: { value: 'form' } });
       fireEvent.change(screen.getByLabelText('Description'), {
         target: { value: 'A login form' },
       });
@@ -386,7 +387,7 @@ describe('Editor', () => {
       expect(onSave).toHaveBeenCalledTimes(1);
       const data = onSave.mock.calls[0][0];
       expect(data.name).toBe('Login Form');
-      expect(data.category).toBe('layout');
+      expect(data.category).toBe('form');
       expect(data.description).toBe('A login form');
       expect(data.blocks).toHaveLength(2);
     });
@@ -396,6 +397,14 @@ describe('Editor', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Save as Composite' }));
       fireEvent.click(screen.getByRole('button', { name: 'Save' }));
       expect(screen.getByRole('alert')).toHaveTextContent('Name is required');
+    });
+
+    it('shows validation error for empty category', () => {
+      render(<Editor defaultValue={BLOCKS} toolbar onSaveAsComposite={vi.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Save as Composite' }));
+      fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'My Composite' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+      expect(screen.getByRole('alert')).toHaveTextContent('Category is required');
     });
 
     it('closes dialog on cancel', () => {


### PR DESCRIPTION
## Summary
- Removes hardcoded `CompositeCategory` enum (`typography | layout | form | widget | media`) from editor and composites package
- Save-as-composite dialog now uses a combobox that suggests existing categories from the sidebar config while accepting any new value
- `CompositeCategorySchema` is now `z.string().min(1)` -- users define their own categories per product/use case

## Why
The editor is baby Figma -- users define their own categories for their sidebar. A course builder might use `lesson`, `quiz`, `module`. The guilds editor might use `page-section`, `hero`, `navigation`. Hardcoding five categories was constraining the design.

## Changes
- **editor.tsx**: Remove `CompositeCategory` type, replace `<select>` with combobox input + suggestion dropdown, add category validation
- **composites/manifest.ts**: `CompositeCategorySchema` -> `z.string().min(1)`
- **ui/index.ts**: Remove `CompositeCategory` export
- **demo**: Sync editor copy, add missing primitives (block-context-menu, escape-keydown, focus-trap, rule-palette)
- **tests**: Update for combobox input, add empty category validation test

## Test plan
- [x] Preflight passes (lint, typecheck, build, all tests)
- [x] Composites tests pass with free-form category
- [x] Editor tests pass with combobox category input
- [ ] Manual: open save dialog, verify combobox shows sidebar categories as suggestions
- [ ] Manual: type a new category, verify it saves

Generated with [Claude Code](https://claude.com/claude-code)