### PR TITLE
fix(registry): JSDoc parser drops 5 of 6 intelligence fields on every component (#1213)

### DIFF
--- a/apps/registry/src/lib/registry/componentService.ts
+++ b/apps/registry/src/lib/registry/componentService.ts
@@ -218,11 +218,36 @@ function versionDeps(deps: string[]): string[] {
 }
 
 /**
- * Parse JSDoc comments from source to extract intelligence metadata
+ * Parse JSDoc comments from source to extract intelligence metadata.
+ *
+ * Accepts both hyphenated (`@cognitive-load`) and camelCase (`@cognitiveLoad`)
+ * tag forms. The hyphen-stripping happens before switch matching, so
+ * `@cognitive-load` and `@cognitiveLoad` both route to the same case.
+ *
+ * Also parses the `@usage-patterns` block format, which holds `DO:` and `NEVER:`
+ * lines in the description, in addition to the legacy `@do` / `@never` separate-tag
+ * form.
+ *
+ * @param source - The source code containing JSDoc comments
+ * @param options - `strict: true` throws when no intelligence fields are found,
+ *                  with the component name in the error message. Default false
+ *                  preserves the silent-undefined behavior used by dev workflows.
  */
-export function parseJSDocFromSource(source: string): ComponentIntelligence | undefined {
+export function parseJSDocFromSource(
+  source: string,
+  options?: { strict?: boolean; componentName?: string },
+): ComponentIntelligence | undefined {
   const blocks = parse(source);
-  if (blocks.length === 0) return undefined;
+  if (blocks.length === 0) {
+    if (options?.strict) {
+      throw new Error(
+        `[parseJSDocFromSource] No JSDoc blocks found in ${options.componentName ?? 'component'}. ` +
+          `Expected at least one of: @cognitive-load, @attention-economics, @accessibility, ` +
+          `@trust-building, @semantic-meaning, @usage-patterns.`,
+      );
+    }
+    return undefined;
+  }
 
   const intelligence: ComponentIntelligence = {};
   let hasAnyField = false;
@@ -230,7 +255,9 @@ export function parseJSDocFromSource(source: string): ComponentIntelligence | un
   // Process all JSDoc blocks
   for (const block of blocks) {
     for (const tag of block.tags) {
-      const tagName = tag.tag.toLowerCase();
+      // Strip hyphens and lowercase so `cognitive-load` and `cognitiveLoad`
+      // both normalize to `cognitiveload`. Source files use the hyphenated form.
+      const tagName = tag.tag.toLowerCase().replace(/-/g, '');
       const value = getTagValue(tag);
 
       switch (tagName) {
@@ -273,8 +300,48 @@ export function parseJSDocFromSource(source: string): ComponentIntelligence | un
           intelligence.usagePatterns.nevers.push(value);
           hasAnyField = true;
           break;
+        case 'usagepatterns': {
+          // Source format: `@usage-patterns` block with `DO:` and `NEVER:` lines
+          // in the description body. Parse each line and route to dos/nevers.
+          if (!intelligence.usagePatterns) {
+            intelligence.usagePatterns = { dos: [], nevers: [] };
+          }
+          // Pull every text line out of the tag's source -- comment-parser stores
+          // the raw lines on tag.source, with each line's `tokens.description` holding
+          // the text after the leading `*`. The description string also has the same
+          // content but flattened, so we use either as available.
+          const linesFromSource = tag.source
+            .map((s) => (s.tokens.description ?? '').trim())
+            .filter((line) => line.length > 0);
+          const lines = linesFromSource.length > 0 ? linesFromSource : value.split('\n');
+          for (const rawLine of lines) {
+            const line = rawLine.trim();
+            if (line.startsWith('DO:')) {
+              const item = line.slice(3).trim();
+              if (item) {
+                intelligence.usagePatterns.dos.push(item);
+                hasAnyField = true;
+              }
+            } else if (line.startsWith('NEVER:')) {
+              const item = line.slice(6).trim();
+              if (item) {
+                intelligence.usagePatterns.nevers.push(item);
+                hasAnyField = true;
+              }
+            }
+          }
+          break;
+        }
       }
     }
+  }
+
+  if (options?.strict && !hasAnyField) {
+    throw new Error(
+      `[parseJSDocFromSource] No intelligence fields found in ${options.componentName ?? 'component'}. ` +
+        `Expected at least one of: @cognitive-load, @attention-economics, @accessibility, ` +
+        `@trust-building, @semantic-meaning, @usage-patterns.`,
+    );
   }
 
   return hasAnyField ? intelligence : undefined;
@@ -348,9 +415,17 @@ export function extractDepsFromSource(content: string): {
  * Analyze source content to extract merged dependencies and intelligence metadata.
  * Shared by loadComponent and loadPrimitive.
  */
+/**
+ * When set, parseJSDocFromSource throws if a component has no intelligence fields.
+ * The build script for production registry deploys should set this so missing
+ * intel fails the build instead of silently shipping empty JSON.
+ */
+const STRICT_INTEL = process.env.RAFTERS_STRICT_INTEL === '1';
+
 function analyzeSource(
   content: string,
   isPrimitive: boolean,
+  componentName?: string,
 ): {
   importDeps: ReturnType<typeof extractDependencies>;
   allExternalDeps: string[];
@@ -361,7 +436,13 @@ function analyzeSource(
   const importDeps = extractDependencies(content);
   const jsDocDeps = extractDepsFromSource(content);
   const primitiveDeps = extractPrimitiveDependencies(content, isPrimitive);
-  const intelligence = parseJSDocFromSource(content);
+  // Only enforce strict intel on the .tsx primary; primitives and shared files
+  // are exempt because they don't carry intelligence metadata.
+  const enforceStrict = STRICT_INTEL && !isPrimitive && componentName !== undefined;
+  const intelligence = parseJSDocFromSource(content, {
+    strict: enforceStrict,
+    componentName,
+  });
 
   // Merge import-extracted and JSDoc-declared deps, deduplicated
   const allExternalDeps = [
@@ -389,11 +470,14 @@ export function loadComponent(name: string): RegistryItem | null {
   let intelligence: ReturnType<typeof parseJSDocFromSource> | undefined;
 
   // Load framework-specific variants
+  // Strict intel is enforced only on the primary .tsx file. Other extensions
+  // (.astro, .vue, .svelte) are framework variants that may not carry their
+  // own JSDoc -- they inherit the .tsx intelligence in the merge below.
   for (const ext of COMPONENT_EXTENSIONS) {
     const filePath = join(componentsDir, `${name}${ext}`);
     try {
       const content = readFileSync(filePath, 'utf-8');
-      const analysis = analyzeSource(content, false);
+      const analysis = analyzeSource(content, false, ext === '.tsx' ? name : undefined);
 
       files.push({
         path: `components/ui/${name}${ext}`,

--- a/apps/website/src/lib/registry/componentService.ts
+++ b/apps/website/src/lib/registry/componentService.ts
@@ -205,11 +205,36 @@ function versionDeps(deps: string[]): string[] {
 }
 
 /**
- * Parse JSDoc comments from source to extract intelligence metadata
+ * Parse JSDoc comments from source to extract intelligence metadata.
+ *
+ * Accepts both hyphenated (`@cognitive-load`) and camelCase (`@cognitiveLoad`)
+ * tag forms. Hyphens are stripped before switch matching, so both forms route
+ * to the same case.
+ *
+ * Also parses the `@usage-patterns` block format, which holds `DO:` and `NEVER:`
+ * lines in the description, in addition to the legacy `@do` / `@never`
+ * separate-tag form.
+ *
+ * @param source - The source code containing JSDoc comments
+ * @param options - `strict: true` throws when no intelligence fields are found,
+ *                  with the component name in the error message. Default false
+ *                  preserves the silent-undefined behavior used by dev workflows.
  */
-export function parseJSDocFromSource(source: string): ComponentIntelligence | undefined {
+export function parseJSDocFromSource(
+  source: string,
+  options?: { strict?: boolean; componentName?: string },
+): ComponentIntelligence | undefined {
   const blocks = parse(source);
-  if (blocks.length === 0) return undefined;
+  if (blocks.length === 0) {
+    if (options?.strict) {
+      throw new Error(
+        `[parseJSDocFromSource] No JSDoc blocks found in ${options.componentName ?? 'component'}. ` +
+          `Expected at least one of: @cognitive-load, @attention-economics, @accessibility, ` +
+          `@trust-building, @semantic-meaning, @usage-patterns.`,
+      );
+    }
+    return undefined;
+  }
 
   const intelligence: ComponentIntelligence = {};
   let hasAnyField = false;
@@ -217,7 +242,9 @@ export function parseJSDocFromSource(source: string): ComponentIntelligence | un
   // Process all JSDoc blocks
   for (const block of blocks) {
     for (const tag of block.tags) {
-      const tagName = tag.tag.toLowerCase();
+      // Strip hyphens and lowercase so `cognitive-load` and `cognitiveLoad`
+      // both normalize to `cognitiveload`. Source files use the hyphenated form.
+      const tagName = tag.tag.toLowerCase().replace(/-/g, '');
       const value = getTagValue(tag);
 
       switch (tagName) {
@@ -260,8 +287,44 @@ export function parseJSDocFromSource(source: string): ComponentIntelligence | un
           intelligence.usagePatterns.nevers.push(value);
           hasAnyField = true;
           break;
+        case 'usagepatterns': {
+          // Source format: `@usage-patterns` block with `DO:` and `NEVER:` lines
+          // in the description body. Parse each line and route to dos/nevers.
+          if (!intelligence.usagePatterns) {
+            intelligence.usagePatterns = { dos: [], nevers: [] };
+          }
+          const linesFromSource = tag.source
+            .map((s) => (s.tokens.description ?? '').trim())
+            .filter((line) => line.length > 0);
+          const lines = linesFromSource.length > 0 ? linesFromSource : value.split('\n');
+          for (const rawLine of lines) {
+            const line = rawLine.trim();
+            if (line.startsWith('DO:')) {
+              const item = line.slice(3).trim();
+              if (item) {
+                intelligence.usagePatterns.dos.push(item);
+                hasAnyField = true;
+              }
+            } else if (line.startsWith('NEVER:')) {
+              const item = line.slice(6).trim();
+              if (item) {
+                intelligence.usagePatterns.nevers.push(item);
+                hasAnyField = true;
+              }
+            }
+          }
+          break;
+        }
       }
     }
+  }
+
+  if (options?.strict && !hasAnyField) {
+    throw new Error(
+      `[parseJSDocFromSource] No intelligence fields found in ${options.componentName ?? 'component'}. ` +
+        `Expected at least one of: @cognitive-load, @attention-economics, @accessibility, ` +
+        `@trust-building, @semantic-meaning, @usage-patterns.`,
+    );
   }
 
   return hasAnyField ? intelligence : undefined;

--- a/apps/website/test/lib/componentService.test.ts
+++ b/apps/website/test/lib/componentService.test.ts
@@ -399,6 +399,92 @@ describe('componentService', () => {
       expect(intel?.usagePatterns?.dos).toContain('Use sparingly for main actions');
       expect(intel?.usagePatterns?.nevers).toContain('Use multiple primary buttons in one view');
     });
+
+    // Issue #1213: hyphenated tag form is what every component in packages/ui actually uses
+    it('parses hyphenated tag form (@cognitive-load, @attention-economics, etc)', () => {
+      const source = `
+        /**
+         * @cognitive-load 3
+         * @attention-economics Size hierarchy: sm=tertiary, default=secondary
+         * @accessibility WCAG AAA compliant
+         * @trust-building Destructive actions require confirmation
+         * @semantic-meaning Variant mapping: default=main actions
+         */
+        export function Button() {}
+      `;
+      const intel = parseJSDocFromSource(source);
+      expect(intel).toBeDefined();
+      expect(intel?.cognitiveLoad).toBe(3);
+      expect(intel?.attentionEconomics).toContain('Size hierarchy');
+      expect(intel?.accessibility).toContain('WCAG AAA');
+      expect(intel?.trustBuilding).toContain('Destructive');
+      expect(intel?.semanticMeaning).toContain('Variant mapping');
+    });
+
+    it('parses @usage-patterns block with DO: and NEVER: lines', () => {
+      const source = `
+        /**
+         * @usage-patterns
+         * DO: Primary: Main user goal, maximum 1 per section
+         * DO: Secondary: Alternative paths, supporting actions
+         * NEVER: Mix more than 2-3 variants in one composition
+         * NEVER: Use destructive without confirmation
+         */
+        export function Button() {}
+      `;
+      const intel = parseJSDocFromSource(source);
+      expect(intel).toBeDefined();
+      expect(intel?.usagePatterns?.dos).toHaveLength(2);
+      expect(intel?.usagePatterns?.dos[0]).toContain('Primary: Main user goal');
+      expect(intel?.usagePatterns?.dos[1]).toContain('Secondary: Alternative paths');
+      expect(intel?.usagePatterns?.nevers).toHaveLength(2);
+      expect(intel?.usagePatterns?.nevers[0]).toContain('Mix more than 2-3 variants');
+      expect(intel?.usagePatterns?.nevers[1]).toContain('Use destructive without confirmation');
+    });
+
+    it('parses real button.tsx source -- all 6 intelligence fields populated', async () => {
+      const fs = await import('node:fs/promises');
+      const path = await import('node:path');
+      const { fileURLToPath } = await import('node:url');
+      const here = path.dirname(fileURLToPath(import.meta.url));
+      const buttonPath = path.resolve(here, '../../../../packages/ui/src/components/ui/button.tsx');
+      const source = await fs.readFile(buttonPath, 'utf-8');
+      const intel = parseJSDocFromSource(source);
+      expect(intel).toBeDefined();
+      expect(intel?.cognitiveLoad).toBeDefined();
+      expect(intel?.attentionEconomics).toBeDefined();
+      expect(intel?.accessibility).toBeDefined();
+      expect(intel?.trustBuilding).toBeDefined();
+      expect(intel?.semanticMeaning).toBeDefined();
+      expect(intel?.usagePatterns).toBeDefined();
+      expect(intel?.usagePatterns?.dos.length).toBeGreaterThan(0);
+      expect(intel?.usagePatterns?.nevers.length).toBeGreaterThan(0);
+    });
+
+    it('strict mode throws when no intelligence fields are found', () => {
+      const source = 'export function Empty() {}';
+      expect(() => parseJSDocFromSource(source, { strict: true, componentName: 'Empty' })).toThrow(
+        /No JSDoc blocks found in Empty/,
+      );
+    });
+
+    it('strict mode throws when JSDoc has no intelligence tags', () => {
+      const source = `
+        /**
+         * Just a description, no intelligence tags
+         * @param x The input
+         */
+        export function NoIntel(x: number) {}
+      `;
+      expect(() =>
+        parseJSDocFromSource(source, { strict: true, componentName: 'NoIntel' }),
+      ).toThrow(/No intelligence fields found in NoIntel/);
+    });
+
+    it('non-strict mode returns undefined silently when no intelligence tags', () => {
+      const source = 'export function Empty() {}';
+      expect(parseJSDocFromSource(source)).toBeUndefined();
+    });
   });
 
   describe('extractDepsFromSource', () => {


### PR DESCRIPTION
## Summary

- componentService.ts switch cases use \`cognitiveload\` / \`attentioneconomics\` / \`trustbuilding\` / \`semanticmeaning\` (no hyphens). Source files use \`@cognitive-load\`, \`@attention-economics\`, \`@trust-building\`, \`@semantic-meaning\`. \`comment-parser\` keeps hyphens in \`tag.tag\`, so \`'cognitive-load'.toLowerCase()\` matches no case. Only \`@accessibility\` survived (no hyphen).
- Audit: 59 components in \`packages/ui/src/components/ui/*.tsx\` use the hyphenated form. Zero use camelCase.
- Result: every component on rafters.studio/registry has shipped empty intelligence (only the accessibility blurb).
- The Design Intelligence Protocol -- the entire pitch -- was silently broken at parse time. **This is the actual reason \`rafters_component\` returns nothing useful and agents fall back to shadcn training.**

Closes #1213.

## The fix

In \`apps/registry/src/lib/registry/componentService.ts\` \`parseJSDocFromSource\`:

1. **Strip hyphens before switch matching**: \`tag.tag.toLowerCase().replace(/-/g, '')\`. Both forms now route to the same case.
2. **Parse \`@usage-patterns\` block format**: a new \`usagepatterns\` case that walks the block's \`DO:\` and \`NEVER:\` lines and pushes them into \`usagePatterns.dos\` / \`usagePatterns.nevers\`. The legacy \`@do\` / \`@never\` separate-tag form still works (backwards compat).
3. **Strict mode option**: \`parseJSDocFromSource(source, { strict: true, componentName })\` throws when no intelligence fields are found, naming the component.
4. **Build-time gate**: \`analyzeSource\` reads \`RAFTERS_STRICT_INTEL=1\` from env. When set, the registry SSG build fails on missing intel in any component .tsx (primitives and shared files exempt). Set this in production deploy scripts so future regressions fail loudly instead of silently shipping empty JSON.
5. **Mirror fix in apps/website**: same parser bug existed in the legacy \`apps/website/src/lib/registry/componentService.ts\`. Fixed in parallel because we do not yet know which app is currently deployed at rafters.studio. Both files needed it.

## Why both apps/registry and apps/website got the fix

Both have a \`componentService.ts\`. apps/registry is the newer standalone SSG (per the recent component audit and the intent to consolidate). apps/website is the legacy mirror still serving live consumers. Until the cutover happens, the live deploy could be either. Belt-and-suspenders: fix both so the redeploy benefits no matter which one rafters.studio runs. Consolidation of the duplication is a separate refactor outside this fix's scope.

## Verification

End-to-end test included: parses the real \`packages/ui/src/components/ui/button.tsx\` source file from the test, asserts all 6 intelligence fields are populated. Currently FAILS without the parser fix (only \`accessibility\` would survive); PASSES with the fix.

Test count: **64 pass** in \`apps/website\` (6 new):
- hyphenated tag form (\`@cognitive-load\`, \`@attention-economics\`, etc)
- \`@usage-patterns\` block with DO:/NEVER: lines
- real button.tsx end-to-end (the regression check)
- strict mode throws on no JSDoc blocks
- strict mode throws on JSDoc without intel tags
- non-strict mode returns undefined silently (existing behavior preserved)

Existing camelCase form (\`@cognitiveLoad\`, separate \`@do\`/\`@never\` tags) still passes -- the original test cases were unchanged.

## Test plan

- [x] All 64 unit tests pass (\`pnpm --filter rafters-website test:unit\`)
- [x] \`pnpm preflight\` clean end-to-end
- [x] legion-simplify quality gate clean: \`019d7e9f-69f2-7b83-8d21-bffb0f3cd63f\`
- [ ] After merge: redeploy rafters.studio, then \`curl https://rafters.studio/registry/components/button.json | jq '.intelligence | keys'\` returns all 6 keys instead of just \`accessibility\`
- [ ] Set \`RAFTERS_STRICT_INTEL=1\` in the production registry build script so the next regression fails the build instead of shipping empty JSON

## Out of scope

- CLI version bump: zero CLI code changes in this PR. The user impact lands when the registry redeploys, not when this merges. Can backfill into the next CLI release CHANGELOG as \"intelligence data now flows after registry parser fix #1213.\"
- Consolidating apps/registry and apps/website componentService duplication: separate refactor.
- Populating any missing intelligence fields on components: out of scope, this is a parser fix not a content fix.
- The MCP tools.ts cleanup discussion (3000 -> 100 lines): the parser fix is the precondition; the MCP cleanup follows in a series of PRs after this one ships.

## Context

- Live broken endpoint (current): \`https://rafters.studio/registry/components/button.json\` -- intelligence has only \`accessibility\`
- Parser file: \`apps/registry/src/lib/registry/componentService.ts:223-281\`
- Mirror: \`apps/website/src/lib/registry/componentService.ts:207-267\`
- Issue: #1213
- This is the highest-leverage change in the entire MCP/registry stack. Once the parser ships and the registry redeploys, agents calling \`rafters_component\` start getting full intelligence per component, and the design system finally has a chance to beat the shadcn training pull.