### PR TITLE
chore(release): rafters v0.0.49

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # rafters
 
-## Unreleased
+## 0.0.49
 
 ### Minor Changes
 
@@ -16,11 +16,6 @@
 
 - fix(mcp): `rafters_pattern` no longer returns hardcoded patterns. Now queries composites by their `solves` and `appliesWhen` fields. Patterns are design intelligence captured in composite manifests, not static data in the MCP server. Search by what the pattern solves (e.g., "hierarchy", "authentication") or use `query` for fuzzy search. Closes #1280.
 - refactor(plugins): schema-first plugin protocol replaces the class-based `GenerationRuleExecutor`. Each plugin is now a `Plugin<I,O>` with a Zod input schema, a Zod output schema, and a pure `transform` function -- no registry access, no name regex, no implicit side effects. `resolveInput` is the single registry-aware layer that builds the typed input struct from token state; `regenerate` calls it per-node; `cascade` does the topological walk and collects all failures into one aggregate error (`cause.code === 'cascade-aggregate'`). `GenerationRuleExecutor`, `rule-engine.ts`, and `validators/typography-a11y.ts` are deleted. All six built-in plugins (scale, state, contrast, invert, calc, example) are rewritten as `definePlugin` default exports. Closes #1232, #1243.
-
-## 0.0.49
-
-### Patch Changes
-
 - fix(schema): `TokenSchema.userOverride` is now required + nullable instead of optional. `null` is the explicit signal that no designer override exists (generated baseline); a populated object signals a documented designer override. Every generator emits `userOverride: null` explicitly -- the field can no longer be accidentally omitted. Patch schemas (`TokenPatchSchema`) keep `userOverride` optional so PATCH payloads do not have to include it. The `onboard.test.ts` sentinel updated from `!== undefined` to `!== null` to match the new contract. Closes #1227.
 
 ## 0.0.48

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "description": "CLI for Rafters design system - scaffold tokens and add components",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bumps `packages/cli/package.json` to 0.0.49.
- Collapses the `## Unreleased` block and the orphaned `## 0.0.49` entry (userOverride patch, never tagged) into a single 0.0.49 release section.

## Release contents

**Minor**
- `rafters init` detects existing tokens (Tailwind v4, shadcn, generic CSS) and offers to import. New `rafters import` standalone command. (#1271)
- Tailwind v4 `@theme` importer covers color/spacing/typography/radius/shadow/motion/opacity. (#1259)
- Orchestrator coordinates the import pipeline; `previewOnboard()` for confidence scoring. (#1270)

**Breaking**
- Removed `rafters_onboard` MCP tool. Token import is a CLI operation now; MCP has 4 focused tools (composite, rule, pattern, component).

**Patch**
- `rafters_pattern` queries composites instead of returning hardcoded data. (#1280)
- Schema-first plugin protocol replaces the class-based `GenerationRuleExecutor`. (#1232, #1243)
- `TokenSchema.userOverride` required + nullable. (#1227)

## Release mechanics

After merge, tag `v0.0.49` on main to trigger the OIDC publish workflow (`npm publish --provenance` + `gh release create --generate-notes`).

## Test plan

- [x] `pnpm --filter=rafters build` passes
- [x] Lefthook preflight (typecheck + lint + test:unit + test:a11y + build) passed on push
- [ ] CI green before merge