### PR TITLE
feat(ui): align/transform token props, fix color pass-through

### DIFF
--- a/packages/ui/src/components/ui/typography-abbr.astro
+++ b/packages/ui/src/components/ui/typography-abbr.astro
@@ -17,6 +17,8 @@ interface Props extends HTMLAttributes<'abbr'> {
   line?: string;
   tracking?: string;
   family?: string;
+  align?: string;
+  transform?: string;
 }
 
 const {
@@ -27,10 +29,21 @@ const {
   line,
   tracking,
   family,
+  align,
+  transform,
   class: className,
   ...attrs
 } = Astro.props;
-const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+const overrides = tokenPropsToClasses({
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+});
 const classes = classy(typographyClasses.abbr, overrides, className);
 ---
 

--- a/packages/ui/src/components/ui/typography-blockquote.astro
+++ b/packages/ui/src/components/ui/typography-blockquote.astro
@@ -16,10 +16,32 @@ interface Props extends HTMLAttributes<'blockquote'> {
   line?: string;
   tracking?: string;
   family?: string;
+  align?: string;
+  transform?: string;
 }
 
-const { size, weight, color, line, tracking, family, class: className, ...attrs } = Astro.props;
-const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+const {
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+  class: className,
+  ...attrs
+} = Astro.props;
+const overrides = tokenPropsToClasses({
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+});
 const classes = classy(typographyClasses.blockquote, overrides, className);
 ---
 

--- a/packages/ui/src/components/ui/typography-code.astro
+++ b/packages/ui/src/components/ui/typography-code.astro
@@ -16,10 +16,32 @@ interface Props extends HTMLAttributes<'code'> {
   line?: string;
   tracking?: string;
   family?: string;
+  align?: string;
+  transform?: string;
 }
 
-const { size, weight, color, line, tracking, family, class: className, ...attrs } = Astro.props;
-const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+const {
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+  class: className,
+  ...attrs
+} = Astro.props;
+const overrides = tokenPropsToClasses({
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+});
 const classes = classy(typographyClasses.code, overrides, className);
 ---
 

--- a/packages/ui/src/components/ui/typography-h1.astro
+++ b/packages/ui/src/components/ui/typography-h1.astro
@@ -19,10 +19,32 @@ interface Props extends HTMLAttributes<'h1'> {
   line?: string;
   tracking?: string;
   family?: string;
+  align?: string;
+  transform?: string;
 }
 
-const { size, weight, color, line, tracking, family, class: className, ...attrs } = Astro.props;
-const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+const {
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+  class: className,
+  ...attrs
+} = Astro.props;
+const overrides = tokenPropsToClasses({
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+});
 const classes = classy(typographyClasses.h1, overrides, className);
 ---
 

--- a/packages/ui/src/components/ui/typography-h2.astro
+++ b/packages/ui/src/components/ui/typography-h2.astro
@@ -16,10 +16,32 @@ interface Props extends HTMLAttributes<'h2'> {
   line?: string;
   tracking?: string;
   family?: string;
+  align?: string;
+  transform?: string;
 }
 
-const { size, weight, color, line, tracking, family, class: className, ...attrs } = Astro.props;
-const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+const {
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+  class: className,
+  ...attrs
+} = Astro.props;
+const overrides = tokenPropsToClasses({
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+});
 const classes = classy(typographyClasses.h2, overrides, className);
 ---
 

--- a/packages/ui/src/components/ui/typography-h3.astro
+++ b/packages/ui/src/components/ui/typography-h3.astro
@@ -15,10 +15,32 @@ interface Props extends HTMLAttributes<'h3'> {
   line?: string;
   tracking?: string;
   family?: string;
+  align?: string;
+  transform?: string;
 }
 
-const { size, weight, color, line, tracking, family, class: className, ...attrs } = Astro.props;
-const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+const {
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+  class: className,
+  ...attrs
+} = Astro.props;
+const overrides = tokenPropsToClasses({
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+});
 const classes = classy(typographyClasses.h3, overrides, className);
 ---
 

--- a/packages/ui/src/components/ui/typography-h4.astro
+++ b/packages/ui/src/components/ui/typography-h4.astro
@@ -15,10 +15,32 @@ interface Props extends HTMLAttributes<'h4'> {
   line?: string;
   tracking?: string;
   family?: string;
+  align?: string;
+  transform?: string;
 }
 
-const { size, weight, color, line, tracking, family, class: className, ...attrs } = Astro.props;
-const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+const {
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+  class: className,
+  ...attrs
+} = Astro.props;
+const overrides = tokenPropsToClasses({
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+});
 const classes = classy(typographyClasses.h4, overrides, className);
 ---
 

--- a/packages/ui/src/components/ui/typography-h5.astro
+++ b/packages/ui/src/components/ui/typography-h5.astro
@@ -16,10 +16,32 @@ interface Props extends HTMLAttributes<'h5'> {
   line?: string;
   tracking?: string;
   family?: string;
+  align?: string;
+  transform?: string;
 }
 
-const { size, weight, color, line, tracking, family, class: className, ...attrs } = Astro.props;
-const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+const {
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+  class: className,
+  ...attrs
+} = Astro.props;
+const overrides = tokenPropsToClasses({
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+});
 const classes = classy(typographyClasses.h4, overrides, className);
 ---
 

--- a/packages/ui/src/components/ui/typography-h6.astro
+++ b/packages/ui/src/components/ui/typography-h6.astro
@@ -16,10 +16,32 @@ interface Props extends HTMLAttributes<'h6'> {
   line?: string;
   tracking?: string;
   family?: string;
+  align?: string;
+  transform?: string;
 }
 
-const { size, weight, color, line, tracking, family, class: className, ...attrs } = Astro.props;
-const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+const {
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+  class: className,
+  ...attrs
+} = Astro.props;
+const overrides = tokenPropsToClasses({
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+});
 const classes = classy(typographyClasses.h4, overrides, className);
 ---
 

--- a/packages/ui/src/components/ui/typography-mark.astro
+++ b/packages/ui/src/components/ui/typography-mark.astro
@@ -16,10 +16,32 @@ interface Props extends HTMLAttributes<'mark'> {
   line?: string;
   tracking?: string;
   family?: string;
+  align?: string;
+  transform?: string;
 }
 
-const { size, weight, color, line, tracking, family, class: className, ...attrs } = Astro.props;
-const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+const {
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+  class: className,
+  ...attrs
+} = Astro.props;
+const overrides = tokenPropsToClasses({
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+});
 const classes = classy(typographyClasses.mark, overrides, className);
 ---
 

--- a/packages/ui/src/components/ui/typography-p.astro
+++ b/packages/ui/src/components/ui/typography-p.astro
@@ -20,10 +20,32 @@ interface Props extends HTMLAttributes<'p'> {
   line?: string;
   tracking?: string;
   family?: string;
+  align?: string;
+  transform?: string;
 }
 
-const { size, weight, color, line, tracking, family, class: className, ...attrs } = Astro.props;
-const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+const {
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+  class: className,
+  ...attrs
+} = Astro.props;
+const overrides = tokenPropsToClasses({
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+});
 const classes = classy(typographyClasses.p, overrides, className);
 ---
 

--- a/packages/ui/src/components/ui/typography-small.astro
+++ b/packages/ui/src/components/ui/typography-small.astro
@@ -16,10 +16,32 @@ interface Props extends HTMLAttributes<'small'> {
   line?: string;
   tracking?: string;
   family?: string;
+  align?: string;
+  transform?: string;
 }
 
-const { size, weight, color, line, tracking, family, class: className, ...attrs } = Astro.props;
-const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+const {
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+  class: className,
+  ...attrs
+} = Astro.props;
+const overrides = tokenPropsToClasses({
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+});
 const classes = classy(typographyClasses.small, overrides, className);
 ---
 

--- a/packages/ui/src/components/ui/typography.astro
+++ b/packages/ui/src/components/ui/typography.astro
@@ -57,6 +57,8 @@ interface Props extends HTMLAttributes<'div'> {
   line?: string;
   tracking?: string;
   family?: string;
+  align?: string;
+  transform?: string;
 }
 
 const {
@@ -68,6 +70,8 @@ const {
   line,
   tracking,
   family,
+  align,
+  transform,
   class: className,
   ...attrs
 } = Astro.props;
@@ -80,7 +84,16 @@ const resolvedVariant =
       ? 'h4'
       : (Element as TypographyVariant));
 const variantClass = typographyClasses[resolvedVariant] ?? typographyClasses.p;
-const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+const overrides = tokenPropsToClasses({
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+});
 const classes = classy(variantClass, overrides, className);
 ---
 

--- a/packages/ui/src/components/ui/typography.classes.ts
+++ b/packages/ui/src/components/ui/typography.classes.ts
@@ -35,35 +35,28 @@ export interface TypographyTokenProps {
   line?: string | undefined;
   tracking?: string | undefined;
   family?: string | undefined;
-}
-
-/**
- * Resolve a color prop to a text utility class.
- * Auto-suffixes with -foreground when the value is a semantic family name
- * (muted, accent, primary, etc.) since text colors use foreground variants.
- * Values already ending in "foreground" pass through unchanged.
- */
-function resolveColorClass(color: string): string {
-  if (color.endsWith('foreground')) return `text-${color}`;
-  return `text-${color}-foreground`;
+  align?: string | undefined;
+  transform?: string | undefined;
 }
 
 /**
  * Build Tailwind utility classes from token props.
  * Returns a string of override classes or empty string if no overrides.
  *
- * Color values auto-resolve to foreground variants:
- *   color="muted"             -> text-muted-foreground
- *   color="foreground"        -> text-foreground
+ * Color values pass through directly as text-{value}:
+ *   color="accent"            -> text-accent
  *   color="accent-foreground" -> text-accent-foreground
+ *   color="muted-foreground"  -> text-muted-foreground
  */
 export function tokenPropsToClasses(props: TypographyTokenProps): string {
   const classes: string[] = [];
   if (props.size) classes.push(`text-${props.size}`);
   if (props.weight) classes.push(`font-${props.weight}`);
-  if (props.color) classes.push(resolveColorClass(props.color));
+  if (props.color) classes.push(`text-${props.color}`);
   if (props.line) classes.push(`leading-${props.line}`);
   if (props.tracking) classes.push(`tracking-${props.tracking}`);
   if (props.family) classes.push(`font-${props.family}`);
+  if (props.align) classes.push(`text-${props.align}`);
+  if (props.transform) classes.push(props.transform);
   return classes.join(' ');
 }

--- a/packages/ui/test/components/typography.test.tsx
+++ b/packages/ui/test/components/typography.test.tsx
@@ -186,7 +186,7 @@ describe('H5', () => {
     const h5 = container.firstChild;
     expect(h5).toHaveClass('text-lg');
     expect(h5).toHaveClass('font-bold');
-    expect(h5).toHaveClass('text-muted-foreground');
+    expect(h5).toHaveClass('text-muted');
   });
 });
 
