### PR TITLE
fix(mcp): resolve component paths from config for consumer projects (#948)

### DIFF
--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -15,7 +15,7 @@
 
 import { existsSync } from 'node:fs';
 import { readdir, readFile } from 'node:fs/promises';
-import { basename, join } from 'node:path';
+import { basename, join, relative } from 'node:path';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { NodePersistenceAdapter } from '@rafters/design-tokens';
 import {
@@ -660,6 +660,23 @@ export class RaftersToolHandler {
   }
 
   /**
+   * Load and cache the project's Rafters config from .rafters/config.rafters.json.
+   * Returns null when no config exists or when it cannot be parsed.
+   */
+  private async loadConfig(): Promise<RaftersConfig | null> {
+    try {
+      const paths = getRaftersPaths(this.projectRoot);
+      if (!existsSync(paths.config)) {
+        return null;
+      }
+      const content = await readFile(paths.config, 'utf-8');
+      return JSON.parse(content) as RaftersConfig;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * Extract compact component vocabulary
    */
   private async getComponentVocabulary(): Promise<{
@@ -669,10 +686,8 @@ export class RaftersToolHandler {
     // Read installed components from config
     let installed: string[] = [];
     try {
-      const paths = getRaftersPaths(this.projectRoot);
-      if (existsSync(paths.config)) {
-        const content = await readFile(paths.config, 'utf-8');
-        const config = JSON.parse(content) as RaftersConfig;
+      const config = await this.loadConfig();
+      if (config) {
         installed = config.installed?.components ?? [];
       }
     } catch {
@@ -735,18 +750,24 @@ export class RaftersToolHandler {
   // ==================== Tool 3: Component ====================
 
   /**
-   * Get path to UI components directory
+   * Get path to UI components directory.
+   * Reads componentsPath from .rafters/config.rafters.json when available,
+   * falls back to the monorepo layout for local development.
    */
-  private getComponentsPath(): string {
-    const monorepoPath = join(this.projectRoot, 'packages/ui/src/components/ui');
-    return monorepoPath;
+  private async getComponentsPath(): Promise<string> {
+    const config = await this.loadConfig();
+    if (config?.componentsPath) {
+      return join(this.projectRoot, config.componentsPath);
+    }
+    // Fallback: monorepo development layout
+    return join(this.projectRoot, 'packages/ui/src/components/ui');
   }
 
   /**
    * Load component metadata from source file
    */
   private async loadComponentMetadata(name: string): Promise<ComponentMetadata | null> {
-    const componentsPath = this.getComponentsPath();
+    const componentsPath = await this.getComponentsPath();
     const filePath = join(componentsPath, `${name}.tsx`);
 
     try {
@@ -769,7 +790,7 @@ export class RaftersToolHandler {
         sizes: extractSizes(source),
         dependencies: extractDependencies(source),
         primitives: extractPrimitiveDependencies(source),
-        filePath: `packages/ui/src/components/ui/${name}.tsx`,
+        filePath: relative(this.projectRoot, join(componentsPath, `${name}.tsx`)),
       };
 
       if (hasAnyDeps(jsDocDeps)) {
@@ -869,7 +890,7 @@ export class RaftersToolHandler {
 
       if (!metadata) {
         // Try to provide helpful suggestions
-        const componentsPath = this.getComponentsPath();
+        const componentsPath = await this.getComponentsPath();
         let available: string[] = [];
         try {
           const files = await readdir(componentsPath);

--- a/packages/cli/test/mcp/tools.test.ts
+++ b/packages/cli/test/mcp/tools.test.ts
@@ -331,6 +331,97 @@ export function MultiDep() { return null; }`,
       expect(data.jsDocDependencies).toBeDefined();
       expect(data.jsDocDependencies.runtime).toEqual(['nanostores@^0.11.0', 'zustand@^4.0.0']);
     });
+
+    it('should read components from config-specified path', async () => {
+      // Write config with a consumer-style componentsPath
+      await writeFile(
+        join(testDir, '.rafters', 'config.rafters.json'),
+        JSON.stringify({
+          framework: 'vite',
+          componentsPath: 'src/components/ui',
+          primitivesPath: 'src/lib/primitives',
+          compositesPath: 'src/composites',
+          cssPath: null,
+          shadcn: false,
+          exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
+        }),
+      );
+
+      // Write component at the config-specified path (NOT the monorepo fallback)
+      const consumerDir = join(testDir, 'src/components/ui');
+      await mkdir(consumerDir, { recursive: true });
+      await writeFile(
+        join(consumerDir, 'my-button.tsx'),
+        `/**
+ * A custom button
+ * @cognitive-load 2/10
+ */
+export function MyButton() { return null; }`,
+      );
+
+      const result = await handler.handleToolCall('rafters_component', {
+        name: 'my-button',
+      });
+
+      expect(result.isError).toBeFalsy();
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.name).toBe('my-button');
+      expect(data.displayName).toBe('My Button');
+    });
+
+    it('should fall back to monorepo path when no config exists', async () => {
+      // No config file written -- should use packages/ui/src/components/ui
+      const monorepoDir = join(testDir, 'packages/ui/src/components/ui');
+      await mkdir(monorepoDir, { recursive: true });
+      await writeFile(
+        join(monorepoDir, 'fallback-comp.tsx'),
+        `/**
+ * Fallback component
+ * @cognitive-load 1/10
+ */
+export function FallbackComp() { return null; }`,
+      );
+
+      const result = await handler.handleToolCall('rafters_component', {
+        name: 'fallback-comp',
+      });
+
+      expect(result.isError).toBeFalsy();
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.name).toBe('fallback-comp');
+    });
+
+    it('should not find component at monorepo path when config specifies different path', async () => {
+      // Write config pointing to src/components/ui
+      await writeFile(
+        join(testDir, '.rafters', 'config.rafters.json'),
+        JSON.stringify({
+          framework: 'vite',
+          componentsPath: 'src/components/ui',
+          primitivesPath: 'src/lib/primitives',
+          compositesPath: 'src/composites',
+          cssPath: null,
+          shadcn: false,
+          exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
+        }),
+      );
+
+      // Write component ONLY at the monorepo path (wrong location for consumer)
+      const monorepoDir = join(testDir, 'packages/ui/src/components/ui');
+      await mkdir(monorepoDir, { recursive: true });
+      await writeFile(
+        join(monorepoDir, 'wrong-place.tsx'),
+        `/** @cognitive-load 1/10 */
+export function WrongPlace() { return null; }`,
+      );
+
+      const result = await handler.handleToolCall('rafters_component', {
+        name: 'wrong-place',
+      });
+
+      // Should NOT find it because config says to look in src/components/ui
+      expect(result.isError).toBe(true);
+    });
   });
 
   describe('rafters_token', () => {


### PR DESCRIPTION
## Summary
- `getComponentsPath()` now reads `componentsPath` from `.rafters/config.rafters.json`
- Falls back to monorepo path `packages/ui/src/components/ui` when no config exists (dev mode)
- Extracted shared `loadConfig()` method for reuse across tool handlers
- Tests verify config-based and fallback path resolution

Fixes #948

## Test plan
- [x] Typecheck clean
- [x] New tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)