### PR TITLE
refactor(ui): add forwardRef and displayName to all subcomponents

### DIFF
--- a/packages/ui/src/components/ui/alert-dialog.tsx
+++ b/packages/ui/src/components/ui/alert-dialog.tsx
@@ -552,6 +552,20 @@ export function AlertDialogCancel({
   );
 }
 
+// ==================== Display Names ====================
+
+AlertDialog.displayName = 'AlertDialog';
+AlertDialogTrigger.displayName = 'AlertDialogTrigger';
+AlertDialogPortal.displayName = 'AlertDialogPortal';
+AlertDialogOverlay.displayName = 'AlertDialogOverlay';
+AlertDialogContent.displayName = 'AlertDialogContent';
+AlertDialogHeader.displayName = 'AlertDialogHeader';
+AlertDialogFooter.displayName = 'AlertDialogFooter';
+AlertDialogTitle.displayName = 'AlertDialogTitle';
+AlertDialogDescription.displayName = 'AlertDialogDescription';
+AlertDialogAction.displayName = 'AlertDialogAction';
+AlertDialogCancel.displayName = 'AlertDialogCancel';
+
 // ==================== Namespaced Export (shadcn style) ====================
 
 AlertDialog.Trigger = AlertDialogTrigger;

--- a/packages/ui/src/components/ui/badge.tsx
+++ b/packages/ui/src/components/ui/badge.tsx
@@ -23,7 +23,7 @@
  * <Badge variant="warning">Pending Review</Badge>
  * ```
  */
-import type * as React from 'react';
+import * as React from 'react';
 import classy from '../../primitives/classy';
 
 export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
@@ -67,16 +67,20 @@ const sizeClasses: Record<string, string> = {
   lg: 'px-3 py-1 text-sm',
 };
 
-export function Badge({ className, variant = 'default', size = 'default', ...props }: BadgeProps) {
-  const baseClasses =
-    'inline-flex items-center justify-center rounded-full font-semibold transition-colors';
+export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
+  ({ className, variant = 'default', size = 'default', ...props }, ref) => {
+    const baseClasses =
+      'inline-flex items-center justify-center rounded-full font-semibold transition-colors';
 
-  const classes = classy(
-    baseClasses,
-    variantClasses[variant] ?? variantClasses.default,
-    sizeClasses[size] ?? sizeClasses.default,
-    className,
-  );
+    const classes = classy(
+      baseClasses,
+      variantClasses[variant] ?? variantClasses.default,
+      sizeClasses[size] ?? sizeClasses.default,
+      className,
+    );
 
-  return <span className={classes} {...props} />;
-}
+    return <span ref={ref} className={classes} {...props} />;
+  },
+);
+
+Badge.displayName = 'Badge';

--- a/packages/ui/src/components/ui/carousel.tsx
+++ b/packages/ui/src/components/ui/carousel.tsx
@@ -412,6 +412,15 @@ export function useCarousel() {
   };
 }
 
+// ==================== Display Names ====================
+
+Carousel.displayName = 'Carousel';
+CarouselContent.displayName = 'CarouselContent';
+CarouselItem.displayName = 'CarouselItem';
+CarouselPrevious.displayName = 'CarouselPrevious';
+CarouselNext.displayName = 'CarouselNext';
+CarouselIndicators.displayName = 'CarouselIndicators';
+
 // ==================== Namespaced Export ====================
 
 Carousel.Content = CarouselContent;

--- a/packages/ui/src/components/ui/command.tsx
+++ b/packages/ui/src/components/ui/command.tsx
@@ -547,6 +547,18 @@ export function CommandShortcut({ className, ...props }: CommandShortcutProps): 
   );
 }
 
+// ==================== Display Names ====================
+
+Command.displayName = 'Command';
+CommandDialog.displayName = 'CommandDialog';
+CommandInput.displayName = 'CommandInput';
+CommandList.displayName = 'CommandList';
+CommandEmpty.displayName = 'CommandEmpty';
+CommandGroup.displayName = 'CommandGroup';
+CommandItem.displayName = 'CommandItem';
+CommandSeparator.displayName = 'CommandSeparator';
+CommandShortcut.displayName = 'CommandShortcut';
+
 // ==================== Namespaced Export ====================
 
 Command.Dialog = CommandDialog;

--- a/packages/ui/src/components/ui/context-menu.tsx
+++ b/packages/ui/src/components/ui/context-menu.tsx
@@ -1137,5 +1137,10 @@ ContextMenu.Sub = ContextMenuSub;
 ContextMenu.SubTrigger = ContextMenuSubTrigger;
 ContextMenu.SubContent = ContextMenuSubContent;
 
+ContextMenu.displayName = 'ContextMenu';
+ContextMenuPortal.displayName = 'ContextMenuPortal';
+ContextMenuShortcut.displayName = 'ContextMenuShortcut';
+ContextMenuSub.displayName = 'ContextMenuSub';
+
 // Re-export root as ContextMenuRoot alias for shadcn compatibility
 export { ContextMenu as ContextMenuRoot };

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -521,6 +521,19 @@ export function DialogClose({ asChild, onClick, children, ...props }: DialogClos
   );
 }
 
+// ==================== Display Names ====================
+
+Dialog.displayName = 'Dialog';
+DialogTrigger.displayName = 'DialogTrigger';
+DialogPortal.displayName = 'DialogPortal';
+DialogOverlay.displayName = 'DialogOverlay';
+DialogContent.displayName = 'DialogContent';
+DialogHeader.displayName = 'DialogHeader';
+DialogFooter.displayName = 'DialogFooter';
+DialogTitle.displayName = 'DialogTitle';
+DialogDescription.displayName = 'DialogDescription';
+DialogClose.displayName = 'DialogClose';
+
 // ==================== Namespaced Export (shadcn style) ====================
 
 Dialog.Trigger = DialogTrigger;

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -1045,5 +1045,10 @@ DropdownMenu.Sub = DropdownMenuSub;
 DropdownMenu.SubTrigger = DropdownMenuSubTrigger;
 DropdownMenu.SubContent = DropdownMenuSubContent;
 
+DropdownMenu.displayName = 'DropdownMenu';
+DropdownMenuPortal.displayName = 'DropdownMenuPortal';
+DropdownMenuShortcut.displayName = 'DropdownMenuShortcut';
+DropdownMenuSub.displayName = 'DropdownMenuSub';
+
 // Re-export root as DropdownMenuRoot alias for shadcn compatibility
 export { DropdownMenu as DropdownMenuRoot };

--- a/packages/ui/src/components/ui/grid.tsx
+++ b/packages/ui/src/components/ui/grid.tsx
@@ -290,6 +290,11 @@ function GridItem({ priority, colSpan, rowSpan, className, children, ...props }:
   );
 }
 
+// ==================== Display Names ====================
+
+GridRoot.displayName = 'Grid';
+GridItem.displayName = 'GridItem';
+
 // ==================== Compound Export ====================
 
 export const Grid = Object.assign(GridRoot, {

--- a/packages/ui/src/components/ui/input-otp.tsx
+++ b/packages/ui/src/components/ui/input-otp.tsx
@@ -305,6 +305,13 @@ export function InputOTPSeparator({
   );
 }
 
+// ==================== Display Names ====================
+
+InputOTP.displayName = 'InputOTP';
+InputOTPGroup.displayName = 'InputOTPGroup';
+InputOTPSlot.displayName = 'InputOTPSlot';
+InputOTPSeparator.displayName = 'InputOTPSeparator';
+
 // ==================== Namespaced Export ====================
 
 InputOTP.Group = InputOTPGroup;

--- a/packages/ui/src/components/ui/kbd.tsx
+++ b/packages/ui/src/components/ui/kbd.tsx
@@ -10,7 +10,7 @@
  * @usage-patterns
  * DO: Use in tooltips to show keyboard shortcuts
  * DO: Use in menus alongside action items
- * DO: Use platform-appropriate modifier keys (⌘ for Mac, Ctrl for Windows)
+ * DO: Use platform-appropriate modifier keys (Cmd for Mac, Ctrl for Windows)
  * DO: Combine multiple Kbd elements for key combinations
  * NEVER: Use for non-keyboard content, use without context
  *
@@ -20,20 +20,18 @@
  * <Kbd>Enter</Kbd>
  *
  * // Key combination
- * <span className="flex gap-1">
- *   <Kbd>⌘</Kbd>
- *   <Kbd>S</Kbd>
- * </span>
+ * <Kbd>Cmd</Kbd> + <Kbd>S</Kbd>
  * ```
  */
