### PR TITLE
refactor(ui): all 44 components use shared .classes.ts

### DIFF
--- a/packages/ui/src/components/ui/accordion.classes.ts
+++ b/packages/ui/src/components/ui/accordion.classes.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared accordion class definitions
+ *
+ * Imported by accordion.tsx (React) to keep inline strings
+ * in a single source of truth.
+ */
+
+export const accordionItemClasses = 'border-b';
+
+export const accordionTriggerHeadingClasses = 'flex';
+
+export const accordionTriggerClasses =
+  'flex flex-1 items-center justify-between py-4 font-medium transition-all ' +
+  'hover:underline ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ' +
+  'disabled:pointer-events-none disabled:opacity-50';
+
+export const accordionTriggerIconClasses =
+  'h-4 w-4 shrink-0 transition-transform duration-200 ' + 'data-[state=open]:rotate-180';
+
+export const accordionContentClasses =
+  'overflow-hidden text-sm transition-all ' +
+  'data-[state=closed]:animate-accordion-up ' +
+  'data-[state=open]:animate-accordion-down';
+
+export const accordionContentInnerClasses = 'pb-4 pt-0';

--- a/packages/ui/src/components/ui/accordion.tsx
+++ b/packages/ui/src/components/ui/accordion.tsx
@@ -27,6 +27,14 @@
 
 import * as React from 'react';
 import classy from '../../primitives/classy';
+import {
+  accordionContentClasses,
+  accordionContentInnerClasses,
+  accordionItemClasses,
+  accordionTriggerClasses,
+  accordionTriggerHeadingClasses,
+  accordionTriggerIconClasses,
+} from './accordion.classes';
 
 // ==================== Context ====================
 
