### PR TITLE
fix(tokens): align animation shorthand var() names with Tailwind-native emission

### DIFF
--- a/packages/design-tokens/src/exporters/tailwind.ts
+++ b/packages/design-tokens/src/exporters/tailwind.ts
@@ -375,9 +375,15 @@ function generateThemeBlock(groups: GroupedTokens): string {
         // Decomposed parts: --rafters-* only, no Tailwind utility
         lines.push(`  --rafters-${token.name}: ${value};`);
       } else {
-        // Composites: --shadow-* for Tailwind utility generation
-        const key = token.name.replace(/^shadow-/, '');
-        lines.push(`  --shadow-${key}: ${value};`);
+        // Composites: --shadow-* for Tailwind utility generation.
+        // The DEFAULT scale emits a token named 'shadow' (no suffix) which maps
+        // to Tailwind's --shadow (bare). Other scales emit --shadow-sm, --shadow-md, etc.
+        if (token.name === 'shadow') {
+          lines.push(`  --shadow: ${value};`);
+        } else {
+          const key = token.name.replace(/^shadow-/, '');
+          lines.push(`  --shadow-${key}: ${value};`);
+        }
       }
     }
     lines.push('');
@@ -923,8 +929,14 @@ function generateThemeBlockWithVarRefs(groups: GroupedTokens): string {
   if (groups.shadow.length > 0) {
     for (const token of groups.shadow) {
       if (isShadowDecomposedPart(token.name)) continue;
-      const key = token.name.replace(/^shadow-/, '');
-      lines.push(`  --shadow-${key}: var(--rafters-${token.name});`);
+      // The DEFAULT scale emits a token named 'shadow' (no suffix) which maps
+      // to Tailwind's --shadow (bare). Other scales emit --shadow-sm, --shadow-md, etc.
+      if (token.name === 'shadow') {
+        lines.push(`  --shadow: var(--rafters-${token.name});`);
+      } else {
+        const key = token.name.replace(/^shadow-/, '');
+        lines.push(`  --shadow-${key}: var(--rafters-${token.name});`);
+      }
     }
     lines.push('');
   }

--- a/packages/design-tokens/src/exporters/tailwind.ts
+++ b/packages/design-tokens/src/exporters/tailwind.ts
@@ -36,6 +36,15 @@ function isShadowDecomposedPart(name: string): boolean {
   return SHADOW_PART_SUFFIX.test(name);
 }
 
+/**
+ * Map a composite shadow token name to its Tailwind CSS custom property name.
+ * The DEFAULT scale token 'shadow' maps to --shadow (bare).
+ * All other scales strip the leading prefix: 'shadow-sm' -> --shadow-sm.
+ */
+function shadowTokenToTailwindProp(name: string): string {
+  return name === 'shadow' ? '--shadow' : `--shadow-${name.replace(/^shadow-/, '')}`;
+}
+
 /** Check if a breakpoint token is a media query condition, not a dimension */
 function isMediaQueryToken(token: Token): boolean {
   return typeof token.value === 'string' && token.value.startsWith('(');
@@ -376,14 +385,7 @@ function generateThemeBlock(groups: GroupedTokens): string {
         lines.push(`  --rafters-${token.name}: ${value};`);
       } else {
         // Composites: --shadow-* for Tailwind utility generation.
-        // The DEFAULT scale emits a token named 'shadow' (no suffix) which maps
-        // to Tailwind's --shadow (bare). Other scales emit --shadow-sm, --shadow-md, etc.
-        if (token.name === 'shadow') {
-          lines.push(`  --shadow: ${value};`);
-        } else {
-          const key = token.name.replace(/^shadow-/, '');
-          lines.push(`  --shadow-${key}: ${value};`);
-        }
+        lines.push(`  ${shadowTokenToTailwindProp(token.name)}: ${value};`);
       }
     }
     lines.push('');
@@ -929,14 +931,7 @@ function generateThemeBlockWithVarRefs(groups: GroupedTokens): string {
   if (groups.shadow.length > 0) {
     for (const token of groups.shadow) {
       if (isShadowDecomposedPart(token.name)) continue;
-      // The DEFAULT scale emits a token named 'shadow' (no suffix) which maps
-      // to Tailwind's --shadow (bare). Other scales emit --shadow-sm, --shadow-md, etc.
-      if (token.name === 'shadow') {
-        lines.push(`  --shadow: var(--rafters-${token.name});`);
-      } else {
-        const key = token.name.replace(/^shadow-/, '');
-        lines.push(`  --shadow-${key}: var(--rafters-${token.name});`);
-      }
+      lines.push(`  ${shadowTokenToTailwindProp(token.name)}: var(--rafters-${token.name});`);
     }
     lines.push('');
   }

--- a/packages/design-tokens/src/generators/motion.ts
+++ b/packages/design-tokens/src/generators/motion.ts
@@ -519,16 +519,14 @@ export function generateMotionTokens(
           ? 0
           : Math.round(progression.compute(baseTransitionDuration, durationDef.step));
       durationValue = `${durationMs}ms`;
-      // Use Tailwind-native --duration-* names (canonical emission in tailwind.ts).
-      // motion-duration-fast -> --duration-fast, matching what the exporter defines.
+      // Use Tailwind-native --duration-* names: must match what the exporter defines in tailwind.ts.
       durationRef = `var(--duration-${anim.duration})`;
     }
 
     // Get easing
     const easingDef = easingDefs[anim.easing];
     if (!easingDef) continue;
-    // Use Tailwind-native --ease-* names (canonical emission in tailwind.ts).
-    // motion-easing-ease-out -> --ease-ease-out, matching what the exporter defines.
+    // Use Tailwind-native --ease-* names: must match what the exporter defines in tailwind.ts.
     const easingRef = `var(--ease-${anim.easing})`;
 
     // Build animation value

--- a/packages/design-tokens/src/generators/motion.ts
+++ b/packages/design-tokens/src/generators/motion.ts
@@ -519,13 +519,17 @@ export function generateMotionTokens(
           ? 0
           : Math.round(progression.compute(baseTransitionDuration, durationDef.step));
       durationValue = `${durationMs}ms`;
-      durationRef = `var(--motion-duration-${anim.duration})`;
+      // Use Tailwind-native --duration-* names (canonical emission in tailwind.ts).
+      // motion-duration-fast -> --duration-fast, matching what the exporter defines.
+      durationRef = `var(--duration-${anim.duration})`;
     }
 
     // Get easing
     const easingDef = easingDefs[anim.easing];
     if (!easingDef) continue;
-    const easingRef = `var(--motion-easing-${anim.easing})`;
+    // Use Tailwind-native --ease-* names (canonical emission in tailwind.ts).
+    // motion-easing-ease-out -> --ease-ease-out, matching what the exporter defines.
+    const easingRef = `var(--ease-${anim.easing})`;
 
     // Build animation value
     const iterations = anim.iterations || '';

--- a/packages/design-tokens/test/color-wheel-integration.test.ts
+++ b/packages/design-tokens/test/color-wheel-integration.test.ts
@@ -309,10 +309,23 @@ describe('colorWheel -> TokenRegistry integration', () => {
       const registry = await buildRegistry(TAILWIND_BLUE_500);
       const css = registryToTailwind(registry, { darkMode: 'class' });
 
+      // External runtime variables set by third-party libraries at runtime.
+      // These are intentionally undefined in generated CSS -- they are injected
+      // by the library (e.g. Radix UI) during DOM rendering, not by the token system.
+      const EXTERNAL_RUNTIME_VARS = new Set([
+        'radix-accordion-content-height',
+        'radix-collapsible-content-height',
+        'radix-dialog-content-height',
+        'radix-popover-content-available-height',
+      ]);
+
       const varRefMatches = [...css.matchAll(/var\(--([\w-]+)\)/g)];
       const varDefMatches = [...css.matchAll(/--([\w-]+)\s*:/g)];
 
-      const varRefs = varRefMatches.map((m) => m[1]).filter((r): r is string => r !== undefined);
+      const varRefs = varRefMatches
+        .map((m) => m[1])
+        .filter((r): r is string => r !== undefined)
+        .filter((r) => !EXTERNAL_RUNTIME_VARS.has(r));
       const varDefs = new Set(
         varDefMatches.map((m) => m[1]).filter((d): d is string => d !== undefined),
       );

--- a/packages/design-tokens/test/exporters/tailwind.test.ts
+++ b/packages/design-tokens/test/exporters/tailwind.test.ts
@@ -126,6 +126,24 @@ describe('tokensToTailwind', () => {
     expect(css).toContain('--shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);');
   });
 
+  it('should export the DEFAULT shadow token as --shadow (not --shadow-shadow)', () => {
+    // Regression: the old replace(/^shadow-/, '') on a token named 'shadow' produced
+    // '--shadow-shadow'. The DEFAULT scale must map to bare '--shadow'.
+    const tokens: Token[] = [
+      {
+        name: 'shadow',
+        value: '0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)',
+        category: 'shadow',
+        namespace: 'shadow',
+      },
+    ];
+
+    const css = tokensToTailwind(tokens);
+
+    expect(css).toContain('--shadow:');
+    expect(css).not.toContain('--shadow-shadow');
+  });
+
   it('should export depth tokens', () => {
     const tokens: Token[] = [
       { name: 'depth-dropdown', value: '10', category: 'depth', namespace: 'depth' },

--- a/packages/design-tokens/test/generators.test.ts
+++ b/packages/design-tokens/test/generators.test.ts
@@ -537,8 +537,9 @@ describe('Token Structure Validation', () => {
       // Animation shorthands use Tailwind-native names (--duration-*, --ease-*) so they
       // resolve against the same custom properties that the Tailwind exporter defines.
       // See: packages/design-tokens/src/exporters/tailwind.ts motion duration/easing blocks.
-      expect(fadeIn?.value).toContain('var(--duration-');
-      expect(fadeIn?.value).toContain('var(--ease-');
+      // fade-in uses duration: 'fast' and easing: 'ease-out' per the animation definitions.
+      expect(fadeIn?.value).toContain('var(--duration-fast)');
+      expect(fadeIn?.value).toContain('var(--ease-ease-out)');
     });
 
     it('animation tokens with fixed durations use literal values', () => {

--- a/packages/design-tokens/test/generators.test.ts
+++ b/packages/design-tokens/test/generators.test.ts
@@ -534,8 +534,11 @@ describe('Token Structure Validation', () => {
 
     it('animation tokens reference duration and easing tokens via var()', () => {
       const fadeIn = result.tokens.find((t) => t.name === 'motion-animation-fade-in');
-      expect(fadeIn?.value).toContain('var(--motion-duration-');
-      expect(fadeIn?.value).toContain('var(--motion-easing-');
+      // Animation shorthands use Tailwind-native names (--duration-*, --ease-*) so they
+      // resolve against the same custom properties that the Tailwind exporter defines.
+      // See: packages/design-tokens/src/exporters/tailwind.ts motion duration/easing blocks.
+      expect(fadeIn?.value).toContain('var(--duration-');
+      expect(fadeIn?.value).toContain('var(--ease-');
     });
 
     it('animation tokens with fixed durations use literal values', () => {


### PR DESCRIPTION
## Summary

Closes #1236. Part of #1224.

- **Option 1 chosen**: Tailwind-native names (`--duration-*`, `--ease-*`) are canonical. Animation shorthand tokens in `motion.ts` are updated to reference `var(--duration-fast)` / `var(--ease-ease-out)` -- the same names the Tailwind exporter already defines. No new aliases, no dual emission.
- Fixed a pre-existing shadow DEFAULT token naming bug: the `shadow` (DEFAULT scale) token was being emitted as `--shadow-shadow` instead of `--shadow` in `generateThemeBlock` and `generateThemeBlockWithVarRefs`, causing `var(--shadow)` (from elevation-overlay) to be undefined.
- Added `EXTERNAL_RUNTIME_VARS` allowlist for known Radix UI runtime variables (`--radix-accordion-content-height`, etc.) in the integration test. These are set by the library at DOM render time -- not by the token system -- and should not be treated as broken references.

**Why Option 1 over Option 2:** The exporter already has a clear single-emission pattern for motion tokens. Adding dual emission would create two sources of truth for every duration and easing value. Option 1 is a single, minimal change in the generator layer with no schema or cascade impact.

## Files touched

- `packages/design-tokens/src/generators/motion.ts` -- animation shorthand var() refs changed from `--motion-duration-*` / `--motion-easing-*` to `--duration-*` / `--ease-*`
- `packages/design-tokens/src/exporters/tailwind.ts` -- shadow DEFAULT token now emits `--shadow:` (not `--shadow-shadow:`) in both `generateThemeBlock` and `generateThemeBlockWithVarRefs`
- `packages/design-tokens/test/color-wheel-integration.test.ts` -- Radix allowlist added to `every var() reference` test
- `packages/design-tokens/test/generators.test.ts` -- assertion updated to match new canonical var() names

## Radix allowlist

```typescript
const EXTERNAL_RUNTIME_VARS = new Set([
  'radix-accordion-content-height',
  'radix-collapsible-content-height',
  'radix-dialog-content-height',
  'radix-popover-content-available-height',
]);
```

## Test plan

- [x] `pnpm preflight` passes (exit 0, lefthook pre-push clean)
- [x] `every var() reference in produced CSS has a corresponding definition` now passes (was failing with 71 unresolved refs)
- [x] `generators.test.ts` animation token assertion updated and passes
- [x] Full design-tokens suite: 283 passed, 2 pre-existing failures (#1237 cascade, #1225 static family list -- not in scope)
- [x] No unrelated behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)