### PR TITLE
feat(onboard): orchestrator coordinates import pipeline with MCP tool (#1270)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Minor Changes
+
+- feat(onboard): orchestrator coordinates the import pipeline. `onboard()` detects the best importer (shadcn or generic-css), checks confidence thresholds, and runs the import. `previewOnboard()` returns all compatible importers sorted by confidence for analysis without importing. New MCP tool `rafters_onboard` exposes this to agents: `action: "analyze"` previews what would be imported, `action: "import"` runs the import. Forceimporter option allows bypassing auto-detection. Closes #1270.
+
 ### Patch Changes
 
 - fix(mcp): `rafters_pattern` no longer returns hardcoded patterns. Now queries composites by their `solves` and `appliesWhen` fields. Patterns are design intelligence captured in composite manifests, not static data in the MCP server. Search by what the pattern solves (e.g., "hierarchy", "authentication") or use `query` for fuzzy search. Closes #1280.

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -1,12 +1,13 @@
 /**
  * MCP Tools for Rafters Design System
  *
- * 4 focused tools for agent composition:
+ * 5 focused tools for agent composition:
  *
  * 1. rafters_composite - Query composites with designer intent
  * 2. rafters_rule - Query or create validation rules
  * 3. rafters_pattern - Design pattern guidance (do/never)
  * 4. rafters_component - Component intelligence
+ * 5. rafters_onboard - Import design tokens from CSS files
  */
 
 import { readdir } from 'node:fs/promises';
@@ -21,6 +22,7 @@ import {
   registerComposite,
   searchComposites,
 } from '@rafters/composites';
+import { onboard, previewOnboard } from '../onboard/orchestrator.js';
 import { registryClient } from '../registry/client.js';
 import { getRaftersPaths } from '../utils/paths.js';
 
@@ -98,6 +100,31 @@ export const TOOL_DEFINITIONS = [
       required: ['name'],
     },
   },
+  {
+    name: 'rafters_onboard',
+    description:
+      'Import design tokens from existing CSS files (shadcn, generic CSS custom properties). Detects source format, converts to Rafters tokens, and returns them for review.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        action: {
+          type: 'string',
+          enum: ['analyze', 'import'],
+          description:
+            'analyze: preview what would be imported. import: run the import and return tokens.',
+        },
+        path: {
+          type: 'string',
+          description: 'Project path to analyze/import from. Defaults to current directory.',
+        },
+        importer: {
+          type: 'string',
+          description: 'Force a specific importer (shadcn, generic-css). Auto-detects if omitted.',
+        },
+      },
+      required: ['action'],
+    },
+  },
 ] as const;
 
 // ==================== Tool Handler ====================
@@ -120,6 +147,8 @@ export class RaftersToolHandler {
         return this.handlePattern(args as { solves?: string; query?: string });
       case 'rafters_component':
         return this.handleComponent(args.name as string);
+      case 'rafters_onboard':
+        return this.handleOnboard(args as { action: string; path?: string; importer?: string });
       default:
         return {
           content: [{ type: 'text', text: JSON.stringify({ error: `Unknown tool: ${name}` }) }],
@@ -346,6 +375,127 @@ export class RaftersToolHandler {
           {
             type: 'text',
             text: JSON.stringify({ error: message }),
+          },
+        ],
+      };
+    }
+  }
+
+  private async handleOnboard(args: {
+    action: string;
+    path?: string;
+    importer?: string;
+  }): Promise<CallToolResult> {
+    const { action, path, importer } = args;
+    const projectPath = path ?? this.projectRoot ?? process.cwd();
+
+    try {
+      if (action === 'analyze') {
+        // Preview what would be imported
+        const results = await previewOnboard(projectPath);
+
+        if (results.length === 0) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  status: 'no_source_detected',
+                  message: 'No compatible design token source found',
+                  suggestion:
+                    'Ensure project has CSS files with custom properties (shadcn globals.css or variables.css)',
+                }),
+              },
+            ],
+          };
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  status: 'ready',
+                  detectedSources: results,
+                  recommendation: results[0],
+                  nextStep: `Call rafters_onboard with action: "import" to import ${results[0]?.importer} tokens`,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      }
+
+      if (action === 'import') {
+        // Run the import
+        const result = await onboard(projectPath, importer ? { forceImporter: importer } : {});
+
+        if (!result.success) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  status: 'failed',
+                  source: result.source,
+                  warnings: result.warnings,
+                }),
+              },
+            ],
+          };
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  status: 'success',
+                  source: result.source,
+                  confidence: result.confidence,
+                  sourcePaths: result.sourcePaths,
+                  stats: result.stats,
+                  tokens: result.tokens,
+                  warnings: result.warnings.length > 0 ? result.warnings : undefined,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              error: `Unknown action: ${action}`,
+              validActions: ['analyze', 'import'],
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      // Log full error for debugging
+      if (process.env.DEBUG || process.env.RAFTERS_DEBUG) {
+        console.error(`[rafters_onboard] ${action} failed for ${projectPath}:`, err);
+      }
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              error: message,
+              action,
+              path: projectPath,
+            }),
           },
         ],
       };

