### PR TITLE
fix(test): replace non-null assertions in container tests

### DIFF
--- a/packages/ui/test/components/container.test.tsx
+++ b/packages/ui/test/components/container.test.tsx
@@ -7,11 +7,17 @@ function getGapValue(el: Element): string | null {
   return match?.[1] ?? null;
 }
 
+function firstChild(container: HTMLElement): Element {
+  const el = container.firstElementChild;
+  expect(el).not.toBeNull();
+  return el as Element;
+}
+
 describe('Container', () => {
   describe('gap prop', () => {
     it('does not apply flex or gap classes when gap is not set', () => {
       const { container } = render(<Container>content</Container>);
-      const el = container.firstElementChild as Element;
+      const el = firstChild(container);
       expect(el.className).not.toContain('flex-col');
       expect(el.className).not.toContain('gap-');
     });
@@ -23,7 +29,7 @@ describe('Container', () => {
             content
           </Container>,
         );
-        expect(getGapValue(container.firstElementChild!)).toBe('3');
+        expect(getGapValue(firstChild(container))).toBe('3');
       });
 
       it('xl uses section-padding tier (spacing-6)', () => {
@@ -32,7 +38,7 @@ describe('Container', () => {
             content
           </Container>,
         );
-        expect(getGapValue(container.firstElementChild!)).toBe('6');
+        expect(getGapValue(firstChild(container))).toBe('6');
       });
 
       it('7xl uses upper section-padding tier (spacing-12)', () => {
@@ -41,7 +47,7 @@ describe('Container', () => {
             content
           </Container>,
         );
-        expect(getGapValue(container.firstElementChild!)).toBe('12');
+        expect(getGapValue(firstChild(container))).toBe('12');
       });
 
       it('smaller sizes get smaller gaps than larger sizes', () => {
@@ -55,14 +61,14 @@ describe('Container', () => {
             7xl
           </Container>,
         );
-        expect(Number(getGapValue(smC.firstElementChild!))).toBeLessThan(
-          Number(getGapValue(xlC.firstElementChild!)),
+        expect(Number(getGapValue(firstChild(smC)))).toBeLessThan(
+          Number(getGapValue(firstChild(xlC))),
         );
       });
 
       it('falls back to spacing-6 when no size is set', () => {
         const { container } = render(<Container gap>content</Container>);
-        expect(getGapValue(container.firstElementChild!)).toBe('6');
+        expect(getGapValue(firstChild(container))).toBe('6');
       });
 
       it('full falls back to spacing-6', () => {
@@ -71,7 +77,7 @@ describe('Container', () => {
             content
           </Container>,
         );
-        expect(getGapValue(container.firstElementChild!)).toBe('6');
+        expect(getGapValue(firstChild(container))).toBe('6');
       });
     });
 
@@ -82,7 +88,7 @@ describe('Container', () => {
             content
           </Container>,
         );
-        expect(getGapValue(container.firstElementChild!)).toBe('8');
+        expect(getGapValue(firstChild(container))).toBe('8');
       });
 
       it('gap="0" applies gap-0 regardless of size', () => {
@@ -91,7 +97,7 @@ describe('Container', () => {
             content
           </Container>,
         );
-        expect(getGapValue(container.firstElementChild!)).toBe('0');
+        expect(getGapValue(firstChild(container))).toBe('0');
       });
     });
 
@@ -101,7 +107,7 @@ describe('Container', () => {
           content
         </Container>,
       );
-      const el = container.firstElementChild as Element;
+      const el = firstChild(container);
       expect(el.className).toContain('flex');
       expect(el.className).toContain('flex-col');
     });
@@ -112,7 +118,7 @@ describe('Container', () => {
           content
         </Container>,
       );
-      const el = container.firstElementChild as Element;
+      const el = firstChild(container);
       expect(el.className).toContain('p-4');
       expect(el.className).toContain('gap-6');
       expect(el.className).toContain('custom');


### PR DESCRIPTION
## Summary
- Extract `firstChild()` helper that asserts non-null before casting
- Eliminates 9 biome `noNonNullAssertion` warnings on `container.firstElementChild!`

Closes #959

## Test plan
- [x] All 3264 UI tests pass
- [x] No non-null assertions remain in container.test.tsx

Generated with [Claude Code](https://claude.com/claude-code)