### PR TITLE
fix(tailwind): remove double-prefix on spacing and radius :root vars

### DIFF
--- a/packages/design-tokens/src/exporters/tailwind.ts
+++ b/packages/design-tokens/src/exporters/tailwind.ts
@@ -1012,7 +1012,7 @@ function generateVarsRootBlock(groups: GroupedTokens): string {
     for (const token of groups.spacing) {
       const value = tokenValueToCSS(token);
       if (value === null) continue;
-      lines.push(`  --rafters-spacing-${token.name}: ${value};`);
+      lines.push(`  --rafters-${token.name}: ${value};`);
     }
     lines.push('');
   }
@@ -1035,7 +1035,7 @@ function generateVarsRootBlock(groups: GroupedTokens): string {
     for (const token of groups.radius) {
       const value = tokenValueToCSS(token);
       if (value === null) continue;
-      lines.push(`  --rafters-radius-${token.name}: ${value};`);
+      lines.push(`  --rafters-${token.name}: ${value};`);
     }
     lines.push('');
   }


### PR DESCRIPTION
## Summary
- Fix double-prefix bug in Tailwind exporter `:root` block where spacing tokens emitted `--rafters-spacing-spacing-*` and radius tokens emitted `--rafters-radius-radius-*`
- Token names already include the category prefix (e.g. `spacing-base`, `radius-base`), so the exporter just needs `--rafters-${token.name}` -- same pattern typography and shadow groups already use
- This broke `var()` cascade chains: derived radius tokens referencing `var(--rafters-radius-base)` never resolved because the actual property was `--rafters-radius-radius-base`. Setting `radius-base: 0` will now correctly cascade to all derived radius tokens

## Test plan
- [x] All 213 design-tokens tests pass
- [x] Lefthook pre-commit (unit, lint, typecheck) passes
- [ ] @shingle verify on sean.silvius.me that radius-base: 0 cascades to square corners

🤖 Generated with [Claude Code](https://claude.com/claude-code)