### PR TITLE
chore(cli): bump to v0.0.18

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rafters
 
+## 0.0.18
+
+### Patch Changes
+
+- Re-release with OIDC trust policy updated for rafters-studio org
+
 ## 0.0.17
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "CLI for Rafters design system - scaffold tokens and add components",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- Re-release after updating npm OIDC trust policy for rafters-studio org
- v0.0.17 release failed because npm provenance was still trusting the old GitHub org

## After merge
Tag v0.0.18 to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)