### PR TITLE
fix(mcp): resolve component files by framework target, not hardcoded .tsx

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rafters
 
+## 0.0.37
+
+### Patch Changes
+
+- fix(mcp): resolve component files by framework target instead of hardcoding .tsx (#1146). MCP tools now find .astro, .vue, and .svelte components using componentTarget from config. Also reads .classes.ts companions for variant/size data. Fixes rafters_component returning null in all non-React consumer projects.
+
 ## 0.0.36
 
 ### Patch Changes

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -10,7 +10,11 @@ import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { RegistryClient } from '../registry/client.js';
 import type { RegistryFile, RegistryItem } from '../registry/types.js';
-import { type ComponentTarget, frameworkToTarget, targetToExtension } from '../utils/detect.js';
+import {
+  type ComponentTarget,
+  resolveComponentTarget,
+  targetToExtension,
+} from '../utils/detect.js';
 import { DEFAULT_EXPORTS } from '../utils/exports.js';
 import {
   type InstallRegistryDepsResult,
@@ -86,9 +90,7 @@ export function getInstalledNames(config: RaftersConfig | null): string[] {
  * Resolve the component target from config, falling back to framework detection.
  */
 function getComponentTarget(config: RaftersConfig | null): ComponentTarget {
-  if (config?.componentTarget) return config.componentTarget;
-  if (config?.framework) return frameworkToTarget(config.framework);
-  return 'react';
+  return resolveComponentTarget(config);
 }
 
 /**

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -48,6 +48,11 @@ import {
 } from '@rafters/shared';
 import type { RaftersConfig } from '../commands/init.js';
 import { registryClient } from '../registry/client.js';
+import {
+  COMPONENT_EXTENSIONS,
+  resolveComponentTarget,
+  targetToExtension,
+} from '../utils/detect.js';
 import { getRaftersPaths } from '../utils/paths.js';
 import {
   BUDGET_TIERS,
@@ -984,12 +989,34 @@ export class RaftersToolHandler {
   }
 
   /**
-   * Load component metadata from source file
+   * Find the actual component file on disk for a given name.
+   * Checks the config's componentTarget extension first, then falls back
+   * to all known extensions so Astro projects with React islands also work.
+   */
+  private async resolveComponentFile(componentsPath: string, name: string): Promise<string | null> {
+    const config = await this.loadConfig();
+    const preferredExt = targetToExtension(resolveComponentTarget(config));
+    const preferred = join(componentsPath, `${name}${preferredExt}`);
+    if (existsSync(preferred)) return preferred;
+
+    for (const ext of COMPONENT_EXTENSIONS) {
+      if (ext === preferredExt) continue;
+      const candidate = join(componentsPath, `${name}${ext}`);
+      if (existsSync(candidate)) return candidate;
+    }
+    return null;
+  }
+
+  /**
+   * Load component metadata from source file.
+   * Resolves the actual file extension from the config's componentTarget
+   * and merges variant/size data from .classes.ts companions when present.
    */
   private async loadComponentMetadata(name: string): Promise<ComponentMetadata | null> {
     const componentsPath = await this.getComponentsPath();
     if (!componentsPath) return null;
-    const filePath = join(componentsPath, `${name}.tsx`);
+    const filePath = await this.resolveComponentFile(componentsPath, name);
+    if (!filePath) return null;
 
     try {
       const source = await readFile(filePath, 'utf-8');
@@ -1003,16 +1030,32 @@ export class RaftersToolHandler {
         // JSDoc parsing failure should not prevent component metadata from being returned
       }
 
+      let variants = extractVariants(source);
+      let sizes = extractSizes(source);
+
+      // Merge variant/size data from .classes.ts companion when present
+      try {
+        const classesSource = await readFile(join(componentsPath, `${name}.classes.ts`), 'utf-8');
+        if (!variants || variants.length === 0) {
+          variants = extractVariants(classesSource);
+        }
+        if (!sizes || sizes.length === 0) {
+          sizes = extractSizes(classesSource);
+        }
+      } catch {
+        // No .classes.ts companion or read failure -- non-fatal
+      }
+
       const metadata: ComponentMetadata = {
         name,
         displayName: toDisplayName(name),
         category: this.inferCategory(name),
-        variants: extractVariants(source),
-        sizes: extractSizes(source),
+        variants,
+        sizes,
         dependencies: extractDependencies(source),
         primitives: extractPrimitiveDependencies(source),
         // projectRoot is guaranteed non-null here: handleToolCall guards it
-        filePath: relative(this.projectRoot as string, join(componentsPath, `${name}.tsx`)),
+        filePath: relative(this.projectRoot as string, filePath),
       };
 
       if (hasAnyDeps(jsDocDeps)) {
@@ -1118,8 +1161,14 @@ export class RaftersToolHandler {
           try {
             const files = await readdir(componentsPath);
             available = files
-              .filter((f) => f.endsWith('.tsx'))
-              .map((f) => basename(f, '.tsx'))
+              .filter(
+                (f) =>
+                  COMPONENT_EXTENSIONS.some((ext) => f.endsWith(ext)) && !f.includes('.classes.'),
+              )
+              .map((f) => {
+                const ext = COMPONENT_EXTENSIONS.find((e) => f.endsWith(e));
+                return ext ? basename(f, ext) : basename(f);
+              })
               .filter((n) => n.includes(name) || name.includes(n))
               .slice(0, 5);
           } catch {

--- a/packages/cli/src/utils/detect.ts
+++ b/packages/cli/src/utils/detect.ts
@@ -152,6 +152,11 @@ export function frameworkToTarget(framework: Framework): ComponentTarget {
 }
 
 /**
+ * All supported component file extensions, derived from ComponentTarget values.
+ */
+export const COMPONENT_EXTENSIONS = ['.tsx', '.astro', '.vue', '.svelte'] as const;
+
+/**
  * Map a component target to its preferred file extension.
  */
 export function targetToExtension(target: ComponentTarget): string {
@@ -162,6 +167,17 @@ export function targetToExtension(target: ComponentTarget): string {
     svelte: '.svelte',
   };
   return map[target];
+}
+
+/**
+ * Resolve the component target from a config, falling back to framework detection.
+ */
+export function resolveComponentTarget(
+  config: { componentTarget?: ComponentTarget; framework?: Framework } | null,
+): ComponentTarget {
+  if (config?.componentTarget) return config.componentTarget;
+  if (config?.framework) return frameworkToTarget(config.framework);
+  return 'react';
 }
 
 /**


### PR DESCRIPTION
## Summary

- MCP `rafters_component` assumed all components were `.tsx`, returning null for Astro/Vue/Svelte consumers
- Now resolves files using `componentTarget` from config with fallback through all known extensions
- Reads `.classes.ts` companion files for variant/size data when the primary component lacks them
- Extracted shared `COMPONENT_EXTENSIONS` constant and `resolveComponentTarget()` into `detect.ts` to eliminate duplication with `add.ts`

Closes #1146

## Test plan

- [ ] 286 CLI unit tests pass
- [ ] 17 integration tests pass
- [ ] Verify `rafters_component button` returns metadata in shingle project (`~/projects/rafters-studio/shingle/sites/sean.silvius.me`)
- [ ] Verify suggestions listing shows `.astro` components when component not found
- [ ] Verify monorepo `.tsx` resolution still works (no regression)

Generated with [Claude Code](https://claude.com/claude-code)