### PR TITLE
fix(editor): remove stale biome suppression comment

### DIFF
--- a/apps/demo/src/components/ui/editor.tsx
+++ b/apps/demo/src/components/ui/editor.tsx
@@ -396,7 +396,6 @@ function SaveCompositeDialog({
 
   return createPortal(
     <>
-      {/* biome-ignore lint/a11y/noStaticElementInteractions: modal overlay dismiss is a standard pattern */}
       <div
         className={classy('fixed inset-0 z-50 bg-black/50')}
         onClick={onCancel}

--- a/packages/ui/src/components/ui/editor.tsx
+++ b/packages/ui/src/components/ui/editor.tsx
@@ -396,7 +396,6 @@ function SaveCompositeDialog({
 
   return createPortal(
     <>
-      {/* biome-ignore lint/a11y/noStaticElementInteractions: modal overlay dismiss is a standard pattern */}
       <div
         className={classy('fixed inset-0 z-50 bg-black/50')}
         onClick={onCancel}


### PR DESCRIPTION
## Summary
- Remove unused `noStaticElementInteractions` suppression from modal overlay div
- The `aria-hidden="true"` attribute makes the suppression unnecessary
- Fixed in both `packages/ui` and `apps/demo` copies

Closes #961

## Test plan
- [x] `pnpm biome check` passes with zero warnings on both files

Generated with [Claude Code](https://claude.com/claude-code)