### PR TITLE
chore: release v0.0.37

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "description": "CLI for Rafters design system - scaffold tokens and add components",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- Version bump to 0.0.37
- Includes fix from PR #1147: MCP component resolution for non-React consumers

## After merge

Tag `v0.0.37` and publish to npm. Shingle is blocked on this release.

Generated with [Claude Code](https://claude.com/claude-code)