### PR TITLE
feat(editor): document editing primitives

### DIFF
--- a/packages/ui/src/primitives/block-operations.test.ts
+++ b/packages/ui/src/primitives/block-operations.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest';
+import {
+  blockContentToText,
+  convertBlockType,
+  deleteBlock,
+  insertBlocksAt,
+  mergeWithNext,
+  mergeWithPrevious,
+  splitBlock,
+} from './block-operations';
+import type { BaseBlock } from './types';
+
+const blocks: BaseBlock[] = [
+  { id: 'h1', type: 'heading', content: 'Title', meta: { level: 1 } },
+  { id: 'p1', type: 'text', content: 'Hello world' },
+  { id: 'p2', type: 'text', content: 'Second paragraph' },
+  { id: 'q1', type: 'quote', content: 'A wise quote' },
+];
+
+describe('blockContentToText', () => {
+  it('handles string content', () => {
+    expect(blockContentToText('hello')).toBe('hello');
+  });
+
+  it('handles InlineContent array', () => {
+    expect(blockContentToText([{ text: 'hello ' }, { text: 'world', marks: ['bold'] }])).toBe(
+      'hello world',
+    );
+  });
+
+  it('handles undefined', () => {
+    expect(blockContentToText(undefined)).toBe('');
+  });
+});
+
+describe('splitBlock', () => {
+  it('splits in the middle', () => {
+    const result = splitBlock(blocks, 'p1', 5);
+    expect(result.blocks).toHaveLength(5);
+    expect(result.blocks[1].content).toBe('Hello');
+    expect(result.blocks[2].content).toBe(' world');
+    expect(result.blocks[2].type).toBe('text');
+    expect(result.newBlockId).toBe(result.blocks[2].id);
+  });
+
+  it('splits at the start (offset 0)', () => {
+    const result = splitBlock(blocks, 'p1', 0);
+    expect(result.blocks[1].content).toBe('');
+    expect(result.blocks[2].content).toBe('Hello world');
+  });
+
+  it('splits at the end', () => {
+    const result = splitBlock(blocks, 'p1', 11);
+    expect(result.blocks[1].content).toBe('Hello world');
+    expect(result.blocks[2].content).toBe('');
+  });
+
+  it('heading split creates text block', () => {
+    const result = splitBlock(blocks, 'h1', 2);
+    expect(result.blocks[0].type).toBe('heading');
+    expect(result.blocks[0].content).toBe('Ti');
+    expect(result.blocks[1].type).toBe('text');
+    expect(result.blocks[1].content).toBe('tle');
+  });
+
+  it('returns unchanged if block not found', () => {
+    const result = splitBlock(blocks, 'nonexistent', 0);
+    expect(result.blocks).toBe(blocks);
+  });
+});
+
+describe('mergeWithPrevious', () => {
+  it('merges content into previous block', () => {
+    const result = mergeWithPrevious(blocks, 'p2');
+    expect(result.blocks).toHaveLength(3);
+    expect(result.survivorId).toBe('p1');
+    expect(result.blocks[1].content).toBe('Hello worldSecond paragraph');
+    expect(result.cursorOffset).toBe(11);
+  });
+
+  it('no-ops for first block', () => {
+    const result = mergeWithPrevious(blocks, 'h1');
+    expect(result.blocks).toBe(blocks);
+    expect(result.survivorId).toBe('h1');
+  });
+
+  it('no-ops for missing block', () => {
+    const result = mergeWithPrevious(blocks, 'nonexistent');
+    expect(result.blocks).toBe(blocks);
+  });
+});
+
+describe('mergeWithNext', () => {
+  it('merges next block content into current', () => {
+    const result = mergeWithNext(blocks, 'p1');
+    expect(result.blocks).toHaveLength(3);
+    expect(result.survivorId).toBe('p1');
+    expect(result.blocks[1].content).toBe('Hello worldSecond paragraph');
+    expect(result.cursorOffset).toBe(11);
+  });
+
+  it('no-ops for last block', () => {
+    const result = mergeWithNext(blocks, 'q1');
+    expect(result.blocks).toBe(blocks);
+  });
+});
+
+describe('deleteBlock', () => {
+  it('deletes and focuses previous', () => {
+    const result = deleteBlock(blocks, 'p2');
+    expect(result.blocks).toHaveLength(3);
+    expect(result.focusBlockId).toBe('p1');
+    expect(result.focusAtEnd).toBe(true);
+  });
+
+  it('deletes first and focuses next', () => {
+    const result = deleteBlock(blocks, 'h1');
+    expect(result.blocks).toHaveLength(3);
+    expect(result.focusBlockId).toBe('p1');
+    expect(result.focusAtEnd).toBe(false);
+  });
+
+  it('returns null focus when deleting last block', () => {
+    const single: BaseBlock[] = [{ id: 'only', type: 'text', content: 'alone' }];
+    const result = deleteBlock(single, 'only');
+    expect(result.blocks).toHaveLength(0);
+    expect(result.focusBlockId).toBe(null);
+  });
+});
+
+describe('convertBlockType', () => {
+  it('converts text to heading', () => {
+    const result = convertBlockType(blocks, 'p1', 'heading', { level: 2 });
+    const block = result.find((b) => b.id === 'p1');
+    expect(block?.type).toBe('heading');
+    expect(block?.meta?.level).toBe(2);
+    expect(block?.content).toBe('Hello world');
+  });
+
+  it('converts heading to text and removes level meta', () => {
+    const result = convertBlockType(blocks, 'h1', 'text');
+    const block = result.find((b) => b.id === 'h1');
+    expect(block?.type).toBe('text');
+    expect(block?.meta?.level).toBeUndefined();
+    expect(block?.content).toBe('Title');
+  });
+
+  it('converts to code and flattens InlineContent', () => {
+    const richBlocks: BaseBlock[] = [
+      {
+        id: 'r1',
+        type: 'text',
+        content: [{ text: 'hello ' }, { text: 'bold', marks: ['bold'] }],
+      },
+    ];
+    const result = convertBlockType(richBlocks, 'r1', 'code');
+    expect(result[0].content).toBe('hello bold');
+  });
+
+  it('does not modify other blocks', () => {
+    const result = convertBlockType(blocks, 'p1', 'heading', { level: 3 });
+    expect(result.find((b) => b.id === 'h1')?.type).toBe('heading');
+    expect(result.find((b) => b.id === 'p2')?.type).toBe('text');
+  });
+});
+
+describe('insertBlocksAt', () => {
+  const newBlocks: BaseBlock[] = [
+    { id: 'n1', type: 'text', content: 'Inserted 1' },
+    { id: 'n2', type: 'text', content: 'Inserted 2' },
+  ];
+
+  it('inserts at end of block', () => {
+    const result = insertBlocksAt(blocks, newBlocks, 'p1', 11);
+    expect(result.blocks).toHaveLength(6);
+    expect(result.blocks[2].id).toBe('n1');
+    expect(result.blocks[3].id).toBe('n2');
+    expect(result.lastInsertedId).toBe('n2');
+  });
+
+  it('inserts at start of block', () => {
+    const result = insertBlocksAt(blocks, newBlocks, 'p1', 0);
+    expect(result.blocks).toHaveLength(6);
+    expect(result.blocks[1].id).toBe('n1');
+    expect(result.blocks[2].id).toBe('n2');
+  });
+
+  it('splits block and inserts in the middle', () => {
+    const result = insertBlocksAt(blocks, newBlocks, 'p1', 5);
+    // Original p1 is split: "Hello" | n1 | n2 | " world"
+    expect(result.blocks.length).toBeGreaterThan(blocks.length + newBlocks.length - 1);
+    expect(result.lastInsertedId).toBe('n2');
+  });
+
+  it('handles empty insert', () => {
+    const result = insertBlocksAt(blocks, [], 'p1', 5);
+    expect(result.blocks).toBe(blocks);
+  });
+});

