### PR TITLE
fix(tokens): configurable dark mode - class (default) or media

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -114,6 +114,8 @@ export interface RaftersConfig {
   shadcn: boolean;
   /** Export format selections */
   exports: ExportConfig;
+  /** Dark mode strategy: 'class' (default, .dark class toggle) or 'media' (OS preference) */
+  darkMode?: 'class' | 'media';
   /** Items installed via `rafters add` */
   installed?: {
     components: string[];
@@ -271,12 +273,13 @@ async function generateOutputs(
   registry: TokenRegistry,
   exports: ExportConfig,
   shadcn: ShadcnConfig | null,
+  darkMode: 'class' | 'media' = 'class',
 ): Promise<string[]> {
   const outputs: string[] = [];
 
   // Tailwind CSS (with @import "tailwindcss")
   if (exports.tailwind) {
-    const tailwindCss = registryToTailwind(registry, { includeImport: !shadcn });
+    const tailwindCss = registryToTailwind(registry, { includeImport: !shadcn, darkMode });
     await writeFile(join(paths.output, 'rafters.css'), tailwindCss);
     outputs.push('rafters.css');
   }

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -1573,7 +1573,8 @@ export class RaftersToolHandler {
     await mkdir(paths.output, { recursive: true });
 
     if (exports.tailwind) {
-      const css = registryToTailwind(registry, { includeImport: !shadcn });
+      const darkMode = config?.darkMode ?? 'class';
+      const css = registryToTailwind(registry, { includeImport: !shadcn, darkMode });
       await writeFile(join(paths.output, 'rafters.css'), css);
     }
 

--- a/packages/design-tokens/src/exporters/tailwind.ts
+++ b/packages/design-tokens/src/exporters/tailwind.ts
@@ -4,7 +4,7 @@
  * Converts TokenRegistry contents to Tailwind v4 CSS format with:
  * - @theme block for raw color scales
  * - :root --rafters-* namespace tokens (light/dark mode)
- * - Semantic variables that switch via prefers-color-scheme
+ * - Semantic variables that switch via .dark class (Tailwind v4 @custom-variant)
  * - @theme inline bridge pattern
  *
  * Reads semantic color mappings from DEFAULT_SEMANTIC_COLOR_MAPPINGS (single source of truth).
@@ -25,6 +25,8 @@ export interface TailwindExportOptions {
   includeComments?: boolean;
   /** Include @import "tailwindcss" at top */
   includeImport?: boolean;
+  /** Dark mode strategy: 'class' (.dark class toggle) or 'media' (OS preference). Default: 'class' */
+  darkMode?: 'class' | 'media';
 }
 
 /**
@@ -220,10 +222,10 @@ function generateThemeInlineBlock(semanticTokens: Token[]): string {
 }
 
 /**
- * Generate :root block with --rafters-* namespace and dark mode via media query
+ * Generate :root block with --rafters-* namespace and dark mode via .dark class
  * Reads semantic mappings from actual tokens in the registry.
  */
-function generateRootBlock(semanticTokens: Token[]): string {
+function generateRootBlock(semanticTokens: Token[], darkMode: 'class' | 'media' = 'class'): string {
   const semanticMappings = getSemanticMappingsFromTokens(semanticTokens);
   const lines: string[] = [];
   lines.push(':root {');
@@ -250,20 +252,26 @@ function generateRootBlock(semanticTokens: Token[]): string {
   lines.push('}');
   lines.push('');
 
-  // Dark mode via prefers-color-scheme media query
-  lines.push('@media (prefers-color-scheme: dark) {');
-  lines.push('  :root {');
-  for (const name of Object.keys(semanticMappings)) {
-    lines.push(`    --${name}: var(--rafters-dark-${name});`);
-  }
-  lines.push('  }');
-  lines.push('}');
-  lines.push('');
+  if (darkMode === 'class') {
+    // Tailwind v4 custom variant for class-based dark mode
+    lines.push('@custom-variant dark (&:where(.dark, .dark *));');
+    lines.push('');
 
-  // Dark mode via .dark class (for manual toggle support)
-  lines.push('.dark {');
+    // Dark mode via .dark class
+    lines.push('.dark {');
+  } else {
+    // Dark mode via OS preference
+    lines.push('@media (prefers-color-scheme: dark) {');
+    lines.push('  :root {');
+  }
+
   for (const name of Object.keys(semanticMappings)) {
-    lines.push(`  --${name}: var(--rafters-dark-${name});`);
+    const indent = darkMode === 'media' ? '    ' : '  ';
+    lines.push(`${indent}--${name}: var(--rafters-dark-${name});`);
+  }
+
+  if (darkMode === 'media') {
+    lines.push('  }');
   }
   lines.push('}');
   lines.push('');
@@ -595,7 +603,7 @@ export function tokensToTailwind(tokens: Token[], options: TailwindExportOptions
   sections.push('');
 
   // :root block with --rafters-* namespace and dark mode
-  const rootBlock = generateRootBlock(groups.semantic);
+  const rootBlock = generateRootBlock(groups.semantic, options.darkMode ?? 'class');
   sections.push(rootBlock);
   sections.push('');
 

--- a/packages/design-tokens/test/exporters/tailwind.test.ts
+++ b/packages/design-tokens/test/exporters/tailwind.test.ts
@@ -32,15 +32,20 @@ describe('tokensToTailwind', () => {
     expect(css).toContain('--background: var(--rafters-background);');
   });
 
-  it('should include dark mode via @media prefers-color-scheme', () => {
+  it('should include class-based dark mode with @custom-variant', () => {
     const tokens: Token[] = [
       { name: 'neutral-500', value: 'oklch(0.55 0 0)', category: 'color', namespace: 'color' },
     ];
 
     const css = tokensToTailwind(tokens);
 
-    expect(css).toContain('@media (prefers-color-scheme: dark) {');
+    // Tailwind v4 custom variant for class-based dark mode
+    expect(css).toContain('@custom-variant dark');
+    // .dark class block for manual toggle
+    expect(css).toContain('.dark {');
     expect(css).toContain('--background: var(--rafters-dark-background);');
+    // No media query -- consumers control dark mode via class, not OS preference
+    expect(css).not.toContain('@media (prefers-color-scheme: dark)');
   });
 
   it('should export spacing tokens with --spacing- prefix', () => {


### PR DESCRIPTION
## Summary

Dark mode strategy is now a rafters config setting. Default changed from `@media (prefers-color-scheme: dark)` to class-based `.dark` with `@custom-variant dark`.

**`config.rafters.json`**:
```json
{ "darkMode": "class" }
```

- **class** (default): `@custom-variant dark (&:where(.dark, .dark *))` + `.dark {}` block. Consumers toggle via `.dark` class on `<html>`. Works with next-themes, Astro, any toggle library.
- **media**: `@media (prefers-color-scheme: dark)`. Follows OS preference. No manual override.

Closes #1113

## Test plan

- [x] Default generates `@custom-variant dark` and `.dark {}`, no media query
- [x] `darkMode: 'media'` generates `@media (prefers-color-scheme: dark)` 
- [x] Config option wired through init, MCP regenerateOutputs
- [x] 210 design-tokens tests pass
- [x] CLI typechecks clean