### PR TITLE
feat(mcp): rafters_vocabulary for intent-based token queries (#1250)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Minor Changes
 
 - feat(onboard): orchestrator coordinates the import pipeline. `onboard()` detects the best importer (shadcn or generic-css), checks confidence thresholds, and runs the import. `previewOnboard()` returns all compatible importers sorted by confidence for analysis without importing. New MCP tool `rafters_onboard` exposes this to agents: `action: "analyze"` previews what would be imported, `action: "import"` runs the import. Forceimporter option allows bypassing auto-detection. Closes #1270.
+- feat(mcp): `rafters_vocabulary` tool for intent-based token queries. Without filters, returns a compact index with suggested queries instead of dumping all tokens. Supports `category` (color, spacing, typography, etc.), `intent` (semantic search across token metadata), and `family` (color family filter). Tailwind class hints included in compact output. Addresses consumer feedback from shingle about vocabulary being a firehose. Closes #1250.
 
 ### Patch Changes
 

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -1,13 +1,14 @@
 /**
  * MCP Tools for Rafters Design System
  *
- * 5 focused tools for agent composition:
+ * 6 focused tools for agent composition:
  *
  * 1. rafters_composite - Query composites with designer intent
  * 2. rafters_rule - Query or create validation rules
  * 3. rafters_pattern - Design pattern guidance (do/never)
  * 4. rafters_component - Component intelligence
  * 5. rafters_onboard - Import design tokens from CSS files
+ * 6. rafters_vocabulary - Query design tokens with intent-based filtering
  */
 
 import { readdir } from 'node:fs/promises';
@@ -22,6 +23,8 @@ import {
   registerComposite,
   searchComposites,
 } from '@rafters/composites';
+import { NodePersistenceAdapter } from '@rafters/design-tokens';
+import type { Token } from '@rafters/shared';
 import { onboard, previewOnboard } from '../onboard/orchestrator.js';
 import { registryClient } from '../registry/client.js';
 import { getRaftersPaths } from '../utils/paths.js';
@@ -125,6 +128,46 @@ export const TOOL_DEFINITIONS = [
       required: ['action'],
     },
   },
+  {
+    name: 'rafters_vocabulary',
+    description:
+      'Query design tokens with intent-based filtering. Without filters, returns a compact index with suggested queries. Use category/intent/family filters to get specific tokens instead of the full dump.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        category: {
+          type: 'string',
+          enum: [
+            'color',
+            'spacing',
+            'typography',
+            'radius',
+            'shadow',
+            'motion',
+            'fill',
+            'focus',
+            'elevation',
+            'breakpoint',
+            'depth',
+          ],
+          description: 'Filter by token category',
+        },
+        intent: {
+          type: 'string',
+          description: 'Semantic intent search (e.g., "warnings", "form validation", "navigation")',
+        },
+        family: {
+          type: 'string',
+          description: 'Filter by color family (e.g., "primary", "destructive", "accent")',
+        },
+        include_values: {
+          type: 'boolean',
+          description: 'Include full token values in response (default: false for compact output)',
+        },
+      },
+      required: [],
+    },
+  },
 ] as const;
 
 // ==================== Tool Handler ====================
@@ -149,6 +192,10 @@ export class RaftersToolHandler {
         return this.handleComponent(args.name as string);
       case 'rafters_onboard':
         return this.handleOnboard(args as { action: string; path?: string; importer?: string });
+      case 'rafters_vocabulary':
+        return this.handleVocabulary(
+          args as { category?: string; intent?: string; family?: string; include_values?: boolean },
+        );
       default:
         return {
           content: [{ type: 'text', text: JSON.stringify({ error: `Unknown tool: ${name}` }) }],
@@ -500,5 +547,201 @@ export class RaftersToolHandler {
         ],
       };
     }
