### PR TITLE
fix(cli): move @rafters/composites to devDependencies

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rafters
 
+## 0.0.50
+
+### Patch Changes
+
+- fix(cli): move `@rafters/composites` from `dependencies` to `devDependencies` so it is no longer listed as a runtime dep in the published tarball. The package is private to the workspace and is bundled into `dist/index.js` by tsup (`noExternal`), matching how `@rafters/color-utils`, `@rafters/design-tokens`, `@rafters/shared`, and `@rafters/studio` are already handled. Fixes `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND: "@rafters/composites@workspace:*" is in the dependencies but no package named "@rafters/composites" is present in the workspace` when running `pnpm dlx rafters@0.0.49`. Regression from #1252.
+
 ## 0.0.49
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "description": "CLI for Rafters design system - scaffold tokens and add components",
   "license": "MIT",
   "type": "module",
@@ -33,7 +33,6 @@
     "@antfu/ni": "^28.1.0",
     "@inquirer/prompts": "^8.2.0",
     "@modelcontextprotocol/sdk": "^1.25.1",
-    "@rafters/composites": "workspace:*",
     "commander": "^13.0.0",
     "css-tree": "^3.2.1",
     "execa": "^9.6.1",
@@ -43,6 +42,7 @@
   "devDependencies": {
     "@playwright/test": "catalog:",
     "@rafters/color-utils": "workspace:*",
+    "@rafters/composites": "workspace:*",
     "@rafters/design-tokens": "workspace:*",
     "@rafters/shared": "workspace:*",
     "@rafters/studio": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,9 +339,6 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.1
         version: 1.25.1(hono@4.11.0)(zod@4.3.6)
-      '@rafters/composites':
-        specifier: workspace:*
-        version: link:../composites
       commander:
         specifier: ^13.0.0
         version: 13.1.0
@@ -364,6 +361,9 @@ importers:
       '@rafters/color-utils':
         specifier: workspace:*
         version: link:../color-utils
+      '@rafters/composites':
+        specifier: workspace:*
+        version: link:../composites
       '@rafters/design-tokens':
         specifier: workspace:*
         version: link:../design-tokens


### PR DESCRIPTION
## Summary

\`pnpm dlx rafters@0.0.49\` fails with:

\`\`\`
ERR_PNPM_WORKSPACE_PKG_NOT_FOUND
"@rafters/composites@workspace:*" is in the dependencies but no package named "@rafters/composites" is present in the workspace
\`\`\`

\`@rafters/composites\` is a private workspace package bundled into \`dist/index.js\` by tsup's \`noExternal\` list, but #1252 added it to \`dependencies\` instead of \`devDependencies\`. When published, \`workspace:*\` ships into consumers' environments where composites cannot be resolved.

Moves it to \`devDependencies\` -- matching how \`@rafters/color-utils\`, \`@rafters/design-tokens\`, \`@rafters/shared\`, and \`@rafters/studio\` are already handled. Build output is unchanged (tsup still bundles it).

Bumps to v0.0.50.

## Test plan

- [x] \`pnpm --filter=rafters build\` clean (tsup bundles composites into dist/index.js as before)
- [x] \`pnpm --filter=rafters typecheck\` clean
- [x] \`pnpm preflight\` clean
- [ ] After merge + publish: \`pnpm dlx rafters@0.0.50 init\` resolves without ERR_PNPM_WORKSPACE_PKG_NOT_FOUND