### PR TITLE
test(mcp): add error path coverage for MCP tools

### DIFF
--- a/packages/cli/test/mcp/tools.test.ts
+++ b/packages/cli/test/mcp/tools.test.ts
@@ -814,10 +814,7 @@ export function Button() { return null; }`,
     });
 
     it('should handle corrupt token file in token lookup gracefully', async () => {
-      await writeFile(
-        join(testDir, '.rafters', 'tokens', 'spacing.rafters.json'),
-        '{corrupt',
-      );
+      await writeFile(join(testDir, '.rafters', 'tokens', 'spacing.rafters.json'), '{corrupt');
 
       const result = await handler.handleToolCall('rafters_token', {
         name: 'spacing-1',


### PR DESCRIPTION
## Summary
- Add 7 tests covering previously untested error handling paths in MCP tools
- Validates resilience to missing directories, corrupt files, invalid inputs
- Confirms static fallbacks work when dynamic sources fail

Closes #963

## Test plan
- [x] All 54 MCP tool tests pass (7 new)
- [x] All 237 CLI unit tests pass

Generated with [Claude Code](https://claude.com/claude-code)