### PR TITLE
feat(cli): intentional onboarding and MCP write access

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -26,8 +26,6 @@ import {
   frameworkToTarget,
   hasAstroReact,
   isTailwindV3,
-  parseCssVariables,
-  type ShadcnColors,
   type ShadcnConfig,
 } from '../utils/detect.js';
 import {
@@ -584,28 +582,6 @@ export async function init(options: InitOptions): Promise<void> {
   }
 
   // Fresh initialization
-  let existingColors: { light: ShadcnColors; dark: ShadcnColors } | null = null;
-
-  if (shadcn?.tailwind?.css) {
-    const cssPath = join(cwd, shadcn.tailwind.css);
-    try {
-      const cssContent = await readFile(cssPath, 'utf-8');
-      existingColors = parseCssVariables(cssContent);
-      const backupPath = await backupCss(cssPath);
-
-      log({
-        event: 'init:shadcn_detected',
-        cssPath: shadcn.tailwind.css,
-        backupPath,
-        colorsFound: {
-          light: Object.keys(existingColors.light).length,
-          dark: Object.keys(existingColors.dark).length,
-        },
-      });
-    } catch (err) {
-      log({ event: 'init:shadcn_css_error', error: String(err) });
-    }
-  }
 
   // Prompt for export formats (use defaults in agent mode or non-interactive)
   let exports: ExportConfig;
@@ -631,43 +607,6 @@ export async function init(options: InitOptions): Promise<void> {
   });
 
   const { registry } = result;
