### PR TITLE
chore: release v0.0.28

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # rafters
 
+## 0.0.28
+
+### Minor Changes
+
+- MCP write access: `rafters_token` tool now supports set, create, and reset actions with mandatory why-gate reasoning
+- `rafters_onboard` MCP tool: analyze existing CSS for design decisions, map them to tokens with the designer in the loop
+- Init stripped to scaffold-only: no more automatic shadcn color mapping, detects existing design decisions and directs to MCP onboarding
+- System preamble updated with intentional onboarding guidance
+- 22 Astro components: Alert, Avatar, Breadcrumb, Empty, Image, Item, Pagination, Progress, Spinner, Table, Tabs, Tooltip (with shared .classes.ts for React/Astro parity)
+
 ## 0.0.27
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "CLI for Rafters design system - scaffold tokens and add components",
   "license": "MIT",
   "type": "module",

--- a/packages/shared/src/version.ts
+++ b/packages/shared/src/version.ts
@@ -3,4 +3,4 @@
  * Used by the CLI package.json, the API root endpoint, and anywhere
  * else that needs to report the current version.
  */
-export const RAFTERS_VERSION = '0.0.27';
+export const RAFTERS_VERSION = '0.0.28';


### PR DESCRIPTION
## Summary

Version bump to 0.0.28. Tag after merge.

### What's in 0.0.28

- **MCP write access**: `rafters_token` supports set, create, reset with mandatory why-gate
- **`rafters_onboard` tool**: analyze existing CSS, map design decisions to tokens with designer in the loop
- **Init stripped to scaffold-only**: no more automatic shadcn color mapping, directs to MCP onboarding
- **22 Astro components**: Alert, Avatar, Breadcrumb, Empty, Image, Item, Pagination, Progress, Spinner, Table, Tabs, Tooltip (shared .classes.ts for React/Astro parity)
- **Create token endpoint**: POST /api/tokens/:name for arbitrary color families
- **Async color enrichment**: WebSocket-based intelligence fill-in from api.rafters.studio