### PR TITLE
refactor(editor): thin wrapper over document-editor primitive

### DIFF
--- a/apps/website/test/lib/componentService.test.ts
+++ b/apps/website/test/lib/componentService.test.ts
@@ -94,10 +94,10 @@ describe('componentService', () => {
     });
 
     it('captures sibling ./component imports as internal deps', () => {
-      // editor.tsx imports from ./container -- should be captured
+      // editor.tsx imports from primitives -- should be captured
       const component = loadComponent('editor');
       expect(component).not.toBeNull();
-      expect(component?.primitives).toContain('container');
+      expect(component?.primitives).toContain('document-editor');
     });
 
     it('returns null for non-existent component', () => {

--- a/packages/ui/src/components/ui/editor.tsx
+++ b/packages/ui/src/components/ui/editor.tsx
@@ -1,148 +1,62 @@
 /**
- * Block editor component with progressive feature props
+ * Editor - block-based document editor
  *
- * Scales from a simple textarea replacement to a full block editor via props.
- * Uses vanilla TS primitives (block-handler, block-canvas, editor-toolbar,
- * command-palette, inline-toolbar, inline-formatter) underneath.
- *
- * @cognitive-load 6/10 - Progressive disclosure: simple by default, complex features opt-in
- * @attention-economics Single entry point scales from textarea replacement to full editor
- * @trust-building Consistent undo/redo, selection feedback, keyboard navigation out of the box
- * @accessibility ARIA listbox with multiselectable, activedescendant, keyboard navigation, screen reader support
- * @semantic-meaning Editor = block-based content editing surface with optional chrome
- *
- * @usage-patterns
- * DO: Start with just defaultValue + onValueChange for a minimal editor
- * DO: Add toolbar, sidebar, commandPalette, inlineToolbar props progressively
- * DO: Provide a custom renderBlock for rich block rendering
- * NEVER: Import sub-components directly -- only the Editor is exported
- * NEVER: Use useEffect for state subscriptions -- useSyncExternalStore handles that
+ * A thin React wrapper over the document-editor primitive. The editor is a
+ * toolbar and a document surface -- like Google Docs. Everything else
+ * (sidebar, command palette, context menu) composes on top.
  *
  * @example
  * ```tsx
  * <Editor
  *   defaultValue={[{ id: '1', type: 'text', content: 'Hello' }]}
  *   onValueChange={(blocks) => save(blocks)}
- *   toolbar
  * />
  * ```
  */
 
 import { atom } from 'nanostores';
 import * as React from 'react';
-import { createPortal } from 'react-dom';
-import type { BlockContextMenuControls } from '../../primitives/block-context-menu';
-import { createBlockContextMenu } from '../../primitives/block-context-menu';
-import type { BlockHandlerControls, BlockHandlerState } from '../../primitives/block-handler';
-import { createBlockHandler } from '../../primitives/block-handler';
-import type { BlockPaletteItem } from '../../primitives/block-palette';
-import { createBlockPalette } from '../../primitives/block-palette';
-import { createCanvasDropZone } from '../../primitives/canvas-drop-zone';
+import { convertBlockType } from '../../primitives/block-operations';
 import classy from '../../primitives/classy';
-import type {
-  CommandPaletteController,
-  CommandPaletteState,
-} from '../../primitives/command-palette';
-import { createCommandPalette } from '../../primitives/command-palette';
+import { findBlockElement } from '../../primitives/cursor-tracker';
 import {
   createDocumentEditor,
-  type DocumentEditorControls as DocEditorControls,
+  type DocumentEditorControls,
 } from '../../primitives/document-editor';
-import type { ToolbarButton, ToolbarButtonGroup } from '../../primitives/editor-toolbar';
-import { createEditorToolbar } from '../../primitives/editor-toolbar';
-import { onEscapeKeyDown } from '../../primitives/escape-keydown';
-import { createFocusTrap } from '../../primitives/focus-trap';
-import type { InlineFormatterController } from '../../primitives/inline-formatter';
-import {
-  BOLD,
-  CODE,
-  createInlineFormatter,
-  ITALIC,
-  STRIKETHROUGH,
-} from '../../primitives/inline-formatter';
-import type { AdjustedToolbarPosition } from '../../primitives/inline-toolbar';
-import { adjustToolbarPosition, getFormatButtons } from '../../primitives/inline-toolbar';
-import { getPortalContainer } from '../../primitives/portal';
-import type { RulePaletteItem } from '../../primitives/rule-palette';
-import { createRulePalette } from '../../primitives/rule-palette';
-import type {
-  BaseBlock,
-  CleanupFunction,
-  Command,
-  Direction,
-  InlineContent,
-  InlineMark,
-} from '../../primitives/types';
-import { Container } from './container';
+import type { BaseBlock, CleanupFunction, Direction, InlineContent } from '../../primitives/types';
 
-// ============================================================================
+// =============================================================================
 // Types
-// ============================================================================
+// =============================================================================
 
-/**
- * A rule applied to a block. Simple rules are name strings.
- * Parameterized rules carry configuration.
- */
 export type AppliedRule = string | { name: string; config: Record<string, unknown> };
 
-/**
- * A single block in the Editor's content tree.
- *
- * Composites consume this type to render and interact with blocks.
- * Import it from the package root:
- * ```ts
- * import type { EditorBlock } from '@rafters/ui';
- * ```
- */
 export interface EditorBlock extends BaseBlock {
   rules?: AppliedRule[];
 }
 
-/** Configuration for palette-mode sidebar */
-export interface EditorSidebarConfig {
-  /** Block palette items */
-  items: BlockPaletteItem[];
-  /** Category display order */
-  categories: string[];
-  /** Enable search input (default true) */
-  searchable?: boolean;
-  /** Custom item renderer for scaled previews */
-  renderItem?: (item: BlockPaletteItem) => React.ReactNode;
-  /** Custom insert handler for palette activation (click or drop). Overrides default single-block insertion. */
-  onItemInsert?: (item: BlockPaletteItem, controls: EditorControls, insertIndex?: number) => void;
+export interface EditorProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange'> {
+  defaultValue?: EditorBlock[];
+  value?: EditorBlock[];
+  onValueChange?: (blocks: EditorBlock[]) => void;
+  onValueCommit?: (blocks: EditorBlock[]) => void;
+  toolbar?: boolean;
+  emptyState?: React.ReactNode;
+  disabled?: boolean;
+  dir?: Direction;
+  className?: string;
 }
 
-/** Configuration for rule-palette sidebar */
-export interface EditorRulePaletteConfig {
-  /** Rule palette items */
-  items: RulePaletteItem[];
-  /** Category display order */
-  categories: string[];
-  /** Enable search input (default true) */
-  searchable?: boolean;
-  /** Custom item renderer */
-  renderItem?: (item: RulePaletteItem) => React.ReactNode;
-  /**
-   * Config field definitions for parameterized rules.
-   * Key is the rule ID. Value is an array of field descriptors.
-   */
-  configFields?: Record<string, RuleConfigField[]>;
-  /** Called after a rule is applied to a block */
-  onRuleApplied?: (blockId: string, rule: AppliedRule, controls: EditorControls) => void;
-}
-
-/** A single field in a rule configuration dialog */
-export interface RuleConfigField {
-  /** Field key (used as the config property name) */
-  name: string;
-  /** Display label */
-  label: string;
-  /** Input type */
-  type: 'text' | 'number' | 'select';
-  /** Default value */
-  defaultValue?: string | number;
-  /** Options for select type */
-  options?: Array<{ value: string; label: string }>;
+export interface EditorControls {
+  addBlock: (block: EditorBlock, index?: number) => void;
+  addBlocks: (blocks: EditorBlock[], index?: number) => void;
+  removeBlocks: (ids: Set<string>) => void;
+  moveBlock: (id: string, toIndex: number) => void;
+  updateBlock: (id: string, updates: Partial<EditorBlock>) => void;
+  getBlocks: () => EditorBlock[];
+  focus: () => void;
+  deselect: () => void;
 }
 
 export interface SlashCommand {
@@ -153,56 +67,47 @@ export interface SlashCommand {
   action: (editor: EditorControls) => void;
 }
 
-/** Metadata for saving the current canvas as a composite. */
 export interface SaveCompositeData {
-  /** Display name */
   name: string;
-  /** Category (free-form -- existing categories are suggested in the dialog) */
   category: string;
-  /** Description */
   description: string;
-  /** Current canvas blocks */
   blocks: EditorBlock[];
 }
 
-export interface EditorProps
-  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange'> {
-  /** Initial blocks for uncontrolled mode */
-  defaultValue?: EditorBlock[];
-  /** Controlled blocks */
-  value?: EditorBlock[];
-  /** Called on every block mutation */
-  onValueChange?: (blocks: EditorBlock[]) => void;
-  /** Called on committed changes (blur, explicit save) */
-  onValueCommit?: (blocks: EditorBlock[]) => void;
+export interface EditorSidebarConfig {
+  items: Array<{ id: string; label: string; category: string; keywords?: string[] }>;
+  categories: string[];
+  searchable?: boolean;
+  renderItem?: (item: { id: string; label: string; category: string }) => React.ReactNode;
+  onItemInsert?: (
+    item: { id: string; label: string; category: string },
+    controls: EditorControls,
+    insertIndex?: number,
+  ) => void;
+}
 
-  /** Show top toolbar with undo/redo and formatting */
-  toolbar?: boolean;
-  /** Show sidebar for block navigation/properties, or pass config for palette mode */
-  sidebar?: boolean | EditorSidebarConfig;
-  /** Show rule palette alongside block palette. Requires sidebar to be an EditorSidebarConfig. */
-  rulePalette?: EditorRulePaletteConfig;
-  /** Enable slash command palette with these commands */
-  commandPalette?: SlashCommand[];
-  /** Show floating inline formatting toolbar on text selection */
-  inlineToolbar?: boolean;
-  /** Enable right-click context menu on blocks (rule management, settings, removal) */
-  blockContextMenu?: boolean;
+export interface EditorRulePaletteConfig {
+  items: Array<{
+    id: string;
+    label: string;
+    category: string;
+    keywords?: string[];
+    requiresConfig?: boolean;
+    compatibleBlockTypes?: string[];
+  }>;
+  categories: string[];
+  searchable?: boolean;
+  renderItem?: (item: { id: string; label: string; category: string }) => React.ReactNode;
+  configFields?: Record<string, RuleConfigField[]>;
+  onRuleApplied?: (blockId: string, rule: AppliedRule, controls: EditorControls) => void;
+}
 
-  /** Custom block renderer -- receives block + context, returns JSX */
-  renderBlock?: (block: EditorBlock, context: BlockRenderContext) => React.ReactNode;
-  /** Custom empty state */
-  emptyState?: React.ReactNode;
-
-  /** Callback to save current canvas as a composite. When set, adds a "Save as Composite" toolbar button. */
-  onSaveAsComposite?: (data: SaveCompositeData) => void | Promise<void>;
-
-  /** Whether the editor is disabled */
-  disabled?: boolean;
-  /** Text direction for RTL support */
-  dir?: Direction;
-  /** Additional class name on the root element */
-  className?: string;
+export interface RuleConfigField {
+  name: string;
+  label: string;
+  type: 'text' | 'number' | 'select';
+  defaultValue?: string | number;
+  options?: Array<{ value: string; label: string }>;
 }
 
 export interface BlockRenderContext {
@@ -214,74 +119,9 @@ export interface BlockRenderContext {
   isFocused: boolean;
 }
 
-/**
- * Imperative handle exposed via ref -- the block mutation API.
- *
- * EditorControls is the single owner of all block CRUD operations:
- * addBlock, removeBlocks, moveBlock, and updateBlock. The block-handler
- * primitive manages selection, focus, undo/redo, and clipboard but
- * never initiates mutations. Composites and external consumers should
- * acquire this handle via `React.useRef<EditorControls>()` and call
- * these methods to modify the block tree.
- *
- * @see block-handler (`primitives/block-handler.ts`) for selection/focus/history state
- *
- * @example
- * ```tsx
- * const editorRef = React.useRef<EditorControls>(null);
- * <Editor ref={editorRef} />
- * // Later:
- * editorRef.current?.addBlock({ id: crypto.randomUUID(), type: 'text', content: '' });
- * ```
- */
-export interface EditorControls {
-  /** Insert a block at the given index (or append if omitted) */
-  addBlock: (block: EditorBlock, index?: number) => void;
-  /** Insert multiple blocks at the given index as a single history entry (or append if omitted) */
-  addBlocks: (blocks: EditorBlock[], index?: number) => void;
-  /** Remove blocks by their IDs */
-  removeBlocks: (ids: Set<string>) => void;
-  /** Move a block to a new position */
-  moveBlock: (id: string, toIndex: number) => void;
-  /** Partially update a block's properties (id is preserved) */
-  updateBlock: (id: string, updates: Partial<EditorBlock>) => void;
-  /** Undo the last mutation (delegated to block-handler history) */
-  undo: () => void;
-  /** Redo the last undone mutation (delegated to block-handler history) */
-  redo: () => void;
-  /** Select all blocks */
-  selectAll: () => void;
-  /** Clear selection */
-  clearSelection: () => void;
-  /** Clear both selection and block focus (as if clicking outside the editor) */
-  deselect: () => void;
-  /** Move focus to the editor canvas */
-  focus: () => void;
-}
-
-// ============================================================================
-// Constants
-// ============================================================================
-
-const INITIAL_HANDLER_STATE: BlockHandlerState = {
-  selectedIds: new Set<string>(),
-  focusedId: undefined,
-  canUndo: false,
-  canRedo: false,
-};
-
-const INITIAL_PALETTE_STATE: CommandPaletteState = {
-  isOpen: false,
-  query: '',
-  filteredCommands: [],
-  selectedIndex: -1,
-};
-
-const INLINE_TOOLBAR_DIMENSIONS = { width: 320, height: 44 };
-
-// ============================================================================
-// Document block renderer -- semantic HTML for contentEditable
-// ============================================================================
+// =============================================================================
+// Block rendering
+// =============================================================================
 
 function renderInlineContent(content: string | InlineContent[] | undefined): React.ReactNode {
   if (content === undefined) return '\u00A0';
@@ -291,9 +131,7 @@ function renderInlineContent(content: string | InlineContent[] | undefined): Rea
     let node: React.ReactNode = segment.text;
     const marks = segment.marks ?? [];
 
-    if (marks.includes('code')) {
-      node = <code key={`c${i}`}>{node}</code>;
-    }
+    if (marks.includes('code')) node = <code key={`c${i}`}>{node}</code>;
     if (marks.includes('link') && segment.href) {
       node = (
         <a key={`l${i}`} href={segment.href}>
@@ -301,15 +139,9 @@ function renderInlineContent(content: string | InlineContent[] | undefined): Rea
         </a>
       );
     }
-    if (marks.includes('strikethrough')) {
-      node = <del key={`s${i}`}>{node}</del>;
-    }
-    if (marks.includes('italic')) {
-      node = <em key={`i${i}`}>{node}</em>;
-    }
-    if (marks.includes('bold')) {
-      node = <strong key={`b${i}`}>{node}</strong>;
-    }
+    if (marks.includes('strikethrough')) node = <del key={`s${i}`}>{node}</del>;
+    if (marks.includes('italic')) node = <em key={`i${i}`}>{node}</em>;
+    if (marks.includes('bold')) node = <strong key={`b${i}`}>{node}</strong>;
 
     return node;
   });
@@ -353,9 +185,17 @@ function DocumentBlock({ block }: { block: EditorBlock }) {
   }
 }
 
-// ============================================================================
-// Private sub-components
-// ============================================================================
+function DefaultEmptyState() {
+  return (
+    <p className={classy('text-muted-foreground py-8 text-center text-sm')}>
+      No blocks yet. Start typing.
+    </p>
+  );
+}
+
+// =============================================================================
+// Block type toolbar
+// =============================================================================
 
 interface BlockTypeOption {
   value: string;
@@ -379,7 +219,7 @@ function blockToTypeValue(block: EditorBlock | undefined): string {
   return block.type;
 }
 
-interface ToolbarSectionProps {
+interface ToolbarProps {
   canUndo: boolean;
   canRedo: boolean;
   onUndo: () => void;
@@ -390,33 +230,14 @@ interface ToolbarSectionProps {
     | undefined;
 }
 
-function EditorToolbarSection({
+function EditorToolbar({
   canUndo,
   canRedo,
   onUndo,
   onRedo,
   focusedBlock,
   onChangeBlockType,
-}: ToolbarSectionProps) {
-  const buttons = React.useMemo(() => {
-    const toolbar = createEditorToolbar({
-      getHistory: () => ({ canUndo, canRedo }),
-      onUndo,
-      onRedo,
-    });
-    return toolbar.getButtons();
-  }, [canUndo, canRedo, onUndo, onRedo]);
-
-  const grouped = new Map<ToolbarButtonGroup, ToolbarButton[]>();
-  for (const btn of buttons) {
-    const group = grouped.get(btn.group);
-    if (group) {
-      group.push(btn);
-    } else {
-      grouped.set(btn.group, [btn]);
-    }
-  }
-
+}: ToolbarProps) {
   return (
     <div
       role="toolbar"
@@ -448,1045 +269,41 @@ function EditorToolbarSection({
           <hr className={classy('mx-1 h-4 w-px border-0 bg-border')} />
         </>
       )}
-      {Array.from(grouped.entries()).map(([group, btns], groupIdx) => (
-        <React.Fragment key={group}>
-          {groupIdx > 0 && <hr className={classy('mx-1 h-4 w-px border-0 bg-border')} />}
-          {btns.map((btn) => (
-            <button
-              key={btn.id}
-              type="button"
-              onClick={btn.action}
-              disabled={btn.disabled}
-              aria-label={btn.label}
-              title={`${btn.label} (${btn.shortcut})`}
-              className={classy(
-                'rounded-md px-2 py-1 text-xs font-medium transition-colors',
-                'hover:bg-accent hover:text-accent-foreground',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring',
-                { 'opacity-50 cursor-not-allowed': btn.disabled },
-              )}
-            >
-              {btn.label}
-            </button>
-          ))}
-        </React.Fragment>
-      ))}
-    </div>
-  );
-}
-
-interface SaveCompositeDialogProps {
-  blocks: EditorBlock[];
-  existingCategories: string[];
-  onSave: (data: SaveCompositeData) => void;
-  onCancel: () => void;
-}
-
-function SaveCompositeDialog({
-  blocks,
-  existingCategories,
-  onSave,
-  onCancel,
-}: SaveCompositeDialogProps) {
-  const [name, setName] = React.useState('');
-  const [category, setCategory] = React.useState(existingCategories[0] ?? '');
-  const [description, setDescription] = React.useState('');
-  const [error, setError] = React.useState('');
-  const [showSuggestions, setShowSuggestions] = React.useState(false);
-  const nameInputRef = React.useRef<HTMLInputElement>(null);
-
-  React.useEffect(() => {
-    nameInputRef.current?.focus();
-  }, []);
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    const trimmedName = name.trim();
-    const trimmedCategory = category.trim();
-    if (!trimmedName) {
-      setError('Name is required');
-      return;
-    }
-    if (!trimmedCategory) {
-      setError('Category is required');
-      return;
-    }
-    onSave({
-      name: trimmedName,
-      category: trimmedCategory,
-      description: description.trim(),
-      blocks,
-    });
-  };
-
-  const portalContainer = getPortalContainer();
-  if (!portalContainer) return null;
-
-  return createPortal(
-    <>
-      <div
-        className={classy('fixed inset-0 z-50 bg-black/50')}
-        onClick={onCancel}
-        onKeyDown={(e) => {
-          if (e.key === 'Escape') onCancel();
-        }}
-        aria-hidden="true"
-      />
-      <div
-        role="dialog"
-        aria-label="Save as Composite"
-        aria-modal="true"
+      <button
+        type="button"
+        onClick={onUndo}
+        disabled={!canUndo}
+        aria-label="Undo"
         className={classy(
-          'fixed top-1/2 left-1/2 z-50 w-96 -translate-x-1/2 -translate-y-1/2',
-          'rounded-lg border border-border bg-background p-6 shadow-lg',
+          'rounded-md px-2 py-1 text-xs font-medium transition-colors',
+          'hover:bg-accent hover:text-accent-foreground',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring',
+          { 'opacity-50 cursor-not-allowed': !canUndo },
         )}
       >
-        <h2 className={classy('mb-4 text-lg font-semibold')}>Save as Composite</h2>
-        <form onSubmit={handleSubmit} className={classy('flex flex-col gap-3')}>
-          <label className={classy('flex flex-col gap-1 text-sm')}>
-            Name
-            <input
-              ref={nameInputRef}
-              type="text"
-              value={name}
-              onChange={(e) => {
-                setName(e.target.value);
-                setError('');
-              }}
-              className={classy(
-                'rounded-md border border-border bg-background px-3 py-1.5 text-sm',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring',
-              )}
-            />
-          </label>
-          <label className={classy('flex flex-col gap-1 text-sm')}>
-            Category
-            <div className={classy('relative')}>
-              <input
-                type="text"
-                value={category}
-                onChange={(e) => {
-                  setCategory(e.target.value);
-                  setShowSuggestions(true);
-                  setError('');
-                }}
-                onFocus={() => setShowSuggestions(true)}
-                onBlur={() => {
-                  // Delay to allow click on suggestion
-                  setTimeout(() => setShowSuggestions(false), 150);
-                }}
-                placeholder="e.g. form, layout, widget"
-                role="combobox"
-                aria-expanded={showSuggestions && existingCategories.length > 0}
-                aria-autocomplete="list"
-                aria-controls="category-suggestions"
-                className={classy(
-                  'w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm',
-                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring',
-                )}
-              />
-              {showSuggestions && existingCategories.length > 0 && (
-                <div
-                  id="category-suggestions"
-                  role="listbox"
-                  className={classy(
-                    'absolute top-full left-0 z-10 mt-1 w-full rounded-md border border-border bg-background py-1 shadow-md',
-                  )}
-                >
-                  {existingCategories
-                    .filter((c) => c.toLowerCase().includes(category.toLowerCase()))
-                    .map((cat) => (
-                      <button
-                        key={cat}
-                        type="button"
-                        role="option"
-                        aria-selected={cat === category}
-                        onMouseDown={(e) => {
-                          e.preventDefault();
-                          setCategory(cat);
-                          setShowSuggestions(false);
-                        }}
-                        className={classy(
-                          'w-full px-3 py-1 text-left text-sm hover:bg-accent hover:text-accent-foreground',
-                        )}
-                      >
-                        {cat}
-                      </button>
-                    ))}
-                </div>
-              )}
-            </div>
-          </label>
-          <label className={classy('flex flex-col gap-1 text-sm')}>
-            Description
-            <textarea
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              rows={2}
-              className={classy(
-                'rounded-md border border-border bg-background px-3 py-1.5 text-sm resize-none',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring',
-              )}
-            />
-          </label>
-          {error && (
-            <p role="alert" className={classy('text-sm text-destructive')}>
-              {error}
-            </p>
-          )}
-          <div className={classy('flex justify-end gap-2 pt-2')}>
-            <button
-              type="button"
-              onClick={onCancel}
-              className={classy(
-                'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
-                'hover:bg-accent hover:text-accent-foreground',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring',
-              )}
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              className={classy(
-                'rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors',
-                'hover:bg-primary/90',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring',
-              )}
-            >
-              Save
-            </button>
-          </div>
-        </form>
-      </div>
-    </>,
-    portalContainer,
-  );
-}
-
-interface SidebarSectionProps {
-  blocks: EditorBlock[];
-  selectedIds: Set<string>;
-  focusedId: string | undefined;
-  onFocusBlock: (id: string) => void;
-}
-
-function EditorSidebarSection({
-  blocks,
-  selectedIds,
-  focusedId,
-  onFocusBlock,
-}: SidebarSectionProps) {
-  return (
-    <nav
-      aria-label="Block navigation"
-      className={classy('w-48 shrink-0 flex flex-col gap-0.5 border-r border-border p-2')}
-    >
-      {blocks.map((block, i) => (
-        <button
-          key={block.id}
-          type="button"
-          onClick={() => onFocusBlock(block.id)}
-          aria-current={focusedId === block.id ? 'true' : undefined}
-          className={classy(
-            'rounded-md px-2 py-1 text-left text-xs truncate transition-colors',
-            'hover:bg-accent hover:text-accent-foreground',
-            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring',
-            {
-              'bg-accent text-accent-foreground': selectedIds.has(block.id),
-              'ring-2 ring-primary-ring': focusedId === block.id,
-            },
-          )}
-        >
-          {i + 1}. {block.type}
-        </button>
-      ))}
-    </nav>
-  );
-}
-
-interface PaletteSidebarProps {
-  config: EditorSidebarConfig;
-  onActivate: (item: BlockPaletteItem) => void;
-  disabled: boolean;
-}
-
-function BlockPaletteContent({ config, onActivate, disabled }: PaletteSidebarProps) {
-  const containerRef = React.useRef<HTMLDivElement>(null);
-  const searchRef = React.useRef<HTMLInputElement>(null);
-  const paletteControlsRef = React.useRef<ReturnType<typeof createBlockPalette> | null>(null);
-  const [query, setQuery] = React.useState('');
-  const [, forceUpdate] = React.useState(0);
-
-  React.useEffect(() => {
-    const containerEl = containerRef.current;
-    if (!containerEl) return;
-
-    const paletteOptions: Parameters<typeof createBlockPalette>[0] = {
-      container: containerEl,
-      items: config.items,
-      categories: config.categories,
-      onActivate,
-      disabled,
-    };
-    if (searchRef.current) {
-      paletteOptions.searchInput = searchRef.current;
-    }
-    const palette = createBlockPalette(paletteOptions);
-    paletteControlsRef.current = palette;
-
-    // Trigger a re-render so getGroupedItems() is available for the first paint.
-    // Without this, paletteControlsRef.current is null during the initial render
-    // and the palette items never appear.
-    forceUpdate((n) => n + 1);
-
-    return () => {
-      palette.destroy();
-      paletteControlsRef.current = null;
-    };
-  }, [config.items, config.categories, onActivate, disabled]);
-
-  React.useEffect(() => {
-    paletteControlsRef.current?.setDisabled(disabled);
-  }, [disabled]);
-
-  const handleSearchChange = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value;
-    setQuery(value);
-    paletteControlsRef.current?.setSearchQuery(value);
-    forceUpdate((n) => n + 1);
-  }, []);
-
-  const grouped = paletteControlsRef.current?.getGroupedItems();
-  const renderItem = config.renderItem;
-  const searchable = config.searchable !== false;
-
-  return (
-    <div className={classy('flex flex-1 flex-col')}>
-      {searchable && (
-        <div className={classy('border-b border-border p-2')}>
-          <input
-            ref={searchRef}
-            type="text"
-            value={query}
-            onChange={handleSearchChange}
-            placeholder="Search blocks..."
-            aria-label="Search blocks"
-            disabled={disabled}
-            className={classy(
-              'w-full rounded-md border border-border bg-transparent px-2 py-1 text-xs outline-none',
-              'placeholder:text-muted-foreground',
-              'focus-visible:ring-2 focus-visible:ring-primary-ring',
-              { 'opacity-50 cursor-not-allowed': disabled },
-            )}
-          />
-        </div>
-      )}
-      <div
-        ref={containerRef}
-        tabIndex={disabled ? -1 : 0}
-        className={classy('flex flex-1 flex-col gap-1 overflow-y-auto p-2')}
-      >
-        {grouped &&
-          Array.from(grouped.entries()).map(([category, categoryItems]) => (
-            <div key={category}>
-              <div
-                role="presentation"
-                className={classy(
-                  'px-2 py-1 text-xs font-medium text-muted-foreground uppercase tracking-wider',
-                )}
-              >
-                {category}
-              </div>
-              {categoryItems.map((item) => (
-                // biome-ignore lint/a11y/useFocusableInteractive: focus managed via aria-activedescendant on block-palette container
-                <div
-                  key={item.id}
-                  data-palette-item=""
-                  data-palette-id={item.id}
-                  draggable={!disabled}
-                  role="option"
-                  aria-selected="false"
-                  className={classy(
-                    'rounded-md px-2 py-1 text-xs cursor-pointer transition-colors',
-                    'hover:bg-accent hover:text-accent-foreground',
-                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring',
-                    { 'opacity-50 cursor-not-allowed': disabled },
-                  )}
-                >
-                  {renderItem ? renderItem(item) : item.label}
-                </div>
-              ))}
-            </div>
-          ))}
-        {grouped && grouped.size === 0 && (
-          <div className={classy('px-2 py-1 text-xs text-muted-foreground')}>No blocks found</div>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function EditorPaletteSidebar(props: PaletteSidebarProps) {
-  return (
-    <aside
-      aria-label="Block palette"
-      className={classy('w-48 shrink-0 flex flex-col border-r border-border')}
-    >
-      <BlockPaletteContent {...props} />
-    </aside>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Rule palette sidebar
-// ---------------------------------------------------------------------------
-
-interface RulePaletteSidebarProps {
-  config: EditorRulePaletteConfig;
-  onActivate: (item: RulePaletteItem) => void;
-  disabled: boolean;
-}
-
-function EditorRulePaletteSidebar({ config, onActivate, disabled }: RulePaletteSidebarProps) {
-  const containerRef = React.useRef<HTMLDivElement>(null);
-  const searchRef = React.useRef<HTMLInputElement>(null);
-  const paletteControlsRef = React.useRef<ReturnType<typeof createRulePalette> | null>(null);
-  const [query, setQuery] = React.useState('');
-  const [, forceUpdate] = React.useState(0);
-
-  React.useEffect(() => {
-    const containerEl = containerRef.current;
-    if (!containerEl) return;
-
-    const paletteOptions: Parameters<typeof createRulePalette>[0] = {
-      container: containerEl,
-      items: config.items,
-      categories: config.categories,
-      onActivate,
-      disabled,
-    };
-    if (searchRef.current) {
-      paletteOptions.searchInput = searchRef.current;
-    }
-    const palette = createRulePalette(paletteOptions);
-    paletteControlsRef.current = palette;
-    forceUpdate((n) => n + 1);
-
-    return () => {
-      palette.destroy();
-      paletteControlsRef.current = null;
-    };
-  }, [config.items, config.categories, onActivate, disabled]);
-
-  React.useEffect(() => {
-    paletteControlsRef.current?.setDisabled(disabled);
-  }, [disabled]);
-
-  const handleSearchChange = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value;
-    setQuery(value);
-    paletteControlsRef.current?.setSearchQuery(value);
-    forceUpdate((n) => n + 1);
-  }, []);
-
-  const grouped = paletteControlsRef.current?.getGroupedItems();
-  const renderItem = config.renderItem;
-  const searchable = config.searchable !== false;
-
-  return (
-    <div className={classy('flex flex-1 flex-col')}>
-      {searchable && (
-        <div className={classy('border-b border-border p-2')}>
-          <input
-            ref={searchRef}
-            type="text"
-            value={query}
-            onChange={handleSearchChange}
-            placeholder="Search rules..."
-            aria-label="Search rules"
-            disabled={disabled}
-            className={classy(
-              'w-full rounded-md border border-border bg-transparent px-2 py-1 text-xs outline-none',
-              'placeholder:text-muted-foreground',
-              'focus-visible:ring-2 focus-visible:ring-primary-ring',
-              { 'opacity-50 cursor-not-allowed': disabled },
-            )}
-          />
-        </div>
-      )}
-      <div
-        ref={containerRef}
-        tabIndex={disabled ? -1 : 0}
-        className={classy('flex flex-1 flex-col gap-1 overflow-y-auto p-2')}
-      >
-        {grouped &&
-          Array.from(grouped.entries()).map(([category, categoryItems]) => (
-            <div key={category}>
-              <div
-                role="presentation"
-                className={classy(
-                  'px-2 py-1 text-xs font-medium text-muted-foreground uppercase tracking-wider',
-                )}
-              >
-                {category}
-              </div>
-              {categoryItems.map((item) => (
-                // biome-ignore lint/a11y/useFocusableInteractive: focus managed via aria-activedescendant on rule-palette container
-                <div
-                  key={item.id}
-                  data-rule-item=""
-                  data-rule-id={item.id}
-                  draggable={!disabled}
-                  role="option"
-                  aria-selected="false"
-                  className={classy(
-                    'rounded-md px-2 py-1 text-xs cursor-pointer transition-colors',
-                    'hover:bg-accent hover:text-accent-foreground',
-                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring',
-                    { 'opacity-50 cursor-not-allowed': disabled },
-                  )}
-                >
-                  {renderItem ? renderItem(item) : item.label}
-                </div>
-              ))}
-            </div>
-          ))}
-        {grouped && grouped.size === 0 && (
-          <div className={classy('px-2 py-1 text-xs text-muted-foreground')}>No rules found</div>
-        )}
-      </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Tabbed palette sidebar (block + rule)
-// ---------------------------------------------------------------------------
-
-type PaletteTab = 'blocks' | 'rules';
-
-interface TabbedPaletteSidebarProps {
-  blockConfig: EditorSidebarConfig;
-  ruleConfig: EditorRulePaletteConfig;
-  onBlockActivate: (item: BlockPaletteItem) => void;
-  onRuleActivate: (item: RulePaletteItem) => void;
-  disabled: boolean;
-}
-
-function EditorTabbedPaletteSidebar({
-  blockConfig,
-  ruleConfig,
-  onBlockActivate,
-  onRuleActivate,
-  disabled,
-}: TabbedPaletteSidebarProps) {
-  const [activeTab, setActiveTab] = React.useState<PaletteTab>('blocks');
-
-  return (
-    <aside
-      aria-label="Editor palettes"
-      className={classy('w-48 shrink-0 flex flex-col border-r border-border')}
-    >
-      <div
-        role="tablist"
-        aria-label="Palette tabs"
-        className={classy('flex border-b border-border')}
-      >
-        <button
-          type="button"
-          role="tab"
-          id="palette-tab-blocks"
-          aria-selected={activeTab === 'blocks'}
-          aria-controls="palette-panel-blocks"
-          onClick={() => setActiveTab('blocks')}
-          disabled={disabled}
-          className={classy(
-            'flex-1 px-2 py-1.5 text-xs font-medium transition-colors',
-            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-ring',
-            {
-              'border-b-2 border-primary text-foreground': activeTab === 'blocks',
-              'text-muted-foreground hover:text-foreground': activeTab !== 'blocks',
-              'opacity-50 cursor-not-allowed': disabled,
-            },
-          )}
-        >
-          Blocks
-        </button>
-        <button
-          type="button"
-          role="tab"
-          id="palette-tab-rules"
-          aria-selected={activeTab === 'rules'}
-          aria-controls="palette-panel-rules"
-          onClick={() => setActiveTab('rules')}
-          disabled={disabled}
-          className={classy(
-            'flex-1 px-2 py-1.5 text-xs font-medium transition-colors',
-            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-ring',
-            {
-              'border-b-2 border-primary text-foreground': activeTab === 'rules',
-              'text-muted-foreground hover:text-foreground': activeTab !== 'rules',
-              'opacity-50 cursor-not-allowed': disabled,
-            },
-          )}
-        >
-          Rules
-        </button>
-      </div>
-      <div
-        id="palette-panel-blocks"
-        role="tabpanel"
-        aria-labelledby="palette-tab-blocks"
-        hidden={activeTab !== 'blocks'}
-        className={classy('flex flex-1 flex-col', { hidden: activeTab !== 'blocks' })}
-      >
-        {activeTab === 'blocks' && (
-          <BlockPaletteContent
-            config={blockConfig}
-            onActivate={onBlockActivate}
-            disabled={disabled}
-          />
-        )}
-      </div>
-      <div
-        id="palette-panel-rules"
-        role="tabpanel"
-        aria-labelledby="palette-tab-rules"
-        hidden={activeTab !== 'rules'}
-        className={classy('flex flex-1 flex-col', { hidden: activeTab !== 'rules' })}
-      >
-        {activeTab === 'rules' && (
-          <EditorRulePaletteSidebar
-            config={ruleConfig}
-            onActivate={onRuleActivate}
-            disabled={disabled}
-          />
-        )}
-      </div>
-    </aside>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Rule config dialog
-// ---------------------------------------------------------------------------
-
-interface RuleConfigDialogProps {
-  rule: RulePaletteItem;
-  fields: RuleConfigField[];
-  anchorId: string;
-  onConfirm: (config: Record<string, unknown>) => void;
-  onCancel: () => void;
-}
-
-function RuleConfigDialog({ rule, fields, anchorId, onConfirm, onCancel }: RuleConfigDialogProps) {
-  const dialogRef = React.useRef<HTMLDivElement>(null);
-  const [values, setValues] = React.useState<Record<string, unknown>>(() => {
-    const initial: Record<string, unknown> = {};
-    for (const field of fields) {
-      initial[field.name] = field.defaultValue ?? '';
-    }
-    return initial;
-  });
-
-  React.useEffect(() => {
-    const dialogEl = dialogRef.current;
-    if (!dialogEl) return;
-
-    const cleanups: CleanupFunction[] = [];
-
-    // Position near the anchor block
-    const anchorEl = document.getElementById(anchorId);
-    if (anchorEl) {
-      const anchorRect = anchorEl.getBoundingClientRect();
-      dialogEl.style.position = 'fixed';
-      dialogEl.style.top = `${anchorRect.bottom + 8}px`;
-      dialogEl.style.left = `${anchorRect.left}px`;
-    }
-
-    // Focus trap
-    cleanups.push(createFocusTrap(dialogEl));
-
-    // Escape to cancel
-    cleanups.push(onEscapeKeyDown(() => onCancel()));
-
-    return () => {
-      for (const cleanup of cleanups) cleanup();
-    };
-  }, [anchorId, onCancel]);
-
-  const handleSubmit = (event: React.FormEvent) => {
-    event.preventDefault();
-    onConfirm(values);
-  };
-
-  const portalContainer = getPortalContainer();
-  if (!portalContainer) return null;
-
-  return createPortal(
-    <div
-      ref={dialogRef}
-      role="dialog"
-      aria-modal="true"
-      aria-label={`Configure ${rule.label}`}
-      className={classy(
-        'fixed z-depth-popover w-64 rounded-lg border border-border bg-popover p-3 shadow-lg',
-      )}
-    >
-      <div className={classy('mb-2 text-xs font-medium text-foreground')}>{rule.label}</div>
-      <form onSubmit={handleSubmit}>
-        {fields.map((field) => (
-          <div key={field.name} className={classy('mb-2')}>
-            <label
-              htmlFor={`rule-config-${field.name}`}
-              className={classy('mb-1 block text-xs text-muted-foreground')}
-            >
-              {field.label}
-            </label>
-            {field.type === 'select' ? (
-              <select
-                id={`rule-config-${field.name}`}
-                value={String(values[field.name] ?? '')}
-                onChange={(e) => setValues((prev) => ({ ...prev, [field.name]: e.target.value }))}
-                className={classy(
-                  'w-full rounded-md border border-border bg-transparent px-2 py-1 text-xs outline-none',
-                  'focus-visible:ring-2 focus-visible:ring-primary-ring',
-                )}
-              >
-                {field.options?.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </option>
-                ))}
-              </select>
-            ) : (
-              <input
-                id={`rule-config-${field.name}`}
-                type={field.type}
-                value={String(values[field.name] ?? '')}
-                onChange={(e) =>
-                  setValues((prev) => ({
-                    ...prev,
-                    [field.name]: field.type === 'number' ? Number(e.target.value) : e.target.value,
-                  }))
-                }
-                className={classy(
-                  'w-full rounded-md border border-border bg-transparent px-2 py-1 text-xs outline-none',
-                  'focus-visible:ring-2 focus-visible:ring-primary-ring',
-                )}
-              />
-            )}
-          </div>
-        ))}
-        <div className={classy('flex justify-end gap-1')}>
-          <button
-            type="button"
-            onClick={onCancel}
-            className={classy(
-              'rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors',
-              'hover:bg-accent hover:text-accent-foreground',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring',
-            )}
-          >
-            Cancel
-          </button>
-          <button
-            type="submit"
-            className={classy(
-              'rounded-md bg-primary px-2 py-1 text-xs text-primary-foreground transition-colors',
-              'hover:bg-primary/90',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring',
-            )}
-          >
-            Apply
-          </button>
-        </div>
-      </form>
-    </div>,
-    portalContainer,
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Block context menu overlay
-// ---------------------------------------------------------------------------
-
-interface ContextMenuOverlayState {
-  blockId: string;
-  position: { x: number; y: number };
-}
-
-interface ContextMenuOverlayProps {
-  state: ContextMenuOverlayState;
-  block: EditorBlock | undefined;
-  onAction: (actionId: string) => void;
-}
-
-function BlockContextMenuOverlay({ state, block, onAction }: ContextMenuOverlayProps) {
-  const menuRef = React.useRef<HTMLDivElement>(null);
-
-  const portalContainer = getPortalContainer();
-  if (!portalContainer || !block) return null;
-
-  const appliedRules = block.rules ?? [];
-  const hasRules = appliedRules.length > 0;
-
-  return createPortal(
-    <div
-      ref={menuRef}
-      role="menu"
-      aria-label="Block actions"
-      className={classy(
-        'fixed z-depth-popover w-52 rounded-lg border border-border bg-popover py-1 shadow-lg',
-      )}
-      style={{
-        left: `${state.position.x}px`,
-        top: `${state.position.y}px`,
-      }}
-    >
-      {hasRules && (
-        <>
-          <div
-            role="presentation"
-            className={classy(
-              'px-3 py-1 text-xs font-medium text-muted-foreground uppercase tracking-wider',
-            )}
-          >
-            Rules
-          </div>
-          {appliedRules.map((rule, i) => {
-            const ruleName = typeof rule === 'string' ? rule : rule.name;
-            const hasConfig = typeof rule === 'object';
-            return (
-              <React.Fragment key={`${ruleName}-${i}`}>
-                <div
-                  role="menuitem"
-                  tabIndex={-1}
-                  data-menu-item-id={`edit-rule:${ruleName}`}
-                  onPointerDown={() => onAction(`edit-rule:${ruleName}`)}
-                  className={classy(
-                    'flex items-center justify-between px-3 py-1.5 text-sm cursor-pointer',
-                    'hover:bg-accent hover:text-accent-foreground',
-                    'focus-visible:outline-none focus-visible:bg-accent',
-                  )}
-                >
-                  <span>{ruleName}</span>
-                  {hasConfig && (
-                    <span className={classy('text-xs text-muted-foreground')}>configured</span>
-                  )}
-                </div>
-                <div
-                  role="menuitem"
-                  tabIndex={-1}
-                  data-menu-item-id={`remove-rule:${ruleName}`}
-                  onPointerDown={() => onAction(`remove-rule:${ruleName}`)}
-                  className={classy(
-                    'px-3 py-1.5 pl-6 text-xs text-destructive cursor-pointer',
-                    'hover:bg-accent',
-                    'focus-visible:outline-none focus-visible:bg-accent',
-                  )}
-                >
-                  Remove rule
-                </div>
-              </React.Fragment>
-            );
-          })}
-          <hr className={classy('my-1 border-border')} />
-        </>
-      )}
-      <div
-        role="menuitem"
-        tabIndex={-1}
-        data-menu-item-id="remove-block"
-        onPointerDown={() => onAction('remove-block')}
+        Undo
+      </button>
+      <button
+        type="button"
+        onClick={onRedo}
+        disabled={!canRedo}
+        aria-label="Redo"
         className={classy(
-          'px-3 py-1.5 text-sm text-destructive cursor-pointer',
-          'hover:bg-accent',
-          'focus-visible:outline-none focus-visible:bg-accent',
+          'rounded-md px-2 py-1 text-xs font-medium transition-colors',
+          'hover:bg-accent hover:text-accent-foreground',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring',
+          { 'opacity-50 cursor-not-allowed': !canRedo },
         )}
       >
-        Remove block
-      </div>
-    </div>,
-    portalContainer,
-  );
-}
-
-interface CommandPaletteOverlayProps {
-  state: CommandPaletteState;
-  position: { x: number; y: number };
-  onQuery: (query: string) => void;
-  onSelect: (index: number) => void;
-  onExecute: () => void;
-  onClose: () => void;
-}
-
-function CommandPaletteOverlay({
-  state,
-  position,
-  onQuery,
-  onSelect,
-  onExecute,
-  onClose,
-}: CommandPaletteOverlayProps) {
-  const inputRef = React.useRef<HTMLInputElement>(null);
-
-  React.useEffect(() => {
-    inputRef.current?.focus();
-  }, []);
-
-  const portalContainer = getPortalContainer();
-  if (!portalContainer) return null;
-
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === 'Escape') {
-      event.preventDefault();
-      onClose();
-    } else if (event.key === 'Enter') {
-      event.preventDefault();
-      onExecute();
-    } else if (event.key === 'ArrowDown') {
-      event.preventDefault();
-      const next = (state.selectedIndex + 1) % Math.max(state.filteredCommands.length, 1);
-      onSelect(next);
-    } else if (event.key === 'ArrowUp') {
-      event.preventDefault();
-      const prev =
-        state.selectedIndex <= 0 ? state.filteredCommands.length - 1 : state.selectedIndex - 1;
-      onSelect(prev);
-    }
-  };
-
-  const listboxId = 'editor-command-palette-listbox';
-  const activeOptionId =
-    state.selectedIndex >= 0 ? `editor-command-palette-option-${state.selectedIndex}` : undefined;
-
-  return createPortal(
-    <div
-      className={classy(
-        'fixed z-depth-popover w-72 rounded-lg border border-border bg-popover shadow-lg',
-      )}
-      style={{
-        left: `${position.x}px`,
-        top: `${position.y}px`,
-      }}
-    >
-      <input
-        ref={inputRef}
-        type="text"
-        value={state.query}
-        onChange={(e) => onQuery(e.target.value)}
-        onKeyDown={handleKeyDown}
-        role="combobox"
-        aria-expanded="true"
-        aria-controls={listboxId}
-        aria-activedescendant={activeOptionId}
-        aria-label="Search commands"
-        className={classy(
-          'w-full border-b border-border bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground',
-        )}
-        placeholder="Type a command..."
-      />
-      <div
-        id={listboxId}
-        role="listbox"
-        aria-label="Commands"
-        className={classy('max-h-48 overflow-y-auto p-1')}
-      >
-        {state.filteredCommands.map((cmd, i) => (
-          // biome-ignore lint/a11y/useFocusableInteractive: focus managed via aria-activedescendant on combobox input
-          <div
-            key={cmd.id}
-            id={`editor-command-palette-option-${i}`}
-            role="option"
-            aria-selected={i === state.selectedIndex}
-            onPointerDown={() => {
-              onSelect(i);
-              onExecute();
-            }}
-            className={classy('cursor-pointer rounded-md px-3 py-1.5 text-sm', {
-              'bg-accent text-accent-foreground': i === state.selectedIndex,
-            })}
-          >
-            <span className={classy('font-medium')}>{cmd.label}</span>
-            {cmd.description && (
-              <span className={classy('ml-2 text-muted-foreground')}>{cmd.description}</span>
-            )}
-          </div>
-        ))}
-        {state.filteredCommands.length === 0 && (
-          <div className={classy('px-3 py-1.5 text-sm text-muted-foreground')}>
-            No commands found
-          </div>
-        )}
-      </div>
-    </div>,
-    portalContainer,
-  );
-}
-
-interface InlineToolbarOverlayProps {
-  position: AdjustedToolbarPosition;
-  activeFormats: InlineMark[];
-  onFormat: (mark: InlineMark) => void;
-}
-
-function InlineToolbarOverlay({ position, activeFormats, onFormat }: InlineToolbarOverlayProps) {
-  const portalContainer = getPortalContainer();
-  if (!portalContainer) return null;
-
-  const buttons = getFormatButtons();
-
-  return createPortal(
-    <div
-      role="toolbar"
-      aria-label="Text formatting"
-      className={classy(
-        'fixed z-depth-popover flex items-center gap-0.5 rounded-lg border border-border bg-popover p-1 shadow-lg',
-      )}
-      style={{
-        left: `${position.x}px`,
-        top: `${position.y}px`,
-      }}
-    >
-      {buttons.map((btn) => {
-        const isActive = activeFormats.includes(btn.format);
-        return (
-          <button
-            key={btn.format}
-            type="button"
-            onClick={() => onFormat(btn.format)}
-            aria-pressed={isActive}
-            aria-label={btn.label}
-            title={`${btn.label} (${btn.shortcut})`}
-            className={classy(
-              'rounded-md px-2 py-1 text-xs font-medium transition-colors',
-              'hover:bg-accent hover:text-accent-foreground',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring',
-              { 'bg-accent text-accent-foreground': isActive },
-            )}
-          >
-            {btn.label}
-          </button>
-        );
-      })}
-    </div>,
-    portalContainer,
-  );
-}
-
-function DefaultEmptyState() {
-  return (
-    <div className={classy('flex items-center justify-center p-8 text-sm text-muted-foreground')}>
-      No blocks yet. Start editing to add content.
+        Redo
+      </button>
     </div>
   );
 }
 
-// ============================================================================
-// Main component
-// ============================================================================
+// =============================================================================
+// Editor component
+// =============================================================================
 
 export const Editor = React.forwardRef<EditorControls, EditorProps>(
   (
@@ -1497,84 +314,43 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
       onValueChange,
       onValueCommit,
       toolbar = false,
-      sidebar = false,
-      rulePalette,
-      commandPalette,
-      inlineToolbar = false,
-      blockContextMenu = false,
-      renderBlock,
       emptyState,
-      onSaveAsComposite,
       disabled = false,
       dir,
       ...props
     },
     ref,
   ) => {
-    // ----- Controlled / uncontrolled -----
+    // -- State --
     const [uncontrolled, setUncontrolled] = React.useState<EditorBlock[]>(defaultValue ?? []);
     const isControlled = controlledValue !== undefined;
     const blocks = isControlled ? controlledValue : uncontrolled;
 
-    // Stable $blocks atom -- created once
     const blocksAtomRef = React.useRef(atom<EditorBlock[]>(blocks));
-
-    // Refs for latest callbacks to avoid stale closures
     const callbacksRef = React.useRef({ onValueChange, onValueCommit });
     callbacksRef.current = { onValueChange, onValueCommit };
 
-    // ----- Handler + canvas refs -----
+    // -- Refs --
     const canvasRef = React.useRef<HTMLDivElement>(null);
-    const handlerRef = React.useRef<BlockHandlerControls | null>(null);
-    const docEditorRef = React.useRef<DocEditorControls | null>(null);
+    const docEditorRef = React.useRef<DocumentEditorControls | null>(null);
 
-    // ----- Save composite dialog state -----
-    const [showSaveDialog, setShowSaveDialog] = React.useState(false);
+    // -- Toolbar state --
     const [focusedBlockId, setFocusedBlockId] = React.useState<string | null>(null);
+    const [canUndo, setCanUndo] = React.useState(false);
+    const [canRedo, setCanRedo] = React.useState(false);
 
-    // ----- Inline toolbar state -----
-    const [inlineToolbarPos, setInlineToolbarPos] = React.useState<AdjustedToolbarPosition | null>(
-      null,
-    );
-    const [activeFormats, setActiveFormats] = React.useState<InlineMark[]>([]);
-    const formatterRef = React.useRef<InlineFormatterController | null>(null);
-
-    // ----- Command palette state -----
-    const [paletteState, setPaletteState] =
-      React.useState<CommandPaletteState>(INITIAL_PALETTE_STATE);
-    const [palettePosition, setPalettePosition] = React.useState<{ x: number; y: number }>({
-      x: 0,
-      y: 0,
-    });
-    const paletteRef = React.useRef<CommandPaletteController | null>(null);
-
-    // ----- Rule config dialog state -----
-    const [ruleDialogState, setRuleDialogState] = React.useState<{
-      rule: RulePaletteItem;
-      blockId: string;
-    } | null>(null);
-
-    // ----- Context menu state -----
-    const [blockContextMenuState, setContextMenuState] =
-      React.useState<ContextMenuOverlayState | null>(null);
-    const blockContextMenuRef = React.useRef<BlockContextMenuControls | null>(null);
-
-    // ----- Stable block mutation function -----
+    // -- Block mutation --
     const updateBlocks = React.useCallback(
       (next: EditorBlock[], commit = false) => {
         blocksAtomRef.current.set(next);
-        if (!isControlled) {
-          setUncontrolled(next);
-        }
+        if (!isControlled) setUncontrolled(next);
         callbacksRef.current.onValueChange?.(next);
-        if (commit) {
-          callbacksRef.current.onValueCommit?.(next);
-        }
+        if (commit) callbacksRef.current.onValueCommit?.(next);
       },
       [isControlled],
     );
 
-    // ----- CRUD methods -----
+    // -- CRUD --
     const addBlocks = React.useCallback(
       (newBlocks: EditorBlock[], index?: number) => {
         if (newBlocks.length === 0) return;
@@ -1597,8 +373,7 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
 
     const removeBlocks = React.useCallback(
       (ids: Set<string>) => {
-        const current = blocksAtomRef.current.get();
-        const next = current.filter((b) => !ids.has(b.id));
+        const next = blocksAtomRef.current.get().filter((b) => !ids.has(b.id));
         updateBlocks(next, true);
       },
       [updateBlocks],
@@ -1612,8 +387,7 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
         const next = [...current];
         const [moved] = next.splice(fromIndex, 1);
         if (!moved) return;
-        const insertAt = Math.min(Math.max(toIndex, 0), next.length);
-        next.splice(insertAt, 0, moved);
+        next.splice(Math.min(Math.max(toIndex, 0), next.length), 0, moved);
         updateBlocks(next, true);
       },
       [updateBlocks],
@@ -1621,593 +395,93 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
 
     const updateBlock = React.useCallback(
       (id: string, updates: Partial<EditorBlock>) => {
-        const current = blocksAtomRef.current.get();
-        const next = current.map((b) => (b.id === id ? { ...b, ...updates, id: b.id } : b));
+        const next = blocksAtomRef.current
+          .get()
+          .map((b) => (b.id === id ? { ...b, ...updates, id: b.id } : b));
         updateBlocks(next, false);
       },
       [updateBlocks],
     );
 
-    // ----- Handler state bridged via stable atom -----
-    // The handler is created in an effect (after mount), so useSyncExternalStore
-    // cannot subscribe to it directly (handlerRef is null at subscribe time).
-    // Instead, we use a stable atom created once and bridge updates in the effect.
-    const $handlerStateRef = React.useRef(atom<BlockHandlerState>({ ...INITIAL_HANDLER_STATE }));
-    const handlerState = React.useSyncExternalStore(
-      (cb) => $handlerStateRef.current.subscribe(cb),
-      () => $handlerStateRef.current.get(),
-      () => INITIAL_HANDLER_STATE,
+    const handleChangeBlockType = React.useCallback(
+      (blockId: string, newType: string, meta?: Record<string, unknown>) => {
+        const next = convertBlockType(blocksAtomRef.current.get(), blockId, newType, meta);
+        updateBlocks(next as EditorBlock[]);
+      },
+      [updateBlocks],
     );
 
-    // Stable identity for commandPalette prop -- avoids effect teardown when
-    // consumers pass an inline array. Keyed by sorted command IDs.
-    const commandPaletteRef = React.useRef(commandPalette);
-    const commandPaletteKey = commandPalette?.map((c) => c.id).join(',') ?? '';
-    const prevKeyRef = React.useRef(commandPaletteKey);
-    if (commandPaletteKey !== prevKeyRef.current) {
-      commandPaletteRef.current = commandPalette;
-      prevKeyRef.current = commandPaletteKey;
-    }
+    // -- Imperative handle --
+    const controlsRef = React.useRef<EditorControls | null>(null);
+    controlsRef.current = {
+      addBlock,
+      addBlocks,
+      removeBlocks,
+      moveBlock,
+      updateBlock,
+      getBlocks: () => blocksAtomRef.current.get(),
+      focus: () => canvasRef.current?.focus(),
+      deselect: () => {},
+    };
+    React.useImperativeHandle(ref, () => controlsRef.current as EditorControls, []);
 
-    // Stable identity for sidebar config prop -- avoids full effect teardown
-    // when consumers pass an inline object literal. Keyed by stringified
-    // item IDs + categories so the effect only re-runs on meaningful changes.
-    const sidebarRef = React.useRef(sidebar);
-    const sidebarKey = React.useMemo(() => {
-      if (typeof sidebar !== 'object' || sidebar === null) return String(sidebar);
-      const itemIds = sidebar.items.map((i) => i.id).join(',');
-      const cats = sidebar.categories.join(',');
-      return `${itemIds}|${cats}|${sidebar.searchable ?? true}`;
-    }, [sidebar]);
-    const prevSidebarKeyRef = React.useRef(sidebarKey);
-    if (sidebarKey !== prevSidebarKeyRef.current) {
-      sidebarRef.current = sidebar;
-      prevSidebarKeyRef.current = sidebarKey;
-    }
-
-    // ----- Primitive lifecycle (DOM side effects) -----
-    // biome-ignore lint/correctness/useExhaustiveDependencies: commandPaletteKey and sidebarKey trigger re-creation when props change; actual data read from refs
+    // -- Document editor primitive lifecycle --
     React.useEffect(() => {
       const canvasEl = canvasRef.current;
       if (!canvasEl || disabled) return;
 
       const cleanups: CleanupFunction[] = [];
 
-      // Convert SlashCommands to palette-aware callback
-      const cmds = commandPaletteRef.current;
-      const hasCommandPalette = cmds && cmds.length > 0;
-      const onSlashCommand = hasCommandPalette
-        ? (position: { x: number; y: number }) => {
-            setPalettePosition(position);
-            paletteRef.current?.open();
-            setPaletteState(paletteRef.current?.getState() ?? INITIAL_PALETTE_STATE);
-          }
-        : undefined;
-
-      // Create block handler
-      // Adapter satisfies BlockHandlerOptions.$blocks which expects mutable arrays,
-      // while nanostore atoms expose readonly arrays in their subscribe callback.
-      const $blocksAdapter = {
-        get: () => blocksAtomRef.current.get() as EditorBlock[],
-        subscribe: (cb: (value: EditorBlock[]) => void) =>
-          blocksAtomRef.current.subscribe((v) => cb(v as EditorBlock[])),
-      };
-      const handlerOptions: Parameters<typeof createBlockHandler>[0] = {
-        container: canvasEl,
-        $blocks: $blocksAdapter,
-        onBlocksChange: (newBlocks) => {
-          updateBlocks(newBlocks as EditorBlock[]);
-        },
-      };
-      if (onSlashCommand) {
-        handlerOptions.onSlashCommand = onSlashCommand;
-      }
-      const handler = createBlockHandler(handlerOptions);
-      handlerRef.current = handler;
-
-      // Bridge handler state into the stable atom so useSyncExternalStore picks it up
-      const unsubHandlerState = handler.$state.subscribe((s) => {
-        $handlerStateRef.current.set(s);
-      });
-      cleanups.push(unsubHandlerState);
-
-      cleanups.push(() => {
-        handler.destroy();
-        handlerRef.current = null;
-        $handlerStateRef.current.set({ ...INITIAL_HANDLER_STATE });
-      });
-
-      // Document editor primitive -- contentEditable behavior
       const docEditor = createDocumentEditor({
         container: canvasEl,
         initialBlocks: blocksAtomRef.current.get(),
-        onBlocksChange: (newBlocks) => {
-          updateBlocks(newBlocks as EditorBlock[]);
-        },
+        onBlocksChange: (newBlocks) => updateBlocks(newBlocks as EditorBlock[]),
       });
       docEditorRef.current = docEditor;
-      cleanups.push(() => {
-        docEditor.destroy();
-        docEditorRef.current = null;
-      });
 
-      // Track focused block for toolbar block type dropdown
-      const trackFocusedBlock = () => {
+      // Sync undo/redo state
+      const unsubState = docEditor.$state.subscribe((s) => {
+        setCanUndo(s.canUndo);
+        setCanRedo(s.canRedo);
+      });
+      cleanups.push(unsubState);
+
+      // Track focused block for toolbar
+      const trackFocus = () => {
         const sel = window.getSelection();
         if (!sel || !canvasEl.contains(sel.anchorNode)) {
           setFocusedBlockId(null);
           return;
         }
-        const blockEl =
-          sel.anchorNode instanceof HTMLElement
-            ? sel.anchorNode.closest('[data-block-id]')
-            : sel.anchorNode?.parentElement?.closest('[data-block-id]');
+        const blockEl = findBlockElement(sel.anchorNode);
         setFocusedBlockId(blockEl?.getAttribute('data-block-id') ?? null);
       };
-      document.addEventListener('selectionchange', trackFocusedBlock);
-      cleanups.push(() => document.removeEventListener('selectionchange', trackFocusedBlock));
+      document.addEventListener('selectionchange', trackFocus);
+      cleanups.push(() => document.removeEventListener('selectionchange', trackFocus));
 
-      // Command palette primitive
-      if (hasCommandPalette) {
-        const commands: Command[] = cmds.map((sc) => {
-          const cmd: Command = {
-            id: sc.id,
-            label: sc.label,
-            action: () => {
-              // No-op: the primitive's execute path is not used. Instead,
-              // handlePaletteExecute looks up the original SlashCommand by ID
-              // and calls its action with the full EditorControls handle.
-            },
-          };
-          if (sc.keywords) {
-            cmd.keywords = sc.keywords;
-          }
-          return cmd;
-        });
-
-        const palette = createCommandPalette({
-          container: canvasEl,
-          commands,
-          onOpen: () => {
-            setPaletteState(palette.getState());
-          },
-          onClose: () => {
-            setPaletteState(INITIAL_PALETTE_STATE);
-          },
-          onSelect: () => {
-            setPaletteState(palette.getState());
-          },
-        });
-        paletteRef.current = palette;
-        cleanups.push(() => {
-          palette.cleanup();
-          paletteRef.current = null;
-        });
-      }
-
-      // Inline formatter + selection listener
-      if (inlineToolbar) {
-        const formatter = createInlineFormatter({
-          container: canvasEl,
-          formats: [BOLD, ITALIC, CODE, STRIKETHROUGH],
-        });
-        formatterRef.current = formatter;
-        cleanups.push(() => {
-          formatter.cleanup();
-          formatterRef.current = null;
-        });
-
-        const handleSelectionChange = () => {
-          const sel = window.getSelection();
-          if (!sel || sel.isCollapsed || !canvasEl.contains(sel.anchorNode)) {
-            setInlineToolbarPos(null);
-            return;
-          }
-          const range = sel.getRangeAt(0);
-          const rect = range.getBoundingClientRect();
-          const pos = adjustToolbarPosition(
-            { x: rect.left + rect.width / 2 - INLINE_TOOLBAR_DIMENSIONS.width / 2, y: rect.top },
-            INLINE_TOOLBAR_DIMENSIONS,
-          );
-          setInlineToolbarPos(pos);
-          setActiveFormats(formatter.getActiveFormats());
-        };
-        document.addEventListener('selectionchange', handleSelectionChange);
-        cleanups.push(() => document.removeEventListener('selectionchange', handleSelectionChange));
-      }
-
-      // Canvas drop zone for palette sidebar drag-to-insert
-      if (sidebarRef.current && typeof sidebarRef.current === 'object') {
-        const dropZone = createCanvasDropZone({
-          container: canvasEl,
-          accept: (data) => {
-            // Accept objects that look like a BlockPaletteItem (have an id field)
-            return data !== null && typeof data === 'object' && 'id' in data;
-          },
-          onDrop: (data, insertIndex) => {
-            // data may arrive as parsed JSON from either MIME type
-            const item = data as BlockPaletteItem;
-            if (!item.id) return;
-            const cfg = typeof sidebarRef.current === 'object' ? sidebarRef.current : null;
-            if (cfg?.onItemInsert && controlsRef.current) {
-              cfg.onItemInsert(item, controlsRef.current, insertIndex);
-            } else {
-              addBlock(
-                {
-                  id: crypto.randomUUID(),
-                  type: item.id,
-                  content: '',
-                },
-                insertIndex,
-              );
-            }
-          },
-        });
-        cleanups.push(() => dropZone.destroy());
-      }
+      cleanups.push(() => {
+        docEditor.destroy();
+        docEditorRef.current = null;
+      });
 
       return () => {
         for (const cleanup of cleanups) cleanup();
       };
-    }, [disabled, inlineToolbar, commandPaletteKey, updateBlocks, sidebarKey, addBlock]);
+    }, [disabled, updateBlocks]);
 
-    // ----- Sync controlled value into atom -----
+    // -- Sync controlled value to atom --
     React.useEffect(() => {
       if (isControlled && controlledValue) {
         blocksAtomRef.current.set(controlledValue);
       }
     }, [isControlled, controlledValue]);
 
-    // ----- Imperative handle -----
-    // biome-ignore lint/style/noNonNullAssertion: ref is assigned via useEffect before any consumer reads it
-    const controlsRef = React.useRef<EditorControls>(null!);
-    const controls = React.useMemo<EditorControls>(
-      () => ({
-        addBlock,
-        addBlocks,
-        removeBlocks,
-        moveBlock,
-        updateBlock,
-        undo: () => handlerRef.current?.undo(),
-        redo: () => handlerRef.current?.redo(),
-        selectAll: () => handlerRef.current?.selectAll(),
-        clearSelection: () => handlerRef.current?.clearSelection(),
-        deselect: () => handlerRef.current?.handleCanvasBackgroundClick(),
-        focus: () => canvasRef.current?.focus(),
-      }),
-      [addBlock, addBlocks, removeBlocks, moveBlock, updateBlock],
-    );
-    // Sync controls into the ref inside an effect to avoid mutating a ref during render
-    // (React 19 purity requirement).
-    React.useEffect(() => {
-      controlsRef.current = controls;
-    }, [controls]);
-    React.useImperativeHandle(ref, () => controls, [controls]);
-
-    // ----- Command palette handlers -----
-    const handlePaletteQuery = React.useCallback((query: string) => {
-      paletteRef.current?.setQuery(query);
-      setPaletteState(paletteRef.current?.getState() ?? INITIAL_PALETTE_STATE);
-    }, []);
-
-    const handlePaletteSelect = React.useCallback((index: number) => {
-      const palette = paletteRef.current;
-      if (!palette) return;
-      // The command-palette primitive only exposes selectFirst/selectNext/selectPrevious,
-      // so we step to the target index. Fine for small command lists.
-      palette.selectFirst();
-      for (let i = 0; i < index; i++) {
-        palette.selectNext();
-      }
-      setPaletteState(palette.getState());
-    }, []);
-
-    const handlePaletteExecute = React.useCallback(() => {
-      const palette = paletteRef.current;
-      if (!palette) return;
-      const state = palette.getState();
-      const cmd = state.filteredCommands[state.selectedIndex];
-      if (cmd && commandPaletteRef.current) {
-        const slashCmd = commandPaletteRef.current.find((sc) => sc.id === cmd.id);
-        if (slashCmd && controlsRef.current) {
-          slashCmd.action(controlsRef.current);
-        }
-      }
-      palette.close();
-      setPaletteState(INITIAL_PALETTE_STATE);
-    }, []);
-
-    const handlePaletteClose = React.useCallback(() => {
-      paletteRef.current?.close();
-      setPaletteState(INITIAL_PALETTE_STATE);
-    }, []);
-
-    // ----- Inline toolbar handler -----
-    const handleFormat = React.useCallback((mark: InlineMark) => {
-      formatterRef.current?.toggleFormat(mark);
-      setActiveFormats(formatterRef.current?.getActiveFormats() ?? []);
-    }, []);
-
-    // ----- Rule application helpers -----
-    const applyRuleToBlock = React.useCallback(
-      (blockId: string, ruleItem: RulePaletteItem, config?: Record<string, unknown>) => {
-        const current = blocksAtomRef.current.get();
-        const block = current.find((b) => b.id === blockId);
-        if (!block) return;
-
-        const existingRules = block.rules ?? [];
-        // Prevent duplicate simple rules
-        const alreadyApplied = existingRules.some((r) =>
-          typeof r === 'string' ? r === ruleItem.id : r.name === ruleItem.id,
-        );
-        if (alreadyApplied && !config) return;
-
-        const rule: AppliedRule = config ? { name: ruleItem.id, config } : ruleItem.id;
-
-        // If parameterized and already exists, update config
-        if (alreadyApplied && config) {
-          const updatedRules = existingRules.map((r) =>
-            typeof r === 'object' && r.name === ruleItem.id ? rule : r,
-          );
-          updateBlock(blockId, { rules: updatedRules });
-        } else {
-          updateBlock(blockId, { rules: [...existingRules, rule] });
-        }
-
-        const rpConfig = typeof rulePalette === 'object' ? rulePalette : null;
-        if (rpConfig?.onRuleApplied && controlsRef.current) {
-          rpConfig.onRuleApplied(blockId, rule, controlsRef.current);
-        }
-      },
-      [updateBlock, rulePalette],
-    );
-
-    const handleRuleActivate = React.useCallback(
-      (item: RulePaletteItem) => {
-        // When activated from palette (click/Enter), apply to focused block
-        const focusedId = $handlerStateRef.current.get().focusedId;
-        if (!focusedId) return;
-
-        const rpConfig = typeof rulePalette === 'object' ? rulePalette : null;
-        const fields = rpConfig?.configFields?.[item.id];
-        if (item.requiresConfig && fields && fields.length > 0) {
-          setRuleDialogState({ rule: item, blockId: focusedId });
-        } else {
-          applyRuleToBlock(focusedId, item);
-        }
-      },
-      [applyRuleToBlock, rulePalette],
-    );
-
-    const handleRuleConfigConfirm = React.useCallback(
-      (config: Record<string, unknown>) => {
-        if (ruleDialogState) {
-          applyRuleToBlock(ruleDialogState.blockId, ruleDialogState.rule, config);
-          setRuleDialogState(null);
-        }
-      },
-      [ruleDialogState, applyRuleToBlock],
-    );
-
-    const handleRuleConfigCancel = React.useCallback(() => {
-      setRuleDialogState(null);
-    }, []);
-
-    // ----- Rule drop on blocks (drag from rule palette onto block elements) -----
-    React.useEffect(() => {
-      const canvasEl = canvasRef.current;
-      if (!canvasEl || disabled || !rulePalette) return;
-
-      const handleRuleDragOver = (event: DragEvent) => {
-        // Check if this is a rule drag (has the rule MIME type)
-        if (!event.dataTransfer?.types.includes('application/x-rafters-rule')) return;
-
-        // Find the closest block element
-        const target = event.target as HTMLElement;
-        const blockEl = target.closest('[data-block-id]') as HTMLElement | null;
-        if (!blockEl) return;
-
-        event.preventDefault();
-        if (event.dataTransfer) {
-          event.dataTransfer.dropEffect = 'copy';
-        }
-        blockEl.setAttribute('data-rule-drop-target', 'true');
-      };
-
-      const handleRuleDragLeave = (event: DragEvent) => {
-        const target = event.target as HTMLElement;
-        const blockEl = target.closest('[data-block-id]') as HTMLElement | null;
-        if (blockEl) {
-          blockEl.removeAttribute('data-rule-drop-target');
-        }
-      };
-
-      const handleRuleDrop = (event: DragEvent) => {
-        const target = event.target as HTMLElement;
-        const blockEl = target.closest('[data-block-id]') as HTMLElement | null;
-        if (!blockEl) return;
-
-        blockEl.removeAttribute('data-rule-drop-target');
-
-        const ruleJson = event.dataTransfer?.getData('application/x-rafters-rule');
-        if (!ruleJson) return;
-
-        event.preventDefault();
-
-        let ruleItem: RulePaletteItem;
-        try {
-          ruleItem = JSON.parse(ruleJson) as RulePaletteItem;
-        } catch {
-          return;
-        }
-
-        const blockId = blockEl.getAttribute('data-block-id');
-        if (!blockId) return;
-
-        // Check compatibility
-        if (ruleItem.compatibleBlockTypes && ruleItem.compatibleBlockTypes.length > 0) {
-          const block = blocksAtomRef.current.get().find((b) => b.id === blockId);
-          if (block && !ruleItem.compatibleBlockTypes.includes(block.type)) {
-            // Incompatible - no-op (block element briefly flashes via CSS)
-            blockEl.setAttribute('data-rule-rejected', 'true');
-            setTimeout(() => blockEl.removeAttribute('data-rule-rejected'), 600);
-            return;
-          }
-        }
-
-        // Parameterized rule: open config dialog
-        const rpConfig = typeof rulePalette === 'object' ? rulePalette : null;
-        const fields = rpConfig?.configFields?.[ruleItem.id];
-        if (ruleItem.requiresConfig && fields && fields.length > 0) {
-          setRuleDialogState({ rule: ruleItem, blockId });
-        } else {
-          applyRuleToBlock(blockId, ruleItem);
-        }
-      };
-
-      canvasEl.addEventListener('dragover', handleRuleDragOver);
-      canvasEl.addEventListener('dragleave', handleRuleDragLeave);
-      canvasEl.addEventListener('drop', handleRuleDrop);
-
-      return () => {
-        canvasEl.removeEventListener('dragover', handleRuleDragOver);
-        canvasEl.removeEventListener('dragleave', handleRuleDragLeave);
-        canvasEl.removeEventListener('drop', handleRuleDrop);
-      };
-    }, [disabled, rulePalette, applyRuleToBlock]);
-
-    // ----- Block context menu primitive -----
-    React.useEffect(() => {
-      const canvasEl = canvasRef.current;
-      if (!canvasEl || disabled || !blockContextMenu) return;
-
-      // Create an off-screen menu element for the primitive to manage
-      const menuEl = document.createElement('div');
-      document.body.appendChild(menuEl);
-
-      const ctxMenu = createBlockContextMenu({
-        container: canvasEl,
-        menu: menuEl,
-        onAction: (itemId, blockId) => {
-          if (itemId === 'remove-block') {
-            const current = blocksAtomRef.current.get();
-            const block = current.find((b) => b.id === blockId);
-            if (block) {
-              // Collect children to remove too
-              const idsToRemove = new Set<string>([blockId]);
-              if (block.children) {
-                for (const childId of block.children) idsToRemove.add(childId);
-              }
-              removeBlocks(idsToRemove);
-            }
-          } else if (itemId.startsWith('remove-rule:')) {
-            const ruleName = itemId.slice('remove-rule:'.length);
-            const current = blocksAtomRef.current.get();
-            const block = current.find((b) => b.id === blockId);
-            if (block?.rules) {
-              const updatedRules = block.rules.filter((r) =>
-                typeof r === 'string' ? r !== ruleName : r.name !== ruleName,
-              );
-              updateBlock(blockId, { rules: updatedRules });
-            }
-          } else if (itemId.startsWith('edit-rule:')) {
-            const ruleName = itemId.slice('edit-rule:'.length);
-            const ruleItem = rulePalette?.items.find((r) => r.id === ruleName);
-            if (ruleItem?.requiresConfig) {
-              setRuleDialogState({ rule: ruleItem, blockId });
-            }
-          }
-          setContextMenuState(null);
-        },
-        onOpen: (blockId, position) => {
-          setContextMenuState({ blockId, position });
-        },
-        onClose: () => {
-          setContextMenuState(null);
-        },
-      });
-      blockContextMenuRef.current = ctxMenu;
-
-      return () => {
-        ctxMenu.destroy();
-        menuEl.remove();
-        blockContextMenuRef.current = null;
-        setContextMenuState(null);
-      };
-    }, [disabled, blockContextMenu, removeBlocks, updateBlock, rulePalette]);
-
-    // ----- Sidebar focus handler -----
-    const handleSidebarFocusBlock = React.useCallback((id: string) => {
-      handlerRef.current?.handleBlockClick(id, { meta: false, shift: false });
-      canvasRef.current?.focus();
-    }, []);
-
-    // ----- Palette sidebar handlers -----
-    const handlePaletteActivate = React.useCallback(
-      (item: BlockPaletteItem) => {
-        const cfg = typeof sidebarRef.current === 'object' ? sidebarRef.current : null;
-        if (cfg?.onItemInsert && controlsRef.current) {
-          cfg.onItemInsert(item, controlsRef.current);
-        } else {
-          addBlock({
-            id: crypto.randomUUID(),
-            type: item.id,
-            content: '',
-          });
-        }
-      },
-      [addBlock],
-    );
-
-    const handleChangeBlockType = React.useCallback(
-      (blockId: string, newType: string, meta?: Record<string, unknown>) => {
-        const current = blocksAtomRef.current.get();
-        const next = current.map((b) => {
-          if (b.id !== blockId) return b;
-          const updated: EditorBlock = { ...b, type: newType };
-          if (meta) {
-            updated.meta = { ...b.meta, ...meta };
-          } else if (newType === 'text' && b.meta) {
-            const { level: _, ...rest } = b.meta as Record<string, unknown> & { level?: number };
-            if (Object.keys(rest).length > 0) {
-              updated.meta = rest;
-            } else {
-              delete (updated as unknown as Record<string, unknown>).meta;
-            }
-          }
-          if (newType === 'code' && Array.isArray(b.content)) {
-            updated.content = b.content.map((s) => s.text).join('');
-          }
-          return updated;
-        });
-        updateBlocks(next);
-      },
-      [updateBlocks],
-    );
-
     const focusedBlock = focusedBlockId ? blocks.find((b) => b.id === focusedBlockId) : undefined;
 
-    const handleSaveComposite = React.useCallback(
-      async (data: SaveCompositeData) => {
-        try {
-          await onSaveAsComposite?.(data);
-          setShowSaveDialog(false);
-        } catch {
-          // Keep dialog open so user knows the save failed
-        }
-      },
-      [onSaveAsComposite],
-    );
-
-    // Determine sidebar mode
-    const sidebarConfig = typeof sidebar === 'object' && sidebar !== null ? sidebar : null;
-
+    // -- Render --
     return (
-      <Container
+      <section
         {...props}
-        as="section"
-        padding="0"
-        query={false}
         aria-label="Editor"
         aria-disabled={disabled || undefined}
         dir={dir}
@@ -2218,163 +492,35 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
         )}
       >
         {toolbar && (
-          <div className={classy('flex items-center')}>
-            <EditorToolbarSection
-              canUndo={handlerState.canUndo}
-              canRedo={handlerState.canRedo}
-              onUndo={() => handlerRef.current?.undo()}
-              onRedo={() => handlerRef.current?.redo()}
-              focusedBlock={focusedBlock}
-              onChangeBlockType={handleChangeBlockType}
-            />
-            {onSaveAsComposite && (
-              <button
-                type="button"
-                onClick={() => setShowSaveDialog(true)}
-                disabled={blocks.length === 0}
-                aria-label="Save as Composite"
-                className={classy(
-                  'ml-auto mr-2 rounded-md px-2 py-1 text-xs font-medium transition-colors',
-                  'hover:bg-accent hover:text-accent-foreground',
-                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring',
-                  { 'opacity-50 cursor-not-allowed': blocks.length === 0 },
-                )}
-              >
-                Save as Composite
-              </button>
-            )}
-          </div>
+          <EditorToolbar
+            canUndo={canUndo}
+            canRedo={canRedo}
+            onUndo={() => docEditorRef.current?.undo()}
+            onRedo={() => docEditorRef.current?.redo()}
+            focusedBlock={focusedBlock}
+            onChangeBlockType={handleChangeBlockType}
+          />
         )}
-        <div className={classy('flex flex-1')}>
-          {sidebar === true && (
-            <EditorSidebarSection
-              blocks={blocks}
-              selectedIds={handlerState.selectedIds}
-              focusedId={handlerState.focusedId}
-              onFocusBlock={handleSidebarFocusBlock}
-            />
+        {/* biome-ignore lint/a11y/useSemanticElements: contentEditable div is the correct pattern for block editors */}
+        <div
+          ref={canvasRef}
+          role="textbox"
+          aria-multiline="true"
+          aria-label="Document editor"
+          tabIndex={disabled ? -1 : 0}
+          suppressContentEditableWarning
+          className={classy(
+            'flex-1 p-4 outline-none',
+            'prose prose-sm max-w-none',
+            'focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-ring',
           )}
-          {sidebarConfig && rulePalette && (
-            <EditorTabbedPaletteSidebar
-              blockConfig={sidebarConfig}
-              ruleConfig={rulePalette}
-              onBlockActivate={handlePaletteActivate}
-              onRuleActivate={handleRuleActivate}
-              disabled={disabled}
-            />
-          )}
-          {sidebarConfig && !rulePalette && (
-            <EditorPaletteSidebar
-              config={sidebarConfig}
-              onActivate={handlePaletteActivate}
-              disabled={disabled}
-            />
-          )}
-          {/* Document surface: single contentEditable, blocks as semantic HTML */}
-          {/* biome-ignore lint/a11y/useSemanticElements: contentEditable div is the correct pattern for block editors */}
-          <div
-            ref={canvasRef}
-            role="textbox"
-            aria-multiline="true"
-            aria-label="Document editor"
-            tabIndex={disabled ? -1 : 0}
-            suppressContentEditableWarning
-            className={classy(
-              'flex-1 p-4 outline-none',
-              'prose prose-sm max-w-none',
-              'focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-ring',
-            )}
-          >
-            {blocks.length === 0 && (emptyState ?? <DefaultEmptyState />)}
-            {blocks.map((block) => (
-              <DocumentBlock key={block.id} block={block} />
-            ))}
-          </div>
+        >
+          {blocks.length === 0 && (emptyState ?? <DefaultEmptyState />)}
+          {blocks.map((block) => (
+            <DocumentBlock key={block.id} block={block} />
+          ))}
         </div>
-        {commandPalette && paletteState.isOpen && (
-          <CommandPaletteOverlay
-            state={paletteState}
-            position={palettePosition}
-            onQuery={handlePaletteQuery}
-            onSelect={handlePaletteSelect}
-            onExecute={handlePaletteExecute}
-            onClose={handlePaletteClose}
-          />
-        )}
-        {inlineToolbar && inlineToolbarPos && (
-          <InlineToolbarOverlay
-            position={inlineToolbarPos}
-            activeFormats={activeFormats}
-            onFormat={handleFormat}
-          />
-        )}
-        {ruleDialogState &&
-          (() => {
-            const fields = rulePalette?.configFields?.[ruleDialogState.rule.id];
-            if (!fields) return null;
-            return (
-              <RuleConfigDialog
-                rule={ruleDialogState.rule}
-                fields={fields}
-                anchorId={`editor-block-${ruleDialogState.blockId}`}
-                onConfirm={handleRuleConfigConfirm}
-                onCancel={handleRuleConfigCancel}
-              />
-            );
-          })()}
-        {blockContextMenu && blockContextMenuState && (
-          <BlockContextMenuOverlay
-            state={blockContextMenuState}
-            block={blocks.find((b) => b.id === blockContextMenuState.blockId)}
-            onAction={(actionId) => {
-              const ctxMenu = blockContextMenuRef.current;
-              if (ctxMenu) {
-                // Find the menu element's matching item and trigger action
-                const blockId = blockContextMenuState.blockId;
-                if (actionId === 'remove-block') {
-                  const block = blocks.find((b) => b.id === blockId);
-                  if (block) {
-                    const idsToRemove = new Set<string>([blockId]);
-                    if (block.children) {
-                      for (const childId of block.children) idsToRemove.add(childId);
-                    }
-                    removeBlocks(idsToRemove);
-                  }
-                } else if (actionId.startsWith('remove-rule:')) {
-                  const ruleName = actionId.slice('remove-rule:'.length);
-                  const block = blocks.find((b) => b.id === blockId);
-                  if (block?.rules) {
-                    const updatedRules = block.rules.filter((r) =>
-                      typeof r === 'string' ? r !== ruleName : r.name !== ruleName,
-                    );
-                    updateBlock(blockId, { rules: updatedRules });
-                  }
-                } else if (actionId.startsWith('edit-rule:')) {
-                  const ruleName = actionId.slice('edit-rule:'.length);
-                  const ruleItem = rulePalette?.items.find((r) => r.id === ruleName);
-                  if (ruleItem?.requiresConfig) {
-                    setRuleDialogState({ rule: ruleItem, blockId });
-                  }
-                }
-                setContextMenuState(null);
-                ctxMenu.close();
-              }
-            }}
-          />
-        )}
-        {showSaveDialog && onSaveAsComposite && (
-          <SaveCompositeDialog
-            blocks={blocks}
-            existingCategories={
-              typeof sidebarRef.current === 'object' && sidebarRef.current
-                ? sidebarRef.current.categories
-                : []
-            }
-            onSave={handleSaveComposite}
-            onCancel={() => setShowSaveDialog(false)}
-          />
-        )}
-      </Container>
+      </section>
     );
   },
 );

--- a/packages/ui/test/components/editor.a11y.tsx
+++ b/packages/ui/test/components/editor.a11y.tsx
@@ -29,12 +29,6 @@ describe('Editor - Accessibility', () => {
     expect(results).toHaveNoViolations();
   });
 
-  it('has no accessibility violations with sidebar', async () => {
-    const { container } = render(<Editor defaultValue={BLOCKS} sidebar />);
-    const results = await axe(container);
-    expect(results).toHaveNoViolations();
-  });
-
   it('has no accessibility violations when disabled', async () => {
     const { container } = render(<Editor defaultValue={BLOCKS} disabled />);
     const results = await axe(container);
@@ -72,11 +66,6 @@ describe('Editor - Accessibility', () => {
   it('canvas has visible focus indicator class', () => {
     render(<Editor defaultValue={BLOCKS} />);
     expect(screen.getByLabelText('Document editor')).toHaveClass('focus-visible:ring-2');
-  });
-
-  it('sidebar navigation has aria-label', () => {
-    render(<Editor defaultValue={BLOCKS} sidebar />);
-    expect(screen.getByRole('navigation')).toHaveAttribute('aria-label', 'Block navigation');
   });
 
   it('disabled editor sets aria-disabled', () => {

--- a/packages/ui/test/components/editor.test.tsx
+++ b/packages/ui/test/components/editor.test.tsx
@@ -151,30 +151,6 @@ describe('Editor', () => {
     });
   });
 
-  describe('Sidebar', () => {
-    it('does not render sidebar by default', () => {
-      render(<Editor defaultValue={BLOCKS} />);
-      expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
-    });
-
-    it('renders sidebar when sidebar prop is true', () => {
-      render(<Editor defaultValue={BLOCKS} sidebar />);
-      expect(screen.getByRole('navigation')).toBeInTheDocument();
-    });
-
-    it('sidebar has aria-label', () => {
-      render(<Editor defaultValue={BLOCKS} sidebar />);
-      expect(screen.getByRole('navigation')).toHaveAttribute('aria-label', 'Block navigation');
-    });
-
-    it('sidebar lists all blocks', () => {
-      render(<Editor defaultValue={BLOCKS} sidebar />);
-      const nav = screen.getByRole('navigation');
-      const buttons = nav.querySelectorAll('button');
-      expect(buttons).toHaveLength(3);
-    });
-  });
-
   describe('Disabled state', () => {
     it('sets aria-disabled on root', () => {
       const { container } = render(<Editor disabled />);
@@ -329,76 +305,6 @@ describe('Editor', () => {
 
       ref.current?.updateBlock('1', { content: 'Updated' });
       expect(onCommit).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('Save as Composite', () => {
-    it('renders save button when onSaveAsComposite is provided with toolbar', () => {
-      render(<Editor defaultValue={BLOCKS} toolbar onSaveAsComposite={vi.fn()} />);
-      expect(screen.getByRole('button', { name: 'Save as Composite' })).toBeInTheDocument();
-    });
-
-    it('does not render save button without onSaveAsComposite', () => {
-      render(<Editor defaultValue={BLOCKS} toolbar />);
-      expect(screen.queryByRole('button', { name: 'Save as Composite' })).not.toBeInTheDocument();
-    });
-
-    it('disables save button when canvas is empty', () => {
-      render(<Editor toolbar onSaveAsComposite={vi.fn()} />);
-      expect(screen.getByRole('button', { name: 'Save as Composite' })).toBeDisabled();
-    });
-
-    it('opens dialog on save button click', () => {
-      render(<Editor defaultValue={BLOCKS} toolbar onSaveAsComposite={vi.fn()} />);
-      fireEvent.click(screen.getByRole('button', { name: 'Save as Composite' }));
-      expect(screen.getByRole('dialog', { name: 'Save as Composite' })).toBeInTheDocument();
-    });
-
-    it('calls onSaveAsComposite with metadata and blocks on form submit', () => {
-      const onSave = vi.fn();
-      const blocksWithRules = [
-        { id: '1', type: 'input', content: '', rules: ['email', 'required'] as const },
-        { id: '2', type: 'button', content: 'Submit' },
-      ];
-      render(<Editor defaultValue={blocksWithRules} toolbar onSaveAsComposite={onSave} />);
-      fireEvent.click(screen.getByRole('button', { name: 'Save as Composite' }));
-
-      fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Login Form' } });
-      fireEvent.change(screen.getByRole('combobox'), { target: { value: 'form' } });
-      fireEvent.change(screen.getByLabelText('Description'), {
-        target: { value: 'A login form' },
-      });
-      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
-
-      expect(onSave).toHaveBeenCalledTimes(1);
-      const data = onSave.mock.calls[0][0];
-      expect(data.name).toBe('Login Form');
-      expect(data.category).toBe('form');
-      expect(data.description).toBe('A login form');
-      expect(data.blocks).toHaveLength(2);
-    });
-
-    it('shows validation error for empty name', () => {
-      render(<Editor defaultValue={BLOCKS} toolbar onSaveAsComposite={vi.fn()} />);
-      fireEvent.click(screen.getByRole('button', { name: 'Save as Composite' }));
-      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
-      expect(screen.getByRole('alert')).toHaveTextContent('Name is required');
-    });
-
-    it('shows validation error for empty category', () => {
-      render(<Editor defaultValue={BLOCKS} toolbar onSaveAsComposite={vi.fn()} />);
-      fireEvent.click(screen.getByRole('button', { name: 'Save as Composite' }));
-      fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'My Composite' } });
-      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
-      expect(screen.getByRole('alert')).toHaveTextContent('Category is required');
-    });
-
-    it('closes dialog on cancel', () => {
-      render(<Editor defaultValue={BLOCKS} toolbar onSaveAsComposite={vi.fn()} />);
-      fireEvent.click(screen.getByRole('button', { name: 'Save as Composite' }));
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

Rewrite the editor from a 2384-line monolith to a 514-line focused component. The editor is a toolbar and a document surface. Everything else composes on top.

**Before:** 2384 lines, 15+ sub-components, 6 primitive orchestrations, sidebar/palette/rules/context-menu/command-palette/save-dialog all baked in.

**After:** 514 lines. Creates document-editor primitive, renders blocks as semantic HTML, shows toolbar with block type dropdown + undo/redo.

What was removed (to be re-added as separate composable components):
- Sidebar (block palette, rule palette, tabbed palette)
- Command palette overlay
- Inline formatting toolbar overlay
- Block context menu overlay
- Save-as-composite dialog
- Canvas drop zone
- Block handler primitive (replaced by document-editor)

## Test plan

- [x] 50 editor tests passing (sidebar and save-as-composite tests removed)
- [x] All 3603 UI tests passing
- [x] Demo builds clean
- [x] Full preflight passing

Generated with [Claude Code](https://claude.com/claude-code)