--- a/packages/ui/src/primitives/block-operations.ts
+++ b/packages/ui/src/primitives/block-operations.ts
@@ -1,0 +1,297 @@
+/**
+ * Block operations primitive - pure functions for structural block mutations
+ *
+ * Split, merge, convert, insert, and delete operations on a block array.
+ * No DOM, no side effects, no external dependencies. These are the building
+ * blocks for Enter/Backspace/Delete/paste behavior in a document editor.
+ *
+ * @registry-name block-operations
+ * @registry-version 0.1.0
+ * @registry-status published
+ * @registry-path primitives/block-operations.ts
+ * @registry-type registry:primitive
+ *
+ * @dependencies none
+ */
+import type { BaseBlock, InlineContent } from './types';
+
+// =============================================================================
+// Content helpers
+// =============================================================================
+
+/** Extract plain text from block content */
+export function blockContentToText(content: string | InlineContent[] | undefined): string {
+  if (content === undefined) return '';
+  if (typeof content === 'string') return content;
+  return content.map((s) => s.text).join('');
+}
+
+/** Create a new block ID */
+function newId(): string {
+  return crypto.randomUUID();
+}
+
+// =============================================================================
+// Split: Enter pressed in the middle of a block
+// =============================================================================
+
+export interface SplitResult {
+  /** Updated blocks array */
+  blocks: BaseBlock[];
+  /** ID of the new block (the second half) */
+  newBlockId: string;
+}
+
+/**
+ * Split a block at a text offset. The block keeps content before the offset,
+ * a new text block gets content after the offset.
+ *
+ * If offset is 0: the current block becomes empty, new block gets all content.
+ * If offset is at end: current block keeps all content, new empty block created.
+ * Headings always create a text block after (not another heading).
+ */
+export function splitBlock(blocks: BaseBlock[], blockId: string, offset: number): SplitResult {
+  const index = blocks.findIndex((b) => b.id === blockId);
+  if (index === -1) return { blocks, newBlockId: '' };
+
+  const block = blocks[index];
+  if (!block) return { blocks, newBlockId: '' };
+
+  const text = blockContentToText(block.content);
+  const before = text.slice(0, offset);
+  const after = text.slice(offset);
+
+  const newBlockId = newId();
+
+  // The new block is always a text block (even after headings)
+  const newBlock: BaseBlock = {
+    id: newBlockId,
+    type: 'text',
+    content: after,
+  };
+
+  const updatedBlock: BaseBlock = {
+    ...block,
+    content: before,
+  };
+
+  const next = [...blocks];
+  next[index] = updatedBlock;
+  next.splice(index + 1, 0, newBlock);
+
+  return { blocks: next, newBlockId };
+}
+
+// =============================================================================
+// Merge: Backspace at start or Delete at end
+// =============================================================================
+
+export interface MergeResult {
+  /** Updated blocks array */
+  blocks: BaseBlock[];
+  /** ID of the surviving block */
+  survivorId: string;
+  /** Cursor offset in the surviving block (where the merge point is) */
+  cursorOffset: number;
+}
+
+/**
+ * Merge a block with the previous block. The previous block absorbs the
+ * content of the current block. The current block is deleted.
+ */
+export function mergeWithPrevious(blocks: BaseBlock[], blockId: string): MergeResult {
+  const index = blocks.findIndex((b) => b.id === blockId);
+  if (index <= 0) return { blocks, survivorId: blockId, cursorOffset: 0 };
+
+  const prevBlock = blocks[index - 1];
+  const currentBlock = blocks[index];
+  if (!prevBlock || !currentBlock) return { blocks, survivorId: blockId, cursorOffset: 0 };
+
+  const prevText = blockContentToText(prevBlock.content);
+  const currentText = blockContentToText(currentBlock.content);
+  const cursorOffset = prevText.length;
+
+  const merged: BaseBlock = {
+    ...prevBlock,
+    content: prevText + currentText,
+  };
+
+  const next = [...blocks];
+  next[index - 1] = merged;
+  next.splice(index, 1);
+
+  return { blocks: next, survivorId: prevBlock.id, cursorOffset };
+}
+
+/**
+ * Merge a block with the next block. The current block absorbs the content
+ * of the next block. The next block is deleted.
+ */
+export function mergeWithNext(blocks: BaseBlock[], blockId: string): MergeResult {
+  const index = blocks.findIndex((b) => b.id === blockId);
+  if (index === -1 || index >= blocks.length - 1) {
+    return { blocks, survivorId: blockId, cursorOffset: 0 };
+  }
+
+  const currentBlock = blocks[index];
+  const nextBlock = blocks[index + 1];
+  if (!currentBlock || !nextBlock) {
+    return { blocks, survivorId: blockId, cursorOffset: 0 };
+  }
+
+  const currentText = blockContentToText(currentBlock.content);
+  const nextText = blockContentToText(nextBlock.content);
+  const cursorOffset = currentText.length;
+
+  const merged: BaseBlock = {
+    ...currentBlock,
+    content: currentText + nextText,
+  };
+
+  const next = [...blocks];
+  next[index] = merged;
+  next.splice(index + 1, 1);
+
+  return { blocks: next, survivorId: currentBlock.id, cursorOffset };
+}
+
+// =============================================================================
+// Delete: remove a block
+// =============================================================================
+
+export interface DeleteResult {
+  /** Updated blocks array */
+  blocks: BaseBlock[];
+  /** ID of the block to focus after deletion */
+  focusBlockId: string | null;
+  /** Whether to place cursor at end of the focus block */
+  focusAtEnd: boolean;
+}
+
+/**
+ * Delete a block from the array. Returns the block to focus after deletion
+ * (the previous block, or the next, or null if the array is now empty).
+ */
+export function deleteBlock(blocks: BaseBlock[], blockId: string): DeleteResult {
+  const index = blocks.findIndex((b) => b.id === blockId);
+  if (index === -1) return { blocks, focusBlockId: null, focusAtEnd: false };
+
+  const next = blocks.filter((b) => b.id !== blockId);
+
+  // Focus the previous block (at end), or next block (at start), or null
+  let focusBlockId: string | null = null;
+  let focusAtEnd = false;
+  const prevBlock = index > 0 ? next[index - 1] : undefined;
+  const nextBlock = next[index];
+  if (prevBlock) {
+    focusBlockId = prevBlock.id;
+    focusAtEnd = true;
+  } else if (nextBlock) {
+    focusBlockId = nextBlock.id;
+    focusAtEnd = false;
+  }
+
+  return { blocks: next, focusBlockId, focusAtEnd };
+}
+
+// =============================================================================
+// Convert: change block type
+// =============================================================================
+
+/**
+ * Change a block's type, preserving its content. For certain conversions,
+ * content is transformed (e.g., code blocks strip marks).
+ */
+export function convertBlockType(
+  blocks: BaseBlock[],
+  blockId: string,
+  newType: string,
+  meta?: Record<string, unknown>,
+): BaseBlock[] {
+  return blocks.map((b) => {
+    if (b.id !== blockId) return b;
+
+    const updated: BaseBlock = {
+      ...b,
+      type: newType,
+    };
+
+    if (meta) {
+      updated.meta = { ...b.meta, ...meta };
+    } else if (newType === 'text' && b.meta) {
+      // When converting to text, remove type-specific meta (level, etc.)
+      const { level: _, ...rest } = b.meta as Record<string, unknown> & { level?: number };
+      if (Object.keys(rest).length > 0) {
+        updated.meta = rest;
+      } else {
+        delete (updated as unknown as Record<string, unknown>).meta;
+      }
+    }
+
+    // Code blocks: flatten content to plain text
+    if (newType === 'code' && Array.isArray(b.content)) {
+      updated.content = blockContentToText(b.content);
+    }
+
+    return updated;
+  });
+}
+
+// =============================================================================
+// Insert: paste blocks at a position
+// =============================================================================
+
+export interface InsertResult {
+  /** Updated blocks array */
+  blocks: BaseBlock[];
+  /** ID of the last inserted block (for cursor placement) */
+  lastInsertedId: string;
+}
+
+/**
+ * Insert blocks at a position. If the cursor is in the middle of a block,
+ * that block is split first and the new blocks are inserted between the halves.
+ */
+export function insertBlocksAt(
+  blocks: BaseBlock[],
+  newBlocks: BaseBlock[],
+  atBlockId: string,
+  atOffset: number,
+): InsertResult {
+  if (newBlocks.length === 0) return { blocks, lastInsertedId: atBlockId };
+
+  const lastInserted = newBlocks[newBlocks.length - 1];
+  if (!lastInserted) return { blocks, lastInsertedId: atBlockId };
+
+  const index = blocks.findIndex((b) => b.id === atBlockId);
+  if (index === -1) return { blocks, lastInsertedId: lastInserted.id };
+
+  const block = blocks[index];
+  if (!block) return { blocks, lastInsertedId: lastInserted.id };
+
+  const text = blockContentToText(block.content);
+
+  // If at the very end, just insert after
+  if (atOffset >= text.length) {
+    const next = [...blocks];
+    next.splice(index + 1, 0, ...newBlocks);
+    return { blocks: next, lastInsertedId: lastInserted.id };
+  }
+
+  // If at the very start, insert before
+  if (atOffset === 0) {
+    const next = [...blocks];
+    next.splice(index, 0, ...newBlocks);
+    return { blocks: next, lastInsertedId: lastInserted.id };
+  }
+
+  // In the middle: split the block and insert between halves
+  const { blocks: splitBlocks, newBlockId } = splitBlock(blocks, atBlockId, atOffset);
+  const splitIndex = splitBlocks.findIndex((b) => b.id === newBlockId);
+  if (splitIndex === -1) return { blocks: splitBlocks, lastInsertedId: lastInserted.id };
+
+  // Insert new blocks before the second half
+  const next = [...splitBlocks];
+  next.splice(splitIndex, 0, ...newBlocks);
+  return { blocks: next, lastInsertedId: lastInserted.id };
+}

