### PR TITLE
chore: release v0.0.32

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,8 +1,14 @@
 # rafters
 
-## Unreleased
+## 0.0.32
+
+### Minor Changes
 
 - `rafters init` writes `.claude/skills/rafters-frontend/SKILL.md` to consumer project -- agents see Container, Grid, and typography examples every session
+- Configurable dark mode: `darkMode: 'class'` (default, `.dark` class toggle) or `'media'` (OS preference) in config.rafters.json
+
+### Patch Changes
+
 - `classy` detects layout utilities (`flex`, `gap-*`, `p-*`, `m-*`): strips on components, warns on consumer code
 - Fix `@/` import paths doubling `src/` prefix in Astro/Vite projects
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "CLI for Rafters design system - scaffold tokens and add components",
   "license": "MIT",
   "type": "module",

--- a/packages/shared/src/version.ts
+++ b/packages/shared/src/version.ts
@@ -3,4 +3,4 @@
  * Used by the CLI package.json, the API root endpoint, and anywhere
  * else that needs to report the current version.
  */
-export const RAFTERS_VERSION = '0.0.31';
+export const RAFTERS_VERSION = '0.0.32';


### PR DESCRIPTION
## 0.0.32

### Minor Changes
- `rafters init` writes `.claude/skills/rafters-frontend/SKILL.md` to consumer project
- Configurable dark mode: `darkMode: 'class'` (default) or `'media'` in config

### Patch Changes
- `classy` detects layout utilities: strips on components, warns on consumer code
- Fix `@/` import paths doubling `src/` prefix in Astro/Vite projects