-
-  // If we have existing shadcn colors, update the registry
-  if (existingColors) {
-    const tokenMap: Record<string, keyof ShadcnColors> = {
-      background: 'background',
-      foreground: 'foreground',
-      card: 'card',
-      'card-foreground': 'cardForeground',
-      popover: 'popover',
-      'popover-foreground': 'popoverForeground',
-      primary: 'primary',
-      'primary-foreground': 'primaryForeground',
-      secondary: 'secondary',
-      'secondary-foreground': 'secondaryForeground',
-      muted: 'muted',
-      'muted-foreground': 'mutedForeground',
-      accent: 'accent',
-      'accent-foreground': 'accentForeground',
-      destructive: 'destructive',
-      'destructive-foreground': 'destructiveForeground',
-      border: 'border',
-      input: 'input',
-      ring: 'ring',
-    };
-
-    for (const [tokenName, colorKey] of Object.entries(tokenMap)) {
-      const colorValue = existingColors.light[colorKey];
-      if (colorValue && registry.has(tokenName)) {
-        registry.updateToken(tokenName, colorValue);
-      }
-    }
-
-    log({
-      event: 'init:colors_imported',
-      count: Object.keys(existingColors.light).length,
-    });
-  }
 
   log({
     event: 'init:generated',
@@ -751,9 +690,48 @@ export async function init(options: InitOptions): Promise<void> {
   };
   await writeFile(paths.config, JSON.stringify(config, null, 2));
 
+  // Check if the project has existing design decisions that should be onboarded intentionally
+  const existingCssPath = detectedCssPath ?? (shadcn?.tailwind?.css || null);
+  if (existingCssPath) {
+    try {
+      const cssContent = await readFile(join(cwd, existingCssPath), 'utf-8');
+      if (hasExistingDesignDecisions(cssContent)) {
+        log({
+          event: 'init:existing_design_detected',
+          cssPath: existingCssPath,
+          action: 'run rafters_onboard analyze to begin migration',
+        });
+      }
+    } catch {
+      // CSS file unreadable, skip detection
+    }
+  }
+
   log({
     event: 'init:complete',
     outputs: [...outputs, 'config.rafters.json'],
     path: paths.output,
   });
+}
+
+/**
+ * Check if CSS content contains design decisions beyond boilerplate.
+ * Does NOT interpret the content -- just detects that something is there.
+ */
+function hasExistingDesignDecisions(css: string): boolean {
+  // Strip comments
+  const stripped = css.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*/g, '');
+
+  // Strip imports and tailwind directives
+  const withoutBoilerplate = stripped
+    .replace(/@import\s+['"][^'"]+['"];?/g, '')
+    .replace(/@tailwind\s+\w+;?/g, '')
+    .trim();
+
+  if (withoutBoilerplate.length === 0) return false;
+
+  const hasCustomProperties = /--[\w-]+\s*:/.test(stripped);
+  const hasThemeBlock = /@theme\s*\{/.test(stripped);
+
+  return hasCustomProperties || hasThemeBlock;
 }

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -14,7 +14,7 @@
  */
 
 import { existsSync } from 'node:fs';
-import { readdir, readFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
 import { basename, join, relative } from 'node:path';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import {
@@ -23,8 +23,13 @@ import {
   DEFAULT_SPACING_MULTIPLIERS,
   DEFAULT_TYPOGRAPHY_SCALE,
   NodePersistenceAdapter,
+  registryToTailwind,
+  registryToTypeScript,
+  TokenRegistry,
+  toDTCG,
 } from '@rafters/design-tokens';
 import {
+  COMPUTED,
   type ColorValue,
   type ComponentMetadata,
   extractDependencies,
@@ -498,7 +503,7 @@ export const TOOL_DEFINITIONS = [
   {
     name: 'rafters_token',
     description:
-      'Get full intelligence for a design token: current value, derivation rule, dependencies, dependents (cascade impact), and human override context. Shows what the system computes vs what a designer chose and why. Use when you need to understand token relationships or respect designer decisions.',
+      'Read or write a design token. Read: returns full intelligence (value, derivation, dependencies, cascade impact, override context). Write: set/create/reset tokens with mandatory reason (why-gate). Every write cascades through the dependency graph, persists to disk, and regenerates CSS/TS/DTCG outputs.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -506,6 +511,30 @@ export const TOOL_DEFINITIONS = [
           type: 'string',
           description:
             'Token name (e.g., "spacing-6", "primary-500", "spacing-base"). Use rafters_vocabulary to see available tokens.',
+        },
+        action: {
+          type: 'string',
+          enum: ['get', 'set', 'create', 'reset'],
+          description:
+            'Action to perform. get (default): read token intelligence. set: update existing token value. create: add a new token. reset: clear override, restore computed value.',
+        },
+        value: {
+          type: 'string',
+          description: 'New token value (required for set and create actions).',
+        },
+        reason: {
+          type: 'string',
+          description:
+            'Why this change is being made (required for set, create, and reset). Every mutation needs a reason that captures design INTENT.',
+        },
+        namespace: {
+          type: 'string',
+          description:
+            'Token namespace (required for create). E.g., "color", "spacing", "typography".',
+        },
+        category: {
+          type: 'string',
+          description: 'Token category (required for create). E.g., "color", "spacing", "font".',
         },
       },
       required: ['name'],
@@ -578,8 +607,11 @@ export class RaftersToolHandler {
         return this.getPattern(args.pattern as string);
       case 'rafters_component':
         return this.getComponent(args.name as string);
-      case 'rafters_token':
-        return this.getToken(args.name as string);
+      case 'rafters_token': {
+        const action = (args.action as string) ?? 'get';
+        if (action === 'get') return this.getToken(args.name as string);
+        return this.writeToken(action, args);
+      }
       case 'rafters_cognitive_budget':
         return this.getCognitiveBudget(
           args.components as string[],
@@ -1219,6 +1251,265 @@ export class RaftersToolHandler {
       };
     } catch (error) {
       return this.handleError('getToken', error);
+    }
+  }
+
+  // ==================== Token Write Operations ====================
+
+  /**
+   * Handle set, create, and reset actions for rafters_token.
+   * Loads the full registry, mutates, cascades, persists, and regenerates outputs.
+   */
+  private async writeToken(action: string, args: Record<string, unknown>): Promise<CallToolResult> {
+    const name = args.name as string;
+    const reason = args.reason as string | undefined;
+    const value = args.value as string | undefined;
+
+    // Why-gate: every mutation needs a reason
+    if (!reason) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              error: 'Reason is required for every token mutation.',
+              hint: 'Every change needs a WHY that captures design intent, not just origin.',
+              bad: 'imported from globals.css',
+              good: 'Brand blue from --brand-primary, primary identity color per designer',
+            }),
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    if (!this.adapter || !this.projectRoot) {
+      return { content: [{ type: 'text', text: NO_PROJECT_ERROR }], isError: true };
+    }
+
+    try {
+      // Load full registry
+      const allTokens = await this.adapter.load();
+      const registry = new TokenRegistry(allTokens);
+      registry.setAdapter(this.adapter);
+
+      switch (action) {
+        case 'set': {
+          if (!value) {
+            return {
+              content: [{ type: 'text', text: '{"error": "value is required for set action"}' }],
+              isError: true,
+            };
+          }
+          const existing = registry.get(name);
+          if (!existing) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify({
+                    error: `Token "${name}" not found. Use action: "create" for new tokens.`,
+                  }),
+                },
+              ],
+              isError: true,
+            };
+          }
+
+          // Set with userOverride tracking
+          const previousValue = existing.value;
+          existing.userOverride = {
+            previousValue:
+              typeof previousValue === 'string' ? previousValue : JSON.stringify(previousValue),
+            reason,
+          };
+          await registry.set(name, value);
+
+          const affected = this.getAffectedTokens(registry, name);
+          await this.regenerateOutputs(registry);
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  ok: true,
+                  action: 'set',
+                  name,
+                  reason,
+                  cascaded: affected,
+                }),
+              },
+            ],
+          };
+        }
+
+        case 'create': {
+          const namespace = args.namespace as string | undefined;
+          const category = args.category as string | undefined;
+
+          if (!value) {
+            return {
+              content: [{ type: 'text', text: '{"error": "value is required for create action"}' }],
+              isError: true,
+            };
+          }
+          if (!namespace) {
+            return {
+              content: [
+                { type: 'text', text: '{"error": "namespace is required for create action"}' },
+              ],
+              isError: true,
+            };
+          }
+          if (!category) {
+            return {
+              content: [
+                { type: 'text', text: '{"error": "category is required for create action"}' },
+              ],
+              isError: true,
+            };
+          }
+          if (registry.has(name)) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify({
+                    error: `Token "${name}" already exists. Use action: "set" to update.`,
+                  }),
+                },
+              ],
+              isError: true,
+            };
+          }
+
+          const newToken: Token = {
+            name,
+            namespace,
+            category,
+            value,
+            containerQueryAware: true,
+            userOverride: {
+              previousValue: '',
+              reason,
+            },
+          };
+
+          registry.add(newToken);
+          await this.adapter.save(registry.list());
+          await this.regenerateOutputs(registry);
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  ok: true,
+                  action: 'create',
+                  name,
+                  namespace,
+                  reason,
+                }),
+              },
+            ],
+          };
+        }
+
+        case 'reset': {
+          const existing = registry.get(name);
+          if (!existing) {
+            return {
+              content: [
+                { type: 'text', text: JSON.stringify({ error: `Token "${name}" not found.` }) },
+              ],
+              isError: true,
+            };
+          }
+
+          await registry.set(name, COMPUTED);
+
+          const affected = this.getAffectedTokens(registry, name);
+          await this.regenerateOutputs(registry);
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  ok: true,
+                  action: 'reset',
+                  name,
+                  reason,
+                  cascaded: affected,
+                }),
+              },
+            ],
+          };
+        }
+
+        default:
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  error: `Unknown action: ${action}. Use get, set, create, or reset.`,
+                }),
+              },
+            ],
+            isError: true,
+          };
+      }
+    } catch (error) {
+      return this.handleError('writeToken', error);
+    }
+  }
+
+  /**
+   * Get list of tokens that would be affected by changing the given token
+   */
+  private getAffectedTokens(registry: TokenRegistry, tokenName: string): string[] {
+    const affected: string[] = [];
+    for (const token of registry.list()) {
+      if (token.dependsOn?.includes(tokenName)) {
+        affected.push(token.name);
+      }
+    }
+    return affected;
+  }
+
+  /**
+   * Regenerate output files (CSS, TS, DTCG) from registry state
+   */
+  private async regenerateOutputs(registry: TokenRegistry): Promise<void> {
+    if (!this.projectRoot) return;
+
+    const paths = getRaftersPaths(this.projectRoot);
+    const config = await this.loadConfig();
+    const exports = config?.exports ?? {
+      tailwind: true,
+      typescript: true,
+      dtcg: false,
+      compiled: false,
+    };
+    const shadcn = config?.shadcn ?? false;
+
+    await mkdir(paths.output, { recursive: true });
+
+    if (exports.tailwind) {
+      const css = registryToTailwind(registry, { includeImport: !shadcn });
+      await writeFile(join(paths.output, 'rafters.css'), css);
+    }
+
+    if (exports.typescript) {
+      const ts = registryToTypeScript(registry, { includeJSDoc: true });
+      await writeFile(join(paths.output, 'rafters.ts'), ts);
+    }
+
+    if (exports.dtcg) {
+      const json = toDTCG(registry.list());
+      await writeFile(join(paths.output, 'rafters.json'), JSON.stringify(json, null, 2));
     }
   }
 