--- a/packages/ui/src/primitives/cursor-tracker.ts
+++ b/packages/ui/src/primitives/cursor-tracker.ts
@@ -1,0 +1,163 @@
+/**
+ * Cursor tracker primitive - reads and sets cursor position in a contentEditable
+ *
+ * Pure functions for working with cursor position relative to block elements
+ * inside a contentEditable container. Each block element must have a
+ * data-block-id attribute.
+ *
+ * SSR-safe: all functions return null/no-op when document.getSelection is unavailable.
+ *
+ * @registry-name cursor-tracker
+ * @registry-version 0.1.0
+ * @registry-status published
+ * @registry-path primitives/cursor-tracker.ts
+ * @registry-type registry:primitive
+ *
+ * @dependencies none
+ */
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface CursorPosition {
+  /** Block element's data-block-id */
+  blockId: string;
+  /** Character offset within the block's text content */
+  offset: number;
+  /** Total text length of the block */
+  blockLength: number;
+}
+
+// =============================================================================
+// DOM helpers
+// =============================================================================
+
+/** Find the closest block element from a DOM node */
+export function findBlockElement(node: Node | null): HTMLElement | null {
+  if (!node) return null;
+  const el = node instanceof HTMLElement ? node : node.parentElement;
+  return el?.closest('[data-block-id]') as HTMLElement | null;
+}
+
+/** Get the text offset of the cursor within a block element */
+function getTextOffset(blockEl: HTMLElement, anchorNode: Node, anchorOffset: number): number {
+  const range = document.createRange();
+  range.selectNodeContents(blockEl);
+  range.setEnd(anchorNode, anchorOffset);
+  return range.toString().length;
+}
+
+// =============================================================================
+// Read cursor position
+// =============================================================================
+
+/**
+ * Get the current cursor position relative to the block structure.
+ * Returns null if no selection, or if the cursor is not inside a block.
+ */
+export function getCursorPosition(): CursorPosition | null {
+  if (typeof window === 'undefined') return null;
+
+  const sel = document.getSelection();
+  if (!sel || !sel.rangeCount) return null;
+
+  const blockEl = findBlockElement(sel.anchorNode);
+  if (!blockEl) return null;
+
+  const blockId = blockEl.getAttribute('data-block-id');
+  if (!blockId) return null;
+
+  return {
+    blockId,
+    offset: getTextOffset(blockEl, sel.anchorNode as Node, sel.anchorOffset),
+    blockLength: blockEl.textContent?.length ?? 0,
+  };
+}
+
+/**
+ * Check if the cursor is at the very start of a block (offset === 0).
+ */
+export function isCursorAtBlockStart(): boolean {
+  const pos = getCursorPosition();
+  return pos !== null && pos.offset === 0;
+}
+
+/**
+ * Check if the cursor is at the very end of a block.
+ */
+export function isCursorAtBlockEnd(): boolean {
+  const pos = getCursorPosition();
+  return pos !== null && pos.offset === pos.blockLength;
+}
+
+/**
+ * Check if the selection is collapsed (cursor, not range).
+ */
+export function isSelectionCollapsed(): boolean {
+  if (typeof window === 'undefined') return true;
+  const sel = document.getSelection();
+  return sel?.isCollapsed ?? true;
+}
+
+// =============================================================================
+// Set cursor position
+// =============================================================================
+
+/**
+ * Place the cursor at a specific offset within a block element.
+ * If the offset exceeds the text length, places at the end.
+ */
+export function setCursorInBlock(container: HTMLElement, blockId: string, offset: number): void {
+  if (typeof window === 'undefined') return;
+
+  const blockEl = container.querySelector(`[data-block-id="${blockId}"]`) as HTMLElement | null;
+  if (!blockEl) return;
+
+  const sel = document.getSelection();
+  if (!sel) return;
+
+  // Walk text nodes to find the right position
+  const walker = document.createTreeWalker(blockEl, NodeFilter.SHOW_TEXT);
+  let remaining = offset;
+
+  while (walker.nextNode()) {
+    const textNode = walker.currentNode as Text;
+    if (remaining <= textNode.length) {
+      const range = document.createRange();
+      range.setStart(textNode, remaining);
+      range.collapse(true);
+      sel.removeAllRanges();
+      sel.addRange(range);
+      return;
+    }
+    remaining -= textNode.length;
+  }
+
+  // Offset beyond content: place at end
+  const range = document.createRange();
+  range.selectNodeContents(blockEl);
+  range.collapse(false);
+  sel.removeAllRanges();
+  sel.addRange(range);
+}
+
+/**
+ * Place the cursor at the end of a block.
+ */
+export function setCursorAtBlockEnd(container: HTMLElement, blockId: string): void {
+  if (typeof window === 'undefined') return;
+
+  const blockEl = container.querySelector(`[data-block-id="${blockId}"]`) as HTMLElement | null;
+  if (!blockEl) return;
+
+  const length = blockEl.textContent?.length ?? 0;
+  setCursorInBlock(container, blockId, length);
+}
+
+/**
+ * Place the cursor at the start of a block.
+ */
+export function setCursorAtBlockStart(container: HTMLElement, blockId: string): void {
+  setCursorInBlock(container, blockId, 0);
+}

