### PR TITLE
fix(registry): use optional chain in componentService

### DIFF
--- a/apps/website/src/lib/registry/componentService.ts
+++ b/apps/website/src/lib/registry/componentService.ts
@@ -556,7 +556,7 @@ export function extractSiblingImports(content: string): string[] {
 
   for (const match of matches) {
     const pkg = match[1];
-    if (pkg && pkg.startsWith('./') && !pkg.slice(2).includes('/')) {
+    if (pkg?.startsWith('./') && !pkg.slice(2).includes('/')) {
       const name = basename(pkg).replace(/\.(tsx?|jsx?)$/, '');
       if (name && !siblings.includes(name)) {
         siblings.push(name);


### PR DESCRIPTION
## Summary
- Replace `pkg && pkg.startsWith` with `pkg?.startsWith` per biome `useOptionalChain`
- Codebase now has zero biome warnings across all 620 checked files

Closes #967

## Test plan
- [x] `pnpm biome check` passes with zero warnings

Generated with [Claude Code](https://claude.com/claude-code)