### PR TITLE
chore(cli): bump to v0.0.19

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rafters
 
+## 0.0.19
+
+### Patch Changes
+
+- Fix repository URL for npm provenance verification (ezmode-games -> rafters-studio)
+
 ## 0.0.18
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "CLI for Rafters design system - scaffold tokens and add components",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
Bump after repository URL fix. Ready for npm publish.

## After merge
Tag v0.0.19 to trigger release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)