--- a/packages/cli/src/onboard/orchestrator.ts
+++ b/packages/cli/src/onboard/orchestrator.ts
@@ -1,0 +1,204 @@
+/**
+ * Onboarding Orchestrator
+ *
+ * Coordinates the import process: detect source, run importer, output tokens.
+ * This is the main entry point for the onboarding system.
+ */
+
+import type { Token } from '@rafters/shared';
+import { genericCSSImporter } from './importers/generic-css.js';
+import {
+  detectAllImporters,
+  findBestImporter,
+  type ImporterDetection,
+  type ImportResult,
+  registerImporter,
+} from './importers/index.js';
+import { shadcnImporter } from './importers/shadcn.js';
+
+// Register built-in importers on module load
+let importersRegistered = false;
+
+function ensureImportersRegistered(): void {
+  if (importersRegistered) return;
+  registerImporter(shadcnImporter);
+  registerImporter(genericCSSImporter);
+  importersRegistered = true;
+}
+
+/**
+ * Result of running the orchestrator
+ */
+export interface OnboardResult {
+  /** Whether the onboarding succeeded */
+  success: boolean;
+  /** Imported tokens (empty if failed) */
+  tokens: Token[];
+  /** Which importer was used */
+  source: string | null;
+  /** Detection confidence (0-1) */
+  confidence: number;
+  /** What triggered detection */
+  detectedBy: string[];
+  /** Source file paths */
+  sourcePaths: string[];
+  /** Warnings and errors from the import process */
+  warnings: ImportResult['warnings'];
+  /** Statistics */
+  stats: {
+    variablesProcessed: number;
+    tokensCreated: number;
+    skipped: number;
+  };
+}
+
+/**
+ * Options for the onboard function
+ */
+export interface OnboardOptions {
+  /** Force a specific importer by ID */
+  forceImporter?: string;
+  /** Minimum confidence threshold (0-1) */
+  minConfidence?: number;
+}
+
+/**
+ * Onboard a project by detecting and importing design tokens
+ *
+ * @param projectPath - Path to the project root
+ * @param options - Optional configuration
+ * @returns Onboard result with tokens and metadata
+ */
+export async function onboard(
+  projectPath: string,
+  options: OnboardOptions = {},
+): Promise<OnboardResult> {
+  ensureImportersRegistered();
+
+  const { forceImporter, minConfidence = 0 } = options;
+
+  // Find the best importer
+  let match:
+    | {
+        importer: { metadata: { id: string }; import: typeof shadcnImporter.import };
+        detection: ImporterDetection;
+      }
+    | undefined;
+
+  if (forceImporter) {
+    // Force a specific importer
+    const allMatches = await detectAllImporters(projectPath);
+    match = allMatches.find((m) => m.importer.metadata.id === forceImporter);
+
+    if (!match) {
+      return {
+        success: false,
+        tokens: [],
+        source: null,
+        confidence: 0,
+        detectedBy: [],
+        sourcePaths: [],
+        warnings: [
+          {
+            level: 'error',
+            message: `Importer "${forceImporter}" not found or cannot handle this project`,
+          },
+        ],
+        stats: { variablesProcessed: 0, tokensCreated: 0, skipped: 0 },
+      };
+    }
+  } else {
+    // Auto-detect the best importer
+    match = await findBestImporter(projectPath);
+
+    if (!match) {
+      return {
+        success: false,
+        tokens: [],
+        source: null,
+        confidence: 0,
+        detectedBy: [],
+        sourcePaths: [],
+        warnings: [
+          {
+            level: 'error',
+            message: 'No compatible design token source detected',
+            suggestion: 'Ensure your project has CSS files with custom properties',
+          },
+        ],
+        stats: { variablesProcessed: 0, tokensCreated: 0, skipped: 0 },
+      };
+    }
+  }
+
+  // Check confidence threshold
+  if (match.detection.confidence < minConfidence) {
+    return {
+      success: false,
+      tokens: [],
+      source: match.importer.metadata.id,
+      confidence: match.detection.confidence,
+      detectedBy: match.detection.detectedBy,
+      sourcePaths: match.detection.sourcePaths,
+      warnings: [
+        {
+          level: 'error',
+          message: `Detection confidence ${(match.detection.confidence * 100).toFixed(0)}% is below threshold ${(minConfidence * 100).toFixed(0)}%`,
+        },
+      ],
+      stats: { variablesProcessed: 0, tokensCreated: 0, skipped: 0 },
+    };
+  }
+
+  // Run the import
+  const result = await match.importer.import(projectPath, match.detection);
+
+  // Check for import errors
+  const hasErrors = result.warnings.some((w) => w.level === 'error');
+
+  return {
+    success: !hasErrors && result.tokens.length > 0,
+    tokens: result.tokens,
+    source: result.source,
+    confidence: match.detection.confidence,
+    detectedBy: match.detection.detectedBy,
+    sourcePaths: match.detection.sourcePaths,
+    warnings: result.warnings,
+    stats: {
+      variablesProcessed: result.variablesProcessed,
+      tokensCreated: result.tokensCreated,
+      skipped: result.skipped,
+    },
+  };
+}
+
+/**
+ * Preview what would be imported without actually importing
+ *
+ * @param projectPath - Path to the project root
+ * @returns Detection results for all compatible importers
+ */
+export async function previewOnboard(projectPath: string): Promise<
+  Array<{
+    importer: string;
+    name: string;
+    confidence: number;
+    detectedBy: string[];
+    sourcePaths: string[];
+  }>
+> {
+  ensureImportersRegistered();
+
+  const matches = await detectAllImporters(projectPath);
+
+  return matches.map((m) => ({
+    importer: m.importer.metadata.id,
+    name: m.importer.metadata.name,
+    confidence: m.detection.confidence,
+    detectedBy: m.detection.detectedBy,
+    sourcePaths: m.detection.sourcePaths,
+  }));
+}
+
+// Re-export for convenience
+export { registerImporter } from './importers/index.js';