@@ -240,7 +248,7 @@ export function AccordionItem({
       <div
         data-state={isOpen ? 'open' : 'closed'}
         data-disabled={disabled ? '' : undefined}
-        className={classy('border-b', className)}
+        className={classy(accordionItemClasses, className)}
         {...props}
       >
         {children}
@@ -273,7 +281,7 @@ export function AccordionTrigger({
   }, [disabled, onItemToggle, value]);
 
   return (
-    <h3 className="flex">
+    <h3 className={accordionTriggerHeadingClasses}>
       <button
         type="button"
         id={triggerId}
@@ -282,13 +290,7 @@ export function AccordionTrigger({
         data-state={isOpen ? 'open' : 'closed'}
         data-accordion-trigger
         disabled={disabled}
-        className={classy(
-          'flex flex-1 items-center justify-between py-4 font-medium transition-all',
-          'hover:underline',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-          'disabled:pointer-events-none disabled:opacity-50',
-          className,
-        )}
+        className={classy(accordionTriggerClasses, className)}
         onClick={handleClick}
         {...props}
       >
@@ -304,10 +306,7 @@ export function AccordionTrigger({
           strokeLinecap="round"
           strokeLinejoin="round"
           aria-hidden="true"
-          className={classy(
-            'h-4 w-4 shrink-0 transition-transform duration-200',
-            'data-[state=open]:rotate-180',
-          )}
+          className={classy(accordionTriggerIconClasses)}
           data-state={isOpen ? 'open' : 'closed'}
         >
           <polyline points="6 9 12 15 18 9" />
@@ -347,15 +346,10 @@ export function AccordionContent({
       aria-labelledby={triggerId}
       data-state={isOpen ? 'open' : 'closed'}
       hidden={!isOpen}
-      className={classy(
-        'overflow-hidden text-sm transition-all',
-        'data-[state=closed]:animate-accordion-up',
-        'data-[state=open]:animate-accordion-down',
-        className,
-      )}
+      className={classy(accordionContentClasses, className)}
       {...props}
     >
-      <div className="pb-4 pt-0">{children}</div>
+      <div className={accordionContentInnerClasses}>{children}</div>
     </div>
   );
 }

--- a/packages/ui/src/components/ui/alert-dialog.classes.ts
+++ b/packages/ui/src/components/ui/alert-dialog.classes.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared class definitions for AlertDialog component
+ */
+
+export const alertDialogOverlayClasses = 'fixed inset-0 z-depth-overlay bg-foreground/80';
+
+export const alertDialogContainerClasses =
+  'fixed inset-0 z-depth-modal flex items-center justify-center p-4';
+
+export const alertDialogContentClasses =
+  'relative grid w-full max-w-lg gap-4 border bg-background p-6 shadow-lg sm:rounded-lg';
+
+export const alertDialogHeaderClasses = 'flex flex-col space-y-2 text-center sm:text-left';
+
+export const alertDialogFooterClasses =
+  'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2';
+
+export const alertDialogTitleClasses = 'text-lg font-semibold';
+
+export const alertDialogDescriptionClasses = 'text-sm text-muted-foreground';
+
+export const alertDialogActionClasses =
+  'inline-flex h-10 items-center justify-center rounded-md bg-destructive px-4 py-2 text-sm font-medium text-destructive-foreground ring-offset-background transition-colors hover:bg-destructive/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50';
+
+export const alertDialogCancelClasses =
+  'mt-2 inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 sm:mt-0';

--- a/packages/ui/src/components/ui/alert-dialog.tsx
+++ b/packages/ui/src/components/ui/alert-dialog.tsx
@@ -57,6 +57,17 @@ import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap';
 import { getPortalContainer } from '../../primitives/portal';
 import { mergeProps } from '../../primitives/slot';
+import {
+  alertDialogActionClasses,
+  alertDialogCancelClasses,
+  alertDialogContainerClasses,
+  alertDialogContentClasses,
+  alertDialogDescriptionClasses,
+  alertDialogFooterClasses,
+  alertDialogHeaderClasses,
+  alertDialogOverlayClasses,
+  alertDialogTitleClasses,
+} from './alert-dialog.classes';
 
 // Context for sharing alert dialog state
 interface AlertDialogContextValue {
@@ -239,7 +250,7 @@ export function AlertDialogOverlay({
 
   const overlayProps = {
     ...ariaProps,
-    className: classy('fixed inset-0 z-depth-overlay bg-foreground/80', className),
+    className: classy(alertDialogOverlayClasses, className),
     ...props,
   };
 
@@ -357,13 +368,10 @@ export function AlertDialogContent({
   }
 
   // Render using a centered container
-  const containerClass = classy('fixed inset-0 z-depth-modal flex items-center justify-center p-4');
+  const containerClass = classy(alertDialogContainerClasses);
 
   // Default styles matching shadcn AlertDialogContent
-  const innerClass = classy(
-    'relative grid w-full max-w-lg gap-4 border bg-background p-6 shadow-lg sm:rounded-lg',
-    className,
-  );
+  const innerClass = classy(alertDialogContentClasses, className);
 
   const innerProps = {
     ref: contentRef,
@@ -419,12 +427,7 @@ export function AlertDialogContent({
 export interface AlertDialogHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export function AlertDialogHeader({ className, ...props }: AlertDialogHeaderProps) {
-  return (
-    <div
-      className={classy('flex flex-col space-y-2 text-center sm:text-left', className)}
-      {...props}
-    />
-  );
+  return <div className={classy(alertDialogHeaderClasses, className)} {...props} />;
 }
 
 // ==================== AlertDialogFooter ====================
@@ -432,12 +435,7 @@ export function AlertDialogHeader({ className, ...props }: AlertDialogHeaderProp
 export interface AlertDialogFooterProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export function AlertDialogFooter({ className, ...props }: AlertDialogFooterProps) {
-  return (
-    <div
-      className={classy('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
-      {...props}
-    />
-  );
+  return <div className={classy(alertDialogFooterClasses, className)} {...props} />;
 }
 
 // ==================== AlertDialogTitle ====================
@@ -451,7 +449,7 @@ export function AlertDialogTitle({ asChild, className, ...props }: AlertDialogTi
 
   const titleProps = {
     id: titleId,
-    className: classy('text-lg font-semibold', className),
+    className: classy(alertDialogTitleClasses, className),
     ...props,
   };
 
@@ -480,7 +478,7 @@ export function AlertDialogDescription({
 
   const descriptionProps = {
     id: descriptionId,
-    className: classy('text-sm text-muted-foreground', className),
+    className: classy(alertDialogDescriptionClasses, className),
     ...props,
   };
 
@@ -513,10 +511,7 @@ export function AlertDialogAction({
     onOpenChange(false);
   };
 
-  const buttonClass = classy(
-    'inline-flex h-10 items-center justify-center rounded-md bg-destructive px-4 py-2 text-sm font-medium text-destructive-foreground ring-offset-background transition-colors hover:bg-destructive/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
-    className,
-  );
+  const buttonClass = classy(alertDialogActionClasses, className);
 
   if (asChild && React.isValidElement(props.children)) {
     const child = props.children as React.ReactElement<Record<string, unknown>>;
@@ -553,10 +548,7 @@ export function AlertDialogCancel({
     onOpenChange(false);
   };
 
-  const buttonClass = classy(
-    'mt-2 inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 sm:mt-0',
-    className,
-  );
+  const buttonClass = classy(alertDialogCancelClasses, className);
 
   if (asChild && React.isValidElement(props.children)) {
     const child = props.children as React.ReactElement<Record<string, unknown>>;

--- a/packages/ui/src/components/ui/checkbox.classes.ts
+++ b/packages/ui/src/components/ui/checkbox.classes.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared class definitions for Checkbox component
+ */
+
+export const checkboxBaseClasses =
+  'inline-flex items-center justify-center shrink-0 ' +
+  'rounded-sm border ' +
+  'transition-colors ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ' +
+  'disabled:pointer-events-none disabled:opacity-50';
+
+export const checkboxVariantClasses: Record<
+  string,
+  { border: string; checked: string; ring: string }
+> = {
+  default: {
+    border: 'border-primary',
+    checked: 'data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+    ring: 'focus-visible:ring-primary-ring',
+  },
+  primary: {
+    border: 'border-primary',
+    checked: 'data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+    ring: 'focus-visible:ring-primary-ring',
+  },
+  secondary: {
+    border: 'border-secondary',
+    checked: 'data-[state=checked]:bg-secondary data-[state=checked]:text-secondary-foreground',
+    ring: 'focus-visible:ring-secondary-ring',
+  },
+  destructive: {
+    border: 'border-destructive',
+    checked: 'data-[state=checked]:bg-destructive data-[state=checked]:text-destructive-foreground',
+    ring: 'focus-visible:ring-destructive-ring',
+  },
+  success: {
+    border: 'border-success',
+    checked: 'data-[state=checked]:bg-success data-[state=checked]:text-success-foreground',
+    ring: 'focus-visible:ring-success-ring',
+  },
+  warning: {
+    border: 'border-warning',
+    checked: 'data-[state=checked]:bg-warning data-[state=checked]:text-warning-foreground',
+    ring: 'focus-visible:ring-warning-ring',
+  },
+  info: {
+    border: 'border-info',
+    checked: 'data-[state=checked]:bg-info data-[state=checked]:text-info-foreground',
+    ring: 'focus-visible:ring-info-ring',
+  },
+  accent: {
+    border: 'border-accent',
+    checked: 'data-[state=checked]:bg-accent data-[state=checked]:text-accent-foreground',
+    ring: 'focus-visible:ring-accent-ring',
+  },
+};
+
+export const checkboxSizeClasses: Record<string, { box: string; icon: string }> = {
+  sm: { box: 'h-3.5 w-3.5', icon: 'h-2.5 w-2.5' },
+  default: { box: 'h-4 w-4', icon: 'h-3 w-3' },
+  lg: { box: 'h-5 w-5', icon: 'h-4 w-4' },
+};

--- a/packages/ui/src/components/ui/checkbox.tsx
+++ b/packages/ui/src/components/ui/checkbox.tsx
@@ -24,6 +24,11 @@
  */
 import * as React from 'react';
 import classy from '../../primitives/classy';
+import {
+  checkboxBaseClasses,
+  checkboxSizeClasses,
+  checkboxVariantClasses,
+} from './checkbox.classes';
 
 export interface CheckboxProps
   extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> {
@@ -47,55 +52,9 @@ export interface CheckboxProps
   size?: 'sm' | 'default' | 'lg';
 }
 
-// Variant classes for checked state
-const variantClasses: Record<string, { border: string; checked: string; ring: string }> = {
-  default: {
-    border: 'border-primary',
-    checked: 'data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
-    ring: 'focus-visible:ring-primary-ring',
-  },
-  primary: {
-    border: 'border-primary',
-    checked: 'data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
-    ring: 'focus-visible:ring-primary-ring',
-  },
-  secondary: {
-    border: 'border-secondary',
-    checked: 'data-[state=checked]:bg-secondary data-[state=checked]:text-secondary-foreground',
-    ring: 'focus-visible:ring-secondary-ring',
-  },
-  destructive: {
-    border: 'border-destructive',
-    checked: 'data-[state=checked]:bg-destructive data-[state=checked]:text-destructive-foreground',
-    ring: 'focus-visible:ring-destructive-ring',
-  },
-  success: {
-    border: 'border-success',
-    checked: 'data-[state=checked]:bg-success data-[state=checked]:text-success-foreground',
-    ring: 'focus-visible:ring-success-ring',
-  },
-  warning: {
-    border: 'border-warning',
-    checked: 'data-[state=checked]:bg-warning data-[state=checked]:text-warning-foreground',
-    ring: 'focus-visible:ring-warning-ring',
-  },
-  info: {
-    border: 'border-info',
-    checked: 'data-[state=checked]:bg-info data-[state=checked]:text-info-foreground',
-    ring: 'focus-visible:ring-info-ring',
-  },
-  accent: {
-    border: 'border-accent',
-    checked: 'data-[state=checked]:bg-accent data-[state=checked]:text-accent-foreground',
-    ring: 'focus-visible:ring-accent-ring',
-  },
-};
-
-const sizeClasses: Record<string, { box: string; icon: string }> = {
-  sm: { box: 'h-3.5 w-3.5', icon: 'h-2.5 w-2.5' },
-  default: { box: 'h-4 w-4', icon: 'h-3 w-3' },
-  lg: { box: 'h-5 w-5', icon: 'h-4 w-4' },
-};
+// Re-export variant and size classes from shared file
+const variantClasses = checkboxVariantClasses;
+const sizeClasses = checkboxSizeClasses;
 
 export const Checkbox = React.forwardRef<HTMLButtonElement, CheckboxProps>(
   (
@@ -155,14 +114,7 @@ export const Checkbox = React.forwardRef<HTMLButtonElement, CheckboxProps>(
     const s = sizeClasses[size] || sizeClasses.default;
 
     // Base styles per docs/COMPONENT_STYLING_REFERENCE.md
-    const baseClasses =
-      'inline-flex items-center justify-center shrink-0 ' +
-      'rounded-sm border ' +
-      'transition-colors ' +
-      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ' +
-      'disabled:pointer-events-none disabled:opacity-50';
-
-    const cls = classy(baseClasses, s?.box, v?.border, v?.checked, v?.ring, className);
+    const cls = classy(checkboxBaseClasses, s?.box, v?.border, v?.checked, v?.ring, className);
 
     return (
       // biome-ignore lint/a11y/useSemanticElements: Custom checkbox with visual styling not possible with native input

--- a/packages/ui/src/components/ui/collapsible.classes.ts
+++ b/packages/ui/src/components/ui/collapsible.classes.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared collapsible class definitions
+ *
+ * Imported by collapsible.tsx (React) to keep inline strings
+ * in a single source of truth.
+ */
+
+export const collapsibleContentClasses =
+  'overflow-hidden transition-all ' +
+  'data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down';

--- a/packages/ui/src/components/ui/collapsible.tsx
+++ b/packages/ui/src/components/ui/collapsible.tsx
@@ -28,6 +28,7 @@
 import * as React from 'react';
 import classy from '../../primitives/classy';
 import { mergeProps } from '../../primitives/slot';
+import { collapsibleContentClasses } from './collapsible.classes';
 
 // Context for sharing collapsible state
 interface CollapsibleContextValue {
@@ -209,13 +210,7 @@ export function CollapsibleContent({
     'data-state': open ? 'open' : 'closed',
     'data-disabled': disabled ? '' : undefined,
     hidden: !open,
-    className: classy(
-      // Base transition styles for height animation
-      'overflow-hidden transition-all',
-      // Animation states
-      'data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down',
-      className,
-    ),
+    className: classy(collapsibleContentClasses, className),
     ...props,
   };
 

--- a/packages/ui/src/components/ui/command.classes.ts
+++ b/packages/ui/src/components/ui/command.classes.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared class definitions for Command component
+ */
+
+export const commandRootClasses =
+  'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground';
+
+export const commandDialogBackdropClasses =
+  'fixed inset-0 z-depth-overlay bg-foreground/80 cursor-default';
+
+export const commandDialogClasses =
+  'fixed left-1/2 top-1/2 z-depth-modal w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-lg border bg-popover shadow-lg';
+
+export const commandDialogCommandClasses = '[&_[data-command-input-wrapper]]:border-b';
+
+export const commandInputWrapperClasses = 'flex items-center border-b px-3';
+
+export const commandInputSearchIconClasses = 'mr-2 shrink-0 opacity-50';
+
+export const commandInputClasses =
+  'flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50';
+
+export const commandListClasses = 'max-h-80 overflow-y-auto overflow-x-hidden';
+
+export const commandEmptyClasses = 'py-6 text-center text-sm';
+
+export const commandGroupClasses = 'overflow-hidden p-1 text-foreground';
+
+export const commandGroupHeadingClasses = 'px-2 py-1.5 text-xs font-medium text-muted-foreground';
+
+export const commandItemClasses =
+  'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[selected]:bg-accent data-[selected]:text-accent-foreground';
+
+export const commandSeparatorClasses = '-mx-1 h-px bg-border';
+
+export const commandShortcutClasses = 'ml-auto text-xs tracking-widest text-muted-foreground';

--- a/packages/ui/src/components/ui/command.tsx
+++ b/packages/ui/src/components/ui/command.tsx
@@ -34,6 +34,22 @@
 
 import * as React from 'react';
 import classy from '../../primitives/classy';
+import {
+  commandDialogBackdropClasses,
+  commandDialogClasses,
+  commandDialogCommandClasses,
+  commandEmptyClasses,
+  commandGroupClasses,
+  commandGroupHeadingClasses,
+  commandInputClasses,
+  commandInputSearchIconClasses,
+  commandInputWrapperClasses,
+  commandItemClasses,
+  commandListClasses,
+  commandRootClasses,
+  commandSeparatorClasses,
+  commandShortcutClasses,
+} from './command.classes';
 
 // ==================== Context ====================
 
@@ -162,14 +178,7 @@ export function Command({
 
   return (
     <CommandContext.Provider value={contextValue}>
-      <div
-        data-command=""
-        className={classy(
-          'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground',
-          className,
-        )}
-        {...props}
-      >
+      <div data-command="" className={classy(commandRootClasses, className)} {...props}>
         {children}
       </div>
     </CommandContext.Provider>
@@ -211,21 +220,13 @@ export function CommandDialog({
       {/* Backdrop */}
       <button
         type="button"
-        className="fixed inset-0 z-depth-overlay bg-foreground/80 cursor-default"
+        className={commandDialogBackdropClasses}
         onClick={() => onOpenChange?.(false)}
         aria-label="Close command palette"
       />
       {/* Dialog */}
-      <div
-        data-command-dialog=""
-        className={classy(
-          'fixed left-1/2 top-1/2 z-depth-modal w-full max-w-lg -translate-x-1/2 -translate-y-1/2',
-          'rounded-lg border bg-popover shadow-lg',
-          className,
-        )}
-        {...props}
-      >
-        <Command className="[&_[data-command-input-wrapper]]:border-b">{children}</Command>
+      <div data-command-dialog="" className={classy(commandDialogClasses, className)} {...props}>
+        <Command className={commandDialogCommandClasses}>{children}</Command>
       </div>
     </>
   );
@@ -289,7 +290,7 @@ export function CommandInput({
     activeIndex >= 0 && items[activeIndex] ? getItemId(items[activeIndex]) : undefined;
 
   return (
-    <div data-command-input-wrapper="" className="flex items-center border-b px-3">
+    <div data-command-input-wrapper="" className={commandInputWrapperClasses}>
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="16"
@@ -300,7 +301,7 @@ export function CommandInput({
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
-        className="mr-2 shrink-0 opacity-50"
+        className={commandInputSearchIconClasses}
         aria-hidden="true"
       >
         <circle cx="11" cy="11" r="8" />
@@ -322,12 +323,7 @@ export function CommandInput({
         onChange={(e) => onValueChange(e.target.value)}
         onKeyDown={handleKeyDown}
         data-command-input=""
-        className={classy(
-          'flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none',
-          'placeholder:text-muted-foreground',
-          'disabled:cursor-not-allowed disabled:opacity-50',
-          className,
-        )}
+        className={classy(commandInputClasses, className)}
         {...props}
       />
     </div>
@@ -350,7 +346,7 @@ export function CommandList({
       id={listId}
       role="listbox"
       data-command-list=""
-      className={classy('max-h-80 overflow-y-auto overflow-x-hidden', className)}
+      className={classy(commandListClasses, className)}
       {...props}
     >
       {children}
@@ -380,7 +376,7 @@ export function CommandEmpty({
   if (visibleItems.length > 0 || !value) return null;
 
   return (
-    <div data-command-empty="" className={classy('py-6 text-center text-sm', className)} {...props}>
+    <div data-command-empty="" className={classy(commandEmptyClasses, className)} {...props}>
       {children}
     </div>
   );
@@ -406,15 +402,11 @@ export function CommandGroup({
       role="group"
       aria-labelledby={heading ? headingId : undefined}
       data-command-group=""
-      className={classy('overflow-hidden p-1 text-foreground', className)}
+      className={classy(commandGroupClasses, className)}
       {...props}
     >
       {heading && (
-        <div
-          id={headingId}
-          data-command-group-heading=""
-          className="px-2 py-1.5 text-xs font-medium text-muted-foreground"
-        >
+        <div id={headingId} data-command-group-heading="" className={commandGroupHeadingClasses}>
           {heading}
         </div>
       )}
@@ -503,12 +495,7 @@ export function CommandItem({
       data-disabled={disabled || undefined}
       onClick={handleClick}
       onMouseEnter={handleMouseEnter}
-      className={classy(
-        'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none',
-        'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-        'data-[selected]:bg-accent data-[selected]:text-accent-foreground',
-        className,
-      )}
+      className={classy(commandItemClasses, className)}
       {...props}
     >
       {children}
@@ -527,7 +514,7 @@ export function CommandSeparator({
   return (
     <div
       data-command-separator=""
-      className={classy('-mx-1 h-px bg-border', className)}
+      className={classy(commandSeparatorClasses, className)}
       {...props}
     />
   );
@@ -541,7 +528,7 @@ export function CommandShortcut({ className, ...props }: CommandShortcutProps): 
   return (
     <span
       data-command-shortcut=""
-      className={classy('ml-auto text-xs tracking-widest text-muted-foreground', className)}
+      className={classy(commandShortcutClasses, className)}
       {...props}
     />
   );

--- a/packages/ui/src/components/ui/context-menu.classes.ts
+++ b/packages/ui/src/components/ui/context-menu.classes.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared class definitions for ContextMenu component
+ */
+
+export const contextMenuContentClasses =
+  'z-depth-dropdown min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md';
+
+export const contextMenuContentAnimationClasses =
+  'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95';
+
+export const contextMenuSubContentAnimationClasses =
+  'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95';
+
+export const contextMenuLabelClasses = 'px-2 py-1.5 text-sm font-semibold';
+
+export const contextMenuItemClasses =
+  'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+
+export const contextMenuCheckboxItemClasses =
+  'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+
+export const contextMenuCheckboxIndicatorClasses =
+  'absolute left-2 flex h-3.5 w-3.5 items-center justify-center';
+
+export const contextMenuCheckIconClasses = 'h-4 w-4';
+
+export const contextMenuRadioItemClasses =
+  'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+
+export const contextMenuRadioIndicatorClasses =
+  'absolute left-2 flex h-3.5 w-3.5 items-center justify-center';
+
+export const contextMenuRadioDotClasses = 'h-2 w-2 rounded-full bg-current';
+
+export const contextMenuSeparatorClasses = '-mx-1 my-1 h-px border-0 bg-muted';
+
+export const contextMenuShortcutClasses = 'ml-auto text-xs tracking-widest opacity-60';
+
+export const contextMenuSubTriggerClasses =
+  'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+
+export const contextMenuSubTriggerIconClasses = 'ml-auto h-4 w-4';

--- a/packages/ui/src/components/ui/context-menu.tsx
+++ b/packages/ui/src/components/ui/context-menu.tsx
@@ -39,6 +39,23 @@ import { getPortalContainer } from '../../primitives/portal';
 import { createRovingFocus } from '../../primitives/roving-focus';
 import { mergeProps } from '../../primitives/slot';
 import { createTypeahead } from '../../primitives/typeahead';
+import {
+  contextMenuCheckboxIndicatorClasses,
+  contextMenuCheckboxItemClasses,
+  contextMenuCheckIconClasses,
+  contextMenuContentAnimationClasses,
+  contextMenuContentClasses,
+  contextMenuItemClasses,
+  contextMenuLabelClasses,
+  contextMenuRadioDotClasses,
+  contextMenuRadioIndicatorClasses,
+  contextMenuRadioItemClasses,
+  contextMenuSeparatorClasses,
+  contextMenuShortcutClasses,
+  contextMenuSubContentAnimationClasses,
+  contextMenuSubTriggerClasses,
+  contextMenuSubTriggerIconClasses,
+} from './context-menu.classes';
 
 // ==================== Types ====================
 
@@ -407,13 +424,7 @@ export const ContextMenuContent = React.forwardRef<HTMLDivElement, ContextMenuCo
       role: 'menu',
       'aria-orientation': 'vertical' as const,
       'data-state': open ? 'open' : 'closed',
-      className: classy(
-        'z-depth-dropdown min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
-        'data-[state=open]:animate-in data-[state=closed]:animate-out',
-        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-        'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-        className,
-      ),
+      className: classy(contextMenuContentClasses, contextMenuContentAnimationClasses, className),
       style: contentStyle,
       ...props,
     };
@@ -475,7 +486,7 @@ export const ContextMenuLabel = React.forwardRef<HTMLDivElement, ContextMenuLabe
     return (
       <div
         ref={ref}
-        className={classy('px-2 py-1.5 text-sm font-semibold', inset && 'pl-8', className)}
+        className={classy(contextMenuLabelClasses, inset && 'pl-8', className)}
         {...props}
       />
     );
@@ -528,13 +539,7 @@ export const ContextMenuItem = React.forwardRef<HTMLDivElement, ContextMenuItemP
         tabIndex={disabled ? undefined : -1}
         aria-disabled={disabled || undefined}
         data-disabled={disabled ? '' : undefined}
-        className={classy(
-          'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none',
-          'transition-colors focus:bg-accent focus:text-accent-foreground',
-          'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-          inset && 'pl-8',
-          className,
-        )}
+        className={classy(contextMenuItemClasses, inset && 'pl-8', className)}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
         {...props}
@@ -609,20 +614,15 @@ export const ContextMenuCheckboxItem = React.forwardRef<
         aria-disabled={disabled || undefined}
         data-disabled={disabled ? '' : undefined}
         data-state={checked ? 'checked' : 'unchecked'}
-        className={classy(
-          'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none',
-          'transition-colors focus:bg-accent focus:text-accent-foreground',
-          'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-          className,
-        )}
+        className={classy(contextMenuCheckboxItemClasses, className)}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
         {...props}
       >
-        <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <span className={contextMenuCheckboxIndicatorClasses}>
           {checked && (
             <svg
-              className="h-4 w-4"
+              className={contextMenuCheckIconClasses}
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -726,18 +726,13 @@ export const ContextMenuRadioItem = React.forwardRef<HTMLDivElement, ContextMenu
         aria-disabled={disabled || undefined}
         data-disabled={disabled ? '' : undefined}
         data-state={checked ? 'checked' : 'unchecked'}
-        className={classy(
-          'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none',
-          'transition-colors focus:bg-accent focus:text-accent-foreground',
-          'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-          className,
-        )}
+        className={classy(contextMenuRadioItemClasses, className)}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
         {...props}
       >
-        <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-          {checked && <span className="h-2 w-2 rounded-full bg-current" aria-hidden="true" />}
+        <span className={contextMenuRadioIndicatorClasses}>
+          {checked && <span className={contextMenuRadioDotClasses} aria-hidden="true" />}
         </span>
         {children}
       </div>
@@ -753,9 +748,7 @@ export interface ContextMenuSeparatorProps extends React.HTMLAttributes<HTMLHREl
 
 export const ContextMenuSeparator = React.forwardRef<HTMLHRElement, ContextMenuSeparatorProps>(
   ({ className, ...props }, ref) => {
-    return (
-      <hr ref={ref} className={classy('-mx-1 my-1 h-px border-0 bg-muted', className)} {...props} />
-    );
+    return <hr ref={ref} className={classy(contextMenuSeparatorClasses, className)} {...props} />;
   },
 );
 
@@ -766,9 +759,7 @@ ContextMenuSeparator.displayName = 'ContextMenuSeparator';
 export interface ContextMenuShortcutProps extends React.HTMLAttributes<HTMLSpanElement> {}
 
 export function ContextMenuShortcut({ className, ...props }: ContextMenuShortcutProps) {
-  return (
-    <span className={classy('ml-auto text-xs tracking-widest opacity-60', className)} {...props} />
-  );
+  return <span className={classy(contextMenuShortcutClasses, className)} {...props} />;
 }
 
 // ==================== ContextMenuSub ====================
@@ -906,14 +897,7 @@ export const ContextMenuSubTrigger = React.forwardRef<HTMLDivElement, ContextMen
         aria-disabled={disabled || undefined}
         data-disabled={disabled ? '' : undefined}
         data-state={open ? 'open' : 'closed'}
-        className={classy(
-          'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none',
-          'transition-colors focus:bg-accent focus:text-accent-foreground',
-          'data-[state=open]:bg-accent',
-          'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-          inset && 'pl-8',
-          className,
-        )}
+        className={classy(contextMenuSubTriggerClasses, inset && 'pl-8', className)}
         onPointerEnter={handlePointerEnter}
         onPointerLeave={handlePointerLeave}
         onKeyDown={handleKeyDown}
@@ -921,7 +905,7 @@ export const ContextMenuSubTrigger = React.forwardRef<HTMLDivElement, ContextMen
       >
         {children}
         <svg
-          className="ml-auto h-4 w-4"
+          className={contextMenuSubTriggerIconClasses}
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -1113,10 +1097,8 @@ export const ContextMenuSubContent = React.forwardRef<HTMLDivElement, ContextMen
           aria-orientation="vertical"
           data-state={open ? 'open' : 'closed'}
           className={classy(
-            'z-depth-dropdown min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
-            'data-[state=open]:animate-in data-[state=closed]:animate-out',
-            'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-            'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+            contextMenuContentClasses,
+            contextMenuSubContentAnimationClasses,
             className,
           )}
           style={contentStyle}

--- a/packages/ui/src/components/ui/dialog.classes.ts
+++ b/packages/ui/src/components/ui/dialog.classes.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared class definitions for Dialog component
+ */
+
+export const dialogOverlayClasses = 'fixed inset-0 z-depth-overlay bg-foreground/80';
+
+export const dialogCloseButtonClasses =
+  'absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground';
+
+export const dialogCloseIconClasses = 'h-4 w-4';
+
+export const dialogContainerClasses =
+  'fixed inset-0 z-depth-modal flex items-center justify-center p-4';
+
+export const dialogContentClasses =
+  'relative w-full max-w-lg rounded-lg border border-card-border bg-card p-6 text-card-foreground shadow-lg';
+
+export const dialogHeaderClasses = 'flex flex-col space-y-1.5 text-center sm:text-left';
+
+export const dialogFooterClasses = 'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2';
+
+export const dialogTitleClasses = 'text-lg font-semibold leading-none tracking-tight';
+
+export const dialogDescriptionClasses = 'text-sm text-muted-foreground';

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -58,6 +58,17 @@ import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap'
 import { onPointerDownOutside } from '../../primitives/outside-click';
 import { getPortalContainer } from '../../primitives/portal';
 import { mergeProps } from '../../primitives/slot';
+import {
+  dialogCloseButtonClasses,
+  dialogCloseIconClasses,
+  dialogContainerClasses,
+  dialogContentClasses,
+  dialogDescriptionClasses,
+  dialogFooterClasses,
+  dialogHeaderClasses,
+  dialogOverlayClasses,
+  dialogTitleClasses,
+} from './dialog.classes';
 
 // Context for sharing dialog state
 interface DialogContextValue {
@@ -223,7 +234,7 @@ export function DialogOverlay({ asChild, forceMount, className, ...props }: Dial
 
   const overlayProps = {
     ...ariaProps,
-    className: classy('fixed inset-0 z-depth-overlay bg-foreground/80', className),
+    className: classy(dialogOverlayClasses, className),
     ...props,
   };
 
@@ -338,7 +349,7 @@ export function DialogContent({
     <button
       type="button"
       onClick={() => onOpenChange(false)}
-      className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
+      className={dialogCloseButtonClasses}
       aria-label="Close"
     >
       <svg
@@ -351,7 +362,7 @@ export function DialogContent({
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
-        className="h-4 w-4"
+        className={dialogCloseIconClasses}
         aria-hidden="true"
       >
         <path d="M18 6 6 18" />
@@ -362,12 +373,9 @@ export function DialogContent({
   ) : null;
 
   // Render using a centered container
-  const containerClass = classy('fixed inset-0 z-depth-modal flex items-center justify-center p-4');
+  const containerClass = classy(dialogContainerClasses);
 
-  const innerClass = classy(
-    'relative w-full max-w-lg rounded-lg border border-card-border bg-card p-6 text-card-foreground shadow-lg',
-    className,
-  );
+  const innerClass = classy(dialogContentClasses, className);
 
   const innerProps = {
     ref: contentRef,
@@ -431,12 +439,7 @@ export function DialogContent({
 export interface DialogHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export function DialogHeader({ className, ...props }: DialogHeaderProps) {
-  return (
-    <div
-      className={classy('flex flex-col space-y-1.5 text-center sm:text-left', className)}
-      {...props}
-    />
-  );
+  return <div className={classy(dialogHeaderClasses, className)} {...props} />;
 }
 
 // ==================== Dialog.Footer ====================
@@ -444,12 +447,7 @@ export function DialogHeader({ className, ...props }: DialogHeaderProps) {
 export interface DialogFooterProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export function DialogFooter({ className, ...props }: DialogFooterProps) {
-  return (
-    <div
-      className={classy('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
-      {...props}
-    />
-  );
+  return <div className={classy(dialogFooterClasses, className)} {...props} />;
 }
 
 // ==================== Dialog.Title ====================
@@ -463,7 +461,7 @@ export function DialogTitle({ asChild, className, ...props }: DialogTitleProps) 
 
   const titleProps = {
     id: titleId,
-    className: classy('text-lg font-semibold leading-none tracking-tight', className),
+    className: classy(dialogTitleClasses, className),
     ...props,
   };
 
@@ -488,7 +486,7 @@ export function DialogDescription({ asChild, className, ...props }: DialogDescri
 
   const descriptionProps = {
     id: descriptionId,
-    className: classy('text-sm text-muted-foreground', className),
+    className: classy(dialogDescriptionClasses, className),
     ...props,
   };
 

--- a/packages/ui/src/components/ui/dropdown-menu.classes.ts
+++ b/packages/ui/src/components/ui/dropdown-menu.classes.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared class definitions for DropdownMenu component
+ */
+
+export const dropdownMenuContentClasses =
+  'z-depth-dropdown min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md';
+
+export const dropdownMenuContentAnimationClasses =
+  'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2';
+
+export const dropdownMenuLabelClasses = 'px-2 py-1.5 text-sm font-semibold';
+
+export const dropdownMenuItemClasses =
+  'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+
+export const dropdownMenuCheckboxItemClasses =
+  'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+
+export const dropdownMenuCheckboxIndicatorClasses =
+  'absolute left-2 flex h-3.5 w-3.5 items-center justify-center';
+
+export const dropdownMenuRadioItemClasses =
+  'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+
+export const dropdownMenuRadioIndicatorClasses =
+  'absolute left-2 flex h-3.5 w-3.5 items-center justify-center';
+
+export const dropdownMenuRadioDotClasses = 'h-2 w-2 rounded-full bg-current';
+
+export const dropdownMenuSeparatorClasses = '-mx-1 my-1 h-px border-0 bg-muted';
+
+export const dropdownMenuShortcutClasses = 'ml-auto text-xs tracking-widest opacity-60';
+
+export const dropdownMenuSubTriggerClasses =
+  'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+
+export const dropdownMenuSubTriggerIconClasses = 'ml-auto h-4 w-4';
+
+export const dropdownMenuCheckIconClasses = 'h-4 w-4';

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -41,6 +41,22 @@ import { createRovingFocus } from '../../primitives/roving-focus';
 import { mergeProps } from '../../primitives/slot';
 import { createTypeahead } from '../../primitives/typeahead';
 import type { Align, Side } from '../../primitives/types';
+import {
+  dropdownMenuCheckboxIndicatorClasses,
+  dropdownMenuCheckboxItemClasses,
+  dropdownMenuCheckIconClasses,
+  dropdownMenuContentAnimationClasses,
+  dropdownMenuContentClasses,
+  dropdownMenuItemClasses,
+  dropdownMenuLabelClasses,
+  dropdownMenuRadioDotClasses,
+  dropdownMenuRadioIndicatorClasses,
+  dropdownMenuRadioItemClasses,
+  dropdownMenuSeparatorClasses,
+  dropdownMenuShortcutClasses,
+  dropdownMenuSubTriggerClasses,
+  dropdownMenuSubTriggerIconClasses,
+} from './dropdown-menu.classes';
 
 // ==================== Types ====================
 
@@ -447,15 +463,7 @@ export const DropdownMenuContent = React.forwardRef<HTMLDivElement, DropdownMenu
       'data-state': open ? 'open' : 'closed',
       'data-side': position.side,
       'data-align': position.align,
-      className: classy(
-        'z-depth-dropdown min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
-        'data-[state=open]:animate-in data-[state=closed]:animate-out',
-        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-        'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-        'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2',
-        'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        className,
-      ),
+      className: classy(dropdownMenuContentClasses, dropdownMenuContentAnimationClasses, className),
       style: contentStyle,
       ...props,
     };
@@ -518,7 +526,7 @@ export const DropdownMenuLabel = React.forwardRef<HTMLDivElement, DropdownMenuLa
     return (
       <div
         ref={ref}
-        className={classy('px-2 py-1.5 text-sm font-semibold', inset && 'pl-8', className)}
+        className={classy(dropdownMenuLabelClasses, inset && 'pl-8', className)}
         {...props}
       />
     );
@@ -571,13 +579,7 @@ export const DropdownMenuItem = React.forwardRef<HTMLDivElement, DropdownMenuIte
         tabIndex={disabled ? undefined : -1}
         aria-disabled={disabled || undefined}
         data-disabled={disabled ? '' : undefined}
-        className={classy(
-          'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none',
-          'transition-colors focus:bg-accent focus:text-accent-foreground',
-          'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-          inset && 'pl-8',
-          className,
-        )}
+        className={classy(dropdownMenuItemClasses, inset && 'pl-8', className)}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
         {...props}
@@ -652,20 +654,15 @@ export const DropdownMenuCheckboxItem = React.forwardRef<
         aria-disabled={disabled || undefined}
         data-disabled={disabled ? '' : undefined}
         data-state={checked ? 'checked' : 'unchecked'}
-        className={classy(
-          'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none',
-          'transition-colors focus:bg-accent focus:text-accent-foreground',
-          'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-          className,
-        )}
+        className={classy(dropdownMenuCheckboxItemClasses, className)}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
         {...props}
       >
-        <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <span className={dropdownMenuCheckboxIndicatorClasses}>
           {checked && (
             <svg
-              className="h-4 w-4"
+              className={dropdownMenuCheckIconClasses}
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -769,18 +766,13 @@ export const DropdownMenuRadioItem = React.forwardRef<HTMLDivElement, DropdownMe
         aria-disabled={disabled || undefined}
         data-disabled={disabled ? '' : undefined}
         data-state={checked ? 'checked' : 'unchecked'}
-        className={classy(
-          'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none',
-          'transition-colors focus:bg-accent focus:text-accent-foreground',
-          'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-          className,
-        )}
+        className={classy(dropdownMenuRadioItemClasses, className)}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
         {...props}
       >
-        <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-          {checked && <span className="h-2 w-2 rounded-full bg-current" aria-hidden="true" />}
+        <span className={dropdownMenuRadioIndicatorClasses}>
+          {checked && <span className={dropdownMenuRadioDotClasses} aria-hidden="true" />}
         </span>
         {children}
       </div>
@@ -796,9 +788,7 @@ export interface DropdownMenuSeparatorProps extends React.HTMLAttributes<HTMLHRE
 
 export const DropdownMenuSeparator = React.forwardRef<HTMLHRElement, DropdownMenuSeparatorProps>(
   ({ className, ...props }, ref) => {
-    return (
-      <hr ref={ref} className={classy('-mx-1 my-1 h-px border-0 bg-muted', className)} {...props} />
-    );
+    return <hr ref={ref} className={classy(dropdownMenuSeparatorClasses, className)} {...props} />;
   },
 );
 
@@ -809,9 +799,7 @@ DropdownMenuSeparator.displayName = 'DropdownMenuSeparator';
 export interface DropdownMenuShortcutProps extends React.HTMLAttributes<HTMLSpanElement> {}
 
 export function DropdownMenuShortcut({ className, ...props }: DropdownMenuShortcutProps) {
-  return (
-    <span className={classy('ml-auto text-xs tracking-widest opacity-60', className)} {...props} />
-  );
+  return <span className={classy(dropdownMenuShortcutClasses, className)} {...props} />;
 }
 
 // ==================== DropdownMenuSub ====================
@@ -952,14 +940,7 @@ export const DropdownMenuSubTrigger = React.forwardRef<HTMLDivElement, DropdownM
         aria-disabled={disabled || undefined}
         data-disabled={disabled ? '' : undefined}
         data-state={open ? 'open' : 'closed'}
-        className={classy(
-          'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none',
-          'transition-colors focus:bg-accent focus:text-accent-foreground',
-          'data-[state=open]:bg-accent',
-          'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-          inset && 'pl-8',
-          className,
-        )}
+        className={classy(dropdownMenuSubTriggerClasses, inset && 'pl-8', className)}
         onPointerEnter={handlePointerEnter}
         onPointerLeave={handlePointerLeave}
         onKeyDown={handleKeyDown}
@@ -967,7 +948,7 @@ export const DropdownMenuSubTrigger = React.forwardRef<HTMLDivElement, DropdownM
       >
         {children}
         <svg
-          className="ml-auto h-4 w-4"
+          className={dropdownMenuSubTriggerIconClasses}
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"

--- a/packages/ui/src/components/ui/hover-card.classes.ts
+++ b/packages/ui/src/components/ui/hover-card.classes.ts
@@ -1,0 +1,6 @@
+/**
+ * Shared class definitions for HoverCard component
+ */
+
+export const hoverCardContentClasses =
+  'z-depth-popover w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-lg outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2';

--- a/packages/ui/src/components/ui/hover-card.tsx
+++ b/packages/ui/src/components/ui/hover-card.tsx
@@ -43,6 +43,7 @@ import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { getPortalContainer } from '../../primitives/portal';
 import { mergeProps } from '../../primitives/slot';
 import type { Align, Side } from '../../primitives/types';
+import { hoverCardContentClasses } from './hover-card.classes';
 
 // ==================== Global state for skip delay ====================
 
@@ -555,15 +556,7 @@ export function HoverCardContent({
     return null;
   }
 
-  const contentClassName = classy(
-    'z-depth-popover w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-lg outline-none',
-    'data-[state=open]:animate-in data-[state=closed]:animate-out',
-    'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-    'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-    'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2',
-    'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-    className,
-  );
+  const contentClassName = classy(hoverCardContentClasses, className);
 
   const style: React.CSSProperties = {
     position: 'fixed',

--- a/packages/ui/src/components/ui/menubar.classes.ts
+++ b/packages/ui/src/components/ui/menubar.classes.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared class definitions for Menubar component
+ */
+
+export const menubarRootClasses = 'flex h-9 items-center gap-1 rounded-md border bg-background p-1';
+
+export const menubarTriggerClasses =
+  'flex cursor-default select-none items-center rounded-sm px-3 py-1 text-sm font-medium outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground';
+
+export const menubarContentClasses =
+  'z-depth-dropdown min-w-48 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md';
+
+export const menubarContentAnimationClasses =
+  'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2';
+
+export const menubarLabelClasses = 'px-2 py-1.5 text-sm font-semibold';
+
+export const menubarItemClasses =
+  'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+
+export const menubarCheckboxItemClasses =
+  'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+
+export const menubarCheckboxIndicatorClasses =
+  'absolute left-2 flex h-3.5 w-3.5 items-center justify-center';
+
+export const menubarCheckIconClasses = 'h-4 w-4';
+
+export const menubarRadioItemClasses =
+  'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+
+export const menubarRadioIndicatorClasses =
+  'absolute left-2 flex h-3.5 w-3.5 items-center justify-center';
+
+export const menubarRadioDotClasses = 'h-2 w-2 rounded-full bg-current';
+
+export const menubarSeparatorClasses = '-mx-1 my-1 h-px border-0 bg-muted';
+
+export const menubarShortcutClasses = 'ml-auto text-xs tracking-widest opacity-60';
+
+export const menubarSubTriggerClasses =
+  'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+
+export const menubarSubTriggerIconClasses = 'ml-auto h-4 w-4';

--- a/packages/ui/src/components/ui/menubar.tsx
+++ b/packages/ui/src/components/ui/menubar.tsx
@@ -48,6 +48,24 @@ import { createRovingFocus } from '../../primitives/roving-focus';
 import { mergeProps } from '../../primitives/slot';
 import { createTypeahead } from '../../primitives/typeahead';
 import type { Align, Side } from '../../primitives/types';
+import {
+  menubarCheckboxIndicatorClasses,
+  menubarCheckboxItemClasses,
+  menubarCheckIconClasses,
+  menubarContentAnimationClasses,
+  menubarContentClasses,
+  menubarItemClasses,
+  menubarLabelClasses,
+  menubarRadioDotClasses,
+  menubarRadioIndicatorClasses,
+  menubarRadioItemClasses,
+  menubarRootClasses,
+  menubarSeparatorClasses,
+  menubarShortcutClasses,
+  menubarSubTriggerClasses,
+  menubarSubTriggerIconClasses,
+  menubarTriggerClasses,
+} from './menubar.classes';
 
 // ==================== Types ====================
 
@@ -225,10 +243,7 @@ const MenubarRoot = React.forwardRef<HTMLDivElement, MenubarProps>(
         <div
           ref={menubarRef}
           role="menubar"
-          className={classy(
-            'flex h-9 items-center gap-1 rounded-md border bg-background p-1',
-            className,
-          )}
+          className={classy(menubarRootClasses, className)}
           onKeyDown={handleKeyDown}
           {...props}
         >
@@ -375,12 +390,7 @@ export const MenubarTrigger = React.forwardRef<HTMLButtonElement, MenubarTrigger
         type="button"
         role="menuitem"
         tabIndex={-1}
-        className={classy(
-          'flex cursor-default select-none items-center rounded-sm px-3 py-1 text-sm font-medium outline-none',
-          'focus:bg-accent focus:text-accent-foreground',
-          'data-[state=open]:bg-accent data-[state=open]:text-accent-foreground',
-          className,
-        )}
+        className={classy(menubarTriggerClasses, className)}
         onClick={handleClick}
         onPointerEnter={handlePointerEnter}
         onKeyDown={handleKeyDown}
@@ -679,15 +689,7 @@ export const MenubarContent = React.forwardRef<HTMLDivElement, MenubarContentPro
       'data-state': open ? 'open' : 'closed',
       'data-side': position.side,
       'data-align': position.align,
-      className: classy(
-        'z-depth-dropdown min-w-48 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
-        'data-[state=open]:animate-in data-[state=closed]:animate-out',
-        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-        'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-        'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2',
-        'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        className,
-      ),
+      className: classy(menubarContentClasses, menubarContentAnimationClasses, className),
       style: contentStyle,
       onKeyDown: handleKeyDown,
       ...props,
@@ -750,7 +752,7 @@ export const MenubarLabel = React.forwardRef<HTMLDivElement, MenubarLabelProps>(
     return (
       <div
         ref={ref}
-        className={classy('px-2 py-1.5 text-sm font-semibold', inset && 'pl-8', className)}
+        className={classy(menubarLabelClasses, inset && 'pl-8', className)}
         {...props}
       />
     );
@@ -802,13 +804,7 @@ export const MenubarItem = React.forwardRef<HTMLDivElement, MenubarItemProps>(
         tabIndex={disabled ? undefined : -1}
         aria-disabled={disabled || undefined}
         data-disabled={disabled ? '' : undefined}
-        className={classy(
-          'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none',
-          'transition-colors focus:bg-accent focus:text-accent-foreground',
-          'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-          inset && 'pl-8',
-          className,
-        )}
+        className={classy(menubarItemClasses, inset && 'pl-8', className)}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
         {...props}
@@ -880,20 +876,15 @@ export const MenubarCheckboxItem = React.forwardRef<HTMLDivElement, MenubarCheck
         aria-disabled={disabled || undefined}
         data-disabled={disabled ? '' : undefined}
         data-state={checked ? 'checked' : 'unchecked'}
-        className={classy(
-          'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none',
-          'transition-colors focus:bg-accent focus:text-accent-foreground',
-          'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-          className,
-        )}
+        className={classy(menubarCheckboxItemClasses, className)}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
         {...props}
       >
-        <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <span className={menubarCheckboxIndicatorClasses}>
           {checked && (
             <svg
-              className="h-4 w-4"
+              className={menubarCheckIconClasses}
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -997,18 +988,13 @@ export const MenubarRadioItem = React.forwardRef<HTMLDivElement, MenubarRadioIte
         aria-disabled={disabled || undefined}
         data-disabled={disabled ? '' : undefined}
         data-state={checked ? 'checked' : 'unchecked'}
-        className={classy(
-          'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none',
-          'transition-colors focus:bg-accent focus:text-accent-foreground',
-          'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-          className,
-        )}
+        className={classy(menubarRadioItemClasses, className)}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
         {...props}
       >
-        <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-          {checked && <span className="h-2 w-2 rounded-full bg-current" aria-hidden="true" />}
+        <span className={menubarRadioIndicatorClasses}>
+          {checked && <span className={menubarRadioDotClasses} aria-hidden="true" />}
         </span>
         {children}
       </div>
@@ -1024,9 +1010,7 @@ export interface MenubarSeparatorProps extends React.HTMLAttributes<HTMLHRElemen
 
 export const MenubarSeparator = React.forwardRef<HTMLHRElement, MenubarSeparatorProps>(
   ({ className, ...props }, ref) => {
-    return (
-      <hr ref={ref} className={classy('-mx-1 my-1 h-px border-0 bg-muted', className)} {...props} />
-    );
+    return <hr ref={ref} className={classy(menubarSeparatorClasses, className)} {...props} />;
   },
 );
 
@@ -1037,9 +1021,7 @@ MenubarSeparator.displayName = 'MenubarSeparator';
 export interface MenubarShortcutProps extends React.HTMLAttributes<HTMLSpanElement> {}
 
 export function MenubarShortcut({ className, ...props }: MenubarShortcutProps) {
-  return (
-    <span className={classy('ml-auto text-xs tracking-widest opacity-60', className)} {...props} />
-  );
+  return <span className={classy(menubarShortcutClasses, className)} {...props} />;
 }
 
 // ==================== MenubarSub ====================
@@ -1175,14 +1157,7 @@ export const MenubarSubTrigger = React.forwardRef<HTMLDivElement, MenubarSubTrig
         aria-disabled={disabled || undefined}
         data-disabled={disabled ? '' : undefined}
         data-state={open ? 'open' : 'closed'}
-        className={classy(
-          'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none',
-          'transition-colors focus:bg-accent focus:text-accent-foreground',
-          'data-[state=open]:bg-accent',
-          'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-          inset && 'pl-8',
-          className,
-        )}
+        className={classy(menubarSubTriggerClasses, inset && 'pl-8', className)}
         onPointerEnter={handlePointerEnter}
         onPointerLeave={handlePointerLeave}
         onKeyDown={handleKeyDown}
@@ -1190,7 +1165,7 @@ export const MenubarSubTrigger = React.forwardRef<HTMLDivElement, MenubarSubTrig
       >
         {children}
         <svg
-          className="ml-auto h-4 w-4"
+          className={menubarSubTriggerIconClasses}
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"

--- a/packages/ui/src/components/ui/navigation-menu.classes.ts
+++ b/packages/ui/src/components/ui/navigation-menu.classes.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared class definitions for NavigationMenu component
+ */
+
+export const navigationMenuRootClasses =
+  'relative z-10 flex max-w-max flex-1 items-center justify-center';
+
+export const navigationMenuListClasses =
+  'group flex flex-1 list-none items-center justify-center gap-1';
+
+export const navigationMenuTriggerClasses =
+  'group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50';
+
+export const navigationMenuTriggerChevronClasses = 'ml-1 h-3 w-3 transition-transform duration-200';
+
+export const navigationMenuContentClasses = 'left-0 top-0 w-full';
+
+export const navigationMenuContentActiveClasses = 'animate-in fade-in-0 zoom-in-95';
+
+export const navigationMenuLinkClasses =
+  'block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
+
+export const navigationMenuViewportClasses =
+  'mt-1.5 h-min w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg origin-top-center';
+
+export const navigationMenuViewportActiveClasses = 'animate-in fade-in-0 zoom-in-95';
+
+export const navigationMenuIndicatorClasses =
+  'bottom-0 z-10 flex h-2.5 items-end justify-center overflow-hidden transition-transform duration-200';
+
+export const navigationMenuIndicatorActiveClasses = 'animate-in fade-in';
+
+export const navigationMenuIndicatorArrowClasses =
+  'top-full h-2 w-2 rotate-45 rounded-tl-sm bg-border shadow-md';

--- a/packages/ui/src/components/ui/navigation-menu.tsx
+++ b/packages/ui/src/components/ui/navigation-menu.tsx
@@ -42,6 +42,20 @@ import classy from '../../primitives/classy';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { onPointerDownOutside } from '../../primitives/outside-click';
 import { mergeProps } from '../../primitives/slot';
+import {
+  navigationMenuContentActiveClasses,
+  navigationMenuContentClasses,
+  navigationMenuIndicatorActiveClasses,
+  navigationMenuIndicatorArrowClasses,
+  navigationMenuIndicatorClasses,
+  navigationMenuLinkClasses,
+  navigationMenuListClasses,
+  navigationMenuRootClasses,
+  navigationMenuTriggerChevronClasses,
+  navigationMenuTriggerClasses,
+  navigationMenuViewportActiveClasses,
+  navigationMenuViewportClasses,
+} from './navigation-menu.classes';
 
 // ==================== Types ====================
 
@@ -191,10 +205,7 @@ export function NavigationMenu({
       <nav
         aria-label="Main navigation"
         data-orientation={orientation}
-        className={classy(
-          'relative z-10 flex max-w-max flex-1 items-center justify-center',
-          className,
-        )}
+        className={classy(navigationMenuRootClasses, className)}
         {...props}
       >
         {children}
@@ -217,10 +228,7 @@ export const NavigationMenuList = React.forwardRef<HTMLUListElement, NavigationM
       <ul
         ref={ref}
         data-orientation={orientation}
-        className={classy(
-          'group flex flex-1 list-none items-center justify-center gap-1',
-          className,
-        )}
+        className={classy(navigationMenuListClasses, className)}
         {...props}
       />
     );
@@ -383,15 +391,7 @@ export const NavigationMenuTrigger = React.forwardRef<
       aria-controls={contentId}
       aria-haspopup="menu"
       data-state={isActive ? 'open' : 'closed'}
-      className={classy(
-        'group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2',
-        'text-sm font-medium transition-colors',
-        'hover:bg-accent hover:text-accent-foreground',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-        'disabled:pointer-events-none disabled:opacity-50',
-        isActive && 'bg-accent-subtle',
-        className,
-      )}
+      className={classy(navigationMenuTriggerClasses, isActive && 'bg-accent-subtle', className)}
       onPointerEnter={handlePointerEnter}
       onPointerLeave={handlePointerLeave}
       onClick={handleClick}
@@ -400,7 +400,7 @@ export const NavigationMenuTrigger = React.forwardRef<
     >
       {children}
       <ChevronDown
-        className={classy('ml-1 h-3 w-3 transition-transform duration-200')}
+        className={classy(navigationMenuTriggerChevronClasses)}
         style={{ transform: isActive ? 'rotate(180deg)' : undefined }}
         aria-hidden="true"
       />
@@ -481,8 +481,8 @@ export const NavigationMenuContent = React.forwardRef<HTMLDivElement, Navigation
         aria-labelledby={triggerId}
         data-state={isActive ? 'open' : 'closed'}
         className={classy(
-          'left-0 top-0 w-full',
-          isActive && 'animate-in fade-in-0 zoom-in-95',
+          navigationMenuContentClasses,
+          isActive && navigationMenuContentActiveClasses,
           className,
         )}
         style={{ position: 'absolute' }}
@@ -516,14 +516,7 @@ export const NavigationMenuLink = React.forwardRef<HTMLAnchorElement, Navigation
       context?.onValueChange('');
     }, [context]);
 
-    const cls = classy(
-      'block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors',
-      'hover:bg-accent hover:text-accent-foreground',
-      'focus-visible:bg-accent focus-visible:text-accent-foreground',
-      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-      active && 'bg-accent-subtle',
-      className,
-    );
+    const cls = classy(navigationMenuLinkClasses, active && 'bg-accent-subtle', className);
 
     if (asChild && React.isValidElement(children)) {
       const child = children as React.ReactElement<
@@ -616,9 +609,8 @@ export const NavigationMenuViewport = React.forwardRef<HTMLDivElement, Navigatio
           ref={composedRef}
           data-state={isOpen ? 'open' : 'closed'}
           className={classy(
-            'mt-1.5 h-min w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg',
-            'origin-top-center',
-            isOpen && 'animate-in fade-in-0 zoom-in-95',
+            navigationMenuViewportClasses,
+            isOpen && navigationMenuViewportActiveClasses,
             className,
           )}
           style={{
@@ -695,9 +687,8 @@ export const NavigationMenuIndicator = React.forwardRef<
       ref={ref}
       data-state={isVisible ? 'visible' : 'hidden'}
       className={classy(
-        'bottom-0 z-10 flex h-2.5 items-end justify-center overflow-hidden',
-        'transition-transform duration-200',
-        isVisible && 'animate-in fade-in',
+        navigationMenuIndicatorClasses,
+        isVisible && navigationMenuIndicatorActiveClasses,
         className,
       )}
       style={{
@@ -708,10 +699,7 @@ export const NavigationMenuIndicator = React.forwardRef<
       aria-hidden="true"
       {...props}
     >
-      <div
-        className="top-full h-2 w-2 rotate-45 rounded-tl-sm bg-border shadow-md"
-        style={{ position: 'relative' }}
-      />
+      <div className={navigationMenuIndicatorArrowClasses} style={{ position: 'relative' }} />
     </div>
   );
 });

--- a/packages/ui/src/components/ui/popover.classes.ts
+++ b/packages/ui/src/components/ui/popover.classes.ts
@@ -1,0 +1,6 @@
+/**
+ * Shared class definitions for Popover component
+ */
+
+export const popoverContentClasses =
+  'z-depth-popover w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2';

--- a/packages/ui/src/components/ui/popover.tsx
+++ b/packages/ui/src/components/ui/popover.tsx
@@ -48,6 +48,7 @@ import { Float, useFloatContext } from '../../primitives/float';
 import { getPortalContainer } from '../../primitives/portal';
 import { mergeProps } from '../../primitives/slot';
 import type { Align, Side } from '../../primitives/types';
+import { popoverContentClasses } from './popover.classes';
 
 // Context to track if we're inside a portal (to avoid double-wrapping)
 const PopoverPortalContext = React.createContext<boolean>(false);
@@ -247,15 +248,7 @@ export function PopoverContent({
       disablePortal={isInsidePortal}
       container={!isInsidePortal ? container : undefined}
       role="dialog"
-      className={classy(
-        'z-depth-popover w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none',
-        'data-[state=open]:animate-in data-[state=closed]:animate-out',
-        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-        'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-        'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2',
-        'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        className,
-      )}
+      className={classy(popoverContentClasses, className)}
       {...props}
     >
       {children}

--- a/packages/ui/src/components/ui/radio-group.classes.ts
+++ b/packages/ui/src/components/ui/radio-group.classes.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared class definitions for RadioGroup component
+ */
+
+export const radioGroupHorizontalClasses = 'flex gap-2';
+
+export const radioGroupVerticalClasses = 'grid gap-2';
+
+export const radioGroupItemBaseClasses =
+  'inline-flex items-center justify-center ' +
+  'aspect-square h-4 w-4 ' +
+  'rounded-full ' +
+  'border border-primary ' +
+  'text-primary ' +
+  'transition-colors ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ' +
+  'disabled:cursor-not-allowed disabled:opacity-50';
+
+export const radioGroupItemIndicatorClasses = 'block h-2 w-2 rounded-full bg-current';

--- a/packages/ui/src/components/ui/radio-group.tsx
+++ b/packages/ui/src/components/ui/radio-group.tsx
@@ -32,6 +32,12 @@
 import * as React from 'react';
 import classy from '../../primitives/classy';
 import { createRovingFocus } from '../../primitives/roving-focus';
+import {
+  radioGroupHorizontalClasses,
+  radioGroupItemBaseClasses,
+  radioGroupItemIndicatorClasses,
+  radioGroupVerticalClasses,
+} from './radio-group.classes';
 
 // ==================== Types ====================
 
@@ -148,7 +154,8 @@ export const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(
       [value, handleValueChange, disabled, orientation, name],
     );
 
-    const baseClasses = orientation === 'horizontal' ? 'flex gap-2' : 'grid gap-2';
+    const baseClasses =
+      orientation === 'horizontal' ? radioGroupHorizontalClasses : radioGroupVerticalClasses;
 
     return (
       <RadioGroupContext.Provider value={contextValue}>
@@ -202,15 +209,6 @@ export const RadioGroupItem = React.forwardRef<HTMLButtonElement, RadioGroupItem
     );
 
     // Base styles
-    const baseClasses =
-      'inline-flex items-center justify-center ' +
-      'aspect-square h-4 w-4 ' +
-      'rounded-full ' +
-      'border border-primary ' +
-      'text-primary ' +
-      'transition-colors ' +
-      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ' +
-      'disabled:cursor-not-allowed disabled:opacity-50';
 
     return (
       // biome-ignore lint/a11y/useSemanticElements: Custom radio with visual styling not possible with native input
@@ -222,12 +220,12 @@ export const RadioGroupItem = React.forwardRef<HTMLButtonElement, RadioGroupItem
         data-state={isChecked ? 'checked' : 'unchecked'}
         disabled={isDisabled}
         name={name}
-        className={classy(baseClasses, className)}
+        className={classy(radioGroupItemBaseClasses, className)}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
         {...props}
       >
-        {isChecked && <span className="block h-2 w-2 rounded-full bg-current" aria-hidden="true" />}
+        {isChecked && <span className={radioGroupItemIndicatorClasses} aria-hidden="true" />}
         {children}
       </button>
     );

--- a/packages/ui/src/components/ui/resizable.classes.ts
+++ b/packages/ui/src/components/ui/resizable.classes.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared resizable class definitions
+ *
+ * Imported by resizable.tsx (React) to keep inline strings
+ * in a single source of truth.
+ */
+
+export const resizablePanelGroupClasses = 'flex h-full w-full';
+
+export const resizablePanelClasses = 'relative';
+
+export const resizableHandleClasses =
+  'relative flex items-center justify-center bg-border ' +
+  'after:absolute after:inset-y-0 after:left-1/2 after:-translate-x-1/2 ' +
+  'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1';
+
+export const resizableHandleHorizontalClasses = 'w-px cursor-col-resize after:w-1';
+
+export const resizableHandleVerticalClasses = 'h-px cursor-row-resize after:h-1';
+
+export const resizableHandleDisabledClasses = 'cursor-not-allowed opacity-50';
+
+export const resizableHandleDraggingClasses = 'bg-primary';
+
+export const resizableHandleGripClasses =
+  'z-10 flex items-center justify-center rounded-sm border bg-border';
+
+export const resizableHandleGripHorizontalClasses = 'h-4 w-3';
+
+export const resizableHandleGripVerticalClasses = 'h-3 w-4';
+
+export const resizableHandleGripIconClasses = 'size-2.5';

--- a/packages/ui/src/components/ui/resizable.tsx
+++ b/packages/ui/src/components/ui/resizable.tsx
@@ -33,6 +33,19 @@
 
 import * as React from 'react';
 import classy from '../../primitives/classy';
+import {
+  resizableHandleClasses,
+  resizableHandleDisabledClasses,
+  resizableHandleDraggingClasses,
+  resizableHandleGripClasses,
+  resizableHandleGripHorizontalClasses,
+  resizableHandleGripIconClasses,
+  resizableHandleGripVerticalClasses,
+  resizableHandleHorizontalClasses,
+  resizableHandleVerticalClasses,
+  resizablePanelClasses,
+  resizablePanelGroupClasses,
+} from './resizable.classes';
 
 // ==================== Types ====================
 
@@ -311,7 +324,7 @@ export function ResizablePanelGroup({
         data-panel-group=""
         data-direction={direction}
         className={classy(
-          'flex h-full w-full',
+          resizablePanelGroupClasses,
           direction === 'horizontal' ? 'flex-row' : 'flex-col',
           className,
         )}
@@ -409,7 +422,7 @@ export function ResizablePanel({
       data-panel=""
       data-panel-id={id}
       data-collapsed={collapsed}
-      className={classy('relative', className)}
+      className={classy(resizablePanelClasses, className)}
       style={style}
       {...props}
     >
@@ -528,14 +541,12 @@ export function ResizableHandle({
       data-disabled={disabled}
       data-dragging={isDragging}
       className={classy(
-        'relative flex items-center justify-center bg-border',
-        'after:absolute after:inset-y-0 after:left-1/2 after:-translate-x-1/2',
+        resizableHandleClasses,
         direction === 'horizontal'
-          ? 'w-px cursor-col-resize after:w-1'
-          : 'h-px cursor-row-resize after:h-1',
-        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1',
-        disabled && 'cursor-not-allowed opacity-50',
-        isDragging && 'bg-primary',
+          ? resizableHandleHorizontalClasses
+          : resizableHandleVerticalClasses,
+        disabled && resizableHandleDisabledClasses,
+        isDragging && resizableHandleDraggingClasses,
         className,
       )}
       onMouseDown={handleMouseDown}
@@ -545,8 +556,10 @@ export function ResizableHandle({
       {withHandle && (
         <div
           className={classy(
-            'z-10 flex items-center justify-center rounded-sm border bg-border',
-            direction === 'horizontal' ? 'h-4 w-3' : 'h-3 w-4',
+            resizableHandleGripClasses,
+            direction === 'horizontal'
+              ? resizableHandleGripHorizontalClasses
+              : resizableHandleGripVerticalClasses,
           )}
         >
           <svg
@@ -557,7 +570,10 @@ export function ResizableHandle({
             strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
-            className={classy('size-2.5', direction === 'horizontal' ? 'rotate-90' : '')}
+            className={classy(
+              resizableHandleGripIconClasses,
+              direction === 'horizontal' ? 'rotate-90' : '',
+            )}
             aria-hidden="true"
           >
             <title>Drag handle</title>

--- a/packages/ui/src/components/ui/scroll-area.classes.ts
+++ b/packages/ui/src/components/ui/scroll-area.classes.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared scroll area class definitions
+ *
+ * Imported by scroll-area.tsx (React) to keep inline strings
+ * in a single source of truth.
+ */
+
+export const scrollAreaBaseClasses = 'h-full w-full rounded-sm @md:rounded-md @lg:rounded-lg';
+
+export const scrollAreaScrollbarBaseClasses =
+  '[&::-webkit-scrollbar]:w-2.5 ' +
+  '[&::-webkit-scrollbar]:h-2.5 ' +
+  '[&::-webkit-scrollbar-track]:bg-transparent ' +
+  '[&::-webkit-scrollbar-thumb]:rounded-full ' +
+  '[&::-webkit-scrollbar-thumb]:bg-border ' +
+  '[&::-webkit-scrollbar-corner]:bg-transparent';
+
+export const scrollAreaOrientationClasses: Record<string, string> = {
+  vertical: 'overflow-y-auto overflow-x-hidden',
+  horizontal: 'overflow-x-auto overflow-y-hidden',
+  both: 'overflow-auto',
+};
+
+export const scrollBarBaseClasses = 'flex touch-none select-none transition-colors';
+
+export const scrollBarOrientationClasses: Record<string, string> = {
+  vertical: 'h-full w-2.5 border-l border-l-transparent p-px',
+  horizontal: 'h-2.5 w-full flex-col border-t border-t-transparent p-px',
+};
+
+export const scrollBarThumbClasses = 'flex-1 rounded-full bg-border';

--- a/packages/ui/src/components/ui/scroll-area.tsx
+++ b/packages/ui/src/components/ui/scroll-area.tsx
@@ -39,6 +39,14 @@
  */
 import * as React from 'react';
 import classy from '../../primitives/classy';
+import {
+  scrollAreaBaseClasses,
+  scrollAreaOrientationClasses,
+  scrollAreaScrollbarBaseClasses,
+  scrollBarBaseClasses,
+  scrollBarOrientationClasses,
+  scrollBarThumbClasses,
+} from './scroll-area.classes';
 
 export interface ScrollAreaProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Scroll direction: vertical, horizontal, or both */
@@ -50,35 +58,15 @@ export interface ScrollBarProps extends React.HTMLAttributes<HTMLDivElement> {
   orientation?: 'vertical' | 'horizontal';
 }
 
-// Scrollbar styling classes using webkit pseudo-elements
-const scrollbarBase = [
-  // Scrollbar width/height
-  '[&::-webkit-scrollbar]:w-2.5',
-  '[&::-webkit-scrollbar]:h-2.5',
-  // Track styling
-  '[&::-webkit-scrollbar-track]:bg-transparent',
-  // Thumb styling
-  '[&::-webkit-scrollbar-thumb]:rounded-full',
-  '[&::-webkit-scrollbar-thumb]:bg-border',
-  // Corner (where scrollbars meet)
-  '[&::-webkit-scrollbar-corner]:bg-transparent',
-].join(' ');
-
-const orientationStyles = {
-  vertical: 'overflow-y-auto overflow-x-hidden',
-  horizontal: 'overflow-x-auto overflow-y-hidden',
-  both: 'overflow-auto',
-};
-
 export const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
   ({ className, orientation = 'vertical', children, ...props }, ref) => {
     return (
       <div
         ref={ref}
         className={classy(
-          'h-full w-full rounded-sm @md:rounded-md @lg:rounded-lg',
-          scrollbarBase,
-          orientationStyles[orientation],
+          scrollAreaBaseClasses,
+          scrollAreaScrollbarBaseClasses,
+          scrollAreaOrientationClasses[orientation],
           className,
         )}
         {...props}
@@ -99,22 +87,17 @@ ScrollArea.displayName = 'ScrollArea';
  */
 export const ScrollBar = React.forwardRef<HTMLDivElement, ScrollBarProps>(
   ({ className, orientation = 'vertical', ...props }, ref) => {
-    const orientationClasses = {
-      vertical: 'h-full w-2.5 border-l border-l-transparent p-px',
-      horizontal: 'h-2.5 w-full flex-col border-t border-t-transparent p-px',
-    };
-
     return (
       <div
         ref={ref}
         className={classy(
-          'flex touch-none select-none transition-colors',
-          orientationClasses[orientation],
+          scrollBarBaseClasses,
+          scrollBarOrientationClasses[orientation],
           className,
         )}
         {...props}
       >
-        <div className="flex-1 rounded-full bg-border" />
+        <div className={scrollBarThumbClasses} />
       </div>
     );
   },

--- a/packages/ui/src/components/ui/select.classes.ts
+++ b/packages/ui/src/components/ui/select.classes.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared class definitions for Select component
+ */
+
+export const selectTriggerBaseClasses =
+  'flex w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-3 text-sm ring-offset-background';
+
+export const selectTriggerPlaceholderClasses = 'placeholder:text-muted-foreground';
+
+export const selectTriggerFocusClasses =
+  'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2';
+
+export const selectTriggerDisabledClasses = 'disabled:cursor-not-allowed disabled:opacity-50';
+
+export const selectTriggerLineClampClasses = '[&>span]:line-clamp-1';
+
+export const selectValuePlaceholderClasses = 'text-muted-foreground';
+
+export const selectChevronClasses = 'size-4 shrink-0 opacity-50';
+
+export const selectContentBaseClasses =
+  'z-depth-dropdown max-h-96 min-w-32 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md';
+
+export const selectContentAnimateClasses =
+  'data-[state=open]:animate-in data-[state=closed]:animate-out';
+
+export const selectContentFadeClasses =
+  'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0';
+
+export const selectContentZoomClasses =
+  'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95';
+
+export const selectContentSlideClasses =
+  'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2';
+
+export const selectContentPaddingClasses = 'p-1';
+
+export const selectViewportClasses = 'p-1';
+
+export const selectLabelClasses = 'py-1.5 pl-8 pr-2 text-sm font-semibold';
+
+export const selectItemBaseClasses =
+  'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none';
+
+export const selectItemFocusClasses = 'focus:bg-accent focus:text-accent-foreground';
+
+export const selectItemDisabledClasses =
+  'data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+
+export const selectItemIndicatorClasses =
+  'absolute left-2 flex h-3.5 w-3.5 items-center justify-center';
+
+export const selectSeparatorClasses = '-mx-1 my-1 h-px bg-muted';
+
+export const selectIconClasses = 'ml-auto h-4 w-4 shrink-0 opacity-50';
+
+export const selectScrollButtonClasses = 'flex cursor-default items-center justify-center py-1';
+
+export const selectScrollIconClasses = 'size-4';

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -53,6 +53,31 @@ import { createRovingFocus } from '../../primitives/roving-focus';
 import { mergeProps } from '../../primitives/slot';
 import { createTypeahead } from '../../primitives/typeahead';
 import type { Align, Side } from '../../primitives/types';
+import {
+  selectChevronClasses,
+  selectContentAnimateClasses,
+  selectContentBaseClasses,
+  selectContentFadeClasses,
+  selectContentPaddingClasses,
+  selectContentSlideClasses,
+  selectContentZoomClasses,
+  selectIconClasses,
+  selectItemBaseClasses,
+  selectItemDisabledClasses,
+  selectItemFocusClasses,
+  selectItemIndicatorClasses,
+  selectLabelClasses,
+  selectScrollButtonClasses,
+  selectScrollIconClasses,
+  selectSeparatorClasses,
+  selectTriggerBaseClasses,
+  selectTriggerDisabledClasses,
+  selectTriggerFocusClasses,
+  selectTriggerLineClampClasses,
+  selectTriggerPlaceholderClasses,
+  selectValuePlaceholderClasses,
+  selectViewportClasses,
+} from './select.classes';
 
 // ==================== Context ====================
 
@@ -259,11 +284,11 @@ export function SelectTrigger({
   };
 
   const buttonClassName = classy(
-    'flex w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-3 text-sm ring-offset-background',
-    'placeholder:text-muted-foreground',
-    'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
-    'disabled:cursor-not-allowed disabled:opacity-50',
-    '[&>span]:line-clamp-1',
+    selectTriggerBaseClasses,
+    selectTriggerPlaceholderClasses,
+    selectTriggerFocusClasses,
+    selectTriggerDisabledClasses,
+    selectTriggerLineClampClasses,
     size === 'default' && 'h-9 py-2',
     size === 'sm' && 'h-8 py-1.5',
     className,
@@ -293,7 +318,7 @@ export function SelectTrigger({
       strokeWidth="2"
       strokeLinecap="round"
       strokeLinejoin="round"
-      className="size-4 shrink-0 opacity-50"
+      className={selectChevronClasses}
     >
       <path d="m6 9 6 6 6-6" />
     </svg>
@@ -355,7 +380,7 @@ export function SelectValue({
   const displayValue = label ?? (hasValue ? value : placeholder);
   const isPlaceholder = !hasValue;
 
-  const spanClassName = classy(isPlaceholder ? 'text-muted-foreground' : '', className);
+  const spanClassName = classy(isPlaceholder ? selectValuePlaceholderClasses : '', className);
 
   if (asChild && React.isValidElement(children)) {
     const child = children as React.ReactElement<Record<string, unknown>>;
@@ -627,12 +652,11 @@ export function SelectContent({
   };
 
   const contentClassName = classy(
-    'z-depth-dropdown max-h-96 min-w-32 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md',
-    'data-[state=open]:animate-in data-[state=closed]:animate-out',
-    'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-    'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-    'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2',
-    'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+    selectContentBaseClasses,
+    selectContentAnimateClasses,
+    selectContentFadeClasses,
+    selectContentZoomClasses,
+    selectContentSlideClasses,
     className,
   );
 
@@ -661,7 +685,7 @@ export function SelectContent({
       })()
     ) : (
       <div {...contentProps}>
-        <div className="p-1">{children}</div>
+        <div className={selectContentPaddingClasses}>{children}</div>
       </div>
     );
 
@@ -680,7 +704,7 @@ export interface SelectViewportProps extends React.HTMLAttributes<HTMLDivElement
 }
 
 export function SelectViewport({ className, children, asChild, ...props }: SelectViewportProps) {
-  const viewportClassName = classy('p-1', className);
+  const viewportClassName = classy(selectViewportClasses, className);
 
   if (asChild && React.isValidElement(children)) {
     const child = children as React.ReactElement<Record<string, unknown>>;
@@ -709,7 +733,7 @@ export interface SelectGroupProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 export function SelectGroup({ className, children, asChild, ...props }: SelectGroupProps) {
-  const groupClassName = classy('', className);
+  const groupClassName = classy(className);
 
   if (asChild && React.isValidElement(children)) {
     const child = children as React.ReactElement<Record<string, unknown>>;
@@ -740,7 +764,7 @@ export interface SelectLabelProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 export function SelectLabel({ className, children, asChild, ...props }: SelectLabelProps) {
-  const labelClassName = classy('py-1.5 pl-8 pr-2 text-sm font-semibold', className);
+  const labelClassName = classy(selectLabelClasses, className);
 
   if (asChild && React.isValidElement(children)) {
     const child = children as React.ReactElement<Record<string, unknown>>;
@@ -831,9 +855,9 @@ export function SelectItem({
   };
 
   const itemClassName = classy(
-    'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none',
-    'focus:bg-accent focus:text-accent-foreground',
-    'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+    selectItemBaseClasses,
+    selectItemFocusClasses,
+    selectItemDisabledClasses,
     className,
   );
 
@@ -862,7 +886,7 @@ export function SelectItem({
 
   return (
     <div {...itemProps}>
-      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <span className={selectItemIndicatorClasses}>
         {isSelected && (
           <svg
             aria-hidden="true"
@@ -892,7 +916,7 @@ export interface SelectSeparatorProps extends React.HTMLAttributes<HTMLDivElemen
 }
 
 export function SelectSeparator({ className, asChild, ...props }: SelectSeparatorProps) {
-  const separatorClassName = classy('-mx-1 my-1 h-px bg-muted', className);
+  const separatorClassName = classy(selectSeparatorClasses, className);
 
   if (asChild && React.isValidElement(props.children)) {
     const child = props.children as React.ReactElement<Record<string, unknown>>;
@@ -922,7 +946,7 @@ export interface SelectIconProps extends React.HTMLAttributes<HTMLSpanElement> {
  * This component is kept for backwards compatibility.
  */
 export function SelectIcon({ className, children, asChild, ...props }: SelectIconProps) {
-  const iconClassName = classy('ml-auto h-4 w-4 shrink-0 opacity-50', className);
+  const iconClassName = classy(selectIconClasses, className);
 
   if (asChild && React.isValidElement(children)) {
     const child = children as React.ReactElement<Record<string, unknown>>;
@@ -975,7 +999,7 @@ export function SelectScrollUpButton({
   asChild,
   ...props
 }: SelectScrollUpButtonProps) {
-  const buttonClassName = classy('flex cursor-default items-center justify-center py-1', className);
+  const buttonClassName = classy(selectScrollButtonClasses, className);
 
   if (asChild && React.isValidElement(children)) {
     const child = children as React.ReactElement<Record<string, unknown>>;
@@ -1005,7 +1029,7 @@ export function SelectScrollUpButton({
           strokeWidth="2"
           strokeLinecap="round"
           strokeLinejoin="round"
-          className="size-4"
+          className={selectScrollIconClasses}
         >
           <path d="m18 15-6-6-6 6" />
         </svg>
@@ -1030,7 +1054,7 @@ export function SelectScrollDownButton({
   asChild,
   ...props
 }: SelectScrollDownButtonProps) {
-  const buttonClassName = classy('flex cursor-default items-center justify-center py-1', className);
+  const buttonClassName = classy(selectScrollButtonClasses, className);
 
   if (asChild && React.isValidElement(children)) {
     const child = children as React.ReactElement<Record<string, unknown>>;
@@ -1060,7 +1084,7 @@ export function SelectScrollDownButton({
           strokeWidth="2"
           strokeLinecap="round"
           strokeLinejoin="round"
-          className="size-4"
+          className={selectScrollIconClasses}
         >
           <path d="m6 9 6 6 6-6" />
         </svg>

--- a/packages/ui/src/components/ui/sheet.classes.ts
+++ b/packages/ui/src/components/ui/sheet.classes.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared class definitions for Sheet component
+ */
+
+export const sheetOverlayClasses =
+  'fixed inset-0 z-depth-overlay bg-foreground/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0';
+
+export const sheetContentClasses =
+  'fixed z-depth-modal gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-500 data-[state=closed]:duration-300';
+
+export const sheetCloseButtonClasses =
+  'absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary';
+
+export const sheetCloseIconClasses = 'h-4 w-4';
+
+export const sheetHeaderClasses = 'flex flex-col space-y-2 text-center sm:text-left';
+
+export const sheetFooterClasses = 'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2';
+
+export const sheetTitleClasses = 'text-lg font-semibold text-foreground';
+
+export const sheetDescriptionClasses = 'text-sm text-muted-foreground';

--- a/packages/ui/src/components/ui/sheet.tsx
+++ b/packages/ui/src/components/ui/sheet.tsx
@@ -59,6 +59,16 @@ import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap'
 import { onPointerDownOutside } from '../../primitives/outside-click';
 import { getPortalContainer } from '../../primitives/portal';
 import { mergeProps } from '../../primitives/slot';
+import {
+  sheetCloseButtonClasses,
+  sheetCloseIconClasses,
+  sheetContentClasses,
+  sheetDescriptionClasses,
+  sheetFooterClasses,
+  sheetHeaderClasses,
+  sheetOverlayClasses,
+  sheetTitleClasses,
+} from './sheet.classes';
 
 // Context for sharing sheet state
 interface SheetContextValue {
@@ -227,12 +237,7 @@ export function SheetOverlay({ asChild, forceMount, className, ...props }: Sheet
 
   const overlayProps = {
     ...ariaProps,
-    className: classy(
-      'fixed inset-0 z-depth-overlay bg-foreground/80',
-      'data-[state=open]:animate-in data-[state=closed]:animate-out',
-      'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-      className,
-    ),
+    className: classy(sheetOverlayClasses, className),
     ...props,
   };
 
@@ -349,17 +354,11 @@ export function SheetContent({
     return null;
   }
 
-  const contentClassName = classy(
-    'fixed z-depth-modal gap-4 bg-background p-6 shadow-lg transition ease-in-out',
-    'data-[state=open]:animate-in data-[state=closed]:animate-out',
-    'data-[state=open]:duration-500 data-[state=closed]:duration-300',
-    sideVariants[side],
-    className,
-  );
+  const contentClassName = classy(sheetContentClasses, sideVariants[side], className);
 
   // Close button component (X icon)
   const closeButton = shouldShowCloseButton ? (
-    <SheetClose className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+    <SheetClose className={sheetCloseButtonClasses}>
       <svg
         aria-hidden="true"
         xmlns="http://www.w3.org/2000/svg"
@@ -371,7 +370,7 @@ export function SheetContent({
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
-        className="h-4 w-4"
+        className={sheetCloseIconClasses}
       >
         <path d="M18 6 6 18" />
         <path d="m6 6 12 12" />
@@ -433,12 +432,7 @@ export function SheetContent({
 export interface SheetHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export function SheetHeader({ className, ...props }: SheetHeaderProps) {
-  return (
-    <div
-      className={classy('flex flex-col space-y-2 text-center sm:text-left', className)}
-      {...props}
-    />
-  );
+  return <div className={classy(sheetHeaderClasses, className)} {...props} />;
 }
 
 // ==================== Sheet.Footer ====================
@@ -446,12 +440,7 @@ export function SheetHeader({ className, ...props }: SheetHeaderProps) {
 export interface SheetFooterProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export function SheetFooter({ className, ...props }: SheetFooterProps) {
-  return (
-    <div
-      className={classy('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
-      {...props}
-    />
-  );
+  return <div className={classy(sheetFooterClasses, className)} {...props} />;
 }
 
 // ==================== Sheet.Title ====================
@@ -465,7 +454,7 @@ export function SheetTitle({ asChild, className, ...props }: SheetTitleProps) {
 
   const titleProps = {
     id: titleId,
-    className: classy('text-lg font-semibold text-foreground', className),
+    className: classy(sheetTitleClasses, className),
     ...props,
   };
 
@@ -490,7 +479,7 @@ export function SheetDescription({ asChild, className, ...props }: SheetDescript
 
   const descriptionProps = {
     id: descriptionId,
-    className: classy('text-sm text-muted-foreground', className),
+    className: classy(sheetDescriptionClasses, className),
     ...props,
   };
 

--- a/packages/ui/src/components/ui/sidebar.classes.ts
+++ b/packages/ui/src/components/ui/sidebar.classes.ts
@@ -1,0 +1,154 @@
+/**
+ * Shared sidebar class definitions
+ *
+ * Imported by sidebar.tsx (React) to keep inline strings
+ * in a single source of truth.
+ */
+
+export const sidebarProviderClasses =
+  'group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar';
+
+export const sidebarNonCollapsibleClasses =
+  'flex h-full w-64 flex-col bg-sidebar text-sidebar-foreground';
+
+export const sidebarMobileOverlayClasses =
+  'fixed inset-0 z-depth-overlay bg-foreground/80 cursor-default';
+
+export const sidebarMobilePanelClasses =
+  'fixed inset-y-0 z-depth-modal flex h-svh w-72 flex-col bg-sidebar text-sidebar-foreground ' +
+  'transition-transform duration-200 ease-in-out';
+
+export const sidebarMobilePanelLeftClasses = 'left-0 data-[state=closed]:-translate-x-full';
+
+export const sidebarMobilePanelRightClasses = 'right-0 data-[state=closed]:translate-x-full';
+
+export const sidebarMobileInnerClasses = 'flex h-full w-full flex-col';
+
+export const sidebarDesktopWrapperClasses = 'group peer hidden md:block';
+
+export const sidebarDesktopGapClasses =
+  'relative h-svh w-64 bg-transparent transition-all duration-200 ease-linear ' +
+  'group-data-[collapsible=offcanvas]:w-0 ' +
+  'group-data-[collapsible=icon]:w-12';
+
+export const sidebarDesktopFixedClasses =
+  'fixed inset-y-0 z-depth-navigation flex h-svh w-64 flex-col transition-all duration-200 ease-linear ' +
+  'group-data-[collapsible=icon]:w-12';
+
+export const sidebarDesktopFixedLeftClasses = 'left-0 group-data-[collapsible=offcanvas]:-left-64';
+
+export const sidebarDesktopFixedRightClasses =
+  'right-0 group-data-[collapsible=offcanvas]:-right-64';
+
+export const sidebarDesktopVariantDefaultClasses =
+  'border-r group-data-[side=right]:border-l group-data-[side=right]:border-r-0';
+
+export const sidebarDesktopVariantFloatingInsetClasses = 'p-2 group-data-[collapsible=icon]:w-16';
+
+export const sidebarContentWrapperClasses =
+  'flex h-full w-full flex-col bg-sidebar text-sidebar-foreground';
+
+export const sidebarContentWrapperFloatingClasses = 'rounded-lg border shadow-sm';
+
+export const sidebarContentWrapperInsetClasses = 'rounded-lg shadow-sm';
+
+export const sidebarTriggerClasses = 'inline-flex items-center justify-center size-7';
+
+export const sidebarRailClasses =
+  'hidden w-4 -translate-x-1/2 transition-all ease-linear md:flex ' +
+  'absolute inset-y-0 z-20 after:absolute after:inset-y-0 after:left-1/2 after:w-0.5 ' +
+  'hover:after:bg-sidebar-border cursor-ew-resize ' +
+  'group-data-[side=left]:-right-4 group-data-[side=right]:left-0 ' +
+  'in-data-[variant=floating]:in-data-[side=left]:-right-6 ' +
+  'in-data-[variant=floating]:in-data-[side=right]:left-2 ' +
+  'in-data-[variant=inset]:in-data-[side=left]:-right-6 ' +
+  'in-data-[variant=inset]:in-data-[side=right]:left-2';
+
+export const sidebarInsetClasses =
+  'relative flex w-full min-h-svh flex-1 flex-col bg-background ' +
+  'peer-data-[variant=inset]:min-h-[calc(100svh-theme(spacing.4))] ' +
+  'md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm';
+
+export const sidebarHeaderClasses = 'flex flex-col gap-2 p-2';
+
+export const sidebarFooterClasses = 'flex flex-col gap-2 p-2';
+
+export const sidebarContentClasses =
+  'flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden';
+
+export const sidebarGroupClasses = 'relative flex w-full min-w-0 flex-col p-2';
+
+export const sidebarGroupLabelClasses =
+  'flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-none ' +
+  'ring-sidebar-ring transition-all duration-200 ease-linear focus-visible:ring-2 ' +
+  'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0';
+
+export const sidebarGroupActionClasses =
+  'absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 ' +
+  'text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground ' +
+  'focus-visible:ring-2 after:absolute after:-inset-2 after:md:hidden ' +
+  'group-data-[collapsible=icon]:hidden';
+
+export const sidebarGroupContentClasses = 'w-full';
+
+export const sidebarMenuClasses = 'flex w-full min-w-0 flex-col gap-1';
+
+export const sidebarMenuItemClasses = 'group/menu-item relative';
+
+export const sidebarMenuButtonClasses =
+  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ' +
+  'ring-sidebar-ring transition-all hover:bg-sidebar-accent hover:text-sidebar-accent-foreground ' +
+  'focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 ' +
+  'group-has-data-[sidebar=menu-action]/menu-item:pr-8 ' +
+  'aria-disabled:pointer-events-none aria-disabled:opacity-50 ' +
+  'data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground ' +
+  'group-data-[collapsible=icon]:size-8 group-data-[collapsible=icon]:p-2 ' +
+  'group-data-[collapsible=icon]:group-has-data-[sidebar=menu-action]/menu-item:pr-2';
+
+export const sidebarMenuButtonSmClasses = 'text-xs';
+
+export const sidebarMenuButtonLgClasses = 'text-sm group-data-[collapsible=icon]:p-0';
+
+export const sidebarMenuButtonOutlineClasses =
+  'bg-background shadow-sm hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-none';
+
+export const sidebarMenuActionClasses =
+  'absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 ' +
+  'text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground ' +
+  'focus-visible:ring-2 peer-hover/menu-button:text-sidebar-accent-foreground ' +
+  'after:absolute after:-inset-2 after:md:hidden ' +
+  'group-data-[collapsible=icon]:hidden';
+
+export const sidebarMenuActionShowOnHoverClasses =
+  'group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground md:opacity-0';
+
+export const sidebarMenuBadgeClasses =
+  'pointer-events-none absolute right-1 flex h-5 min-w-5 select-none items-center justify-center ' +
+  'rounded-md px-1 text-xs font-medium tabular-nums text-sidebar-foreground ' +
+  'peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground ' +
+  'group-data-[collapsible=icon]:hidden';
+
+export const sidebarMenuSkeletonClasses = 'flex h-8 items-center gap-2 rounded-md px-2';
+
+export const sidebarMenuSkeletonIconClasses =
+  'size-4 shrink-0 animate-pulse rounded-md bg-sidebar-accent';
+
+export const sidebarMenuSkeletonTextClasses =
+  'h-4 max-w-[--skeleton-width] flex-1 animate-pulse rounded-md bg-sidebar-accent';
+
+export const sidebarMenuSubClasses =
+  'ml-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border pl-2.5 py-0.5 ' +
+  'group-data-[collapsible=icon]:hidden';
+
+export const sidebarMenuSubButtonClasses =
+  'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-none ' +
+  'ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground ' +
+  'focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 ' +
+  'aria-disabled:pointer-events-none aria-disabled:opacity-50 ' +
+  'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground';
+
+export const sidebarMenuSubButtonSmClasses = 'text-xs';
+
+export const sidebarMenuSubButtonMdClasses = 'text-sm';
+
+export const sidebarSeparatorClasses = 'mx-2 h-px w-auto bg-sidebar-border';

--- a/packages/ui/src/components/ui/sidebar.tsx
+++ b/packages/ui/src/components/ui/sidebar.tsx
@@ -50,6 +50,52 @@
 import * as React from 'react';
 import classy from '../../primitives/classy';
 import { mergeProps } from '../../primitives/slot';
+import {
+  sidebarContentClasses,
+  sidebarContentWrapperClasses,
+  sidebarContentWrapperFloatingClasses,
+  sidebarContentWrapperInsetClasses,
+  sidebarDesktopFixedClasses,
+  sidebarDesktopFixedLeftClasses,
+  sidebarDesktopFixedRightClasses,
+  sidebarDesktopGapClasses,
+  sidebarDesktopVariantDefaultClasses,
+  sidebarDesktopVariantFloatingInsetClasses,
+  sidebarDesktopWrapperClasses,
+  sidebarFooterClasses,
+  sidebarGroupActionClasses,
+  sidebarGroupClasses,
+  sidebarGroupContentClasses,
+  sidebarGroupLabelClasses,
+  sidebarHeaderClasses,
+  sidebarInsetClasses,
+  sidebarMenuActionClasses,
+  sidebarMenuActionShowOnHoverClasses,
+  sidebarMenuBadgeClasses,
+  sidebarMenuButtonClasses,
+  sidebarMenuButtonLgClasses,
+  sidebarMenuButtonOutlineClasses,
+  sidebarMenuButtonSmClasses,
+  sidebarMenuClasses,
+  sidebarMenuItemClasses,
+  sidebarMenuSkeletonClasses,
+  sidebarMenuSkeletonIconClasses,
+  sidebarMenuSkeletonTextClasses,
+  sidebarMenuSubButtonClasses,
+  sidebarMenuSubButtonMdClasses,
+  sidebarMenuSubButtonSmClasses,
+  sidebarMenuSubClasses,
+  sidebarMobileInnerClasses,
+  sidebarMobileOverlayClasses,
+  sidebarMobilePanelClasses,
+  sidebarMobilePanelLeftClasses,
+  sidebarMobilePanelRightClasses,
+  sidebarNonCollapsibleClasses,
+  sidebarProviderClasses,
+  sidebarRailClasses,
+  sidebarSeparatorClasses,
+  sidebarTriggerClasses,
+} from './sidebar.classes';
 
 // ==================== Types ====================
 
@@ -177,10 +223,7 @@ export function SidebarProvider({
       <div
         data-sidebar="provider"
         style={style}
-        className={classy(
-          'group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar',
-          className,
-        )}
+        className={classy(sidebarProviderClasses, className)}
         {...props}
       >
         {children}
@@ -213,10 +256,7 @@ export function Sidebar({
         data-sidebar="sidebar"
         data-variant={variant}
         data-side={side}
-        className={classy(
-          'flex h-full w-64 flex-col bg-sidebar text-sidebar-foreground',
-          className,
-        )}
+        className={classy(sidebarNonCollapsibleClasses, className)}
         {...props}
       >
         {children}
@@ -233,7 +273,7 @@ export function Sidebar({
           <button
             type="button"
             data-sidebar="overlay"
-            className="fixed inset-0 z-depth-overlay bg-foreground/80 cursor-default"
+            className={sidebarMobileOverlayClasses}
             onClick={() => setOpenMobile(false)}
             aria-label="Close sidebar"
           />
@@ -246,16 +286,13 @@ export function Sidebar({
           data-side={side}
           data-state={openMobile ? 'open' : 'closed'}
           className={classy(
-            'fixed inset-y-0 z-depth-modal flex h-svh w-72 flex-col bg-sidebar text-sidebar-foreground',
-            'transition-transform duration-200 ease-in-out',
-            side === 'left'
-              ? 'left-0 data-[state=closed]:-translate-x-full'
-              : 'right-0 data-[state=closed]:translate-x-full',
+            sidebarMobilePanelClasses,
+            side === 'left' ? sidebarMobilePanelLeftClasses : sidebarMobilePanelRightClasses,
             className,
           )}
           {...props}
         >
-          <div className="flex h-full w-full flex-col">{children}</div>
+          <div className={sidebarMobileInnerClasses}>{children}</div>
         </div>
       </>
     );
@@ -269,29 +306,20 @@ export function Sidebar({
       data-collapsible={state === 'collapsed' ? collapsible : ''}
       data-variant={variant}
       data-side={side}
-      className="group peer hidden md:block"
+      className={sidebarDesktopWrapperClasses}
     >
       {/* Gap element for smooth transition */}
-      <div
-        className={classy(
-          'relative h-svh w-64 bg-transparent transition-all duration-200 ease-linear',
-          'group-data-[collapsible=offcanvas]:w-0',
-          'group-data-[collapsible=icon]:w-12',
-        )}
-      />
+      <div className={classy(sidebarDesktopGapClasses)} />
 
       {/* Actual sidebar content */}
       <div
         className={classy(
-          'fixed inset-y-0 z-depth-navigation flex h-svh w-64 flex-col transition-all duration-200 ease-linear',
-          side === 'left'
-            ? 'left-0 group-data-[collapsible=offcanvas]:-left-64'
-            : 'right-0 group-data-[collapsible=offcanvas]:-right-64',
-          'group-data-[collapsible=icon]:w-12',
+          sidebarDesktopFixedClasses,
+          side === 'left' ? sidebarDesktopFixedLeftClasses : sidebarDesktopFixedRightClasses,
           // Variants
           variant === 'floating' || variant === 'inset'
-            ? 'p-2 group-data-[collapsible=icon]:w-16'
-            : 'border-r group-data-[side=right]:border-l group-data-[side=right]:border-r-0',
+            ? sidebarDesktopVariantFloatingInsetClasses
+            : sidebarDesktopVariantDefaultClasses,
           className,
         )}
         {...props}
@@ -299,9 +327,9 @@ export function Sidebar({
         <div
           data-sidebar="content-wrapper"
           className={classy(
-            'flex h-full w-full flex-col bg-sidebar text-sidebar-foreground',
-            variant === 'floating' && 'rounded-lg border shadow-sm',
-            variant === 'inset' && 'rounded-lg shadow-sm',
+            sidebarContentWrapperClasses,
+            variant === 'floating' && sidebarContentWrapperFloatingClasses,
+            variant === 'inset' && sidebarContentWrapperInsetClasses,
           )}
         >
           {children}
@@ -327,7 +355,7 @@ export function SidebarTrigger({ asChild, className, onClick, ...props }: Sideba
 
   const triggerProps = {
     'data-sidebar': 'trigger',
-    className: classy('inline-flex items-center justify-center size-7', className),
+    className: classy(sidebarTriggerClasses, className),
     onClick: handleClick,
     ...props,
   };
@@ -379,17 +407,7 @@ export function SidebarRail({ className, ...props }: SidebarRailProps) {
       tabIndex={-1}
       onClick={toggleSidebar}
       title="Toggle Sidebar"
-      className={classy(
-        'hidden w-4 -translate-x-1/2 transition-all ease-linear md:flex',
-        'absolute inset-y-0 z-20 after:absolute after:inset-y-0 after:left-1/2 after:w-0.5',
-        'hover:after:bg-sidebar-border cursor-ew-resize',
-        'group-data-[side=left]:-right-4 group-data-[side=right]:left-0',
-        'in-data-[variant=floating]:in-data-[side=left]:-right-6',
-        'in-data-[variant=floating]:in-data-[side=right]:left-2',
-        'in-data-[variant=inset]:in-data-[side=left]:-right-6',
-        'in-data-[variant=inset]:in-data-[side=right]:left-2',
-        className,
-      )}
+      className={classy(sidebarRailClasses, className)}
       {...props}
     />
   );
@@ -401,16 +419,7 @@ export interface SidebarInsetProps extends React.HTMLAttributes<HTMLDivElement> 
 
 export function SidebarInset({ className, ...props }: SidebarInsetProps) {
   return (
-    <main
-      data-sidebar="inset"
-      className={classy(
-        'relative flex w-full min-h-svh flex-1 flex-col bg-background',
-        'peer-data-[variant=inset]:min-h-[calc(100svh-theme(spacing.4))]',
-        'md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm',
-        className,
-      )}
-      {...props}
-    />
+    <main data-sidebar="inset" className={classy(sidebarInsetClasses, className)} {...props} />
   );
 }
 
@@ -420,11 +429,7 @@ export interface SidebarHeaderProps extends React.HTMLAttributes<HTMLDivElement>
 
 export function SidebarHeader({ className, ...props }: SidebarHeaderProps) {
   return (
-    <div
-      data-sidebar="header"
-      className={classy('flex flex-col gap-2 p-2', className)}
-      {...props}
-    />
+    <div data-sidebar="header" className={classy(sidebarHeaderClasses, className)} {...props} />
   );
 }
 
@@ -434,11 +439,7 @@ export interface SidebarFooterProps extends React.HTMLAttributes<HTMLDivElement>
 
 export function SidebarFooter({ className, ...props }: SidebarFooterProps) {
   return (
-    <div
-      data-sidebar="footer"
-      className={classy('flex flex-col gap-2 p-2', className)}
-      {...props}
-    />
+    <div data-sidebar="footer" className={classy(sidebarFooterClasses, className)} {...props} />
   );
 }
 
@@ -448,14 +449,7 @@ export interface SidebarContentProps extends React.HTMLAttributes<HTMLDivElement
 
 export function SidebarContent({ className, ...props }: SidebarContentProps) {
   return (
-    <div
-      data-sidebar="content"
-      className={classy(
-        'flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden',
-        className,
-      )}
-      {...props}
-    />
+    <div data-sidebar="content" className={classy(sidebarContentClasses, className)} {...props} />
   );
 }
 
@@ -464,13 +458,7 @@ export function SidebarContent({ className, ...props }: SidebarContentProps) {
 export interface SidebarGroupProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export function SidebarGroup({ className, ...props }: SidebarGroupProps) {
-  return (
-    <div
-      data-sidebar="group"
-      className={classy('relative flex w-full min-w-0 flex-col p-2', className)}
-      {...props}
-    />
-  );
+  return <div data-sidebar="group" className={classy(sidebarGroupClasses, className)} {...props} />;
 }
 
 // ==================== Sidebar.GroupLabel ====================
@@ -487,12 +475,7 @@ export function SidebarGroupLabel({
 }: SidebarGroupLabelProps) {
   const labelProps = {
     'data-sidebar': 'group-label',
-    className: classy(
-      'flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-none',
-      'ring-sidebar-ring transition-all duration-200 ease-linear focus-visible:ring-2',
-      'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
-      className,
-    ),
+    className: classy(sidebarGroupLabelClasses, className),
     ...props,
   };
 
@@ -518,13 +501,7 @@ export function SidebarGroupAction({
 }: SidebarGroupActionProps) {
   const actionProps = {
     'data-sidebar': 'group-action',
-    className: classy(
-      'absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0',
-      'text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
-      'focus-visible:ring-2 after:absolute after:-inset-2 after:md:hidden',
-      'group-data-[collapsible=icon]:hidden',
-      className,
-    ),
+    className: classy(sidebarGroupActionClasses, className),
     ...props,
   };
 
@@ -545,7 +522,13 @@ export function SidebarGroupAction({
 export interface SidebarGroupContentProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export function SidebarGroupContent({ className, ...props }: SidebarGroupContentProps) {
-  return <div data-sidebar="group-content" className={classy('w-full', className)} {...props} />;
+  return (
+    <div
+      data-sidebar="group-content"
+      className={classy(sidebarGroupContentClasses, className)}
+      {...props}
+    />
+  );
 }
 
 // ==================== Sidebar.Menu ====================
@@ -553,13 +536,7 @@ export function SidebarGroupContent({ className, ...props }: SidebarGroupContent
 export interface SidebarMenuProps extends React.HTMLAttributes<HTMLUListElement> {}
 
 export function SidebarMenu({ className, ...props }: SidebarMenuProps) {
-  return (
-    <ul
-      data-sidebar="menu"
-      className={classy('flex w-full min-w-0 flex-col gap-1', className)}
-      {...props}
-    />
-  );
+  return <ul data-sidebar="menu" className={classy(sidebarMenuClasses, className)} {...props} />;
 }
 
 // ==================== Sidebar.MenuItem ====================
@@ -568,11 +545,7 @@ export interface SidebarMenuItemProps extends React.HTMLAttributes<HTMLLIElement
 
 export function SidebarMenuItem({ className, ...props }: SidebarMenuItemProps) {
   return (
-    <li
-      data-sidebar="menu-item"
-      className={classy('group/menu-item relative', className)}
-      {...props}
-    />
+    <li data-sidebar="menu-item" className={classy(sidebarMenuItemClasses, className)} {...props} />
   );
 }
 
@@ -599,21 +572,12 @@ export function SidebarMenuButton({
     'data-size': size,
     'data-active': isActive,
     className: classy(
-      'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none',
-      'ring-sidebar-ring transition-all hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
-      'focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50',
-      'group-has-data-[sidebar=menu-action]/menu-item:pr-8',
-      'aria-disabled:pointer-events-none aria-disabled:opacity-50',
-      'data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground',
-      // Icon collapsible mode
-      'group-data-[collapsible=icon]:size-8 group-data-[collapsible=icon]:p-2',
-      'group-data-[collapsible=icon]:group-has-data-[sidebar=menu-action]/menu-item:pr-2',
+      sidebarMenuButtonClasses,
       // Size variants
-      size === 'sm' && 'text-xs',
-      size === 'lg' && 'text-sm group-data-[collapsible=icon]:p-0',
+      size === 'sm' && sidebarMenuButtonSmClasses,
+      size === 'lg' && sidebarMenuButtonLgClasses,
       // Variant styles
-      variant === 'outline' &&
-        'bg-background shadow-sm hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-none',
+      variant === 'outline' && sidebarMenuButtonOutlineClasses,
       className,
     ),
     ...props,
@@ -648,13 +612,8 @@ export function SidebarMenuAction({
   const actionProps = {
     'data-sidebar': 'menu-action',
     className: classy(
-      'absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0',
-      'text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
-      'focus-visible:ring-2 peer-hover/menu-button:text-sidebar-accent-foreground',
-      'after:absolute after:-inset-2 after:md:hidden',
-      'group-data-[collapsible=icon]:hidden',
-      showOnHover &&
-        'group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground md:opacity-0',
+      sidebarMenuActionClasses,
+      showOnHover && sidebarMenuActionShowOnHoverClasses,
       className,
     ),
     ...props,
@@ -680,13 +639,7 @@ export function SidebarMenuBadge({ className, ...props }: SidebarMenuBadgeProps)
   return (
     <div
       data-sidebar="menu-badge"
-      className={classy(
-        'pointer-events-none absolute right-1 flex h-5 min-w-5 select-none items-center justify-center',
-        'rounded-md px-1 text-xs font-medium tabular-nums text-sidebar-foreground',
-        'peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground',
-        'group-data-[collapsible=icon]:hidden',
-        className,
-      )}
+      className={classy(sidebarMenuBadgeClasses, className)}
       {...props}
     />
   );
@@ -709,12 +662,12 @@ export function SidebarMenuSkeleton({
   return (
     <div
       data-sidebar="menu-skeleton"
-      className={classy('flex h-8 items-center gap-2 rounded-md px-2', className)}
+      className={classy(sidebarMenuSkeletonClasses, className)}
       {...props}
     >
-      {showIcon && <div className="size-4 shrink-0 animate-pulse rounded-md bg-sidebar-accent" />}
+      {showIcon && <div className={sidebarMenuSkeletonIconClasses} />}
       <div
-        className="h-4 max-w-[--skeleton-width] flex-1 animate-pulse rounded-md bg-sidebar-accent"
+        className={sidebarMenuSkeletonTextClasses}
         style={{ '--skeleton-width': width } as React.CSSProperties}
       />
     </div>
@@ -727,15 +680,7 @@ export interface SidebarMenuSubProps extends React.HTMLAttributes<HTMLUListEleme
 
 export function SidebarMenuSub({ className, ...props }: SidebarMenuSubProps) {
   return (
-    <ul
-      data-sidebar="menu-sub"
-      className={classy(
-        'ml-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border pl-2.5 py-0.5',
-        'group-data-[collapsible=icon]:hidden',
-        className,
-      )}
-      {...props}
-    />
+    <ul data-sidebar="menu-sub" className={classy(sidebarMenuSubClasses, className)} {...props} />
   );
 }
 
@@ -768,13 +713,9 @@ export function SidebarMenuSubButton({
     'data-size': size,
     'data-active': isActive,
     className: classy(
-      'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-none',
-      'ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
-      'focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50',
-      'aria-disabled:pointer-events-none aria-disabled:opacity-50',
-      'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground',
-      size === 'sm' && 'text-xs',
-      size === 'md' && 'text-sm',
+      sidebarMenuSubButtonClasses,
+      size === 'sm' && sidebarMenuSubButtonSmClasses,
+      size === 'md' && sidebarMenuSubButtonMdClasses,
       className,
     ),
     ...props,
@@ -796,7 +737,7 @@ export function SidebarSeparator({ className, ...props }: SidebarSeparatorProps)
   return (
     <div
       data-sidebar="separator"
-      className={classy('mx-2 h-px w-auto bg-sidebar-border', className)}
+      className={classy(sidebarSeparatorClasses, className)}
       {...props}
     />
   );

--- a/packages/ui/src/components/ui/slider.classes.ts
+++ b/packages/ui/src/components/ui/slider.classes.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared class definitions for Slider component
+ */
+
+export const sliderContainerBaseClasses = 'relative flex touch-none select-none items-center';
+
+export const sliderTrackBaseClasses = 'relative grow overflow-hidden rounded-full bg-muted';
+
+export const sliderRangeBaseClasses = 'absolute';
+
+export const sliderThumbBaseClasses = 'absolute block rounded-full border-2 bg-background';
+
+export const sliderThumbInteractionClasses =
+  'ring-offset-background transition-colors ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2';
+
+export const sliderVariantClasses: Record<string, { range: string; thumb: string; ring: string }> =
+  {
+    default: {
+      range: 'bg-primary',
+      thumb: 'border-primary',
+      ring: 'focus-visible:ring-primary-ring',
+    },
+    primary: {
+      range: 'bg-primary',
+      thumb: 'border-primary',
+      ring: 'focus-visible:ring-primary-ring',
+    },
+    secondary: {
+      range: 'bg-secondary',
+      thumb: 'border-secondary',
+      ring: 'focus-visible:ring-secondary-ring',
+    },
+    destructive: {
+      range: 'bg-destructive',
+      thumb: 'border-destructive',
+      ring: 'focus-visible:ring-destructive-ring',
+    },
+    success: {
+      range: 'bg-success',
+      thumb: 'border-success',
+      ring: 'focus-visible:ring-success-ring',
+    },
+    warning: {
+      range: 'bg-warning',
+      thumb: 'border-warning',
+      ring: 'focus-visible:ring-warning-ring',
+    },
+    info: { range: 'bg-info', thumb: 'border-info', ring: 'focus-visible:ring-info-ring' },
+    accent: { range: 'bg-accent', thumb: 'border-accent', ring: 'focus-visible:ring-accent-ring' },
+  };
+
+export const sliderSizeClasses: Record<string, { track: string; thumb: string }> = {
+  sm: { track: 'h-1', thumb: 'h-4 w-4' },
+  default: { track: 'h-2', thumb: 'h-5 w-5' },
+  lg: { track: 'h-3', thumb: 'h-6 w-6' },
+};

--- a/packages/ui/src/components/ui/slider.tsx
+++ b/packages/ui/src/components/ui/slider.tsx
@@ -25,6 +25,15 @@
  */
 import * as React from 'react';
 import classy from '../../primitives/classy';
+import {
+  sliderContainerBaseClasses,
+  sliderRangeBaseClasses,
+  sliderSizeClasses,
+  sliderThumbBaseClasses,
+  sliderThumbInteractionClasses,
+  sliderTrackBaseClasses,
+  sliderVariantClasses,
+} from './slider.classes';
 
 export interface SliderProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange' | 'defaultValue'> {
@@ -58,47 +67,9 @@ export interface SliderProps
   size?: 'sm' | 'default' | 'lg';
 }
 
-// Variant classes for the range indicator and thumb
-const variantClasses: Record<string, { range: string; thumb: string; ring: string }> = {
-  default: {
-    range: 'bg-primary',
-    thumb: 'border-primary',
-    ring: 'focus-visible:ring-primary-ring',
-  },
-  primary: {
-    range: 'bg-primary',
-    thumb: 'border-primary',
-    ring: 'focus-visible:ring-primary-ring',
-  },
-  secondary: {
-    range: 'bg-secondary',
-    thumb: 'border-secondary',
-    ring: 'focus-visible:ring-secondary-ring',
-  },
-  destructive: {
-    range: 'bg-destructive',
-    thumb: 'border-destructive',
-    ring: 'focus-visible:ring-destructive-ring',
-  },
-  success: {
-    range: 'bg-success',
-    thumb: 'border-success',
-    ring: 'focus-visible:ring-success-ring',
-  },
-  warning: {
-    range: 'bg-warning',
-    thumb: 'border-warning',
-    ring: 'focus-visible:ring-warning-ring',
-  },
-  info: { range: 'bg-info', thumb: 'border-info', ring: 'focus-visible:ring-info-ring' },
-  accent: { range: 'bg-accent', thumb: 'border-accent', ring: 'focus-visible:ring-accent-ring' },
-};
-
-const sliderSizeClasses: Record<string, { track: string; thumb: string }> = {
-  sm: { track: 'h-1', thumb: 'h-4 w-4' },
-  default: { track: 'h-2', thumb: 'h-5 w-5' },
-  lg: { track: 'h-3', thumb: 'h-6 w-6' },
-};
+// Re-export variant and size classes from shared file
+const variantClasses = sliderVariantClasses;
+const sizeClassMap = sliderSizeClasses;
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
@@ -328,10 +299,10 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
 
     // Get variant and size classes with explicit defaults
     const v = variantClasses[variant] ?? variantClasses.default;
-    const s = sliderSizeClasses[size] ?? { track: 'h-2', thumb: 'h-5 w-5' };
+    const s = sizeClassMap[size] ?? { track: 'h-2', thumb: 'h-5 w-5' };
 
     const containerClasses = classy(
-      'relative flex touch-none select-none items-center',
+      sliderContainerBaseClasses,
       {
         'w-full': isHorizontal,
         'h-full flex-col': !isHorizontal,
@@ -340,14 +311,10 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
       className,
     );
 
-    const trackClasses = classy(
-      'relative grow overflow-hidden rounded-full bg-muted',
-      isHorizontal && s.track,
-      {
-        'w-full': isHorizontal,
-        'h-full w-2': !isHorizontal,
-      },
-    );
+    const trackClasses = classy(sliderTrackBaseClasses, isHorizontal && s.track, {
+      'w-full': isHorizontal,
+      'h-full w-2': !isHorizontal,
+    });
 
     const rangeStyle: React.CSSProperties = isHorizontal
       ? {
@@ -371,7 +338,7 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
         <div ref={trackRef} className={trackClasses} onPointerDown={handleTrackClick}>
           {/* Range indicator */}
           <div
-            className={classy('absolute', v?.range)}
+            className={classy(sliderRangeBaseClasses, v?.range)}
             style={{
               ...rangeStyle,
               ...(isHorizontal ? { top: 0, bottom: 0 } : { left: 0, right: 0 }),
@@ -408,11 +375,10 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
               aria-labelledby={ariaLabelledby}
               aria-describedby={ariaDescribedby}
               className={classy(
-                'absolute block rounded-full border-2 bg-background',
+                sliderThumbBaseClasses,
                 s?.thumb,
                 v?.thumb,
-                'ring-offset-background transition-colors',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+                sliderThumbInteractionClasses,
                 v?.ring,
                 {
                   'cursor-grab': !disabled,

--- a/packages/ui/src/components/ui/switch.classes.ts
+++ b/packages/ui/src/components/ui/switch.classes.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared class definitions for Switch component
+ */
+
+export const switchTrackBaseClasses = 'peer inline-flex shrink-0 cursor-pointer items-center';
+
+export const switchTrackShapeClasses = 'rounded-full border-2 border-transparent';
+
+export const switchTrackTransitionClasses = 'transition-colors';
+
+export const switchTrackFocusClasses =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background';
+
+export const switchTrackDisabledClasses = 'disabled:cursor-not-allowed disabled:opacity-50';
+
+export const switchTrackUncheckedClasses = 'bg-input';
+
+export const switchThumbBaseClasses =
+  'pointer-events-none block rounded-full bg-background shadow-lg ring-0';
+
+export const switchThumbTransitionClasses = 'transition-transform';
+
+export const switchThumbUncheckedClasses = 'translate-x-0';
+
+export const switchVariantClasses: Record<string, { checked: string; ring: string }> = {
+  default: { checked: 'bg-primary', ring: 'focus-visible:ring-primary-ring' },
+  primary: { checked: 'bg-primary', ring: 'focus-visible:ring-primary-ring' },
+  secondary: { checked: 'bg-secondary', ring: 'focus-visible:ring-secondary-ring' },
+  destructive: { checked: 'bg-destructive', ring: 'focus-visible:ring-destructive-ring' },
+  success: { checked: 'bg-success', ring: 'focus-visible:ring-success-ring' },
+  warning: { checked: 'bg-warning', ring: 'focus-visible:ring-warning-ring' },
+  info: { checked: 'bg-info', ring: 'focus-visible:ring-info-ring' },
+  accent: { checked: 'bg-accent', ring: 'focus-visible:ring-accent-ring' },
+};
+
+export const switchSizeClasses: Record<
+  string,
+  { track: string; thumb: string; translate: string }
+> = {
+  sm: { track: 'h-5 w-9', thumb: 'h-4 w-4', translate: 'translate-x-4' },
+  default: { track: 'h-6 w-11', thumb: 'h-5 w-5', translate: 'translate-x-5' },
+  lg: { track: 'h-7 w-14', thumb: 'h-6 w-6', translate: 'translate-x-7' },
+};

--- a/packages/ui/src/components/ui/switch.tsx
+++ b/packages/ui/src/components/ui/switch.tsx
@@ -24,6 +24,19 @@
  */
 import * as React from 'react';
 import classy from '../../primitives/classy';
+import {
+  switchSizeClasses,
+  switchThumbBaseClasses,
+  switchThumbTransitionClasses,
+  switchThumbUncheckedClasses,
+  switchTrackBaseClasses,
+  switchTrackDisabledClasses,
+  switchTrackFocusClasses,
+  switchTrackShapeClasses,
+  switchTrackTransitionClasses,
+  switchTrackUncheckedClasses,
+  switchVariantClasses,
+} from './switch.classes';
 
 export interface SwitchProps
   extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> {
@@ -47,23 +60,9 @@ export interface SwitchProps
   size?: 'sm' | 'default' | 'lg';
 }
 
-// Variant classes for checked state
-const variantClasses: Record<string, { checked: string; ring: string }> = {
-  default: { checked: 'bg-primary', ring: 'focus-visible:ring-primary-ring' },
-  primary: { checked: 'bg-primary', ring: 'focus-visible:ring-primary-ring' },
-  secondary: { checked: 'bg-secondary', ring: 'focus-visible:ring-secondary-ring' },
-  destructive: { checked: 'bg-destructive', ring: 'focus-visible:ring-destructive-ring' },
-  success: { checked: 'bg-success', ring: 'focus-visible:ring-success-ring' },
-  warning: { checked: 'bg-warning', ring: 'focus-visible:ring-warning-ring' },
-  info: { checked: 'bg-info', ring: 'focus-visible:ring-info-ring' },
-  accent: { checked: 'bg-accent', ring: 'focus-visible:ring-accent-ring' },
-};
-
-const sizeClasses: Record<string, { track: string; thumb: string; translate: string }> = {
-  sm: { track: 'h-5 w-9', thumb: 'h-4 w-4', translate: 'translate-x-4' },
-  default: { track: 'h-6 w-11', thumb: 'h-5 w-5', translate: 'translate-x-5' },
-  lg: { track: 'h-7 w-14', thumb: 'h-6 w-6', translate: 'translate-x-7' },
-};
+// Re-export variant and size classes from shared file
+const variantClasses = switchVariantClasses;
+const sizeClasses = switchSizeClasses;
 
 export const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
   (
@@ -125,23 +124,23 @@ export const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
 
     // Track (background) styles per docs/COMPONENT_STYLING_REFERENCE.md
     const trackClasses = classy(
-      'peer inline-flex shrink-0 cursor-pointer items-center',
+      switchTrackBaseClasses,
       s?.track,
-      'rounded-full border-2 border-transparent',
-      'transition-colors',
-      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+      switchTrackShapeClasses,
+      switchTrackTransitionClasses,
+      switchTrackFocusClasses,
       v?.ring,
-      'disabled:cursor-not-allowed disabled:opacity-50',
-      checked ? v?.checked : 'bg-input',
+      switchTrackDisabledClasses,
+      checked ? v?.checked : switchTrackUncheckedClasses,
       className,
     );
 
     // Thumb (movable indicator) styles
     const thumbClasses = classy(
-      'pointer-events-none block rounded-full bg-background shadow-lg ring-0',
+      switchThumbBaseClasses,
       s?.thumb,
-      'transition-transform',
-      checked ? s?.translate : 'translate-x-0',
+      switchThumbTransitionClasses,
+      checked ? s?.translate : switchThumbUncheckedClasses,
     );
 
     return (

--- a/packages/ui/src/components/ui/textarea.classes.ts
+++ b/packages/ui/src/components/ui/textarea.classes.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared class definitions for Textarea component
+ */
+
+export const textareaBaseClasses =
+  'flex w-full rounded-md border bg-background ' +
+  'ring-offset-background ' +
+  'placeholder:text-muted-foreground ' +
+  'focus-visible:outline-none focus-visible:ring-offset-2 ' +
+  'disabled:cursor-not-allowed disabled:opacity-50';
+
+export const textareaVariantClasses: Record<string, string> = {
+  default: 'border-primary focus-visible:ring-2 focus-visible:ring-primary-ring',
+  primary: 'border-primary focus-visible:ring-2 focus-visible:ring-primary-ring',
+  secondary: 'border-secondary focus-visible:ring-2 focus-visible:ring-secondary-ring',
+  destructive: 'border-destructive focus-visible:ring-2 focus-visible:ring-destructive-ring',
+  success: 'border-success focus-visible:ring-2 focus-visible:ring-success-ring',
+  warning: 'border-warning focus-visible:ring-2 focus-visible:ring-warning-ring',
+  info: 'border-info focus-visible:ring-2 focus-visible:ring-info-ring',
+  muted: 'border-muted focus-visible:ring-2 focus-visible:ring-ring',
+  accent: 'border-accent focus-visible:ring-2 focus-visible:ring-accent-ring',
+};
+
+export const textareaSizeClasses: Record<string, string> = {
+  sm: 'min-h-16 px-2 py-1 text-xs',
+  default: 'min-h-20 px-3 py-2 text-sm',
+  lg: 'min-h-28 px-4 py-3 text-base',
+};

--- a/packages/ui/src/components/ui/textarea.tsx
+++ b/packages/ui/src/components/ui/textarea.tsx
@@ -22,6 +22,11 @@
  */
 import * as React from 'react';
 import classy from '../../primitives/classy';
+import {
+  textareaBaseClasses,
+  textareaSizeClasses,
+  textareaVariantClasses,
+} from './textarea.classes';
 
 export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   variant?:
@@ -37,36 +42,14 @@ export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextArea
   size?: 'sm' | 'default' | 'lg';
 }
 
-// Variant classes per docs/COMPONENT_STYLING_REFERENCE.md
-const variantClasses: Record<string, string> = {
-  default: 'border-primary focus-visible:ring-2 focus-visible:ring-primary-ring',
-  primary: 'border-primary focus-visible:ring-2 focus-visible:ring-primary-ring',
-  secondary: 'border-secondary focus-visible:ring-2 focus-visible:ring-secondary-ring',
-  destructive: 'border-destructive focus-visible:ring-2 focus-visible:ring-destructive-ring',
-  success: 'border-success focus-visible:ring-2 focus-visible:ring-success-ring',
-  warning: 'border-warning focus-visible:ring-2 focus-visible:ring-warning-ring',
-  info: 'border-info focus-visible:ring-2 focus-visible:ring-info-ring',
-  muted: 'border-muted focus-visible:ring-2 focus-visible:ring-ring',
-  accent: 'border-accent focus-visible:ring-2 focus-visible:ring-accent-ring',
-};
-
-const sizeClasses: Record<string, string> = {
-  sm: 'min-h-16 px-2 py-1 text-xs',
-  default: 'min-h-20 px-3 py-2 text-sm',
-  lg: 'min-h-28 px-4 py-3 text-base',
-};
+// Re-export variant and size classes from shared file
+const variantClasses = textareaVariantClasses;
+const sizeClasses = textareaSizeClasses;
 
 export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, disabled, variant = 'default', size = 'default', ...props }, ref) => {
-    const baseClasses =
-      'flex w-full rounded-md border bg-background ' +
-      'ring-offset-background ' +
-      'placeholder:text-muted-foreground ' +
-      'focus-visible:outline-none focus-visible:ring-offset-2 ' +
-      'disabled:cursor-not-allowed disabled:opacity-50';
-
     const cls = classy(
-      baseClasses,
+      textareaBaseClasses,
       variantClasses[variant] ?? variantClasses.default,
       sizeClasses[size] ?? sizeClasses.default,
       className,

--- a/packages/ui/src/components/ui/toggle-group.classes.ts
+++ b/packages/ui/src/components/ui/toggle-group.classes.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared toggle group class definitions
+ *
+ * Imported by toggle-group.tsx (React) to keep inline strings
+ * in a single source of truth.
+ */
+
+export const toggleGroupClasses = 'inline-flex items-center justify-center gap-1 rounded-lg';
+
+export const toggleGroupDefaultVariantClasses = 'bg-muted p-1';
+
+export const toggleGroupItemBaseClasses =
+  'inline-flex items-center justify-center ' +
+  'rounded-md ' +
+  'text-sm font-medium ' +
+  'transition-colors ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ' +
+  'disabled:pointer-events-none disabled:opacity-50 ' +
+  'hover:bg-muted hover:text-muted-foreground';
+
+export const toggleGroupItemSizeClasses: Record<string, string> = {
+  default: 'h-9 px-3',
+  sm: 'h-8 px-2',
+  lg: 'h-10 px-4',
+};
+
+export const toggleGroupItemOutlineClasses = 'border border-input bg-transparent';
+
+export const toggleGroupItemOutlinePressedClasses = 'bg-accent text-accent-foreground';
+
+export const toggleGroupItemDefaultClasses = 'bg-transparent';
+
+export const toggleGroupItemDefaultPressedClasses = 'bg-background text-foreground shadow-sm';

--- a/packages/ui/src/components/ui/toggle-group.tsx
+++ b/packages/ui/src/components/ui/toggle-group.tsx
@@ -33,6 +33,16 @@
 import * as React from 'react';
 import classy from '../../primitives/classy';
 import { createRovingFocus } from '../../primitives/roving-focus';
+import {
+  toggleGroupClasses,
+  toggleGroupDefaultVariantClasses,
+  toggleGroupItemBaseClasses,
+  toggleGroupItemDefaultClasses,
+  toggleGroupItemDefaultPressedClasses,
+  toggleGroupItemOutlineClasses,
+  toggleGroupItemOutlinePressedClasses,
+  toggleGroupItemSizeClasses,
+} from './toggle-group.classes';
 
 // ==================== Context ====================
 
@@ -156,8 +166,8 @@ export function ToggleGroup({
 
   // Group styling
   const groupClasses = classy(
-    'inline-flex items-center justify-center gap-1 rounded-lg',
-    variant === 'default' && 'bg-muted p-1',
+    toggleGroupClasses,
+    variant === 'default' && toggleGroupDefaultVariantClasses,
     className,
   );
 
@@ -187,12 +197,6 @@ export interface ToggleGroupItemProps extends React.HTMLAttributes<HTMLButtonEle
   /** Whether this item is disabled */
   disabled?: boolean;
 }
-
-const sizeClasses: Record<string, string> = {
-  default: 'h-9 px-3',
-  sm: 'h-8 px-2',
-  lg: 'h-10 px-4',
-};
 
 export function ToggleGroupItem({
   value,
@@ -235,25 +239,18 @@ export function ToggleGroupItem({
   const getVariantClasses = () => {
     if (variant === 'outline') {
       return classy(
-        'border border-input bg-transparent',
-        isPressed && 'bg-accent text-accent-foreground',
+        toggleGroupItemOutlineClasses,
+        isPressed && toggleGroupItemOutlinePressedClasses,
       );
     }
     // default variant
-    return classy('bg-transparent', isPressed && 'bg-background text-foreground shadow-sm');
+    return classy(toggleGroupItemDefaultClasses, isPressed && toggleGroupItemDefaultPressedClasses);
   };
 
   const itemClasses = classy(
-    // Base styles
-    'inline-flex items-center justify-center',
-    'rounded-md',
-    'text-sm font-medium',
-    'transition-colors',
-    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-    'disabled:pointer-events-none disabled:opacity-50',
-    'hover:bg-muted hover:text-muted-foreground',
+    toggleGroupItemBaseClasses,
     // Size
-    sizeClasses[size] ?? sizeClasses.default,
+    toggleGroupItemSizeClasses[size] ?? toggleGroupItemSizeClasses.default,
     // Variant
     getVariantClasses(),
     className,

--- a/packages/ui/src/components/ui/toggle.classes.ts
+++ b/packages/ui/src/components/ui/toggle.classes.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared toggle class definitions
+ *
+ * Imported by toggle.tsx (React) to keep inline strings
+ * in a single source of truth.
+ */
+
+export const toggleBaseClasses =
+  'inline-flex items-center justify-center ' +
+  'rounded-md ' +
+  'text-sm font-medium ' +
+  'transition-colors ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ' +
+  'disabled:pointer-events-none disabled:opacity-50';
+
+export const toggleVariantClasses: Record<string, string> = {
+  default:
+    'bg-transparent data-[state=on]:bg-primary data-[state=on]:text-primary-foreground hover:bg-muted',
+  primary:
+    'bg-transparent data-[state=on]:bg-primary data-[state=on]:text-primary-foreground hover:bg-muted',
+  secondary:
+    'bg-transparent data-[state=on]:bg-secondary data-[state=on]:text-secondary-foreground hover:bg-muted',
+  destructive:
+    'bg-transparent data-[state=on]:bg-destructive data-[state=on]:text-destructive-foreground hover:bg-muted',
+  success:
+    'bg-transparent data-[state=on]:bg-success data-[state=on]:text-success-foreground hover:bg-muted',
+  warning:
+    'bg-transparent data-[state=on]:bg-warning data-[state=on]:text-warning-foreground hover:bg-muted',
+  info: 'bg-transparent data-[state=on]:bg-info data-[state=on]:text-info-foreground hover:bg-muted',
+  accent:
+    'bg-transparent data-[state=on]:bg-accent data-[state=on]:text-accent-foreground hover:bg-muted',
+  outline:
+    'border border-input bg-transparent data-[state=on]:bg-accent data-[state=on]:text-accent-foreground hover:bg-muted',
+  ghost:
+    'bg-transparent data-[state=on]:bg-accent data-[state=on]:text-accent-foreground hover:bg-accent hover:text-accent-foreground',
+};
+
+export const toggleSizeClasses: Record<string, string> = {
+  default: 'h-10 px-3',
+  sm: 'h-9 px-2.5',
+  lg: 'h-11 px-5',
+};

--- a/packages/ui/src/components/ui/toggle.tsx
+++ b/packages/ui/src/components/ui/toggle.tsx
@@ -24,6 +24,7 @@
 import * as React from 'react';
 import classy from '../../primitives/classy';
 import { mergeProps } from '../../primitives/slot';
+import { toggleBaseClasses, toggleSizeClasses, toggleVariantClasses } from './toggle.classes';
 
 export interface ToggleProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** Visual variant per docs/COMPONENT_STYLING_REFERENCE.md */
@@ -49,35 +50,6 @@ export interface ToggleProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   /** Render as child element (polymorphic) */
   asChild?: boolean;
 }
-
-// Variant classes for pressed state per docs/COMPONENT_STYLING_REFERENCE.md
-const variantClasses: Record<string, string> = {
-  default:
-    'bg-transparent data-[state=on]:bg-primary data-[state=on]:text-primary-foreground hover:bg-muted',
-  primary:
-    'bg-transparent data-[state=on]:bg-primary data-[state=on]:text-primary-foreground hover:bg-muted',
-  secondary:
-    'bg-transparent data-[state=on]:bg-secondary data-[state=on]:text-secondary-foreground hover:bg-muted',
-  destructive:
-    'bg-transparent data-[state=on]:bg-destructive data-[state=on]:text-destructive-foreground hover:bg-muted',
-  success:
-    'bg-transparent data-[state=on]:bg-success data-[state=on]:text-success-foreground hover:bg-muted',
-  warning:
-    'bg-transparent data-[state=on]:bg-warning data-[state=on]:text-warning-foreground hover:bg-muted',
-  info: 'bg-transparent data-[state=on]:bg-info data-[state=on]:text-info-foreground hover:bg-muted',
-  accent:
-    'bg-transparent data-[state=on]:bg-accent data-[state=on]:text-accent-foreground hover:bg-muted',
-  outline:
-    'border border-input bg-transparent data-[state=on]:bg-accent data-[state=on]:text-accent-foreground hover:bg-muted',
-  ghost:
-    'bg-transparent data-[state=on]:bg-accent data-[state=on]:text-accent-foreground hover:bg-accent hover:text-accent-foreground',
-};
-
-const sizeClasses: Record<string, string> = {
-  default: 'h-10 px-3',
-  sm: 'h-9 px-2.5',
-  lg: 'h-11 px-5',
-};
 
 export function Toggle({
   className,
@@ -109,19 +81,10 @@ export function Toggle({
     [pressed, isControlled, onPressedChange, onClick],
   );
 
-  // Base styles per docs/COMPONENT_STYLING_REFERENCE.md
-  const baseClasses =
-    'inline-flex items-center justify-center ' +
-    'rounded-md ' +
-    'text-sm font-medium ' +
-    'transition-colors ' +
-    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ' +
-    'disabled:pointer-events-none disabled:opacity-50';
-
   const cls = classy(
-    baseClasses,
-    variantClasses[variant] ?? '',
-    sizeClasses[size] ?? '',
+    toggleBaseClasses,
+    toggleVariantClasses[variant] ?? '',
+    toggleSizeClasses[size] ?? '',
     className,
   );
 


### PR DESCRIPTION
## Summary

Every component now imports class strings from a shared `.classes.ts` file. 44 files total. When the aesthetic changes, each component's styles are in one place.

23 components extracted in this PR (select, dialog, checkbox, textarea, switch, radio-group, slider, dropdown-menu, context-menu, command, alert-dialog, sheet, popover, hover-card, menubar, navigation-menu, accordion, collapsible, resizable, scroll-area, sidebar, toggle, toggle-group). badge, card, and 21 others were already done.

No visual changes. Same classes, different source of truth. 3609 tests pass.

Closes #1124

- All 44 components use shared .classes.ts for Astro parity and single-source styling

## Test plan

- [x] 3609 UI tests pass
- [x] Typecheck clean
- [x] Biome format clean