### PR TITLE
feat(tokens): add font-serif default to typography generator

### DIFF
--- a/packages/design-tokens/src/generators/typography.ts
+++ b/packages/design-tokens/src/generators/typography.ts
@@ -84,6 +84,23 @@ export function generateTypographyTokens(
     },
   });
 
+  tokens.push({
+    name: 'font-serif',
+    value: 'Georgia, "Times New Roman", Times, serif',
+    category: 'typography',
+    namespace: 'typography',
+    semanticMeaning: 'Serif font family for editorial and long-form content',
+    usageContext: ['editorial', 'long-form', 'articles', 'blockquotes'],
+    description:
+      'Serif font family. System serif stack by default. Override in global.css @theme with your imported serif font.',
+    generatedAt: timestamp,
+    containerQueryAware: false,
+    usagePatterns: {
+      do: ['Override in global.css @theme to match imported serif font'],
+      never: ['Use without importing an actual serif font for production'],
+    },
+  });
+
   // Font-family role tokens -- semantic assignments that designers can override
   tokens.push({
     name: 'font-heading',


### PR DESCRIPTION
## Summary
- Adds `font-serif` token with system serif stack (Georgia, Times New Roman, serif)
- Ensures `font-serif` utility class generates in Tailwind v4 out of the box
- Designer overrides in their site's global.css @theme with imported serif font

## Test plan
- [ ] `font-serif` utility class generates in Tailwind v4 output
- [ ] Default value is system serif stack
- [ ] Site can override with custom serif in global.css @theme

Generated with [Claude Code](https://claude.com/claude-code)