### PR TITLE
chore: release v0.0.25

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # rafters
 
+## 0.0.25
+
+### Minor Changes
+
+- Correct token API contract: getters return full Token data, setters take value + reason, return { ok: true }
+- GET / returns structured API info: system metadata, rules, endpoint docs
+- RAFTERS_VERSION constant in @rafters/shared for version consistency
+- POST /api/shutdown for graceful studio server stop
+- POST /color/build: OKLCH in, full ColorValue out
+
 ## 0.0.24
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "CLI for Rafters design system - scaffold tokens and add components",
   "license": "MIT",
   "type": "module",

--- a/packages/shared/src/version.ts
+++ b/packages/shared/src/version.ts
@@ -3,4 +3,4 @@
  * Used by the CLI package.json, the API root endpoint, and anywhere
  * else that needs to report the current version.
  */
-export const RAFTERS_VERSION = '0.0.24';
+export const RAFTERS_VERSION = '0.0.25';


### PR DESCRIPTION
Version bump + changelog. After merge, tag v0.0.25.