### PR TITLE
feat(mcp): family checklist, status action, and completeness tracking

### DIFF
--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -588,9 +588,9 @@ export const TOOL_DEFINITIONS = [
       properties: {
         action: {
           type: 'string',
-          enum: ['analyze', 'map'],
+          enum: ['analyze', 'map', 'status'],
           description:
-            'analyze: scan project CSS and return structured findings. map: execute confirmed mappings. First call without confirmed returns instructions to ask the designer. Second call with confirmed: true executes.',
+            'analyze: scan CSS and return findings + family checklist. status: show which of the 11 families have designer decisions vs defaults. map: execute confirmed mappings (requires confirmed: true after designer review).',
         },
         confirmed: {
           type: 'boolean',
@@ -1611,6 +1611,24 @@ export class RaftersToolHandler {
   };
 
   /**
+   * The 11 semantic color families every design system needs.
+   * Defaults are not wrong. Unexamined defaults are wrong.
+   */
+  private static readonly SEMANTIC_FAMILIES = [
+    'primary',
+    'secondary',
+    'tertiary',
+    'accent',
+    'neutral',
+    'success',
+    'warning',
+    'destructive',
+    'info',
+    'highlight',
+    'muted',
+  ] as const;
+
+  /**
    * Handle rafters_onboard tool calls
    */
   private async onboard(args: Record<string, unknown>): Promise<CallToolResult> {
@@ -1619,6 +1637,8 @@ export class RaftersToolHandler {
     switch (action) {
       case 'analyze':
         return this.analyzeProject();
+      case 'status':
+        return this.getOnboardStatus();
       case 'map': {
         const confirmed = args.confirmed as boolean | undefined;
         if (!confirmed) {
@@ -1742,11 +1762,27 @@ export class RaftersToolHandler {
         // No package.json
       }
 
-      // Count existing rafters tokens
+      // Count existing tokens and check family status
       let existingTokenCount = 0;
+      const familyStatus: Record<
+        string,
+        { status: 'default' | 'designer' | 'unmapped'; reason?: string }
+      > = {};
+
       if (this.adapter) {
         const tokens = await this.adapter.load();
         existingTokenCount = tokens.length;
+
+        for (const family of RaftersToolHandler.SEMANTIC_FAMILIES) {
+          const token = tokens.find((t) => t.name === family);
+          if (!token) {
+            familyStatus[family] = { status: 'unmapped' };
+          } else if (token.userOverride?.reason) {
+            familyStatus[family] = { status: 'designer', reason: token.userOverride.reason };
+          } else {
+            familyStatus[family] = { status: 'default' };
+          }
+        }
       }
 
       // Detect color scale patterns (e.g., --color-blaze-50 through --color-blaze-950)
@@ -1789,10 +1825,17 @@ export class RaftersToolHandler {
         }
       }
 
+      const designerCount = Object.values(familyStatus).filter(
+        (s) => s.status === 'designer',
+      ).length;
+      const totalFamilies = RaftersToolHandler.SEMANTIC_FAMILIES.length;
+
       const result = {
         framework,
         cssFiles: cssFindings,
         colorFamilies: detectedFamilies.length > 0 ? detectedFamilies : undefined,
+        familyStatus,
+        familyCoverage: `${designerCount}/${totalFamilies} semantic families have designer decisions`,
         shadcn,
         designDependencies: designDeps,
         existingTokenCount,
@@ -1807,6 +1850,77 @@ export class RaftersToolHandler {
       };
     } catch (error) {
       return this.handleError('analyzeProject', error);
+    }
+  }
+
+  /**
+   * Check onboarding completeness -- which families have designer decisions
+   */
+  private async getOnboardStatus(): Promise<CallToolResult> {
+    if (!this.adapter || !this.projectRoot) {
+      return { content: [{ type: 'text', text: NO_PROJECT_ERROR }], isError: true };
+    }
+
+    try {
+      const tokens = await this.adapter.load();
+      const mapped: string[] = [];
+      const defaultsRemaining: string[] = [];
+      const unmapped: string[] = [];
+
+      for (const family of RaftersToolHandler.SEMANTIC_FAMILIES) {
+        const token = tokens.find((t) => t.name === family);
+        if (!token) {
+          unmapped.push(family);
+        } else if (token.userOverride?.reason) {
+          mapped.push(family);
+        } else {
+          defaultsRemaining.push(family);
+        }
+      }
+
+      // Find custom color families (non-semantic, in color namespace, with designer reason)
+      const semanticSet = new Set<string>(RaftersToolHandler.SEMANTIC_FAMILIES);
+      const customFamilies = tokens
+        .filter(
+          (t) =>
+            t.namespace === 'color' &&
+            !semanticSet.has(t.name) &&
+            t.userOverride?.reason &&
+            !t.name.includes('-'),
+        )
+        .map((t) => t.name);
+
+      const complete = defaultsRemaining.length === 0 && unmapped.length === 0;
+      const coverage = `${mapped.length}/${RaftersToolHandler.SEMANTIC_FAMILIES.length}`;
+
+      let guidance: string;
+      if (complete) {
+        guidance = 'All semantic families have designer decisions. Onboarding is complete.';
+      } else if (defaultsRemaining.length > 0) {
+        guidance = `${defaultsRemaining.length} families still use generated defaults: ${defaultsRemaining.join(', ')}. Ask the designer: do these defaults work, or should we choose specific colors? If the defaults are intentional, confirm them with a reason.`;
+      } else {
+        guidance = `${unmapped.length} families are unmapped: ${unmapped.join(', ')}. These need designer decisions.`;
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                complete,
+                coverage,
+                families: { mapped, defaultsRemaining, unmapped, customFamilies },
+                guidance,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    } catch (error) {
+      return this.handleError('getOnboardStatus', error);
     }
   }
 

--- a/packages/cli/test/mcp/onboard.test.ts
+++ b/packages/cli/test/mcp/onboard.test.ts
@@ -418,6 +418,146 @@ describe('rafters_onboard analyze', () => {
     // Default color system has 535 tokens
     expect(data.existingTokenCount).toBeGreaterThanOrEqual(500);
   });
+
+  it('includes family checklist showing all 11 families as defaults after init', async () => {
+    fixturePath = await createOnboardFixture('family-checklist', {
+      css: { 'src/index.css': CSS_CLEAN_OKLCH },
+      seedTokens: true,
+    });
+
+    const handler = new RaftersToolHandler(fixturePath);
+    const result = await handler.handleToolCall('rafters_onboard', { action: 'analyze' });
+    const data = JSON.parse((result.content[0] as { text: string }).text);
+
+    // All 11 families should be present in the checklist
+    expect(data.familyStatus).toBeDefined();
+    const families = Object.keys(data.familyStatus);
+    expect(families).toContain('primary');
+    expect(families).toContain('secondary');
+    expect(families).toContain('destructive');
+    expect(families).toContain('accent');
+    expect(families).toContain('neutral');
+    expect(families).toContain('success');
+    expect(families).toContain('warning');
+    expect(families).toContain('info');
+    expect(families).toContain('highlight');
+    expect(families).toContain('muted');
+    expect(families).toContain('tertiary');
+
+    // Most should be defaults, tertiary may be unmapped (not in default generators)
+    for (const family of families) {
+      const status = data.familyStatus[family].status;
+      expect(status === 'default' || status === 'unmapped').toBe(true);
+    }
+
+    // Coverage should be 0/11 (no designer decisions yet)
+    expect(data.familyCoverage).toBe('0/11 semantic families have designer decisions');
+  });
+});
+
+describe('rafters_onboard status', () => {
+  let fixturePath: string;
+
+  afterEach(async () => {
+    if (fixturePath) await rm(fixturePath, { recursive: true, force: true });
+  });
+
+  it('shows all defaults after fresh init', async () => {
+    fixturePath = await createOnboardFixture('status-fresh', {
+      css: { 'src/index.css': CSS_CLEAN_OKLCH },
+      seedTokens: true,
+    });
+
+    const handler = new RaftersToolHandler(fixturePath);
+    const result = await handler.handleToolCall('rafters_onboard', { action: 'status' });
+    const data = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(data.complete).toBe(false);
+    expect(data.coverage).toBe('0/11');
+    expect(data.families.mapped).toHaveLength(0);
+    // 10 defaults + 1 unmapped (tertiary not in default generators)
+    const totalUnaddressed = data.families.defaultsRemaining.length + data.families.unmapped.length;
+    expect(totalUnaddressed).toBe(11);
+  });
+
+  it('tracks progress after designer maps some families', async () => {
+    fixturePath = await createOnboardFixture('status-partial', {
+      css: { 'src/index.css': CSS_HORRIBLE_LEGACY },
+      seedTokens: true,
+    });
+
+    const handler = new RaftersToolHandler(fixturePath);
+
+    // Designer maps 3 families
+    await handler.handleToolCall('rafters_onboard', {
+      action: 'map',
+      confirmed: true,
+      mappings: [
+        {
+          source: '--brand-blue',
+          target: 'primary',
+          value: '#2563eb',
+          reason: 'This blue has been on our nav since 2019',
+        },
+        {
+          source: '--brand-red',
+          target: 'destructive',
+          value: 'rgb(220, 38, 38)',
+          reason: 'Legal required this exact red for error states',
+        },
+        {
+          source: '--brand-green',
+          target: 'success',
+          value: 'hsl(142, 71%, 45%)',
+          reason: 'Chosen for deuteranopia distinguishability',
+        },
+      ],
+    });
+
+    // Check status
+    const result = await handler.handleToolCall('rafters_onboard', { action: 'status' });
+    const data = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(data.complete).toBe(false);
+    expect(data.coverage).toBe('3/11');
+    expect(data.families.mapped).toContain('primary');
+    expect(data.families.mapped).toContain('destructive');
+    expect(data.families.mapped).toContain('success');
+    // 8 remaining = defaults + unmapped
+    const remaining = data.families.defaultsRemaining.length + data.families.unmapped.length;
+    expect(remaining).toBe(8);
+    expect(data.families.defaultsRemaining).not.toContain('primary');
+  });
+
+  it('includes custom families created during onboarding', async () => {
+    fixturePath = await createOnboardFixture('status-custom', {
+      css: { 'src/index.css': CSS_EXISTING_SCALES },
+      seedTokens: true,
+    });
+
+    const handler = new RaftersToolHandler(fixturePath);
+
+    // Create custom faction families
+    await handler.handleToolCall('rafters_onboard', {
+      action: 'map',
+      confirmed: true,
+      mappings: [
+        {
+          source: '--color-blaze-500',
+          target: 'blaze',
+          value: 'oklch(0.62 0.20 45)',
+          reason: 'Mandalorian faction color',
+          namespace: 'color',
+          category: 'color',
+        },
+      ],
+    });
+
+    const result = await handler.handleToolCall('rafters_onboard', { action: 'status' });
+    const data = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(data.families.customFamilies).toContain('blaze');
+  });
 });
 
 // ==================== Designer Decisions ====================


### PR DESCRIPTION
## Summary

- **Family checklist in analyze** (#1101): Returns `familyStatus` for all 11 semantic families with status (default/designer/unmapped) and `familyCoverage` fraction. Agent sees "0/11 families have designer decisions" immediately.
- **Status action** (#1102): `rafters_onboard status` shows mapped families, defaults remaining, unmapped, and custom families. Guidance tells the agent what to ask next.
- Unexamined defaults are wrong. Even keeping a default needs a confirmed reason.

Closes #1101, closes #1102

## Test plan

- [x] Analyze includes familyStatus for all 11 families after init
- [x] All families show as default or unmapped (tertiary not in generators)
- [x] Status shows 0/11 after fresh init
- [x] Status tracks to 3/11 after mapping primary, destructive, success
- [x] Custom families (blaze) appear in status customFamilies
- [x] 20 onboard tests pass, 286 total
- [x] Preflight passes

Generated with [Claude Code](https://claude.com/claude-code)