### PR TITLE
feat(studio): create token endpoint and async color enrichment

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # rafters
 
+## 0.0.27
+
+### Minor Changes
+
+- POST /api/tokens/:name creates arbitrary color families when token does not exist (201 response)
+- Async color enrichment via WebSocket: fires api.rafters.studio fetch before local math, intelligence fills in live via `rafters:color-enriched` event
+- Client-side `onColorEnriched()` listener in @rafters/studio for async intelligence data
+
 ## 0.0.26
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "CLI for Rafters design system - scaffold tokens and add components",
   "license": "MIT",
   "type": "module",

--- a/packages/shared/src/version.ts
+++ b/packages/shared/src/version.ts
@@ -3,4 +3,4 @@
  * Used by the CLI package.json, the API root endpoint, and anywhere
  * else that needs to report the current version.
  */
-export const RAFTERS_VERSION = '0.0.26';
+export const RAFTERS_VERSION = '0.0.27';

--- a/packages/studio/src/api/index.ts
+++ b/packages/studio/src/api/index.ts
@@ -77,6 +77,20 @@ export function setToken(options: SetTokenOptions): Promise<UpdateResult> {
 /**
  * Listen for CSS updates (for UI feedback).
  */
+/**
+ * Listen for color intelligence enrichment (arrives async after local math).
+ * The intelligence section fills in live as the API responds.
+ */
+export function onColorEnriched(
+  callback: (data: { name: string; intelligence: unknown }) => void,
+): () => void {
+  if (!isHmrAvailable()) return () => {};
+  // biome-ignore lint/style/noNonNullAssertion: checked by isHmrAvailable
+  const hot = import.meta.hot!;
+  hot.on('rafters:color-enriched', callback);
+  return () => hot.off('rafters:color-enriched', callback);
+}
+
 export function onCssUpdated(callback: () => void): () => void {
   if (!isHmrAvailable()) {
     if (import.meta.env?.DEV) {

--- a/packages/studio/src/api/vite-plugin.ts
+++ b/packages/studio/src/api/vite-plugin.ts
@@ -307,14 +307,6 @@ export async function handlePostToken(
   name: string,
   registry: TokenRegistry,
 ): Promise<void> {
-  // Token must exist for update
-  const existingToken = registry.get(name);
-  if (!existingToken) {
-    res.statusCode = 404;
-    res.end(JSON.stringify({ ok: false, error: `Token "${name}" not found` }));
-    return;
-  }
-
   // Parse request body
   let body: unknown;
   try {
@@ -326,7 +318,63 @@ export async function handlePostToken(
     return;
   }
 
-  // Validate patch data against namespace-specific schema
+  const existingToken = registry.get(name);
+
+  // CREATE: token does not exist
+  if (!existingToken) {
+    const createSchema = z.object({
+      namespace: z.string().min(1),
+      category: z.string().min(1),
+      value: z.union([z.string(), ColorValueSchema, ColorReferenceSchema]),
+      userOverride: z.object({
+        previousValue: z.union([z.string(), ColorValueSchema, ColorReferenceSchema]),
+        reason: z.string().min(1, 'Reason is required. Every token needs a why.'),
+        context: z.string().optional(),
+      }),
+      description: z.string().optional(),
+    });
+
+    const createResult = createSchema.safeParse(body);
+    if (!createResult.success) {
+      res.statusCode = 400;
+      const issues = createResult.error.issues;
+      const message = issues[0]
+        ? `${issues[0].path.join('.') || 'body'}: ${issues[0].message}`
+        : createResult.error.message;
+      res.end(JSON.stringify({ ok: false, error: message }));
+      return;
+    }
+
+    const newToken = {
+      name,
+      namespace: createResult.data.namespace,
+      category: createResult.data.category,
+      value: createResult.data.value,
+      userOverride: createResult.data.userOverride,
+      containerQueryAware: true,
+      description: createResult.data.description,
+    };
+
+    const tokenResult = TokenSchema.safeParse(newToken);
+    if (!tokenResult.success) {
+      res.statusCode = 400;
+      res.end(JSON.stringify({ ok: false, error: tokenResult.error.message }));
+      return;
+    }
+
+    try {
+      registry.add(tokenResult.data);
+      const response = TokenResponseSchema.parse({ ok: true, token: registry.get(name) });
+      res.statusCode = 201;
+      res.end(JSON.stringify(response));
+    } catch (error) {
+      res.statusCode = 500;
+      res.end(JSON.stringify({ ok: false, error: String(error) }));
+    }
+    return;
+  }
+
+  // UPDATE: token exists -- validate patch against namespace-specific schema
   const namespaceSchema = getNamespacePatchSchema(existingToken.namespace);
   const patchResult = namespaceSchema.safeParse(body);
   if (!patchResult.success) {
@@ -519,7 +567,6 @@ export function studioApiPlugin(): Plugin {
 
       // Listen for token updates from client
       server.ws.on('rafters:set-token', async (rawData: unknown, client) => {
-        // Validate incoming message
         const parsed = SetTokenMessageSchema.safeParse(rawData);
         if (!parsed.success) {
           client.send('rafters:token-updated', {
@@ -532,12 +579,34 @@ export function studioApiPlugin(): Plugin {
         const data = parsed.data;
         const shouldPersist = data.persist !== false;
 
+        // Detect color tokens for async enrichment
+        const existingToken = registry.get(data.name);
+        const isColorFamily =
+          existingToken?.namespace === 'color' &&
+          typeof data.value === 'object' &&
+          data.value !== null &&
+          'scale' in data.value;
+
+        // Fire API enrichment before local math (non-blocking)
+        let enrichmentPromise: Promise<unknown> | null = null;
+        if (isColorFamily) {
+          const colorValue = data.value as { scale?: Array<{ l: number; c: number; h: number }> };
+          const base = colorValue.scale?.[5]; // scale position 500 is the base
+          if (base) {
+            const l = base.l.toFixed(3);
+            const c = base.c.toFixed(3);
+            const h = Math.round(base.h);
+            enrichmentPromise = fetch(`https://api.rafters.studio/color/${l}-${c}-${h}?sync=true`)
+              .then((r) => (r.ok ? r.json() : null))
+              .catch(() => null);
+          }
+        }
+
         try {
+          // Local update (instant feedback)
           if (shouldPersist) {
-            // Full save: update + cascade + persist (callback handles CSS)
             await registry.set(data.name, data.value);
           } else {
-            // Instant feedback: update in-memory only (callback handles CSS)
             registry.updateToken(data.name, data.value);
           }
           client.send('rafters:token-updated', {
@@ -545,6 +614,28 @@ export function studioApiPlugin(): Plugin {
             name: data.name,
             persisted: shouldPersist,
           });
+
+          // Merge enrichment when it arrives
+          if (enrichmentPromise) {
+            const enrichment = await enrichmentPromise;
+            if (enrichment && typeof enrichment === 'object' && 'color' in enrichment) {
+              const apiColor = (enrichment as { color: { intelligence?: unknown } }).color;
+              if (apiColor?.intelligence) {
+                const current = registry.get(data.name);
+                if (current && typeof current.value === 'object' && current.value !== null) {
+                  const enrichedValue = {
+                    ...(current.value as Record<string, unknown>),
+                    intelligence: apiColor.intelligence,
+                  } as typeof current.value;
+                  await registry.set(data.name, enrichedValue);
+                  client.send('rafters:color-enriched', {
+                    name: data.name,
+                    intelligence: apiColor.intelligence,
+                  });
+                }
+              }
+            }
+          }
         } catch (error) {
           console.log(`[rafters] Token update failed for "${data.name}": ${error}`);
           client.send('rafters:token-updated', { ok: false, error: String(error) });


### PR DESCRIPTION
## Summary

- **POST /api/tokens/:name** creates arbitrary color families when the token doesn't exist (201 response). Accepts namespace, category, value, and why-gated reason. Enables brands with colors outside the 11 default families.
- **Async color enrichment** fires `api.rafters.studio` fetch before local `buildColorValue()` math so intelligence data fills in live via WebSocket `rafters:color-enriched` event.
- **Client-side `onColorEnriched()`** listener added to `@rafters/studio` for UI components to consume async intelligence.

Closes #1084, closes #1085

## Test plan

- [ ] POST /api/tokens/brand-coral with namespace, category, value, and reason creates new token (201)
- [ ] POST /api/tokens/brand-coral again returns existing-token update path
- [ ] New token appears in CSS custom properties and Tailwind utility classes
- [ ] Color token set triggers async enrichment fetch to api.rafters.studio
- [ ] `onColorEnriched` callback fires when intelligence arrives via WebSocket
- [ ] Local math completes instantly regardless of API latency
- [ ] Preflight passes (typecheck, lint, unit tests, a11y, build)

Generated with [Claude Code](https://claude.com/claude-code)