### PR TITLE
fix(cli): spinner was hiding export format prompt at 120Hz

### DIFF
--- a/packages/cli/src/utils/ui.ts
+++ b/packages/cli/src/utils/ui.ts
@@ -74,12 +74,12 @@ export function log(event: Record<string, unknown>): void {
       break;
 
     case 'init:regenerate':
+      context.spinner?.stop();
       context.spinner = ora('Regenerating from existing config...').start();
       break;
 
     case 'init:loaded':
       context.spinner?.succeed(`Loaded ${event.tokenCount} tokens`);
-      context.spinner = ora('Generating outputs...').start();
       break;
 
     case 'init:existing_design_detected':
@@ -118,12 +118,15 @@ export function log(event: Record<string, unknown>): void {
 
     case 'init:complete': {
       context.spinner?.succeed('Done!');
+      context.spinner = null;
       console.log(`\n  Output: ${event.path}`);
       const outputs = event.outputs as string[];
       for (const file of outputs) {
         console.log(`    - ${file}`);
       }
       console.log('');
+      // Release stdin so process can exit after inquirer prompts
+      if (process.stdin.unref) process.stdin.unref();
       break;
     }
 


### PR DESCRIPTION
init:loaded started a 'Generating outputs...' spinner before the export format prompt rendered. At 120Hz monitor refresh rate, the spinner overwrites the checkbox prompt making it unreadable.

Fix: spinner now starts AFTER the export selection, not before it.