### PR TITLE
feat(onboard): Tailwind v4 @theme importer (#1259)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Minor Changes
 
+- feat(onboard): Tailwind v4 importer detects `@theme` blocks and extracts all design token namespaces (color, spacing, typography, radius, shadow, motion, opacity). Maps Tailwind `--ease-*` and `--duration-*` to rafters `motion-ease-*` and `motion-duration-*` namespace. Skips viewport-only tokens (breakpoint, container). Priority 90 (highest) since `@theme` is unambiguous. Closes #1259.
 - feat(onboard): orchestrator coordinates the import pipeline. `onboard()` detects the best importer (shadcn or generic-css), checks confidence thresholds, and runs the import. `previewOnboard()` returns all compatible importers sorted by confidence for analysis without importing. New MCP tool `rafters_onboard` exposes this to agents: `action: "analyze"` previews what would be imported, `action: "import"` runs the import. Forceimporter option allows bypassing auto-detection. Closes #1270.
 
 ### Patch Changes

--- a/packages/cli/src/onboard/importers/tailwind-v4.ts
+++ b/packages/cli/src/onboard/importers/tailwind-v4.ts
@@ -28,36 +28,35 @@ const TAILWIND_CSS_PATHS = [
 ];
 
 /**
- * Tailwind v4 namespace -> Rafters category/namespace mapping
+ * Tailwind v4 namespace -> Rafters category mapping.
+ * Category and namespace are always identical in Tailwind v4 tokens.
  */
-interface NamespaceMapping {
-  category: string;
-  namespace: string;
-}
-
-const NAMESPACE_MAP: Record<string, NamespaceMapping> = {
-  color: { category: 'color', namespace: 'color' },
-  spacing: { category: 'spacing', namespace: 'spacing' },
-  font: { category: 'typography', namespace: 'typography' },
-  text: { category: 'typography', namespace: 'typography' },
-  leading: { category: 'typography', namespace: 'typography' },
-  tracking: { category: 'typography', namespace: 'typography' },
-  'font-weight': { category: 'typography', namespace: 'typography' },
-  radius: { category: 'radius', namespace: 'radius' },
-  shadow: { category: 'shadow', namespace: 'shadow' },
-  'inset-shadow': { category: 'shadow', namespace: 'shadow' },
-  ease: { category: 'motion', namespace: 'motion' },
-  duration: { category: 'motion', namespace: 'motion' },
-  animate: { category: 'motion', namespace: 'motion' },
-  opacity: { category: 'opacity', namespace: 'opacity' },
-  blur: { category: 'effect', namespace: 'effect' },
+const NAMESPACE_MAP: Record<string, string> = {
+  color: 'color',
+  spacing: 'spacing',
+  font: 'typography',
+  text: 'typography',
+  leading: 'typography',
+  tracking: 'typography',
+  'font-weight': 'typography',
+  radius: 'radius',
+  shadow: 'shadow',
+  'inset-shadow': 'shadow',
+  ease: 'motion',
+  duration: 'motion',
+  animate: 'motion',
+  opacity: 'opacity',
+  blur: 'effect',
 };
 
-// Namespaces to skip -- these are layout/viewport concerns, not design tokens
-const SKIP_NAMESPACES = new Set(['breakpoint', 'container', 'perspective']);
+// Sorted longest-first so "font-weight" matches before "font"
+const SORTED_NAMESPACES = Object.keys(NAMESPACE_MAP).sort((a, b) => b.length - a.length);
 
 /**
  * Extract the Tailwind namespace from a variable name.
+ * Returns null for unmapped namespaces (breakpoint, container, perspective)
+ * which are layout/viewport concerns, not design tokens.
+ *
  * --color-primary-500 -> "color"
  * --spacing-4 -> "spacing"
  * --font-sans -> "font"
@@ -65,18 +64,9 @@ const SKIP_NAMESPACES = new Set(['breakpoint', 'container', 'perspective']);
 function extractNamespace(varName: string): string | null {
   const name = varName.replace(/^--/, '');
 
-  // Try longest match first (font-weight before font)
-  const candidates = Object.keys(NAMESPACE_MAP).sort((a, b) => b.length - a.length);
-  for (const ns of candidates) {
+  for (const ns of SORTED_NAMESPACES) {
     if (name.startsWith(`${ns}-`)) {
       return ns;
-    }
-  }
-
-  // Check skip list
-  for (const skip of SKIP_NAMESPACES) {
-    if (name.startsWith(`${skip}-`)) {
-      return null;
     }
   }
 
@@ -88,10 +78,11 @@ function extractNamespace(varName: string): string | null {
  *
  * Tailwind v4 uses flat namespaced names:
  *   --color-primary-500  -> primary-500
- *   --spacing-4          -> spacing-4
- *   --font-sans          -> font-sans
+ *   --spacing-4          -> 4
+ *   --font-sans          -> sans
  *   --ease-in-out        -> motion-ease-in-out (motion namespace remapped)
  *   --duration-150       -> motion-duration-150 (motion namespace remapped)
+ *   --inset-shadow-sm    -> inset-sm (prefixed to avoid collision with --shadow-sm)
  */
 function buildTokenName(varName: string, twNamespace: string): string {
   const withoutPrefix = varName.replace(/^--/, '');
@@ -104,30 +95,46 @@ function buildTokenName(varName: string, twNamespace: string): string {
   if (twNamespace === 'duration') {
     return `motion-duration-${afterNamespace}`;
   }
+  // Inset shadows get prefixed to avoid collision with shadow tokens
+  if (twNamespace === 'inset-shadow') {
+    return `inset-${afterNamespace}`;
+  }
 
   return afterNamespace || withoutPrefix;
 }
 
 /**
+ * Build an ImportResult with a single error warning and zero counters
+ */
+function errorResult(message: string, file?: string): ImportResult {
+  const warning: ImportWarning = file
+    ? { level: 'error', message, source: { file } }
+    : { level: 'error', message };
+  return {
+    tokens: [],
+    warnings: [warning],
+    source: 'tailwind-v4',
+    variablesProcessed: 0,
+    tokensCreated: 0,
+    skipped: 0,
+  };
+}
+
+/**
  * Convert a Tailwind v4 CSS variable to a Rafters token
  */
-function variableToToken(variable: CSSVariable): {
-  token: Token;
-  warning?: ImportWarning;
-} | null {
+function variableToToken(variable: CSSVariable): Token | null {
   const twNamespace = extractNamespace(variable.name);
   if (!twNamespace) return null;
 
-  const mapping = NAMESPACE_MAP[twNamespace];
-  if (!mapping) return null;
+  const category = NAMESPACE_MAP[twNamespace];
+  if (!category) return null;
 
-  const tokenName = buildTokenName(variable.name, twNamespace);
-
-  const token: Token = {
-    name: tokenName,
+  return {
+    name: buildTokenName(variable.name, twNamespace),
     value: variable.value,
-    category: mapping.category,
-    namespace: mapping.namespace,
+    category,
+    namespace: category,
     userOverride: null,
     semanticMeaning: `Imported from Tailwind v4 ${variable.name}`,
     usageContext:
@@ -136,8 +143,6 @@ function variableToToken(variable: CSSVariable): {
         : ['light mode', 'default'],
     containerQueryAware: true,
   };
-
-  return { token };
 }
 
 export const tailwindV4Importer: Importer = {
@@ -184,6 +189,10 @@ export const tailwindV4Importer: Importer = {
         ) {
           continue;
         }
+        // CSS parse errors skip the file instead of aborting the scan
+        if (err instanceof Error && err.message.includes('parse')) {
+          continue;
+        }
         throw err;
       }
     }
@@ -204,14 +213,7 @@ export const tailwindV4Importer: Importer = {
     } else {
       const sourcePath = detection.sourcePaths[0];
       if (!sourcePath) {
-        return {
-          tokens: [],
-          warnings: [{ level: 'error', message: 'No source path found' }],
-          source: 'tailwind-v4',
-          variablesProcessed: 0,
-          tokensCreated: 0,
-          skipped: 0,
-        };
+        return errorResult('No source path found');
       }
 
       let content: string;
@@ -219,28 +221,14 @@ export const tailwindV4Importer: Importer = {
         content = await readFile(sourcePath, 'utf-8');
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        return {
-          tokens: [],
-          warnings: [{ level: 'error', message: `Failed to read CSS file: ${message}` }],
-          source: 'tailwind-v4',
-          variablesProcessed: 0,
-          tokensCreated: 0,
-          skipped: 0,
-        };
+        return errorResult(`Failed to read CSS file: ${message}`, sourcePath);
       }
 
       try {
         parsed = parseCSSFile(content);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        return {
-          tokens: [],
-          warnings: [{ level: 'error', message: `Failed to parse CSS: ${message}` }],
-          source: 'tailwind-v4',
-          variablesProcessed: 0,
-          tokensCreated: 0,
-          skipped: 0,
-        };
+        return errorResult(`Failed to parse CSS: ${message}`, sourcePath);
       }
     }
 
@@ -249,24 +237,25 @@ export const tailwindV4Importer: Importer = {
     for (const variable of parsed.variables) {
       variablesProcessed++;
 
-      const result = variableToToken(variable);
-      if (!result) {
+      const token = variableToToken(variable);
+      if (!token) {
         skipped++;
         continue;
       }
 
       // Key by namespace+name to avoid cross-namespace collisions (shadow-sm vs radius-sm)
-      const dedupeKey = `${result.token.namespace}:${result.token.name}`;
+      const dedupeKey = `${token.namespace}:${token.name}`;
       if (seenKeys.has(dedupeKey)) {
+        warnings.push({
+          level: 'info',
+          message: `Duplicate token ${dedupeKey} from ${variable.name}, keeping first occurrence`,
+        });
         skipped++;
         continue;
       }
       seenKeys.add(dedupeKey);
 
-      tokens.push(result.token);
-      if (result.warning) {
-        warnings.push(result.warning);
-      }
+      tokens.push(token);
     }
 
     return {

--- a/packages/cli/src/onboard/importers/tailwind-v4.ts
+++ b/packages/cli/src/onboard/importers/tailwind-v4.ts
@@ -1,0 +1,281 @@
+/**
+ * Tailwind v4 Importer
+ *
+ * Imports design tokens from Tailwind v4 @theme blocks.
+ * Tailwind v4 defines all tokens as CSS custom properties inside @theme,
+ * making them straightforward to extract and map to Rafters tokens.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+import type { Token } from '@rafters/shared';
+import { type CSSVariable, parseCSSFile } from '../css-parser.js';
+import type { Importer, ImporterDetection, ImportResult, ImportWarning } from './types.js';
+
+// CSS files where Tailwind v4 @theme blocks live
+const TAILWIND_CSS_PATHS = [
+  'app/globals.css',
+  'src/app/globals.css',
+  'src/index.css',
+  'src/main.css',
+  'src/styles.css',
+  'src/styles/globals.css',
+  'styles/globals.css',
+  'app/app.css',
+  'app/root.css',
+  'theme.css',
+  'src/theme.css',
+];
+
+/**
+ * Tailwind v4 namespace -> Rafters category/namespace mapping
+ */
+interface NamespaceMapping {
+  category: string;
+  namespace: string;
+}
+
+const NAMESPACE_MAP: Record<string, NamespaceMapping> = {
+  color: { category: 'color', namespace: 'color' },
+  spacing: { category: 'spacing', namespace: 'spacing' },
+  font: { category: 'typography', namespace: 'typography' },
+  text: { category: 'typography', namespace: 'typography' },
+  leading: { category: 'typography', namespace: 'typography' },
+  tracking: { category: 'typography', namespace: 'typography' },
+  'font-weight': { category: 'typography', namespace: 'typography' },
+  radius: { category: 'radius', namespace: 'radius' },
+  shadow: { category: 'shadow', namespace: 'shadow' },
+  'inset-shadow': { category: 'shadow', namespace: 'shadow' },
+  ease: { category: 'motion', namespace: 'motion' },
+  duration: { category: 'motion', namespace: 'motion' },
+  animate: { category: 'motion', namespace: 'motion' },
+  opacity: { category: 'opacity', namespace: 'opacity' },
+  blur: { category: 'effect', namespace: 'effect' },
+};
+
+// Namespaces to skip -- these are layout/viewport concerns, not design tokens
+const SKIP_NAMESPACES = new Set(['breakpoint', 'container', 'perspective']);
+
+/**
+ * Extract the Tailwind namespace from a variable name.
+ * --color-primary-500 -> "color"
+ * --spacing-4 -> "spacing"
+ * --font-sans -> "font"
+ */
+function extractNamespace(varName: string): string | null {
+  const name = varName.replace(/^--/, '');
+
+  // Try longest match first (font-weight before font)
+  const candidates = Object.keys(NAMESPACE_MAP).sort((a, b) => b.length - a.length);
+  for (const ns of candidates) {
+    if (name.startsWith(`${ns}-`)) {
+      return ns;
+    }
+  }
+
+  // Check skip list
+  for (const skip of SKIP_NAMESPACES) {
+    if (name.startsWith(`${skip}-`)) {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Build a Rafters token name from a Tailwind v4 variable.
+ *
+ * Tailwind v4 uses flat namespaced names:
+ *   --color-primary-500  -> primary-500
+ *   --spacing-4          -> spacing-4
+ *   --font-sans          -> font-sans
+ *   --ease-in-out        -> motion-ease-in-out (motion namespace remapped)
+ *   --duration-150       -> motion-duration-150 (motion namespace remapped)
+ */
+function buildTokenName(varName: string, twNamespace: string): string {
+  const withoutPrefix = varName.replace(/^--/, '');
+  const afterNamespace = withoutPrefix.slice(twNamespace.length + 1); // +1 for the dash
+
+  // Motion tokens need rafters namespace prefix per feedback memory
+  if (twNamespace === 'ease') {
+    return `motion-ease-${afterNamespace}`;
+  }
+  if (twNamespace === 'duration') {
+    return `motion-duration-${afterNamespace}`;
+  }
+
+  return afterNamespace || withoutPrefix;
+}
+
+/**
+ * Convert a Tailwind v4 CSS variable to a Rafters token
+ */
+function variableToToken(variable: CSSVariable): {
+  token: Token;
+  warning?: ImportWarning;
+} | null {
+  const twNamespace = extractNamespace(variable.name);
+  if (!twNamespace) return null;
+
+  const mapping = NAMESPACE_MAP[twNamespace];
+  if (!mapping) return null;
+
+  const tokenName = buildTokenName(variable.name, twNamespace);
+
+  const token: Token = {
+    name: tokenName,
+    value: variable.value,
+    category: mapping.category,
+    namespace: mapping.namespace,
+    userOverride: null,
+    semanticMeaning: `Imported from Tailwind v4 ${variable.name}`,
+    usageContext:
+      variable.context === 'dark' || variable.context === 'media'
+        ? ['dark mode']
+        : ['light mode', 'default'],
+    containerQueryAware: true,
+  };
+
+  return { token };
+}
+
+export const tailwindV4Importer: Importer = {
+  metadata: {
+    id: 'tailwind-v4',
+    name: 'Tailwind CSS v4',
+    description: 'Import design tokens from Tailwind v4 @theme CSS custom properties',
+    filePatterns: ['*.css'],
+    priority: 90, // Higher than shadcn (80) since @theme is unambiguous
+  },
+
+  async detect(projectPath: string): Promise<ImporterDetection> {
+    const detection: ImporterDetection = {
+      canImport: false,
+      confidence: 0,
+      detectedBy: [],
+      sourcePaths: [],
+    };
+
+    for (const cssPath of TAILWIND_CSS_PATHS) {
+      const fullPath = join(projectPath, cssPath);
+      try {
+        const content = await readFile(fullPath, 'utf-8');
+        const parsed = parseCSSFile(content);
+
+        if (parsed.sourceType === 'tailwind-v4' && parsed.hasThemeBlock) {
+          // Count theme variables for confidence
+          const themeVars = parsed.variables.filter((v) => v.context === 'theme');
+
+          detection.canImport = true;
+          detection.confidence = 0.95; // @theme is very high signal
+          detection.detectedBy.push(
+            `@theme block with ${themeVars.length} variables in ${basename(cssPath)}`,
+          );
+          detection.sourcePaths.push(fullPath);
+          detection.context = { parsed };
+          return detection;
+        }
+      } catch (err) {
+        if (
+          err instanceof Error &&
+          'code' in err &&
+          (err.code === 'ENOENT' || err.code === 'ENOTDIR')
+        ) {
+          continue;
+        }
+        throw err;
+      }
+    }
+
+    return detection;
+  },
+
+  async import(_projectPath: string, detection: ImporterDetection): Promise<ImportResult> {
+    const tokens: Token[] = [];
+    const warnings: ImportWarning[] = [];
+    let variablesProcessed = 0;
+    let skipped = 0;
+
+    let parsed: ReturnType<typeof parseCSSFile>;
+
+    if (detection.context?.parsed) {
+      parsed = detection.context.parsed as ReturnType<typeof parseCSSFile>;
+    } else {
+      const sourcePath = detection.sourcePaths[0];
+      if (!sourcePath) {
+        return {
+          tokens: [],
+          warnings: [{ level: 'error', message: 'No source path found' }],
+          source: 'tailwind-v4',
+          variablesProcessed: 0,
+          tokensCreated: 0,
+          skipped: 0,
+        };
+      }
+
+      let content: string;
+      try {
+        content = await readFile(sourcePath, 'utf-8');
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          tokens: [],
+          warnings: [{ level: 'error', message: `Failed to read CSS file: ${message}` }],
+          source: 'tailwind-v4',
+          variablesProcessed: 0,
+          tokensCreated: 0,
+          skipped: 0,
+        };
+      }
+
+      try {
+        parsed = parseCSSFile(content);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          tokens: [],
+          warnings: [{ level: 'error', message: `Failed to parse CSS: ${message}` }],
+          source: 'tailwind-v4',
+          variablesProcessed: 0,
+          tokensCreated: 0,
+          skipped: 0,
+        };
+      }
+    }
+
+    const seenKeys = new Set<string>();
+
+    for (const variable of parsed.variables) {
+      variablesProcessed++;
+
+      const result = variableToToken(variable);
+      if (!result) {
+        skipped++;
+        continue;
+      }
+
+      // Key by namespace+name to avoid cross-namespace collisions (shadow-sm vs radius-sm)
+      const dedupeKey = `${result.token.namespace}:${result.token.name}`;
+      if (seenKeys.has(dedupeKey)) {
+        skipped++;
+        continue;
+      }
+      seenKeys.add(dedupeKey);
+
+      tokens.push(result.token);
+      if (result.warning) {
+        warnings.push(result.warning);
+      }
+    }
+
+    return {
+      tokens,
+      warnings,
+      source: 'tailwind-v4',
+      variablesProcessed,
+      tokensCreated: tokens.length,
+      skipped,
+    };
+  },
+};

--- a/packages/cli/src/onboard/orchestrator.ts
+++ b/packages/cli/src/onboard/orchestrator.ts
@@ -15,12 +15,14 @@ import {
   registerImporter,
 } from './importers/index.js';
 import { shadcnImporter } from './importers/shadcn.js';
+import { tailwindV4Importer } from './importers/tailwind-v4.js';
 
 // Register built-in importers on module load
 let importersRegistered = false;
 
 function ensureImportersRegistered(): void {
   if (importersRegistered) return;
+  registerImporter(tailwindV4Importer);
   registerImporter(shadcnImporter);
   registerImporter(genericCSSImporter);
   importersRegistered = true;

--- a/packages/cli/test/onboard/importers/tailwind-v4.test.ts
+++ b/packages/cli/test/onboard/importers/tailwind-v4.test.ts
@@ -1,0 +1,258 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { tailwindV4Importer } from '../../../src/onboard/importers/tailwind-v4.js';
+
+// Tailwind v4 CSS with @theme block
+const TAILWIND_V4_CSS = `@import "tailwindcss";
+
+@theme {
+  --color-primary-50: oklch(0.97 0.01 250);
+  --color-primary-100: oklch(0.93 0.02 250);
+  --color-primary-200: oklch(0.87 0.04 250);
+  --color-primary-300: oklch(0.78 0.08 250);
+  --color-primary-400: oklch(0.68 0.12 250);
+  --color-primary-500: oklch(0.55 0.15 250);
+  --color-primary-600: oklch(0.48 0.14 250);
+  --color-primary-700: oklch(0.40 0.12 250);
+  --color-primary-800: oklch(0.33 0.10 250);
+  --color-primary-900: oklch(0.27 0.08 250);
+  --color-primary-950: oklch(0.20 0.06 250);
+
+  --color-accent-500: oklch(0.70 0.20 150);
+
+  --spacing-0: 0px;
+  --spacing-1: 0.25rem;
+  --spacing-2: 0.5rem;
+  --spacing-4: 1rem;
+  --spacing-8: 2rem;
+
+  --font-sans: "Inter", sans-serif;
+  --font-mono: "JetBrains Mono", monospace;
+
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+
+  --radius-sm: 0.25rem;
+  --radius-md: 0.375rem;
+  --radius-lg: 0.5rem;
+
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+
+  --ease-in: cubic-bezier(0.4, 0, 1, 1);
+  --ease-out: cubic-bezier(0, 0, 0.2, 1);
+  --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+
+  --duration-150: 150ms;
+  --duration-300: 300ms;
+
+  --breakpoint-sm: 40rem;
+  --breakpoint-md: 48rem;
+  --breakpoint-lg: 64rem;
+}
+`;
+
+// Minimal Tailwind v4 with just colors
+const MINIMAL_TAILWIND_CSS = `@import "tailwindcss";
+
+@theme {
+  --color-brand: oklch(0.6 0.2 280);
+  --spacing-4: 1rem;
+  --radius-md: 0.375rem;
+}
+`;
+
+// Not Tailwind v4 -- plain CSS
+const PLAIN_CSS = `:root {
+  --brand-color: #ff0000;
+  --spacing-sm: 8px;
+}`;
+
+describe('Tailwind v4 Importer', () => {
+  const testDir = join(process.cwd(), '.test-tw4-importer');
+
+  beforeEach(async () => {
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('metadata', () => {
+    it('has correct id and priority', () => {
+      expect(tailwindV4Importer.metadata.id).toBe('tailwind-v4');
+      expect(tailwindV4Importer.metadata.priority).toBe(90);
+    });
+  });
+
+  describe('detect', () => {
+    it('detects @theme block in src/index.css', async () => {
+      const srcDir = join(testDir, 'src');
+      await mkdir(srcDir, { recursive: true });
+      await writeFile(join(srcDir, 'index.css'), TAILWIND_V4_CSS);
+
+      const detection = await tailwindV4Importer.detect(testDir);
+
+      expect(detection.canImport).toBe(true);
+      expect(detection.confidence).toBe(0.95);
+      expect(detection.detectedBy[0]).toMatch(/@theme/);
+      expect(detection.sourcePaths).toHaveLength(1);
+    });
+
+    it('detects @theme block in app/globals.css', async () => {
+      const appDir = join(testDir, 'app');
+      await mkdir(appDir, { recursive: true });
+      await writeFile(join(appDir, 'globals.css'), TAILWIND_V4_CSS);
+
+      const detection = await tailwindV4Importer.detect(testDir);
+
+      expect(detection.canImport).toBe(true);
+      expect(detection.confidence).toBe(0.95);
+    });
+
+    it('rejects CSS without @theme', async () => {
+      const appDir = join(testDir, 'app');
+      await mkdir(appDir, { recursive: true });
+      await writeFile(join(appDir, 'globals.css'), PLAIN_CSS);
+
+      const detection = await tailwindV4Importer.detect(testDir);
+
+      expect(detection.canImport).toBe(false);
+    });
+
+    it('returns canImport false when no CSS files exist', async () => {
+      const detection = await tailwindV4Importer.detect(testDir);
+
+      expect(detection.canImport).toBe(false);
+      expect(detection.confidence).toBe(0);
+    });
+  });
+
+  describe('import', () => {
+    it('imports all token namespaces', async () => {
+      const srcDir = join(testDir, 'src');
+      await mkdir(srcDir, { recursive: true });
+      await writeFile(join(srcDir, 'index.css'), TAILWIND_V4_CSS);
+
+      const detection = await tailwindV4Importer.detect(testDir);
+      const result = await tailwindV4Importer.import(testDir, detection);
+
+      expect(result.source).toBe('tailwind-v4');
+      expect(result.tokens.length).toBeGreaterThan(0);
+
+      const categories = new Set(result.tokens.map((t) => t.category));
+      expect(categories).toContain('color');
+      expect(categories).toContain('spacing');
+      expect(categories).toContain('typography');
+      expect(categories).toContain('radius');
+      expect(categories).toContain('shadow');
+      expect(categories).toContain('motion');
+    });
+
+    it('maps color scale preserving positions', async () => {
+      const srcDir = join(testDir, 'src');
+      await mkdir(srcDir, { recursive: true });
+      await writeFile(join(srcDir, 'index.css'), TAILWIND_V4_CSS);
+
+      const detection = await tailwindV4Importer.detect(testDir);
+      const result = await tailwindV4Importer.import(testDir, detection);
+
+      const colorTokens = result.tokens.filter((t) => t.category === 'color');
+      const primaryTokens = colorTokens.filter((t) => t.name.startsWith('primary-'));
+      expect(primaryTokens.length).toBe(11); // 50-950
+
+      const primary500 = primaryTokens.find((t) => t.name === 'primary-500');
+      expect(primary500?.value).toBe('oklch(0.55 0.15 250)');
+    });
+
+    it('maps spacing tokens', async () => {
+      const srcDir = join(testDir, 'src');
+      await mkdir(srcDir, { recursive: true });
+      await writeFile(join(srcDir, 'index.css'), TAILWIND_V4_CSS);
+
+      const detection = await tailwindV4Importer.detect(testDir);
+      const result = await tailwindV4Importer.import(testDir, detection);
+
+      const spacing = result.tokens.filter((t) => t.namespace === 'spacing');
+      expect(spacing.length).toBe(5);
+
+      const s4 = spacing.find((t) => t.name === '4');
+      expect(s4?.value).toBe('1rem');
+    });
+
+    it('maps motion tokens with rafters namespace prefix', async () => {
+      const srcDir = join(testDir, 'src');
+      await mkdir(srcDir, { recursive: true });
+      await writeFile(join(srcDir, 'index.css'), TAILWIND_V4_CSS);
+
+      const detection = await tailwindV4Importer.detect(testDir);
+      const result = await tailwindV4Importer.import(testDir, detection);
+
+      const motionTokens = result.tokens.filter((t) => t.namespace === 'motion');
+
+      // --ease-in-out -> motion-ease-in-out
+      const easeInOut = motionTokens.find((t) => t.name === 'motion-ease-in-out');
+      expect(easeInOut).toBeDefined();
+      expect(easeInOut?.value).toContain('cubic-bezier');
+
+      // --duration-150 -> motion-duration-150
+      const dur150 = motionTokens.find((t) => t.name === 'motion-duration-150');
+      expect(dur150).toBeDefined();
+      expect(dur150?.value).toBe('150ms');
+    });
+
+    it('skips breakpoint and container namespaces', async () => {
+      const srcDir = join(testDir, 'src');
+      await mkdir(srcDir, { recursive: true });
+      await writeFile(join(srcDir, 'index.css'), TAILWIND_V4_CSS);
+
+      const detection = await tailwindV4Importer.detect(testDir);
+      const result = await tailwindV4Importer.import(testDir, detection);
+
+      const breakpointTokens = result.tokens.filter((t) => t.name.includes('breakpoint'));
+      expect(breakpointTokens).toHaveLength(0);
+      expect(result.skipped).toBeGreaterThan(0);
+    });
+
+    it('sets userOverride to null on all tokens', async () => {
+      const srcDir = join(testDir, 'src');
+      await mkdir(srcDir, { recursive: true });
+      await writeFile(join(srcDir, 'index.css'), MINIMAL_TAILWIND_CSS);
+
+      const detection = await tailwindV4Importer.detect(testDir);
+      const result = await tailwindV4Importer.import(testDir, detection);
+
+      for (const token of result.tokens) {
+        expect(token.userOverride).toBeNull();
+      }
+    });
+
+    it('includes semantic meaning from source variable', async () => {
+      const srcDir = join(testDir, 'src');
+      await mkdir(srcDir, { recursive: true });
+      await writeFile(join(srcDir, 'index.css'), MINIMAL_TAILWIND_CSS);
+
+      const detection = await tailwindV4Importer.detect(testDir);
+      const result = await tailwindV4Importer.import(testDir, detection);
+
+      const brand = result.tokens.find((t) => t.name === 'brand');
+      expect(brand?.semanticMeaning).toContain('Tailwind v4');
+      expect(brand?.semanticMeaning).toContain('--color-brand');
+    });
+
+    it('reports accurate counts', async () => {
+      const srcDir = join(testDir, 'src');
+      await mkdir(srcDir, { recursive: true });
+      await writeFile(join(srcDir, 'index.css'), TAILWIND_V4_CSS);
+
+      const detection = await tailwindV4Importer.detect(testDir);
+      const result = await tailwindV4Importer.import(testDir, detection);
+
+      expect(result.tokensCreated).toBe(result.tokens.length);
+      expect(result.variablesProcessed).toBe(result.tokensCreated + result.skipped);
+    });
+  });
+});

--- a/packages/cli/test/onboard/importers/tailwind-v4.test.ts
+++ b/packages/cli/test/onboard/importers/tailwind-v4.test.ts
@@ -41,6 +41,9 @@ const TAILWIND_V4_CSS = `@import "tailwindcss";
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1);
 
+  --inset-shadow-sm: inset 0 1px 1px 0 rgb(0 0 0 / 0.05);
+  --inset-shadow-md: inset 0 2px 4px 0 rgb(0 0 0 / 0.05);
+
   --ease-in: cubic-bezier(0.4, 0, 1, 1);
   --ease-out: cubic-bezier(0, 0, 0.2, 1);
   --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
@@ -202,6 +205,28 @@ describe('Tailwind v4 Importer', () => {
       const dur150 = motionTokens.find((t) => t.name === 'motion-duration-150');
       expect(dur150).toBeDefined();
       expect(dur150?.value).toBe('150ms');
+    });
+
+    it('maps inset-shadow without colliding with shadow', async () => {
+      const srcDir = join(testDir, 'src');
+      await mkdir(srcDir, { recursive: true });
+      await writeFile(join(srcDir, 'index.css'), TAILWIND_V4_CSS);
+
+      const detection = await tailwindV4Importer.detect(testDir);
+      const result = await tailwindV4Importer.import(testDir, detection);
+
+      const shadowTokens = result.tokens.filter((t) => t.namespace === 'shadow');
+
+      // --shadow-sm -> sm, --inset-shadow-sm -> inset-sm (no collision)
+      const shadowSm = shadowTokens.find((t) => t.name === 'sm');
+      expect(shadowSm).toBeDefined();
+
+      const insetSm = shadowTokens.find((t) => t.name === 'inset-sm');
+      expect(insetSm).toBeDefined();
+      expect(insetSm?.value).toContain('inset');
+
+      // Both shadow and inset-shadow are present, not deduplicated
+      expect(shadowTokens.length).toBe(4); // sm, md, inset-sm, inset-md
     });
 
     it('skips breakpoint and container namespaces', async () => {


### PR DESCRIPTION
## Summary

- Detects `@theme` blocks in CSS files and extracts all design token namespaces
- Maps color (preserving 50-950 scales), spacing, typography, radius, shadow, motion, opacity
- Remaps `--ease-*` and `--duration-*` to `motion-ease-*` and `motion-duration-*`
- Skips breakpoint/container (viewport concerns, not design tokens)
- Registered in orchestrator at priority 90 (highest -- `@theme` is unambiguous)
- 13 tests covering detection, all namespaces, motion remapping, skip logic, dedup

## Test plan

- [x] Detects @theme block in src/index.css and app/globals.css
- [x] Rejects CSS without @theme
- [x] Maps all 6 token categories (color, spacing, typography, radius, shadow, motion)
- [x] Preserves color scale positions (primary-50 through primary-950)
- [x] Motion tokens get rafters namespace prefix (motion-ease-*, motion-duration-*)
- [x] Breakpoint/container namespaces skipped
- [x] Cross-namespace dedup (shadow-sm vs radius-sm)
- [x] Preflight green

Closes #1259

Generated with [Claude Code](https://claude.ai/code)