### PR TITLE
feat(ui): add primary background option to Container

### DIFF
--- a/packages/ui/src/components/ui/container.classes.ts
+++ b/packages/ui/src/components/ui/container.classes.ts
@@ -93,11 +93,12 @@ export const containerArticleTypography = [
   'max-w-prose',
 ].join(' ');
 
-export type ContainerBackground = 'none' | 'muted' | 'accent' | 'card';
+export type ContainerBackground = 'none' | 'muted' | 'accent' | 'card' | 'primary';
 
 export const containerBackgroundClasses: Record<ContainerBackground, string> = {
   none: '',
   muted: 'bg-muted',
   accent: 'bg-accent',
   card: 'bg-card',
+  primary: 'bg-primary text-primary-foreground',
 };


### PR DESCRIPTION
## Summary
- Adds `background="primary"` to Container (bg-primary text-primary-foreground)
- For dark title sections in cards
- Lost in squash merge of #1185

Generated with [Claude Code](https://claude.com/claude-code)