### PR TITLE
feat(design-tokens): add AI intelligence metadata to DTCG export

### DIFF
--- a/packages/design-tokens/src/exporters/dtcg.ts
+++ b/packages/design-tokens/src/exporters/dtcg.ts
@@ -187,6 +187,23 @@ function buildExtensions(token: Token): Record<string, unknown> {
     extensions.requiredForComponents = token.requiredForComponents;
   }
 
+  // AI intelligence metadata
+  if (token.trustLevel) {
+    extensions.trustLevel = token.trustLevel;
+  }
+  if (token.cognitiveLoad !== undefined) {
+    extensions.cognitiveLoad = token.cognitiveLoad;
+  }
+  if (token.consequence) {
+    extensions.consequence = token.consequence;
+  }
+  if (token.accessibilityLevel) {
+    extensions.accessibilityLevel = token.accessibilityLevel;
+  }
+  if (token.appliesWhen && token.appliesWhen.length > 0) {
+    extensions.appliesWhen = token.appliesWhen;
+  }
+
   // Only include extensions if there's data
   return Object.keys(extensions).length > 0 ? { rafters: extensions } : {};
 }

--- a/packages/design-tokens/test/exporters/dtcg.test.ts
+++ b/packages/design-tokens/test/exporters/dtcg.test.ts
@@ -156,6 +156,53 @@ describe('toDTCG', () => {
       expect(rafters.dependsOn).toEqual(['spacing-base']);
     });
 
+    it('should include AI intelligence metadata in extensions', () => {
+      const tokens: Token[] = [
+        {
+          name: 'color-danger',
+          value: '#ff0000',
+          category: 'color',
+          namespace: 'color',
+          trustLevel: 'critical',
+          cognitiveLoad: 3,
+          consequence: 'destructive',
+          accessibilityLevel: 'AA',
+          appliesWhen: ['destructive actions', 'error states'],
+        },
+      ];
+
+      const result = toDTCG(tokens, { applyTypesToGroup: false });
+      const token = (result.color as Record<string, unknown>).danger as Record<string, unknown>;
+      const rafters = (token.$extensions as Record<string, unknown>).rafters as Record<
+        string,
+        unknown
+      >;
+
+      expect(rafters.trustLevel).toBe('critical');
+      expect(rafters.cognitiveLoad).toBe(3);
+      expect(rafters.consequence).toBe('destructive');
+      expect(rafters.accessibilityLevel).toBe('AA');
+      expect(rafters.appliesWhen).toEqual(['destructive actions', 'error states']);
+    });
+
+    it('should not include empty appliesWhen array in extensions', () => {
+      const tokens: Token[] = [
+        {
+          name: 'color-muted',
+          value: '#999999',
+          category: 'color',
+          namespace: 'color',
+          appliesWhen: [],
+        },
+      ];
+
+      const result = toDTCG(tokens, { applyTypesToGroup: false });
+      const token = (result.color as Record<string, unknown>).muted as Record<string, unknown>;
+
+      // No extensions at all since appliesWhen is empty and no other extension fields
+      expect(token.$extensions).toBeUndefined();
+    });
+
     it('should exclude extensions when includeExtensions=false', () => {
       const tokens: Token[] = [
         {


### PR DESCRIPTION
## Summary
- Export trustLevel, cognitiveLoad, consequence, accessibilityLevel, appliesWhen
- Empty appliesWhen array excluded from output
- All Token type fields already existed in shared types
- 2 new tests

## Test plan
- [x] All 5 AI intelligence fields export correctly
- [x] Empty appliesWhen excluded
- [x] All 200 existing tests pass

Fixes #919
Depends on #918 (code goes after relationship fields section)

Generated with [Claude Code](https://claude.com/claude-code)