### PR TITLE
feat(composites): add designer intent fields to all composites

### DIFF
--- a/apps/demo/src/composites/feature-grid.composite.json
+++ b/apps/demo/src/composites/feature-grid.composite.json
@@ -5,7 +5,21 @@
     "category": "layout",
     "description": "Three-column feature showcase with icons and descriptions",
     "keywords": ["features", "grid", "showcase", "columns"],
-    "cognitiveLoad": 3
+    "cognitiveLoad": 3,
+    "solves": "Showcasing multiple features with equal visual weight",
+    "appliesWhen": ["product pages", "landing pages", "comparison views", "capability overviews"],
+    "usagePatterns": {
+      "do": [
+        "Limit to 3-6 features for scannability",
+        "Use consistent icon style across items",
+        "Keep feature descriptions under 20 words"
+      ],
+      "never": [
+        "Mix different levels of detail across items",
+        "Use more than 9 items in a single grid",
+        "Vary column widths for emphasis"
+      ]
+    }
   },
   "input": [],
   "output": [],

--- a/apps/demo/src/composites/hero-banner.composite.json
+++ b/apps/demo/src/composites/hero-banner.composite.json
@@ -5,7 +5,21 @@
     "category": "typography",
     "description": "Full-width hero section with headline and subtext",
     "keywords": ["hero", "banner", "landing", "headline"],
-    "cognitiveLoad": 2
+    "cognitiveLoad": 2,
+    "solves": "Creating a focal point for page entry and primary action",
+    "appliesWhen": ["landing pages", "marketing pages", "product launches", "campaign pages"],
+    "usagePatterns": {
+      "do": [
+        "Single clear CTA above the fold",
+        "Headline under 10 words",
+        "Contrast ratio 7:1+ for text over images"
+      ],
+      "never": [
+        "Multiple competing CTAs",
+        "Auto-playing video without user consent",
+        "Text that requires scrolling to read"
+      ]
+    }
   },
   "input": [],
   "output": [],

--- a/apps/demo/src/composites/login-form.composite.json
+++ b/apps/demo/src/composites/login-form.composite.json
@@ -5,7 +5,21 @@
     "category": "form",
     "description": "Email and password login with validation",
     "keywords": ["auth", "login", "credentials", "sign-in"],
-    "cognitiveLoad": 4
+    "cognitiveLoad": 4,
+    "solves": "Authenticating users with minimal friction",
+    "appliesWhen": ["sign-in flows", "session restoration", "gated content", "account access"],
+    "usagePatterns": {
+      "do": [
+        "Show password toggle for visibility",
+        "Support password managers with proper autocomplete",
+        "Provide forgot password link near password field"
+      ],
+      "never": [
+        "Disable paste in password fields",
+        "Clear password field on validation error",
+        "Require arbitrary password complexity rules"
+      ]
+    }
   },
   "input": ["email", "password"],
   "output": ["credentials"],

--- a/packages/composites/src/typography/blockquote.composite.json
+++ b/packages/composites/src/typography/blockquote.composite.json
@@ -5,7 +5,21 @@
     "category": "typography",
     "description": "Quoted text block",
     "keywords": ["quote", "citation", "pullquote"],
-    "cognitiveLoad": 1
+    "cognitiveLoad": 1,
+    "solves": "Attributing external voices and highlighting key quotes",
+    "appliesWhen": ["citations", "pull quotes", "testimonials", "external references"],
+    "usagePatterns": {
+      "do": [
+        "Include citation with cite attribute or footer",
+        "Use for actual quotes, not stylistic emphasis",
+        "Keep quotes concise and relevant"
+      ],
+      "never": [
+        "Use blockquote for indentation styling",
+        "Omit attribution for quoted material",
+        "Nest blockquotes more than one level"
+      ]
+    }
   },
   "input": [],
   "output": [],

--- a/packages/composites/src/typography/list.composite.json
+++ b/packages/composites/src/typography/list.composite.json
@@ -5,7 +5,21 @@
     "category": "typography",
     "description": "Ordered or unordered list",
     "keywords": ["ul", "ol", "bullet", "numbered"],
-    "cognitiveLoad": 2
+    "cognitiveLoad": 2,
+    "solves": "Organizing related items into scannable groups",
+    "appliesWhen": ["steps", "options", "features", "requirements", "navigation menus"],
+    "usagePatterns": {
+      "do": [
+        "Use ordered lists for sequential steps",
+        "Use unordered lists for non-sequential items",
+        "Keep list items parallel in structure"
+      ],
+      "never": [
+        "Mix ordered and unordered semantics",
+        "Use lists for layout purposes",
+        "Create lists with single items"
+      ]
+    }
   },
   "input": [],
   "output": [],

