### PR TITLE
fix(cascade): semantic tokens preserve ColorReference through value type changes

### DIFF
--- a/packages/design-tokens/src/registry.ts
+++ b/packages/design-tokens/src/registry.ts
@@ -565,12 +565,10 @@ export class TokenRegistry {
 
     if (typeof resolvedValue === 'object' && 'family' in resolvedValue) {
       const ref = resolvedValue as ColorReference;
-      const existingIsRef =
-        typeof existingToken.value === 'object' &&
-        existingToken.value !== null &&
-        'family' in existingToken.value;
+      // Semantic tokens store ColorReferences; position tokens store CSS strings.
+      const isSemanticToken = existingToken.namespace === 'semantic';
 
-      if (existingIsRef) {
+      if (isSemanticToken) {
         // Semantic token path: update dependsOn[0]=family, dependsOn[1]=dark counterpart.
         // findDarkCounterpart requires WCAG data from the family ColorValue.
         const darkTokenName = this.findDarkCounterpart(ref, existingToken.dependsOn);


### PR DESCRIPTION
## Summary

Fixes #1223 - cascade fails when setting a family-level ColorValue.

The bug: In `applyComputed`, checking if the existing value is a ColorReference fails when the token's value has been temporarily set to a ColorValue (e.g., during colorWheel onboarding). The cascade then converts ColorReferences to CSS strings, breaking semantic token resolution.

**Root cause**: The code was checking `existingToken.value` type to decide whether to keep ColorReferences or convert to CSS strings. But when a semantic token's value is set to a ColorValue during onboarding, this check fails.

**Fix**: Check the token's `namespace` property ('semantic') instead of its current value type. Semantic tokens always store ColorReferences; position tokens (namespace='color' with -NNN suffix) store CSS strings.

## Changes

- `packages/design-tokens/src/registry.ts`: In `applyComputed`, replace value-type check with namespace check

## Test plan

- [x] Run `pnpm test -t "accent-foreground cascades"` - now passes
- [x] Run `pnpm --filter=@rafters/design-tokens test semantic-cascade` - all 20 tests pass
- [x] Run `pnpm preflight` - passes

Generated with [Claude Code](https://claude.ai/code)