### PR TITLE
feat(onboard): rafters init integration + rafters import command (#1271)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,8 +4,13 @@
 
 ### Minor Changes
 
+- feat(onboard): `rafters init` now detects existing design tokens (Tailwind v4 `@theme`, shadcn, generic CSS custom properties) and prompts the user to import them. On confirmation, writes `.rafters/import-pending.json` for review. New `rafters import` command runs the same flow standalone with `--force` and `--importer` options. Import flow moved out of MCP -- agents assemble from pre-made decisions, onboarding is a designer/developer operation. Closes #1271.
 - feat(onboard): Tailwind v4 importer detects `@theme` blocks and extracts all design token namespaces (color, spacing, typography, radius, shadow, motion, opacity). Maps Tailwind `--ease-*` and `--duration-*` to rafters `motion-ease-*` and `motion-duration-*` namespace. Skips viewport-only tokens (breakpoint, container). Priority 90 (highest) since `@theme` is unambiguous. Closes #1259.
-- feat(onboard): orchestrator coordinates the import pipeline. `onboard()` detects the best importer (shadcn or generic-css), checks confidence thresholds, and runs the import. `previewOnboard()` returns all compatible importers sorted by confidence for analysis without importing. New MCP tool `rafters_onboard` exposes this to agents: `action: "analyze"` previews what would be imported, `action: "import"` runs the import. Forceimporter option allows bypassing auto-detection. Closes #1270.
+- feat(onboard): orchestrator coordinates the import pipeline. `onboard()` detects the best importer (shadcn or generic-css), checks confidence thresholds, and runs the import. `previewOnboard()` returns all compatible importers sorted by confidence for analysis without importing. Closes #1270.
+
+### Breaking Changes
+
+- refactor(mcp): removed `rafters_onboard` MCP tool. Token import moved to `rafters init` / `rafters import` CLI commands. MCP now has 4 focused tools (composite, rule, pattern, component) for agent assembly.
 
 ### Patch Changes
 

--- a/packages/cli/src/commands/import.ts
+++ b/packages/cli/src/commands/import.ts
@@ -12,6 +12,7 @@
  */
 
 import { existsSync } from 'node:fs';
+import { rename } from 'node:fs/promises';
 import { relative } from 'node:path';
 import { onboard, previewOnboard } from '../onboard/orchestrator.js';
 import { toImportPending, writeImportPending } from '../onboard/writer.js';
@@ -41,14 +42,25 @@ export async function importCommand(options: ImportOptions): Promise<void> {
     return;
   }
 
-  if (existsSync(paths.importPending) && !options.force) {
+  if (existsSync(paths.importPending)) {
+    if (!options.force) {
+      log({
+        event: 'import:pending_exists',
+        path: relative(cwd, paths.importPending),
+        message:
+          'An import-pending.json already exists. Use --force to overwrite (previous file will be backed up).',
+      });
+      process.exitCode = 1;
+      return;
+    }
+
+    // --force: back up the existing file so in-progress review work isn't lost
+    const backupPath = `${paths.importPending}.backup-${Date.now()}.json`;
+    await rename(paths.importPending, backupPath);
     log({
-      event: 'import:pending_exists',
-      path: relative(cwd, paths.importPending),
-      message: 'An import-pending.json already exists. Use --force to overwrite.',
+      event: 'import:pending_backed_up',
+      backup: relative(cwd, backupPath),
     });
-    process.exitCode = 1;
-    return;
   }
 
   log({ event: 'import:scanning' });

--- a/packages/cli/src/commands/import.ts
+++ b/packages/cli/src/commands/import.ts
@@ -1,0 +1,93 @@
+/**
+ * rafters import
+ *
+ * Scans the project for existing design tokens (CSS custom properties,
+ * Tailwind v4 @theme blocks, shadcn variables), maps them to rafters
+ * tokens via the onboard orchestrator, and writes the result to
+ * `.rafters/import-pending.json` for user review.
+ *
+ * Designers / developers review the pending file (via Studio once the
+ * review UI ships, or by editing the JSON) and accept/reject/modify
+ * each token before it lands in the registry.
+ */
+
+import { existsSync } from 'node:fs';
+import { relative } from 'node:path';
+import { onboard, previewOnboard } from '../onboard/orchestrator.js';
+import { toImportPending, writeImportPending } from '../onboard/writer.js';
+import { getRaftersPaths } from '../utils/paths.js';
+import { log, setAgentMode } from '../utils/ui.js';
+
+interface ImportOptions {
+  force?: boolean;
+  agent?: boolean;
+  importer?: string;
+}
+
+export async function importCommand(options: ImportOptions): Promise<void> {
+  if (options.agent) {
+    setAgentMode(true);
+  }
+
+  const cwd = process.cwd();
+  const paths = getRaftersPaths(cwd);
+
+  if (!existsSync(paths.root)) {
+    log({
+      event: 'import:no_rafters_dir',
+      message: 'No .rafters/ directory found. Run `rafters init` first.',
+    });
+    process.exitCode = 1;
+    return;
+  }
+
+  if (existsSync(paths.importPending) && !options.force) {
+    log({
+      event: 'import:pending_exists',
+      path: relative(cwd, paths.importPending),
+      message: 'An import-pending.json already exists. Use --force to overwrite.',
+    });
+    process.exitCode = 1;
+    return;
+  }
+
+  log({ event: 'import:scanning' });
+
+  // Preview first -- surfaces what was detected even if no tokens come out
+  const preview = await previewOnboard(cwd);
+  if (preview.length === 0) {
+    log({
+      event: 'import:no_source_detected',
+      message: 'No compatible design token source found',
+      suggestion: 'Ensure your project has CSS files with custom properties or @theme blocks',
+    });
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = await onboard(cwd, options.importer ? { forceImporter: options.importer } : {});
+
+  if (!result.success) {
+    log({
+      event: 'import:failed',
+      source: result.source,
+      warnings: result.warnings,
+    });
+    process.exitCode = 1;
+    return;
+  }
+
+  const doc = toImportPending(result, cwd);
+  await writeImportPending(paths.importPending, doc);
+
+  log({
+    event: 'import:complete',
+    path: relative(cwd, paths.importPending),
+    source: result.source,
+    confidence: result.confidence,
+    tokensCreated: result.stats.tokensCreated,
+    skipped: result.stats.skipped,
+    nextStep:
+      'Review and accept tokens in .rafters/import-pending.json, then run `rafters init --rebuild`',
+  });
+}

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -791,8 +791,18 @@ export async function init(options: InitOptions): Promise<void> {
   // Write Claude Code skill so agents follow rafters rules
   await writeRaftersSkill(cwd);
 
-  // Check if the project has existing design decisions that can be onboarded
-  await maybeOnboardExisting(cwd, paths.importPending);
+  // Check if the project has existing design decisions that can be onboarded.
+  // Failures here are non-fatal -- init's primary job already succeeded.
+  try {
+    await maybeOnboardExisting(cwd, paths.importPending);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log({
+      event: 'init:onboard_skipped_after_error',
+      message,
+      suggestion: 'Init completed. Run `rafters import` to retry onboarding.',
+    });
+  }
 
   log({
     event: 'init:complete',
@@ -823,6 +833,18 @@ async function maybeOnboardExisting(cwd: string, importPendingPath: string): Pro
   const best = preview[0];
   if (!best) return;
 
+  // Agent/non-interactive: surface the detection but don't auto-import
+  if (isAgentMode() || !isInteractive()) {
+    log({
+      event: 'import:existing_detected',
+      source: best.importer,
+      confidence: best.confidence,
+      sourcePaths: best.sourcePaths.map((p) => relative(cwd, p)).join(', '),
+      nextStep: 'Run `rafters import` to convert these tokens into pending review.',
+    });
+    return;
+  }
+
   log({
     event: 'import:existing_detected',
     source: best.importer,
@@ -830,15 +852,17 @@ async function maybeOnboardExisting(cwd: string, importPendingPath: string): Pro
     sourcePaths: best.sourcePaths.map((p) => relative(cwd, p)).join(', '),
   });
 
-  // Agent/non-interactive: surface the detection but don't auto-import
-  if (isAgentMode() || !isInteractive()) {
+  // Ctrl-C / Esc at the prompt throws ExitPromptError -- treat as decline
+  let shouldImport: boolean;
+  try {
+    shouldImport = await confirm({
+      message: 'Import these tokens into rafters?',
+      default: true,
+    });
+  } catch {
+    log({ event: 'import:declined' });
     return;
   }
-
-  const shouldImport = await confirm({
-    message: 'Import these tokens into rafters?',
-    default: true,
-  });
 
   if (!shouldImport) {
     log({ event: 'import:declined' });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -20,6 +20,8 @@ import {
   TokenRegistry,
   toDTCG,
 } from '@rafters/design-tokens';
+import { onboard, previewOnboard } from '../onboard/orchestrator.js';
+import { toImportPending, writeImportPending } from '../onboard/writer.js';
 import {
   type ComponentTarget,
   detectProject,
@@ -789,22 +791,8 @@ export async function init(options: InitOptions): Promise<void> {
   // Write Claude Code skill so agents follow rafters rules
   await writeRaftersSkill(cwd);
 
-  // Check if the project has existing design decisions that should be onboarded intentionally
-  const existingCssPath = detectedCssPath ?? (shadcn?.tailwind?.css || null);
-  if (existingCssPath) {
-    try {
-      const cssContent = await readFile(join(cwd, existingCssPath), 'utf-8');
-      if (hasExistingDesignDecisions(cssContent)) {
-        log({
-          event: 'init:existing_design_detected',
-          cssPath: existingCssPath,
-          action: 'run rafters_onboard analyze to begin migration',
-        });
-      }
-    } catch {
-      // CSS file unreadable, skip detection
-    }
-  }
+  // Check if the project has existing design decisions that can be onboarded
+  await maybeOnboardExisting(cwd, paths.importPending);
 
   log({
     event: 'init:complete',
@@ -814,23 +802,68 @@ export async function init(options: InitOptions): Promise<void> {
 }
 
 /**
- * Check if CSS content contains design decisions beyond boilerplate.
- * Does NOT interpret the content -- just detects that something is there.
+ * Detect existing design tokens via the onboard pipeline. When interactive,
+ * prompt the user to import. On confirmation, run the orchestrator and write
+ * `.rafters/import-pending.json` for review. On decline or agent mode, log
+ * the detection so the user knows `rafters import` is available.
+ *
+ * Skips entirely if import-pending.json already exists -- the user has an
+ * in-progress review and init should not clobber it.
  */
-function hasExistingDesignDecisions(css: string): boolean {
-  // Strip comments
-  const stripped = css.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*/g, '');
+async function maybeOnboardExisting(cwd: string, importPendingPath: string): Promise<void> {
+  if (existsSync(importPendingPath)) {
+    return;
+  }
 
-  // Strip imports and tailwind directives
-  const withoutBoilerplate = stripped
-    .replace(/@import\s+['"][^'"]+['"];?/g, '')
-    .replace(/@tailwind\s+\w+;?/g, '')
-    .trim();
+  const preview = await previewOnboard(cwd);
+  if (preview.length === 0) {
+    return;
+  }
 
-  if (withoutBoilerplate.length === 0) return false;
+  const best = preview[0];
+  if (!best) return;
 
-  const hasCustomProperties = /--[\w-]+\s*:/.test(stripped);
-  const hasThemeBlock = /@theme\s*\{/.test(stripped);
+  log({
+    event: 'import:existing_detected',
+    source: best.importer,
+    confidence: best.confidence,
+    sourcePaths: best.sourcePaths.map((p) => relative(cwd, p)).join(', '),
+  });
 
-  return hasCustomProperties || hasThemeBlock;
+  // Agent/non-interactive: surface the detection but don't auto-import
+  if (isAgentMode() || !isInteractive()) {
+    return;
+  }
+
+  const shouldImport = await confirm({
+    message: 'Import these tokens into rafters?',
+    default: true,
+  });
+
+  if (!shouldImport) {
+    log({ event: 'import:declined' });
+    return;
+  }
+
+  log({ event: 'import:scanning' });
+  const result = await onboard(cwd);
+
+  if (!result.success) {
+    log({ event: 'import:failed', source: result.source, warnings: result.warnings });
+    return;
+  }
+
+  const doc = toImportPending(result, cwd);
+  await writeImportPending(importPendingPath, doc);
+
+  log({
+    event: 'import:complete',
+    path: relative(cwd, importPendingPath),
+    source: result.source,
+    confidence: result.confidence,
+    tokensCreated: result.stats.tokensCreated,
+    skipped: result.stats.skipped,
+    nextStep:
+      'Review and accept tokens in .rafters/import-pending.json, then run `rafters init --rebuild`',
+  });
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,7 @@
 
 import { Command } from 'commander';
 import { add } from './commands/add.js';
+import { importCommand } from './commands/import.js';
 import { init } from './commands/init.js';
 import { mcp } from './commands/mcp.js';
 import { studio } from './commands/studio.js';
@@ -26,6 +27,14 @@ program
   .option('--reset', 'Re-run generators fresh, replacing persisted tokens')
   .option('--agent', 'Output JSON for machine consumption')
   .action(withErrorHandler(init));
+
+program
+  .command('import')
+  .description('Import existing design tokens (Tailwind v4, shadcn, generic CSS)')
+  .option('--force', 'Overwrite existing .rafters/import-pending.json')
+  .option('--importer <id>', 'Force a specific importer (tailwind-v4, shadcn, generic-css)')
+  .option('--agent', 'Output JSON for machine consumption')
+  .action(withErrorHandler(importCommand));
 
 program
   .command('add')

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -123,10 +123,17 @@ export class RaftersToolHandler {
         return this.handlePattern(args as { solves?: string; query?: string });
       case 'rafters_component':
         return this.handleComponent(args.name as string);
-      default:
+      default: {
+        const suggestion =
+          name === 'rafters_onboard'
+            ? 'rafters_onboard was removed. Token import is now a CLI operation: run `rafters init` (auto-detects and prompts) or `rafters import` (standalone).'
+            : 'Available tools: rafters_composite, rafters_rule, rafters_pattern, rafters_component.';
         return {
-          content: [{ type: 'text', text: JSON.stringify({ error: `Unknown tool: ${name}` }) }],
+          content: [
+            { type: 'text', text: JSON.stringify({ error: `Unknown tool: ${name}`, suggestion }) },
+          ],
         };
+      }
     }
   }
 

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -1,13 +1,15 @@
 /**
  * MCP Tools for Rafters Design System
  *
- * 5 focused tools for agent composition:
+ * 4 focused tools for agent ASSEMBLY (not design):
  *
  * 1. rafters_composite - Query composites with designer intent
  * 2. rafters_rule - Query or create validation rules
  * 3. rafters_pattern - Design pattern guidance (do/never)
  * 4. rafters_component - Component intelligence
- * 5. rafters_onboard - Import design tokens from CSS files
+ *
+ * Agents assemble from pre-made decisions. Token design lives in Studio.
+ * Token import lives in `rafters init` / `rafters import`, not MCP.
  */
 
 import { readdir } from 'node:fs/promises';
@@ -22,7 +24,6 @@ import {
   registerComposite,
   searchComposites,
 } from '@rafters/composites';
-import { onboard, previewOnboard } from '../onboard/orchestrator.js';
 import { registryClient } from '../registry/client.js';
 import { getRaftersPaths } from '../utils/paths.js';
 
@@ -100,31 +101,6 @@ export const TOOL_DEFINITIONS = [
       required: ['name'],
     },
   },
-  {
-    name: 'rafters_onboard',
-    description:
-      'Import design tokens from existing CSS files (shadcn, generic CSS custom properties). Detects source format, converts to Rafters tokens, and returns them for review.',
-    inputSchema: {
-      type: 'object' as const,
-      properties: {
-        action: {
-          type: 'string',
-          enum: ['analyze', 'import'],
-          description:
-            'analyze: preview what would be imported. import: run the import and return tokens.',
-        },
-        path: {
-          type: 'string',
-          description: 'Project path to analyze/import from. Defaults to current directory.',
-        },
-        importer: {
-          type: 'string',
-          description: 'Force a specific importer (shadcn, generic-css). Auto-detects if omitted.',
-        },
-      },
-      required: ['action'],
-    },
-  },
 ] as const;
 
 // ==================== Tool Handler ====================
@@ -147,8 +123,6 @@ export class RaftersToolHandler {
         return this.handlePattern(args as { solves?: string; query?: string });
       case 'rafters_component':
         return this.handleComponent(args.name as string);
-      case 'rafters_onboard':
-        return this.handleOnboard(args as { action: string; path?: string; importer?: string });
       default:
         return {
           content: [{ type: 'text', text: JSON.stringify({ error: `Unknown tool: ${name}` }) }],
@@ -375,127 +349,6 @@ export class RaftersToolHandler {
           {
             type: 'text',
             text: JSON.stringify({ error: message }),
-          },
-        ],
-      };
-    }
-  }
-
-  private async handleOnboard(args: {
-    action: string;
-    path?: string;
-    importer?: string;
-  }): Promise<CallToolResult> {
-    const { action, path, importer } = args;
-    const projectPath = path ?? this.projectRoot ?? process.cwd();
-
-    try {
-      if (action === 'analyze') {
-        // Preview what would be imported
-        const results = await previewOnboard(projectPath);
-
-        if (results.length === 0) {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: JSON.stringify({
-                  status: 'no_source_detected',
-                  message: 'No compatible design token source found',
-                  suggestion:
-                    'Ensure project has CSS files with custom properties (shadcn globals.css or variables.css)',
-                }),
-              },
-            ],
-          };
-        }
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(
-                {
-                  status: 'ready',
-                  detectedSources: results,
-                  recommendation: results[0],
-                  nextStep: `Call rafters_onboard with action: "import" to import ${results[0]?.importer} tokens`,
-                },
-                null,
-                2,
-              ),
-            },
-          ],
-        };
-      }
-
-      if (action === 'import') {
-        // Run the import
-        const result = await onboard(projectPath, importer ? { forceImporter: importer } : {});
-
-        if (!result.success) {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: JSON.stringify({
-                  status: 'failed',
-                  source: result.source,
-                  warnings: result.warnings,
-                }),
-              },
-            ],
-          };
-        }
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(
-                {
-                  status: 'success',
-                  source: result.source,
-                  confidence: result.confidence,
-                  sourcePaths: result.sourcePaths,
-                  stats: result.stats,
-                  tokens: result.tokens,
-                  warnings: result.warnings.length > 0 ? result.warnings : undefined,
-                },
-                null,
-                2,
-              ),
-            },
-          ],
-        };
-      }
-
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify({
-              error: `Unknown action: ${action}`,
-              validActions: ['analyze', 'import'],
-            }),
-          },
-        ],
-      };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      // Log full error for debugging
-      if (process.env.DEBUG || process.env.RAFTERS_DEBUG) {
-        console.error(`[rafters_onboard] ${action} failed for ${projectPath}:`, err);
-      }
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify({
-              error: message,
-              action,
-              path: projectPath,
-            }),
           },
         ],
       };

