### PR TITLE
fix(color-utils): handle NaN hue from achromatic colors (grays)

### DIFF
--- a/packages/color-utils/src/conversion.ts
+++ b/packages/color-utils/src/conversion.ts
@@ -32,7 +32,8 @@ export function hexToOKLCH(hex: string): OKLCH {
     return {
       l: oklch.coords[0] ?? 0,
       c: oklch.coords[1] ?? 0,
-      h: oklch.coords[2] ?? 0, // Handle undefined hue for achromatic colors
+      // Achromatic colors (grays) get NaN hue from colorjs.io, not undefined
+      h: Number.isNaN(oklch.coords[2]) ? 0 : (oklch.coords[2] ?? 0),
       alpha: oklch.alpha ?? 1,
     };
   } catch (_error) {
@@ -48,9 +49,10 @@ export function hexToOKLCH(hex: string): OKLCH {
  */
 export function roundOKLCH(oklch: OKLCH): OKLCH {
   return {
-    l: Math.round(oklch.l * 1000) / 1000, // 3 decimal places for lightness
-    c: Math.round(oklch.c * 1000) / 1000, // 3 decimal places for chroma
-    h: Math.round(oklch.h), // Whole degrees for hue
-    alpha: oklch.alpha !== undefined ? Math.round(oklch.alpha * 100) / 100 : 1, // 2 decimal places for alpha
+    l: Math.round(oklch.l * 1000) / 1000,
+    c: Math.round(oklch.c * 1000) / 1000,
+    // NaN hue from achromatic colors defaults to 0
+    h: Number.isNaN(oklch.h) ? 0 : Math.round(oklch.h),
+    alpha: oklch.alpha !== undefined ? Math.round(oklch.alpha * 100) / 100 : 1,
   };
 }

--- a/packages/color-utils/test/conversion.test.ts
+++ b/packages/color-utils/test/conversion.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { hexToOKLCH, roundOKLCH } from '../src/conversion.js';
+
+describe('hexToOKLCH', () => {
+  it('converts a standard color', () => {
+    const result = hexToOKLCH('#2563eb');
+    expect(result.l).toBeGreaterThan(0);
+    expect(result.c).toBeGreaterThan(0);
+    expect(result.h).toBeGreaterThan(0);
+    expect(result.alpha).toBe(1);
+  });
+
+  it('handles pure black', () => {
+    const result = hexToOKLCH('#000000');
+    expect(result.l).toBeCloseTo(0, 1);
+    expect(result.c).toBeCloseTo(0, 1);
+    expect(Number.isNaN(result.h)).toBe(false);
+  });
+
+  it('handles pure white', () => {
+    const result = hexToOKLCH('#ffffff');
+    expect(result.l).toBeCloseTo(1, 1);
+    expect(result.c).toBeCloseTo(0, 1);
+    expect(Number.isNaN(result.h)).toBe(false);
+  });
+
+  it('handles pure gray without NaN hue', () => {
+    const result = hexToOKLCH('#9D9D9D');
+    expect(result.l).toBeGreaterThan(0);
+    expect(result.c).toBeCloseTo(0, 2);
+    // Achromatic colors must not have NaN hue
+    expect(Number.isNaN(result.h)).toBe(false);
+    expect(result.h).toBe(0);
+  });
+
+  it('handles mid-gray #808080', () => {
+    const result = hexToOKLCH('#808080');
+    expect(Number.isNaN(result.h)).toBe(false);
+    expect(result.h).toBe(0);
+  });
+
+  it('parses rgb() format', () => {
+    const result = hexToOKLCH('rgb(220, 38, 38)');
+    expect(result.l).toBeGreaterThan(0);
+    expect(result.c).toBeGreaterThan(0);
+  });
+
+  it('parses hsl() format', () => {
+    const result = hexToOKLCH('hsl(142, 71%, 45%)');
+    expect(result.l).toBeGreaterThan(0);
+    expect(result.c).toBeGreaterThan(0);
+  });
+
+  it('parses oklch() format', () => {
+    const result = hexToOKLCH('oklch(0.55 0.2 250)');
+    expect(result.l).toBeCloseTo(0.55, 1);
+    expect(result.c).toBeCloseTo(0.2, 1);
+    expect(result.h).toBeCloseTo(250, 0);
+  });
+
+  it('throws on invalid input', () => {
+    expect(() => hexToOKLCH('not-a-color')).toThrow();
+  });
+});
+
+describe('roundOKLCH', () => {
+  it('rounds to standard precision', () => {
+    const result = roundOKLCH({ l: 0.55123, c: 0.19876, h: 249.7, alpha: 1 });
+    expect(result.l).toBe(0.551);
+    expect(result.c).toBe(0.199);
+    expect(result.h).toBe(250);
+    expect(result.alpha).toBe(1);
+  });
+
+  it('handles NaN hue from achromatic colors', () => {
+    const result = roundOKLCH({ l: 0.5, c: 0, h: Number.NaN, alpha: 1 });
+    expect(Number.isNaN(result.h)).toBe(false);
+    expect(result.h).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

`onboard map` crashes on pure grays (#9D9D9D) because colorjs.io returns `NaN` for achromatic hue, not `undefined`. The `??` operator doesn't catch `NaN`, so it propagates through the entire pipeline.

Reported by huttspawn during huttspawn v2 onboarding.

**Fix**: `hexToOKLCH` and `roundOKLCH` now use `Number.isNaN()` to default achromatic hue to 0.

**Tests**: 11 new conversion tests covering grays, black, white, rgb/hsl/oklch parsing, NaN hue handling.

## Test plan

- [x] hexToOKLCH('#9D9D9D') returns hue 0, not NaN
- [x] hexToOKLCH('#000000') and '#ffffff' return hue 0
- [x] roundOKLCH with NaN hue returns 0
- [x] rgb(), hsl(), oklch() formats all parse correctly
- [x] 112 color-utils tests pass
- [x] Preflight passes

Generated with [Claude Code](https://claude.com/claude-code)