--- a/packages/cli/src/utils/detect.ts
+++ b/packages/cli/src/utils/detect.ts
@@ -16,28 +16,6 @@ export interface ShadcnConfig {
   };
 }
 
-export interface ShadcnColors {
-  background?: string;
-  foreground?: string;
-  card?: string;
-  cardForeground?: string;
-  popover?: string;
-  popoverForeground?: string;
-  primary?: string;
-  primaryForeground?: string;
-  secondary?: string;
-  secondaryForeground?: string;
-  muted?: string;
-  mutedForeground?: string;
-  accent?: string;
-  accentForeground?: string;
-  destructive?: string;
-  destructiveForeground?: string;
-  border?: string;
-  input?: string;
-  ring?: string;
-}
-
 export interface ProjectDetection {
   framework: Framework;
   shadcn: ShadcnConfig | null;
@@ -155,58 +133,6 @@ export async function detectShadcn(cwd: string): Promise<ShadcnConfig | null> {
     return JSON.parse(content) as ShadcnConfig;
   } catch {
     return null;
-  }
-}
-
-/**
- * Parse CSS variables from a CSS file into light/dark color objects
- */
-export function parseCssVariables(css: string): { light: ShadcnColors; dark: ShadcnColors } {
-  const light: ShadcnColors = {};
-  const dark: ShadcnColors = {};
-
-  const rootMatch = css.match(/:root\s*\{([^}]+)\}/);
-  if (rootMatch?.[1]) {
-    parseVariablesIntoColors(rootMatch[1], light);
-  }
-
-  const darkMatch = css.match(/\.dark\s*\{([^}]+)\}/);
-  if (darkMatch?.[1]) {
-    parseVariablesIntoColors(darkMatch[1], dark);
-  }
-
-  return { light, dark };
-}
-
-function parseVariablesIntoColors(block: string, colors: ShadcnColors): void {
-  const varMap: Record<string, keyof ShadcnColors> = {
-    '--background': 'background',
-    '--foreground': 'foreground',
-    '--card': 'card',
-    '--card-foreground': 'cardForeground',
-    '--popover': 'popover',
-    '--popover-foreground': 'popoverForeground',
-    '--primary': 'primary',
-    '--primary-foreground': 'primaryForeground',
-    '--secondary': 'secondary',
-    '--secondary-foreground': 'secondaryForeground',
-    '--muted': 'muted',
-    '--muted-foreground': 'mutedForeground',
-    '--accent': 'accent',
-    '--accent-foreground': 'accentForeground',
-    '--destructive': 'destructive',
-    '--destructive-foreground': 'destructiveForeground',
-    '--border': 'border',
-    '--input': 'input',
-    '--ring': 'ring',
-  };
-
-  for (const [cssVar, colorKey] of Object.entries(varMap)) {
-    const regex = new RegExp(`${cssVar}:\\s*([^;]+);`);
-    const match = block.match(regex);
-    if (match?.[1]) {
-      colors[colorKey] = match[1].trim();
-    }
   }
 }
 

