### PR TITLE
fix(cli): Astro projects no longer install react from .tsx variant deps

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -538,10 +538,12 @@ export async function add(componentArgs: string[], options: AddOptions): Promise
     }
   }
 
-  // Install all resolved items
+  // Install all resolved items, tracking framework-filtered versions for dep collection
   const installed: string[] = [];
   const skipped: string[] = [];
   const installedItems: RegistryItem[] = [];
+  const filteredItems: RegistryItem[] = [];
+  const target = getComponentTarget(config);
 
   for (const item of allItems) {
     // Skip items already tracked in config (unless --overwrite)
@@ -561,6 +563,16 @@ export async function add(componentArgs: string[], options: AddOptions): Promise
       if (result.installed) {
         installed.push(item.name);
         installedItems.push(item);
+
+        // Create a filtered copy with only the framework-selected files
+        // so dependency collection doesn't pull in deps from other frameworks
+        if (item.type === 'ui') {
+          const selection = selectFilesForFramework(item.files, target);
+          filteredItems.push({ ...item, files: selection.files });
+        } else {
+          filteredItems.push(item);
+        }
+
         log({
           event: 'add:installed',
           component: item.name,
@@ -584,7 +596,7 @@ export async function add(componentArgs: string[], options: AddOptions): Promise
     }
   }
 
-  // Collect, filter, and install dependencies (safety-net: never fails the whole command)
+  // Collect, filter, and install dependencies from framework-filtered files only
   const emptyDeps: InstallRegistryDepsResult = {
     installed: [],
     skipped: [],
@@ -593,7 +605,7 @@ export async function add(componentArgs: string[], options: AddOptions): Promise
   };
   let depsResult = emptyDeps;
   try {
-    depsResult = await installRegistryDependencies(allItems, cwd);
+    depsResult = await installRegistryDependencies(filteredItems, cwd);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log({


### PR DESCRIPTION
## Summary

`rafters add container` in an Astro project installed `react@19.2.0` as a dependency even though only the `.astro` file was written. The `.tsx` variant's deps leaked into the install.

**Root cause**: `installRegistryDependencies` collected deps from ALL files in the registry item, not just the framework-filtered files that were actually installed.

**Fix**: Create framework-filtered copies of items using `selectFilesForFramework` before passing to dependency collection. Astro projects only get deps from `.astro` files. React projects only get deps from `.tsx` files.

Closes #1100

## Test plan

- [ ] `rafters add container` in Astro project: no react installed
- [ ] `rafters add container` in React project: react still installed
- [ ] Shared `.classes.ts` deps included regardless of framework
- [ ] Primitives unaffected (no framework filtering)
- [ ] Preflight passes (286 tests)