### PR TITLE
feat(mcp): add rafters_vocabulary tool with intent-based filtering

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Minor Changes
+
+- feat(mcp): add `rafters_vocabulary` tool for filtered design system queries. Supports `category` ("color", "spacing", "typography", "component"), `intent` ("warnings", "text colors", "primary actions"), and `family` ("primary", "destructive", etc.) filters. Empty call returns compact index with suggested queries instead of dumping everything. Addresses agent feedback that vocabulary was a firehose. Closes #1250.
+
 ### Patch Changes
 
 - fix(mcp): `rafters_pattern` no longer returns hardcoded patterns. Now queries composites by their `solves` and `appliesWhen` fields. Patterns are design intelligence captured in composite manifests, not static data in the MCP server. Search by what the pattern solves (e.g., "hierarchy", "authentication") or use `query` for fuzzy search. Closes #1280.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -66,7 +66,24 @@ pnpm dlx rafters studio
 
 ## MCP Tools
 
-Four tools give AI agents complete design system access:
+Five tools give AI agents complete design system access:
+
+### `rafters_vocabulary`
+
+Query design system vocabulary with filters. Empty call returns compact index with suggested queries.
+
+```json
+{}                           // Get compact index + suggested queries
+{ "category": "color" }      // Get color families and scales
+{ "category": "spacing" }    // Get spacing scale
+{ "intent": "warnings" }     // Semantic search: warning colors
+{ "intent": "text colors" }  // Semantic search: text colors
+{ "family": "destructive" }  // Get all tokens in destructive family
+```
+
+**Categories:** `color`, `spacing`, `typography`, `component`
+
+**Intents:** `warnings`, `errors`, `success`, `info`, `text colors`, `primary actions`, `destructive actions`, `muted`, `highlight`
 
 ### `rafters_composite`
 

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -1,12 +1,13 @@
 /**
  * MCP Tools for Rafters Design System
  *
- * 4 focused tools for agent composition:
+ * 5 focused tools for agent composition:
  *
- * 1. rafters_composite - Query composites with designer intent
- * 2. rafters_rule - Query or create validation rules
- * 3. rafters_pattern - Design pattern guidance (do/never)
- * 4. rafters_component - Component intelligence
+ * 1. rafters_vocabulary - Query design system vocabulary with filters
+ * 2. rafters_composite - Query composites with designer intent
+ * 3. rafters_rule - Query or create validation rules
+ * 4. rafters_pattern - Design pattern guidance (do/never)
+ * 5. rafters_component - Component intelligence
  */
 
 import { readdir } from 'node:fs/promises';
