### PR TITLE
feat(composites): add designer intent fields to manifest schema

### DIFF
--- a/packages/cli/src/mcp/composites-tools.spec.ts
+++ b/packages/cli/src/mcp/composites-tools.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * MCP Composites Tools - Specification
+ *
+ * Two tools:
+ * 1. rafters_composite - query composites
+ * 2. rafters_rule - query or create rules
+ */
+
+import { z } from 'zod';
+
+// ============================================================================
+// rafters_composite
+// ============================================================================
+
+export const CompositeQuerySchema = z.object({
+  id: z.string().optional(),
+  query: z.string().optional(),
+  category: z.string().optional(),
+});
+
+export const CompositeResponseSchema = z.object({
+  composites: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      category: z.string(),
+      description: z.string(),
+      cognitiveLoad: z.number(),
+      solves: z.string().optional(),
+      appliesWhen: z.array(z.string()).optional(),
+      usagePatterns: z
+        .object({
+          do: z.array(z.string()),
+          never: z.array(z.string()),
+        })
+        .optional(),
+      input: z.array(z.string()),
+      output: z.array(z.string()),
+      blockCount: z.number(),
+    }),
+  ),
+});
+
+// ============================================================================
+// rafters_rule
+// ============================================================================
+
+export const RuleQuerySchema = z.object({
+  name: z.string().optional(),
+  query: z.string().optional(),
+  // Create mode: provide these to create a new rule
+  create: z
+    .object({
+      name: z.string().regex(/^[a-z0-9-]+$/),
+      description: z.string(),
+      zodSchema: z.string(),
+    })
+    .optional(),
+});
+
+export const RuleResponseSchema = z.object({
+  rules: z.array(
+    z.object({
+      name: z.string(),
+      description: z.string(),
+      source: z.enum(['registry', 'local']),
+    }),
+  ),
+  created: z
+    .object({
+      name: z.string(),
+      path: z.string(),
+    })
+    .optional(),
+});

--- a/packages/composites/src/bridge.ts
+++ b/packages/composites/src/bridge.ts
@@ -8,7 +8,13 @@
  */
 
 import type { BlockPaletteItem } from '@rafters/ui/primitives/block-palette';
-import type { AppliedRule, CompositeBlock, CompositeCategory, CompositeFile } from './manifest';
+import type {
+  AppliedRule,
+  CompositeBlock,
+  CompositeCategory,
+  CompositeFile,
+  UsagePatterns,
+} from './manifest';
 
 /** A block ready for insertion into the editor canvas (same shape as CompositeBlock). */
 export type InstantiatedBlock = CompositeBlock;
@@ -38,6 +44,10 @@ export interface SaveCompositeMetadata {
   category: CompositeCategory;
   description: string;
   cognitiveLoad?: number;
+  // Designer intent (optional)
+  solves?: string;
+  appliesWhen?: string[];
+  usagePatterns?: UsagePatterns;
 }
 
 /**
@@ -244,15 +254,22 @@ export function serializeToComposite(
   const rawLoad = metadata.cognitiveLoad ?? blocks.length;
   const cognitiveLoad = Math.min(10, Math.max(1, rawLoad));
 
+  const manifest: CompositeFile['manifest'] = {
+    id,
+    name: metadata.name,
+    category: metadata.category,
+    description: metadata.description,
+    keywords,
+    cognitiveLoad,
+  };
+
+  // Add optional intent fields if provided
+  if (metadata.solves) manifest.solves = metadata.solves;
+  if (metadata.appliesWhen) manifest.appliesWhen = metadata.appliesWhen;
+  if (metadata.usagePatterns) manifest.usagePatterns = metadata.usagePatterns;
+
   return {
-    manifest: {
-      id,
-      name: metadata.name,
-      category: metadata.category,
-      description: metadata.description,
-      keywords,
-      cognitiveLoad,
-    },
+    manifest,
     input,
     output,
     blocks: blocks.map((b) => {

--- a/packages/composites/src/index.ts
+++ b/packages/composites/src/index.ts
@@ -32,6 +32,7 @@ export type {
   CompositeCategory,
   CompositeFile,
   CompositeManifest,
+  UsagePatterns,
 } from './manifest';
 export {
   AppliedRuleSchema,
@@ -39,6 +40,7 @@ export {
   CompositeCategorySchema,
   CompositeFileSchema,
   CompositeManifestSchema,
+  UsagePatternsSchema,
 } from './manifest';
 export {
   clear as clearRegistry,

--- a/packages/composites/src/manifest.ts
+++ b/packages/composites/src/manifest.ts
@@ -37,6 +37,14 @@ export const CompositeBlockSchema = z.object({
 
 export type CompositeBlock = z.infer<typeof CompositeBlockSchema>;
 
+/** Designer intent - captures WHY and WHEN to use this composite */
+export const UsagePatternsSchema = z.object({
+  do: z.array(z.string()),
+  never: z.array(z.string()),
+});
+
+export type UsagePatterns = z.infer<typeof UsagePatternsSchema>;
+
 /** Zod schema for a composite's manifest metadata */
 export const CompositeManifestSchema = z.object({
   id: z
@@ -48,6 +56,11 @@ export const CompositeManifestSchema = z.object({
   description: z.string(),
   keywords: z.array(z.string()),
   cognitiveLoad: z.number().int().min(1).max(10),
+
+  // Designer intent fields (optional for backwards compatibility)
+  solves: z.string().optional(),
+  appliesWhen: z.array(z.string()).optional(),
+  usagePatterns: UsagePatternsSchema.optional(),
 });
 
 export type CompositeManifest = z.infer<typeof CompositeManifestSchema>;

--- a/packages/composites/src/typography/heading.composite.json
+++ b/packages/composites/src/typography/heading.composite.json
@@ -5,7 +5,21 @@
     "category": "typography",
     "description": "Section heading with configurable level",
     "keywords": ["title", "h1", "h2", "h3", "h4", "h5", "h6"],
-    "cognitiveLoad": 1
+    "cognitiveLoad": 1,
+    "solves": "Semantic document structure with visual hierarchy",
+    "appliesWhen": ["page sections", "content hierarchy", "navigation landmarks"],
+    "usagePatterns": {
+      "do": [
+        "Use H1 once per page",
+        "Follow heading order without skipping levels",
+        "Use for structure not styling"
+      ],
+      "never": [
+        "Skip heading levels (H1 to H3)",
+        "Use headings purely for font size",
+        "Nest H1 inside sections"
+      ]
+    }
   },
   "input": [],
   "output": [],


### PR DESCRIPTION
## Summary
- Adds `solves`, `appliesWhen`, and `usagePatterns` (do/never) fields to CompositeManifestSchema
- These fields capture designer intent so agents learn when/how to use composites, not just what they are
- Updated bridge.ts to pass intent fields through serializeToComposite
- Added example intent fields to heading.composite.json
- Added MCP tool schemas spec for rafters_composite and rafters_rule

## Test plan
- [x] All 132 composites tests pass
- [x] Typecheck clean
- [x] Preflight passes

Generated with [Claude Code](https://claude.ai/code)