### PR TITLE
fix(tailwind): spacing @theme vars broken by --rafters- prefix mismatch

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rafters
 
+## 0.0.41
+
+### Patch Changes
+
+- fix(tailwind): spacing scale variables in @theme block now reference var(--spacing-base) instead of var(--rafters-spacing-base). The @theme block defines --spacing-base but the token values referenced --rafters-spacing-base (the :root namespace), causing all gap-*, p-*, m-* utilities to resolve to empty values. Tailwind generated the CSS rules but they computed to zero because the variable chain was broken.
+
 ## 0.0.40
 
 ### Minor Changes

--- a/packages/design-tokens/src/exporters/tailwind.ts
+++ b/packages/design-tokens/src/exporters/tailwind.ts
@@ -310,13 +310,15 @@ function generateThemeBlock(groups: GroupedTokens): string {
   }
 
   // Spacing tokens -- Tailwind v4 reads --spacing-* for p-*, m-*, gap-*
+  // Token values reference var(--rafters-spacing-base) for the :root layer,
+  // but @theme needs var(--spacing-base) since that's the @theme variable name
   if (groups.spacing.length > 0) {
     for (const token of groups.spacing) {
       const value = tokenValueToCSS(token);
       if (value === null) continue;
-      // Strip "spacing-" prefix: token "spacing-4" becomes "--spacing-4"
       const key = token.name.replace(/^spacing-/, '');
-      lines.push(`  --spacing-${key}: ${value};`);
+      const themeValue = value.replaceAll('var(--rafters-spacing-base)', 'var(--spacing-base)');
+      lines.push(`  --spacing-${key}: ${themeValue};`);
     }
     lines.push('');
   }


### PR DESCRIPTION
## Summary

- The @theme block defines `--spacing-base: 0.25rem` but spacing scale token values reference `var(--rafters-spacing-base)` (the `:root` namespace prefix). This breaks the entire spacing system: `gap-*`, `p-*`, `m-*` utilities resolve to empty/zero because `--rafters-spacing-base` doesn't exist in `@theme` scope.
- Fix: replace `var(--rafters-spacing-base)` with `var(--spacing-base)` in the `@theme` output only. The `:root` block still uses the `--rafters-` prefixed names correctly.

This is why shingle's smugglr.dev has zero spacing despite all the right Tailwind classes being in the markup.

## Test plan

- [ ] 213 design-tokens tests pass
- [ ] Preflight clean
- [ ] `rafters init --rebuild` produces `--spacing-4: calc(var(--spacing-base) * 4)` in the @theme block
- [ ] Consumer site: `gap-4` resolves to `1rem`, not `normal`/empty

Generated with [Claude Code](https://claude.com/claude-code)