### PR TITLE
feat(tokens): element-level typography override system with why-gate (#1165)

### DIFF
--- a/packages/design-tokens/src/exporters/tailwind.ts
+++ b/packages/design-tokens/src/exporters/tailwind.ts
@@ -13,7 +13,7 @@
  * @see https://ui.shadcn.com/docs/theming
  */
 
-import type { ColorReference, ColorValue, Token } from '@rafters/shared';
+import type { ColorReference, ColorValue, Token, TypographyElementOverride } from '@rafters/shared';
 import { DEFAULT_SEMANTIC_COLOR_MAPPINGS } from '../generators/defaults.js';
 import type { TokenRegistry } from '../registry.js';
 
@@ -689,6 +689,61 @@ function generateTypographyCompositeUtilities(compositeTokens: Token[]): string 
 }
 
 /**
+ * Map a typography override property to a Tailwind utility class.
+ */
+function overridePropertyToUtility(property: string, value: string): string {
+  switch (property) {
+    case 'fontFamily':
+      return `font-${value}`;
+    case 'fontWeight':
+      return `font-${value}`;
+    case 'fontSize':
+      return `text-${value}`;
+    case 'lineHeight':
+      return `leading-${value}`;
+    case 'letterSpacing':
+      return `tracking-${value}`;
+    default:
+      return '';
+  }
+}
+
+/**
+ * Generate element-level typography override CSS from registry overrides.
+ * Each override produces a CSS rule with @apply using the base role utility
+ * plus the overridden Tailwind utilities.
+ */
+function generateTypographyOverrideCSS(overrides: TypographyElementOverride[]): string {
+  if (overrides.length === 0) {
+    return '';
+  }
+
+  const lines: string[] = [];
+  lines.push('/* -- Typography Element Overrides -- */');
+
+  for (const override of overrides) {
+    const overrideUtilities: string[] = [];
+    for (const [prop, val] of Object.entries(override.overrides)) {
+      if (val) {
+        const utility = overridePropertyToUtility(prop, val);
+        if (utility) {
+          overrideUtilities.push(utility);
+        }
+      }
+    }
+
+    if (overrideUtilities.length > 0) {
+      lines.push(`/* ${override.element}: diverges from ${override.role} (${override.why}) */`);
+      lines.push(`${override.element} {`);
+      lines.push(`  @apply text-${override.role} ${overrideUtilities.join(' ')};`);
+      lines.push('}');
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
  * Export tokens to Tailwind v4 CSS format
  *
  * @param tokens - Array of tokens to export
@@ -707,7 +762,11 @@ function generateTypographyCompositeUtilities(compositeTokens: Token[]): string 
  * fs.writeFileSync('theme.css', css);
  * ```
  */
-export function tokensToTailwind(tokens: Token[], options: TailwindExportOptions = {}): string {
+export function tokensToTailwind(
+  tokens: Token[],
+  options: TailwindExportOptions = {},
+  typographyOverrides: TypographyElementOverride[] = [],
+): string {
   const { includeImport = true } = options;
 
   if (tokens.length === 0) {
@@ -751,6 +810,13 @@ export function tokensToTailwind(tokens: Token[], options: TailwindExportOptions
     sections.push(typographyUtilities);
   }
 
+  // Typography element overrides (if any)
+  const overrideCSS = generateTypographyOverrideCSS(typographyOverrides);
+  if (overrideCSS) {
+    sections.push('');
+    sections.push(overrideCSS);
+  }
+
   // Article type system - @layer base with @apply compositions
   sections.push('');
   sections.push(generateArticleBaseLayer());
@@ -783,7 +849,8 @@ export function registryToTailwind(
   options?: TailwindExportOptions,
 ): string {
   const tokens = registry.list();
-  return tokensToTailwind(tokens, options);
+  const typographyOverrides = registry.getTypographyOverrides();
+  return tokensToTailwind(tokens, options, typographyOverrides);
 }
 
 /**

--- a/packages/design-tokens/src/registry.ts
+++ b/packages/design-tokens/src/registry.ts
@@ -6,7 +6,13 @@
  * Automatically enriches color tokens with intelligence from Color Intelligence API
  */
 
-import { COMPUTED, type ComputedSymbol, type Token } from '@rafters/shared';
+import {
+  COMPUTED,
+  type ComputedSymbol,
+  type Token,
+  type TypographyElementOverride,
+  TypographyElementOverrideSchema,
+} from '@rafters/shared';
 import { TokenDependencyGraph } from './dependencies';
 import { GenerationRuleExecutor, GenerationRuleParser } from './generation-rules';
 import type { PersistenceAdapter } from './persistence/types';
@@ -55,6 +61,7 @@ export class TokenRegistry {
   private changeCallback?: RegistryChangeCallback;
   private adapter?: PersistenceAdapter;
   private dirtyNamespaces = new Set<string>();
+  private typographyOverrides: Map<string, TypographyElementOverride> = new Map();
 
   constructor(initialTokens?: Token[]) {
     if (initialTokens) {
@@ -759,6 +766,48 @@ export class TokenRegistry {
    */
   parseRuleDependencies(rule: string): string[] {
     return this.dependencyGraph.parseRuleDependencies(rule);
+  }
+
+  // ===========================================================================
+  // Typography Element Overrides
+  // ===========================================================================
+
+  /**
+   * Add a typography element override with why-gate enforcement.
+   * Stores an override for a specific HTML element that diverges from its
+   * assigned typography role.
+   *
+   * @throws If why field is empty (why-gate enforcement)
+   * @throws If role references a non-existent typography composite token
+   */
+  addTypographyOverride(override: TypographyElementOverride): void {
+    // Validate with Zod schema (enforces non-empty why)
+    const parsed = TypographyElementOverrideSchema.parse(override);
+
+    // Validate that the role exists as a typography-composite token
+    const roleToken = this.get(parsed.role);
+    if (!roleToken || roleToken.namespace !== 'typography-composite') {
+      throw new Error(
+        `Typography override for "${parsed.element}" references unknown role "${parsed.role}". ` +
+          'Role must be an existing typography-composite token.',
+      );
+    }
+
+    this.typographyOverrides.set(parsed.element, parsed);
+  }
+
+  /**
+   * Get all typography element overrides.
+   */
+  getTypographyOverrides(): TypographyElementOverride[] {
+    return Array.from(this.typographyOverrides.values());
+  }
+
+  /**
+   * Remove a typography element override.
+   */
+  removeTypographyOverride(element: string): boolean {
+    return this.typographyOverrides.delete(element);
   }
 
   /**

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -560,6 +560,35 @@ export const SemanticTokenSchema = TokenSchema;
 export type SemanticToken = Token;
 
 /**
+ * Typography Element Override Schema
+ * Stores per-element typography overrides with why-gate provenance.
+ * When a designer overrides a specific element's typography (e.g. H3 uses
+ * title-medium but needs font-thin font-sans), this captures the override.
+ */
+export const TypographyElementOverrideSchema = z.object({
+  /** CSS element selector, e.g. 'h3' */
+  element: z.string().min(1),
+  /** Base role this element uses, e.g. 'title-medium' */
+  role: z.string().min(1),
+  /** Only the properties that differ from the role */
+  overrides: z.object({
+    fontFamily: z.string().optional(),
+    fontWeight: z.string().optional(),
+    fontSize: z.string().optional(),
+    lineHeight: z.string().optional(),
+    letterSpacing: z.string().optional(),
+  }),
+  /** Why-gate: reason for the override (required, non-empty) */
+  why: z.string().min(1, 'Why-gate required: provide a reason for this override'),
+  /** Who made the override */
+  who: z.string().min(1),
+  /** When the override was made (ISO timestamp) */
+  when: z.string(),
+});
+
+export type TypographyElementOverride = z.infer<typeof TypographyElementOverrideSchema>;
+
+/**
  * Namespace File Schema
  * File format for .rafters/tokens/{namespace}.rafters.json files
  */


### PR DESCRIPTION
## Summary

- Add TypographyElementOverride Zod schema to @rafters/shared
- Add addTypographyOverride, getTypographyOverrides, removeTypographyOverride to TokenRegistry
- Why-gate enforced: empty why throws
- Role validation: non-existent roles rejected
- Tailwind exporter generates element-level CSS with @apply from overrides

## Test plan

- [x] All 213 design-tokens tests pass
- [x] Typecheck clean
- [x] Biome lint clean

Closes #1165

🤖 Generated with [Claude Code](https://claude.com/claude-code)