-import type * as React from 'react';
+import * as React from 'react';
 import classy from '../../primitives/classy';
 
 export interface KbdProps extends React.HTMLAttributes<HTMLElement> {}
 
-export function Kbd({ className, ...props }: KbdProps) {
+export const Kbd = React.forwardRef<HTMLElement, KbdProps>(({ className, ...props }, ref) => {
   return (
     <kbd
+      ref={ref}
       className={classy(
         'inline-flex items-center justify-center rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-xs font-medium text-muted-foreground shadow-sm',
         className,
@@ -41,4 +39,6 @@ export function Kbd({ className, ...props }: KbdProps) {
       {...props}
     />
   );
-}
+});
+
+Kbd.displayName = 'Kbd';

--- a/packages/ui/src/components/ui/menubar.tsx
+++ b/packages/ui/src/components/ui/menubar.tsx
@@ -1252,6 +1252,11 @@ MenubarSubContent.displayName = 'MenubarSubContent';
 
 // ==================== Namespaced Export (shadcn style) ====================
 
+MenubarMenu.displayName = 'MenubarMenu';
+MenubarPortal.displayName = 'MenubarPortal';
+MenubarShortcut.displayName = 'MenubarShortcut';
+MenubarSub.displayName = 'MenubarSub';
+
 export const Menubar = Object.assign(MenubarRoot, {
   Menu: MenubarMenu,
   Trigger: MenubarTrigger,

--- a/packages/ui/src/components/ui/popover.tsx
+++ b/packages/ui/src/components/ui/popover.tsx
@@ -281,6 +281,15 @@ export function PopoverClose({ asChild, onClick, ...props }: PopoverCloseProps) 
   return <button type="button" onClick={handleClick} {...props} />;
 }
 
+// ==================== Display Names ====================
+
+Popover.displayName = 'Popover';
+PopoverTrigger.displayName = 'PopoverTrigger';
+PopoverAnchor.displayName = 'PopoverAnchor';
+PopoverPortal.displayName = 'PopoverPortal';
+PopoverContent.displayName = 'PopoverContent';
+PopoverClose.displayName = 'PopoverClose';
+
 // ==================== Namespaced Export (shadcn style) ====================
 
 Popover.Trigger = PopoverTrigger;

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -967,5 +967,21 @@ Select.Icon = SelectIcon;
 Select.ScrollUpButton = SelectScrollUpButton;
 Select.ScrollDownButton = SelectScrollDownButton;
 
+// ==================== Display Names ====================
+
+Select.displayName = 'Select';
+SelectTrigger.displayName = 'SelectTrigger';
+SelectValue.displayName = 'SelectValue';
+SelectPortal.displayName = 'SelectPortal';
+SelectContent.displayName = 'SelectContent';
+SelectViewport.displayName = 'SelectViewport';
+SelectGroup.displayName = 'SelectGroup';
+SelectLabel.displayName = 'SelectLabel';
+SelectItem.displayName = 'SelectItem';
+SelectSeparator.displayName = 'SelectSeparator';
+SelectIcon.displayName = 'SelectIcon';
+SelectScrollUpButton.displayName = 'SelectScrollUpButton';
+SelectScrollDownButton.displayName = 'SelectScrollDownButton';
+
 // Re-export root alias
 export { Select as SelectRoot };

--- a/packages/ui/src/components/ui/separator.tsx
+++ b/packages/ui/src/components/ui/separator.tsx
@@ -23,7 +23,7 @@
  * <Separator orientation="vertical" className="h-4" />
  * ```
  */
-import type * as React from 'react';
+import * as React from 'react';
 import classy from '../../primitives/classy';
 
 export interface SeparatorProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -33,24 +33,24 @@ export interface SeparatorProps extends React.HTMLAttributes<HTMLDivElement> {
   decorative?: boolean;
 }
 
-export function Separator({
-  className,
-  orientation = 'horizontal',
-  decorative = true,
-  ...props
-}: SeparatorProps) {
-  const orientationClasses = {
-    horizontal: 'h-px w-full',
-    vertical: 'h-full w-px',
-  };
+export const Separator = React.forwardRef<HTMLDivElement, SeparatorProps>(
+  ({ className, orientation = 'horizontal', decorative = true, ...props }, ref) => {
+    const orientationClasses = {
+      horizontal: 'h-px w-full',
+      vertical: 'h-full w-px',
+    };
 
-  return (
-    // biome-ignore lint/a11y/useAriaPropsSupportedByRole: aria-orientation is valid when role="separator"
-    <div
-      role={decorative ? 'none' : 'separator'}
-      aria-orientation={!decorative ? orientation : undefined}
-      className={classy('shrink-0 bg-border', orientationClasses[orientation], className)}
-      {...props}
-    />
-  );
-}
+    return (
+      // biome-ignore lint/a11y/useAriaPropsSupportedByRole: aria-orientation is valid when role="separator"
+      <div
+        ref={ref}
+        role={decorative ? 'none' : 'separator'}
+        aria-orientation={!decorative ? orientation : undefined}
+        className={classy('shrink-0 bg-border', orientationClasses[orientation], className)}
+        {...props}
+      />
+    );
+  },
+);
+
+Separator.displayName = 'Separator';

--- a/packages/ui/src/components/ui/sheet.tsx
+++ b/packages/ui/src/components/ui/sheet.tsx
@@ -512,6 +512,19 @@ export function SheetClose({ asChild, onClick, ...props }: SheetCloseProps) {
   return <button type="button" onClick={handleClick} {...props} />;
 }
 
+// ==================== Display Names ====================
+
+Sheet.displayName = 'Sheet';
+SheetTrigger.displayName = 'SheetTrigger';
+SheetPortal.displayName = 'SheetPortal';
+SheetOverlay.displayName = 'SheetOverlay';
+SheetContent.displayName = 'SheetContent';
+SheetHeader.displayName = 'SheetHeader';
+SheetFooter.displayName = 'SheetFooter';
+SheetTitle.displayName = 'SheetTitle';
+SheetDescription.displayName = 'SheetDescription';
+SheetClose.displayName = 'SheetClose';
+
 // ==================== Namespaced Export (shadcn style) ====================
 
 Sheet.Trigger = SheetTrigger;

--- a/packages/ui/src/components/ui/sidebar.tsx
+++ b/packages/ui/src/components/ui/sidebar.tsx
@@ -804,6 +804,31 @@ export function SidebarSeparator({ className, ...props }: SidebarSeparatorProps)
   );
 }
 
+// ==================== Display Names ====================
+
+SidebarProvider.displayName = 'SidebarProvider';
+Sidebar.displayName = 'Sidebar';
+SidebarTrigger.displayName = 'SidebarTrigger';
+SidebarRail.displayName = 'SidebarRail';
+SidebarInset.displayName = 'SidebarInset';
+SidebarHeader.displayName = 'SidebarHeader';
+SidebarFooter.displayName = 'SidebarFooter';
+SidebarContent.displayName = 'SidebarContent';
+SidebarGroup.displayName = 'SidebarGroup';
+SidebarGroupLabel.displayName = 'SidebarGroupLabel';
+SidebarGroupAction.displayName = 'SidebarGroupAction';
+SidebarGroupContent.displayName = 'SidebarGroupContent';
+SidebarMenu.displayName = 'SidebarMenu';
+SidebarMenuItem.displayName = 'SidebarMenuItem';
+SidebarMenuButton.displayName = 'SidebarMenuButton';
+SidebarMenuAction.displayName = 'SidebarMenuAction';
+SidebarMenuBadge.displayName = 'SidebarMenuBadge';
+SidebarMenuSkeleton.displayName = 'SidebarMenuSkeleton';
+SidebarMenuSub.displayName = 'SidebarMenuSub';
+SidebarMenuSubItem.displayName = 'SidebarMenuSubItem';
+SidebarMenuSubButton.displayName = 'SidebarMenuSubButton';
+SidebarSeparator.displayName = 'SidebarSeparator';
+
 // ==================== Namespaced Export ====================
 
 Sidebar.Provider = SidebarProvider;

--- a/packages/ui/src/components/ui/skeleton.tsx
+++ b/packages/ui/src/components/ui/skeleton.tsx
@@ -23,7 +23,7 @@
  * <Skeleton className="h-12 w-12 rounded-full" />
  * ```
  */
-import type * as React from 'react';
+import * as React from 'react';
 import classy from '../../primitives/classy';
 
 export interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -53,15 +53,20 @@ const variantClasses: Record<string, string> = {
   accent: 'bg-accent-subtle',
 };
 
-export function Skeleton({ className, variant = 'default', ...props }: SkeletonProps) {
-  return (
-    <div
-      className={classy(
-        'rounded-md animate-pulse motion-reduce:animate-none',
-        variantClasses[variant] ?? variantClasses.default,
-        className,
-      )}
-      {...props}
-    />
-  );
-}
+export const Skeleton = React.forwardRef<HTMLDivElement, SkeletonProps>(
+  ({ className, variant = 'default', ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={classy(
+          'rounded-md animate-pulse motion-reduce:animate-none',
+          variantClasses[variant] ?? variantClasses.default,
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+
+Skeleton.displayName = 'Skeleton';

--- a/packages/ui/src/components/ui/spinner.tsx
+++ b/packages/ui/src/components/ui/spinner.tsx
@@ -18,12 +18,12 @@
  * ```tsx
  * // Button loading state
  * <Button disabled>
- *   <Spinner size="sm" className="mr-2" />
+ *   <Spinner size="sm" />
  *   Saving...
  * </Button>
  * ```
  */
-import type * as React from 'react';
+import * as React from 'react';
 import classy from '../../primitives/classy';
 
 export interface SpinnerProps extends React.HTMLAttributes<HTMLOutputElement> {
@@ -61,24 +61,23 @@ const sizeClasses: Record<string, string> = {
   lg: 'h-8 w-8 border-3',
 };
 
-export function Spinner({
-  className,
-  size = 'default',
-  variant = 'default',
-  ...props
-}: SpinnerProps) {
-  const baseClasses = 'inline-block rounded-full animate-spin motion-reduce:animate-none';
+export const Spinner = React.forwardRef<HTMLOutputElement, SpinnerProps>(
+  ({ className, size = 'default', variant = 'default', ...props }, ref) => {
+    const baseClasses = 'inline-block rounded-full animate-spin motion-reduce:animate-none';
 
-  const classes = classy(
-    baseClasses,
-    sizeClasses[size] ?? sizeClasses.default,
-    variantClasses[variant] ?? variantClasses.default,
-    className,
-  );
+    const classes = classy(
+      baseClasses,
+      sizeClasses[size] ?? sizeClasses.default,
+      variantClasses[variant] ?? variantClasses.default,
+      className,
+    );
 
-  return (
-    <output aria-label="Loading" className={classes} {...props}>
-      <span className="sr-only">Loading</span>
-    </output>
-  );
-}
+    return (
+      <output ref={ref} aria-label="Loading" className={classes} {...props}>
+        <span className="sr-only">Loading</span>
+      </output>
+    );
+  },
+);
+
+Spinner.displayName = 'Spinner';

--- a/packages/ui/src/components/ui/tooltip.tsx
+++ b/packages/ui/src/components/ui/tooltip.tsx
@@ -477,6 +477,14 @@ export function TooltipContent({
   return content;
 }
 
+// ==================== Display Names ====================
+
+TooltipProvider.displayName = 'TooltipProvider';
+Tooltip.displayName = 'Tooltip';
+TooltipTrigger.displayName = 'TooltipTrigger';
+TooltipPortal.displayName = 'TooltipPortal';
+TooltipContent.displayName = 'TooltipContent';
+
 // ==================== Namespaced Export (shadcn style) ====================
 
 Tooltip.Provider = TooltipProvider;


### PR DESCRIPTION
## Summary
- Add displayName to 110+ subcomponents across 19 files
- Add forwardRef to 5 simple components (badge, kbd, skeleton, spinner, separator)
- Context providers and portal wrappers get displayName only (no DOM element to ref)
- Uses table.tsx (8/8) as reference pattern

## Test plan
- [ ] All existing tests pass
- [ ] No API breaking changes (forwardRef is additive)
- [ ] Components render correctly with new ref forwarding

Fixes #933

Generated with [Claude Code](https://claude.com/claude-code)