@@ -382,9 +382,9 @@ describe('TypographyTokenProps', () => {
     expect(container.firstChild).toHaveClass('font-light');
   });
 
-  it('H1 applies color override with -foreground suffix', () => {
+  it('H1 applies color override as direct text class', () => {
     const { container } = render(<H1 color="muted">Title</H1>);
-    expect(container.firstChild).toHaveClass('text-muted-foreground');
+    expect(container.firstChild).toHaveClass('text-muted');
   });
 
   it('H1 applies color override for direct foreground values', () => {
@@ -420,7 +420,7 @@ describe('TypographyTokenProps', () => {
     );
     const p = container.firstChild;
     expect(p).toHaveClass('text-xl');
-    expect(p).toHaveClass('text-muted-foreground');
+    expect(p).toHaveClass('text-muted');
     expect(p).toHaveClass('leading-loose');
   });
 


### PR DESCRIPTION
## Summary
- Add `align` prop (center/start/end) to all typography components
- Add `transform` prop (uppercase/lowercase/capitalize) to all typography components
- Fix color prop: remove -foreground auto-suffix. `color="accent"` now produces `text-accent`, not `text-accent-foreground`. Token props are transparent mappings.

## Test plan
- [ ] `<H1 align="center">` produces `text-center`
- [ ] `<H2 transform="uppercase">` produces `uppercase`
- [ ] `<P color="accent">` produces `text-accent` (not text-accent-foreground)
- [ ] `<P color="accent-foreground">` still produces `text-accent-foreground`

Generated with [Claude Code](https://claude.com/claude-code)