+  }
+
+  private async handleVocabulary(args: {
+    category?: string;
+    intent?: string;
+    family?: string;
+    include_values?: boolean;
+  }): Promise<CallToolResult> {
+    const { category, intent, family, include_values } = args;
+
+    // Load tokens from project
+    if (!this.projectRoot) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              error: 'No project root configured',
+              suggestion: 'Run rafters init first or specify --project-root',
+            }),
+          },
+        ],
+      };
+    }
+
+    try {
+      const adapter = new NodePersistenceAdapter(this.projectRoot);
+      let tokens = await adapter.load();
+
+      if (tokens.length === 0) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                error: 'No tokens found in project',
+                suggestion:
+                  'Run rafters init to generate tokens, or rafters_onboard to import from CSS',
+              }),
+            },
+          ],
+        };
+      }
+
+      // No filters? Return compact index with suggested queries
+      if (!category && !intent && !family) {
+        const categories = [...new Set(tokens.map((t) => t.category))].sort();
+        const namespaces = [...new Set(tokens.map((t) => t.namespace))].sort();
+        const families = this.extractFamilies(tokens);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  totalTokens: tokens.length,
+                  categories,
+                  namespaces,
+                  colorFamilies: families,
+                  suggestedQueries: [
+                    { query: 'category: "color"', description: 'All color tokens' },
+                    { query: 'category: "spacing"', description: 'Spacing scale tokens' },
+                    { query: 'family: "primary"', description: 'Primary color family' },
+                    { query: 'family: "destructive"', description: 'Destructive/error colors' },
+                    { query: 'intent: "warnings"', description: 'Tokens for warning states' },
+                    { query: 'intent: "form validation"', description: 'Form feedback colors' },
+                  ],
+                  tip: 'Use filters to get specific tokens instead of the full dump',
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      }
+
+      // Apply category filter
+      if (category) {
+        tokens = tokens.filter((t) => t.category === category);
+      }
+
+      // Apply family filter (for color tokens)
+      if (family) {
+        tokens = tokens.filter((t) => {
+          // Check if value is a ColorReference with matching family
+          if (typeof t.value === 'object' && t.value !== null && 'family' in t.value) {
+            return t.value.family.toLowerCase().includes(family.toLowerCase());
+          }
+          // Check token name for family
+          return t.name.toLowerCase().includes(family.toLowerCase());
+        });
+      }
+
+      // Apply intent filter (semantic search across multiple fields)
+      if (intent) {
+        const intentLower = intent.toLowerCase();
+        tokens = tokens.filter((t) => {
+          // Search in semantic meaning
+          if (t.semanticMeaning?.toLowerCase().includes(intentLower)) return true;
+          // Search in usage context
+          if (t.usageContext?.some((ctx) => ctx.toLowerCase().includes(intentLower))) return true;
+          // Search in token name
+          if (t.name.toLowerCase().includes(intentLower)) return true;
+          // Search in appliesWhen
+          if (t.appliesWhen?.some((aw) => aw.toLowerCase().includes(intentLower))) return true;
+          return false;
+        });
+      }
+
+      // Format response
+      const response = include_values
+        ? tokens.map((t) => ({
+            name: t.name,
+            value: t.value,
+            category: t.category,
+            namespace: t.namespace,
+            semanticMeaning: t.semanticMeaning,
+            usageContext: t.usageContext,
+            usagePatterns: t.usagePatterns,
+          }))
+        : tokens.map((t) => ({
+            name: t.name,
+            category: t.category,
+            tailwindClass: this.toTailwindClass(t),
+          }));
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                count: tokens.length,
+                filters: { category, intent, family },
+                tokens: response,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      if (process.env.DEBUG || process.env.RAFTERS_DEBUG) {
+        console.error('[rafters_vocabulary] failed:', err);
+      }
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ error: message }),
+          },
+        ],
+      };
+    }
+  }
+
+  /** Extract color family names from tokens */
+  private extractFamilies(tokens: Token[]): string[] {
+    const families = new Set<string>();
+    for (const t of tokens) {
+      if (typeof t.value === 'object' && t.value !== null && 'family' in t.value) {
+        families.add(t.value.family);
+      }
+    }
+    return [...families].sort();
+  }
+
+  /** Convert token to Tailwind class hint */
+  private toTailwindClass(token: Token): string | null {
+    const { name, category, namespace } = token;
+
+    // Color tokens -> text-{name}, bg-{name}, border-{name}
+    if (category === 'color' || namespace === 'color') {
+      return `text-${name} / bg-${name} / border-${name}`;
+    }
+
+    // Spacing tokens -> p-{name}, m-{name}, gap-{name}
+    if (category === 'spacing') {
+      return `p-${name} / m-${name} / gap-${name}`;
+    }
+
+    // Radius tokens -> rounded-{name}
+    if (category === 'radius') {
+      return `rounded-${name}`;
+    }
+
+    // Shadow tokens -> shadow-{name}
+    if (category === 'shadow') {
+      return `shadow-${name}`;
+    }
+
+    return null;
   }
 }