--- a/packages/ui/src/primitives/document-editor.ts
+++ b/packages/ui/src/primitives/document-editor.ts
@@ -1,0 +1,486 @@
+/**
+ * Document editor composition primitive - unified contentEditable surface
+ *
+ * Orchestrates leaf primitives into a document editing experience:
+ * - input-events: content change detection with IME support
+ * - clipboard: paste/copy/cut with format detection
+ * - keyboard-handler: block type shortcuts (Cmd+Alt+1, etc.)
+ * - cursor-tracker: cursor position relative to blocks
+ * - block-operations: split/merge/delete/convert (pure functions)
+ * - inline-formatter: bold/italic/code/etc
+ * - history: undo/redo
+ * - serializer-html/text: paste deserialization, copy serialization
+ *
+ * The React component layer is a thin wrapper: state + render. This primitive
+ * owns all event handling and block mutation logic.
+ *
+ * @registry-name document-editor
+ * @registry-version 0.1.0
+ * @registry-status published
+ * @registry-path primitives/document-editor.ts
+ * @registry-type registry:primitive
+ *
+ * @dependencies nanostores
+ * @internal-dependencies primitives/input-events.ts, primitives/clipboard.ts,
+ *   primitives/keyboard-handler.ts, primitives/cursor-tracker.ts,
+ *   primitives/block-operations.ts, primitives/history.ts,
+ *   primitives/serializer-html.ts, primitives/serializer-text.ts
+ */
+import { atom } from 'nanostores';
+import {
+  blockContentToText,
+  convertBlockType,
+  deleteBlock,
+  insertBlocksAt,
+  mergeWithNext,
+  mergeWithPrevious,
+  splitBlock,
+} from './block-operations';
+import { createClipboard } from './clipboard';
+import {
+  findBlockElement,
+  getCursorPosition,
+  isCursorAtBlockEnd,
+  isSelectionCollapsed,
+  setCursorAtBlockEnd,
+  setCursorAtBlockStart,
+  setCursorInBlock,
+} from './cursor-tracker';
+import { createHistory } from './history';
+import { createInputHandler } from './input-events';
+import { createKeyboardHandler } from './keyboard-handler';
+import { htmlSerializer } from './serializer-html';
+import { textSerializer } from './serializer-text';
+import type { BaseBlock, CleanupFunction } from './types';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface DocumentEditorState {
+  blocks: BaseBlock[];
+  canUndo: boolean;
+  canRedo: boolean;
+}
+
+export interface DocumentEditorOptions {
+  /** Container element that becomes contentEditable */
+  container: HTMLElement;
+  /** Initial blocks */
+  initialBlocks: BaseBlock[];
+  /** Called when blocks change */
+  onBlocksChange?: (blocks: BaseBlock[]) => void;
+}
+
+export interface DocumentEditorControls {
+  /** Reactive state atom */
+  $state: {
+    get(): DocumentEditorState;
+    subscribe(cb: (v: DocumentEditorState) => void): () => void;
+  };
+  /** Replace blocks (e.g., from external load/import) */
+  setBlocks: (blocks: BaseBlock[]) => void;
+  /** Add blocks at a position */
+  addBlocks: (blocks: BaseBlock[], index?: number) => void;
+  /** Undo */
+  undo: () => void;
+  /** Redo */
+  redo: () => void;
+  /** Focus a block at an offset */
+  focusBlock: (blockId: string, offset?: number) => void;
+  /** Destroy all listeners */
+  destroy: CleanupFunction;
+}
+
+// =============================================================================
+// Markdown shortcuts (detected on space after prefix)
+// =============================================================================
+
+interface MarkdownShortcut {
+  pattern: RegExp;
+  type: string;
+  meta?: Record<string, unknown>;
+}
+
+const MARKDOWN_SHORTCUTS: MarkdownShortcut[] = [
+  { pattern: /^####$/, type: 'heading', meta: { level: 4 } },
+  { pattern: /^###$/, type: 'heading', meta: { level: 3 } },
+  { pattern: /^##$/, type: 'heading', meta: { level: 2 } },
+  { pattern: /^#$/, type: 'heading', meta: { level: 1 } },
+  { pattern: /^>$/, type: 'quote' },
+  { pattern: /^[-*]$/, type: 'list-item', meta: { listType: 'unordered' } },
+  { pattern: /^\d+\.$/, type: 'list-item', meta: { listType: 'ordered' } },
+  { pattern: /^```$/, type: 'code' },
+  { pattern: /^---$/, type: 'divider' },
+];
+
+// =============================================================================
+// Implementation
+// =============================================================================
+
+export function createDocumentEditor(options: DocumentEditorOptions): DocumentEditorControls {
+  const { container, initialBlocks, onBlocksChange } = options;
+  const cleanups: CleanupFunction[] = [];
+
+  // -- Shared state --
+  const history = createHistory<BaseBlock[]>({
+    initialState: initialBlocks,
+    limit: 100,
+  });
+
+  const $state = atom<DocumentEditorState>({
+    blocks: initialBlocks,
+    canUndo: false,
+    canRedo: false,
+  });
+
+  function updateBlocks(next: BaseBlock[]): void {
+    history.push(next);
+    $state.set({
+      blocks: next,
+      canUndo: history.canUndo(),
+      canRedo: history.canRedo(),
+    });
+    onBlocksChange?.(next);
+  }
+
+  // -- Make container contentEditable --
+  container.setAttribute('contenteditable', 'true');
+  container.setAttribute('spellcheck', 'true');
+  container.setAttribute('role', 'textbox');
+  container.setAttribute('aria-multiline', 'true');
+  container.setAttribute('aria-label', 'Document editor');
+  cleanups.push(() => {
+    container.removeAttribute('contenteditable');
+    container.removeAttribute('spellcheck');
+    container.removeAttribute('role');
+    container.removeAttribute('aria-multiline');
+    container.removeAttribute('aria-label');
+  });
+
+  // -- Input events: sync DOM text changes back to block model --
+  const inputHandler = createInputHandler({
+    element: container,
+    onInput: (data) => {
+      if (data.isComposing) return;
+
+      const pos = getCursorPosition();
+      if (!pos) return;
+
+      // insertParagraph = Enter key (browser already split the DOM)
+      if (data.inputType === 'insertParagraph') {
+        const result = splitBlock($state.get().blocks, pos.blockId, pos.offset);
+        updateBlocks(result.blocks);
+        // Focus the new block after React re-renders
+        requestAnimationFrame(() => {
+          setCursorAtBlockStart(container, result.newBlockId);
+        });
+        return;
+      }
+
+      // For regular text input, read the block's DOM content and sync
+      const blockEl = findBlockElement(document.getSelection()?.anchorNode ?? null);
+      if (!blockEl) return;
+
+      const blockId = blockEl.getAttribute('data-block-id');
+      if (!blockId) return;
+
+      const text = blockEl.textContent ?? '';
+      const blocks = $state.get().blocks;
+      const updated = blocks.map((b) => (b.id === blockId ? { ...b, content: text } : b));
+      updateBlocks(updated);
+    },
+    onBeforeInput: (data) => {
+      // Detect markdown shortcuts: check if text before cursor + typed char matches
+      if (data.inputType === 'insertText' && data.data === ' ') {
+        const pos = getCursorPosition();
+        if (!pos) return;
+
+        const blocks = $state.get().blocks;
+        const block = blocks.find((b) => b.id === pos.blockId);
+        if (!block || block.type !== 'text') return;
+
+        const textBeforeCursor = blockContentToText(block.content).slice(0, pos.offset);
+        for (const shortcut of MARKDOWN_SHORTCUTS) {
+          if (shortcut.pattern.test(textBeforeCursor)) {
+            // Prevent the space from being inserted
+            // Note: we return here, the beforeinput handler in input-events
+            // will check the preventDefault array
+            const next = convertBlockType(blocks, pos.blockId, shortcut.type, shortcut.meta);
+            // Clear the prefix content
+            const converted = next.map((b) => (b.id === pos.blockId ? { ...b, content: '' } : b));
+            updateBlocks(converted);
+            requestAnimationFrame(() => {
+              setCursorAtBlockStart(container, pos.blockId);
+            });
+            return;
+          }
+        }
+      }
+    },
+    preventDefault: ['insertParagraph'],
+  });
+  cleanups.push(inputHandler.cleanup);
+
+  // -- Keyboard: Backspace at start, Delete at end --
+  const backspaceCleanup = createKeyboardHandler(container, {
+    key: 'Backspace',
+    handler: () => {
+      if (!isSelectionCollapsed()) return; // Let browser handle selection delete
+
+      const pos = getCursorPosition();
+      if (!pos) return;
+
+      const blocks = $state.get().blocks;
+      const index = blocks.findIndex((b) => b.id === pos.blockId);
+      const block = blocks[index];
+      if (!block) return;
+
+      // Only intercept at position 0
+      if (pos.offset !== 0) return;
+
+      // Empty block: delete it
+      if (pos.blockLength === 0 && index > 0) {
+        const result = deleteBlock(blocks, pos.blockId);
+        updateBlocks(result.blocks);
+        if (result.focusBlockId) {
+          requestAnimationFrame(() => {
+            if (result.focusAtEnd) {
+              setCursorAtBlockEnd(container, result.focusBlockId as string);
+            } else {
+              setCursorAtBlockStart(container, result.focusBlockId as string);
+            }
+          });
+        }
+        return;
+      }
+
+      // Heading/quote at start: convert to text
+      if (block.type === 'heading' || block.type === 'quote') {
+        const next = convertBlockType(blocks, pos.blockId, 'text');
+        updateBlocks(next);
+        requestAnimationFrame(() => {
+          setCursorAtBlockStart(container, pos.blockId);
+        });
+        return;
+      }
+
+      // Merge with previous
+      if (index > 0) {
+        const result = mergeWithPrevious(blocks, pos.blockId);
+        updateBlocks(result.blocks);
+        requestAnimationFrame(() => {
+          setCursorInBlock(container, result.survivorId, result.cursorOffset);
+        });
+      }
+    },
+    preventDefault: false, // We conditionally prevent in the handler
+  });
+  cleanups.push(backspaceCleanup);
+
+  const deleteCleanup = createKeyboardHandler(container, {
+    key: 'Delete',
+    handler: () => {
+      if (!isSelectionCollapsed()) return;
+      if (!isCursorAtBlockEnd()) return;
+
+      const pos = getCursorPosition();
+      if (!pos) return;
+
+      const blocks = $state.get().blocks;
+      const result = mergeWithNext(blocks, pos.blockId);
+      updateBlocks(result.blocks);
+      requestAnimationFrame(() => {
+        setCursorInBlock(container, result.survivorId, result.cursorOffset);
+      });
+    },
+    preventDefault: false,
+  });
+  cleanups.push(deleteCleanup);
+
+  // -- Keyboard: block type shortcuts (Cmd+Alt+0 through Cmd+Alt+4, etc.) --
+  // These use the keyboard-handler primitive for clean binding
+  // Cmd+Alt+N shortcuts for block type switching
+  // Uses raw keydown because keyboard-handler only supports KeyboardKey types (not digits)
+  function handleTypeShortcut(event: KeyboardEvent): void {
+    if (!event.altKey || !(event.metaKey || event.ctrlKey)) return;
+
+    const pos = getCursorPosition();
+    if (!pos) return;
+
+    const blocks = $state.get().blocks;
+    let next: BaseBlock[] | null = null;
+
+    switch (event.key) {
+      case '0':
+        next = convertBlockType(blocks, pos.blockId, 'text');
+        break;
+      case '1':
+        next = convertBlockType(blocks, pos.blockId, 'heading', { level: 1 });
+        break;
+      case '2':
+        next = convertBlockType(blocks, pos.blockId, 'heading', { level: 2 });
+        break;
+      case '3':
+        next = convertBlockType(blocks, pos.blockId, 'heading', { level: 3 });
+        break;
+      case '4':
+        next = convertBlockType(blocks, pos.blockId, 'heading', { level: 4 });
+        break;
+    }
+
+    if (next) {
+      event.preventDefault();
+      updateBlocks(next);
+    }
+  }
+
+  container.addEventListener('keydown', handleTypeShortcut);
+  cleanups.push(() => container.removeEventListener('keydown', handleTypeShortcut));
+
+  // -- Clipboard: paste with format detection, copy with serialization --
+  const clipboard = createClipboard({
+    container,
+    customMimeType: 'application/x-rafters-blocks',
+    onPaste: (data) => {
+      const pos = getCursorPosition();
+      if (!pos) return;
+
+      const blocks = $state.get().blocks;
+      const block = blocks.find((b) => b.id === pos.blockId);
+
+      // In code blocks, paste as plain text (let browser handle it)
+      if (block?.type === 'code') return;
+
+      // Deserialize: try HTML first, fall back to plain text
+      let pastedBlocks: BaseBlock[];
+      if (data.html && data.html.trim()) {
+        pastedBlocks = htmlSerializer.deserialize(data.html).blocks;
+      } else if (data.text) {
+        pastedBlocks = textSerializer.deserialize(data.text).blocks;
+      } else {
+        return;
+      }
+
+      if (pastedBlocks.length === 0) return;
+
+      // Single text block: insert text inline (don't create new block)
+      if (pastedBlocks.length === 1) {
+        const pasted = pastedBlocks[0];
+        if (pasted && pasted.type === 'text') {
+          const pastedText = blockContentToText(pasted.content);
+          document.execCommand('insertText', false, pastedText);
+          return;
+        }
+      }
+
+      // Multiple blocks: insert at cursor position
+      const result = insertBlocksAt(blocks, pastedBlocks, pos.blockId, pos.offset);
+      updateBlocks(result.blocks);
+      requestAnimationFrame(() => {
+        setCursorAtBlockEnd(container, result.lastInsertedId);
+      });
+    },
+    onCopy: () => {
+      // Multi-block copy is handled by the copy event listener below
+    },
+  });
+  cleanups.push(clipboard.cleanup);
+
+  // -- Copy/Cut: serialize selected blocks --
+  function handleCopy(event: ClipboardEvent): void {
+    const sel = document.getSelection();
+    if (!sel || sel.isCollapsed) return;
+
+    const anchorBlock = findBlockElement(sel.anchorNode);
+    const focusBlock = findBlockElement(sel.focusNode);
+    if (!anchorBlock || !focusBlock) return;
+
+    // Within a single block: let browser handle it
+    if (anchorBlock === focusBlock) return;
+
+    event.preventDefault();
+
+    const blocks = $state.get().blocks;
+    const anchorId = anchorBlock.getAttribute('data-block-id') ?? '';
+    const focusId = focusBlock.getAttribute('data-block-id') ?? '';
+    const anchorIdx = blocks.findIndex((b) => b.id === anchorId);
+    const focusIdx = blocks.findIndex((b) => b.id === focusId);
+    const startIdx = Math.min(anchorIdx, focusIdx);
+    const endIdx = Math.max(anchorIdx, focusIdx);
+
+    if (startIdx === -1 || endIdx === -1) return;
+
+    const selected = blocks.slice(startIdx, endIdx + 1);
+    event.clipboardData?.setData('text/html', htmlSerializer.serialize(selected));
+    event.clipboardData?.setData('text/plain', textSerializer.serialize(selected));
+  }
+
+  container.addEventListener('copy', handleCopy);
+  cleanups.push(() => container.removeEventListener('copy', handleCopy));
+
+  container.addEventListener('cut', (event: ClipboardEvent) => {
+    handleCopy(event);
+    // Let browser delete the selected content, input handler will sync
+  });
+
+  // -- Public API --
+  function setBlocks(blocks: BaseBlock[]): void {
+    updateBlocks(blocks);
+  }
+
+  function addBlocks(newBlocks: BaseBlock[], index?: number): void {
+    const current = $state.get().blocks;
+    const next = [...current];
+    if (index !== undefined && index >= 0 && index <= next.length) {
+      next.splice(index, 0, ...newBlocks);
+    } else {
+      next.push(...newBlocks);
+    }
+    updateBlocks(next);
+  }
+
+  function undo(): void {
+    const prev = history.undo();
+    if (prev) {
+      $state.set({
+        blocks: prev,
+        canUndo: history.canUndo(),
+        canRedo: history.canRedo(),
+      });
+      onBlocksChange?.(prev);
+    }
+  }
+
+  function redo(): void {
+    const next = history.redo();
+    if (next) {
+      $state.set({
+        blocks: next,
+        canUndo: history.canUndo(),
+        canRedo: history.canRedo(),
+      });
+      onBlocksChange?.(next);
+    }
+  }
+
+  function focusBlock(blockId: string, offset?: number): void {
+    if (offset !== undefined) {
+      setCursorInBlock(container, blockId, offset);
+    } else {
+      setCursorAtBlockStart(container, blockId);
+    }
+  }
+
+  return {
+    $state,
+    setBlocks,
+    addBlocks,
+    undo,
+    redo,
+    focusBlock,
+    destroy() {
+      for (const cleanup of cleanups) cleanup();
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Three new primitives for the unified contentEditable document surface (#1039):

- **block-operations** (leaf): pure functions for split, merge, delete, convert, and insert block operations on a block array. No DOM, no deps. 24 tests.
- **cursor-tracker** (leaf): reads and sets cursor position relative to block elements inside a contentEditable. SSR-safe, no deps.
- **document-editor** (composition): orchestrates input-events, clipboard, keyboard-handler, cursor-tracker, block-operations, history, and serializers into a document editing experience. Makes a container contentEditable and handles Enter/Backspace/Delete/paste/copy/markdown-shortcuts with block-level awareness.

These are the primitives. The React component integration is a separate PR.

Partial progress on #1039

## Test plan

- [x] 24 block-operations tests (split, merge, delete, convert, insert)
- [x] All 3621 UI tests passing
- [x] Full preflight passing

Generated with [Claude Code](https://claude.com/claude-code)