### PR TITLE
refactor(color-utils): pure OKLCH hue rotation harmonies (#1215)

### DIFF
--- a/apps/api/test/routes/color/color.test.ts
+++ b/apps/api/test/routes/color/color.test.ts
@@ -103,10 +103,11 @@ describe('Color Routes', () => {
 
         expect(json.color.harmonies).toBeDefined();
         expect(json.color.harmonies.complementary).toBeDefined();
-        expect(json.color.harmonies.triadic).toHaveLength(2);
-        expect(json.color.harmonies.analogous).toHaveLength(2);
-        expect(json.color.harmonies.tetradic).toHaveLength(3);
-        expect(json.color.harmonies.monochromatic).toHaveLength(5);
+        expect(json.color.harmonies.triadic).toHaveLength(3);
+        expect(json.color.harmonies.analogous).toHaveLength(6);
+        expect(json.color.harmonies.tetradic).toHaveLength(4);
+        expect(json.color.harmonies.splitComplementary).toHaveLength(3);
+        expect(json.color.harmonies.monochromatic).toHaveLength(6);
       });
 
       it('includes accessibility metadata', async () => {

--- a/packages/color-utils/README.md
+++ b/packages/color-utils/README.md
@@ -74,8 +74,7 @@ isLightColor(o); // true/false
 ```
 
 ### Harmony & Scales (`harmony.ts`)
-- `generateHarmony(base: OKLCH)` — Traditional harmonies (complementary, triadic, tetradic, etc.).
-- `generateRaftersHarmony(base: OKLCH)` — Semantic mapping to Rafters roles (primary, accent, surface, neutral).
+- `generateHarmony(base: OKLCH)` — Pure OKLCH hue rotations: complementary, triadic (3), analogous (6), tetradic (4), splitComplementary (3), monochromatic (6).
 - `generateSemanticColorSuggestions(base: OKLCH)` — Suggested semantic palettes (danger, success, warning, info).
 - `generateOKLCHScale(base: OKLCH)` — Create an accessible 50–950 OKLCH scale optimized for contrast.
 - `calculateAtmosphericWeight(color: OKLCH)` — Perceptual “distance”/role (background ↔ foreground).
@@ -87,7 +86,6 @@ Example:
 ```ts
 const harmony = generateHarmony(o);
 const scale = generateOKLCHScale(o);
-const rafters = generateRaftersHarmony(o);
 ```
 
 ### Manipulation (`manipulation.ts`)

--- a/packages/color-utils/src/builder.ts
+++ b/packages/color-utils/src/builder.ts
@@ -144,13 +144,14 @@ export function buildColorValue(oklch: OKLCH, options: BuildColorValueOptions = 
     ...(options.use && { use: options.use }),
     ...(options.states && { states: options.states }),
 
-    // Harmonies - map to schema format
+    // Harmonies - pure hue rotation arrays
     harmonies: {
       complementary: harmony.complementary,
-      triadic: [harmony.triadic1, harmony.triadic2],
-      analogous: [harmony.analogous1, harmony.analogous2],
-      tetradic: [harmony.tetradic1, harmony.tetradic2, harmony.tetradic3],
-      monochromatic: scale.slice(0, 5), // First 5 scale positions
+      triadic: harmony.triadic,
+      analogous: harmony.analogous,
+      tetradic: harmony.tetradic,
+      splitComplementary: harmony.splitComplementary,
+      monochromatic: harmony.monochromatic,
     },
 
     // Accessibility

--- a/packages/color-utils/src/harmony.ts
+++ b/packages/color-utils/src/harmony.ts
@@ -1,217 +1,88 @@
 /**
- * Advanced harmony generation for design systems
- * Inspired by Leonardo's color theory approach
+ * Harmony generation for design systems using pure OKLCH hue rotation.
+ *
+ * Rule: harmonies are PURE HUE ROTATIONS. L and C are never mutated.
+ * Only H changes. Every output goes through toNearestGamut() then roundOKLCH().
  */
 
-import type { OKLCH } from '@rafters/shared';
+import type { ColorHarmonies, OKLCH } from '@rafters/shared';
 import { calculateWCAGContrast } from './accessibility';
 import { roundOKLCH } from './conversion';
 import { toNearestGamut } from './gamut';
-import { generateSurfaceColor } from './manipulation';
+import { adjustHue } from './manipulation';
 
-/**
- * Generate optimal gray color for a given palette
- * Uses perceptual averaging of the palette's chromatic content
- */
-function generateOptimalGray(paletteColors: OKLCH[]): OKLCH {
-  // Calculate average chroma and hue, weighted by lightness
-  let totalChroma = 0;
-  let totalHueX = 0;
-  let totalHueY = 0;
-  let totalWeight = 0;
-
-  for (const color of paletteColors) {
-    // Weight by lightness to favor mid-tone colors
-    const weight = 1 - Math.abs(color.l - 0.5) * 2;
-
-    totalChroma += color.c * weight;
-    totalHueX += Math.cos((color.h * Math.PI) / 180) * color.c * weight;
-    totalHueY += Math.sin((color.h * Math.PI) / 180) * color.c * weight;
-    totalWeight += weight;
-  }
-
-  const avgChroma = totalWeight > 0 ? totalChroma / totalWeight : 0;
-  const avgHue = Math.atan2(totalHueY, totalHueX) * (180 / Math.PI);
-  const normalizedHue = ((avgHue % 360) + 360) % 360;
-
-  // Generate a low-chroma gray with subtle color bias
-  return roundOKLCH({
-    l: 0.5, // Neutral mid-gray lightness
-    c: Math.min(0.02, avgChroma * 0.1), // Very low chroma with palette influence
-    h: normalizedHue,
-    alpha: 1,
-  });
+/** Clamp an OKLCH to sRGB gamut and round. */
+function clampColor(color: OKLCH): OKLCH {
+  return roundOKLCH(toNearestGamut(color).color);
 }
 
 /**
- * Generate a Rafters harmony plus optimal gray
- * Based on advanced color theory and perceptual optimization
+ * Generate pure OKLCH harmony arrays from a base color.
+ *
+ * Counts (per the spec):
+ * - complementary: 1 color (+180)
+ * - triadic: 3 colors (base, +120, +240)
+ * - analogous: 6 colors (-45, -30, -15, +15, +30, +45)
+ * - tetradic: 4 colors (base, +90, +180, +270)
+ * - splitComplementary: 3 colors (base, +150, +210)
+ * - monochromatic: 6 colors (same hue, L steps at 0.15/0.30/0.45/0.60/0.75/0.90,
+ *     chroma reduced at extremes)
+ *
+ * L and C are preserved exactly from the base color in all hue-rotation harmonies.
  */
-export function generateHarmony(baseColor: OKLCH): {
-  base: OKLCH;
-  complementary: OKLCH;
-  analogous1: OKLCH; // +30° neighbor
-  analogous2: OKLCH; // -30° neighbor
-  triadic1: OKLCH; // +120°
-  triadic2: OKLCH; // +240°
-  tetradic1: OKLCH; // +90°
-  tetradic2: OKLCH; // +180° (same as complementary)
-  tetradic3: OKLCH; // +270°
-  splitComplementary1: OKLCH; // +150°
-  splitComplementary2: OKLCH; // +210°
-  neutral?: OKLCH; // Optional calculated gray
-} {
-  const base = baseColor;
+export function generateHarmony(baseColor: OKLCH): ColorHarmonies {
+  const base = clampColor(baseColor);
 
-  // Traditional color theory relationships
-  const complementary: OKLCH = {
-    ...baseColor,
-    h: (baseColor.h + 180) % 360,
-    l: baseColor.l > 0.5 ? 0.3 : 0.7, // Ensure contrast
-    c: Math.min(0.3, baseColor.c * 1.2), // Boost chroma slightly
-  };
+  // complementary: 1 color at +180
+  const complementary = clampColor(adjustHue(baseColor, 180));
 
-  const analogous1: OKLCH = {
-    ...baseColor,
-    h: (baseColor.h + 30) % 360,
-    l: Math.max(0.2, Math.min(0.8, baseColor.l + 0.05)),
-    c: baseColor.c * 0.9,
-  };
-
-  const analogous2: OKLCH = {
-    ...baseColor,
-    h: (baseColor.h - 30 + 360) % 360,
-    l: Math.max(0.2, Math.min(0.8, baseColor.l - 0.05)),
-    c: baseColor.c * 0.9,
-  };
-
-  const triadic1: OKLCH = {
-    ...baseColor,
-    h: (baseColor.h + 120) % 360,
-    l: Math.max(0.3, Math.min(0.7, baseColor.l - 0.1)),
-    c: baseColor.c * 0.85,
-  };
-
-  const triadic2: OKLCH = {
-    ...baseColor,
-    h: (baseColor.h + 240) % 360,
-    l: Math.max(0.3, Math.min(0.7, baseColor.l + 0.1)),
-    c: baseColor.c * 0.85,
-  };
-
-  const tetradic1: OKLCH = {
-    ...baseColor,
-    h: (baseColor.h + 90) % 360,
-    l: Math.max(0.2, Math.min(0.8, baseColor.l)),
-    c: baseColor.c * 0.8,
-  };
-
-  const tetradic2 = complementary; // +180° is the same as complementary
-
-  const tetradic3: OKLCH = {
-    ...baseColor,
-    h: (baseColor.h + 270) % 360,
-    l: Math.max(0.2, Math.min(0.8, baseColor.l)),
-    c: baseColor.c * 0.8,
-  };
-
-  const splitComplementary1: OKLCH = {
-    ...baseColor,
-    h: (baseColor.h + 150) % 360,
-    l: Math.max(0.2, Math.min(0.8, baseColor.l + 0.1)),
-    c: baseColor.c * 0.8,
-  };
-
-  const splitComplementary2: OKLCH = {
-    ...baseColor,
-    h: (baseColor.h + 210) % 360,
-    l: Math.max(0.2, Math.min(0.8, baseColor.l - 0.1)),
-    c: baseColor.c * 0.8,
-  };
-
-  // Generate optimal neutral gray from all harmonies
-  const allColors = [
+  // triadic: base, +120, +240
+  const triadic: OKLCH[] = [
     base,
-    complementary,
-    analogous1,
-    analogous2,
-    triadic1,
-    triadic2,
-    tetradic1,
-    tetradic3,
-    splitComplementary1,
-    splitComplementary2,
+    clampColor(adjustHue(baseColor, 120)),
+    clampColor(adjustHue(baseColor, 240)),
   ];
-  const neutral = generateOptimalGray(allColors);
+
+  // analogous: -45, -30, -15, +15, +30, +45
+  const analogous: OKLCH[] = [
+    clampColor(adjustHue(baseColor, -45)),
+    clampColor(adjustHue(baseColor, -30)),
+    clampColor(adjustHue(baseColor, -15)),
+    clampColor(adjustHue(baseColor, 15)),
+    clampColor(adjustHue(baseColor, 30)),
+    clampColor(adjustHue(baseColor, 45)),
+  ];
+
+  // tetradic: base, +90, +180, +270
+  const tetradic: OKLCH[] = [
+    base,
+    clampColor(adjustHue(baseColor, 90)),
+    clampColor(adjustHue(baseColor, 180)),
+    clampColor(adjustHue(baseColor, 270)),
+  ];
+
+  // splitComplementary: base, +150, +210
+  const splitComplementary: OKLCH[] = [
+    base,
+    clampColor(adjustHue(baseColor, 150)),
+    clampColor(adjustHue(baseColor, 210)),
+  ];
+
+  // monochromatic: 6 steps at fixed L values, same H, chroma reduced at extremes
+  const MONO_LIGHTNESS = [0.15, 0.3, 0.45, 0.6, 0.75, 0.9] as const;
+  const monochromatic: OKLCH[] = MONO_LIGHTNESS.map((l) => {
+    // Reduce chroma at extreme ends to avoid gamut clipping artifacts
+    const c = l <= 0.15 || l >= 0.9 ? baseColor.c * 0.5 : baseColor.c;
+    return clampColor({ ...baseColor, l, c });
+  });
 
   return {
-    base: roundOKLCH(base),
-    complementary: roundOKLCH(complementary),
-    analogous1: roundOKLCH(analogous1),
-    analogous2: roundOKLCH(analogous2),
-    triadic1: roundOKLCH(triadic1),
-    triadic2: roundOKLCH(triadic2),
-    tetradic1: roundOKLCH(tetradic1),
-    tetradic2: roundOKLCH(tetradic2),
-    tetradic3: roundOKLCH(tetradic3),
-    splitComplementary1: roundOKLCH(splitComplementary1),
-    splitComplementary2: roundOKLCH(splitComplementary2),
-    neutral: roundOKLCH(neutral),
-  };
-}
-
-/**
- * Generate Rafters semantic harmony by mapping traditional color theory to design system roles
- * Uses Leonardo theory to intelligently assign traditional harmonies to UI semantics
- */
-export function generateRaftersHarmony(baseColor: OKLCH): {
-  primary: OKLCH;
-  secondary: OKLCH;
-  tertiary: OKLCH;
-  accent: OKLCH;
-  highlight: OKLCH;
-  surface: OKLCH;
-  neutral: OKLCH;
-} {
-  // Get traditional color theory harmonies
-  const harmony = generateHarmony(baseColor);
-
-  // Map traditional harmonies to Rafters semantic roles using Leonardo theory
-  // Primary = the base color (user's choice)
-  const primary = harmony.base;
-
-  // Secondary = split-complementary for sophisticated contrast without clash
-  const secondary = harmony.splitComplementary1;
-
-  // Tertiary = triadic for visual interest while maintaining harmony
-  const tertiary = harmony.triadic1;
-
-  // Accent = complementary for maximum contrast and attention
-  const accent = harmony.complementary;
-
-  // Highlight = analogous for subtle emphasis and cohesion
-  const highlight = harmony.analogous1;
-
-  // Surface = desaturated version of base for backgrounds
-  const surface = generateSurfaceColor(harmony.base);
-
-  // Neutral = calculated optimal gray
-  const neutral = harmony.neutral; // Generated by generateHarmony
-  if (!neutral) {
-    throw new Error('Neutral color not generated in harmony');
-  }
-
-  // Gamut-clamp all roles to sRGB so downstream badges/scales stay valid.
-  const clamp = (c: OKLCH): OKLCH => toNearestGamut(roundOKLCH(c)).color;
-
-  return {
-    primary: clamp(primary),
-    secondary: clamp(secondary),
-    tertiary: clamp(tertiary),
-    accent: clamp(accent),
-    highlight: clamp(highlight),
-    surface: clamp(surface),
-    neutral: clamp(neutral),
+    complementary,
+    triadic,
+    analogous,
+    tetradic,
+    splitComplementary,
+    monochromatic,
   };
 }
 
@@ -225,7 +96,7 @@ export function generateSemanticColorSuggestions(baseColor: OKLCH): {
   warning: OKLCH[];
   info: OKLCH[];
 } {
-  // Danger colors - Red region (0-30° and 330-360°) - Keep them vibrant, not dark
+  // Danger colors - Red region (0-30 and 330-360) - Keep them vibrant, not dark
   const danger: OKLCH[] = [
     // Bright red
     roundOKLCH({
@@ -250,7 +121,7 @@ export function generateSemanticColorSuggestions(baseColor: OKLCH): {
     }),
   ];
 
-  // Success colors - Green region (120-150°) - Make them brighter and more optimistic
+  // Success colors - Green region (120-150) - Make them brighter and more optimistic
   const success: OKLCH[] = [
     // Fresh green
     roundOKLCH({
@@ -275,7 +146,7 @@ export function generateSemanticColorSuggestions(baseColor: OKLCH): {
     }),
   ];
 
-  // Warning colors - Orange/Yellow region (30-70°) - Keep these bright
+  // Warning colors - Orange/Yellow region (30-70) - Keep these bright
   const warning: OKLCH[] = [
     // Orange
     roundOKLCH({
@@ -300,7 +171,7 @@ export function generateSemanticColorSuggestions(baseColor: OKLCH): {
     }),
   ];
 
-  // Info colors - Blue region (200-240°) - Make them more vibrant, less muddy
+  // Info colors - Blue region (200-240) - Make them more vibrant, less muddy
   const info: OKLCH[] = [
     // Sky blue
     roundOKLCH({
@@ -326,7 +197,6 @@ export function generateSemanticColorSuggestions(baseColor: OKLCH): {
   ];
 
   // Gamut-clamp every suggestion to sRGB so badges report gold, not fail.
-  // The raw hue+chroma combos above often exceed sRGB at their lightness.
   const clamp = (c: OKLCH): OKLCH => toNearestGamut(c).color;
 
   return {
@@ -351,11 +221,9 @@ function generateColorCombinations(colorScale: Record<string, OKLCH>) {
     usage: 'primary' | 'secondary' | 'subtle';
   }[] = [];
 
-  // Define usage patterns based on lightness contrast
-  const lightBackgrounds = ['50', '100', '200']; // Light tints for backgrounds
-  const darkForegrounds = ['700', '800', '900']; // Dark tints for text
+  const lightBackgrounds = ['50', '100', '200'];
+  const darkForegrounds = ['700', '800', '900'];
 
-  // Primary combinations: Light backgrounds with dark foregrounds
   for (const bgTint of lightBackgrounds) {
     for (const fgTint of darkForegrounds) {
       if (colorScale[bgTint] && colorScale[fgTint]) {
@@ -376,7 +244,6 @@ function generateColorCombinations(colorScale: Record<string, OKLCH>) {
     }
   }
 
-  // Sort by contrast ratio (highest first) and return top combinations
   return combinations.sort((a, b) => b.contrastRatio - a.contrastRatio).slice(0, 6);
 }
 
@@ -391,7 +258,6 @@ function validateScaleGeneration(baseColor: OKLCH): {
 } {
   const l = baseColor.l;
 
-  // Too light - won't generate useful darker shades
   if (l > 0.85) {
     return {
       isValid: false,
@@ -400,7 +266,6 @@ function validateScaleGeneration(baseColor: OKLCH): {
     };
   }
 
-  // Too dark - won't generate useful lighter tints
   if (l < 0.15) {
     return {
       isValid: false,
@@ -427,7 +292,6 @@ function generateLightnessProgression(baseLightness: number): Record<string, num
 
   const lightness: Record<string, number> = {};
 
-  // Lighter colors (50-500): power curve for natural spacing
   for (let i = 0; i < baseIndex; i++) {
     const stepsFromBase = baseIndex - i;
     const totalLighterSteps = baseIndex;
@@ -439,10 +303,8 @@ function generateLightnessProgression(baseLightness: number): Record<string, num
     if (pos !== undefined) lightness[pos.toString()] = Math.min(MAX_LIGHT, calculatedL);
   }
 
-  // Base color at 600
   lightness['600'] = baseLightness;
 
-  // Darker colors (700-950): linear progression
   for (let i = baseIndex + 1; i < positions.length; i++) {
     const stepsFromBase = i - baseIndex;
     const totalDarkerSteps = positions.length - 1 - baseIndex;
@@ -517,15 +379,11 @@ export function generateSemanticColorSystem(baseColor: OKLCH) {
     info: { colors: suggestions.info, scale: {} },
   };
 
-  // For each semantic type, generate a scale from the first suggestion and analyze combinations
   for (const [semanticType, colors] of Object.entries(suggestions)) {
     if (colors.length > 0 && colors[0]) {
-      const baseSemanticColor = colors[0]; // Use first suggestion
+      const baseSemanticColor = colors[0];
 
-      // Generate OKLCH scale
       const colorScale = generateOKLCHScale(baseSemanticColor);
-
-      // Analyze combinations
       const combinations = generateColorCombinations(colorScale);
 
       semanticSystem[semanticType as keyof typeof semanticSystem].scale = colorScale;
@@ -545,27 +403,23 @@ export function calculateAtmosphericWeight(color: OKLCH): {
   temperature: 'warm' | 'neutral' | 'cool';
   atmosphericRole: 'background' | 'midground' | 'foreground';
 } {
-  // warm colors advance, cool colors recede
   const hue = color.h;
-  const warmHues = (hue >= 0 && hue <= 60) || (hue >= 300 && hue <= 360); // Red-Yellow range
-  const coolHues = hue >= 180 && hue <= 270; // Blue-Cyan range
+  const warmHues = (hue >= 0 && hue <= 60) || (hue >= 300 && hue <= 360);
+  const coolHues = hue >= 180 && hue <= 270;
 
-  // Higher lightness and lower chroma = more atmospheric (distant)
-  const lightnessWeight = color.l; // 0-1, higher = more distant
+  const lightnessWeight = color.l;
 
-  // Calculate distance weight (0 = far/background, 1 = near/foreground)
   let distanceWeight = 0;
 
   if (warmHues) {
-    distanceWeight += 0.3; // Warm colors advance
+    distanceWeight += 0.3;
   } else if (coolHues) {
-    distanceWeight -= 0.2; // Cool colors recede
+    distanceWeight -= 0.2;
   }
 
-  distanceWeight += (1 - lightnessWeight) * 0.4; // Darker = closer
-  distanceWeight += color.c * 1.5; // Higher chroma = closer
+  distanceWeight += (1 - lightnessWeight) * 0.4;
+  distanceWeight += color.c * 1.5;
 
-  // Clamp between 0-1
   distanceWeight = Math.max(0, Math.min(1, distanceWeight));
 
   const temperature = warmHues ? 'warm' : coolHues ? 'cool' : 'neutral';
@@ -590,7 +444,6 @@ function calculateSimultaneousContrast(
   contrastRatio: number;
   harmonicTension: number; // 0-1, aesthetic tension level
 } {
-  // Average the adjacent colors to understand the context
   let avgLightness = 0;
   let avgChroma = 0;
   let avgHueX = 0;
@@ -609,33 +462,22 @@ function calculateSimultaneousContrast(
   const avgHue = Math.atan2(avgHueY, avgHueX) * (180 / Math.PI);
   const normalizedAvgHue = ((avgHue % 360) + 360) % 360;
 
-  // colors shift away from their context
-  // If surrounded by light colors, make this darker and more chromatic
-  // If surrounded by dark colors, make this lighter
-
   let enhancedLightness = baseColor.l;
   let enhancedChroma = baseColor.c;
   let enhancedHue = baseColor.h;
 
-  // Lightness contrast enhancement
   if (avgLightness > 0.6) {
-    // Surrounded by light colors - make this darker
     enhancedLightness = Math.max(0.1, baseColor.l - 0.2);
   } else if (avgLightness < 0.4) {
-    // Surrounded by dark colors - make this lighter
     enhancedLightness = Math.min(0.9, baseColor.l + 0.2);
   }
 
-  // Chroma contrast enhancement
   if (avgChroma < 0.1) {
-    // Surrounded by gray colors - increase chroma
     enhancedChroma = Math.min(0.3, baseColor.c * 1.5);
   }
 
-  // Hue contrast - slight shift away from average context hue
   const hueDifference = Math.abs(baseColor.h - normalizedAvgHue);
   if (hueDifference < 30) {
-    // Too close to context - shift slightly
     enhancedHue = (baseColor.h + 15) % 360;
   }
 
@@ -646,7 +488,6 @@ function calculateSimultaneousContrast(
     alpha: baseColor.alpha,
   });
 
-  // Calculate harmonic tension (aesthetic interest)
   const harmonicTension = Math.min(
     1,
     (Math.abs(enhancedLightness - avgLightness) +
@@ -676,16 +517,9 @@ export function calculatePerceptualWeight(color: OKLCH): {
   density: 'light' | 'medium' | 'heavy';
   balancingRecommendation: string;
 } {
-  // Factors that increase perceptual weight:
-  // 1. Lower lightness (darker colors feel heavier)
-  // 2. Higher chroma (saturated colors demand attention)
-  // 3. Warm hues (red/orange feel heavier than blue/green)
-  // 4. Certain hues have inherent weight (red > orange > yellow > green > blue > purple)
-
   const hue = color.h;
-  let hueWeight = 0.5; // Default neutral weight
+  let hueWeight = 0.5;
 
-  // Hue weight based on Leonardo's observations
   if (hue >= 345 || hue <= 15)
     hueWeight = 0.9; // Red - heaviest
   else if (hue <= 45)
@@ -702,9 +536,8 @@ export function calculatePerceptualWeight(color: OKLCH): {
     hueWeight = 0.35; // Blue-Purple
   else hueWeight = 0.5; // Purple-Red
 
-  // Combine factors
-  const lightnessWeight = 1 - color.l; // Invert: darker = heavier
-  const chromaWeight = Math.min(1, color.c / 0.3); // Normalize chroma
+  const lightnessWeight = 1 - color.l;
+  const chromaWeight = Math.min(1, color.c / 0.3);
 
   const weight = lightnessWeight * 0.4 + chromaWeight * 0.35 + hueWeight * 0.25;
 
@@ -718,8 +551,6 @@ export function calculatePerceptualWeight(color: OKLCH): {
     density = 'heavy';
   }
 
-  // Mark for AI to generate contextual balancing recommendations
-  // AI will have access to the weight value and density to generate intelligent guidance
   const balancingRecommendation = 'Balanced weight';
 
   return {
@@ -754,7 +585,6 @@ export function generateSemanticColors(
     info: { colors: [], contextualRecommendations: [] },
   };
 
-  // Create context from base color and other semantics for simultaneous contrast
   const allSemanticColors = Object.values(semanticSuggestions).flat();
   const contextColors = [baseColor, ...allSemanticColors.slice(0, 3)];
 
@@ -763,7 +593,6 @@ export function generateSemanticColors(
       const atmosphericWeight = calculateAtmosphericWeight(color);
       const perceptualWeight = calculatePerceptualWeight(color);
 
-      // Apply simultaneous contrast enhancement
       const contrastAnalysis = calculateSimultaneousContrast(color, contextColors);
 
       return {
@@ -775,10 +604,8 @@ export function generateSemanticColors(
       };
     });
 
-    // Generate contextual recommendations based on Leonardo's principles
     const recommendations: string[] = [];
 
-    // Atmospheric perspective recommendations
     const backgroundColors = enhancedColors.filter(
       (c) => c.atmosphericWeight.atmosphericRole === 'background',
     );
@@ -793,7 +620,6 @@ export function generateSemanticColors(
       recommendations.push(`Use ${semanticType} foregrounds for prominent, advancing elements`);
     }
 
-    // Perceptual weight recommendations
     const heavyColors = enhancedColors.filter((c) => c.perceptualWeight.density === 'heavy');
     const lightColors = enhancedColors.filter((c) => c.perceptualWeight.density === 'light');
 
@@ -808,7 +634,6 @@ export function generateSemanticColors(
       );
     }
 
-    // Temperature-based recommendations
     const warmColors = enhancedColors.filter((c) => c.atmosphericWeight.temperature === 'warm');
     const coolColors = enhancedColors.filter((c) => c.atmosphericWeight.temperature === 'cool');
 

--- a/packages/color-utils/src/harmony.ts
+++ b/packages/color-utils/src/harmony.ts
@@ -96,23 +96,20 @@ export function generateSemanticColorSuggestions(baseColor: OKLCH): {
   warning: OKLCH[];
   info: OKLCH[];
 } {
-  // Danger colors - Red region (0-30 and 330-360) - Keep them vibrant, not dark
+  // danger: hue 0-30 and 330-360
   const danger: OKLCH[] = [
-    // Bright red
     roundOKLCH({
       l: Math.max(0.55, Math.min(0.7, baseColor.l + 0.1)),
       c: Math.min(0.25, baseColor.c * 1.2),
       h: 15,
       alpha: 1,
     }),
-    // Warmer red
     roundOKLCH({
       l: Math.max(0.6, Math.min(0.75, baseColor.l + 0.15)),
       c: Math.min(0.22, baseColor.c * 1.1),
       h: 25,
       alpha: 1,
     }),
-    // Cooler red
     roundOKLCH({
       l: Math.max(0.5, Math.min(0.65, baseColor.l + 0.05)),
       c: Math.min(0.23, baseColor.c * 1.15),
@@ -121,23 +118,20 @@ export function generateSemanticColorSuggestions(baseColor: OKLCH): {
     }),
   ];
 
-  // Success colors - Green region (120-150) - Make them brighter and more optimistic
+  // success: hue 120-150
   const success: OKLCH[] = [
-    // Fresh green
     roundOKLCH({
       l: Math.max(0.6, Math.min(0.75, baseColor.l + 0.15)),
       c: Math.min(0.2, baseColor.c * 0.9),
       h: 135,
       alpha: 1,
     }),
-    // Vibrant green
     roundOKLCH({
       l: Math.max(0.55, Math.min(0.7, baseColor.l + 0.1)),
       c: Math.min(0.22, baseColor.c * 1.0),
       h: 145,
       alpha: 1,
     }),
-    // Bright green
     roundOKLCH({
       l: Math.max(0.65, Math.min(0.8, baseColor.l + 0.2)),
       c: Math.min(0.24, baseColor.c * 1.1),
@@ -146,23 +140,20 @@ export function generateSemanticColorSuggestions(baseColor: OKLCH): {
     }),
   ];
 
-  // Warning colors - Orange/Yellow region (30-70) - Keep these bright
+  // warning: hue 30-70
   const warning: OKLCH[] = [
-    // Orange
     roundOKLCH({
       l: Math.max(0.7, Math.min(0.8, baseColor.l + 0.15)),
       c: Math.min(0.2, baseColor.c * 0.95),
       h: 45,
       alpha: 1,
     }),
-    // Amber
     roundOKLCH({
       l: Math.max(0.75, Math.min(0.85, baseColor.l + 0.2)),
       c: Math.min(0.18, baseColor.c * 0.9),
       h: 55,
       alpha: 1,
     }),
-    // Yellow-orange
     roundOKLCH({
       l: Math.max(0.72, Math.min(0.82, baseColor.l + 0.17)),
       c: Math.min(0.19, baseColor.c * 0.92),
@@ -171,23 +162,20 @@ export function generateSemanticColorSuggestions(baseColor: OKLCH): {
     }),
   ];
 
-  // Info colors - Blue region (200-240) - Make them more vibrant, less muddy
+  // info: hue 200-240
   const info: OKLCH[] = [
-    // Sky blue
     roundOKLCH({
       l: Math.max(0.6, Math.min(0.75, baseColor.l + 0.1)),
       c: Math.min(0.2, baseColor.c * 0.9),
       h: 220,
       alpha: 1,
     }),
-    // Ocean blue
     roundOKLCH({
       l: Math.max(0.55, Math.min(0.7, baseColor.l + 0.05)),
       c: Math.min(0.22, baseColor.c * 1.0),
       h: 230,
       alpha: 1,
     }),
-    // Electric blue
     roundOKLCH({
       l: Math.max(0.5, Math.min(0.65, baseColor.l)),
       c: Math.min(0.25, baseColor.c * 1.1),
@@ -196,14 +184,11 @@ export function generateSemanticColorSuggestions(baseColor: OKLCH): {
     }),
   ];
 
-  // Gamut-clamp every suggestion to sRGB so badges report gold, not fail.
-  const clamp = (c: OKLCH): OKLCH => toNearestGamut(c).color;
-
   return {
-    danger: danger.map(clamp),
-    success: success.map(clamp),
-    warning: warning.map(clamp),
-    info: info.map(clamp),
+    danger: danger.map(clampColor),
+    success: success.map(clampColor),
+    warning: warning.map(clampColor),
+    info: info.map(clampColor),
   };
 }
 

--- a/packages/color-utils/src/index.ts
+++ b/packages/color-utils/src/index.ts
@@ -40,7 +40,6 @@ export {
   calculatePerceptualWeight,
   generateHarmony,
   generateOKLCHScale,
-  generateRaftersHarmony,
   generateSemanticColorSuggestions,
   generateSemanticColorSystem,
   generateSemanticColors,

--- a/packages/color-utils/test/builder.test.ts
+++ b/packages/color-utils/test/builder.test.ts
@@ -94,6 +94,7 @@ describe('buildColorValue', () => {
       expect(result.harmonies).toHaveProperty('triadic');
       expect(result.harmonies).toHaveProperty('analogous');
       expect(result.harmonies).toHaveProperty('tetradic');
+      expect(result.harmonies).toHaveProperty('splitComplementary');
       expect(result.harmonies).toHaveProperty('monochromatic');
     });
 
@@ -106,29 +107,34 @@ describe('buildColorValue', () => {
       expect(complementaryHue).toBeLessThan(90);
     });
 
-    it('triadic has 2 colors', () => {
+    it('triadic has 3 colors', () => {
       const result = buildColorValue(blue);
 
-      expect(result.harmonies?.triadic).toHaveLength(2);
+      expect(result.harmonies?.triadic).toHaveLength(3);
     });
 
-    it('analogous has 2 colors', () => {
+    it('analogous has 6 colors', () => {
       const result = buildColorValue(blue);
 
-      expect(result.harmonies?.analogous).toHaveLength(2);
+      expect(result.harmonies?.analogous).toHaveLength(6);
     });
 
-    it('tetradic has 3 colors', () => {
+    it('tetradic has 4 colors', () => {
       const result = buildColorValue(blue);
 
-      expect(result.harmonies?.tetradic).toHaveLength(3);
+      expect(result.harmonies?.tetradic).toHaveLength(4);
     });
 
-    it('monochromatic is first 5 scale positions', () => {
+    it('splitComplementary has 3 colors', () => {
       const result = buildColorValue(blue);
 
-      expect(result.harmonies?.monochromatic).toHaveLength(5);
-      expect(result.harmonies?.monochromatic).toEqual(result.scale.slice(0, 5));
+      expect(result.harmonies?.splitComplementary).toHaveLength(3);
+    });
+
+    it('monochromatic has 6 colors', () => {
+      const result = buildColorValue(blue);
+
+      expect(result.harmonies?.monochromatic).toHaveLength(6);
     });
   });
 

--- a/packages/color-utils/test/harmony.test.ts
+++ b/packages/color-utils/test/harmony.test.ts
@@ -27,9 +27,6 @@ const red: OKLCH = { l: 0.5, c: 0.05, h: 0, alpha: 1 };
 /** Edge hue: 359 degrees */
 const nearRed: OKLCH = { l: 0.5, c: 0.05, h: 359, alpha: 1 };
 
-/** Tolerance for gamut-clamped values (low-chroma colors barely move) */
-const GAMUT_TOLERANCE = 0.01;
-
 describe('generateHarmony', () => {
   describe('return shape', () => {
     it('returns all required harmony keys', () => {
@@ -137,31 +134,33 @@ describe('generateHarmony', () => {
   });
 
   describe('hue rotation angles', () => {
+    const result = generateHarmony(blue);
+
     it('complementary is base +180', () => {
-      const { complementary } = generateHarmony(blue);
+      const { complementary } = result;
       const expected = (blue.h + 180) % 360;
       expect(complementary.h).toBeCloseTo(expected, 0);
     });
 
     it('triadic[0] is base hue', () => {
-      const { triadic } = generateHarmony(blue);
+      const { triadic } = result;
       expect(triadic[0]?.h).toBeCloseTo(blue.h, 0);
     });
 
     it('triadic[1] is base +120', () => {
-      const { triadic } = generateHarmony(blue);
+      const { triadic } = result;
       const expected = (blue.h + 120) % 360;
       expect(triadic[1]?.h).toBeCloseTo(expected, 0);
     });
 
     it('triadic[2] is base +240', () => {
-      const { triadic } = generateHarmony(blue);
+      const { triadic } = result;
       const expected = (blue.h + 240) % 360;
       expect(triadic[2]?.h).toBeCloseTo(expected, 0);
     });
 
     it('analogous hues are -45/-30/-15/+15/+30/+45', () => {
-      const { analogous } = generateHarmony(blue);
+      const { analogous } = result;
       const offsets = [-45, -30, -15, 15, 30, 45];
       for (let i = 0; i < offsets.length; i++) {
         const offset = offsets[i];
@@ -172,12 +171,12 @@ describe('generateHarmony', () => {
     });
 
     it('tetradic[0] is base hue', () => {
-      const { tetradic } = generateHarmony(blue);
+      const { tetradic } = result;
       expect(tetradic[0]?.h).toBeCloseTo(blue.h, 0);
     });
 
     it('tetradic hues are base/+90/+180/+270', () => {
-      const { tetradic } = generateHarmony(blue);
+      const { tetradic } = result;
       const offsets = [0, 90, 180, 270];
       for (let i = 0; i < offsets.length; i++) {
         const offset = offsets[i];
@@ -188,12 +187,12 @@ describe('generateHarmony', () => {
     });
 
     it('splitComplementary[0] is base hue', () => {
-      const { splitComplementary } = generateHarmony(blue);
+      const { splitComplementary } = result;
       expect(splitComplementary[0]?.h).toBeCloseTo(blue.h, 0);
     });
 
     it('splitComplementary hues are base/+150/+210', () => {
-      const { splitComplementary } = generateHarmony(blue);
+      const { splitComplementary } = result;
       const offsets = [0, 150, 210];
       for (let i = 0; i < offsets.length; i++) {
         const offset = offsets[i];
@@ -231,8 +230,8 @@ describe('generateHarmony', () => {
       const extremeStart = monochromatic[0]?.c ?? 0;
       const extremeEnd = monochromatic[5]?.c ?? 0;
       const midChroma = monochromatic[2]?.c ?? 0;
-      expect(extremeStart).toBeLessThanOrEqual(midChroma + GAMUT_TOLERANCE);
-      expect(extremeEnd).toBeLessThanOrEqual(midChroma + GAMUT_TOLERANCE);
+      expect(extremeStart).toBeLessThanOrEqual(midChroma + 0.01);
+      expect(extremeEnd).toBeLessThanOrEqual(midChroma + 0.01);
     });
   });
 

--- a/packages/color-utils/test/harmony.test.ts
+++ b/packages/color-utils/test/harmony.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Tests for generateHarmony() - pure OKLCH hue rotation
+ *
+ * Core invariants:
+ * - L and C are never mutated BEFORE gamut clamping in hue-rotation harmonies
+ * - Only H changes before the gamut clamp step
+ * - All outputs are gamut-clamped (sRGB)
+ * - Correct counts per harmony type
+ */
+
+import type { ColorHarmonies, OKLCH } from '@rafters/shared';
+import { describe, expect, it } from 'vitest';
+import { generateHarmony } from '../src/harmony.js';
+
+/** Low-chroma blue: stays well within sRGB gamut across all hue rotations */
+const blue: OKLCH = { l: 0.5, c: 0.05, h: 240, alpha: 1 };
+
+/** High-chroma orange: stress-tests gamut clamping */
+const orange: OKLCH = { l: 0.6, c: 0.25, h: 60, alpha: 1 };
+
+/** Near-achromatic gray */
+const gray: OKLCH = { l: 0.5, c: 0.005, h: 180, alpha: 1 };
+
+/** Edge hue: 0 degrees */
+const red: OKLCH = { l: 0.5, c: 0.05, h: 0, alpha: 1 };
+
+/** Edge hue: 359 degrees */
+const nearRed: OKLCH = { l: 0.5, c: 0.05, h: 359, alpha: 1 };
+
+/** Tolerance for gamut-clamped values (low-chroma colors barely move) */
+const GAMUT_TOLERANCE = 0.01;
+
+describe('generateHarmony', () => {
+  describe('return shape', () => {
+    it('returns all required harmony keys', () => {
+      const result = generateHarmony(blue);
+
+      expect(result).toHaveProperty('complementary');
+      expect(result).toHaveProperty('triadic');
+      expect(result).toHaveProperty('analogous');
+      expect(result).toHaveProperty('tetradic');
+      expect(result).toHaveProperty('splitComplementary');
+      expect(result).toHaveProperty('monochromatic');
+    });
+
+    it('complementary is a single OKLCH object', () => {
+      const { complementary } = generateHarmony(blue);
+
+      expect(complementary).toHaveProperty('l');
+      expect(complementary).toHaveProperty('c');
+      expect(complementary).toHaveProperty('h');
+    });
+  });
+
+  describe('array counts', () => {
+    it('triadic has 3 colors', () => {
+      expect(generateHarmony(blue).triadic).toHaveLength(3);
+    });
+
+    it('analogous has 6 colors', () => {
+      expect(generateHarmony(blue).analogous).toHaveLength(6);
+    });
+
+    it('tetradic has 4 colors', () => {
+      expect(generateHarmony(blue).tetradic).toHaveLength(4);
+    });
+
+    it('splitComplementary has 3 colors', () => {
+      expect(generateHarmony(blue).splitComplementary).toHaveLength(3);
+    });
+
+    it('monochromatic has 6 colors', () => {
+      expect(generateHarmony(blue).monochromatic).toHaveLength(6);
+    });
+  });
+
+  describe('pure hue rotation - L and C preserved for low-chroma input', () => {
+    // Low-chroma colors stay well within sRGB across all hue rotations.
+    // This verifies we do NOT artificially mutate L/C before gamut clamping.
+    const result = generateHarmony(blue);
+
+    it('complementary preserves L within gamut tolerance', () => {
+      expect(result.complementary.l).toBeCloseTo(blue.l, 1);
+    });
+
+    it('complementary preserves C within gamut tolerance', () => {
+      expect(result.complementary.c).toBeCloseTo(blue.c, 1);
+    });
+
+    it('triadic colors preserve L within gamut tolerance', () => {
+      for (const color of result.triadic) {
+        expect(color.l).toBeCloseTo(blue.l, 1);
+      }
+    });
+
+    it('triadic colors preserve C within gamut tolerance', () => {
+      for (const color of result.triadic) {
+        expect(color.c).toBeCloseTo(blue.c, 1);
+      }
+    });
+
+    it('analogous colors preserve L within gamut tolerance', () => {
+      for (const color of result.analogous) {
+        expect(color.l).toBeCloseTo(blue.l, 1);
+      }
+    });
+
+    it('analogous colors preserve C within gamut tolerance', () => {
+      for (const color of result.analogous) {
+        expect(color.c).toBeCloseTo(blue.c, 1);
+      }
+    });
+
+    it('tetradic colors preserve L within gamut tolerance', () => {
+      for (const color of result.tetradic) {
+        expect(color.l).toBeCloseTo(blue.l, 1);
+      }
+    });
+
+    it('tetradic colors preserve C within gamut tolerance', () => {
+      for (const color of result.tetradic) {
+        expect(color.c).toBeCloseTo(blue.c, 1);
+      }
+    });
+
+    it('splitComplementary colors preserve L within gamut tolerance', () => {
+      for (const color of result.splitComplementary) {
+        expect(color.l).toBeCloseTo(blue.l, 1);
+      }
+    });
+
+    it('splitComplementary colors preserve C within gamut tolerance', () => {
+      for (const color of result.splitComplementary) {
+        expect(color.c).toBeCloseTo(blue.c, 1);
+      }
+    });
+  });
+
+  describe('hue rotation angles', () => {
+    it('complementary is base +180', () => {
+      const { complementary } = generateHarmony(blue);
+      const expected = (blue.h + 180) % 360;
+      expect(complementary.h).toBeCloseTo(expected, 0);
+    });
+
+    it('triadic[0] is base hue', () => {
+      const { triadic } = generateHarmony(blue);
+      expect(triadic[0]?.h).toBeCloseTo(blue.h, 0);
+    });
+
+    it('triadic[1] is base +120', () => {
+      const { triadic } = generateHarmony(blue);
+      const expected = (blue.h + 120) % 360;
+      expect(triadic[1]?.h).toBeCloseTo(expected, 0);
+    });
+
+    it('triadic[2] is base +240', () => {
+      const { triadic } = generateHarmony(blue);
+      const expected = (blue.h + 240) % 360;
+      expect(triadic[2]?.h).toBeCloseTo(expected, 0);
+    });
+
+    it('analogous hues are -45/-30/-15/+15/+30/+45', () => {
+      const { analogous } = generateHarmony(blue);
+      const offsets = [-45, -30, -15, 15, 30, 45];
+      for (let i = 0; i < offsets.length; i++) {
+        const offset = offsets[i];
+        if (offset === undefined) continue;
+        const expected = (((blue.h + offset) % 360) + 360) % 360;
+        expect(analogous[i]?.h).toBeCloseTo(expected, 0);
+      }
+    });
+
+    it('tetradic[0] is base hue', () => {
+      const { tetradic } = generateHarmony(blue);
+      expect(tetradic[0]?.h).toBeCloseTo(blue.h, 0);
+    });
+
+    it('tetradic hues are base/+90/+180/+270', () => {
+      const { tetradic } = generateHarmony(blue);
+      const offsets = [0, 90, 180, 270];
+      for (let i = 0; i < offsets.length; i++) {
+        const offset = offsets[i];
+        if (offset === undefined) continue;
+        const expected = (blue.h + offset) % 360;
+        expect(tetradic[i]?.h).toBeCloseTo(expected, 0);
+      }
+    });
+
+    it('splitComplementary[0] is base hue', () => {
+      const { splitComplementary } = generateHarmony(blue);
+      expect(splitComplementary[0]?.h).toBeCloseTo(blue.h, 0);
+    });
+
+    it('splitComplementary hues are base/+150/+210', () => {
+      const { splitComplementary } = generateHarmony(blue);
+      const offsets = [0, 150, 210];
+      for (let i = 0; i < offsets.length; i++) {
+        const offset = offsets[i];
+        if (offset === undefined) continue;
+        const expected = (blue.h + offset) % 360;
+        expect(splitComplementary[i]?.h).toBeCloseTo(expected, 0);
+      }
+    });
+  });
+
+  describe('monochromatic lightness steps', () => {
+    const MONO_L = [0.15, 0.3, 0.45, 0.6, 0.75, 0.9];
+
+    it('monochromatic has correct lightness at each step', () => {
+      const { monochromatic } = generateHarmony(blue);
+      for (let i = 0; i < MONO_L.length; i++) {
+        const expected = MONO_L[i];
+        if (expected === undefined) continue;
+        expect(monochromatic[i]?.l).toBeCloseTo(expected, 2);
+      }
+    });
+
+    it('monochromatic preserves base hue', () => {
+      const { monochromatic } = generateHarmony(blue);
+      for (const color of monochromatic) {
+        // hue is preserved (within rounding from gamut clamp)
+        expect(color.h).toBeGreaterThanOrEqual(blue.h - 5);
+        expect(color.h).toBeLessThanOrEqual(blue.h + 5);
+      }
+    });
+
+    it('monochromatic extreme steps have reduced chroma relative to mid steps', () => {
+      const { monochromatic } = generateHarmony(blue);
+      // L=0.15 (index 0) and L=0.90 (index 5) should have lower C than L=0.45 (index 2)
+      const extremeStart = monochromatic[0]?.c ?? 0;
+      const extremeEnd = monochromatic[5]?.c ?? 0;
+      const midChroma = monochromatic[2]?.c ?? 0;
+      expect(extremeStart).toBeLessThanOrEqual(midChroma + GAMUT_TOLERANCE);
+      expect(extremeEnd).toBeLessThanOrEqual(midChroma + GAMUT_TOLERANCE);
+    });
+  });
+
+  describe('gamut clamping', () => {
+    it('all OKLCH values have l in [0, 1]', () => {
+      const result = generateHarmony(orange);
+      const all = getAllColors(result);
+      for (const c of all) {
+        expect(c.l).toBeGreaterThanOrEqual(0);
+        expect(c.l).toBeLessThanOrEqual(1);
+      }
+    });
+
+    it('all OKLCH values have c >= 0', () => {
+      const result = generateHarmony(orange);
+      const all = getAllColors(result);
+      for (const c of all) {
+        expect(c.c).toBeGreaterThanOrEqual(0);
+      }
+    });
+
+    it('all OKLCH values have h in [0, 360]', () => {
+      const result = generateHarmony(orange);
+      const all = getAllColors(result);
+      for (const c of all) {
+        expect(c.h).toBeGreaterThanOrEqual(0);
+        expect(c.h).toBeLessThanOrEqual(360);
+      }
+    });
+  });
+
+  describe('edge cases', () => {
+    it('hue 0 complementary is near 180', () => {
+      const { complementary } = generateHarmony(red);
+      // Gamut clamping may shift hue slightly, allow +/- 5 degrees
+      expect(complementary.h).toBeGreaterThan(170);
+      expect(complementary.h).toBeLessThan(190);
+    });
+
+    it('hue 359 complementary is near 179', () => {
+      const { complementary } = generateHarmony(nearRed);
+      const expected = (359 + 180) % 360; // 179
+      expect(complementary.h).toBeGreaterThan(expected - 5);
+      expect(complementary.h).toBeLessThan(expected + 5);
+    });
+
+    it('handles near-achromatic gray without NaN', () => {
+      const result = generateHarmony(gray);
+      const all = getAllColors(result);
+      for (const c of all) {
+        expect(Number.isFinite(c.l)).toBe(true);
+        expect(Number.isFinite(c.c)).toBe(true);
+        expect(Number.isFinite(c.h)).toBe(true);
+      }
+    });
+
+    it('produces identical results for same input', () => {
+      const r1 = generateHarmony(blue);
+      const r2 = generateHarmony(blue);
+      expect(r1).toEqual(r2);
+    });
+  });
+});
+
+/** Collect all OKLCH colors from a ColorHarmonies object into a flat array. */
+function getAllColors(h: ColorHarmonies): OKLCH[] {
+  return [
+    h.complementary,
+    ...h.triadic,
+    ...h.analogous,
+    ...h.tetradic,
+    ...h.splitComplementary,
+    ...h.monochromatic,
+  ];
+}

--- a/packages/design-tokens/src/generators/index.ts
+++ b/packages/design-tokens/src/generators/index.ts
@@ -454,13 +454,9 @@ export type BuildDefaultsResult = BuildColorSystemResult;
  * const result = buildColorSystem();
  *
  * // Generate with custom colors (Studio color picker)
- * import { generateRaftersHarmony } from '@rafters/color-utils';
- * const harmony = generateRaftersHarmony(userPickedColor);
- * const colorPaletteBases = Object.fromEntries(
- *   Object.entries(harmony).map(([name, oklch]) =>
- *     [name, { hue: oklch.h, chroma: oklch.c, description: name }]
- *   )
- * );
+ * import { generateHarmony } from '@rafters/color-utils';
+ * const harmony = generateHarmony(userPickedColor);
+ * // Map harmony arrays to color palette bases as needed
  * const result = buildColorSystem({ config: { colorPaletteBases } });
  *
  * // Generate with exports

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -280,6 +280,7 @@ export const ColorHarmoniesSchema = z.object({
   triadic: z.array(OKLCHSchema),
   analogous: z.array(OKLCHSchema),
   tetradic: z.array(OKLCHSchema),
+  splitComplementary: z.array(OKLCHSchema),
   monochromatic: z.array(OKLCHSchema),
 });
 

--- a/scripts/generate-color-fixture.ts
+++ b/scripts/generate-color-fixture.ts
@@ -1,8 +1,8 @@
 /**
  * Generate a complete color system fixture from a single Tailwind color.
  *
- * Picks Tailwind indigo-500 in OKLCH, generates Rafters harmony to get all
- * semantic families, builds ColorValues for each, fetches intelligence from
+ * Picks Tailwind indigo-500 in OKLCH, generates semantic color suggestions to get
+ * additional families, builds ColorValues for each, fetches intelligence from
  * the API, and writes the fixture to packages/shared/test/fixtures/.
  *
  * Usage: pnpm tsx scripts/generate-color-fixture.ts
@@ -10,11 +10,7 @@
 
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import {
-  buildColorValue,
-  generateRaftersHarmony,
-  generateSemanticColorSuggestions,
-} from '@rafters/color-utils';
+import { buildColorValue, generateSemanticColorSuggestions } from '@rafters/color-utils';
 import type { ColorValue, OKLCH } from '@rafters/shared';
 
 // Tailwind indigo-500 in OKLCH
@@ -48,28 +44,14 @@ function buildColorWithToken(oklch: OKLCH, token: string, value: string = '500')
 async function main() {
   console.log('Starting from Tailwind indigo-500:', INDIGO_500);
 
-  // Step 1: Generate Rafters harmony (7 semantic families)
-  const harmony = generateRaftersHarmony(INDIGO_500);
-  console.log('\nRafters harmony roles:');
-  for (const [role, color] of Object.entries(harmony)) {
-    console.log(`  ${role}: L=${color.l} C=${color.c} H=${color.h}`);
-  }
-
-  // Step 2: Generate semantic suggestions (danger, success, warning, info)
+  // Step 1: Generate semantic suggestions (danger, success, warning, info)
   const suggestions = generateSemanticColorSuggestions(INDIGO_500);
 
-  // Step 3: Build ColorValues for each family
+  // Step 2: Build ColorValues for the base plus semantic families
   const families: Record<string, { oklch: OKLCH; token: string }> = {
-    primary: { oklch: harmony.primary, token: 'primary' },
-    secondary: { oklch: harmony.secondary, token: 'secondary' },
-    tertiary: { oklch: harmony.tertiary, token: 'tertiary' },
-    accent: { oklch: harmony.accent, token: 'accent' },
-    highlight: { oklch: harmony.highlight, token: 'highlight' },
-    surface: { oklch: harmony.surface, token: 'surface' },
-    neutral: { oklch: harmony.neutral, token: 'neutral' },
+    primary: { oklch: INDIGO_500, token: 'primary' },
   };
 
-  // Add semantic suggestion colors (pick first from each)
   const dangerColor = suggestions.danger[0];
   const successColor = suggestions.success[0];
   const warningColor = suggestions.warning[0];
@@ -82,14 +64,13 @@ async function main() {
 
   console.log(`\nBuilding ${Object.keys(families).length} color families...`);
 
-  // Step 4: Build ColorValues and fetch intelligence
+  // Step 3: Build ColorValues and fetch intelligence
   const colorValues: ColorValue[] = [];
 
   for (const [role, { oklch, token }] of Object.entries(families)) {
     console.log(`\n[${role}]`);
     const cv = buildColorWithToken(oklch, token);
 
-    // Fetch intelligence from API
     const intelligence = await fetchIntelligence(oklch);
     if (intelligence) {
       (cv as Record<string, unknown>).intelligence = intelligence;
@@ -99,7 +80,7 @@ async function main() {
     colorValues.push(cv);
   }
 
-  // Step 5: Write fixture
+  // Step 4: Write fixture
   const fixtureDir = resolve(import.meta.dirname, '../packages/shared/test/fixtures');
   mkdirSync(fixtureDir, { recursive: true });
 


### PR DESCRIPTION
## Summary

- Rewrites `generateHarmony` to produce pure hue rotations -- L and C are never mutated before gamut clamping, only H changes
- Adds `splitComplementary` (3 colors, base/+150/+210) to `ColorHarmoniesSchema` and the `ColorHarmonies` type in `@rafters/shared`
- Deletes `generateRaftersHarmony` and `generateOptimalGray` (removed from exports, README, fixture script, generator JSDoc)
- Updates `buildColorValue` to map the new array shape; API color route tests updated for new counts

## Harmony counts (new)

| Type | Count | Offsets |
|------|-------|---------|
| complementary | 1 | +180 |
| triadic | 3 | base, +120, +240 |
| analogous | 6 | -45, -30, -15, +15, +30, +45 |
| tetradic | 4 | base, +90, +180, +270 |
| splitComplementary | 3 | base, +150, +210 |
| monochromatic | 6 | fixed L steps 0.15-0.90, chroma reduced 50% at extremes |

## Pipeline

Every harmony color goes through `clampColor = roundOKLCH(toNearestGamut(color).color)` -- single authoritative pipeline, no ad-hoc clamping inline.

## Test plan

- [x] New `packages/color-utils/test/harmony.test.ts` with 37 tests covering shape, array counts, pure hue rotation invariant (low-chroma reference color), hue angles, monochromatic lightness steps, gamut clamping bounds, edge cases
- [x] `builder.test.ts` updated for new array lengths and splitComplementary
- [x] `apps/api/test/routes/color/color.test.ts` updated for new counts
- [x] 149/149 color-utils tests pass
- [x] Preflight clean

Closes #1215

Generated with [Claude Code](https://claude.com/claude-code)