### PR TITLE
refactor(ui): standardize asChild on slot primitive

### DIFF
--- a/packages/ui/src/components/ui/alert-dialog.tsx
+++ b/packages/ui/src/components/ui/alert-dialog.tsx
@@ -56,6 +56,7 @@ import classy from '../../primitives/classy';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap';
 import { getPortalContainer } from '../../primitives/portal';
+import { mergeProps } from '../../primitives/slot';
 
 // Context for sharing alert dialog state
 interface AlertDialogContextValue {
@@ -162,10 +163,16 @@ export function AlertDialogTrigger({ asChild, onClick, ...props }: AlertDialogTr
   };
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, {
-      ...ariaProps,
-      onClick: handleClick,
-    } as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(
+      {
+        ...ariaProps,
+        onClick: handleClick,
+      } as Partial<unknown>,
+      childProps,
+    );
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return <button type="button" onClick={handleClick} {...ariaProps} {...props} />;
@@ -237,7 +244,10 @@ export function AlertDialogOverlay({
   };
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, overlayProps as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(overlayProps as Partial<unknown>, childProps);
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return <div {...overlayProps} />;
@@ -367,7 +377,10 @@ export function AlertDialogContent({
   const renderContent = () => {
     // If asChild, clone the child with inner props
     if (asChild && React.isValidElement(children)) {
-      const child = React.cloneElement(children, innerProps as Partial<unknown>);
+      const innerChild = children as React.ReactElement<Record<string, unknown>>;
+      const innerChildProps = (innerChild.props ?? {}) as Record<string, unknown>;
+      const innerMerged = mergeProps(innerProps as Partial<unknown>, innerChildProps);
+      const child = React.cloneElement(innerChild, innerMerged as Partial<Record<string, unknown>>);
       return <div className={containerClass}>{child}</div>;
     }
 
@@ -443,7 +456,10 @@ export function AlertDialogTitle({ asChild, className, ...props }: AlertDialogTi
   };
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, titleProps as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(titleProps as Partial<unknown>, childProps);
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return <h2 {...titleProps} />;
@@ -469,7 +485,10 @@ export function AlertDialogDescription({
   };
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, descriptionProps as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(descriptionProps as Partial<unknown>, childProps);
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return <p {...descriptionProps} />;
@@ -500,10 +519,16 @@ export function AlertDialogAction({
   );
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, {
-      onClick: handleClick,
-      className: buttonClass,
-    } as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(
+      {
+        onClick: handleClick,
+        className: buttonClass,
+      } as Partial<unknown>,
+      childProps,
+    );
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return <button type="button" onClick={handleClick} className={buttonClass} {...props} />;
@@ -534,11 +559,17 @@ export function AlertDialogCancel({
   );
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, {
-      ref: cancelRef,
-      onClick: handleClick,
-      className: buttonClass,
-    } as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(
+      {
+        ref: cancelRef,
+        onClick: handleClick,
+        className: buttonClass,
+      } as Partial<unknown>,
+      childProps,
+    );
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return (

--- a/packages/ui/src/components/ui/collapsible.tsx
+++ b/packages/ui/src/components/ui/collapsible.tsx
@@ -27,6 +27,7 @@
 
 import * as React from 'react';
 import classy from '../../primitives/classy';
+import { mergeProps } from '../../primitives/slot';
 
 // Context for sharing collapsible state
 interface CollapsibleContextValue {
@@ -163,7 +164,10 @@ export function CollapsibleTrigger({
   };
 
   if (asChild && React.isValidElement(children)) {
-    return React.cloneElement(children, triggerProps as Partial<unknown>);
+    const child = children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(triggerProps as Partial<unknown>, childProps);
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return (
@@ -216,7 +220,10 @@ export function CollapsibleContent({
   };
 
   if (asChild && React.isValidElement(children)) {
-    return React.cloneElement(children, contentProps as Partial<unknown>);
+    const child = children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(contentProps as Partial<unknown>, childProps);
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return <div {...contentProps}>{children}</div>;

--- a/packages/ui/src/components/ui/context-menu.tsx
+++ b/packages/ui/src/components/ui/context-menu.tsx
@@ -37,6 +37,7 @@ import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { onPointerDownOutside } from '../../primitives/outside-click';
 import { getPortalContainer } from '../../primitives/portal';
 import { createRovingFocus } from '../../primitives/roving-focus';
+import { mergeProps } from '../../primitives/slot';
 import { createTypeahead } from '../../primitives/typeahead';
 
 // ==================== Types ====================
@@ -173,12 +174,18 @@ export const ContextMenuTrigger = React.forwardRef<HTMLSpanElement, ContextMenuT
     };
 
     if (asChild && React.isValidElement(children)) {
-      return React.cloneElement(children, {
-        ref,
-        onContextMenu: handleContextMenu,
-        'data-disabled': disabled ? '' : undefined,
-        ...props,
-      } as Partial<unknown>);
+      const child = children as React.ReactElement<Record<string, unknown>>;
+      const childProps = (child.props ?? {}) as Record<string, unknown>;
+      const merged = mergeProps(
+        {
+          ref,
+          onContextMenu: handleContextMenu,
+          'data-disabled': disabled ? '' : undefined,
+          ...props,
+        } as Partial<unknown>,
+        childProps,
+      );
+      return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
     }
 
     return (
@@ -418,7 +425,14 @@ export const ContextMenuContent = React.forwardRef<HTMLDivElement, ContextMenuCo
     if (asChild && React.isValidElement(props.children)) {
       content = (
         <ContextMenuContentContext.Provider value={contentContextValue}>
-          {React.cloneElement(props.children, contentProps as Partial<unknown>)}
+          {(() => {
+            const ch = props.children as React.ReactElement<Record<string, unknown>>;
+            const cp = (ch.props ?? {}) as Record<string, unknown>;
+            return React.cloneElement(
+              ch,
+              mergeProps(contentProps, cp) as Partial<Record<string, unknown>>,
+            );
+          })()}
         </ContextMenuContentContext.Provider>
       );
     } else {

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -228,7 +228,10 @@ export function DialogOverlay({ asChild, forceMount, className, ...props }: Dial
   };
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, overlayProps as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(overlayProps as Partial<unknown>, childProps);
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return <div {...overlayProps} />;
@@ -382,7 +385,10 @@ export function DialogContent({
   const renderContent = () => {
     // If asChild, clone the child with inner props
     if (asChild && React.isValidElement(children)) {
-      const child = React.cloneElement(children, innerProps as Partial<unknown>);
+      const innerChild = children as React.ReactElement<Record<string, unknown>>;
+      const innerChildProps = (innerChild.props ?? {}) as Record<string, unknown>;
+      const innerMerged = mergeProps(innerProps as Partial<unknown>, innerChildProps);
+      const child = React.cloneElement(innerChild, innerMerged as Partial<Record<string, unknown>>);
       return (
         <div className={containerClass}>
           {child}
@@ -466,7 +472,10 @@ export function DialogTitle({ asChild, className, ...props }: DialogTitleProps) 
   };
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, titleProps as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(titleProps as Partial<unknown>, childProps);
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return <h2 {...titleProps} />;
@@ -488,7 +497,10 @@ export function DialogDescription({ asChild, className, ...props }: DialogDescri
   };
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, descriptionProps as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(descriptionProps as Partial<unknown>, childProps);
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return <p {...descriptionProps} />;

--- a/packages/ui/src/components/ui/drawer.tsx
+++ b/packages/ui/src/components/ui/drawer.tsx
@@ -267,7 +267,10 @@ export function DrawerOverlay({
   };
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, overlayProps as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(overlayProps as Partial<unknown>, childProps);
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return <div {...overlayProps} />;
@@ -579,7 +582,10 @@ export function DrawerContent({
   // The core content to render
   const renderContent = () => {
     if (asChild && React.isValidElement(children)) {
-      return React.cloneElement(children, contentProps as Partial<unknown>);
+      const child = children as React.ReactElement<Record<string, unknown>>;
+      const childProps = (child.props ?? {}) as Record<string, unknown>;
+      const merged = mergeProps(contentProps as Partial<unknown>, childProps);
+      return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
     }
 
     return (
@@ -652,7 +658,10 @@ export function DrawerTitle({ asChild, className, ...props }: DrawerTitleProps):
   };
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, titleProps as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(titleProps as Partial<unknown>, childProps);
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return <h2 {...titleProps} />;
@@ -678,7 +687,10 @@ export function DrawerDescription({
   };
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, descriptionProps as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(descriptionProps as Partial<unknown>, childProps);
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return <p {...descriptionProps} />;

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -38,6 +38,7 @@ import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { onPointerDownOutside } from '../../primitives/outside-click';
 import { getPortalContainer } from '../../primitives/portal';
 import { createRovingFocus } from '../../primitives/roving-focus';
+import { mergeProps } from '../../primitives/slot';
 import { createTypeahead } from '../../primitives/typeahead';
 import type { Align, Side } from '../../primitives/types';
 
@@ -189,11 +190,17 @@ export const DropdownMenuTrigger = React.forwardRef<HTMLButtonElement, DropdownM
     };
 
     if (asChild && React.isValidElement(props.children)) {
-      return React.cloneElement(props.children, {
-        ref: composedRef,
-        ...ariaProps,
-        onClick: handleClick,
-      } as Partial<unknown>);
+      const child = props.children as React.ReactElement<Record<string, unknown>>;
+      const childProps = (child.props ?? {}) as Record<string, unknown>;
+      const merged = mergeProps(
+        {
+          ref: composedRef,
+          ...ariaProps,
+          onClick: handleClick,
+        } as Partial<unknown>,
+        childProps,
+      );
+      return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
     }
 
     return (
@@ -458,7 +465,14 @@ export const DropdownMenuContent = React.forwardRef<HTMLDivElement, DropdownMenu
     if (asChild && React.isValidElement(props.children)) {
       content = (
         <DropdownMenuContentContext.Provider value={contentContextValue}>
-          {React.cloneElement(props.children, contentProps as Partial<unknown>)}
+          {(() => {
+            const ch = props.children as React.ReactElement<Record<string, unknown>>;
+            const cp = (ch.props ?? {}) as Record<string, unknown>;
+            return React.cloneElement(
+              ch,
+              mergeProps(contentProps, cp) as Partial<Record<string, unknown>>,
+            );
+          })()}
         </DropdownMenuContentContext.Provider>
       );
     } else {

--- a/packages/ui/src/components/ui/hover-card.tsx
+++ b/packages/ui/src/components/ui/hover-card.tsx
@@ -41,6 +41,7 @@ import classy from '../../primitives/classy';
 import { type CollisionOptions, computePosition } from '../../primitives/collision-detector';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { getPortalContainer } from '../../primitives/portal';
+import { mergeProps } from '../../primitives/slot';
 import type { Align, Side } from '../../primitives/types';
 
 // ==================== Global state for skip delay ====================
@@ -326,10 +327,16 @@ export function HoverCardTrigger({
   };
 
   if (asChild && React.isValidElement(children)) {
-    return React.cloneElement(children, {
-      ...triggerProps,
-      ref: internalRef,
-    } as Partial<unknown>);
+    const child = children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(
+      {
+        ...triggerProps,
+        ref: internalRef,
+      } as Partial<unknown>,
+      childProps,
+    );
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return <a {...triggerProps}>{children}</a>;
@@ -582,7 +589,10 @@ export function HoverCardContent({
   let content: React.ReactElement;
 
   if (asChild && React.isValidElement(children)) {
-    content = React.cloneElement(children, contentProps as Partial<unknown>);
+    const child = children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(contentProps as Partial<unknown>, childProps);
+    content = React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   } else {
     content = <div {...contentProps}>{children}</div>;
   }

--- a/packages/ui/src/components/ui/menubar.tsx
+++ b/packages/ui/src/components/ui/menubar.tsx
@@ -45,6 +45,7 @@ import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { onPointerDownOutside } from '../../primitives/outside-click';
 import { getPortalContainer } from '../../primitives/portal';
 import { createRovingFocus } from '../../primitives/roving-focus';
+import { mergeProps } from '../../primitives/slot';
 import { createTypeahead } from '../../primitives/typeahead';
 import type { Align, Side } from '../../primitives/types';
 
@@ -351,15 +352,21 @@ export const MenubarTrigger = React.forwardRef<HTMLButtonElement, MenubarTrigger
     };
 
     if (asChild && React.isValidElement(props.children)) {
-      return React.cloneElement(props.children, {
-        ref: composedRef,
-        role: 'menuitem',
-        tabIndex: -1,
-        ...ariaProps,
-        onClick: handleClick,
-        onPointerEnter: handlePointerEnter,
-        onKeyDown: handleKeyDown,
-      } as Partial<unknown>);
+      const child = props.children as React.ReactElement<Record<string, unknown>>;
+      const childProps = (child.props ?? {}) as Record<string, unknown>;
+      const merged = mergeProps(
+        {
+          ref: composedRef,
+          role: 'menuitem',
+          tabIndex: -1,
+          ...ariaProps,
+          onClick: handleClick,
+          onPointerEnter: handlePointerEnter,
+          onKeyDown: handleKeyDown,
+        } as Partial<unknown>,
+        childProps,
+      );
+      return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
     }
 
     return (
@@ -691,7 +698,14 @@ export const MenubarContent = React.forwardRef<HTMLDivElement, MenubarContentPro
     if (asChild && React.isValidElement(props.children)) {
       content = (
         <MenubarContentContext.Provider value={contentContextValue}>
-          {React.cloneElement(props.children, contentProps as Partial<unknown>)}
+          {(() => {
+            const ch = props.children as React.ReactElement<Record<string, unknown>>;
+            const cp = (ch.props ?? {}) as Record<string, unknown>;
+            return React.cloneElement(
+              ch,
+              mergeProps(contentProps, cp) as Partial<Record<string, unknown>>,
+            );
+          })()}
         </MenubarContentContext.Provider>
       );
     } else {

--- a/packages/ui/src/components/ui/popover.tsx
+++ b/packages/ui/src/components/ui/popover.tsx
@@ -46,6 +46,7 @@ import { createPortal } from 'react-dom';
 import classy from '../../primitives/classy';
 import { Float, useFloatContext } from '../../primitives/float';
 import { getPortalContainer } from '../../primitives/portal';
+import { mergeProps } from '../../primitives/slot';
 import type { Align, Side } from '../../primitives/types';
 
 // Context to track if we're inside a portal (to avoid double-wrapping)
@@ -94,11 +95,17 @@ export function PopoverTrigger({ asChild, onClick, ...props }: PopoverTriggerPro
   };
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, {
-      ref: anchorRef,
-      ...ariaProps,
-      onClick: handleClick,
-    } as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(
+      {
+        ref: anchorRef,
+        ...ariaProps,
+        onClick: handleClick,
+      } as Partial<unknown>,
+      childProps,
+    );
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return (
@@ -122,9 +129,15 @@ export function PopoverAnchor({ asChild, ...props }: PopoverAnchorProps) {
   const { anchorRef } = useFloatContext();
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, {
-      ref: anchorRef,
-    } as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(
+      {
+        ref: anchorRef,
+      } as Partial<unknown>,
+      childProps,
+    );
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return <div ref={anchorRef as React.RefObject<HTMLDivElement>} {...props} />;
@@ -273,9 +286,15 @@ export function PopoverClose({ asChild, onClick, ...props }: PopoverCloseProps) 
   };
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, {
-      onClick: handleClick,
-    } as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(
+      {
+        onClick: handleClick,
+      } as Partial<unknown>,
+      childProps,
+    );
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return <button type="button" onClick={handleClick} {...props} />;

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -50,6 +50,7 @@ import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { onPointerDownOutside } from '../../primitives/outside-click';
 import { getPortalContainer } from '../../primitives/portal';
 import { createRovingFocus } from '../../primitives/roving-focus';
+import { mergeProps } from '../../primitives/slot';
 import { createTypeahead } from '../../primitives/typeahead';
 import type { Align, Side } from '../../primitives/types';
 
@@ -273,13 +274,19 @@ export function SelectTrigger({
   );
 
   if (asChild && React.isValidElement(children)) {
-    return React.cloneElement(children, {
-      ref: triggerRef,
-      ...ariaProps,
-      disabled,
-      onClick: handleClick,
-      onKeyDown: handleKeyDown,
-    } as Partial<unknown>);
+    const child = children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(
+      {
+        ref: triggerRef,
+        ...ariaProps,
+        disabled,
+        onClick: handleClick,
+        onKeyDown: handleKeyDown,
+      } as Partial<unknown>,
+      childProps,
+    );
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return (
@@ -323,10 +330,16 @@ export function SelectValue({
   const spanClassName = classy(isPlaceholder ? 'text-muted-foreground' : '', className);
 
   if (asChild && React.isValidElement(children)) {
-    return React.cloneElement(children, {
-      className: spanClassName,
-      ...props,
-    } as Partial<unknown>);
+    const child = children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(
+      {
+        className: spanClassName,
+        ...props,
+      } as Partial<unknown>,
+      childProps,
+    );
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return (
@@ -605,7 +618,14 @@ export function SelectContent({
 
   const content =
     asChild && React.isValidElement(children) ? (
-      React.cloneElement(children, contentProps as Partial<unknown>)
+      (() => {
+        const ch = children as React.ReactElement<Record<string, unknown>>;
+        const cp = (ch.props ?? {}) as Record<string, unknown>;
+        return React.cloneElement(
+          ch,
+          mergeProps(contentProps, cp) as Partial<Record<string, unknown>>,
+        );
+      })()
     ) : (
       <div {...contentProps}>
         <div className="p-1">{children}</div>
@@ -630,10 +650,16 @@ export function SelectViewport({ className, children, asChild, ...props }: Selec
   const viewportClassName = classy('p-1', className);
 
   if (asChild && React.isValidElement(children)) {
-    return React.cloneElement(children, {
-      className: viewportClassName,
-      ...props,
-    } as Partial<unknown>);
+    const child = children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(
+      {
+        className: viewportClassName,
+        ...props,
+      } as Partial<unknown>,
+      childProps,
+    );
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return (
@@ -653,11 +679,17 @@ export function SelectGroup({ className, children, asChild, ...props }: SelectGr
   const groupClassName = classy('', className);
 
   if (asChild && React.isValidElement(children)) {
-    return React.cloneElement(children, {
-      className: groupClassName,
-      role: 'group',
-      ...props,
-    } as Partial<unknown>);
+    const child = children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(
+      {
+        className: groupClassName,
+        role: 'group',
+        ...props,
+      } as Partial<unknown>,
+      childProps,
+    );
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return (
@@ -678,10 +710,16 @@ export function SelectLabel({ className, children, asChild, ...props }: SelectLa
   const labelClassName = classy('py-1.5 pl-8 pr-2 text-sm font-semibold', className);
 
   if (asChild && React.isValidElement(children)) {
-    return React.cloneElement(children, {
-      className: labelClassName,
-      ...props,
-    } as Partial<unknown>);
+    const child = children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(
+      {
+        className: labelClassName,
+        ...props,
+      } as Partial<unknown>,
+      childProps,
+    );
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return (
@@ -764,7 +802,10 @@ export function SelectItem({
   };
 
   if (asChild && React.isValidElement(children)) {
-    return React.cloneElement(children, itemProps as Partial<unknown>);
+    const child = children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(itemProps as Partial<unknown>, childProps);
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return (
@@ -802,11 +843,17 @@ export function SelectSeparator({ className, asChild, ...props }: SelectSeparato
   const separatorClassName = classy('-mx-1 my-1 h-px bg-muted', className);
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, {
-      className: separatorClassName,
-      'aria-hidden': true,
-      ...props,
-    } as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(
+      {
+        className: separatorClassName,
+        'aria-hidden': true,
+        ...props,
+      } as Partial<unknown>,
+      childProps,
+    );
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return <div aria-hidden="true" className={separatorClassName} {...props} />;
@@ -826,10 +873,16 @@ export function SelectIcon({ className, children, asChild, ...props }: SelectIco
   const iconClassName = classy('ml-auto h-4 w-4 shrink-0 opacity-50', className);
 
   if (asChild && React.isValidElement(children)) {
-    return React.cloneElement(children, {
-      className: iconClassName,
-      ...props,
-    } as Partial<unknown>);
+    const child = children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(
+      {
+        className: iconClassName,
+        ...props,
+      } as Partial<unknown>,
+      childProps,
+    );
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return (
@@ -873,11 +926,17 @@ export function SelectScrollUpButton({
   const buttonClassName = classy('flex cursor-default items-center justify-center py-1', className);
 
   if (asChild && React.isValidElement(children)) {
-    return React.cloneElement(children, {
-      className: buttonClassName,
-      'aria-hidden': true,
-      ...props,
-    } as Partial<unknown>);
+    const child = children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(
+      {
+        className: buttonClassName,
+        'aria-hidden': true,
+        ...props,
+      } as Partial<unknown>,
+      childProps,
+    );
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return (
@@ -922,11 +981,17 @@ export function SelectScrollDownButton({
   const buttonClassName = classy('flex cursor-default items-center justify-center py-1', className);
 
   if (asChild && React.isValidElement(children)) {
-    return React.cloneElement(children, {
-      className: buttonClassName,
-      'aria-hidden': true,
-      ...props,
-    } as Partial<unknown>);
+    const child = children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(
+      {
+        className: buttonClassName,
+        'aria-hidden': true,
+        ...props,
+      } as Partial<unknown>,
+      childProps,
+    );
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return (

--- a/packages/ui/src/components/ui/sheet.tsx
+++ b/packages/ui/src/components/ui/sheet.tsx
@@ -58,6 +58,7 @@ import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap';
 import { onPointerDownOutside } from '../../primitives/outside-click';
 import { getPortalContainer } from '../../primitives/portal';
+import { mergeProps } from '../../primitives/slot';
 
 // Context for sharing sheet state
 interface SheetContextValue {
@@ -158,10 +159,16 @@ export function SheetTrigger({ asChild, onClick, ...props }: SheetTriggerProps) 
   };
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, {
-      ...ariaProps,
-      onClick: handleClick,
-    } as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(
+      {
+        ...ariaProps,
+        onClick: handleClick,
+      } as Partial<unknown>,
+      childProps,
+    );
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return <button type="button" onClick={handleClick} {...ariaProps} {...props} />;
@@ -230,7 +237,10 @@ export function SheetOverlay({ asChild, forceMount, className, ...props }: Sheet
   };
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, overlayProps as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(overlayProps as Partial<unknown>, childProps);
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return <div {...overlayProps} />;
@@ -385,7 +395,10 @@ export function SheetContent({
   // The core content to render
   const renderContent = () => {
     if (asChild && React.isValidElement(children)) {
-      return React.cloneElement(children, contentProps as Partial<unknown>);
+      const child = children as React.ReactElement<Record<string, unknown>>;
+      const childProps = (child.props ?? {}) as Record<string, unknown>;
+      const merged = mergeProps(contentProps as Partial<unknown>, childProps);
+      return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
     }
 
     return (
@@ -461,7 +474,10 @@ export function SheetTitle({ asChild, className, ...props }: SheetTitleProps) {
   };
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, titleProps as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(titleProps as Partial<unknown>, childProps);
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return <h2 {...titleProps} />;
@@ -483,7 +499,10 @@ export function SheetDescription({ asChild, className, ...props }: SheetDescript
   };
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, descriptionProps as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(descriptionProps as Partial<unknown>, childProps);
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return <p {...descriptionProps} />;
@@ -504,9 +523,15 @@ export function SheetClose({ asChild, onClick, ...props }: SheetCloseProps) {
   };
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, {
-      onClick: handleClick,
-    } as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(
+      {
+        onClick: handleClick,
+      } as Partial<unknown>,
+      childProps,
+    );
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return <button type="button" onClick={handleClick} {...props} />;

--- a/packages/ui/src/components/ui/toggle.tsx
+++ b/packages/ui/src/components/ui/toggle.tsx
@@ -23,6 +23,7 @@
  */
 import * as React from 'react';
 import classy from '../../primitives/classy';
+import { mergeProps } from '../../primitives/slot';
 
 export interface ToggleProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** Visual variant per docs/COMPONENT_STYLING_REFERENCE.md */
@@ -133,7 +134,10 @@ export function Toggle({
   };
 
   if (asChild && React.isValidElement(props.children)) {
-    return React.cloneElement(props.children, buttonProps as Partial<unknown>);
+    const child = props.children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(buttonProps as Partial<unknown>, childProps);
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return (

--- a/packages/ui/src/components/ui/tooltip.tsx
+++ b/packages/ui/src/components/ui/tooltip.tsx
@@ -34,6 +34,7 @@ import { createPortal } from 'react-dom';
 import classy from '../../primitives/classy';
 import { type CollisionOptions, computePosition } from '../../primitives/collision-detector';
 import { getPortalContainer } from '../../primitives/portal';
+import { mergeProps } from '../../primitives/slot';
 
 // ==================== Global state for skip delay ====================
 
@@ -310,10 +311,16 @@ export function TooltipTrigger({ asChild, children, ...props }: TooltipTriggerPr
   };
 
   if (asChild && React.isValidElement(children)) {
-    return React.cloneElement(children, {
-      ...triggerProps,
-      ref: internalRef,
-    } as Partial<unknown>);
+    const child = children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(
+      {
+        ...triggerProps,
+        ref: internalRef,
+      } as Partial<unknown>,
+      childProps,
+    );
+    return React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   }
 
   return (
@@ -464,7 +471,10 @@ export function TooltipContent({
   let content: React.ReactNode;
 
   if (asChild && React.isValidElement(children)) {
-    content = React.cloneElement(children, contentProps as Partial<unknown>);
+    const child = children as React.ReactElement<Record<string, unknown>>;
+    const childProps = (child.props ?? {}) as Record<string, unknown>;
+    const merged = mergeProps(contentProps as Partial<unknown>, childProps);
+    content = React.cloneElement(child, merged as Partial<Record<string, unknown>>);
   } else {
     content = <div {...contentProps}>{children}</div>;
   }

--- a/packages/ui/src/primitives/slot.ts
+++ b/packages/ui/src/primitives/slot.ts
@@ -329,7 +329,7 @@ export function mergeClassNames(parentClass: string, childClass: string): string
  * Props object for framework-agnostic prop merging
  */
 export interface SlotProps {
-  className?: string;
+  className?: string | undefined;
   style?: React.CSSProperties | undefined;
   [key: string]: unknown;
 }


### PR DESCRIPTION
## Summary
- Replace React.cloneElement with mergeProps from slot primitive in all asChild implementations
- 14 files modified, 45 locations updated
- Event handlers now compose correctly (child fires first, then parent)
- Fix SlotProps.className type for exactOptionalPropertyTypes compatibility

## Components updated
toggle, tooltip, alert-dialog, collapsible, context-menu, dialog, drawer, dropdown-menu, hover-card, menubar, popover, select, sheet

## Test plan
- [ ] All existing tests pass
- [ ] Event handlers compose correctly in asChild mode
- [ ] No visual regressions

Fixes #935

Generated with [Claude Code](https://claude.com/claude-code)