### PR TITLE
feat(onboard): generic CSS importer for static color collections

### DIFF
--- a/packages/cli/src/onboard/importers/generic-css.ts
+++ b/packages/cli/src/onboard/importers/generic-css.ts
@@ -244,8 +244,35 @@ export const genericCSSImporter: Importer = {
           skipped: 0,
         };
       }
-      const content = await readFile(sourcePath, 'utf-8');
-      parsed = parseCSSFile(content);
+
+      let content: string;
+      try {
+        content = await readFile(sourcePath, 'utf-8');
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          tokens: [],
+          warnings: [{ level: 'error', message: `Failed to read CSS file: ${message}` }],
+          source: 'generic-css',
+          variablesProcessed: 0,
+          tokensCreated: 0,
+          skipped: 0,
+        };
+      }
+
+      try {
+        parsed = parseCSSFile(content);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          tokens: [],
+          warnings: [{ level: 'error', message: `Failed to parse CSS: ${message}` }],
+          source: 'generic-css',
+          variablesProcessed: 0,
+          tokensCreated: 0,
+          skipped: 0,
+        };
+      }
     }
 
     // Track seen token names to avoid duplicates (prefer light mode)

--- a/packages/cli/src/onboard/importers/generic-css.ts
+++ b/packages/cli/src/onboard/importers/generic-css.ts
@@ -1,0 +1,282 @@
+/**
+ * Generic CSS Importer
+ *
+ * Fallback importer for CSS files with custom properties that don't match
+ * specific frameworks like shadcn. Imports any CSS custom properties as tokens.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+import type { Token } from '@rafters/shared';
+import { type CSSVariable, parseCSSFile } from '../css-parser.js';
+import type { Importer, ImporterDetection, ImportResult, ImportWarning } from './types.js';
+
+// Common CSS file locations to scan
+const CSS_PATHS = [
+  'styles/variables.css',
+  'css/variables.css',
+  'src/styles/variables.css',
+  'src/css/variables.css',
+  'styles/tokens.css',
+  'css/tokens.css',
+  'src/styles/tokens.css',
+  'src/css/tokens.css',
+  'styles/colors.css',
+  'css/colors.css',
+  'app/globals.css',
+  'src/app/globals.css',
+  'styles/globals.css',
+  'src/styles/globals.css',
+  'src/index.css',
+  'index.css',
+];
+
+// Minimum variables needed for import
+const MIN_VARIABLES = 3;
+
+/**
+ * Infer token category from variable name
+ */
+function inferCategory(name: string): string {
+  const n = name.toLowerCase();
+
+  // Radius patterns (check before color since 'border-radius' contains 'border')
+  if (n.includes('radius') || n.includes('rounded')) {
+    return 'radius';
+  }
+
+  // Shadow patterns (check before color)
+  if (n.includes('shadow') || n.includes('elevation')) {
+    return 'shadow';
+  }
+
+  // Color patterns
+  if (
+    n.includes('color') ||
+    n.includes('bg') ||
+    n.includes('background') ||
+    n.includes('foreground') ||
+    n.includes('text') ||
+    n.includes('border') ||
+    n.includes('primary') ||
+    n.includes('secondary') ||
+    n.includes('accent') ||
+    n.includes('muted') ||
+    n.includes('destructive') ||
+    n.includes('success') ||
+    n.includes('warning') ||
+    n.includes('error') ||
+    n.includes('info')
+  ) {
+    return 'color';
+  }
+
+  // Spacing patterns
+  if (
+    n.includes('space') ||
+    n.includes('spacing') ||
+    n.includes('gap') ||
+    n.includes('margin') ||
+    n.includes('padding')
+  ) {
+    return 'spacing';
+  }
+
+  // Typography patterns
+  if (n.includes('font') || n.includes('line-height') || n.includes('letter-spacing')) {
+    return 'typography';
+  }
+
+  // Animation/motion patterns
+  if (
+    n.includes('duration') ||
+    n.includes('delay') ||
+    n.includes('ease') ||
+    n.includes('transition') ||
+    n.includes('animation')
+  ) {
+    return 'motion';
+  }
+
+  // Z-index patterns
+  if (n.includes('z-index') || n.includes('zindex') || n.includes('layer')) {
+    return 'z-index';
+  }
+
+  return 'misc';
+}
+
+/**
+ * Infer namespace from category
+ */
+function inferNamespace(category: string): string {
+  switch (category) {
+    case 'color':
+      return 'color';
+    case 'spacing':
+      return 'spacing';
+    case 'typography':
+      return 'typography';
+    case 'radius':
+      return 'radius';
+    case 'shadow':
+      return 'shadow';
+    case 'motion':
+      return 'motion';
+    case 'z-index':
+      return 'layout';
+    default:
+      return 'misc';
+  }
+}
+
+/**
+ * Normalize variable name to token name
+ * Removes -- prefix and converts to kebab-case
+ */
+function normalizeTokenName(varName: string): string {
+  return varName.replace(/^--/, '');
+}
+
+/**
+ * Convert a CSS variable to a Rafters token
+ */
+function variableToToken(
+  variable: CSSVariable,
+  isDarkVariant: boolean,
+): { token: Token; warning?: ImportWarning } {
+  const baseName = normalizeTokenName(variable.name);
+  const tokenName = isDarkVariant ? `${baseName}-dark` : baseName;
+  const category = inferCategory(baseName);
+  const namespace = inferNamespace(category);
+
+  const token: Token = {
+    name: tokenName,
+    value: variable.value,
+    category,
+    namespace,
+    userOverride: null,
+    semanticMeaning: `Imported from CSS variable ${variable.name}`,
+    usageContext: isDarkVariant ? ['dark mode'] : ['light mode', 'default'],
+    containerQueryAware: true,
+  };
+
+  return { token };
+}
+
+export const genericCSSImporter: Importer = {
+  metadata: {
+    id: 'generic-css',
+    name: 'Generic CSS',
+    description: 'Import design tokens from CSS custom properties',
+    filePatterns: ['*.css'],
+    priority: 10, // Low priority - fallback importer
+  },
+
+  async detect(projectPath: string): Promise<ImporterDetection> {
+    const detection: ImporterDetection = {
+      canImport: false,
+      confidence: 0,
+      detectedBy: [],
+      sourcePaths: [],
+    };
+
+    // Try each potential CSS file location
+    for (const cssPath of CSS_PATHS) {
+      const fullPath = join(projectPath, cssPath);
+      try {
+        const content = await readFile(fullPath, 'utf-8');
+        const parsed = parseCSSFile(content);
+
+        // Skip if this looks like shadcn (let shadcn importer handle it)
+        if (parsed.sourceType === 'shadcn') {
+          continue;
+        }
+
+        // Need minimum number of variables
+        if (parsed.variables.length >= MIN_VARIABLES) {
+          detection.canImport = true;
+          // Lower confidence than shadcn since this is a fallback
+          detection.confidence = 0.5 + Math.min(parsed.variables.length / 100, 0.3);
+          detection.detectedBy.push(
+            `${parsed.variables.length} CSS variables in ${basename(cssPath)}`,
+          );
+          detection.sourcePaths.push(fullPath);
+          detection.context = { parsed };
+          return detection;
+        }
+      } catch (err) {
+        // Only skip for "file not found" errors
+        if (
+          err instanceof Error &&
+          'code' in err &&
+          (err.code === 'ENOENT' || err.code === 'ENOTDIR')
+        ) {
+          continue;
+        }
+        throw err;
+      }
+    }
+
+    return detection;
+  },
+
+  async import(_projectPath: string, detection: ImporterDetection): Promise<ImportResult> {
+    const tokens: Token[] = [];
+    const warnings: ImportWarning[] = [];
+    let variablesProcessed = 0;
+    let skipped = 0;
+
+    // Use cached parsed result if available
+    let parsed: ReturnType<typeof parseCSSFile>;
+
+    if (detection.context?.parsed) {
+      parsed = detection.context.parsed as ReturnType<typeof parseCSSFile>;
+    } else {
+      const sourcePath = detection.sourcePaths[0];
+      if (!sourcePath) {
+        return {
+          tokens: [],
+          warnings: [{ level: 'error', message: 'No source path found' }],
+          source: 'generic-css',
+          variablesProcessed: 0,
+          tokensCreated: 0,
+          skipped: 0,
+        };
+      }
+      const content = await readFile(sourcePath, 'utf-8');
+      parsed = parseCSSFile(content);
+    }
+
+    // Track seen token names to avoid duplicates (prefer light mode)
+    const seenNames = new Set<string>();
+
+    for (const variable of parsed.variables) {
+      variablesProcessed++;
+
+      const isDark = variable.context === 'dark' || variable.context === 'media';
+      const result = variableToToken(variable, isDark);
+
+      // Skip duplicates
+      if (seenNames.has(result.token.name)) {
+        skipped++;
+        continue;
+      }
+      seenNames.add(result.token.name);
+
+      tokens.push(result.token);
+      if (result.warning) {
+        warnings.push(result.warning);
+      }
+    }
+
+    return {
+      tokens,
+      warnings,
+      source: 'generic-css',
+      variablesProcessed,
+      tokensCreated: tokens.length,
+      skipped,
+    };
+  },
+};

