### PR TITLE
fix(registry): exclude shared auxiliary files from component primitives list

### DIFF
--- a/apps/website/src/lib/registry/componentService.ts
+++ b/apps/website/src/lib/registry/componentService.ts
@@ -390,9 +390,14 @@ export function loadComponent(name: string): RegistryItem | null {
         devDependencies: analysis.devDependencies,
       });
 
-      // Merge primitive/internal deps from all variants
+      // Merge primitive/internal deps from all variants.
+      // Filter out shared auxiliary files (e.g. button.classes) -- they are bundled
+      // with the component's files, not standalone primitives.
+      const realPrimitives = analysis.importDeps.internal.filter(
+        (dep) => !SHARED_SUFFIXES.some((suffix) => dep === name + suffix.replace(/\.ts$/, '')),
+      );
       primitivesAll = [
-        ...new Set([...primitivesAll, ...analysis.importDeps.internal, ...analysis.primitiveDeps]),
+        ...new Set([...primitivesAll, ...realPrimitives, ...analysis.primitiveDeps]),
       ];
       internalAll = [...new Set([...internalAll, ...analysis.importDeps.internal])];
 


### PR DESCRIPTION
## Summary
- Fixes `button.classes` (and similar `.types`, `.constants` files) being incorrectly listed in a component's `primitives` array
- The CLI was trying to fetch `button.classes` as a standalone primitive from `/registry/primitives/button.classes.json`, which doesn't exist
- Root cause: import analysis treated `./button.classes` as an internal component dependency, then merged it into primitives
- Fix filters shared auxiliary file names from internal deps before adding to primitives, since these files are already bundled in the component's `files` array
- **Registry-side fix** -- no CLI version bump needed. Existing CLI versions will get correct data after website redeploy.

## Test plan
- [x] Verified filter logic: `button.classes` excluded, `classy` and `slot` pass through
- [ ] Gitpress confirms `rafters add button` works without errors after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)