### PR TITLE
feat(api): POST /api/shutdown to stop the studio

### DIFF
--- a/apps/api/src/routes/index.route.ts
+++ b/apps/api/src/routes/index.route.ts
@@ -55,6 +55,7 @@ const router = createRouter().openapi(
           'DELETE /tokens/:namespace/:name/override': 'Clear override, restore computed',
           'POST /color/build': 'OKLCH -> full ColorValue',
           'POST /tokens/:namespace/reset': 'Regenerate namespace from generators',
+          'POST /api/shutdown': 'Gracefully stop the studio server',
         },
       },
       HttpStatusCodes.OK,

--- a/packages/studio/src/api/vite-plugin.ts
+++ b/packages/studio/src/api/vite-plugin.ts
@@ -562,6 +562,15 @@ export function studioApiPlugin(): Plugin {
           return;
         }
 
+        // /api/shutdown - POST to gracefully stop the studio
+        if (pathname === '/api/shutdown' && req.method === 'POST') {
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ ok: true, message: 'Shutting down' }));
+          console.log('[rafters] Studio shutting down...');
+          setTimeout(() => server.close(), 100);
+          return;
+        }
+
         // /api/color/build - POST to build ColorValue from OKLCH
         if (pathname === '/api/color/build') {
           res.setHeader('Content-Type', 'application/json');


### PR DESCRIPTION
Adds a graceful shutdown endpoint. POST /api/shutdown responds with
{ ok: true } then closes the Vite server. Documented in GET /.