--- a/packages/cli/test/mcp/tools.test.ts
+++ b/packages/cli/test/mcp/tools.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { RaftersToolHandler, TOOL_DEFINITIONS } from '../../src/mcp/tools.js';
 
 describe('TOOL_DEFINITIONS', () => {
-  it('should define 5 tools', () => {
-    expect(TOOL_DEFINITIONS).toHaveLength(5);
+  it('should define 6 tools', () => {
+    expect(TOOL_DEFINITIONS).toHaveLength(6);
   });
 
   it('should have correct tool names', () => {
@@ -13,6 +13,7 @@ describe('TOOL_DEFINITIONS', () => {
     expect(names).toContain('rafters_pattern');
     expect(names).toContain('rafters_component');
     expect(names).toContain('rafters_onboard');
+    expect(names).toContain('rafters_vocabulary');
   });
 
   it('should have descriptions for all tools', () => {
@@ -125,6 +126,32 @@ describe('RaftersToolHandler', () => {
 
       const data = JSON.parse(result.content[0].text as string);
       expect(data.error).toContain('Unknown action');
+    });
+  });
+
+  describe('rafters_vocabulary', () => {
+    it('should return error when no project root configured', async () => {
+      const handler = new RaftersToolHandler(null);
+      const result = await handler.handleToolCall('rafters_vocabulary', {});
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.error).toContain('No project root');
+    });
+
+    it('should return error when project has no tokens', async () => {
+      const { mkdtemp, rm, mkdir } = await import('node:fs/promises');
+      const { join } = await import('node:path');
+      const testDir = await mkdtemp(join(process.cwd(), '.test-mcp-vocab-'));
+      await mkdir(join(testDir, '.rafters', 'tokens'), { recursive: true });
+      try {
+        const handler = new RaftersToolHandler(testDir);
+        const result = await handler.handleToolCall('rafters_vocabulary', {});
+
+        const data = JSON.parse(result.content[0].text as string);
+        expect(data.error).toContain('No tokens found');
+      } finally {
+        await rm(testDir, { recursive: true, force: true });
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- New `rafters_vocabulary` MCP tool for querying design tokens
- Without filters: returns compact index with categories, namespaces, color families, and suggested queries
- With filters: returns matching tokens with optional Tailwind class hints

Filters:
- `category`: color, spacing, typography, radius, shadow, motion, fill, focus, elevation, breakpoint, depth
- `intent`: semantic search across token metadata (name, semanticMeaning, usageContext, appliesWhen)
- `family`: color family filter (primary, destructive, accent, etc.)
- `include_values`: include full token values (default: compact output)

## Test plan

- [x] 15 MCP tool tests pass
- [x] Preflight passes
- [x] Returns error when no project root
- [x] Returns error when project has no tokens

Addresses shingle consumer feedback about vocabulary being a firehose.

Closes #1250