### PR TITLE
fix(ci): add npm registry auth to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           node-version: 24.12
           cache: pnpm
+          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -34,6 +35,8 @@ jobs:
       - name: Publish to npm
         run: npm publish --access=public --provenance
         working-directory: packages/cli
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         run: gh release create "$GITHUB_REF_NAME" --generate-notes


### PR DESCRIPTION
## Summary
- Add `registry-url: https://registry.npmjs.org` to setup-node step
- Add `NODE_AUTH_TOKEN` env to publish step using `NPM_TOKEN` secret
- v0.0.17 release failed with `ENEEDAUTH` because npm wasn't authenticated

## Required
You need an `NPM_TOKEN` secret set in the repo settings (Settings > Secrets > Actions). Generate one at npmjs.com > Access Tokens > Granular Access Token with publish permission for the `rafters` package.

## Test plan
- [ ] Merge this, then re-tag v0.0.17 (delete old tag, retag, push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)