### PR TITLE
chore: release v0.0.29

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # rafters
 
+## 0.0.29
+
+### Minor Changes
+
+- Human confirmation gate on `rafters_onboard map`: tool refuses without `confirmed: true`, instructs agent to ask the designer first
+- Color enrichment pipeline: hex/rgb/hsl/oklch parsed via colorjs.io, enriched through `buildColorValue()` + api.rafters.studio intelligence
+- Scale pattern detection in analyze: detects existing 11-step color families (e.g., --color-blaze-50 through --color-blaze-950)
+- Family checklist in analyze: shows all 11 semantic families with status (default/designer/unmapped) and coverage fraction
+- `rafters_onboard status` action: completeness tracking for onboarding progress
+- @theme block properties now extracted into customProperties (previously only captured as raw strings)
+- 20 onboard integration tests with real designer decision fixtures (legal requirements, colorblind testing, art director intent)
+
 ## 0.0.28
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "CLI for Rafters design system - scaffold tokens and add components",
   "license": "MIT",
   "type": "module",

--- a/packages/shared/src/version.ts
+++ b/packages/shared/src/version.ts
@@ -3,4 +3,4 @@
  * Used by the CLI package.json, the API root endpoint, and anywhere
  * else that needs to report the current version.
  */
-export const RAFTERS_VERSION = '0.0.28';
+export const RAFTERS_VERSION = '0.0.29';


### PR DESCRIPTION
## Summary

Version bump to 0.0.29. Tag after merge.

### What's in 0.0.29

- **Human confirmation gate**: `rafters_onboard map` refuses without `confirmed: true`, tells agent to ask designer first
- **Color enrichment pipeline**: all CSS color formats enriched to full ColorValue (11-step scale, harmonies, accessibility, API intelligence)
- **Scale pattern detection**: analyze detects existing --color-*-50 through --color-*-950 families
- **Family checklist**: analyze returns status for all 11 semantic families (default/designer/unmapped)
- **Status action**: `rafters_onboard status` shows onboarding completeness (3/11 mapped, 8 remaining)
- **@theme fix**: properties inside @theme blocks now extracted into customProperties
- **20 onboard integration tests**: real designer decisions as fixtures, not agent guesses