### PR TITLE
chore: release v0.0.36

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -23,7 +23,8 @@
       "!apps/demo/src/styles/global.css",
       "!**/.rafters",
       "!.claude/worktrees",
-      "!docs-site"
+      "!docs-site",
+      "!docs/templates"
     ]
   },
   "assist": { "actions": { "source": { "organizeImports": "on" } } },

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rafters
 
+## 0.0.36
+
+### Patch Changes
+
+- Fix init --rebuild spinner bugs: orphaned spinner on rebuild path, spinner not nulled on complete, stdin not released after inquirer prompts
+
 ## 0.0.35
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "CLI for Rafters design system - scaffold tokens and add components",
   "license": "MIT",
   "type": "module",

--- a/packages/shared/src/version.ts
+++ b/packages/shared/src/version.ts
@@ -3,4 +3,4 @@
  * Used by the CLI package.json, the API root endpoint, and anywhere
  * else that needs to report the current version.
  */
-export const RAFTERS_VERSION = '0.0.35';
+export const RAFTERS_VERSION = '0.0.36';


### PR DESCRIPTION
Fix spinner bugs on init --rebuild. Exclude docs/templates from biome.