### PR TITLE
refactor(ui): remove dead underscore-prefixed props

### DIFF
--- a/packages/ui/src/components/ui/context-menu.tsx
+++ b/packages/ui/src/components/ui/context-menu.tsx
@@ -233,7 +233,6 @@ export interface ContextMenuContentProps extends React.HTMLAttributes<HTMLDivEle
   forceMount?: boolean;
   onEscapeKeyDown?: (event: KeyboardEvent) => void;
   onPointerDownOutside?: (event: PointerEvent | TouchEvent) => void;
-  onCloseAutoFocus?: (event: Event) => void;
   loop?: boolean;
   alignOffset?: number;
   avoidCollisions?: boolean;
@@ -246,7 +245,6 @@ export const ContextMenuContent = React.forwardRef<HTMLDivElement, ContextMenuCo
       forceMount,
       onEscapeKeyDown: onEscapeKeyDownProp,
       onPointerDownOutside: onPointerDownOutsideProp,
-      onCloseAutoFocus,
       loop = true,
       alignOffset = 0,
       avoidCollisions = true,

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -239,8 +239,6 @@ export function DialogOverlay({ asChild, forceMount, className, ...props }: Dial
 export interface DialogContentProps extends React.HTMLAttributes<HTMLDivElement> {
   asChild?: boolean;
   forceMount?: boolean;
-  onOpenAutoFocus?: (event: Event) => void;
-  onCloseAutoFocus?: (event: Event) => void;
   onEscapeKeyDown?: (event: KeyboardEvent) => void;
   onPointerDownOutside?: (event: PointerEvent | TouchEvent) => void;
   onInteractOutside?: (event: Event) => void;
@@ -255,8 +253,6 @@ export interface DialogContentProps extends React.HTMLAttributes<HTMLDivElement>
 export function DialogContent({
   asChild,
   forceMount,
-  onOpenAutoFocus: _onOpenAutoFocus,
-  onCloseAutoFocus: _onCloseAutoFocus,
   onEscapeKeyDown: onEscapeKeyDownProp,
   onPointerDownOutside: onPointerDownOutsideProp,
   onInteractOutside,

--- a/packages/ui/src/components/ui/popover.tsx
+++ b/packages/ui/src/components/ui/popover.tsx
@@ -166,14 +166,11 @@ export function PopoverPortal({ children, container, forceMount }: PopoverPortal
 // ==================== PopoverContent ====================
 
 export interface PopoverContentProps extends React.HTMLAttributes<HTMLDivElement> {
-  asChild?: boolean;
   forceMount?: boolean;
   side?: Side;
   align?: Align;
   sideOffset?: number;
   alignOffset?: number;
-  onOpenAutoFocus?: (event: Event) => void;
-  onCloseAutoFocus?: (event: Event) => void;
   onEscapeKeyDown?: (event: KeyboardEvent) => void;
   onPointerDownOutside?: (event: PointerEvent | TouchEvent) => void;
   onInteractOutside?: (event: Event) => void;
@@ -182,14 +179,11 @@ export interface PopoverContentProps extends React.HTMLAttributes<HTMLDivElement
 }
 
 export function PopoverContent({
-  asChild: _asChild,
   forceMount,
   side = 'bottom',
   align = 'center',
   sideOffset = 4,
   alignOffset = 0,
-  onOpenAutoFocus: _onOpenAutoFocus,
-  onCloseAutoFocus: _onCloseAutoFocus,
   onEscapeKeyDown,
   onPointerDownOutside,
   onInteractOutside,

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -369,7 +369,6 @@ export interface SelectContentProps extends React.HTMLAttributes<HTMLDivElement>
   align?: Align;
   sideOffset?: number;
   alignOffset?: number;
-  position?: 'item-aligned' | 'popper';
   asChild?: boolean;
 }
 
@@ -380,7 +379,6 @@ export function SelectContent({
   align = 'start',
   sideOffset = 4,
   alignOffset = 0,
-  position: _position = 'popper',
   style,
   asChild,
   ...props

--- a/packages/ui/src/components/ui/sheet.tsx
+++ b/packages/ui/src/components/ui/sheet.tsx
@@ -242,8 +242,6 @@ export interface SheetContentProps extends React.HTMLAttributes<HTMLDivElement> 
   side?: 'top' | 'right' | 'bottom' | 'left';
   asChild?: boolean;
   forceMount?: boolean;
-  onOpenAutoFocus?: (event: Event) => void;
-  onCloseAutoFocus?: (event: Event) => void;
   onEscapeKeyDown?: (event: KeyboardEvent) => void;
   onPointerDownOutside?: (event: PointerEvent | TouchEvent) => void;
   onInteractOutside?: (event: Event) => void;
@@ -266,8 +264,6 @@ export function SheetContent({
   side = 'right',
   asChild,
   forceMount,
-  onOpenAutoFocus: _onOpenAutoFocus,
-  onCloseAutoFocus: _onCloseAutoFocus,
   onEscapeKeyDown: onEscapeKeyDownProp,
   onPointerDownOutside: onPointerDownOutsideProp,
   onInteractOutside,

--- a/packages/ui/src/components/ui/sidebar.tsx
+++ b/packages/ui/src/components/ui/sidebar.tsx
@@ -583,7 +583,6 @@ export interface SidebarMenuButtonProps extends React.ButtonHTMLAttributes<HTMLB
   isActive?: boolean;
   variant?: 'default' | 'outline';
   size?: 'default' | 'sm' | 'lg';
-  tooltip?: string | React.ComponentProps<'div'>;
 }
 
 export function SidebarMenuButton({
@@ -591,7 +590,6 @@ export function SidebarMenuButton({
   isActive = false,
   variant = 'default',
   size = 'default',
-  tooltip: _tooltip,
   className,
   children,
   ...props


### PR DESCRIPTION
## Summary
- Remove unused Radix API placeholder props from 6 components
- popover: _asChild, _onOpenAutoFocus, _onCloseAutoFocus
- sheet: _onOpenAutoFocus, _onCloseAutoFocus
- dialog: _onOpenAutoFocus, _onCloseAutoFocus
- context-menu: onCloseAutoFocus
- sidebar: _tooltip
- select: _position
- 20 lines deleted, zero runtime behavior change

## Test plan
- [ ] All existing tests pass
- [ ] No runtime behavior change (props were already unused)

Fixes #934

Generated with [Claude Code](https://claude.com/claude-code)