### PR TITLE
fix(mcp): rafters_token set on semantic family cascades to derivatives (#1211)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # rafters
 
+## 0.0.48
+
+### Patch Changes
+
+- fix(mcp): `rafters_token set` on a semantic family slot (primary, accent, destructive, etc.) now cascades to all derivatives (-foreground, -hover, -active, -border, -ring, -focus, -subtle) in one call. Previously the cascade only fired from `rafters_onboard map`, so `set` would write the single token and exit, leaving derivatives pointing at the previous family. The cascade machinery from #1152/#1205/#1206 was already correct downstream — only the trigger was missing. Closes #1211.
+- fix(mcp): `dependsOn[0]` on semantic family tokens is now correctly preserved as the bare family name (e.g. `"dim-honest-plum"`) on `set` instead of being overwritten with a family-position string (e.g. `"dim-honest-plum-900"`). Restores the convention enforced everywhere else after #1205's review fix.
+- The `set` response now includes a `familyCascade` array listing the names of derivatives cascaded (empty for non-family targets), so callers can verify the cascade fired.
+
 ## 0.0.47
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "description": "CLI for Rafters design system - scaffold tokens and add components",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -1534,14 +1534,52 @@ export class RaftersToolHandler {
 
           if (parsed) {
             existing.value = parsed;
-            const lightRefStr = `${parsed.family}-${parsed.position}`;
-            const darkRef = dark ?? existing.dependsOn?.[1] ?? lightRefStr;
-            existing.dependsOn = [lightRefStr, darkRef];
+            // dependsOn[0] must be the family name, not a family-position string.
+            // Plugins (state, contrast, invert) and cascadeSemanticFamily all read
+            // dependsOn[0] expecting just the family so they can resolve the
+            // ColorValue and its WCAG/state intelligence data.
+            const darkRef =
+              dark ?? existing.dependsOn?.[1] ?? `${parsed.family}-${parsed.position}`;
+            existing.dependsOn = [parsed.family, darkRef];
           } else {
             existing.value = value;
           }
 
           await registry.setToken(existing);
+
+          // Family-level cascade: re-target all derivatives when a semantic family
+          // slot (primary, accent, destructive, etc.) is repointed to a new family.
+          // Without this, set on `accent` would write only the single token while
+          // accent-foreground/hover/active/border/ring/focus/subtle stayed pointed
+          // at the previous family.
+          const familyCascade: string[] = [];
+          if (
+            parsed &&
+            existing.namespace === 'semantic' &&
+            RaftersToolHandler.SEMANTIC_FAMILY_SET.has(name)
+          ) {
+            const cascadeResults: Array<{
+              source: string;
+              target: string;
+              action: string;
+              ok: boolean;
+              enriched?: boolean;
+              error?: string;
+              persisted?: { value: unknown; dependsOn?: string[] };
+            }> = [];
+            const cascadeTokens = this.cascadeSemanticFamily(
+              registry,
+              name,
+              parsed.family,
+              cascadeResults,
+            );
+            if (cascadeTokens.length > 0) {
+              await registry.setTokens(cascadeTokens);
+              for (const token of cascadeTokens) {
+                familyCascade.push(token.name);
+              }
+            }
+          }
 
           const affected = this.getAffectedTokens(registry, name);
           const outputFiles = await this.regenerateOutputs(registry);
@@ -1561,6 +1599,7 @@ export class RaftersToolHandler {
                     namespace: existing.namespace,
                   },
                   cascaded: affected,
+                  familyCascade,
                   outputFiles,
                 }),
               },