--- a/packages/composites/src/typography/paragraph.composite.json
+++ b/packages/composites/src/typography/paragraph.composite.json
@@ -5,7 +5,21 @@
     "category": "typography",
     "description": "Body text paragraph",
     "keywords": ["text", "body", "p"],
-    "cognitiveLoad": 1
+    "cognitiveLoad": 1,
+    "solves": "Presenting body content in readable chunks",
+    "appliesWhen": ["main content", "descriptions", "explanations", "prose"],
+    "usagePatterns": {
+      "do": [
+        "Keep paragraphs focused on one idea",
+        "Use appropriate line length (45-75 characters)",
+        "Maintain consistent spacing between paragraphs"
+      ],
+      "never": [
+        "Use br tags instead of separate paragraphs",
+        "Create walls of unbroken text",
+        "Use paragraphs for non-textual content"
+      ]
+    }
   },
   "input": [],
   "output": [],

--- a/packages/ui/src/composites/feature-grid.composite.json
+++ b/packages/ui/src/composites/feature-grid.composite.json
@@ -5,7 +5,21 @@
     "category": "layout",
     "description": "Three-column feature showcase with icons and descriptions",
     "keywords": ["features", "grid", "showcase", "benefits"],
-    "cognitiveLoad": 2
+    "cognitiveLoad": 2,
+    "solves": "Showcasing multiple features with equal visual weight",
+    "appliesWhen": ["product pages", "landing pages", "comparison views", "capability overviews"],
+    "usagePatterns": {
+      "do": [
+        "Limit to 3-6 features for scannability",
+        "Use consistent icon style across items",
+        "Keep feature descriptions under 20 words"
+      ],
+      "never": [
+        "Mix different levels of detail across items",
+        "Use more than 9 items in a single grid",
+        "Vary column widths for emphasis"
+      ]
+    }
   },
   "input": [],
   "output": [],

--- a/packages/ui/src/composites/hero-banner.composite.json
+++ b/packages/ui/src/composites/hero-banner.composite.json
@@ -5,7 +5,21 @@
     "category": "layout",
     "description": "Full-width hero section with heading, subheading, and call-to-action",
     "keywords": ["hero", "banner", "landing", "cta"],
-    "cognitiveLoad": 3
+    "cognitiveLoad": 3,
+    "solves": "Creating a focal point for page entry and primary action",
+    "appliesWhen": ["landing pages", "marketing pages", "product launches", "campaign pages"],
+    "usagePatterns": {
+      "do": [
+        "Single clear CTA above the fold",
+        "Headline under 10 words",
+        "Contrast ratio 7:1+ for text over images"
+      ],
+      "never": [
+        "Multiple competing CTAs",
+        "Auto-playing video without user consent",
+        "Text that requires scrolling to read"
+      ]
+    }
   },
   "input": [],
   "output": [],

--- a/packages/ui/src/composites/login-form.composite.json
+++ b/packages/ui/src/composites/login-form.composite.json
@@ -5,7 +5,21 @@
     "category": "form",
     "description": "Email and password login with validation rules",
     "keywords": ["login", "auth", "signin", "credentials"],
-    "cognitiveLoad": 5
+    "cognitiveLoad": 5,
+    "solves": "Authenticating users with minimal friction",
+    "appliesWhen": ["sign-in flows", "session restoration", "gated content", "account access"],
+    "usagePatterns": {
+      "do": [
+        "Show password toggle for visibility",
+        "Support password managers with proper autocomplete",
+        "Provide forgot password link near password field"
+      ],
+      "never": [
+        "Disable paste in password fields",
+        "Clear password field on validation error",
+        "Require arbitrary password complexity rules"
+      ]
+    }
   },
   "input": ["email", "password"],
   "output": ["credentials"],


### PR DESCRIPTION
## Summary

- Adds `solves`, `appliesWhen`, and `usagePatterns` (do/never) to 9 composite files
- Enables `rafters_pattern` MCP tool to return real guidance from composite data
- Completes the pattern of heading.composite.json across all composites

## Changed Files

**Typography composites (packages/composites):**
- blockquote.composite.json
- list.composite.json  
- paragraph.composite.json

**UI composites (packages/ui):**
- feature-grid.composite.json
- hero-banner.composite.json
- login-form.composite.json

**Demo composites (apps/demo):**
- feature-grid.composite.json
- hero-banner.composite.json
- login-form.composite.json

## Test plan

- [ ] MCP tool returns pattern data for solves queries
- [ ] MCP tool returns pattern data for keyword queries
- [ ] Existing composite tests pass

Generated with [Claude Code](https://claude.ai/code)