--- a/packages/cli/test/mcp/tools.test.ts
+++ b/packages/cli/test/mcp/tools.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { RaftersToolHandler, TOOL_DEFINITIONS } from '../../src/mcp/tools.js';
 
 describe('TOOL_DEFINITIONS', () => {
-  it('should define 4 tools', () => {
-    expect(TOOL_DEFINITIONS).toHaveLength(4);
+  it('should define 5 tools', () => {
+    expect(TOOL_DEFINITIONS).toHaveLength(5);
   });
 
   it('should have correct tool names', () => {
@@ -12,6 +12,7 @@ describe('TOOL_DEFINITIONS', () => {
     expect(names).toContain('rafters_rule');
     expect(names).toContain('rafters_pattern');
     expect(names).toContain('rafters_component');
+    expect(names).toContain('rafters_onboard');
   });
 
   it('should have descriptions for all tools', () => {
@@ -94,6 +95,36 @@ describe('RaftersToolHandler', () => {
       const data = JSON.parse(result.content[0].text as string);
       expect(data.composites).toBeDefined();
       expect(Array.isArray(data.composites)).toBe(true);
+    });
+  });
+
+  describe('rafters_onboard', () => {
+    it('should return no_source_detected for analyze on empty directory', async () => {
+      const { mkdtemp, rm } = await import('node:fs/promises');
+      const { join } = await import('node:path');
+      const testDir = await mkdtemp(join(process.cwd(), '.test-mcp-onboard-'));
+      try {
+        const handler = new RaftersToolHandler(null);
+        const result = await handler.handleToolCall('rafters_onboard', {
+          action: 'analyze',
+          path: testDir,
+        });
+
+        const data = JSON.parse(result.content[0].text as string);
+        expect(data.status).toBe('no_source_detected');
+      } finally {
+        await rm(testDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should return error for unknown action', async () => {
+      const handler = new RaftersToolHandler(null);
+      const result = await handler.handleToolCall('rafters_onboard', {
+        action: 'unknown',
+      });
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.error).toContain('Unknown action');
     });
   });
 

--- a/packages/cli/test/onboard/orchestrator.test.ts
+++ b/packages/cli/test/onboard/orchestrator.test.ts
@@ -1,0 +1,209 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { onboard, previewOnboard } from '../../src/onboard/orchestrator.js';
+
+// Sample shadcn CSS
+const SHADCN_CSS = `:root {
+  --background: 0 0% 100%;
+  --foreground: 222 84% 5%;
+  --primary: 222 47% 11%;
+  --secondary: 210 40% 96%;
+  --muted: 210 40% 96%;
+  --radius: 0.5rem;
+}
+
+.dark {
+  --background: 222 84% 5%;
+  --foreground: 0 0% 100%;
+}`;
+
+// Sample generic CSS
+const GENERIC_CSS = `:root {
+  --brand-primary: #3b82f6;
+  --brand-secondary: #10b981;
+  --text-color: #1f2937;
+  --spacing-sm: 0.5rem;
+}`;
+
+// Empty CSS
+const EMPTY_CSS = `body { margin: 0; }`;
+
+describe('Orchestrator', () => {
+  const testDir = join(process.cwd(), '.test-orchestrator');
+
+  beforeEach(async () => {
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('onboard', () => {
+    it('imports tokens from shadcn project', async () => {
+      const appDir = join(testDir, 'app');
+      await mkdir(appDir, { recursive: true });
+      await writeFile(join(appDir, 'globals.css'), SHADCN_CSS);
+
+      const result = await onboard(testDir);
+
+      expect(result.success).toBe(true);
+      expect(result.source).toBe('shadcn');
+      expect(result.tokens.length).toBeGreaterThan(0);
+      expect(result.confidence).toBeGreaterThan(0.7);
+    });
+
+    it('imports tokens from generic CSS project', async () => {
+      const stylesDir = join(testDir, 'styles');
+      await mkdir(stylesDir, { recursive: true });
+      await writeFile(join(stylesDir, 'variables.css'), GENERIC_CSS);
+
+      const result = await onboard(testDir);
+
+      expect(result.success).toBe(true);
+      expect(result.source).toBe('generic-css');
+      expect(result.tokens.length).toBeGreaterThan(0);
+    });
+
+    it('prefers shadcn over generic CSS when both match', async () => {
+      const appDir = join(testDir, 'app');
+      const stylesDir = join(testDir, 'styles');
+      await mkdir(appDir, { recursive: true });
+      await mkdir(stylesDir, { recursive: true });
+      await writeFile(join(appDir, 'globals.css'), SHADCN_CSS);
+      await writeFile(join(stylesDir, 'variables.css'), GENERIC_CSS);
+
+      const result = await onboard(testDir);
+
+      // shadcn has higher confidence and priority
+      expect(result.source).toBe('shadcn');
+    });
+
+    it('returns failure when no compatible source found', async () => {
+      // Empty directory
+      const result = await onboard(testDir);
+
+      expect(result.success).toBe(false);
+      expect(result.tokens).toHaveLength(0);
+      expect(result.warnings.some((w) => w.level === 'error')).toBe(true);
+    });
+
+    it('returns failure for CSS without custom properties', async () => {
+      const stylesDir = join(testDir, 'styles');
+      await mkdir(stylesDir, { recursive: true });
+      await writeFile(join(stylesDir, 'variables.css'), EMPTY_CSS);
+
+      const result = await onboard(testDir);
+
+      expect(result.success).toBe(false);
+    });
+
+    it('can force a specific importer', async () => {
+      // Use generic CSS that both importers can detect
+      const stylesDir = join(testDir, 'styles');
+      await mkdir(stylesDir, { recursive: true });
+      await writeFile(join(stylesDir, 'variables.css'), GENERIC_CSS);
+
+      // Force generic-css explicitly
+      const result = await onboard(testDir, { forceImporter: 'generic-css' });
+
+      expect(result.source).toBe('generic-css');
+      expect(result.success).toBe(true);
+    });
+
+    it('fails when forced importer cannot handle project', async () => {
+      // No CSS files
+      const result = await onboard(testDir, { forceImporter: 'shadcn' });
+
+      expect(result.success).toBe(false);
+      expect(result.warnings[0].message).toContain('not found');
+    });
+
+    it('respects minimum confidence threshold', async () => {
+      const stylesDir = join(testDir, 'styles');
+      await mkdir(stylesDir, { recursive: true });
+      // Create CSS that would have low confidence
+      await writeFile(join(stylesDir, 'variables.css'), GENERIC_CSS);
+
+      const result = await onboard(testDir, { minConfidence: 0.95 });
+
+      expect(result.success).toBe(false);
+      expect(result.warnings[0].message).toContain('below threshold');
+    });
+
+    it('includes stats in result', async () => {
+      const appDir = join(testDir, 'app');
+      await mkdir(appDir, { recursive: true });
+      await writeFile(join(appDir, 'globals.css'), SHADCN_CSS);
+
+      const result = await onboard(testDir);
+
+      expect(result.stats.variablesProcessed).toBeGreaterThan(0);
+      expect(result.stats.tokensCreated).toBeGreaterThan(0);
+      expect(result.stats.skipped).toBeGreaterThanOrEqual(0);
+    });
+
+    it('includes source paths in result', async () => {
+      const appDir = join(testDir, 'app');
+      await mkdir(appDir, { recursive: true });
+      await writeFile(join(appDir, 'globals.css'), SHADCN_CSS);
+
+      const result = await onboard(testDir);
+
+      expect(result.sourcePaths).toHaveLength(1);
+      expect(result.sourcePaths[0]).toContain('globals.css');
+    });
+
+    it('all tokens have required fields', async () => {
+      const appDir = join(testDir, 'app');
+      await mkdir(appDir, { recursive: true });
+      await writeFile(join(appDir, 'globals.css'), SHADCN_CSS);
+
+      const result = await onboard(testDir);
+
+      for (const token of result.tokens) {
+        expect(token.name).toBeDefined();
+        expect(token.value).toBeDefined();
+        expect(token.category).toBeDefined();
+        expect(token.namespace).toBeDefined();
+        expect(token.userOverride).toBeNull();
+      }
+    });
+  });
+
+  describe('previewOnboard', () => {
+    it('returns all compatible importers', async () => {
+      const appDir = join(testDir, 'app');
+      await mkdir(appDir, { recursive: true });
+      await writeFile(join(appDir, 'globals.css'), SHADCN_CSS);
+
+      const results = await previewOnboard(testDir);
+
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].importer).toBe('shadcn');
+      expect(results[0].confidence).toBeGreaterThan(0);
+    });
+
+    it('returns empty array when no importers match', async () => {
+      const results = await previewOnboard(testDir);
+
+      expect(results).toHaveLength(0);
+    });
+
+    it('sorts by confidence', async () => {
+      const appDir = join(testDir, 'app');
+      const stylesDir = join(testDir, 'styles');
+      await mkdir(appDir, { recursive: true });
+      await mkdir(stylesDir, { recursive: true });
+      await writeFile(join(appDir, 'globals.css'), SHADCN_CSS);
+      await writeFile(join(stylesDir, 'variables.css'), GENERIC_CSS);
+
+      const results = await previewOnboard(testDir);
+
+      // Should be sorted by confidence (shadcn first)
+      expect(results[0].importer).toBe('shadcn');
+      expect(results[0].confidence).toBeGreaterThanOrEqual(results[1]?.confidence ?? 0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Orchestrator is the main entry point for the onboarding system
- `onboard()` detects best importer (shadcn or generic-css), checks confidence thresholds, runs import
- `previewOnboard()` returns all compatible importers sorted by confidence for analysis
- New MCP tool `rafters_onboard` exposes this to agents with `analyze` and `import` actions
- Force-importer option allows bypassing auto-detection

## Test plan

- [x] 14 orchestrator tests covering detection, import, forced importer, confidence threshold
- [x] 2 MCP tool tests for rafters_onboard
- [x] All tests pass (287 total)
- [x] Preflight passes

Closes #1270