--- a/packages/cli/src/onboard/writer.ts
+++ b/packages/cli/src/onboard/writer.ts
@@ -5,7 +5,7 @@
  * and writes it to .rafters/import-pending.json for user review.
  */
 
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, rename, writeFile } from 'node:fs/promises';
 import { dirname, relative } from 'node:path';
 import { type ImportPending, ImportPendingSchema, type PendingToken } from '@rafters/shared';
 import type { OnboardResult } from './orchestrator.js';
@@ -34,18 +34,31 @@ export function toImportPending(
     relative(projectRoot, p),
   );
 
-  const tokens: PendingToken[] = result.tokens.map((token) => ({
-    original: {
-      // Reverse the `Imported from X --var-name` convention to recover the source var
-      name: extractSourceVarName(token.semanticMeaning) ?? token.name,
-      value: typeof token.value === 'string' ? token.value : JSON.stringify(token.value),
-      source: primarySource ?? '',
-    },
-    proposed: token,
-    decision: 'pending' as const,
-    confidence: result.confidence,
-    rationale: token.semanticMeaning,
-  }));
+  const tokens: PendingToken[] = result.tokens.map((token) => {
+    // The `original.value` field must carry the source CSS as written.
+    // A non-string Token.value (ColorValue / ColorReference) means the importer
+    // produced an already-resolved object with no source string to show the user.
+    // Fail loudly: importers must be updated to carry the original source string.
+    if (typeof token.value !== 'string') {
+      throw new Error(
+        `Cannot build ImportPending for "${token.name}": token.value is a ${typeof token.value === 'object' ? 'structured object' : typeof token.value}, not a source string. ` +
+          'Importers must produce string values for tokens that map back to source CSS.',
+      );
+    }
+
+    return {
+      original: {
+        // Reverse the `Imported from X --var-name` convention to recover the source var
+        name: extractSourceVarName(token.semanticMeaning) ?? token.name,
+        value: token.value,
+        source: primarySource ?? '',
+      },
+      proposed: token,
+      decision: 'pending' as const,
+      confidence: result.confidence,
+      rationale: token.semanticMeaning,
+    };
+  });
 
   const warnings = result.warnings
     .filter((w) => w.level !== 'error' || result.tokens.length > 0)
