### PR TITLE
feat(ui): typography tag components with token-level props (#1149)

### DIFF
--- a/.claude/skills/rafters-frontend/SKILL.md
+++ b/.claude/skills/rafters-frontend/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: rafters-frontend
+description: Use when building frontend UI in a Rafters project -- enforces Container, Grid, typography components, and design token usage.
+---
+
+## Layout Is Solved
+
+Container and Grid handle ALL layout. You do not write layout code.
+
+```tsx
+// WRONG
+<div className={classy("flex gap-4 p-6")}>
+
+// RIGHT
+<Container>
+  <Grid preset="sidebar-main">
+    <aside>Sidebar</aside>
+    <main>Content</main>
+  </Grid>
+</Container>
+```
+
+**Never use:** flex, grid, gap-*, p-*, m-*, items-*, justify-*
+
+### Grid Presets
+
+| Preset | Use for |
+|---|---|
+| sidebar-main | Navigation + content |
+| form | Label/input pairs |
+| cards | Responsive card grid |
+| row | Horizontal group |
+| stack | Vertical sequence |
+| split | Equal columns |
+
+## Typography -- Components, Not Utilities
+
+| Instead of | Use |
+|---|---|
+| `<p className="text-sm text-muted-foreground">` | `<P size="sm" color="muted">` |
+| `<p>` | `<P>` |
+| `<h1 className="text-4xl font-bold">` | `<H1>` |
+| `<h2>` | `<H2>` |
+| `<h3>` | `<H3>` |
+| `<span className="text-xs">` | `<Small>` |
+| `<span className="text-lg font-semibold">` | `<P size="lg" weight="semibold">` |
+
+## Color -- Tokens, Not Values
+
+Use semantic tokens as Tailwind classes: `bg-primary`, `text-destructive`, `border-success`.
+Never use hex, HSL, or palette internals.
+
+## A Correct Page
+
+```tsx
+import { Container, Grid } from "@rafters/ui"
+import { H1, P } from "@rafters/ui/components/ui/typography"
+import { Card } from "@rafters/ui/components/ui/card"
+import { Button } from "@rafters/ui/components/ui/button"
+
+export default function Page() {
+  return (
+    <Container>
+      <H1>Title</H1>
+      <P size="xl">Description.</P>
+      <Grid preset="cards">
+        <Card>...</Card>
+        <Card>...</Card>
+      </Grid>
+      <Grid preset="row">
+        <Button variant="secondary">Cancel</Button>
+        <Button>Save</Button>
+      </Grid>
+    </Container>
+  )
+}
+```
+
+No flex. No gap. No padding. No text utilities.

--- a/apps/demo/src/components/demos/EditorPlayground.tsx
+++ b/apps/demo/src/components/demos/EditorPlayground.tsx
@@ -28,7 +28,7 @@ import {
 } from '@/components/ui/editor';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { H1, H3, Muted, P } from '@/components/ui/typography';
+import { H1, H3, P } from '@/components/ui/typography';
 import type { BlockPaletteItem } from '@/lib/primitives/block-palette';
 import classy from '@/lib/primitives/classy';
 
@@ -463,7 +463,9 @@ export default function EditorPlayground() {
               Component Gallery
             </a>
           </div>
-          <Muted>Rafters Design Intelligence Protocol</Muted>
+          <P size="sm" color="muted">
+            Rafters Design Intelligence Protocol
+          </P>
         </div>
       </footer>
     </Container>

--- a/apps/demo/src/components/ui/color-inspector.tsx
+++ b/apps/demo/src/components/ui/color-inspector.tsx
@@ -26,7 +26,7 @@ import * as React from 'react';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Container } from '@/components/ui/container';
 import { Grid } from '@/components/ui/grid';
-import { H2, Lead, Muted, P, Small } from '@/components/ui/typography';
+import { H2, P, Small } from '@/components/ui/typography';
 import classy from '@/lib/primitives/classy';
 import type { ScalePosition } from '@/lib/primitives/color-scale';
 import { createColorScale } from '@/lib/primitives/color-scale';
@@ -739,13 +739,15 @@ function ColorDetail({ color, onClose }: ColorDetailProps) {
         data-color-hero=""
       >
         {emotionSentence ? (
-          <Lead
+          <P
+            size="xl"
+            color="muted"
             className={classy('font-light')}
             style={{ color: 'inherit', opacity: 0.85 }}
             data-hero-emotion=""
           >
             {emotionSentence}.
-          </Lead>
+          </P>
         ) : null}
         <div className={classy('flex items-baseline gap-3 mt-4')}>
           <H2 className={classy('text-base')} style={{ color: 'inherit' }}>
@@ -754,9 +756,14 @@ function ColorDetail({ color, onClose }: ColorDetailProps) {
           {color.token ? (
             <Small style={{ color: 'inherit', opacity: 0.5 }}>{color.token}</Small>
           ) : null}
-          <Muted className={classy('ml-auto')} style={{ color: 'inherit', opacity: 0.3 }}>
+          <P
+            size="sm"
+            color="muted"
+            className={classy('ml-auto')}
+            style={{ color: 'inherit', opacity: 0.3 }}
+          >
             {baseColor.l.toFixed(2)} / {baseColor.c.toFixed(3)} / {baseColor.h.toFixed(0)}
-          </Muted>
+          </P>
         </div>
 
         {/* At-a-glance badges: WCAG, APCA, gamut */}
@@ -842,14 +849,24 @@ function ColorDetail({ color, onClose }: ColorDetailProps) {
               <>
                 <P>{intelligence.reasoning}</P>
                 {intelligence.culturalContext ? (
-                  <Muted>{intelligence.culturalContext}</Muted>
+                  <P size="sm" color="muted">
+                    {intelligence.culturalContext}
+                  </P>
                 ) : null}
-                {intelligence.usageGuidance ? <Muted>{intelligence.usageGuidance}</Muted> : null}
+                {intelligence.usageGuidance ? (
+                  <P size="sm" color="muted">
+                    {intelligence.usageGuidance}
+                  </P>
+                ) : null}
                 {intelligence.accessibilityNotes ? (
-                  <Muted>{intelligence.accessibilityNotes}</Muted>
+                  <P size="sm" color="muted">
+                    {intelligence.accessibilityNotes}
+                  </P>
                 ) : null}
                 {intelligence.balancingGuidance ? (
-                  <Muted>{intelligence.balancingGuidance}</Muted>
+                  <P size="sm" color="muted">
+                    {intelligence.balancingGuidance}
+                  </P>
                 ) : null}
               </>
             ) : null}
@@ -992,9 +1009,9 @@ function ColorInspector({ colors, className }: ColorInspectorProps) {
         {selectedColor ? (
           <ColorDetail color={selectedColor} onClose={() => setSelectedIndex(null)} />
         ) : (
-          <Muted className={classy('flex items-center justify-center py-24')}>
+          <P size="sm" color="muted" className={classy('flex items-center justify-center py-24')}>
             Select a color to inspect
-          </Muted>
+          </P>
         )}
       </Container>
     </Container>

--- a/apps/demo/src/layouts/DocLayout.astro
+++ b/apps/demo/src/layouts/DocLayout.astro
@@ -4,7 +4,7 @@
  *
  * Uses Rafters components for semantic structure:
  * - Container: main landmark, article for readable content
- * - Typography: H1, Lead for clear hierarchy
+ * - Typography: H1, P for clear hierarchy
  * - Separator: visual division
  * - Badge: section indicator
  */
@@ -12,7 +12,7 @@
 import { Badge } from '@rafters/ui/components/ui/badge';
 import { Container } from '@rafters/ui/components/ui/container';
 import { Separator } from '@rafters/ui/components/ui/separator';
-import { H1, Lead, Muted } from '@rafters/ui/components/ui/typography';
+import { H1, P } from '@rafters/ui/components/ui/typography';
 import BaseLayout from './BaseLayout.astro';
 
 interface Props {
@@ -43,7 +43,7 @@ const sectionVariants: Record<string, 'default' | 'secondary' | 'muted' | 'accen
         </Badge>
       )}
       <H1 class="mb-4">{title}</H1>
-      <Lead class="max-w-2xl">{description}</Lead>
+      <P size="xl" class="max-w-2xl">{description}</P>
     </header>
 
     <Separator class="mb-8" />

--- a/apps/demo/src/pages/docs/index.astro
+++ b/apps/demo/src/pages/docs/index.astro
@@ -6,7 +6,7 @@
  * - Container: main landmark with size constraint
  * - Grid: linear preset for equal-priority cards
  * - Card: interactive cards for doc links
- * - Typography: H1, H2, Lead, Muted for hierarchy
+ * - Typography: H1, H2, P for hierarchy
  * - Badge: section indicators
  * - Separator: visual division
  */
@@ -17,7 +17,7 @@ import { Card, CardDescription, CardHeader, CardTitle } from '@rafters/ui/compon
 import { Container } from '@rafters/ui/components/ui/container';
 import { Grid } from '@rafters/ui/components/ui/grid';
 import { Separator } from '@rafters/ui/components/ui/separator';
-import { H1, H2, Lead, Muted } from '@rafters/ui/components/ui/typography';
+import { H1, H2, P } from '@rafters/ui/components/ui/typography';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 
 const allDocs = await getCollection('docs', ({ data }) => !data.draft);
@@ -83,21 +83,21 @@ const sectionsWithDocs = sectionOrder.filter((key) => sections[key].docs.length 
   <Container as="main" size="5xl" padding="6">
     {/* Header */}
     <header class="pb-8">
-      <Muted class="mb-2">Design Intelligence Protocol</Muted>
+      <P size="sm" color="muted" class="mb-2">Design Intelligence Protocol</P>
       <H1 class="mb-4">Documentation</H1>
-      <Lead class="max-w-2xl mb-6">
+      <P size="xl" class="max-w-2xl mb-6">
         Learn how Rafters encodes designer judgment into queryable data for AI agents.
-      </Lead>
+      </P>
       
       {/* Stats */}
       <div class="flex gap-6">
         <div class="flex items-center gap-2">
           <span class="text-2xl font-semibold text-primary">{totalDocs}</span>
-          <Muted>articles</Muted>
+          <P size="sm" color="muted">articles</P>
         </div>
         <div class="flex items-center gap-2">
           <span class="text-2xl font-semibold text-primary">{sectionsWithDocs.length}</span>
-          <Muted>sections</Muted>
+          <P size="sm" color="muted">sections</P>
         </div>
       </div>
     </header>
@@ -120,7 +120,7 @@ const sectionsWithDocs = sectionOrder.filter((key) => sections[key].docs.length 
                     {section.docs.length}
                   </Badge>
                 </div>
-                <Muted>{section.description}</Muted>
+                <P size="sm" color="muted">{section.description}</P>
               </div>
             </div>
             
@@ -158,7 +158,7 @@ const sectionsWithDocs = sectionOrder.filter((key) => sections[key].docs.length 
           </svg>
           Component Gallery
         </a>
-        <Muted>Rafters Design Intelligence Protocol</Muted>
+        <P size="sm" color="muted">Rafters Design Intelligence Protocol</P>
       </div>
     </footer>
   </Container>

--- a/apps/demo/src/pages/index.astro
+++ b/apps/demo/src/pages/index.astro
@@ -8,7 +8,7 @@
  * - Container: main landmark with size constraint
  * - Grid: linear preset for equal-priority cards, golden for hero
  * - Card: interactive cards for doc links
- * - Typography: H1, H2, Lead, Muted for hierarchy
+ * - Typography: H1, H2, P for hierarchy
  * - Badge: section indicators
  * - Separator: visual division
  */
@@ -25,7 +25,7 @@ import {
 import { Container } from '@rafters/ui/components/ui/container';
 import { Grid } from '@rafters/ui/components/ui/grid';
 import { Separator } from '@rafters/ui/components/ui/separator';
-import { H1, H2, H3, Lead, Muted, P } from '@rafters/ui/components/ui/typography';
+import { H1, H2, H3, P } from '@rafters/ui/components/ui/typography';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { loadAllComponents } from '../lib/component-registry';
 
@@ -67,23 +67,23 @@ const totalComponents = components.length;
         AI agents don't have taste.<br/>
         <span class="text-muted-foreground">Rafters gives them yours.</span>
       </H1>
-      <Lead class="max-w-2xl mb-8">
+      <P size="xl" class="max-w-2xl mb-8">
         Encode your design judgment into queryable data. AI reads decisions that have already been made instead of guessing at colors, spacing, and hierarchy.
-      </Lead>
+      </P>
       
       {/* Quick stats */}
       <div class="flex gap-8">
         <div>
           <span class="text-3xl font-semibold text-primary">{totalDocs}</span>
-          <Muted class="ml-2">docs</Muted>
+          <P size="sm" color="muted" class="ml-2">docs</P>
         </div>
         <div>
           <span class="text-3xl font-semibold text-primary">{totalComponents}</span>
-          <Muted class="ml-2">components</Muted>
+          <P size="sm" color="muted" class="ml-2">components</P>
         </div>
         <div>
           <span class="text-3xl font-semibold text-primary">4</span>
-          <Muted class="ml-2">MCP tools</Muted>
+          <P size="sm" color="muted" class="ml-2">MCP tools</P>
         </div>
       </div>
     </header>
@@ -93,7 +93,7 @@ const totalComponents = components.length;
     {/* Foundation Systems */}
     <section class="mb-16">
       <H2 class="mb-2">Foundation</H2>
-      <Muted class="mb-8">Mathematical systems that generate consistent, accessible design</Muted>
+      <P size="sm" color="muted" class="mb-8">Mathematical systems that generate consistent, accessible design</P>
       
       <Grid preset="linear" columns={2} gap="6">
         <Card as="article">
@@ -106,7 +106,7 @@ const totalComponents = components.length;
           </CardHeader>
           <CardContent class="space-y-4">
             <div>
-              <Muted class="text-xs mb-2 block">11-position scale (50-950)</Muted>
+              <P size="sm" color="muted" class="text-xs mb-2 block">11-position scale (50-950)</P>
               <div class="flex gap-0.5">
                 <div class="w-6 h-6 rounded-sm" style="background: oklch(0.98 0.02 240);" title="50 - L:0.98"></div>
                 <div class="w-6 h-6 rounded-sm" style="background: oklch(0.95 0.03 240);" title="100 - L:0.95"></div>
@@ -148,7 +148,7 @@ const totalComponents = components.length;
           </CardHeader>
           <CardContent class="space-y-4">
             <div>
-              <Muted class="text-xs mb-2 block">Minor third (1.2) progression</Muted>
+              <P size="sm" color="muted" class="text-xs mb-2 block">Minor third (1.2) progression</P>
               <div class="flex items-end gap-1">
                 <div class="w-4 bg-muted-foreground/40 rounded-sm" style="height: 8px;" title="base / 1.2"></div>
                 <div class="w-4 bg-muted-foreground/50 rounded-sm" style="height: 10px;" title="base"></div>
@@ -182,7 +182,7 @@ const totalComponents = components.length;
     <section class="mb-16">
       <div class="flex items-baseline gap-4 mb-8">
         <H3>Color API</H3>
-        <Muted>Real-time color intelligence via REST</Muted>
+        <P size="sm" color="muted">Real-time color intelligence via REST</P>
       </div>
 
       <Grid preset="linear" columns={2} gap="6">
@@ -249,7 +249,7 @@ const totalComponents = components.length;
     {/* Three Layers */}
     <section class="mb-16">
       <H2 class="mb-2">Three Layers</H2>
-      <Muted class="mb-8">What, where, and why of design decisions</Muted>
+      <P size="sm" color="muted" class="mb-8">What, where, and why of design decisions</P>
       
       <Grid preset="linear" columns={3} gap="6">
         <Card as="article">
@@ -304,7 +304,7 @@ const totalComponents = components.length;
     {/* MCP Tools */}
     <section class="mb-16">
       <H2 class="mb-2">MCP Tools</H2>
-      <Muted class="mb-8">How AI agents query design intelligence</Muted>
+      <P size="sm" color="muted" class="mb-8">How AI agents query design intelligence</P>
 
       <Grid preset="linear" columns={2} gap="6">
         <Card>
@@ -378,7 +378,7 @@ const totalComponents = components.length;
       <div class="flex items-center justify-between mb-8">
         <div>
           <H2 class="mb-2">Documentation</H2>
-          <Muted>Learn the protocol</Muted>
+          <P size="sm" color="muted">Learn the protocol</P>
         </div>
         <a href="/docs" class="text-sm text-primary hover:underline">
           View all docs
@@ -418,7 +418,7 @@ const totalComponents = components.length;
             Documentation
           </a>
         </div>
-        <Muted>Rafters Design Intelligence Protocol</Muted>
+        <P size="sm" color="muted">Rafters Design Intelligence Protocol</P>
       </div>
     </footer>
   </Container>

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rafters
 
+## 0.0.42
+
+### Minor Changes
+
+- feat(ui): typography tag components with token-level props. Individual HTML element components (H1-H6, P, Code, Blockquote, Small, Mark, Abbr) replace the unified Typography component. Each renders its own HTML element with designer-controlled defaults from typography composite roles. Token-level props (size, weight, color, line, tracking, family) allow surgical override of any dimension while staying within the token system. Removed Lead, Large, Muted as separate components -- they are now P with explicit props. Also includes the typography role migration: 27 component .classes.ts files now use semantic role utilities (text-title-medium, text-body-small, etc.) instead of hardcoded Tailwind classes.
+
 ## 0.0.41
 
 ### Patch Changes

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -582,13 +582,13 @@ Container and Grid handle ALL layout. You do not write layout code.
 
 | Instead of | Use |
 |---|---|
-| \`<p className="text-sm text-muted-foreground">\` | \`<Muted>\` |
+| \`<p className="text-sm text-muted-foreground">\` | \`<P size="sm" color="muted">\` |
 | \`<p>\` | \`<P>\` |
 | \`<h1 className="text-4xl font-bold">\` | \`<H1>\` |
 | \`<h2>\` | \`<H2>\` |
 | \`<h3>\` | \`<H3>\` |
 | \`<span className="text-xs">\` | \`<Small>\` |
-| \`<span className="text-lg font-semibold">\` | \`<Large>\` |
+| \`<span className="text-lg font-semibold">\` | \`<P size="lg" weight="semibold">\` |
 
 ## Color -- Tokens, Not Values
 
@@ -599,7 +599,7 @@ Never use hex, HSL, or palette internals.
 
 \`\`\`tsx
 import { Container, Grid } from "@rafters/ui"
-import { H1, Lead } from "@rafters/ui/components/ui/typography"
+import { H1, P } from "@rafters/ui/components/ui/typography"
 import { Card } from "@rafters/ui/components/ui/card"
 import { Button } from "@rafters/ui/components/ui/button"
 
@@ -607,7 +607,7 @@ export default function Page() {
   return (
     <Container>
       <H1>Title</H1>
-      <Lead>Description.</Lead>
+      <P size="xl" color="muted">Description.</P>
       <Grid preset="cards">
         <Card>...</Card>
         <Card>...</Card>

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -14,7 +14,7 @@ import { Input } from '@rafters/ui/components/ui/input';
 import { Separator } from '@rafters/ui/components/ui/separator';
 import { Tabs } from '@rafters/ui/components/ui/tabs';
 import { Tooltip } from '@rafters/ui/components/ui/tooltip';
-import { Muted, Small } from '@rafters/ui/components/ui/typography';
+import { P, Small } from '@rafters/ui/components/ui/typography';
 import { useState } from 'react';
 
 const NAMESPACES = [
@@ -78,7 +78,9 @@ export default function App() {
 
           <Separator className="my-2" />
 
-          <Muted>{NAMESPACES.length} ns</Muted>
+          <P size="sm" color="muted">
+            {NAMESPACES.length} ns
+          </P>
         </Container>
 
         <Container as="section" className="col-span-11 row-span-11" padding="4">
@@ -98,7 +100,9 @@ export default function App() {
                       <CardDescription>Base primary color</CardDescription>
                     </CardHeader>
                     <CardContent>
-                      <Muted>oklch(0.6 0.15 250)</Muted>
+                      <P size="sm" color="muted">
+                        oklch(0.6 0.15 250)
+                      </P>
                     </CardContent>
                   </Card>
                 </Dialog.Trigger>
@@ -124,11 +128,15 @@ export default function App() {
             </Tabs.Content>
 
             <Tabs.Content value="preview">
-              <Muted>Live preview of {currentNamespace?.label} changes</Muted>
+              <P size="sm" color="muted">
+                Live preview of {currentNamespace?.label} changes
+              </P>
             </Tabs.Content>
 
             <Tabs.Content value="code">
-              <Muted>Generated CSS/Tailwind for {currentNamespace?.label}</Muted>
+              <P size="sm" color="muted">
+                Generated CSS/Tailwind for {currentNamespace?.label}
+              </P>
             </Tabs.Content>
           </Tabs>
         </Container>

--- a/packages/ui/src/components/ui/accordion.classes.ts
+++ b/packages/ui/src/components/ui/accordion.classes.ts
@@ -10,7 +10,7 @@ export const accordionItemClasses = 'border-b';
 export const accordionTriggerHeadingClasses = 'flex';
 
 export const accordionTriggerClasses =
-  'flex flex-1 items-center justify-between py-4 font-medium transition-all duration-300 motion-reduce:transition-none ' +
+  'flex flex-1 items-center justify-between py-4 text-title-small transition-all duration-300 motion-reduce:transition-none ' +
   'hover:underline ' +
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ' +
   'disabled:pointer-events-none disabled:opacity-50';
@@ -20,7 +20,7 @@ export const accordionTriggerIconClasses =
   'data-[state=open]:rotate-180';
 
 export const accordionContentClasses =
-  'overflow-hidden text-sm transition-all duration-300 motion-reduce:transition-none ' +
+  'overflow-hidden text-body-small transition-all duration-300 motion-reduce:transition-none ' +
   'data-[state=closed]:animate-accordion-up ' +
   'data-[state=open]:animate-accordion-down';
 

--- a/packages/ui/src/components/ui/alert-dialog.classes.ts
+++ b/packages/ui/src/components/ui/alert-dialog.classes.ts
@@ -15,12 +15,12 @@ export const alertDialogHeaderClasses = 'flex flex-col space-y-2 text-center sm:
 export const alertDialogFooterClasses =
   'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2';
 
-export const alertDialogTitleClasses = 'text-lg font-semibold';
+export const alertDialogTitleClasses = 'text-title-medium';
 
-export const alertDialogDescriptionClasses = 'text-sm text-muted-foreground';
+export const alertDialogDescriptionClasses = 'text-body-small text-muted-foreground';
 
 export const alertDialogActionClasses =
-  'inline-flex h-10 items-center justify-center rounded-md bg-destructive px-4 py-2 text-sm font-medium text-destructive-foreground ring-offset-background transition-colors duration-150 motion-reduce:transition-none hover:bg-destructive/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50';
+  'inline-flex h-10 items-center justify-center rounded-md bg-destructive px-4 py-2 text-label-medium text-destructive-foreground ring-offset-background transition-colors duration-150 motion-reduce:transition-none hover:bg-destructive/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50';
 
 export const alertDialogCancelClasses =
-  'mt-2 inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium ring-offset-background transition-colors duration-150 motion-reduce:transition-none hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 sm:mt-0';
+  'mt-2 inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-label-medium ring-offset-background transition-colors duration-150 motion-reduce:transition-none hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 sm:mt-0';

--- a/packages/ui/src/components/ui/alert.classes.ts
+++ b/packages/ui/src/components/ui/alert.classes.ts
@@ -18,8 +18,8 @@ export const alertVariantClasses: Record<string, string> = {
   accent: 'bg-accent-subtle text-accent-foreground border-accent-border',
 };
 
-export const alertTitleClasses = 'mb-1 font-medium leading-none tracking-tight';
+export const alertTitleClasses = 'mb-1 text-title-small leading-none';
 
-export const alertDescriptionClasses = 'text-sm [&_p]:leading-relaxed';
+export const alertDescriptionClasses = 'text-body-small [&_p]:leading-relaxed';
 
 export const alertActionClasses = 'ml-auto shrink-0';

--- a/packages/ui/src/components/ui/badge.classes.ts
+++ b/packages/ui/src/components/ui/badge.classes.ts
@@ -21,10 +21,10 @@ export const badgeVariantClasses: Record<string, string> = {
 };
 
 export const badgeSizeClasses: Record<string, string> = {
-  sm: 'px-2 py-0.5 text-xs',
-  default: 'px-2.5 py-0.5 text-xs',
-  lg: 'px-3 py-1 text-sm',
+  sm: 'px-2 py-0.5 text-label-small',
+  default: 'px-2.5 py-0.5 text-label-small',
+  lg: 'px-3 py-1 text-label-medium',
 };
 
 export const badgeBaseClasses =
-  'inline-flex items-center justify-center rounded-full font-semibold transition-colors duration-150 motion-reduce:transition-none';
+  'inline-flex items-center justify-center rounded-full transition-colors duration-150 motion-reduce:transition-none';

--- a/packages/ui/src/components/ui/breadcrumb.classes.ts
+++ b/packages/ui/src/components/ui/breadcrumb.classes.ts
@@ -4,14 +4,14 @@
  */
 
 export const breadcrumbListClasses =
-  'flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground @sm:gap-2.5';
+  'flex flex-wrap items-center gap-1.5 break-words text-label-medium text-muted-foreground @sm:gap-2.5';
 
 export const breadcrumbItemClasses = 'inline-flex items-center gap-1.5';
 
 export const breadcrumbLinkClasses =
   'transition-colors duration-150 motion-reduce:transition-none hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
 
-export const breadcrumbPageClasses = 'font-normal text-foreground';
+export const breadcrumbPageClasses = 'text-foreground';
 
 export const breadcrumbSeparatorClasses = '[&>svg]:size-3.5';
 

--- a/packages/ui/src/components/ui/button.classes.ts
+++ b/packages/ui/src/components/ui/button.classes.ts
@@ -58,9 +58,9 @@ export const buttonVariantClasses: Record<string, string> = {
 
 export const buttonSizeClasses: Record<string, string> = {
   default: 'h-10 px-4 py-2',
-  xs: 'h-6 px-2 text-xs',
-  sm: 'h-8 px-3 text-xs',
-  lg: 'h-12 px-6 text-base',
+  xs: 'h-6 px-2 text-label-small',
+  sm: 'h-8 px-3 text-label-small',
+  lg: 'h-12 px-6 text-label-large',
   icon: 'h-10 w-10',
   'icon-xs': 'h-6 w-6',
   'icon-sm': 'h-8 w-8',
@@ -68,7 +68,7 @@ export const buttonSizeClasses: Record<string, string> = {
 };
 
 export const buttonBaseClasses =
-  'inline-flex items-center justify-center gap-2 rounded-md font-medium cursor-pointer ' +
+  'inline-flex items-center justify-center gap-2 rounded-md text-label-large cursor-pointer ' +
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ' +
   'transition-colors duration-150 motion-reduce:transition-none ' +
   'disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none';

--- a/packages/ui/src/components/ui/card.classes.ts
+++ b/packages/ui/src/components/ui/card.classes.ts
@@ -16,9 +16,9 @@ export const cardEditableClasses =
 
 export const cardHeaderClasses = 'flex flex-col gap-1.5 p-6';
 
-export const cardTitleClasses = 'text-2xl font-semibold leading-none tracking-tight';
+export const cardTitleClasses = 'text-title-medium leading-none';
 
-export const cardDescriptionClasses = 'text-sm text-muted-foreground';
+export const cardDescriptionClasses = 'text-body-small text-muted-foreground';
 
 export const cardActionClasses = 'col-start-2 row-span-2 row-start-1 self-start justify-self-end';
 

--- a/packages/ui/src/components/ui/color-inspector.tsx
+++ b/packages/ui/src/components/ui/color-inspector.tsx
@@ -35,7 +35,7 @@ import type { GamutTier, OklchColor } from '../../primitives/types';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from './collapsible';
 import { Container } from './container';
 import { Grid } from './grid';
-import { H2, Lead, Muted, P, Small } from './typography';
+import { H2, P, Small } from './typography';
 
 // ============================================================================
 // Shared helpers
@@ -739,13 +739,15 @@ function ColorDetail({ color, onClose }: ColorDetailProps) {
         data-color-hero=""
       >
         {emotionSentence ? (
-          <Lead
+          <P
+            size="xl"
+            color="muted"
             className={classy('font-light')}
             style={{ color: 'inherit', opacity: 0.85 }}
             data-hero-emotion=""
           >
             {emotionSentence}.
-          </Lead>
+          </P>
         ) : null}
         <div className={classy('flex items-baseline gap-3 mt-4')}>
           <H2 className={classy('text-base')} style={{ color: 'inherit' }}>
@@ -754,9 +756,14 @@ function ColorDetail({ color, onClose }: ColorDetailProps) {
           {color.token ? (
             <Small style={{ color: 'inherit', opacity: 0.5 }}>{color.token}</Small>
           ) : null}
-          <Muted className={classy('ml-auto')} style={{ color: 'inherit', opacity: 0.3 }}>
+          <P
+            size="sm"
+            color="muted"
+            className={classy('ml-auto')}
+            style={{ color: 'inherit', opacity: 0.3 }}
+          >
             {baseColor.l.toFixed(2)} / {baseColor.c.toFixed(3)} / {baseColor.h.toFixed(0)}
-          </Muted>
+          </P>
         </div>
 
         {/* At-a-glance badges: WCAG, APCA, gamut */}
@@ -842,14 +849,24 @@ function ColorDetail({ color, onClose }: ColorDetailProps) {
               <>
                 <P>{intelligence.reasoning}</P>
                 {intelligence.culturalContext ? (
-                  <Muted>{intelligence.culturalContext}</Muted>
+                  <P size="sm" color="muted">
+                    {intelligence.culturalContext}
+                  </P>
                 ) : null}
-                {intelligence.usageGuidance ? <Muted>{intelligence.usageGuidance}</Muted> : null}
+                {intelligence.usageGuidance ? (
+                  <P size="sm" color="muted">
+                    {intelligence.usageGuidance}
+                  </P>
+                ) : null}
                 {intelligence.accessibilityNotes ? (
-                  <Muted>{intelligence.accessibilityNotes}</Muted>
+                  <P size="sm" color="muted">
+                    {intelligence.accessibilityNotes}
+                  </P>
                 ) : null}
                 {intelligence.balancingGuidance ? (
-                  <Muted>{intelligence.balancingGuidance}</Muted>
+                  <P size="sm" color="muted">
+                    {intelligence.balancingGuidance}
+                  </P>
                 ) : null}
               </>
             ) : null}
@@ -992,9 +1009,9 @@ function ColorInspector({ colors, className }: ColorInspectorProps) {
         {selectedColor ? (
           <ColorDetail color={selectedColor} onClose={() => setSelectedIndex(null)} />
         ) : (
-          <Muted className={classy('flex items-center justify-center py-24')}>
+          <P size="sm" color="muted" className={classy('flex items-center justify-center py-24')}>
             Select a color to inspect
-          </Muted>
+          </P>
         )}
       </Container>
     </Container>

--- a/packages/ui/src/components/ui/command.classes.ts
+++ b/packages/ui/src/components/ui/command.classes.ts
@@ -18,19 +18,19 @@ export const commandInputWrapperClasses = 'flex items-center border-b px-3';
 export const commandInputSearchIconClasses = 'mr-2 shrink-0 opacity-50';
 
 export const commandInputClasses =
-  'flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50';
+  'flex h-10 w-full rounded-md bg-transparent py-3 text-body-small outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50';
 
 export const commandListClasses = 'max-h-80 overflow-y-auto overflow-x-hidden';
 
-export const commandEmptyClasses = 'py-6 text-center text-sm';
+export const commandEmptyClasses = 'py-6 text-center text-body-small';
 
 export const commandGroupClasses = 'overflow-hidden p-1 text-foreground';
 
-export const commandGroupHeadingClasses = 'px-2 py-1.5 text-xs font-medium text-muted-foreground';
+export const commandGroupHeadingClasses = 'px-2 py-1.5 text-label-small text-muted-foreground';
 
 export const commandItemClasses =
-  'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors duration-100 motion-reduce:transition-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[selected]:bg-accent data-[selected]:text-accent-foreground';
+  'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-body-small outline-none transition-colors duration-100 motion-reduce:transition-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[selected]:bg-accent data-[selected]:text-accent-foreground';
 
 export const commandSeparatorClasses = '-mx-1 h-px bg-border';
 
-export const commandShortcutClasses = 'ml-auto text-xs tracking-widest text-muted-foreground';
+export const commandShortcutClasses = 'ml-auto text-shortcut text-muted-foreground';

--- a/packages/ui/src/components/ui/context-menu.classes.ts
+++ b/packages/ui/src/components/ui/context-menu.classes.ts
@@ -11,13 +11,13 @@ export const contextMenuContentAnimationClasses =
 export const contextMenuSubContentAnimationClasses =
   'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95';
 
-export const contextMenuLabelClasses = 'px-2 py-1.5 text-sm font-semibold';
+export const contextMenuLabelClasses = 'px-2 py-1.5 text-label-medium';
 
 export const contextMenuItemClasses =
-  'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+  'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-body-small outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
 
 export const contextMenuCheckboxItemClasses =
-  'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+  'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-body-small outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
 
 export const contextMenuCheckboxIndicatorClasses =
   'absolute left-2 flex h-3.5 w-3.5 items-center justify-center';
@@ -25,7 +25,7 @@ export const contextMenuCheckboxIndicatorClasses =
 export const contextMenuCheckIconClasses = 'h-4 w-4';
 
 export const contextMenuRadioItemClasses =
-  'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+  'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-body-small outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
 
 export const contextMenuRadioIndicatorClasses =
   'absolute left-2 flex h-3.5 w-3.5 items-center justify-center';
@@ -34,9 +34,9 @@ export const contextMenuRadioDotClasses = 'h-2 w-2 rounded-full bg-current';
 
 export const contextMenuSeparatorClasses = '-mx-1 my-1 h-px border-0 bg-muted';
 
-export const contextMenuShortcutClasses = 'ml-auto text-xs tracking-widest opacity-60';
+export const contextMenuShortcutClasses = 'ml-auto text-shortcut opacity-60';
 
 export const contextMenuSubTriggerClasses =
-  'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+  'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-body-small outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
 
 export const contextMenuSubTriggerIconClasses = 'ml-auto h-4 w-4';

--- a/packages/ui/src/components/ui/dialog.classes.ts
+++ b/packages/ui/src/components/ui/dialog.classes.ts
@@ -19,6 +19,6 @@ export const dialogHeaderClasses = 'flex flex-col space-y-1.5 text-center sm:tex
 
 export const dialogFooterClasses = 'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2';
 
-export const dialogTitleClasses = 'text-lg font-semibold leading-none tracking-tight';
+export const dialogTitleClasses = 'text-title-medium leading-none';
 
-export const dialogDescriptionClasses = 'text-sm text-muted-foreground';
+export const dialogDescriptionClasses = 'text-body-small text-muted-foreground';

--- a/packages/ui/src/components/ui/dropdown-menu.classes.ts
+++ b/packages/ui/src/components/ui/dropdown-menu.classes.ts
@@ -8,19 +8,19 @@ export const dropdownMenuContentClasses =
 export const dropdownMenuContentAnimationClasses =
   'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2';
 
-export const dropdownMenuLabelClasses = 'px-2 py-1.5 text-sm font-semibold';
+export const dropdownMenuLabelClasses = 'px-2 py-1.5 text-label-medium';
 
 export const dropdownMenuItemClasses =
-  'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+  'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-body-small outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
 
 export const dropdownMenuCheckboxItemClasses =
-  'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+  'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-body-small outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
 
 export const dropdownMenuCheckboxIndicatorClasses =
   'absolute left-2 flex h-3.5 w-3.5 items-center justify-center';
 
 export const dropdownMenuRadioItemClasses =
-  'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+  'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-body-small outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
 
 export const dropdownMenuRadioIndicatorClasses =
   'absolute left-2 flex h-3.5 w-3.5 items-center justify-center';
@@ -29,10 +29,10 @@ export const dropdownMenuRadioDotClasses = 'h-2 w-2 rounded-full bg-current';
 
 export const dropdownMenuSeparatorClasses = '-mx-1 my-1 h-px border-0 bg-muted';
 
-export const dropdownMenuShortcutClasses = 'ml-auto text-xs tracking-widest opacity-60';
+export const dropdownMenuShortcutClasses = 'ml-auto text-shortcut opacity-60';
 
 export const dropdownMenuSubTriggerClasses =
-  'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+  'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-body-small outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
 
 export const dropdownMenuSubTriggerIconClasses = 'ml-auto h-4 w-4';
 

--- a/packages/ui/src/components/ui/empty.classes.ts
+++ b/packages/ui/src/components/ui/empty.classes.ts
@@ -7,8 +7,8 @@ export const emptyBaseClasses = 'flex flex-col items-center justify-center gap-4
 
 export const emptyIconClasses = 'text-muted-foreground [&>svg]:h-12 [&>svg]:w-12';
 
-export const emptyTitleClasses = 'text-lg font-semibold text-foreground';
+export const emptyTitleClasses = 'text-title-medium text-foreground';
 
-export const emptyDescriptionClasses = 'max-w-sm text-sm text-muted-foreground';
+export const emptyDescriptionClasses = 'max-w-sm text-body-small text-muted-foreground';
 
 export const emptyActionClasses = '';

--- a/packages/ui/src/components/ui/input.classes.ts
+++ b/packages/ui/src/components/ui/input.classes.ts
@@ -25,7 +25,7 @@ export const inputVariantClasses: Record<string, string> = {
 };
 
 export const inputSizeClasses: Record<string, string> = {
-  sm: 'h-8 px-2 text-xs',
-  default: 'h-10 px-3 text-sm',
-  lg: 'h-12 px-4 text-base',
+  sm: 'h-8 px-2 text-label-small',
+  default: 'h-10 px-3 text-body-small',
+  lg: 'h-12 px-4 text-body-medium',
 };

--- a/packages/ui/src/components/ui/item.classes.ts
+++ b/packages/ui/src/components/ui/item.classes.ts
@@ -9,9 +9,9 @@ export const itemBaseClasses =
   'aria-selected:bg-accent aria-selected:text-accent-foreground';
 
 export const itemSizeClasses: Record<string, string> = {
-  default: 'px-3 py-2 text-sm',
-  sm: 'px-2 py-1.5 text-xs',
-  lg: 'px-4 py-3 text-base',
+  default: 'px-3 py-2 text-body-small',
+  sm: 'px-2 py-1.5 text-label-small',
+  lg: 'px-4 py-3 text-body-medium',
 };
 
 export const itemFocusClasses =
@@ -29,4 +29,4 @@ export const itemContentClasses = 'flex min-w-0 flex-1 flex-col';
 
 export const itemLabelClasses = 'truncate';
 
-export const itemDescriptionClasses = 'truncate text-muted-foreground text-xs mt-0.5';
+export const itemDescriptionClasses = 'truncate text-muted-foreground text-label-small mt-0.5';

--- a/packages/ui/src/components/ui/kbd.classes.ts
+++ b/packages/ui/src/components/ui/kbd.classes.ts
@@ -4,4 +4,4 @@
  */
 
 export const kbdBaseClasses =
-  'inline-flex items-center justify-center rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-xs font-medium text-muted-foreground shadow-sm';
+  'inline-flex items-center justify-center rounded border border-border bg-muted px-1.5 py-0.5 text-code-small text-muted-foreground shadow-sm';

--- a/packages/ui/src/components/ui/label.classes.ts
+++ b/packages/ui/src/components/ui/label.classes.ts
@@ -3,7 +3,7 @@
  */
 
 export const labelBaseClasses =
-  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70';
+  'text-label-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70';
 
 export const labelVariantClasses: Record<string, string> = {
   default: 'text-foreground',

--- a/packages/ui/src/components/ui/menubar.classes.ts
+++ b/packages/ui/src/components/ui/menubar.classes.ts
@@ -5,7 +5,7 @@
 export const menubarRootClasses = 'flex h-9 items-center gap-1 rounded-md border bg-background p-1';
 
 export const menubarTriggerClasses =
-  'flex cursor-default select-none items-center rounded-sm px-3 py-1 text-sm font-medium outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground';
+  'flex cursor-default select-none items-center rounded-sm px-3 py-1 text-label-medium outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground';
 
 export const menubarContentClasses =
   'z-depth-dropdown min-w-48 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg';
@@ -13,13 +13,13 @@ export const menubarContentClasses =
 export const menubarContentAnimationClasses =
   'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2';
 
-export const menubarLabelClasses = 'px-2 py-1.5 text-sm font-semibold';
+export const menubarLabelClasses = 'px-2 py-1.5 text-label-medium';
 
 export const menubarItemClasses =
-  'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+  'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-body-small outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
 
 export const menubarCheckboxItemClasses =
-  'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+  'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-body-small outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
 
 export const menubarCheckboxIndicatorClasses =
   'absolute left-2 flex h-3.5 w-3.5 items-center justify-center';
@@ -27,7 +27,7 @@ export const menubarCheckboxIndicatorClasses =
 export const menubarCheckIconClasses = 'h-4 w-4';
 
 export const menubarRadioItemClasses =
-  'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+  'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-body-small outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
 
 export const menubarRadioIndicatorClasses =
   'absolute left-2 flex h-3.5 w-3.5 items-center justify-center';
@@ -36,9 +36,9 @@ export const menubarRadioDotClasses = 'h-2 w-2 rounded-full bg-current';
 
 export const menubarSeparatorClasses = '-mx-1 my-1 h-px border-0 bg-muted';
 
-export const menubarShortcutClasses = 'ml-auto text-xs tracking-widest opacity-60';
+export const menubarShortcutClasses = 'ml-auto text-shortcut opacity-60';
 
 export const menubarSubTriggerClasses =
-  'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+  'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-body-small outline-none transition-colors duration-100 motion-reduce:transition-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
 
 export const menubarSubTriggerIconClasses = 'ml-auto h-4 w-4';

--- a/packages/ui/src/components/ui/navigation-menu.classes.ts
+++ b/packages/ui/src/components/ui/navigation-menu.classes.ts
@@ -9,7 +9,7 @@ export const navigationMenuListClasses =
   'group flex flex-1 list-none items-center justify-center gap-1';
 
 export const navigationMenuTriggerClasses =
-  'group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors duration-150 motion-reduce:transition-none hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50';
+  'group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-label-medium transition-colors duration-150 motion-reduce:transition-none hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50';
 
 export const navigationMenuTriggerChevronClasses =
   'ml-1 h-3 w-3 transition-transform duration-200 motion-reduce:transition-none';
@@ -19,7 +19,7 @@ export const navigationMenuContentClasses = 'left-0 top-0 w-full';
 export const navigationMenuContentActiveClasses = 'animate-in fade-in-0 zoom-in-95';
 
 export const navigationMenuLinkClasses =
-  'block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors duration-150 motion-reduce:transition-none hover:bg-accent hover:text-accent-foreground active:bg-muted active:text-foreground focus-visible:bg-accent focus-visible:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
+  'block select-none space-y-1 rounded-md p-3 no-underline outline-none transition-colors duration-150 motion-reduce:transition-none hover:bg-accent hover:text-accent-foreground active:bg-muted active:text-foreground focus-visible:bg-accent focus-visible:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
 
 export const navigationMenuViewportClasses =
   'mt-1.5 h-min w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg origin-top-center';

--- a/packages/ui/src/components/ui/pagination.classes.ts
+++ b/packages/ui/src/components/ui/pagination.classes.ts
@@ -8,7 +8,7 @@ export const paginationNavClasses = 'mx-auto flex w-full justify-center';
 export const paginationContentClasses = 'flex flex-row items-center gap-1';
 
 export const paginationLinkBaseClasses =
-  'inline-flex items-center justify-center rounded-md text-sm font-medium ' +
+  'inline-flex items-center justify-center rounded-md text-label-medium ' +
   'transition-colors duration-150 motion-reduce:transition-none ' +
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ' +
   'disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none ' +

--- a/packages/ui/src/components/ui/select.classes.ts
+++ b/packages/ui/src/components/ui/select.classes.ts
@@ -3,7 +3,7 @@
  */
 
 export const selectTriggerBaseClasses =
-  'flex w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-3 text-sm shadow-sm ring-offset-background hover:border-input-hover';
+  'flex w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-3 text-body-small shadow-sm ring-offset-background hover:border-input-hover';
 
 export const selectTriggerPlaceholderClasses = 'placeholder:text-muted-foreground';
 
@@ -37,10 +37,10 @@ export const selectContentPaddingClasses = 'p-1';
 
 export const selectViewportClasses = 'p-1';
 
-export const selectLabelClasses = 'py-1.5 pl-8 pr-2 text-sm font-semibold';
+export const selectLabelClasses = 'py-1.5 pl-8 pr-2 text-label-medium';
 
 export const selectItemBaseClasses =
-  'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none';
+  'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-body-small outline-none';
 
 export const selectItemFocusClasses = 'focus:bg-accent focus:text-accent-foreground';
 

--- a/packages/ui/src/components/ui/sheet.classes.ts
+++ b/packages/ui/src/components/ui/sheet.classes.ts
@@ -17,6 +17,6 @@ export const sheetHeaderClasses = 'flex flex-col space-y-2 text-center sm:text-l
 
 export const sheetFooterClasses = 'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2';
 
-export const sheetTitleClasses = 'text-lg font-semibold text-foreground';
+export const sheetTitleClasses = 'text-title-medium text-foreground';
 
-export const sheetDescriptionClasses = 'text-sm text-muted-foreground';
+export const sheetDescriptionClasses = 'text-body-small text-muted-foreground';

--- a/packages/ui/src/components/ui/sidebar.classes.ts
+++ b/packages/ui/src/components/ui/sidebar.classes.ts
@@ -79,7 +79,7 @@ export const sidebarContentClasses =
 export const sidebarGroupClasses = 'relative flex w-full min-w-0 flex-col p-2';
 
 export const sidebarGroupLabelClasses =
-  'flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-none ' +
+  'flex h-8 shrink-0 items-center rounded-md px-2 text-label-small text-sidebar-foreground/70 outline-none ' +
   'ring-sidebar-ring transition-all duration-200 ease-linear motion-reduce:transition-none focus-visible:ring-2 ' +
   'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0';
 
@@ -96,7 +96,7 @@ export const sidebarMenuClasses = 'flex w-full min-w-0 flex-col gap-1';
 export const sidebarMenuItemClasses = 'group/menu-item relative';
 
 export const sidebarMenuButtonClasses =
-  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ' +
+  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-label-medium outline-none ' +
   'ring-sidebar-ring transition-all duration-150 motion-reduce:transition-none hover:bg-sidebar-accent hover:text-sidebar-accent-foreground ' +
   'focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 ' +
   'group-has-data-[sidebar=menu-action]/menu-item:pr-8 ' +
@@ -105,9 +105,9 @@ export const sidebarMenuButtonClasses =
   'group-data-[collapsible=icon]:size-8 group-data-[collapsible=icon]:p-2 ' +
   'group-data-[collapsible=icon]:group-has-data-[sidebar=menu-action]/menu-item:pr-2';
 
-export const sidebarMenuButtonSmClasses = 'text-xs';
+export const sidebarMenuButtonSmClasses = 'text-label-small';
 
-export const sidebarMenuButtonLgClasses = 'text-sm group-data-[collapsible=icon]:p-0';
+export const sidebarMenuButtonLgClasses = 'text-label-medium group-data-[collapsible=icon]:p-0';
 
 export const sidebarMenuButtonOutlineClasses =
   'bg-background shadow-sm hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-none';
@@ -124,7 +124,7 @@ export const sidebarMenuActionShowOnHoverClasses =
 
 export const sidebarMenuBadgeClasses =
   'pointer-events-none absolute right-1 flex h-5 min-w-5 select-none items-center justify-center ' +
-  'rounded-md px-1 text-xs font-medium tabular-nums text-sidebar-foreground ' +
+  'rounded-md px-1 text-label-small tabular-nums text-sidebar-foreground ' +
   'peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground ' +
   'group-data-[collapsible=icon]:hidden';
 
@@ -147,8 +147,8 @@ export const sidebarMenuSubButtonClasses =
   'aria-disabled:pointer-events-none aria-disabled:opacity-50 ' +
   'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground';
 
-export const sidebarMenuSubButtonSmClasses = 'text-xs';
+export const sidebarMenuSubButtonSmClasses = 'text-label-small';
 
-export const sidebarMenuSubButtonMdClasses = 'text-sm';
+export const sidebarMenuSubButtonMdClasses = 'text-label-medium';
 
 export const sidebarSeparatorClasses = 'mx-2 h-px w-auto bg-sidebar-border';

--- a/packages/ui/src/components/ui/table.classes.ts
+++ b/packages/ui/src/components/ui/table.classes.ts
@@ -3,7 +3,7 @@
  * Used by both table.tsx (React) and table.astro (Astro)
  */
 
-export const tableRootClasses = 'w-full caption-bottom text-sm';
+export const tableRootClasses = 'w-full caption-bottom text-body-small';
 
 export const tableWrapperClasses = 'relative w-full overflow-auto';
 
@@ -11,15 +11,15 @@ export const tableHeaderClasses = '[&_tr]:border-b';
 
 export const tableBodyClasses = '[&_tr:last-child]:border-0';
 
-export const tableFooterClasses = 'border-t bg-muted/50 font-medium [&>tr]:last:border-b-0';
+export const tableFooterClasses = 'border-t bg-muted/50 text-label-medium [&>tr]:last:border-b-0';
 
 export const tableRowClasses =
   'border-b transition-colors duration-150 motion-reduce:transition-none hover:bg-muted/50 data-[state=selected]:bg-muted';
 
 export const tableHeadClasses =
-  'h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-0.5';
+  'h-10 px-2 text-left align-middle text-label-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-0.5';
 
 export const tableCellClasses =
   'p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-0.5';
 
-export const tableCaptionClasses = 'text-sm text-muted-foreground';
+export const tableCaptionClasses = 'text-body-small text-muted-foreground';

--- a/packages/ui/src/components/ui/tabs.classes.ts
+++ b/packages/ui/src/components/ui/tabs.classes.ts
@@ -8,7 +8,7 @@ export const tabsListClasses =
 
 export const tabsTriggerBaseClasses = [
   'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5',
-  'text-sm font-medium ring-offset-background transition-all duration-200 motion-reduce:transition-none cursor-pointer',
+  'text-label-medium ring-offset-background transition-all duration-200 motion-reduce:transition-none cursor-pointer',
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
   'disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none',
 ].join(' ');

--- a/packages/ui/src/components/ui/textarea.classes.ts
+++ b/packages/ui/src/components/ui/textarea.classes.ts
@@ -24,7 +24,7 @@ export const textareaVariantClasses: Record<string, string> = {
 };
 
 export const textareaSizeClasses: Record<string, string> = {
-  sm: 'min-h-16 px-2 py-1 text-xs',
-  default: 'min-h-20 px-3 py-2 text-sm',
-  lg: 'min-h-28 px-4 py-3 text-base',
+  sm: 'min-h-16 px-2 py-1 text-label-small',
+  default: 'min-h-20 px-3 py-2 text-body-small',
+  lg: 'min-h-28 px-4 py-3 text-body-medium',
 };

--- a/packages/ui/src/components/ui/toggle-group.classes.ts
+++ b/packages/ui/src/components/ui/toggle-group.classes.ts
@@ -12,7 +12,7 @@ export const toggleGroupDefaultVariantClasses = 'bg-muted p-1';
 export const toggleGroupItemBaseClasses =
   'inline-flex items-center justify-center ' +
   'rounded-md ' +
-  'text-sm font-medium ' +
+  'text-label-large ' +
   'transition-all duration-200 motion-reduce:transition-none ' +
   'active:scale-[0.98] ' +
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ' +

--- a/packages/ui/src/components/ui/toggle.classes.ts
+++ b/packages/ui/src/components/ui/toggle.classes.ts
@@ -8,7 +8,7 @@
 export const toggleBaseClasses =
   'inline-flex items-center justify-center ' +
   'rounded-md ' +
-  'text-sm font-medium ' +
+  'text-label-large ' +
   'transition-all duration-200 motion-reduce:transition-none ' +
   'active:scale-[0.98] ' +
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ' +

--- a/packages/ui/src/components/ui/tooltip.classes.ts
+++ b/packages/ui/src/components/ui/tooltip.classes.ts
@@ -6,4 +6,4 @@
 export const tooltipTriggerClasses = 'inline-flex';
 
 export const tooltipContentClasses =
-  'z-50 overflow-hidden rounded-md bg-foreground px-3 py-1.5 text-sm text-background shadow-lg transition-opacity duration-150 motion-reduce:transition-none';
+  'z-50 overflow-hidden rounded-md bg-foreground px-3 py-1.5 text-body-small text-background shadow-lg transition-opacity duration-150 motion-reduce:transition-none';

--- a/packages/ui/src/components/ui/typography.tsx
+++ b/packages/ui/src/components/ui/typography.tsx
@@ -5,13 +5,13 @@
  * @attention-economics Hierarchy guides reading: H1=page title (one per page), H2=sections, H3=subsections, body text flows naturally
  * @trust-building Consistent typography builds readability and professionalism
  * @accessibility Proper heading hierarchy for screen readers; sufficient contrast ratios
- * @semantic-meaning Element mapping: H1-H4=document structure, P=body content, Lead=introductions, Muted=secondary info, Code=technical content
+ * @semantic-meaning Element mapping: H1-H6=document structure, P=body content (with token overrides for lead/muted variants), Code=technical content
  *
  * @usage-patterns
  * DO: Use H1 once per page for main title
  * DO: Follow heading hierarchy (H1 -> H2 -> H3, never skip)
- * DO: Use Lead for introductory paragraphs
- * DO: Use Muted for supplementary information
+ * DO: Use P with size/color token props for variant styling (e.g., lead, muted)
+ * DO: Use token props to override individual typography dimensions
  * NEVER: Skip heading levels (H1 -> H3)
  * NEVER: Use headings for styling only (use CSS instead)
  * NEVER: Use multiple H1s on a single page
@@ -20,14 +20,14 @@
  * ```tsx
  * // Page structure
  * <H1>Page Title</H1>
- * <Lead>This is an introduction to the page content.</Lead>
+ * <P size="xl" color="muted">This is an introduction to the page content.</P>
  *
  * <H2>Section Title</H2>
  * <P>Body paragraph with standard styling.</P>
  *
  * <H3>Subsection</H3>
  * <P>More content here.</P>
- * <Muted>Last updated: Jan 2025</Muted>
+ * <P size="sm" color="muted">Last updated: Jan 2025</P>
  *
  * // Code example
  * <P>Use the <Code>useState</Code> hook for local state.</P>
@@ -76,10 +76,55 @@ export interface EditableTypographyProps {
 
 import { typographyClasses } from './typography.classes';
 
-export interface TypographyProps extends React.HTMLAttributes<HTMLElement> {
-  /** Override the default HTML element */
-  as?: React.ElementType;
+/**
+ * Token-level typography props for surgical override of any dimension.
+ * All props reference token scale positions. The component applies role
+ * defaults, then explicit props override individual dimensions.
+ *
+ * size="xl" -> text-xl (reads --font-size-xl from @theme)
+ * weight="thin" -> font-thin (reads --font-weight-thin from @theme)
+ * color="muted" -> text-muted-foreground
+ * line="relaxed" -> leading-relaxed
+ * tracking="wide" -> tracking-wide
+ * family="code" -> font-code (reads --font-code from @theme)
+ */
+export interface TypographyTokenProps {
+  /** Font size scale position override. Maps to text-{value} utility. */
+  size?: string | undefined;
+  /** Font weight override. Maps to font-{value} utility. */
+  weight?: string | undefined;
+  /** Text color override. Maps to text-{value} for semantic colors, text-{value}-foreground for named colors. */
+  color?: string | undefined;
+  /** Line height override. Maps to leading-{value} utility. */
+  line?: string | undefined;
+  /** Letter spacing override. Maps to tracking-{value} utility. */
+  tracking?: string | undefined;
+  /** Font family role override. Maps to font-{value} utility. */
+  family?: string | undefined;
 }
+
+/**
+ * Build Tailwind utility classes from token props.
+ * Returns a string of override classes or empty string if no overrides.
+ */
+function tokenPropsToClasses(props: TypographyTokenProps): string {
+  const classes: string[] = [];
+  if (props.size) classes.push(`text-${props.size}`);
+  if (props.weight) classes.push(`font-${props.weight}`);
+  if (props.color) {
+    if (props.color === 'foreground' || props.color.endsWith('-foreground')) {
+      classes.push(`text-${props.color}`);
+    } else {
+      classes.push(`text-${props.color}-foreground`);
+    }
+  }
+  if (props.line) classes.push(`leading-${props.line}`);
+  if (props.tracking) classes.push(`tracking-${props.tracking}`);
+  if (props.family) classes.push(`font-${props.family}`);
+  return classes.join(' ');
+}
+
+export interface TypographyProps extends React.HTMLAttributes<HTMLElement>, TypographyTokenProps {}
 
 /**
  * Extended props for editable heading components (R-200a)
@@ -934,8 +979,13 @@ function useEditableQuote({
 export const H1 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
   (
     {
-      as,
       className,
+      size,
+      weight,
+      color,
+      line,
+      tracking,
+      family,
       editable,
       onChange,
       onFocus,
@@ -960,9 +1010,8 @@ export const H1 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
       onBackspaceAtStart,
     });
 
-    const Component = as ?? 'h1';
+    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
 
-    // Combine refs
     const combinedRef = (element: HTMLHeadingElement | null) => {
       (elementRef as React.MutableRefObject<HTMLElement | null>).current = element;
       if (typeof ref === 'function') {
@@ -973,12 +1022,12 @@ export const H1 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
     };
 
     return (
-      <Component
+      <h1
         ref={combinedRef}
         className={classy(
           typographyClasses.h1,
+          overrides,
           editable && 'outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 rounded',
-          // Placeholder styling should be applied via CSS using [data-placeholder]:empty:before
           className,
         )}
         data-editable={editable || undefined}
@@ -986,7 +1035,7 @@ export const H1 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
         {...props}
       >
         {children}
-      </Component>
+      </h1>
     );
   },
 );
@@ -1001,8 +1050,13 @@ H1.displayName = 'H1';
 export const H2 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
   (
     {
-      as,
       className,
+      size,
+      weight,
+      color,
+      line,
+      tracking,
+      family,
       editable,
       onChange,
       onFocus,
@@ -1027,7 +1081,7 @@ export const H2 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
       onBackspaceAtStart,
     });
 
-    const Component = as ?? 'h2';
+    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
 
     const combinedRef = (element: HTMLHeadingElement | null) => {
       (elementRef as React.MutableRefObject<HTMLElement | null>).current = element;
@@ -1039,12 +1093,12 @@ export const H2 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
     };
 
     return (
-      <Component
+      <h2
         ref={combinedRef}
         className={classy(
           typographyClasses.h2,
+          overrides,
           editable && 'outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 rounded',
-          // Placeholder styling should be applied via CSS using [data-placeholder]:empty:before
           className,
         )}
         data-editable={editable || undefined}
@@ -1052,7 +1106,7 @@ export const H2 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
         {...props}
       >
         {children}
-      </Component>
+      </h2>
     );
   },
 );
@@ -1067,8 +1121,13 @@ H2.displayName = 'H2';
 export const H3 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
   (
     {
-      as,
       className,
+      size,
+      weight,
+      color,
+      line,
+      tracking,
+      family,
       editable,
       onChange,
       onFocus,
@@ -1093,7 +1152,7 @@ export const H3 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
       onBackspaceAtStart,
     });
 
-    const Component = as ?? 'h3';
+    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
 
     const combinedRef = (element: HTMLHeadingElement | null) => {
       (elementRef as React.MutableRefObject<HTMLElement | null>).current = element;
@@ -1105,12 +1164,12 @@ export const H3 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
     };
 
     return (
-      <Component
+      <h3
         ref={combinedRef}
         className={classy(
           typographyClasses.h3,
+          overrides,
           editable && 'outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 rounded',
-          // Placeholder styling should be applied via CSS using [data-placeholder]:empty:before
           className,
         )}
         data-editable={editable || undefined}
@@ -1118,7 +1177,7 @@ export const H3 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
         {...props}
       >
         {children}
-      </Component>
+      </h3>
     );
   },
 );
@@ -1133,8 +1192,13 @@ H3.displayName = 'H3';
 export const H4 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
   (
     {
-      as,
       className,
+      size,
+      weight,
+      color,
+      line,
+      tracking,
+      family,
       editable,
       onChange,
       onFocus,
@@ -1159,7 +1223,7 @@ export const H4 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
       onBackspaceAtStart,
     });
 
-    const Component = as ?? 'h4';
+    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
 
     const combinedRef = (element: HTMLHeadingElement | null) => {
       (elementRef as React.MutableRefObject<HTMLElement | null>).current = element;
@@ -1171,12 +1235,12 @@ export const H4 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
     };
 
     return (
-      <Component
+      <h4
         ref={combinedRef}
         className={classy(
           typographyClasses.h4,
+          overrides,
           editable && 'outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 rounded',
-          // Placeholder styling should be applied via CSS using [data-placeholder]:empty:before
           className,
         )}
         data-editable={editable || undefined}
@@ -1184,11 +1248,47 @@ export const H4 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
         {...props}
       >
         {children}
-      </Component>
+      </h4>
     );
   },
 );
 H4.displayName = 'H4';
+
+/**
+ * H5 - Minor heading
+ * Use for fine-grained subsections. Shares visual treatment with H4.
+ */
+export const H5 = React.forwardRef<HTMLHeadingElement, TypographyProps>(
+  ({ className, size, weight, color, line, tracking, family, ...props }, ref) => {
+    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+    return (
+      <h5
+        ref={ref as React.Ref<HTMLHeadingElement>}
+        className={classy(typographyClasses.h4, overrides, className)}
+        {...props}
+      />
+    );
+  },
+);
+H5.displayName = 'H5';
+
+/**
+ * H6 - Lowest-level heading
+ * Use for the finest subsections. Shares visual treatment with H4.
+ */
+export const H6 = React.forwardRef<HTMLHeadingElement, TypographyProps>(
+  ({ className, size, weight, color, line, tracking, family, ...props }, ref) => {
+    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+    return (
+      <h6
+        ref={ref as React.Ref<HTMLHeadingElement>}
+        className={classy(typographyClasses.h4, overrides, className)}
+        {...props}
+      />
+    );
+  },
+);
+H6.displayName = 'H6';
 
 /**
  * P - Body paragraph
@@ -1222,8 +1322,13 @@ H4.displayName = 'H4';
 export const P = React.forwardRef<HTMLParagraphElement, EditableParagraphProps>(
   (
     {
-      as,
       className,
+      size,
+      weight,
+      color,
+      line,
+      tracking,
+      family,
       editable,
       onChange,
       onFocus,
@@ -1252,7 +1357,7 @@ export const P = React.forwardRef<HTMLParagraphElement, EditableParagraphProps>(
       onSlashCommand,
     });
 
-    const Component = as ?? 'p';
+    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
 
     // Combine refs
     const combinedRef = (element: HTMLParagraphElement | null) => {
@@ -1265,10 +1370,11 @@ export const P = React.forwardRef<HTMLParagraphElement, EditableParagraphProps>(
     };
 
     return (
-      <Component
+      <p
         ref={combinedRef}
         className={classy(
           typographyClasses.p,
+          overrides,
           editable && 'outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 rounded',
           className,
         )}
@@ -1277,59 +1383,23 @@ export const P = React.forwardRef<HTMLParagraphElement, EditableParagraphProps>(
         {...props}
       >
         {children}
-      </Component>
+      </p>
     );
   },
 );
 P.displayName = 'P';
 
 /**
- * Lead - Introductory paragraph
- * Larger, muted text for page or section introductions
- */
-export const Lead = React.forwardRef<HTMLParagraphElement, TypographyProps>(
-  ({ as, className, ...props }, ref) => {
-    const Component = as ?? 'p';
-    return (
-      <Component
-        ref={ref as React.Ref<HTMLParagraphElement>}
-        className={classy(typographyClasses.lead, className)}
-        {...props}
-      />
-    );
-  },
-);
-Lead.displayName = 'Lead';
-
-/**
- * Large - Emphasized text
- * Larger, semibold text for emphasis
- */
-export const Large = React.forwardRef<HTMLDivElement, TypographyProps>(
-  ({ as, className, ...props }, ref) => {
-    const Component = as ?? 'div';
-    return (
-      <Component
-        ref={ref as React.Ref<HTMLDivElement>}
-        className={classy(typographyClasses.large, className)}
-        {...props}
-      />
-    );
-  },
-);
-Large.displayName = 'Large';
-
-/**
  * Small - Smaller text
  * For fine print, captions, or supporting text
  */
 export const Small = React.forwardRef<HTMLElement, TypographyProps>(
-  ({ as, className, ...props }, ref) => {
-    const Component = as ?? 'small';
+  ({ className, size, weight, color, line, tracking, family, ...props }, ref) => {
+    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
     return (
-      <Component
+      <small
         ref={ref as React.Ref<HTMLElement>}
-        className={classy(typographyClasses.small, className)}
+        className={classy(typographyClasses.small, overrides, className)}
         {...props}
       />
     );
@@ -1338,34 +1408,16 @@ export const Small = React.forwardRef<HTMLElement, TypographyProps>(
 Small.displayName = 'Small';
 
 /**
- * Muted - Secondary text
- * De-emphasized text for metadata or supplementary info
- */
-export const Muted = React.forwardRef<HTMLParagraphElement, TypographyProps>(
-  ({ as, className, ...props }, ref) => {
-    const Component = as ?? 'p';
-    return (
-      <Component
-        ref={ref as React.Ref<HTMLParagraphElement>}
-        className={classy(typographyClasses.muted, className)}
-        {...props}
-      />
-    );
-  },
-);
-Muted.displayName = 'Muted';
-
-/**
  * Code - Inline code
  * Monospace text for code snippets, commands, or technical terms
  */
 export const Code = React.forwardRef<HTMLElement, TypographyProps>(
-  ({ as, className, ...props }, ref) => {
-    const Component = as ?? 'code';
+  ({ className, size, weight, color, line, tracking, family, ...props }, ref) => {
+    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
     return (
-      <Component
+      <code
         ref={ref as React.Ref<HTMLElement>}
-        className={classy(typographyClasses.code, className)}
+        className={classy(typographyClasses.code, overrides, className)}
         {...props}
       />
     );
@@ -1401,8 +1453,13 @@ Code.displayName = 'Code';
 export const Blockquote = React.forwardRef<HTMLQuoteElement, EditableQuoteProps>(
   (
     {
-      as,
       className,
+      size,
+      weight,
+      color,
+      line,
+      tracking,
+      family,
       editable,
       onChange,
       onFocus,
@@ -1431,6 +1488,8 @@ export const Blockquote = React.forwardRef<HTMLQuoteElement, EditableQuoteProps>
       onSelectionChange,
     });
 
+    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+
     const citationRef = useRef<HTMLElement>(null);
 
     const handleCitationInput = useCallback(() => {
@@ -1438,8 +1497,6 @@ export const Blockquote = React.forwardRef<HTMLQuoteElement, EditableQuoteProps>
       const text = citationRef.current.textContent ?? '';
       onCitationChange(text);
     }, [onCitationChange]);
-
-    const Component = as ?? 'blockquote';
 
     // Combine refs
     const combinedRef = (element: HTMLQuoteElement | null) => {
@@ -1452,10 +1509,11 @@ export const Blockquote = React.forwardRef<HTMLQuoteElement, EditableQuoteProps>
     };
 
     return (
-      <Component
+      <blockquote
         ref={combinedRef}
         className={classy(
           typographyClasses.blockquote,
+          overrides,
           editable && 'outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 rounded',
           className,
         )}
@@ -1479,7 +1537,7 @@ export const Blockquote = React.forwardRef<HTMLQuoteElement, EditableQuoteProps>
             {citation}
           </cite>
         )}
-      </Component>
+      </blockquote>
     );
   },
 );
@@ -1958,12 +2016,12 @@ CodeBlock.displayName = 'CodeBlock';
  * ```
  */
 export const Mark = React.forwardRef<HTMLElement, TypographyProps>(
-  ({ as, className, ...props }, ref) => {
-    const Component = as ?? 'mark';
+  ({ className, size, weight, color, line, tracking, family, ...props }, ref) => {
+    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
     return (
-      <Component
+      <mark
         ref={ref as React.Ref<HTMLElement>}
-        className={classy(typographyClasses.mark, className)}
+        className={classy(typographyClasses.mark, overrides, className)}
         {...props}
       />
     );
@@ -1981,12 +2039,12 @@ Mark.displayName = 'Mark';
  * ```
  */
 export const Abbr = React.forwardRef<HTMLElement, TypographyProps & { title: string }>(
-  ({ as, className, title, ...props }, ref) => {
-    const Component = as ?? 'abbr';
+  ({ className, size, weight, color, line, tracking, family, title, ...props }, ref) => {
+    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
     return (
-      <Component
+      <abbr
         ref={ref as React.Ref<HTMLElement>}
-        className={classy(typographyClasses.abbr, className)}
+        className={classy(typographyClasses.abbr, overrides, className)}
         title={title}
         {...props}
       />

--- a/packages/ui/test/components/alert.test.tsx
+++ b/packages/ui/test/components/alert.test.tsx
@@ -81,9 +81,8 @@ describe('AlertTitle', () => {
   it('applies styling classes', () => {
     render(<AlertTitle>Title</AlertTitle>);
     const title = screen.getByRole('heading');
-    expect(title.className).toContain('font-medium');
+    expect(title.className).toContain('text-title-small');
     expect(title.className).toContain('leading-none');
-    expect(title.className).toContain('tracking-tight');
   });
 
   it('forwards ref correctly', () => {
@@ -96,7 +95,7 @@ describe('AlertTitle', () => {
     render(<AlertTitle className="custom-title">Title</AlertTitle>);
     const title = screen.getByRole('heading');
     expect(title.className).toContain('custom-title');
-    expect(title.className).toContain('font-medium');
+    expect(title.className).toContain('text-title-small');
   });
 });
 
@@ -109,7 +108,7 @@ describe('AlertDescription', () => {
   it('applies styling classes', () => {
     render(<AlertDescription data-testid="desc">Description</AlertDescription>);
     const desc = screen.getByTestId('desc');
-    expect(desc.className).toContain('text-sm');
+    expect(desc.className).toContain('text-body-small');
   });
 
   it('forwards ref correctly', () => {
@@ -126,7 +125,7 @@ describe('AlertDescription', () => {
     );
     const desc = screen.getByTestId('desc');
     expect(desc.className).toContain('custom-desc');
-    expect(desc.className).toContain('text-sm');
+    expect(desc.className).toContain('text-body-small');
   });
 });
 

--- a/packages/ui/test/components/badge.test.tsx
+++ b/packages/ui/test/components/badge.test.tsx
@@ -66,8 +66,7 @@ describe('Badge', () => {
     expect(badge).toHaveClass('rounded-full');
     expect(badge).toHaveClass('px-2.5');
     expect(badge).toHaveClass('py-0.5');
-    expect(badge).toHaveClass('text-xs');
-    expect(badge).toHaveClass('font-semibold');
+    expect(badge).toHaveClass('text-label-small');
     expect(badge).toHaveClass('transition-colors');
   });
 

--- a/packages/ui/test/components/breadcrumb.test.tsx
+++ b/packages/ui/test/components/breadcrumb.test.tsx
@@ -97,7 +97,7 @@ describe('BreadcrumbList', () => {
     expect(list).toHaveClass('flex');
     expect(list).toHaveClass('flex-wrap');
     expect(list).toHaveClass('items-center');
-    expect(list).toHaveClass('text-sm');
+    expect(list).toHaveClass('text-label-medium');
     expect(list).toHaveClass('text-muted-foreground');
   });
 
@@ -360,7 +360,6 @@ describe('BreadcrumbPage', () => {
       </Breadcrumb>,
     );
     const page = screen.getByTestId('page');
-    expect(page).toHaveClass('font-normal');
     expect(page).toHaveClass('text-foreground');
   });
 

--- a/packages/ui/test/components/card.test.tsx
+++ b/packages/ui/test/components/card.test.tsx
@@ -166,16 +166,14 @@ describe('CardTitle', () => {
   it('applies default styles', () => {
     const { container } = render(<CardTitle>Title</CardTitle>);
     const title = container.firstChild;
-    expect(title).toHaveClass('text-2xl');
-    expect(title).toHaveClass('font-semibold');
+    expect(title).toHaveClass('text-title-medium');
     expect(title).toHaveClass('leading-none');
-    expect(title).toHaveClass('tracking-tight');
   });
 
   it('merges custom className', () => {
     const { container } = render(<CardTitle className="custom">Title</CardTitle>);
     expect(container.firstChild).toHaveClass('custom');
-    expect(container.firstChild).toHaveClass('text-2xl');
+    expect(container.firstChild).toHaveClass('text-title-medium');
   });
 
   it('forwards ref', () => {
@@ -195,14 +193,14 @@ describe('CardDescription', () => {
   it('applies default styles', () => {
     const { container } = render(<CardDescription>Description</CardDescription>);
     const desc = container.firstChild;
-    expect(desc).toHaveClass('text-sm');
+    expect(desc).toHaveClass('text-body-small');
     expect(desc).toHaveClass('text-muted-foreground');
   });
 
   it('merges custom className', () => {
     const { container } = render(<CardDescription className="custom">Desc</CardDescription>);
     expect(container.firstChild).toHaveClass('custom');
-    expect(container.firstChild).toHaveClass('text-sm');
+    expect(container.firstChild).toHaveClass('text-body-small');
   });
 
   it('forwards ref', () => {

--- a/packages/ui/test/components/empty.test.tsx
+++ b/packages/ui/test/components/empty.test.tsx
@@ -124,8 +124,7 @@ describe('EmptyTitle', () => {
     const { container } = render(<EmptyTitle>Title</EmptyTitle>);
     const title = container.firstChild;
     // mb-2 removed -- parent uses gap instead
-    expect(title).toHaveClass('text-lg');
-    expect(title).toHaveClass('font-semibold');
+    expect(title).toHaveClass('text-title-medium');
     expect(title).toHaveClass('text-foreground');
   });
 
@@ -137,7 +136,7 @@ describe('EmptyTitle', () => {
   it('merges custom className', () => {
     const { container } = render(<EmptyTitle className="custom-title">Title</EmptyTitle>);
     expect(container.firstChild).toHaveClass('custom-title');
-    expect(container.firstChild).toHaveClass('text-lg');
+    expect(container.firstChild).toHaveClass('text-title-medium');
   });
 
   it('forwards ref', () => {
@@ -169,7 +168,7 @@ describe('EmptyDescription', () => {
     const desc = container.firstChild;
     // mb-4 removed -- parent uses gap instead
     expect(desc).toHaveClass('max-w-sm');
-    expect(desc).toHaveClass('text-sm');
+    expect(desc).toHaveClass('text-body-small');
     expect(desc).toHaveClass('text-muted-foreground');
   });
 
@@ -183,7 +182,7 @@ describe('EmptyDescription', () => {
       <EmptyDescription className="custom-desc">Description</EmptyDescription>,
     );
     expect(container.firstChild).toHaveClass('custom-desc');
-    expect(container.firstChild).toHaveClass('text-sm');
+    expect(container.firstChild).toHaveClass('text-body-small');
   });
 
   it('forwards ref', () => {

--- a/packages/ui/test/components/item.test.tsx
+++ b/packages/ui/test/components/item.test.tsx
@@ -61,12 +61,14 @@ describe('Item', () => {
       </div>,
     );
 
-    expect(screen.getByText('Small').parentElement?.parentElement?.className).toContain('text-xs');
+    expect(screen.getByText('Small').parentElement?.parentElement?.className).toContain(
+      'text-label-small',
+    );
     expect(screen.getByText('Default').parentElement?.parentElement?.className).toContain(
-      'text-sm',
+      'text-body-small',
     );
     expect(screen.getByText('Large').parentElement?.parentElement?.className).toContain(
-      'text-base',
+      'text-body-medium',
     );
   });
 

--- a/packages/ui/test/components/kbd.test.tsx
+++ b/packages/ui/test/components/kbd.test.tsx
@@ -25,9 +25,7 @@ describe('Kbd', () => {
     expect(kbd).toHaveClass('bg-muted');
     expect(kbd).toHaveClass('px-1.5');
     expect(kbd).toHaveClass('py-0.5');
-    expect(kbd).toHaveClass('font-mono');
-    expect(kbd).toHaveClass('text-xs');
-    expect(kbd).toHaveClass('font-medium');
+    expect(kbd).toHaveClass('text-code-small');
     expect(kbd).toHaveClass('text-muted-foreground');
     expect(kbd).toHaveClass('shadow-sm');
   });

--- a/packages/ui/test/components/label.test.tsx
+++ b/packages/ui/test/components/label.test.tsx
@@ -16,8 +16,7 @@ describe('Label', () => {
   it('applies base typography classes', () => {
     const { container } = render(<Label>Username</Label>);
     const label = container.firstChild;
-    expect(label).toHaveClass('text-sm');
-    expect(label).toHaveClass('font-medium');
+    expect(label).toHaveClass('text-label-medium');
     expect(label).toHaveClass('leading-none');
   });
 
@@ -31,7 +30,7 @@ describe('Label', () => {
   it('merges custom className', () => {
     const { container } = render(<Label className="custom-class">Test</Label>);
     expect(container.firstChild).toHaveClass('custom-class');
-    expect(container.firstChild).toHaveClass('text-sm');
+    expect(container.firstChild).toHaveClass('text-label-medium');
   });
 
   it('passes through HTML attributes', () => {

--- a/packages/ui/test/components/sheet.test.tsx
+++ b/packages/ui/test/components/sheet.test.tsx
@@ -662,7 +662,7 @@ describe('Sheet - Title and Description styling', () => {
 
     await waitFor(() => {
       const title = screen.getByTestId('title');
-      expect(title).toHaveClass('text-lg', 'font-semibold');
+      expect(title).toHaveClass('text-title-medium');
     });
   });
 
@@ -680,7 +680,7 @@ describe('Sheet - Title and Description styling', () => {
 
     await waitFor(() => {
       const description = screen.getByTestId('description');
-      expect(description).toHaveClass('text-sm');
+      expect(description).toHaveClass('text-body-small');
     });
   });
 

--- a/packages/ui/test/components/typography-a11y.test.tsx
+++ b/packages/ui/test/components/typography-a11y.test.tsx
@@ -10,11 +10,10 @@ import {
   H2,
   H3,
   H4,
-  Large,
-  Lead,
+  H5,
+  H6,
   List,
   Mark,
-  Muted,
   P,
   Small,
 } from '../../src/components/ui/typography';
@@ -26,8 +25,12 @@ describe('H1 - Accessibility', () => {
     expect(results).toHaveNoViolations();
   });
 
-  it('has no violations with custom as prop', async () => {
-    const { container } = render(<H1 as="div">Styled as Heading</H1>);
+  it('has no violations with token overrides', async () => {
+    const { container } = render(
+      <H1 size="3xl" weight="light">
+        Styled Heading
+      </H1>,
+    );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
@@ -75,17 +78,17 @@ describe('P - Accessibility', () => {
   });
 });
 
-describe('Lead - Accessibility', () => {
+describe('H5 - Accessibility', () => {
   it('has no accessibility violations', async () => {
-    const { container } = render(<Lead>Introduction to the page content.</Lead>);
+    const { container } = render(<H5>Minor Heading</H5>);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
 });
 
-describe('Large - Accessibility', () => {
+describe('H6 - Accessibility', () => {
   it('has no accessibility violations', async () => {
-    const { container } = render(<Large>Emphasized text</Large>);
+    const { container } = render(<H6>Lowest Heading</H6>);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
@@ -99,9 +102,13 @@ describe('Small - Accessibility', () => {
   });
 });
 
-describe('Muted - Accessibility', () => {
+describe('P with muted token - Accessibility', () => {
   it('has no accessibility violations', async () => {
-    const { container } = render(<Muted>Secondary information</Muted>);
+    const { container } = render(
+      <P size="sm" color="muted">
+        Secondary information
+      </P>,
+    );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
@@ -153,7 +160,9 @@ describe('Typography - Heading hierarchy', () => {
     const { container } = render(
       <article>
         <H1>Page Title</H1>
-        <Lead>Introduction paragraph.</Lead>
+        <P size="xl" color="muted">
+          Introduction paragraph.
+        </P>
         <H2>Section 1</H2>
         <P>Content for section 1.</P>
         <H3>Subsection 1.1</H3>
@@ -188,8 +197,12 @@ describe('Typography - Complete page structure', () => {
         <article>
           <header>
             <H1>Article Title</H1>
-            <Lead>This is an introduction to the article content.</Lead>
-            <Muted>Published: January 2025</Muted>
+            <P size="xl" color="muted">
+              This is an introduction to the article content.
+            </P>
+            <P size="sm" color="muted">
+              Published: January 2025
+            </P>
           </header>
 
           <section>
@@ -207,13 +220,17 @@ describe('Typography - Complete page structure', () => {
 
           <section>
             <H2>Second Section</H2>
-            <Large>An emphasized statement</Large>
+            <P size="lg" weight="semibold">
+              An emphasized statement
+            </P>
             <P>Regular paragraph following the emphasis.</P>
             <Small>A note in smaller text.</Small>
           </section>
 
           <footer>
-            <Muted>Last updated: January 2025</Muted>
+            <P size="sm" color="muted">
+              Last updated: January 2025
+            </P>
           </footer>
         </article>
       </main>,

--- a/packages/ui/test/components/typography.test.tsx
+++ b/packages/ui/test/components/typography.test.tsx
@@ -10,13 +10,12 @@ import {
   H2,
   H3,
   H4,
+  H5,
+  H6,
   htmlToInlineContent,
   inlineContentToHtml,
-  Large,
-  Lead,
   List,
   Mark,
-  Muted,
   P,
   Small,
   typographyClasses,
@@ -39,16 +38,6 @@ describe('H1', () => {
     expect(h1).toHaveClass('scroll-m-20');
     expect(h1).toHaveClass('@lg:text-5xl');
     expect(h1).toHaveClass('text-foreground');
-  });
-
-  it('renders as custom element via as prop', () => {
-    render(
-      <H1 as="span" data-testid="h1">
-        Styled as H1
-      </H1>,
-    );
-    const element = screen.getByTestId('h1');
-    expect(element.tagName).toBe('SPAN');
   });
 
   it('merges custom className', () => {
@@ -90,16 +79,6 @@ describe('H2', () => {
     expect(h2).toHaveClass('text-foreground');
   });
 
-  it('renders as custom element via as prop', () => {
-    render(
-      <H2 as="div" data-testid="h2">
-        Styled as H2
-      </H2>,
-    );
-    const element = screen.getByTestId('h2');
-    expect(element.tagName).toBe('DIV');
-  });
-
   it('merges custom className', () => {
     const { container } = render(<H2 className="custom-class">Heading</H2>);
     expect(container.firstChild).toHaveClass('custom-class');
@@ -128,16 +107,6 @@ describe('H3', () => {
     expect(h3).toHaveClass('tracking-tight');
     expect(h3).toHaveClass('scroll-m-20');
     expect(h3).toHaveClass('text-foreground');
-  });
-
-  it('renders as custom element via as prop', () => {
-    render(
-      <H3 as="span" data-testid="h3">
-        Styled as H3
-      </H3>,
-    );
-    const element = screen.getByTestId('h3');
-    expect(element.tagName).toBe('SPAN');
   });
 
   it('merges custom className', () => {
@@ -170,16 +139,6 @@ describe('H4', () => {
     expect(h4).toHaveClass('text-foreground');
   });
 
-  it('renders as custom element via as prop', () => {
-    render(
-      <H4 as="div" data-testid="h4">
-        Styled as H4
-      </H4>,
-    );
-    const element = screen.getByTestId('h4');
-    expect(element.tagName).toBe('DIV');
-  });
-
   it('merges custom className', () => {
     const { container } = render(<H4 className="custom-class">Heading</H4>);
     expect(container.firstChild).toHaveClass('custom-class');
@@ -190,6 +149,81 @@ describe('H4', () => {
     const ref = createRef<HTMLHeadingElement>();
     render(<H4 ref={ref}>Heading</H4>);
     expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
+  });
+});
+
+describe('H5', () => {
+  it('renders as h5', () => {
+    render(<H5 data-testid="h5">Heading 5</H5>);
+    const heading = screen.getByTestId('h5');
+    expect(heading.tagName).toBe('H5');
+  });
+
+  it('applies h4 base styles', () => {
+    const { container } = render(<H5>Heading</H5>);
+    const h5 = container.firstChild;
+    expect(h5).toHaveClass('text-xl');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<H5 className="custom-class">Heading</H5>);
+    expect(container.firstChild).toHaveClass('custom-class');
+    expect(container.firstChild).toHaveClass('text-xl');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLHeadingElement>();
+    render(<H5 ref={ref}>Heading</H5>);
+    expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
+  });
+
+  it('applies token prop overrides', () => {
+    const { container } = render(
+      <H5 size="lg" weight="bold" color="muted">
+        Heading
+      </H5>,
+    );
+    const h5 = container.firstChild;
+    expect(h5).toHaveClass('text-lg');
+    expect(h5).toHaveClass('font-bold');
+    expect(h5).toHaveClass('text-muted-foreground');
+  });
+});
+
+describe('H6', () => {
+  it('renders as h6', () => {
+    render(<H6 data-testid="h6">Heading 6</H6>);
+    const heading = screen.getByTestId('h6');
+    expect(heading.tagName).toBe('H6');
+  });
+
+  it('applies h4 base styles', () => {
+    const { container } = render(<H6>Heading</H6>);
+    const h6 = container.firstChild;
+    expect(h6).toHaveClass('text-xl');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<H6 className="custom-class">Heading</H6>);
+    expect(container.firstChild).toHaveClass('custom-class');
+    expect(container.firstChild).toHaveClass('text-xl');
+  });
+
+  it('forwards ref', () => {
+    const ref = createRef<HTMLHeadingElement>();
+    render(<H6 ref={ref}>Heading</H6>);
+    expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
+  });
+
+  it('applies token prop overrides', () => {
+    const { container } = render(
+      <H6 size="sm" tracking="wide">
+        Heading
+      </H6>,
+    );
+    const h6 = container.firstChild;
+    expect(h6).toHaveClass('text-sm');
+    expect(h6).toHaveClass('tracking-wide');
   });
 });
 
@@ -207,16 +241,6 @@ describe('P', () => {
     expect(p).toHaveClass('text-foreground');
   });
 
-  it('renders as custom element via as prop', () => {
-    render(
-      <P as="span" data-testid="p">
-        Styled as P
-      </P>,
-    );
-    const element = screen.getByTestId('p');
-    expect(element.tagName).toBe('SPAN');
-  });
-
   it('merges custom className', () => {
     const { container } = render(<P className="custom-class">Paragraph</P>);
     expect(container.firstChild).toHaveClass('custom-class');
@@ -227,81 +251,6 @@ describe('P', () => {
     const ref = createRef<HTMLParagraphElement>();
     render(<P ref={ref}>Paragraph</P>);
     expect(ref.current).toBeInstanceOf(HTMLParagraphElement);
-  });
-});
-
-describe('Lead', () => {
-  it('renders as p by default', () => {
-    render(<Lead data-testid="lead">Lead paragraph</Lead>);
-    const lead = screen.getByTestId('lead');
-    expect(lead.tagName).toBe('P');
-  });
-
-  it('applies correct styles', () => {
-    const { container } = render(<Lead>Lead</Lead>);
-    const lead = container.firstChild;
-    expect(lead).toHaveClass('text-xl');
-    expect(lead).toHaveClass('text-muted-foreground');
-  });
-
-  it('renders as custom element via as prop', () => {
-    render(
-      <Lead as="div" data-testid="lead">
-        Styled as Lead
-      </Lead>,
-    );
-    const element = screen.getByTestId('lead');
-    expect(element.tagName).toBe('DIV');
-  });
-
-  it('merges custom className', () => {
-    const { container } = render(<Lead className="custom-class">Lead</Lead>);
-    expect(container.firstChild).toHaveClass('custom-class');
-    expect(container.firstChild).toHaveClass('text-xl');
-  });
-
-  it('forwards ref', () => {
-    const ref = createRef<HTMLParagraphElement>();
-    render(<Lead ref={ref}>Lead</Lead>);
-    expect(ref.current).toBeInstanceOf(HTMLParagraphElement);
-  });
-});
-
-describe('Large', () => {
-  it('renders as div by default', () => {
-    render(<Large data-testid="large">Large text</Large>);
-    const large = screen.getByTestId('large');
-    expect(large.tagName).toBe('DIV');
-  });
-
-  it('applies correct styles', () => {
-    const { container } = render(<Large>Large</Large>);
-    const large = container.firstChild;
-    expect(large).toHaveClass('text-lg');
-    expect(large).toHaveClass('font-semibold');
-    expect(large).toHaveClass('text-foreground');
-  });
-
-  it('renders as custom element via as prop', () => {
-    render(
-      <Large as="span" data-testid="large">
-        Styled as Large
-      </Large>,
-    );
-    const element = screen.getByTestId('large');
-    expect(element.tagName).toBe('SPAN');
-  });
-
-  it('merges custom className', () => {
-    const { container } = render(<Large className="custom-class">Large</Large>);
-    expect(container.firstChild).toHaveClass('custom-class');
-    expect(container.firstChild).toHaveClass('text-lg');
-  });
-
-  it('forwards ref', () => {
-    const ref = createRef<HTMLDivElement>();
-    render(<Large ref={ref}>Large</Large>);
-    expect(ref.current).toBeInstanceOf(HTMLDivElement);
   });
 });
 
@@ -321,16 +270,6 @@ describe('Small', () => {
     expect(small).toHaveClass('text-foreground');
   });
 
-  it('renders as custom element via as prop', () => {
-    render(
-      <Small as="span" data-testid="small">
-        Styled as Small
-      </Small>,
-    );
-    const element = screen.getByTestId('small');
-    expect(element.tagName).toBe('SPAN');
-  });
-
   it('merges custom className', () => {
     const { container } = render(<Small className="custom-class">Small</Small>);
     expect(container.firstChild).toHaveClass('custom-class');
@@ -341,43 +280,6 @@ describe('Small', () => {
     const ref = createRef<HTMLElement>();
     render(<Small ref={ref}>Small</Small>);
     expect(ref.current).toBeInstanceOf(HTMLElement);
-  });
-});
-
-describe('Muted', () => {
-  it('renders as p by default', () => {
-    render(<Muted data-testid="muted">Muted text</Muted>);
-    const muted = screen.getByTestId('muted');
-    expect(muted.tagName).toBe('P');
-  });
-
-  it('applies correct styles', () => {
-    const { container } = render(<Muted>Muted</Muted>);
-    const muted = container.firstChild;
-    expect(muted).toHaveClass('text-sm');
-    expect(muted).toHaveClass('text-muted-foreground');
-  });
-
-  it('renders as custom element via as prop', () => {
-    render(
-      <Muted as="span" data-testid="muted">
-        Styled as Muted
-      </Muted>,
-    );
-    const element = screen.getByTestId('muted');
-    expect(element.tagName).toBe('SPAN');
-  });
-
-  it('merges custom className', () => {
-    const { container } = render(<Muted className="custom-class">Muted</Muted>);
-    expect(container.firstChild).toHaveClass('custom-class');
-    expect(container.firstChild).toHaveClass('text-sm');
-  });
-
-  it('forwards ref', () => {
-    const ref = createRef<HTMLParagraphElement>();
-    render(<Muted ref={ref}>Muted</Muted>);
-    expect(ref.current).toBeInstanceOf(HTMLParagraphElement);
   });
 });
 
@@ -398,16 +300,6 @@ describe('Code', () => {
     expect(code).toHaveClass('font-mono');
     expect(code).toHaveClass('text-sm');
     expect(code).toHaveClass('text-foreground');
-  });
-
-  it('renders as custom element via as prop', () => {
-    render(
-      <Code as="span" data-testid="code">
-        Styled as Code
-      </Code>,
-    );
-    const element = screen.getByTestId('code');
-    expect(element.tagName).toBe('SPAN');
   });
 
   it('merges custom className', () => {
@@ -439,16 +331,6 @@ describe('Blockquote', () => {
     expect(quote).toHaveClass('pl-6');
     expect(quote).toHaveClass('italic');
     expect(quote).toHaveClass('text-foreground');
-  });
-
-  it('renders as custom element via as prop', () => {
-    render(
-      <Blockquote as="div" data-testid="quote">
-        Styled as Blockquote
-      </Blockquote>,
-    );
-    const element = screen.getByTestId('quote');
-    expect(element.tagName).toBe('DIV');
   });
 
   it('merges custom className', () => {
@@ -489,12 +371,100 @@ describe('typographyClasses', () => {
   });
 });
 
+describe('TypographyTokenProps', () => {
+  it('H1 applies size override', () => {
+    const { container } = render(<H1 size="3xl">Title</H1>);
+    expect(container.firstChild).toHaveClass('text-3xl');
+  });
+
+  it('H1 applies weight override', () => {
+    const { container } = render(<H1 weight="light">Title</H1>);
+    expect(container.firstChild).toHaveClass('font-light');
+  });
+
+  it('H1 applies color override with -foreground suffix', () => {
+    const { container } = render(<H1 color="muted">Title</H1>);
+    expect(container.firstChild).toHaveClass('text-muted-foreground');
+  });
+
+  it('H1 applies color override for direct foreground values', () => {
+    const { container } = render(<H1 color="foreground">Title</H1>);
+    expect(container.firstChild).toHaveClass('text-foreground');
+  });
+
+  it('H1 applies color override for already-suffixed values', () => {
+    const { container } = render(<H1 color="accent-foreground">Title</H1>);
+    expect(container.firstChild).toHaveClass('text-accent-foreground');
+  });
+
+  it('H1 applies line height override', () => {
+    const { container } = render(<H1 line="relaxed">Title</H1>);
+    expect(container.firstChild).toHaveClass('leading-relaxed');
+  });
+
+  it('H1 applies tracking override', () => {
+    const { container } = render(<H1 tracking="tight">Title</H1>);
+    expect(container.firstChild).toHaveClass('tracking-tight');
+  });
+
+  it('H1 applies family override', () => {
+    const { container } = render(<H1 family="code">Title</H1>);
+    expect(container.firstChild).toHaveClass('font-code');
+  });
+
+  it('P applies multiple token overrides', () => {
+    const { container } = render(
+      <P size="xl" color="muted" line="loose">
+        Lead text
+      </P>,
+    );
+    const p = container.firstChild;
+    expect(p).toHaveClass('text-xl');
+    expect(p).toHaveClass('text-muted-foreground');
+    expect(p).toHaveClass('leading-loose');
+  });
+
+  it('Blockquote applies token overrides', () => {
+    const { container } = render(<Blockquote size="lg">Quote</Blockquote>);
+    expect(container.firstChild).toHaveClass('text-lg');
+  });
+
+  it('Code applies token overrides', () => {
+    const { container } = render(<Code size="xs">snippet</Code>);
+    expect(container.firstChild).toHaveClass('text-xs');
+  });
+
+  it('Small applies token overrides', () => {
+    const { container } = render(<Small weight="bold">Fine print</Small>);
+    expect(container.firstChild).toHaveClass('font-bold');
+  });
+
+  it('Mark applies token overrides', () => {
+    const { container } = render(<Mark color="accent">highlighted</Mark>);
+    expect(container.firstChild).toHaveClass('text-accent-foreground');
+  });
+
+  it('token overrides appear after base classes and before className', () => {
+    const { container } = render(
+      <H1 size="xl" className="extra">
+        Title
+      </H1>,
+    );
+    const el = container.firstChild as HTMLElement;
+    expect(el).toHaveClass('text-4xl');
+    expect(el).toHaveClass('text-xl');
+    expect(el).toHaveClass('extra');
+  });
+});
+
 describe('Typography composition', () => {
   it('renders a complete page structure', () => {
     render(
       <article>
         <H1 data-testid="h1">Page Title</H1>
-        <Lead data-testid="lead">Introduction paragraph.</Lead>
+        <P size="xl" color="muted" data-testid="lead">
+          Introduction paragraph.
+        </P>
         <H2 data-testid="h2">Section Title</H2>
         <P data-testid="p">Body paragraph with standard styling.</P>
         <H3 data-testid="h3">Subsection</H3>
@@ -502,7 +472,9 @@ describe('Typography composition', () => {
           Use the <Code data-testid="code">useState</Code> hook.
         </P>
         <Blockquote data-testid="quote">Design is how it works.</Blockquote>
-        <Muted data-testid="muted">Last updated: Jan 2025</Muted>
+        <P size="sm" color="muted" data-testid="muted">
+          Last updated: Jan 2025
+        </P>
       </article>,
     );
 
@@ -929,16 +901,6 @@ describe('Editable Paragraph (R-200b)', () => {
       render(<P data-testid="p">Content</P>);
       const paragraph = screen.getByTestId('p');
       expect(paragraph.tagName).toBe('P');
-    });
-
-    it('can render as a different element', () => {
-      render(
-        <P as="div" data-testid="p">
-          Content
-        </P>,
-      );
-      const element = screen.getByTestId('p');
-      expect(element.tagName).toBe('DIV');
     });
   });
 });
@@ -1602,16 +1564,6 @@ describe('Mark', () => {
     expect(mark.className).toContain('text-accent-foreground');
   });
 
-  it('renders as custom element via as prop', () => {
-    render(
-      <Mark as="span" data-testid="mark">
-        Highlighted
-      </Mark>,
-    );
-    const mark = screen.getByTestId('mark');
-    expect(mark.tagName).toBe('SPAN');
-  });
-
   it('merges custom className', () => {
     render(
       <Mark data-testid="mark" className="custom-mark">
@@ -1674,16 +1626,6 @@ describe('Abbr', () => {
     expect(abbr.className).toContain('cursor-help');
     expect(abbr.className).toContain('underline');
     expect(abbr.className).toContain('decoration-dotted');
-  });
-
-  it('renders as custom element via as prop', () => {
-    render(
-      <Abbr as="span" data-testid="abbr" title="Test">
-        TLA
-      </Abbr>,
-    );
-    const abbr = screen.getByTestId('abbr');
-    expect(abbr.tagName).toBe('SPAN');
   });
 
   it('merges custom className', () => {


### PR DESCRIPTION
## Summary

- Individual HTML element components (H1-H6, P, Code, Blockquote, Small, Mark, Abbr) replace the unified Typography component
- Token-level props (size, weight, color, line, tracking, family) for surgical override of any dimension within the token system
- Removed Lead, Large, Muted as separate components -- now `<P size="xl">`, `<P size="sm" color="muted">`
- Removed `as` prop from all components -- each renders its own HTML element
- Added H5, H6 components
- Includes missing typography role migration: 27 .classes.ts files updated to semantic role utilities
- Updated all consumers (demo app, color-inspector, studio, CLI templates)

## Test plan

- [x] All 3607 UI tests pass (161 test files)
- [x] All 213 design-tokens tests pass
- [x] Typecheck clean across workspace
- [x] Biome lint clean
- [x] Demo app builds
- [x] Website builds
- [x] Preflight passes
- [x] MDX component override pattern verified (H1-H6, P accept standard children/ref)

Closes #1149

🤖 Generated with [Claude Code](https://claude.com/claude-code)