@@ -27,6 +28,31 @@ import { getRaftersPaths } from '../utils/paths.js';
 // ==================== Tool Definitions ====================
 
 export const TOOL_DEFINITIONS = [
+  {
+    name: 'rafters_vocabulary',
+    description:
+      'Query design system vocabulary: colors, spacing, typography, components. Use filters to narrow results. Empty call returns compact index with suggested queries.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        category: {
+          type: 'string',
+          enum: ['color', 'spacing', 'typography', 'component'],
+          description: 'Filter by token category',
+        },
+        intent: {
+          type: 'string',
+          description:
+            'Semantic search: "warnings", "text colors", "error states", "primary actions"',
+        },
+        family: {
+          type: 'string',
+          description: 'Color family filter: "primary", "destructive", "success", "warning", etc.',
+        },
+      },
+      required: [],
+    },
+  },
   {
     name: 'rafters_composite',
     description:
@@ -112,6 +138,10 @@ export class RaftersToolHandler {
 
   async handleToolCall(name: string, args: Record<string, unknown>): Promise<CallToolResult> {
     switch (name) {
+      case 'rafters_vocabulary':
+        return this.handleVocabulary(
+          args as { category?: string; intent?: string; family?: string },
+        );
       case 'rafters_composite':
         return this.handleComposite(args);
       case 'rafters_rule':
@@ -172,6 +202,318 @@ export class RaftersToolHandler {
     }
 
     this.compositesLoaded = true;
+  }
+
+  private async handleVocabulary(args: {
+    category?: string;
+    intent?: string;
+    family?: string;
+  }): Promise<CallToolResult> {
+    const { category, intent, family } = args;
+
+    // Color families available in the system
+    const colorFamilies = [
+      'primary',
+      'secondary',
+      'tertiary',
+      'accent',
+      'destructive',
+      'success',
+      'warning',
+      'info',
+      'muted',
+      'highlight',
+      'neutral',
+    ];
+
+    // Spacing scale
+    const spacingScale = ['0', '1', '2', '3', '4', '5', '6', '8', '10', '12', '16', '20', '24'];
+
+    // Typography scale
+    const typographyScale = ['xs', 'sm', 'base', 'lg', 'xl', '2xl', '3xl', '4xl', '5xl'];
+
+    // Components available
+    const components = [
+      'accordion',
+      'alert',
+      'alert-dialog',
+      'avatar',
+      'badge',
+      'button',
+      'card',
+      'checkbox',
+      'collapsible',
+      'command',
+      'context-menu',
+      'dialog',
+      'dropdown-menu',
+      'form',
+      'hover-card',
+      'input',
+      'label',
+      'menubar',
+      'navigation-menu',
+      'popover',
+      'progress',
+      'radio-group',
+      'scroll-area',
+      'select',
+      'separator',
+      'sheet',
+      'skeleton',
+      'slider',
+      'switch',
+      'table',
+      'tabs',
+      'textarea',
+      'toast',
+      'toggle',
+      'toggle-group',
+      'tooltip',
+    ];
+
+    // Intent mappings for semantic search
+    const intentMappings: Record<string, { families?: string[]; description: string }> = {
+      warnings: { families: ['warning'], description: 'Attention-requiring states' },
+      errors: { families: ['destructive'], description: 'Error and failure states' },
+      success: { families: ['success'], description: 'Success and completion states' },
+      info: { families: ['info'], description: 'Informational messages' },
+      'text colors': { families: ['neutral', 'primary'], description: 'Text and typography' },
+      'primary actions': { families: ['primary', 'accent'], description: 'Call-to-action buttons' },
+      'destructive actions': { families: ['destructive'], description: 'Dangerous operations' },
+      danger: { families: ['destructive'], description: 'Dangerous or destructive states' },
+      muted: { families: ['muted'], description: 'De-emphasized content' },
+      highlight: { families: ['highlight'], description: 'Emphasized content' },
+    };
+
+    // No params: return compact index with suggested queries
+    if (!category && !intent && !family) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                index: {
+                  colors: colorFamilies,
+                  spacing: spacingScale,
+                  typography: typographyScale,
+                  components: components.slice(0, 10),
+                  componentCount: components.length,
+                },
+                suggestedQueries: [
+                  { intent: 'warnings', description: 'Get warning/alert colors' },
+                  { intent: 'text colors', description: 'Get text and typography colors' },
+                  { intent: 'primary actions', description: 'Get CTA button colors' },
+                  { family: 'destructive', description: 'Get destructive/error colors' },
+                  { category: 'spacing', description: 'Get spacing scale' },
+                  { category: 'component', description: 'List all components' },
+                ],
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    }
+
+    // Category filter
+    if (category) {
+      switch (category) {
+        case 'color':
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  {
+                    category: 'color',
+                    families: colorFamilies,
+                    scales: [
+                      '50',
+                      '100',
+                      '200',
+                      '300',
+                      '400',
+                      '500',
+                      '600',
+                      '700',
+                      '800',
+                      '900',
+                      '950',
+                    ],
+                    semanticRoles: ['foreground', 'background', 'border'],
+                    usage: 'Use family-scale format: primary-500, destructive-foreground',
+                  },
+                  null,
+                  2,
+                ),
+              },
+            ],
+          };
+        case 'spacing':
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  {
+                    category: 'spacing',
+                    scale: spacingScale,
+                    usage: 'Use Tailwind utilities: p-4, m-2, gap-6',
+                  },
+                  null,
+                  2,
+                ),
+              },
+            ],
+          };
+        case 'typography':
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  {
+                    category: 'typography',
+                    sizes: typographyScale,
+                    weights: ['normal', 'medium', 'semibold', 'bold'],
+                    families: ['sans', 'serif', 'mono'],
+                    usage: 'Use Tailwind utilities: text-lg, font-semibold',
+                  },
+                  null,
+                  2,
+                ),
+              },
+            ],
+          };
+        case 'component':
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({ category: 'component', components }, null, 2),
+              },
+            ],
+          };
+        default:
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  error: `Unknown category: ${category}`,
+                  available: ['color', 'spacing', 'typography', 'component'],
+                }),
+              },
+            ],
+          };
+      }
+    }
+
+    // Intent filter - semantic search
+    if (intent) {
+      const intentLower = intent.toLowerCase();
+      const matched = Object.entries(intentMappings).find(
+        ([key]) => intentLower.includes(key) || key.includes(intentLower),
+      );
+
+      if (matched) {
+        const [matchedIntent, info] = matched;
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  intent: matchedIntent,
+                  description: info.description,
+                  families: info.families,
+                  tokens: info.families?.flatMap((f) => [
+                    `${f}-500`,
+                    `${f}-foreground`,
+                    `${f}-background`,
+                  ]),
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              error: `No tokens found for intent: ${intent}`,
+              suggestedIntents: Object.keys(intentMappings),
+            }),
+          },
+        ],
+      };
+    }
+
+    // Family filter
+    if (family) {
+      const familyLower = family.toLowerCase();
+      if (colorFamilies.includes(familyLower)) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  family: familyLower,
+                  tokens: {
+                    scale: [
+                      `${familyLower}-50`,
+                      `${familyLower}-100`,
+                      `${familyLower}-200`,
+                      `${familyLower}-300`,
+                      `${familyLower}-400`,
+                      `${familyLower}-500`,
+                      `${familyLower}-600`,
+                      `${familyLower}-700`,
+                      `${familyLower}-800`,
+                      `${familyLower}-900`,
+                      `${familyLower}-950`,
+                    ],
+                    semantic: [
+                      `${familyLower}-foreground`,
+                      `${familyLower}-background`,
+                      `${familyLower}-border`,
+                    ],
+                  },
+                  usage: `Use with Tailwind: bg-${familyLower}-500, text-${familyLower}-foreground`,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              error: `Unknown color family: ${family}`,
+              available: colorFamilies,
+            }),
+          },
+        ],
+      };
+    }
+
+    return {
+      content: [{ type: 'text', text: JSON.stringify({ error: 'No valid filter provided' }) }],
+    };
   }
 
   private async handleComposite(args: Record<string, unknown>): Promise<CallToolResult> {

--- a/packages/cli/test/mcp/tools.test.ts
+++ b/packages/cli/test/mcp/tools.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, it } from 'vitest';
 import { RaftersToolHandler, TOOL_DEFINITIONS } from '../../src/mcp/tools.js';
 
 describe('TOOL_DEFINITIONS', () => {
-  it('should define 4 tools', () => {
-    expect(TOOL_DEFINITIONS).toHaveLength(4);
+  it('should define 5 tools', () => {
+    expect(TOOL_DEFINITIONS).toHaveLength(5);
   });
 
   it('should have correct tool names', () => {
     const names = TOOL_DEFINITIONS.map((t) => t.name);
+    expect(names).toContain('rafters_vocabulary');
     expect(names).toContain('rafters_composite');
     expect(names).toContain('rafters_rule');
     expect(names).toContain('rafters_pattern');
@@ -30,6 +31,75 @@ describe('TOOL_DEFINITIONS', () => {
 });
 
 describe('RaftersToolHandler', () => {
+  describe('rafters_vocabulary', () => {
+    it('should return compact index with no params', async () => {
+      const handler = new RaftersToolHandler(null);
+      const result = await handler.handleToolCall('rafters_vocabulary', {});
+
+      expect(result.content).toHaveLength(1);
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.index).toBeDefined();
+      expect(data.index.colors).toContain('primary');
+      expect(data.index.spacing).toContain('4');
+      expect(data.suggestedQueries).toBeDefined();
+    });
+
+    it('should filter by category color', async () => {
+      const handler = new RaftersToolHandler(null);
+      const result = await handler.handleToolCall('rafters_vocabulary', {
+        category: 'color',
+      });
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.category).toBe('color');
+      expect(data.families).toContain('primary');
+      expect(data.families).toContain('destructive');
+    });
+
+    it('should filter by category spacing', async () => {
+      const handler = new RaftersToolHandler(null);
+      const result = await handler.handleToolCall('rafters_vocabulary', {
+        category: 'spacing',
+      });
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.category).toBe('spacing');
+      expect(data.scale).toContain('4');
+    });
+
+    it('should filter by intent', async () => {
+      const handler = new RaftersToolHandler(null);
+      const result = await handler.handleToolCall('rafters_vocabulary', {
+        intent: 'warnings',
+      });
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.families).toContain('warning');
+    });
+
+    it('should filter by family', async () => {
+      const handler = new RaftersToolHandler(null);
+      const result = await handler.handleToolCall('rafters_vocabulary', {
+        family: 'destructive',
+      });
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.family).toBe('destructive');
+      expect(data.tokens.scale).toContain('destructive-500');
+    });
+
+    it('should return error for unknown family', async () => {
+      const handler = new RaftersToolHandler(null);
+      const result = await handler.handleToolCall('rafters_vocabulary', {
+        family: 'nonexistent',
+      });
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.error).toBeDefined();
+      expect(data.available).toContain('primary');
+    });
+  });
+
   describe('rafters_pattern', () => {
     it('should return patterns from composites with usagePatterns', async () => {
       const handler = new RaftersToolHandler(null);


### PR DESCRIPTION
## Summary

- Adds `rafters_vocabulary` as the first MCP tool (before composite, rule, pattern, component)
- Supports three filter modes: `category`, `intent`, `family`
- Empty call returns compact index with suggested queries instead of dumping everything
- Addresses agent feedback that vocabulary was a firehose

## Filter modes

| Filter | Example | Returns |
|--------|---------|---------|
| `category: "color"` | Color families and scales | |
| `category: "spacing"` | Spacing scale values | |
| `category: "typography"` | Type sizes, weights, families | |
| `category: "component"` | Full component list | |
| `intent: "warnings"` | Warning family tokens | |
| `intent: "text colors"` | Neutral/primary tokens for text | |
| `intent: "primary actions"` | CTA button colors | |
| `family: "destructive"` | All destructive scale + semantic tokens | |

## Test plan

- [x] Unit tests for all filter modes
- [x] Unit test for empty call (compact index)
- [x] Unit test for unknown family error
- [x] Preflight passing

Closes #1250

Generated with [Claude Code](https://claude.ai/code)