### PR TITLE
feat(color-picker): wire perceptual hue warp and vivid hue bar

### DIFF
--- a/packages/ui/src/components/ui/color-picker.tsx
+++ b/packages/ui/src/components/ui/color-picker.tsx
@@ -26,6 +26,7 @@ import * as React from 'react';
 import classy from '../../primitives/classy';
 import type { ColorPickerStateControls } from '../../primitives/color-picker';
 import { createColorPickerState, getGamutTier } from '../../primitives/color-picker';
+import { barPosFromHue } from '../../primitives/oklch-gamut';
 import type { Direction, GamutTier, OklchColor } from '../../primitives/types';
 
 export interface ColorPickerProps
@@ -204,7 +205,7 @@ export const ColorPicker = React.forwardRef<HTMLDivElement, ColorPickerProps>(
             ref={hueThumbRef}
             aria-hidden="true"
             className="pointer-events-none absolute top-1/2 h-5 w-5 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white shadow-md"
-            style={{ left: `${(color.h / 360) * 100}%` }}
+            style={{ left: `${barPosFromHue(color.h) * 100}%` }}
           />
         </div>
 

--- a/packages/ui/src/primitives/color-picker.ts
+++ b/packages/ui/src/primitives/color-picker.ts
@@ -55,7 +55,7 @@ import { createColorInput, updateColorInput } from './color-input';
 import { createSwatch, updateSwatch } from './color-swatch';
 import { createHueBar, updateHueBar } from './hue-bar';
 import { createInteractive } from './interactive';
-import { inP3, inSrgb } from './oklch-gamut';
+import { hueFromBarPos, inP3, inSrgb } from './oklch-gamut';
 import type {
   CleanupFunction,
   Direction,
@@ -200,7 +200,7 @@ export function createColorPickerState(options: ColorPickerStateOptions): ColorP
       ...dirOption,
       onMove: (point: NormalizedPoint) => {
         const cur = $color.get();
-        const newColor = { ...cur, h: point.left * 360 };
+        const newColor = { ...cur, h: hueFromBarPos(point.left) };
         $color.set(newColor);
         onColorChange?.(newColor);
       },
@@ -218,7 +218,9 @@ export function createColorPickerState(options: ColorPickerStateOptions): ColorP
   cleanups.push(createColorArea(areaCanvas, { hue: initialColor.h, maxChroma: safeMaxChroma }));
 
   // Hue bar canvas
-  cleanups.push(createHueBar(hueCanvas, { lightness: initialColor.l, chroma: initialColor.c }));
+  cleanups.push(
+    createHueBar(hueCanvas, { lightness: initialColor.l, chroma: initialColor.c, vivid: true }),
+  );
 
   // Color inputs
   const fields: ColorInputField[] = [
@@ -255,7 +257,7 @@ export function createColorPickerState(options: ColorPickerStateOptions): ColorP
   // Subscribe to color changes and propagate to leaf primitives
   const unsubColor = $color.subscribe((color) => {
     updateColorArea(areaCanvas, { hue: color.h, maxChroma: safeMaxChroma });
-    updateHueBar(hueCanvas, { lightness: color.l, chroma: color.c });
+    updateHueBar(hueCanvas, { lightness: color.l, chroma: color.c, vivid: true });
     updateColorInput(fields, {
       value: { l: color.l, c: color.c, h: color.h },
       onChange: () => {},


### PR DESCRIPTION
## Summary
- Map hue bar interaction through `hueFromBarPos()` for perceptual warp
- Enable `vivid: true` on hue bar for peak-chroma rendering
- Use `barPosFromHue()` for hue thumb positioning in React component

## Test plan
- [x] All 54 color-picker tests pass (primitive + component + a11y)
- [x] Full UI suite passes (3397 tests)
- [x] Biome clean on changed files
- [x] Minimal changes: 2 files, 8 insertions, 5 deletions

Closes #977
Depends on: #979, #980

🤖 Generated with [Claude Code](https://claude.com/claude-code)