@@ -78,10 +91,13 @@ function extractSourceVarName(semanticMeaning: string | undefined): string | nul
 }
 
 /**
- * Write an ImportPending document to disk.
- * Creates parent directories as needed.
+ * Write an ImportPending document to disk atomically.
+ * Creates parent directories as needed. Writes to a temp file and renames
+ * so that a concurrent reader never sees a partially-written file.
  */
 export async function writeImportPending(path: string, doc: ImportPending): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, `${JSON.stringify(doc, null, 2)}\n`, 'utf-8');
+  const tmp = `${path}.tmp-${process.pid}`;
+  await writeFile(tmp, `${JSON.stringify(doc, null, 2)}\n`, 'utf-8');
+  await rename(tmp, path);
 }

--- a/packages/cli/src/onboard/writer.ts
+++ b/packages/cli/src/onboard/writer.ts
@@ -1,0 +1,87 @@
+/**
+ * Import Pending Writer
+ *
+ * Converts orchestrator OnboardResult into the ImportPending schema
+ * and writes it to .rafters/import-pending.json for user review.
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, relative } from 'node:path';
+import { type ImportPending, ImportPendingSchema, type PendingToken } from '@rafters/shared';
+import type { OnboardResult } from './orchestrator.js';
+
+/**
+ * Convert an OnboardResult into an ImportPending document.
+ *
+ * Each token from the orchestrator becomes a PendingToken with:
+ *   - original: best-effort reconstruction from the source variable name
+ *   - proposed: the token the importer produced
+ *   - decision: 'pending' (user hasn't reviewed yet)
+ *   - confidence: inherited from system confidence (per-token confidence
+ *     would require importer changes, so for now we use system confidence)
+ *   - rationale: the token's own semanticMeaning field
+ */
+export function toImportPending(
+  result: OnboardResult,
+  projectRoot: string,
+  now: Date = new Date(),
+): ImportPending {
+  if (!result.source) {
+    throw new Error('Cannot build ImportPending from a failed onboard result');
+  }
+
+  const [primarySource, ...additionalSources] = result.sourcePaths.map((p) =>
+    relative(projectRoot, p),
+  );
+
+  const tokens: PendingToken[] = result.tokens.map((token) => ({
+    original: {
+      // Reverse the `Imported from X --var-name` convention to recover the source var
+      name: extractSourceVarName(token.semanticMeaning) ?? token.name,
+      value: typeof token.value === 'string' ? token.value : JSON.stringify(token.value),
+      source: primarySource ?? '',
+    },
+    proposed: token,
+    decision: 'pending' as const,
+    confidence: result.confidence,
+    rationale: token.semanticMeaning,
+  }));
+
+  const warnings = result.warnings
+    .filter((w) => w.level !== 'error' || result.tokens.length > 0)
+    .map((w) => ({ level: w.level, message: w.message }));
+
+  const doc: ImportPending = {
+    version: '1.0',
+    createdAt: now.toISOString(),
+    detectedSystem: result.source,
+    systemConfidence: result.confidence,
+    source: primarySource ?? '',
+    ...(additionalSources.length > 0 ? { additionalSources } : {}),
+    ...(warnings.length > 0 ? { warnings } : {}),
+    tokens,
+  };
+
+  // Validate before returning so any schema drift fails loudly
+  return ImportPendingSchema.parse(doc);
+}
+
+/**
+ * Extract the source variable name from a semanticMeaning string.
+ * Importers write "Imported from <system> --var-name" or "Imported from CSS variable --var-name".
+ * Returns the --var-name portion or null if the pattern doesn't match.
+ */
+function extractSourceVarName(semanticMeaning: string | undefined): string | null {
+  if (!semanticMeaning) return null;
+  const match = semanticMeaning.match(/(--[\w-]+)/);
+  return match?.[1] ?? null;
+}
+
+/**
+ * Write an ImportPending document to disk.
+ * Creates parent directories as needed.
+ */
+export async function writeImportPending(path: string, doc: ImportPending): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(doc, null, 2)}\n`, 'utf-8');
+}

--- a/packages/cli/src/utils/paths.ts
+++ b/packages/cli/src/utils/paths.ts
@@ -9,6 +9,7 @@ export interface RaftersPaths {
   config: string;
   tokens: string;
   output: string;
+  importPending: string;
 }
 
 /**
@@ -21,6 +22,7 @@ export function getRaftersPaths(projectRoot: string = process.cwd()): RaftersPat
     config: join(root, 'config.rafters.json'),
     tokens: join(root, 'tokens'),
     output: join(root, 'output'),
+    importPending: join(root, 'import-pending.json'),
   };
 }
 

--- a/packages/cli/src/utils/ui.ts
+++ b/packages/cli/src/utils/ui.ts
@@ -237,8 +237,12 @@ export function log(event: Record<string, unknown>): void {
 
     case 'import:pending_exists':
       context.spinner?.stop();
-      console.log(`  ${event.message}`);
+      console.error(`${event.message}`);
       console.log(`  Existing file: ${event.path}`);
+      break;
+
+    case 'import:pending_backed_up':
+      console.log(`  Previous import-pending backed up: ${event.backup}`);
       break;
 
     case 'import:failed': {

--- a/packages/cli/src/utils/ui.ts
+++ b/packages/cli/src/utils/ui.ts
@@ -218,6 +218,67 @@ export function log(event: Record<string, unknown>): void {
       context.spinner?.fail(event.message as string);
       break;
 
+    // Import events
+    case 'import:scanning':
+      context.spinner = ora('Scanning for design tokens...').start();
+      break;
+
+    case 'import:no_source_detected':
+      context.spinner?.fail('No design tokens detected');
+      console.log(`  ${event.message}`);
+      if (event.suggestion) {
+        console.log(`  ${event.suggestion}`);
+      }
+      break;
+
+    case 'import:no_rafters_dir':
+      console.error(`${event.message}`);
+      break;
+
+    case 'import:pending_exists':
+      context.spinner?.stop();
+      console.log(`  ${event.message}`);
+      console.log(`  Existing file: ${event.path}`);
+      break;
+
+    case 'import:failed': {
+      context.spinner?.fail(`Import failed (source: ${event.source ?? 'unknown'})`);
+      const warnings = (event.warnings as Array<{ level: string; message: string }>) ?? [];
+      for (const w of warnings) {
+        console.log(`  [${w.level}] ${w.message}`);
+      }
+      break;
+    }
+
+    case 'import:complete': {
+      const conf = Math.round((event.confidence as number) * 100);
+      context.spinner?.succeed(
+        `Imported ${event.tokensCreated} tokens from ${event.source} (${conf}% confidence)`,
+      );
+      if ((event.skipped as number) > 0) {
+        console.log(`  Skipped: ${event.skipped}`);
+      }
+      console.log(`  Written: ${event.path}`);
+      console.log('');
+      console.log(`  ${event.nextStep}`);
+      console.log('');
+      break;
+    }
+
+    case 'import:existing_detected':
+      context.spinner?.info('Existing design tokens detected');
+      console.log(
+        `  Source: ${event.source} (${Math.round((event.confidence as number) * 100)}% confidence)`,
+      );
+      console.log(`  Found in: ${event.sourcePaths}`);
+      console.log('');
+      break;
+
+    case 'import:declined':
+      console.log('  Skipped import. You can run `rafters import` later.');
+      console.log('');
+      break;
+
     default:
       // Fallback for unknown events
       if (context.spinner) {

--- a/packages/cli/test/commands/import.test.ts
+++ b/packages/cli/test/commands/import.test.ts
@@ -82,6 +82,24 @@ describe('rafters import command', () => {
     expect(parsed.version).toBe('1.0');
   });
 
+  it('backs up existing pending file when --force is passed', async () => {
+    const { readdir } = await import('node:fs/promises');
+    const src = join(testDir, 'src');
+    await mkdir(src, { recursive: true });
+    await writeFile(join(src, 'index.css'), TAILWIND_CSS);
+    await writeFile(join(testDir, '.rafters', 'import-pending.json'), '{"version":"0.0"}');
+
+    await importCommand({ agent: true, force: true });
+
+    const raftersDir = join(testDir, '.rafters');
+    const entries = await readdir(raftersDir);
+    const backups = entries.filter((f) => f.startsWith('import-pending.json.backup-'));
+    expect(backups.length).toBe(1);
+
+    const backupRaw = await readFile(join(raftersDir, backups[0] as string), 'utf-8');
+    expect(JSON.parse(backupRaw).version).toBe('0.0');
+  });
+
   it('respects --importer to force a specific importer', async () => {
     const src = join(testDir, 'src');
     await mkdir(src, { recursive: true });

--- a/packages/cli/test/commands/import.test.ts
+++ b/packages/cli/test/commands/import.test.ts
@@ -1,0 +1,99 @@
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { ImportPendingSchema } from '@rafters/shared';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { importCommand } from '../../src/commands/import.js';
+import { setAgentMode } from '../../src/utils/ui.js';
+
+const TAILWIND_CSS = `@import "tailwindcss";
+
+@theme {
+  --color-primary-500: oklch(0.55 0.15 250);
+  --spacing-4: 1rem;
+  --radius-md: 0.375rem;
+}
+`;
+
+describe('rafters import command', () => {
+  const testDir = join(process.cwd(), '.test-import-cmd');
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    await mkdir(testDir, { recursive: true });
+    await mkdir(join(testDir, '.rafters'), { recursive: true });
+    process.chdir(testDir);
+    process.exitCode = 0;
+    setAgentMode(true); // silence non-JSON ui output and avoid spinners
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(testDir, { recursive: true, force: true });
+    setAgentMode(false);
+    process.exitCode = 0;
+  });
+
+  it('exits with error when .rafters/ is missing', async () => {
+    await rm(join(testDir, '.rafters'), { recursive: true, force: true });
+    await importCommand({ agent: true });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('exits with error when import-pending.json already exists without --force', async () => {
+    await writeFile(join(testDir, '.rafters', 'import-pending.json'), '{}');
+    const src = join(testDir, 'src');
+    await mkdir(src, { recursive: true });
+    await writeFile(join(src, 'index.css'), TAILWIND_CSS);
+
+    await importCommand({ agent: true });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('exits with error when no source is detected', async () => {
+    await importCommand({ agent: true });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('writes import-pending.json on successful Tailwind v4 import', async () => {
+    const src = join(testDir, 'src');
+    await mkdir(src, { recursive: true });
+    await writeFile(join(src, 'index.css'), TAILWIND_CSS);
+
+    await importCommand({ agent: true });
+
+    const raw = await readFile(join(testDir, '.rafters', 'import-pending.json'), 'utf-8');
+    const parsed = JSON.parse(raw);
+    const doc = ImportPendingSchema.parse(parsed);
+    expect(doc.detectedSystem).toBe('tailwind-v4');
+    expect(doc.tokens.length).toBeGreaterThan(0);
+  });
+
+  it('overwrites existing pending file when --force is passed', async () => {
+    const src = join(testDir, 'src');
+    await mkdir(src, { recursive: true });
+    await writeFile(join(src, 'index.css'), TAILWIND_CSS);
+    await writeFile(join(testDir, '.rafters', 'import-pending.json'), '{"version":"0.0"}');
+
+    await importCommand({ agent: true, force: true });
+
+    const raw = await readFile(join(testDir, '.rafters', 'import-pending.json'), 'utf-8');
+    const parsed = JSON.parse(raw);
+    expect(parsed.version).toBe('1.0');
+  });
+
+  it('respects --importer to force a specific importer', async () => {
+    const src = join(testDir, 'src');
+    await mkdir(src, { recursive: true });
+    // Tailwind v4 CSS -- but force generic-css importer
+    await writeFile(join(src, 'index.css'), TAILWIND_CSS);
+
+    await importCommand({ agent: true, importer: 'generic-css' });
+
+    // Tailwind @theme variables have context='theme' which generic-css skips
+    // (shadcn detection first). So forcing generic-css may not produce tokens
+    // if the @theme block is the only source. Just verify the command ran
+    // without throwing -- the forced importer may legitimately find nothing.
+    expect([0, 1]).toContain(process.exitCode ?? 0);
+  });
+});

--- a/packages/cli/test/mcp/tools.test.ts
+++ b/packages/cli/test/mcp/tools.test.ts
@@ -109,6 +109,17 @@ describe('RaftersToolHandler', () => {
 
       const data = JSON.parse(result.content[0].text as string);
       expect(data.error).toContain('Unknown tool');
+      expect(data.suggestion).toContain('Available tools');
+    });
+
+    it('should point rafters_onboard callers to the CLI', async () => {
+      const handler = new RaftersToolHandler(null);
+      const result = await handler.handleToolCall('rafters_onboard', {});
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.error).toContain('Unknown tool');
+      expect(data.suggestion).toContain('rafters init');
+      expect(data.suggestion).toContain('rafters import');
     });
   });
 });

--- a/packages/cli/test/mcp/tools.test.ts
+++ b/packages/cli/test/mcp/tools.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { RaftersToolHandler, TOOL_DEFINITIONS } from '../../src/mcp/tools.js';
 
 describe('TOOL_DEFINITIONS', () => {
-  it('should define 5 tools', () => {
-    expect(TOOL_DEFINITIONS).toHaveLength(5);
+  it('should define 4 tools', () => {
+    expect(TOOL_DEFINITIONS).toHaveLength(4);
   });
 
   it('should have correct tool names', () => {
@@ -12,7 +12,11 @@ describe('TOOL_DEFINITIONS', () => {
     expect(names).toContain('rafters_rule');
     expect(names).toContain('rafters_pattern');
     expect(names).toContain('rafters_component');
-    expect(names).toContain('rafters_onboard');
+  });
+
+  it('should not include rafters_onboard (moved to rafters init / rafters import)', () => {
+    const names = TOOL_DEFINITIONS.map((t) => t.name);
+    expect(names).not.toContain('rafters_onboard');
   });
 
   it('should have descriptions for all tools', () => {
@@ -95,36 +99,6 @@ describe('RaftersToolHandler', () => {
       const data = JSON.parse(result.content[0].text as string);
       expect(data.composites).toBeDefined();
       expect(Array.isArray(data.composites)).toBe(true);
-    });
-  });
-
-  describe('rafters_onboard', () => {
-    it('should return no_source_detected for analyze on empty directory', async () => {
-      const { mkdtemp, rm } = await import('node:fs/promises');
-      const { join } = await import('node:path');
-      const testDir = await mkdtemp(join(process.cwd(), '.test-mcp-onboard-'));
-      try {
-        const handler = new RaftersToolHandler(null);
-        const result = await handler.handleToolCall('rafters_onboard', {
-          action: 'analyze',
-          path: testDir,
-        });
-
-        const data = JSON.parse(result.content[0].text as string);
-        expect(data.status).toBe('no_source_detected');
-      } finally {
-        await rm(testDir, { recursive: true, force: true });
-      }
-    });
-
-    it('should return error for unknown action', async () => {
-      const handler = new RaftersToolHandler(null);
-      const result = await handler.handleToolCall('rafters_onboard', {
-        action: 'unknown',
-      });
-
-      const data = JSON.parse(result.content[0].text as string);
-      expect(data.error).toContain('Unknown action');
     });
   });
 

--- a/packages/cli/test/onboard/writer.test.ts
+++ b/packages/cli/test/onboard/writer.test.ts
@@ -1,0 +1,147 @@
+import { mkdir, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { ImportPendingSchema, type Token } from '@rafters/shared';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { OnboardResult } from '../../src/onboard/orchestrator.js';
+import { toImportPending, writeImportPending } from '../../src/onboard/writer.js';
+
+const token: Token = {
+  name: 'primary-500',
+  value: 'oklch(0.55 0.15 250)',
+  category: 'color',
+  namespace: 'color',
+  userOverride: null,
+  containerQueryAware: true,
+  semanticMeaning: 'Imported from Tailwind v4 --color-primary-500',
+};
+
+const successfulResult: OnboardResult = {
+  success: true,
+  tokens: [token],
+  source: 'tailwind-v4',
+  confidence: 0.95,
+  detectedBy: ['@theme block'],
+  sourcePaths: ['/project/src/index.css'],
+  warnings: [],
+  stats: { variablesProcessed: 1, tokensCreated: 1, skipped: 0 },
+};
+
+const projectRoot = '/project';
+
+describe('toImportPending', () => {
+  it('builds a valid ImportPending document', () => {
+    const doc = toImportPending(successfulResult, projectRoot);
+    expect(() => ImportPendingSchema.parse(doc)).not.toThrow();
+  });
+
+  it('converts tokens to pending tokens with pending decision', () => {
+    const doc = toImportPending(successfulResult, projectRoot);
+    expect(doc.tokens).toHaveLength(1);
+    expect(doc.tokens[0]?.decision).toBe('pending');
+    expect(doc.tokens[0]?.proposed).toEqual(token);
+  });
+
+  it('recovers source variable name from semanticMeaning', () => {
+    const doc = toImportPending(successfulResult, projectRoot);
+    expect(doc.tokens[0]?.original.name).toBe('--color-primary-500');
+  });
+
+  it('falls back to token name when semanticMeaning lacks a --var', () => {
+    const result: OnboardResult = {
+      ...successfulResult,
+      tokens: [{ ...token, semanticMeaning: 'no var here' }],
+    };
+    const doc = toImportPending(result, projectRoot);
+    expect(doc.tokens[0]?.original.name).toBe('primary-500');
+  });
+
+  it('stores source as project-relative path', () => {
+    const doc = toImportPending(successfulResult, projectRoot);
+    expect(doc.source).toBe('src/index.css');
+  });
+
+  it('captures detectedSystem and systemConfidence', () => {
+    const doc = toImportPending(successfulResult, projectRoot);
+    expect(doc.detectedSystem).toBe('tailwind-v4');
+    expect(doc.systemConfidence).toBe(0.95);
+  });
+
+  it('includes additionalSources when multiple paths exist', () => {
+    const result: OnboardResult = {
+      ...successfulResult,
+      sourcePaths: ['/project/src/index.css', '/project/src/theme.css'],
+    };
+    const doc = toImportPending(result, projectRoot);
+    expect(doc.additionalSources).toEqual(['src/theme.css']);
+  });
+
+  it('omits additionalSources when only one path', () => {
+    const doc = toImportPending(successfulResult, projectRoot);
+    expect(doc.additionalSources).toBeUndefined();
+  });
+
+  it('propagates info/warning warnings', () => {
+    const result: OnboardResult = {
+      ...successfulResult,
+      warnings: [
+        { level: 'info', message: 'Duplicate token skipped' },
+        { level: 'warning', message: 'Unknown namespace' },
+      ],
+    };
+    const doc = toImportPending(result, projectRoot);
+    expect(doc.warnings).toHaveLength(2);
+  });
+
+  it('throws on a failed onboard result', () => {
+    const failed: OnboardResult = {
+      success: false,
+      tokens: [],
+      source: null,
+      confidence: 0,
+      detectedBy: [],
+      sourcePaths: [],
+      warnings: [{ level: 'error', message: 'boom' }],
+      stats: { variablesProcessed: 0, tokensCreated: 0, skipped: 0 },
+    };
+    expect(() => toImportPending(failed, projectRoot)).toThrow(/failed onboard/);
+  });
+});
+
+describe('writeImportPending', () => {
+  const testDir = join(process.cwd(), '.test-writer');
+  const pendingPath = join(testDir, '.rafters', 'import-pending.json');
+
+  beforeEach(async () => {
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('writes a valid JSON file that parses back through the schema', async () => {
+    const doc = toImportPending(successfulResult, testDir);
+    await writeImportPending(pendingPath, doc);
+
+    const raw = await readFile(pendingPath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    expect(() => ImportPendingSchema.parse(parsed)).not.toThrow();
+    expect(parsed.detectedSystem).toBe('tailwind-v4');
+  });
+
+  it('creates parent directories if missing', async () => {
+    const deep = join(testDir, 'a', 'b', 'c', 'pending.json');
+    const doc = toImportPending(successfulResult, testDir);
+    await writeImportPending(deep, doc);
+
+    const raw = await readFile(deep, 'utf-8');
+    expect(raw).toContain('"version": "1.0"');
+  });
+
+  it('ends file with newline', async () => {
+    const doc = toImportPending(successfulResult, testDir);
+    await writeImportPending(pendingPath, doc);
+    const raw = await readFile(pendingPath, 'utf-8');
+    expect(raw.endsWith('\n')).toBe(true);
+  });
+});

--- a/packages/cli/test/onboard/writer.test.ts
+++ b/packages/cli/test/onboard/writer.test.ts
@@ -105,6 +105,16 @@ describe('toImportPending', () => {
     };
     expect(() => toImportPending(failed, projectRoot)).toThrow(/failed onboard/);
   });
+
+  it('fails loudly when a token.value is not a string', () => {
+    // ColorValue or ColorReference shaped value -- no source string to render
+    const colorRef: Token = {
+      ...token,
+      value: { token: 'primary-500' } as unknown as Token['value'],
+    };
+    const result: OnboardResult = { ...successfulResult, tokens: [colorRef] };
+    expect(() => toImportPending(result, projectRoot)).toThrow(/not a source string/);
+  });
 });
 
 describe('writeImportPending', () => {


### PR DESCRIPTION
## Summary

Moves onboarding out of MCP and into the CLI where it belongs. This is the MVP integration that lets huttspawn and shingle run `rafters init` in projects with existing Tailwind/shadcn/generic CSS and get those tokens imported as pending review.

### `rafters init` (interactive)
- After scaffolding `.rafters/`, runs `previewOnboard`
- If existing tokens detected and stdin is a TTY: prompts to import
- On yes: runs orchestrator, writes `.rafters/import-pending.json`
- Agent / non-interactive mode: logs detection with `nextStep` pointing to `rafters import`
- Skips entirely when `import-pending.json` already exists (preserves in-progress review)
- Onboarding failures are non-fatal -- init's primary job already succeeded
- Ctrl-C at the prompt is caught and treated as decline, not an error

### `rafters import` (standalone)
- `--force` backs up the existing pending file to `import-pending.json.backup-<timestamp>.json` before overwriting
- `--importer <id>` forces shadcn / tailwind-v4 / generic-css
- `--agent` outputs JSON for machine consumption
- Exits 1 with clear messaging on each failure path (no .rafters/, pending exists, no source, failed import)

### MCP cleanup
- Removed `rafters_onboard` tool -- agents assemble from pre-made decisions, import is a designer/developer operation
- MCP now has 4 focused tools: composite, rule, pattern, component
- Unknown tool errors include a `suggestion` field; `rafters_onboard` specifically points callers to the CLI

### New `onboard/writer.ts`
- `toImportPending()` converts `OnboardResult` to `ImportPending` schema
- Validates through `ImportPendingSchema.parse()` at the boundary -- schema drift fails loudly
- `writeImportPending()` writes atomically (tmp + rename)
- Fails loudly on non-string `Token.value` (would lose shape via `JSON.stringify`)

## Review fixes applied

From silent-failure-hunter audit:
- Ctrl-C handling at confirm prompt
- Non-fatal onboard failures in init
- Fail-loud on non-string Token.value
- Atomic writes
- --force backup
- Agent-mode nextStep
- Unknown MCP tool suggestion

## Test plan

- [x] 24 new unit tests (13 writer + 7 import + 2 MCP unknown + 2 new)
- [x] 308 CLI tests total, all passing
- [x] 23 shared schema tests still passing
- [x] Typecheck + biome + preflight green
- [x] MCP tool count test verifies 4 tools and explicit exclusion of rafters_onboard

Closes #1271

Generated with [Claude Code](https://claude.ai/code)