### PR TITLE
fix(cli): update repository URL from ezmode-games to rafters-studio

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,7 +51,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ezmode-games/rafters.git",
+    "url": "git+https://github.com/rafters-studio/rafters.git",
     "directory": "packages/cli"
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary
npm provenance verification failed because package.json repository.url still pointed to `ezmode-games/rafters`. Updated to `rafters-studio/rafters`.

## After merge
Bump to v0.0.19 and retag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)