--- a/packages/cli/src/utils/ui.ts
+++ b/packages/cli/src/utils/ui.ts
@@ -52,15 +52,6 @@ export function log(event: Record<string, unknown>): void {
       context.spinner = ora('Generating tokens...').start();
       break;
 
-    case 'init:shadcn_detected': {
-      context.spinner?.info('Found existing shadcn colors');
-      console.log(`  Backed up: ${event.backupPath}`);
-      const colors = event.colorsFound as { light: number; dark: number };
-      console.log(`  Colors: ${colors.light} light, ${colors.dark} dark`);
-      context.spinner = ora('Generating tokens...').start();
-      break;
-    }
-
     case 'init:generated':
       context.spinner?.succeed(`Generated ${event.tokenCount} tokens`);
       context.spinner = ora('Saving registry...').start();
@@ -91,8 +82,16 @@ export function log(event: Record<string, unknown>): void {
       context.spinner = ora('Generating outputs...').start();
       break;
 
-    case 'init:colors_imported':
-      console.log(`  Imported ${event.count} existing colors`);
+    case 'init:existing_design_detected':
+      context.spinner?.info('Existing design system detected');
+      console.log(`  Found design decisions in ${event.cssPath}`);
+      console.log('');
+      console.log('  Your existing CSS has design decisions that should be');
+      console.log('  migrated intentionally, not automatically.');
+      console.log('');
+      console.log('  Ask your AI agent: "Onboard my existing design system to Rafters"');
+      console.log('');
+      context.spinner = ora('Finishing up...').start();
       break;
 
     case 'init:prompting_exports':

--- a/packages/cli/test/utils/detect.test.ts
+++ b/packages/cli/test/utils/detect.test.ts
@@ -8,7 +8,6 @@ import {
   detectShadcn,
   detectTailwindVersion,
   isTailwindV3,
-  parseCssVariables,
 } from '../../src/utils/detect.js';
 
 describe('detectFramework', () => {
@@ -280,103 +279,6 @@ describe('detectShadcn', () => {
   it('should return null when components.json does not exist', async () => {
     const result = await detectShadcn(testDir);
     expect(result).toBeNull();
-  });
-});
-
-describe('parseCssVariables', () => {
-  it('should parse light mode variables from :root', () => {
-    const css = `
-:root {
-  --background: 0 0% 100%;
-  --foreground: 222.2 84% 4.9%;
-  --primary: 222.2 47.4% 11.2%;
-  --primary-foreground: 210 40% 98%;
-}
-`;
-
-    const { light, dark } = parseCssVariables(css);
-
-    expect(light.background).toBe('0 0% 100%');
-    expect(light.foreground).toBe('222.2 84% 4.9%');
-    expect(light.primary).toBe('222.2 47.4% 11.2%');
-    expect(light.primaryForeground).toBe('210 40% 98%');
-    expect(dark).toEqual({});
-  });
-
-  it('should parse dark mode variables from .dark', () => {
-    const css = `
-:root {
-  --background: 0 0% 100%;
-}
-
-.dark {
-  --background: 222.2 84% 4.9%;
-  --foreground: 210 40% 98%;
-}
-`;
-
-    const { light, dark } = parseCssVariables(css);
-
-    expect(light.background).toBe('0 0% 100%');
-    expect(dark.background).toBe('222.2 84% 4.9%');
-    expect(dark.foreground).toBe('210 40% 98%');
-  });
-
-  it('should parse all shadcn color variables', () => {
-    const css = `
-:root {
-  --background: 0 0% 100%;
-  --foreground: 222.2 84% 4.9%;
-  --card: 0 0% 100%;
-  --card-foreground: 222.2 84% 4.9%;
-  --popover: 0 0% 100%;
-  --popover-foreground: 222.2 84% 4.9%;
-  --primary: 222.2 47.4% 11.2%;
-  --primary-foreground: 210 40% 98%;
-  --secondary: 210 40% 96.1%;
-  --secondary-foreground: 222.2 47.4% 11.2%;
-  --muted: 210 40% 96.1%;
-  --muted-foreground: 215.4 16.3% 46.9%;
-  --accent: 210 40% 96.1%;
-  --accent-foreground: 222.2 47.4% 11.2%;
-  --destructive: 0 84.2% 60.2%;
-  --destructive-foreground: 210 40% 98%;
-  --border: 214.3 31.8% 91.4%;
-  --input: 214.3 31.8% 91.4%;
-  --ring: 222.2 84% 4.9%;
-}
-`;
-
-    const { light } = parseCssVariables(css);
-
-    expect(light.background).toBeDefined();
-    expect(light.foreground).toBeDefined();
-    expect(light.card).toBeDefined();
-    expect(light.cardForeground).toBeDefined();
-    expect(light.popover).toBeDefined();
-    expect(light.popoverForeground).toBeDefined();
-    expect(light.primary).toBeDefined();
-    expect(light.primaryForeground).toBeDefined();
-    expect(light.secondary).toBeDefined();
-    expect(light.secondaryForeground).toBeDefined();
-    expect(light.muted).toBeDefined();
-    expect(light.mutedForeground).toBeDefined();
-    expect(light.accent).toBeDefined();
-    expect(light.accentForeground).toBeDefined();
-    expect(light.destructive).toBeDefined();
-    expect(light.destructiveForeground).toBeDefined();
-    expect(light.border).toBeDefined();
-    expect(light.input).toBeDefined();
-    expect(light.ring).toBeDefined();
-  });
-
-  it('should return empty objects for CSS without variables', () => {
-    const css = `body { margin: 0; }`;
-
-    const { light, dark } = parseCssVariables(css);
-
-    expect(light).toEqual({});
-    expect(dark).toEqual({});
   });
 });
 


### PR DESCRIPTION
## Summary

- **Strip init to scaffold-only** (#1088): Remove `parseCssVariables`, `ShadcnColors` interface, `tokenMap` color mapping, and `parseVariablesIntoColors`. Init no longer tries to mechanically import shadcn colors. Instead detects existing CSS design decisions and directs to MCP onboarding.
- **MCP write access for `rafters_token`** (#1089): Add `set`, `create`, and `reset` actions. Every mutation requires a reason (why-gate enforced). Writes cascade through dependency graph, persist to `.rafters/tokens/`, and regenerate CSS/TS/DTCG outputs. Works without the studio server.
- **Existing design detection** (partial #1092): `hasExistingDesignDecisions()` checks for custom properties and `@theme` blocks. Outputs onboarding message to human or structured JSON to agent.

## Test plan

- [ ] `rafters init` on blank project works as before (defaults generated)
- [ ] `rafters init` on project with existing CSS custom properties shows onboarding message
- [ ] `rafters_token` with `action: "get"` (or no action) returns read-only intelligence as before
- [ ] `rafters_token` with `action: "set"` updates token, cascades, regenerates outputs
- [ ] `rafters_token` with `action: "create"` adds new token with namespace/category
- [ ] `rafters_token` with `action: "reset"` clears override via COMPUTED
- [ ] All write actions without `reason` return why-gate error
- [ ] `create` on existing token returns 409-equivalent error
- [ ] `set` on nonexistent token returns 404-equivalent error
- [ ] Preflight passes (typecheck, lint, 266 unit tests, a11y, build)

Generated with [Claude Code](https://claude.com/claude-code)