### PR TITLE
feat(ui): add Logo component with mark, typemark, and full variants

### DIFF
--- a/packages/ui/src/components/ui/logo.tsx
+++ b/packages/ui/src/components/ui/logo.tsx
@@ -78,10 +78,7 @@ const VIEWBOXES: Record<LogoVariant, string> = {
 
 export const Logo = React.forwardRef<SVGSVGElement, LogoProps>(
   ({ variant = 'full', size = 'md', className, ...props }, ref) => {
-    const cls = classy(
-      SIZE_CLASSES[variant][size],
-      className,
-    );
+    const cls = classy(SIZE_CLASSES[variant][size], className);
 
     return (
       <svg


### PR DESCRIPTION
## Summary
- Logo component with three variants: `full` (mark + wordmark), `mark` (chevron only), `typemark` (text only)
- Five sizes: xs, sm, md, lg, xl
- Inherits color via `currentColor` -- works with any design system token
- The mark is the architecturally accurate rafter at 22 degrees with perspective asymmetry
- Proper JSDoc intelligence metadata (cognitive load, attention economics, usage patterns)
- Accessible: `aria-label` and `role="img"`

## Usage
```tsx
<Logo />                          // full, md
<Logo variant="mark" size="sm" /> // chevron only, small
<Logo variant="typemark" />       // text only
```

## Test plan
- [ ] Visual verification of all three variants at all sizes
- [ ] Verify viewBox crops correctly for mark-only and typemark-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)