### PR TITLE
chore: release rafters v0.0.21

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "CLI for Rafters design system - scaffold tokens and add components",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Bump to v0.0.21. After merge, tag v0.0.21 to publish to npm.