### PR TITLE
feat(tokens): composite typography generator (#1163)

### DIFF
--- a/packages/design-tokens/src/generators/index.ts
+++ b/packages/design-tokens/src/generators/index.ts
@@ -53,6 +53,7 @@ import { generateSpacingTokens } from './spacing.js';
 import type { BaseSystemConfig, ResolvedSystemConfig } from './types.js';
 import { DEFAULT_SYSTEM_CONFIG, resolveConfig } from './types.js';
 import { generateTypographyTokens } from './typography.js';
+import { generateTypographyCompositeTokens } from './typography-composite.js';
 
 export { generateBreakpointTokens } from './breakpoint.js';
 // Export all generators individually
@@ -70,6 +71,7 @@ export { generateSpacingTokens } from './spacing.js';
 // Export types
 export * from './types.js';
 export { generateTypographyTokens } from './typography.js';
+export { generateTypographyCompositeTokens } from './typography-composite.js';
 
 /**
  * Generator configuration - defines name and how to call each generator
@@ -121,6 +123,12 @@ function createGeneratorDefs(colorPaletteBases?: Record<string, ColorPaletteBase
 
     // Semantic tokens (depend on color)
     { name: 'semantic', generate: (config) => generateSemanticTokens(config) },
+
+    // Typography composites (depend on typography)
+    {
+      name: 'typography-composite',
+      generate: (config) => generateTypographyCompositeTokens(config),
+    },
 
     // Derived tokens (depend on spacing/foundation)
     {
@@ -364,6 +372,10 @@ export function getGeneratorInfo(): Array<{ name: string; description: string }>
     { name: 'motion', description: 'Duration, easing, and delay tokens for animations' },
     { name: 'elevation', description: 'Elevation levels pairing depth with shadows' },
     { name: 'focus', description: 'Focus ring tokens for WCAG 2.2 compliance' },
+    {
+      name: 'typography-composite',
+      description: 'Composite typography roles mapping semantic roles to font properties',
+    },
   ];
 }
 

--- a/packages/design-tokens/src/generators/typography-composite.ts
+++ b/packages/design-tokens/src/generators/typography-composite.ts
@@ -1,0 +1,93 @@
+/**
+ * Typography Composite Generator
+ *
+ * Generates composite typography tokens -- one per semantic role.
+ * Each token stores the full typographic treatment (family, size, weight,
+ * line-height, tracking) as structured JSON data. The exporter reads
+ * these composites to generate @utility classes.
+ *
+ * Same pattern as semantic.ts for colors: reads from a single source of
+ * truth in defaults.ts, produces Token objects with rich intelligence metadata.
+ */
+
+import type { Token } from '@rafters/shared';
+import {
+  DEFAULT_TYPOGRAPHY_COMPOSITE_MAPPINGS,
+  TYPOGRAPHY_ROLE_CONSUMERS,
+  type TypographyCompositeMapping,
+} from './defaults.js';
+import type { GeneratorResult, ResolvedSystemConfig } from './types.js';
+
+/**
+ * Map a font-family role to the token it depends on.
+ */
+function familyRoleToDependency(role: TypographyCompositeMapping['fontFamily']): string {
+  switch (role) {
+    case 'heading':
+      return 'font-heading';
+    case 'body':
+      return 'font-body';
+    case 'code':
+      return 'font-code';
+  }
+}
+
+/**
+ * Generate composite typography tokens from the single source of truth.
+ *
+ * Uses DEFAULT_TYPOGRAPHY_COMPOSITE_MAPPINGS from defaults.ts which contains
+ * all typography role definitions with property references.
+ */
+export function generateTypographyCompositeTokens(_config: ResolvedSystemConfig): GeneratorResult {
+  const tokens: Token[] = [];
+  const timestamp = new Date().toISOString();
+
+  for (const [name, mapping] of Object.entries(DEFAULT_TYPOGRAPHY_COMPOSITE_MAPPINGS)) {
+    const familyDep = familyRoleToDependency(mapping.fontFamily);
+
+    const dependsOn = [
+      familyDep,
+      `font-size-${mapping.fontSize}`,
+      `font-weight-${mapping.fontWeight}`,
+      `line-height-${mapping.lineHeight}`,
+      `letter-spacing-${mapping.letterSpacing}`,
+    ];
+
+    const compositeValue = JSON.stringify({
+      fontFamily: mapping.fontFamily,
+      fontSize: mapping.fontSize,
+      fontWeight: mapping.fontWeight,
+      lineHeight: mapping.lineHeight,
+      letterSpacing: mapping.letterSpacing,
+      ...(mapping.responsive ? { responsive: mapping.responsive } : {}),
+    });
+
+    const consumers = TYPOGRAPHY_ROLE_CONSUMERS[name] ?? [];
+
+    tokens.push({
+      name,
+      value: compositeValue,
+      category: 'typography',
+      namespace: 'typography-composite',
+      semanticMeaning: mapping.meaning,
+      usageContext: mapping.contexts,
+      trustLevel: mapping.trustLevel,
+      consequence: mapping.consequence,
+      dependsOn,
+      applicableComponents: consumers,
+      containerQueryAware: true,
+      generateUtilityClass: true,
+      description: `Typography composite: font-${mapping.fontFamily} text-${mapping.fontSize} font-${mapping.fontWeight}. ${mapping.meaning}`,
+      generatedAt: timestamp,
+      usagePatterns: {
+        do: mapping.do,
+        never: mapping.never,
+      },
+    });
+  }
+
+  return {
+    namespace: 'typography-composite',
+    tokens,
+  };
+}


### PR DESCRIPTION
## Summary

- New typography-composite.ts generator producing 14 composite tokens from DEFAULT_TYPOGRAPHY_COMPOSITE_MAPPINGS
- Each composite stores family, size, weight, line-height, and tracking as structured JSON
- Wired into generator orchestration in index.ts after typography and semantic generators
- Full intelligence metadata (semanticMeaning, usageContext, usagePatterns, applicableComponents)

## Test plan

- [x] All 213 design-tokens tests pass
- [x] Typecheck clean
- [x] Biome lint clean

Closes #1163

🤖 Generated with [Claude Code](https://claude.com/claude-code)