--- a/packages/cli/src/onboard/importers/shadcn.ts
+++ b/packages/cli/src/onboard/importers/shadcn.ts
@@ -284,8 +284,35 @@ export const shadcnImporter: Importer = {
           skipped: 0,
         };
       }
-      const content = await readFile(sourcePath, 'utf-8');
-      parsed = parseCSSFile(content);
+
+      let content: string;
+      try {
+        content = await readFile(sourcePath, 'utf-8');
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          tokens: [],
+          warnings: [{ level: 'error', message: `Failed to read CSS file: ${message}` }],
+          source: 'shadcn',
+          variablesProcessed: 0,
+          tokensCreated: 0,
+          skipped: 0,
+        };
+      }
+
+      try {
+        parsed = parseCSSFile(content);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          tokens: [],
+          warnings: [{ level: 'error', message: `Failed to parse CSS: ${message}` }],
+          source: 'shadcn',
+          variablesProcessed: 0,
+          tokensCreated: 0,
+          skipped: 0,
+        };
+      }
     }
 
     for (const variable of parsed.variables) {

--- a/packages/cli/test/onboard/importers/generic-css.test.ts
+++ b/packages/cli/test/onboard/importers/generic-css.test.ts
@@ -1,0 +1,327 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { genericCSSImporter } from '../../../src/onboard/importers/generic-css.js';
+
+// Sample generic CSS with various variable types
+const GENERIC_CSS = `:root {
+  --brand-primary: #3b82f6;
+  --brand-secondary: #10b981;
+  --text-color: #1f2937;
+  --background-color: #ffffff;
+  --spacing-sm: 0.5rem;
+  --spacing-md: 1rem;
+  --spacing-lg: 2rem;
+  --font-size-base: 16px;
+  --border-radius: 4px;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.1);
+  --transition-duration: 200ms;
+}
+
+.dark {
+  --text-color: #f9fafb;
+  --background-color: #111827;
+}
+`;
+
+// Minimal CSS with just a few variables
+const MINIMAL_CSS = `:root {
+  --color-1: red;
+  --color-2: blue;
+  --color-3: green;
+}`;
+
+// CSS that looks like shadcn (should be skipped)
+const SHADCN_CSS = `:root {
+  --background: 0 0% 100%;
+  --foreground: 222 84% 5%;
+  --primary: 222 47% 11%;
+  --secondary: 210 40% 96%;
+  --muted: 210 40% 96%;
+}`;
+
+// CSS with only 2 variables (below threshold)
+const INSUFFICIENT_CSS = `:root {
+  --one: red;
+  --two: blue;
+}`;
+
+describe('Generic CSS Importer', () => {
+  const testDir = join(process.cwd(), '.test-generic-css-importer');
+
+  beforeEach(async () => {
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('metadata', () => {
+    it('has correct id and low priority', () => {
+      expect(genericCSSImporter.metadata.id).toBe('generic-css');
+      expect(genericCSSImporter.metadata.priority).toBe(10);
+    });
+
+    it('is a fallback importer', () => {
+      // Priority 10 is lower than shadcn (80)
+      expect(genericCSSImporter.metadata.priority).toBeLessThan(80);
+    });
+  });
+
+  describe('detect', () => {
+    it('detects CSS files with variables', async () => {
+      const stylesDir = join(testDir, 'styles');
+      await mkdir(stylesDir, { recursive: true });
+      await writeFile(join(stylesDir, 'variables.css'), GENERIC_CSS);
+
+      const detection = await genericCSSImporter.detect(testDir);
+
+      expect(detection.canImport).toBe(true);
+      expect(detection.confidence).toBeGreaterThan(0.5);
+      expect(detection.sourcePaths).toHaveLength(1);
+    });
+
+    it('skips shadcn-style CSS', async () => {
+      const appDir = join(testDir, 'app');
+      await mkdir(appDir, { recursive: true });
+      await writeFile(join(appDir, 'globals.css'), SHADCN_CSS);
+
+      const detection = await genericCSSImporter.detect(testDir);
+
+      // Should not detect shadcn CSS - let shadcn importer handle it
+      expect(detection.canImport).toBe(false);
+    });
+
+    it('requires minimum number of variables', async () => {
+      const stylesDir = join(testDir, 'styles');
+      await mkdir(stylesDir, { recursive: true });
+      await writeFile(join(stylesDir, 'variables.css'), INSUFFICIENT_CSS);
+
+      const detection = await genericCSSImporter.detect(testDir);
+
+      expect(detection.canImport).toBe(false);
+    });
+
+    it('returns false when no CSS files exist', async () => {
+      const detection = await genericCSSImporter.detect(testDir);
+
+      expect(detection.canImport).toBe(false);
+      expect(detection.confidence).toBe(0);
+    });
+
+    it('increases confidence with more variables', async () => {
+      const stylesDir = join(testDir, 'styles');
+      await mkdir(stylesDir, { recursive: true });
+
+      // Create CSS with many variables
+      const manyVars = `:root {\n${Array.from({ length: 50 }, (_, i) => `  --var-${i}: value;`).join('\n')}\n}`;
+      await writeFile(join(stylesDir, 'variables.css'), manyVars);
+
+      const detection = await genericCSSImporter.detect(testDir);
+
+      expect(detection.canImport).toBe(true);
+      expect(detection.confidence).toBeGreaterThan(0.7);
+    });
+  });
+
+  describe('import', () => {
+    it('imports tokens from CSS variables', async () => {
+      const stylesDir = join(testDir, 'styles');
+      await mkdir(stylesDir, { recursive: true });
+      await writeFile(join(stylesDir, 'variables.css'), GENERIC_CSS);
+
+      const detection = await genericCSSImporter.detect(testDir);
+      const result = await genericCSSImporter.import(testDir, detection);
+
+      expect(result.source).toBe('generic-css');
+      expect(result.tokens.length).toBeGreaterThan(0);
+      expect(result.tokensCreated).toBe(result.tokens.length);
+    });
+
+    it('infers color category for color-related variables', async () => {
+      const stylesDir = join(testDir, 'styles');
+      await mkdir(stylesDir, { recursive: true });
+      await writeFile(join(stylesDir, 'variables.css'), GENERIC_CSS);
+
+      const detection = await genericCSSImporter.detect(testDir);
+      const result = await genericCSSImporter.import(testDir, detection);
+
+      const brandPrimary = result.tokens.find((t) => t.name === 'brand-primary');
+      expect(brandPrimary).toBeDefined();
+      expect(brandPrimary?.category).toBe('color');
+      expect(brandPrimary?.namespace).toBe('color');
+    });
+
+    it('infers spacing category for spacing variables', async () => {
+      const stylesDir = join(testDir, 'styles');
+      await mkdir(stylesDir, { recursive: true });
+      await writeFile(join(stylesDir, 'variables.css'), GENERIC_CSS);
+
+      const detection = await genericCSSImporter.detect(testDir);
+      const result = await genericCSSImporter.import(testDir, detection);
+
+      const spacingMd = result.tokens.find((t) => t.name === 'spacing-md');
+      expect(spacingMd).toBeDefined();
+      expect(spacingMd?.category).toBe('spacing');
+      expect(spacingMd?.namespace).toBe('spacing');
+    });
+
+    it('infers radius category for border-radius variables', async () => {
+      const stylesDir = join(testDir, 'styles');
+      await mkdir(stylesDir, { recursive: true });
+      await writeFile(join(stylesDir, 'variables.css'), GENERIC_CSS);
+
+      const detection = await genericCSSImporter.detect(testDir);
+      const result = await genericCSSImporter.import(testDir, detection);
+
+      const radius = result.tokens.find((t) => t.name === 'border-radius');
+      expect(radius).toBeDefined();
+      expect(radius?.category).toBe('radius');
+    });
+
+    it('infers motion category for duration variables', async () => {
+      const stylesDir = join(testDir, 'styles');
+      await mkdir(stylesDir, { recursive: true });
+      await writeFile(join(stylesDir, 'variables.css'), GENERIC_CSS);
+
+      const detection = await genericCSSImporter.detect(testDir);
+      const result = await genericCSSImporter.import(testDir, detection);
+
+      const duration = result.tokens.find((t) => t.name === 'transition-duration');
+      expect(duration).toBeDefined();
+      expect(duration?.category).toBe('motion');
+    });
+
+    it('creates dark mode variants with -dark suffix', async () => {
+      const stylesDir = join(testDir, 'styles');
+      await mkdir(stylesDir, { recursive: true });
+      await writeFile(join(stylesDir, 'variables.css'), GENERIC_CSS);
+
+      const detection = await genericCSSImporter.detect(testDir);
+      const result = await genericCSSImporter.import(testDir, detection);
+
+      const darkTokens = result.tokens.filter((t) => t.name.endsWith('-dark'));
+      expect(darkTokens.length).toBeGreaterThan(0);
+
+      const darkBg = result.tokens.find((t) => t.name === 'background-color-dark');
+      expect(darkBg).toBeDefined();
+      expect(darkBg?.usageContext).toContain('dark mode');
+    });
+
+    it('sets userOverride to null on all tokens', async () => {
+      const stylesDir = join(testDir, 'styles');
+      await mkdir(stylesDir, { recursive: true });
+      await writeFile(join(stylesDir, 'variables.css'), MINIMAL_CSS);
+
+      const detection = await genericCSSImporter.detect(testDir);
+      const result = await genericCSSImporter.import(testDir, detection);
+
+      for (const token of result.tokens) {
+        expect(token.userOverride).toBeNull();
+      }
+    });
+
+    it('preserves original CSS values', async () => {
+      const stylesDir = join(testDir, 'styles');
+      await mkdir(stylesDir, { recursive: true });
+      await writeFile(join(stylesDir, 'variables.css'), GENERIC_CSS);
+
+      const detection = await genericCSSImporter.detect(testDir);
+      const result = await genericCSSImporter.import(testDir, detection);
+
+      const brandPrimary = result.tokens.find((t) => t.name === 'brand-primary');
+      expect(brandPrimary?.value).toBe('#3b82f6');
+    });
+
+    it('creates separate light and dark mode tokens', async () => {
+      const stylesDir = join(testDir, 'styles');
+      await mkdir(stylesDir, { recursive: true });
+      // CSS with same variable in both :root and .dark
+      const cssWithModes = `:root {
+  --color-primary: red;
+  --color-secondary: blue;
+  --color-accent: green;
+}
+.dark {
+  --color-primary: darkred;
+  --color-secondary: darkblue;
+  --color-accent: darkgreen;
+}`;
+      await writeFile(join(stylesDir, 'variables.css'), cssWithModes);
+
+      const detection = await genericCSSImporter.detect(testDir);
+      const result = await genericCSSImporter.import(testDir, detection);
+
+      // Should have both light and dark variants
+      const primaryLight = result.tokens.find((t) => t.name === 'color-primary');
+      const primaryDark = result.tokens.find((t) => t.name === 'color-primary-dark');
+      expect(primaryLight).toBeDefined();
+      expect(primaryDark).toBeDefined();
+      expect(primaryLight?.value).toBe('red');
+      expect(primaryDark?.value).toBe('darkred');
+    });
+  });
+
+  describe('category inference', () => {
+    it('categorizes background as color', async () => {
+      const stylesDir = join(testDir, 'styles');
+      await mkdir(stylesDir, { recursive: true });
+      await writeFile(
+        join(stylesDir, 'variables.css'),
+        `:root {
+  --bg-primary: white;
+  --bg-secondary: gray;
+  --background-main: blue;
+}`,
+      );
+
+      const detection = await genericCSSImporter.detect(testDir);
+      const result = await genericCSSImporter.import(testDir, detection);
+
+      for (const token of result.tokens) {
+        expect(token.category).toBe('color');
+      }
+    });
+
+    it('categorizes shadow as shadow', async () => {
+      const stylesDir = join(testDir, 'styles');
+      await mkdir(stylesDir, { recursive: true });
+      await writeFile(
+        join(stylesDir, 'variables.css'),
+        `:root {
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.1);
+  --elevation-1: 0 2px 4px rgba(0,0,0,0.1);
+  --box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+}`,
+      );
+
+      const detection = await genericCSSImporter.detect(testDir);
+      const result = await genericCSSImporter.import(testDir, detection);
+
+      for (const token of result.tokens) {
+        expect(token.category).toBe('shadow');
+      }
+    });
+
+    it('uses misc for unrecognized patterns', async () => {
+      const stylesDir = join(testDir, 'styles');
+      await mkdir(stylesDir, { recursive: true });
+      await writeFile(
+        join(stylesDir, 'variables.css'),
+        `:root {
+  --custom-thing: value;
+  --my-var: 123;
+  --foo-bar: baz;
+}`,
+      );
+
+      const detection = await genericCSSImporter.detect(testDir);
+      const result = await genericCSSImporter.import(testDir, detection);
+
+      for (const token of result.tokens) {
+        expect(token.category).toBe('misc');
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fallback importer for CSS files with custom properties that don't match specific frameworks like shadcn.

- Low priority (10) so framework-specific importers take precedence
- Infers category from variable names (color, spacing, radius, motion, etc.)
- Creates dark mode variants with -dark suffix
- Skips shadcn-style CSS to avoid conflicts

## Test plan

- [x] 19 tests covering detection, import, and category inference
- [x] Preflight passes

Closes #1258

Generated with [Claude Code](https://claude.com/claude-code)