--- a/packages/cli/test/mcp/set-cascade.test.ts
+++ b/packages/cli/test/mcp/set-cascade.test.ts
@@ -63,6 +63,7 @@ async function createCascadeFixture(name: string): Promise<string> {
  */
 async function enrichFamily(
   handler: RaftersToolHandler,
+  projectRoot: string,
   semanticTarget: string,
   oklchValue: string,
 ): Promise<string> {
@@ -81,9 +82,7 @@ async function enrichFamily(
   expect(result.isError).toBeFalsy();
 
   // Read back the semantic token to discover the perceptual family name
-  const adapter = new NodePersistenceAdapter(
-    (handler as unknown as { projectRoot: string }).projectRoot,
-  );
+  const adapter = new NodePersistenceAdapter(projectRoot);
   const tokens = await adapter.load();
   const semanticToken = tokens.find((t) => t.name === semanticTarget);
   const ref = semanticToken?.value as { family?: string } | undefined;
@@ -105,7 +104,7 @@ describe('rafters_token set semantic family cascade', () => {
     const handler = new RaftersToolHandler(fixturePath);
 
     // Step 1: enrich a new perceptual family under the accent slot
-    const familyName = await enrichFamily(handler, 'accent', 'oklch(0.65 0.2 40)');
+    const familyName = await enrichFamily(handler, fixturePath, 'accent', 'oklch(0.65 0.2 40)');
 
     // Step 2: re-target accent to a specific position of that family
     const result = await handler.handleToolCall('rafters_token', {
@@ -137,7 +136,7 @@ describe('rafters_token set semantic family cascade', () => {
     fixturePath = await createCascadeFixture('depson-shape');
     const handler = new RaftersToolHandler(fixturePath);
 
-    const familyName = await enrichFamily(handler, 'accent', 'oklch(0.65 0.2 40)');
+    const familyName = await enrichFamily(handler, fixturePath, 'accent', 'oklch(0.65 0.2 40)');
 
     await handler.handleToolCall('rafters_token', {
       action: 'set',
@@ -158,7 +157,7 @@ describe('rafters_token set semantic family cascade', () => {
     fixturePath = await createCascadeFixture('derivative-no-cascade');
     const handler = new RaftersToolHandler(fixturePath);
 
-    const familyName = await enrichFamily(handler, 'accent', 'oklch(0.65 0.2 40)');
+    const familyName = await enrichFamily(handler, fixturePath, 'accent', 'oklch(0.65 0.2 40)');
 
     const result = await handler.handleToolCall('rafters_token', {
       action: 'set',
@@ -177,7 +176,7 @@ describe('rafters_token set semantic family cascade', () => {
     fixturePath = await createCascadeFixture('preserve-overrides');
     const handler = new RaftersToolHandler(fixturePath);
 
-    const familyName = await enrichFamily(handler, 'accent', 'oklch(0.65 0.2 40)');
+    const familyName = await enrichFamily(handler, fixturePath, 'accent', 'oklch(0.65 0.2 40)');
 
     // First, manually pin accent-hover with a non-auto-cascade reason
     await handler.handleToolCall('rafters_token', {

--- a/packages/cli/test/mcp/set-cascade.test.ts
+++ b/packages/cli/test/mcp/set-cascade.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Integration tests for `rafters_token set` semantic family cascade.
+ *
+ * Verifies the fix from #1211: setting a semantic family slot (primary, accent,
+ * destructive, etc.) cascades to all derivatives (-foreground, -hover, -active,
+ * -border, -ring, -focus, -subtle) instead of writing only the single token.
+ *
+ * Setup pattern:
+ * 1. Build a fixture project with seeded default tokens.
+ * 2. Run rafters_onboard map to enrich a perceptual color family + create palette
+ *    positions. This is the prep step before the user can set a semantic at it.
+ * 3. Run rafters_token set on the semantic family slot.
+ * 4. Verify the cascade list and that derivatives moved to the new family.
+ */
+
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { NodePersistenceAdapter } from '@rafters/design-tokens';
+import { afterEach, describe, expect, it } from 'vitest';
+import { RaftersToolHandler } from '../../src/mcp/tools.js';
+
+async function createCascadeFixture(name: string): Promise<string> {
+  const dir = join(tmpdir(), `rafters-set-cascade-${name}-${Date.now()}`);
+  await mkdir(join(dir, '.rafters', 'tokens'), { recursive: true });
+  await mkdir(join(dir, '.rafters', 'output'), { recursive: true });
+  await mkdir(join(dir, 'src'), { recursive: true });
+  await writeFile(join(dir, 'src', 'index.css'), '@import "tailwindcss";\n');
+  await writeFile(
+    join(dir, 'package.json'),
+    JSON.stringify({
+      name,
+      version: '0.1.0',
+      devDependencies: { tailwindcss: '^4.1.0', vite: '^6.0.0' },
+    }),
+  );
+  await writeFile(
+    join(dir, '.rafters', 'config.rafters.json'),
+    JSON.stringify({
+      framework: 'vite',
+      componentsPath: 'src/components/ui',
+      primitivesPath: 'src/lib/primitives',
+      compositesPath: 'src/composites',
+      cssPath: 'src/index.css',
+      shadcn: false,
+      exports: { tailwind: true, typescript: false, dtcg: false, compiled: false },
+      installed: { components: [], primitives: [], composites: [] },
+    }),
+  );
+
+  // Seed the registry with default tokens
+  const { buildColorSystem } = await import('@rafters/design-tokens');
+  const { registry } = buildColorSystem({});
+  const adapter = new NodePersistenceAdapter(dir);
+  await adapter.save(registry.list());
+
+  return dir;
+}
+
+/**
+ * Enrich a perceptual color family via rafters_onboard map.
+ * Returns the perceptual family name (the registry key for the ColorValue).
+ */
+async function enrichFamily(
+  handler: RaftersToolHandler,
+  semanticTarget: string,
+  oklchValue: string,
+): Promise<string> {
+  const result = await handler.handleToolCall('rafters_onboard', {
+    action: 'map',
+    confirmed: true,
+    mappings: [
+      {
+        source: '--test-source',
+        target: semanticTarget,
+        value: oklchValue,
+        reason: `test fixture: enrich ${semanticTarget} for cascade test`,
+      },
+    ],
+  });
+  expect(result.isError).toBeFalsy();
+
+  // Read back the semantic token to discover the perceptual family name
+  const adapter = new NodePersistenceAdapter(
+    (handler as unknown as { projectRoot: string }).projectRoot,
+  );
+  const tokens = await adapter.load();
+  const semanticToken = tokens.find((t) => t.name === semanticTarget);
+  const ref = semanticToken?.value as { family?: string } | undefined;
+  if (!ref?.family) {
+    throw new Error(`Failed to enrich ${semanticTarget}: no perceptual family on value`);
+  }
+  return ref.family;
+}
+
+describe('rafters_token set semantic family cascade', () => {
+  let fixturePath: string;
+
+  afterEach(async () => {
+    if (fixturePath) await rm(fixturePath, { recursive: true, force: true });
+  });
+
+  it('cascades all accent derivatives when accent is re-targeted to a new family', async () => {
+    fixturePath = await createCascadeFixture('accent-cascade');
+    const handler = new RaftersToolHandler(fixturePath);
+
+    // Step 1: enrich a new perceptual family under the accent slot
+    const familyName = await enrichFamily(handler, 'accent', 'oklch(0.65 0.2 40)');
+
+    // Step 2: re-target accent to a specific position of that family
+    const result = await handler.handleToolCall('rafters_token', {
+      action: 'set',
+      name: 'accent',
+      value: `${familyName}-900`,
+      reason: 'cascade test: point accent at new family',
+    });
+
+    expect(result.isError).toBeFalsy();
+    const data = JSON.parse((result.content[0] as { text: string }).text);
+    expect(data.ok).toBe(true);
+    expect(Array.isArray(data.familyCascade)).toBe(true);
+    expect(data.familyCascade.length).toBeGreaterThan(0);
+    expect(data.familyCascade).toEqual(
+      expect.arrayContaining(['accent-foreground', 'accent-hover', 'accent-active']),
+    );
+
+    // Step 3: verify a derivative actually moved on disk
+    const adapter = new NodePersistenceAdapter(fixturePath);
+    const tokens = await adapter.load();
+    const accentHover = tokens.find((t) => t.name === 'accent-hover');
+    expect(accentHover).toBeDefined();
+    const hoverValue = accentHover?.value as { family?: string } | undefined;
+    expect(hoverValue?.family).toBe(familyName);
+  });
+
+  it('preserves dependsOn[0] as family name not family-position', async () => {
+    fixturePath = await createCascadeFixture('depson-shape');
+    const handler = new RaftersToolHandler(fixturePath);
+
+    const familyName = await enrichFamily(handler, 'accent', 'oklch(0.65 0.2 40)');
+
+    await handler.handleToolCall('rafters_token', {
+      action: 'set',
+      name: 'accent',
+      value: `${familyName}-900`,
+      reason: 'cascade test: dependsOn shape check',
+    });
+
+    const adapter = new NodePersistenceAdapter(fixturePath);
+    const tokens = await adapter.load();
+    const accent = tokens.find((t) => t.name === 'accent');
+    expect(accent?.dependsOn?.[0]).toBe(familyName);
+    // Must NOT be a family-position string like "rust-orange-900"
+    expect(accent?.dependsOn?.[0]).not.toMatch(/-\d+$/);
+  });
+
+  it('does not cascade when target is a derivative not a family slot', async () => {
+    fixturePath = await createCascadeFixture('derivative-no-cascade');
+    const handler = new RaftersToolHandler(fixturePath);
+
+    const familyName = await enrichFamily(handler, 'accent', 'oklch(0.65 0.2 40)');
+
+    const result = await handler.handleToolCall('rafters_token', {
+      action: 'set',
+      name: 'accent-hover',
+      value: `${familyName}-700`,
+      reason: 'cascade test: single derivative override should not cascade',
+    });
+
+    expect(result.isError).toBeFalsy();
+    const data = JSON.parse((result.content[0] as { text: string }).text);
+    expect(data.ok).toBe(true);
+    expect(data.familyCascade).toEqual([]);
+  });
+
+  it('preserves human overrides on derivatives during family cascade', async () => {
+    fixturePath = await createCascadeFixture('preserve-overrides');
+    const handler = new RaftersToolHandler(fixturePath);
+
+    const familyName = await enrichFamily(handler, 'accent', 'oklch(0.65 0.2 40)');
+
+    // First, manually pin accent-hover with a non-auto-cascade reason
+    await handler.handleToolCall('rafters_token', {
+      action: 'set',
+      name: 'accent-hover',
+      value: 'neutral-700',
+      reason: 'designer-pinned hover state for accessibility audit',
+    });
+
+    // Then re-target the family
+    await handler.handleToolCall('rafters_token', {
+      action: 'set',
+      name: 'accent',
+      value: `${familyName}-900`,
+      reason: 'family swap',
+    });
+
+    // accent-hover should still be neutral-700
+    const adapter = new NodePersistenceAdapter(fixturePath);
+    const tokens = await adapter.load();
+    const accentHover = tokens.find((t) => t.name === 'accent-hover');
+    const hoverValue = accentHover?.value as { family?: string; position?: string } | undefined;
+    expect(hoverValue?.family).toBe('neutral');
+    expect(hoverValue?.position).toBe('700');
+  });
+});


### PR DESCRIPTION
## Summary

- Wires \`writeToken\` set case to call \`cascadeSemanticFamily\` when the target is a semantic family slot (primary, accent, destructive, etc.) so derivatives (-foreground, -hover, -active, -border, -ring, -focus, -subtle) re-target in one tool call.
- Fixes the \`dependsOn[0]\` shape bug: writeToken was setting it to a family-position string (e.g. \`\"dim-honest-plum-900\"\`) instead of the bare family name (e.g. \`\"dim-honest-plum\"\`), violating the convention enforced everywhere else after #1205's review fix.
- Surfaces a \`familyCascade\` array on the set response listing derivative names so callers can verify the cascade fired.
- Bumps to 0.0.48 with changelog in the same commit.

Closes #1211.

## Why

Reported live by shingle on 2026-04-11: \`rafters_token set accent <family-position>\` returned \`ok: true\` and persisted the value, but \`accent-foreground\`, \`accent-hover\`, \`accent-active\`, etc. all stayed pointed at the previous family.

\`cascadeSemanticFamily\` (\`packages/cli/src/mcp/tools.ts:1864\`) has been called from exactly one site since it was introduced in #1152: inside \`mapTokens\` (the \`rafters_onboard map\` handler). Verified across all branches with \`git log -G cascadeSemanticFamily\`. The function has been refined six times (#1152 cluster + #1206) but has never been wired into \`writeToken\`.

The downstream rule machinery from #1205 + #1206 was already correct -- state plugin reads \`colorValue.stateReferences\` and the base token's actual position, contrast plugin reads the WCAG AAA pair matrix, invert plugin uses \`findDarkCounterpartIndex\`, \`regenerateToken\` updates dark counterparts via the matrix. Every layer downstream of the trigger does the right thing. Only the trigger from \`set\` was missing.

## What changed

### \`packages/cli/src/mcp/tools.ts\` (cccfc7c)

In \`writeToken\` \`case 'set'\`:

1. **dependsOn shape fix** -- \`existing.dependsOn = [parsed.family, darkRef]\` instead of \`[lightRefStr, darkRef]\`. dependsOn[0] is now the bare family name, matching what plugins and \`cascadeSemanticFamily\` expect. Without this fix, even a future cascade on the same token would have been broken.

2. **Cascade hookup** -- after \`await registry.setToken(existing)\`, check \`parsed && existing.namespace === 'semantic' && SEMANTIC_FAMILY_SET.has(name)\`. If true, call \`cascadeSemanticFamily(registry, name, parsed.family, cascadeResults)\` and persist via \`registry.setTokens(cascadeTokens)\`. Membership check ensures setting \`accent-hover\` does NOT trigger family cascade -- single derivative override only.

3. **Response field** -- new \`familyCascade: string[]\` on the set response with the names of cascaded tokens (empty array for non-family targets).

### \`packages/cli/test/mcp/set-cascade.test.ts\` (cccfc7c, refactored in d42c21b)

Four integration tests, all passing:
- cascades all accent derivatives when accent is re-targeted to a new family
- preserves dependsOn[0] as family name not family-position
- does not cascade when target is a derivative not a family slot
- preserves human overrides on derivatives during family cascade

Each test seeds a real temp project, runs \`rafters_onboard map\` to enrich a perceptual family (the prep step shingle does), then exercises \`rafters_token set\` and verifies disk state through a fresh \`NodePersistenceAdapter\`.

### \`packages/cli/CHANGELOG.md\` + \`packages/cli/package.json\` (cccfc7c)

\`0.0.48\` patch with three entries (cascade hookup, dependsOn shape fix, familyCascade response field). Same commit as the code per project rule.

## Test plan

- [x] All four cascade tests pass (\`pnpm --filter rafters exec vitest run test/mcp/set-cascade.test.ts\`)
- [x] Existing 290 cli unit tests still pass
- [x] Existing 255 design-tokens tests still pass
- [x] \`pnpm preflight\` clean end-to-end (typecheck + lint + unit + a11y + build)
- [x] \`legion-simplify\` quality gate clean for HEAD (one MED finding fixed in d42c21b: removed unsafe \`as unknown as\` cast in enrichFamily helper, takes projectRoot parameter now)
- [ ] Manual verification: enrich a perceptual family on apps/demo or shingle, then \`rafters_token set accent <family>-900\` and confirm response \`familyCascade\` lists derivatives, and generated CSS reflects the new family on every accent-* utility class

## Out of scope

- New cascade for non-color tokens (spacing, typography). Different trigger model, separate issue.
- Restructuring \`cascadeSemanticFamily\` itself. Function is correct as-is.
- Routing \`writeToken\` set through \`mapTokens\` -- mapTokens runs OKLCH enrichment + palette position creation, wrong for the \"point at existing family\" case.
- Moving cascade logic into \`registry.setToken\`. Registry is intentionally generic; semantic-family awareness lives in the MCP tools layer.

## References

- Issue: #1211 (filed earlier in this session)
- Cascade function: \`packages/cli/src/mcp/tools.ts:1864\`
- Original cascade introduction: #1152 (\`aa4da1d\`)
- Most recent cascade refinement: #1206 (\`e64e582\`)
- Semantic dependency graph wire-up: #1205 (\`1a02ff8\`)