### PR TITLE
feat(color-area): add gamut edge fading and CSS-pixel rendering

### DIFF
--- a/packages/ui/src/primitives/color-area.ts
+++ b/packages/ui/src/primitives/color-area.ts
@@ -80,7 +80,7 @@ function renderArea(canvas: HTMLCanvasElement, options: ColorAreaOptions): void 
     for (let y = startY; y < cssHeight; y++) {
       const c = (1 - y / maxY) * maxChroma;
       const distPx = ((mc - c) / maxChroma) * cssHeight;
-      const t = distPx >= FADE_PX ? 1 : distPx / FADE_PX;
+      const t = distPx >= FADE_PX ? 1 : Math.max(0, distPx / FADE_PX);
       ctx.globalAlpha = t * t;
       ctx.fillStyle = `oklch(${l} ${c} ${hue})`;
       ctx.fillRect(x, y, 1, 1);


### PR DESCRIPTION
## Summary
- Precompute `findMaxChroma` per lightness column into a Float32Array for gamut boundary detection
- Fade pixels near the gamut edge with 16px quadratic alpha falloff instead of hard black cutoff
- Switch from backing-pixel to CSS-pixel resolution rendering via `ctx.setTransform`, yielding ~4x fewer iterations on retina displays
- Skip extreme lightness pixels (L < 0.01 or L > 0.99) where colors collapse

## Test plan
- [x] All 7 existing color-area tests pass unchanged
- [x] Biome lint clean
- [ ] Visual verification in demo app color picker

Closes #976

Generated with [Claude Code](https://claude.com/claude-code)