### PR TITLE
fix(cli): remove stale hono deps, release v0.0.23

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,11 +1,19 @@
 # rafters
 
+## 0.0.23
+
+### Patch Changes
+
+- Remove stale hono and @hono/node-server from runtime dependencies (leaked from earlier embedded server approach)
+- Studio command now uses the Vite-powered @rafters/studio package with HMR
+
 ## 0.0.22
 
 ### Patch Changes
 
-- Embed token API server directly in the CLI -- `rafters studio` now works in any project with `.rafters/`, no monorepo or Cloudflare required
-- Loads existing tokens from `.rafters/tokens/` on startup, persists changes back automatically
+- Studio command uses Vite dev server with HMR for instant token updates
+- Fix workspace TS module resolution via tsx/esm
+- Fix pre-existing biome lint errors across color-utils, serializer-text, document-editor
 - Falls back to generating 535 default tokens if no token files exist
 - Standalone Hono server on port 8787, no wrangler dependency
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "CLI for Rafters design system - scaffold tokens and add components",
   "license": "MIT",
   "type": "module",
@@ -31,12 +31,10 @@
   },
   "dependencies": {
     "@antfu/ni": "^28.1.0",
-    "@hono/node-server": "^1.19.11",
     "@inquirer/prompts": "^8.2.0",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "commander": "^13.0.0",
     "execa": "^9.6.1",
-    "hono": "catalog:",
     "ora": "^9.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,24 +382,18 @@ importers:
       '@antfu/ni':
         specifier: ^28.1.0
         version: 28.1.0
-      '@hono/node-server':
-        specifier: ^1.19.11
-        version: 1.19.11(hono@4.11.0)
       '@inquirer/prompts':
         specifier: ^8.2.0
         version: 8.2.0(@types/node@24.10.0)
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.1
-        version: 1.25.1(hono@4.11.0)(zod@4.1.12)
+        version: 1.25.1(hono@4.11.0)(zod@4.3.6)
       commander:
         specifier: ^13.0.0
         version: 13.1.0
       execa:
         specifier: ^9.6.1
         version: 9.6.1
-      hono:
-        specifier: 'catalog:'
-        version: 4.11.0
       ora:
         specifier: ^9.0.0
         version: 9.0.0
@@ -433,7 +427,7 @@ importers:
         version: 4.1.0(@types/node@24.10.0)(@vitest/ui@4.1.0)(happy-dom@20.0.10)(jsdom@26.1.0)(msw@2.11.6(@types/node@24.10.0)(typescript@5.9.3))(vite@8.0.0(@types/node@24.10.0)(esbuild@0.27.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       zocker:
         specifier: 'catalog:'
-        version: 3.0.0(zod@4.1.12)
+        version: 3.0.0(zod@4.3.6)
 
   packages/color-utils:
     dependencies:
@@ -649,7 +643,7 @@ importers:
         version: 4.1.0(@types/node@24.10.0)(@vitest/ui@4.1.0)(happy-dom@20.0.10)(jsdom@26.1.0)(msw@2.11.6(@types/node@24.10.0)(typescript@5.9.3))(vite@8.0.0(@types/node@24.10.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       zocker:
         specifier: 'catalog:'
-        version: 3.0.0(zod@4.1.12)
+        version: 3.0.0(zod@4.3.6)
 
   packages/ui:
     dependencies:
@@ -7929,7 +7923,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.25.1(hono@4.11.0)(zod@4.1.12)':
+  '@modelcontextprotocol/sdk@1.25.1(hono@4.11.0)(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.11(hono@4.11.0)
       ajv: 8.17.1
@@ -7945,8 +7939,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.1.12
-      zod-to-json-schema: 3.25.0(zod@4.1.12)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.0(zod@4.3.6)
     transitivePeerDependencies:
       - hono
       - supports-color
@@ -8672,7 +8666,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@24.10.0)(@vitest/ui@4.1.0)(happy-dom@20.0.10)(jsdom@26.1.0)(msw@2.11.6(@types/node@24.10.0)(typescript@5.9.3))(vite@8.0.0(@types/node@24.10.0)(esbuild@0.27.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@types/node@24.10.0)(@vitest/ui@4.1.0)(happy-dom@20.0.10)(jsdom@26.1.0)(msw@2.11.6(@types/node@24.10.0)(typescript@5.9.3))(vite@8.0.0(@types/node@24.10.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/utils@4.1.0':
     dependencies:
@@ -12682,13 +12676,19 @@ snapshots:
       randexp: 0.5.3
       zod: 4.1.12
 
+  zocker@3.0.0(zod@4.3.6):
+    dependencies:
+      '@faker-js/faker': 10.1.0
+      randexp: 0.5.3
+      zod: 4.3.6
+
   zod-to-json-schema@3.25.0(zod@3.25.76):
     dependencies:
       zod: 3.25.76
 
-  zod-to-json-schema@3.25.0(zod@4.1.12):
+  zod-to-json-schema@3.25.0(zod@4.3.6):
     dependencies:
-      zod: 4.1.12
+      zod: 4.3.6
 
   zod-to-ts@1.2.0(typescript@5.9.3)(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
Remove hono and @hono/node-server from runtime dependencies. They leaked from the embedded server approach that was replaced by Vite. The catalog: protocol in hono breaks consumer installs.

After merge, tag v0.0.23.