### PR TITLE
fix(cli): save config exports when config file is missing

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -378,10 +378,23 @@ async function regenerateFromExisting(
   // Generate outputs
   const outputs = await generateOutputs(cwd, paths, registry, exports, shadcn);
 
-  // Update config with new export settings
+  // Update config with new export settings (create if missing)
   if (existingConfig) {
     existingConfig.exports = exports;
     await writeFile(paths.config, JSON.stringify(existingConfig, null, 2));
+  } else {
+    const frameworkPaths = COMPONENT_PATHS[framework] || COMPONENT_PATHS.unknown;
+    const newConfig: RaftersConfig = {
+      framework,
+      componentsPath: frameworkPaths.components,
+      primitivesPath: frameworkPaths.primitives,
+      compositesPath: frameworkPaths.composites,
+      cssPath: null,
+      shadcn: !!shadcn,
+      exports,
+      installed: { components: [], primitives: [], composites: [] },
+    };
+    await writeFile(paths.config, JSON.stringify(newConfig, null, 2));
   }
 
   log({
@@ -494,10 +507,23 @@ async function resetToDefaults(
   // Generate outputs
   const outputs = await generateOutputs(cwd, paths, registry, exports, shadcn);
 
-  // Update config with new export settings
+  // Update config with new export settings (create if missing)
   if (existingConfig) {
     existingConfig.exports = exports;
     await writeFile(paths.config, JSON.stringify(existingConfig, null, 2));
+  } else {
+    const frameworkPaths = COMPONENT_PATHS[framework] || COMPONENT_PATHS.unknown;
+    const newConfig: RaftersConfig = {
+      framework,
+      componentsPath: frameworkPaths.components,
+      primitivesPath: frameworkPaths.primitives,
+      compositesPath: frameworkPaths.composites,
+      cssPath: null,
+      shadcn: !!shadcn,
+      exports,
+      installed: { components: [], primitives: [], composites: [] },
+    };
+    await writeFile(paths.config, JSON.stringify(newConfig, null, 2));
   }
 
   log({


### PR DESCRIPTION
## Summary

- Both `--rebuild` and `--reset` paths silently dropped user export selections (dtcg, compiled) when `config.rafters.json` was missing or corrupted
- Now creates a fresh config with the correct export flags instead of discarding them
- Files were generated correctly but config didn't reflect it

## Root cause

The save logic was guarded by `if (existingConfig)` -- if config failed to load, the new exports were never written to disk.

## Test plan

- [x] All 259 unit tests pass
- [x] TypeScript compiles cleanly
- [x] Biome passes

Closes #994

Generated with [Claude Code](https://claude.com/claude-code)