### PR TITLE
fix(composites): remove non-null assertions in bridge.ts

### DIFF
--- a/packages/composites/src/bridge.ts
+++ b/packages/composites/src/bridge.ts
@@ -129,16 +129,18 @@ function expandBlocks(
         continue;
       }
       // Composite not found -- fall through to create a placeholder
+      const placeholderId = idMap.get(block.id) ?? block.id;
       result.push({
-        id: idMap.get(block.id)!,
+        id: placeholderId,
         type: 'text',
         content: `Unknown composite: ${compositeId}`,
       });
       continue;
     }
 
+    const newId = idMap.get(block.id) ?? block.id;
     const instantiated: InstantiatedBlock = {
-      id: idMap.get(block.id)!,
+      id: newId,
       type: block.type,
     };
 


### PR DESCRIPTION
## Summary
- Replace `idMap.get(block.id)!` with `idMap.get(block.id) ?? block.id` fallback
- Eliminates 2 biome `noNonNullAssertion` warnings

Closes #965

## Test plan
- [x] All 132 composites tests pass
- [x] `pnpm biome check` clean

Generated with [Claude Code](https://claude.com/claude-code)