### PR TITLE
fix(ui): silence classy layout-utility warning

### DIFF
--- a/packages/ui/src/primitives/classy.ts
+++ b/packages/ui/src/primitives/classy.ts
@@ -34,8 +34,6 @@ export interface ClassyOptions {
   tokenMap?: TokenMap;
   /** Allow arbitrary values like w-[10px] (default: false) */
   allowArbitrary?: boolean;
-  /** Component context: strip layout utilities (default: false, warn instead) */
-  component?: boolean;
   /** Custom warning handler */
   warn?: (msg: string) => void;
   /** Custom class normalization */
@@ -166,49 +164,6 @@ function defaultWarn(msg: string) {
   }
 }
 
-/**
- * Layout utilities that Container and Grid handle.
- * Components should never receive these. Consumer code gets a warning.
- */
-const LAYOUT_UTILITY_PATTERNS = [
-  /^flex$/,
-  /^flex-(col|row|wrap|nowrap|1|auto|initial|none)$/,
-  /^inline-flex$/,
-  /^grid$/,
-  /^grid-cols-/,
-  /^grid-rows-/,
-  /^col-span-/,
-  /^row-span-/,
-  /^gap-/,
-  /^space-(x|y)-/,
-  /^p-/,
-  /^px-/,
-  /^py-/,
-  /^pt-/,
-  /^pr-/,
-  /^pb-/,
-  /^pl-/,
-  /^m-/,
-  /^mx-/,
-  /^my-/,
-  /^mt-/,
-  /^mr-/,
-  /^mb-/,
-  /^ml-/,
-  /^items-/,
-  /^justify-/,
-  /^self-/,
-  /^place-/,
-  /^content-/,
-];
-
-/**
- * Check if a utility (without modifiers) is a layout utility
- */
-function isLayoutUtility(utility: string): boolean {
-  return LAYOUT_UTILITY_PATTERNS.some((pattern) => pattern.test(utility));
-}
-
 function flatten(inputs: ClassInput[], out: unknown[] = []): unknown[] {
   for (const i of inputs) {
     if (i == null || i === false) continue;
@@ -228,31 +183,16 @@ function flatten(inputs: ClassInput[], out: unknown[] = []): unknown[] {
 export function createClassy(options?: ClassyOptions) {
   const tokenMap = options?.tokenMap;
   const allowArbitrary = options?.allowArbitrary ?? false;
-  const isComponent = options?.component ?? false;
   const warn = options?.warn ?? defaultWarn;
   const normalize = options?.normalize ?? ((s: string) => s);
 
   /**
-   * Process a single class string, checking for arbitrary values and layout utilities
+   * Process a single class string, checking for arbitrary values
    */
   function processClass(cls: string, seen: Set<string>, out: string[]): void {
     if (!allowArbitrary && hasArbitraryValue(cls)) {
       warn(`classy: arbitrary value '${cls}' skipped`);
       return;
-    }
-
-    // Check for layout utilities that Container and Grid handle
-    const parsed = parseTailwindClass(cls);
-    if (parsed.isValid && isLayoutUtility(parsed.utility)) {
-      if (isComponent) {
-        // Components: strip layout utilities silently -- they handle their own layout
-        warn(`classy: layout utility '${cls}' stripped from component. Use Container and Grid.`);
-        return;
-      }
-      // Consumer code: warn but allow
-      warn(
-        `classy: layout utility '${cls}' detected. Container and Grid handle layout in Rafters.`,
-      );
     }
 
     const norm = normalize(cls);

--- a/packages/ui/test/primitives/classy.test.ts
+++ b/packages/ui/test/primitives/classy.test.ts
@@ -53,80 +53,12 @@ describe('classy - bracket blocking', () => {
   });
 });
 
-describe('classy - layout utility detection', () => {
-  it('warns on layout utilities in consumer code but keeps them', () => {
+describe('classy - layout utilities pass through', () => {
+  it('passes layout utilities through silently', () => {
     const spy = vi.fn();
     const c = createClassy({ warn: spy });
-    const out = c('flex', 'gap-4', 'bg-primary');
-    // Consumer: warns but allows
-    expect(out).toBe('flex gap-4 bg-primary');
-    expect(spy).toHaveBeenCalledTimes(2);
-    expect(spy.mock.calls[0][0]).toContain('layout utility');
-    expect(spy.mock.calls[1][0]).toContain('layout utility');
-  });
-
-  it('strips layout utilities in component context', () => {
-    const spy = vi.fn();
-    const c = createClassy({ component: true, warn: spy });
-    const out = c('flex', 'gap-4', 'bg-primary');
-    // Component: strips layout, keeps color
-    expect(out).toBe('bg-primary');
-    expect(spy).toHaveBeenCalledTimes(2);
-    expect(spy.mock.calls[0][0]).toContain('stripped');
-  });
-
-  it('detects all layout utility patterns', () => {
-    const spy = vi.fn();
-    const c = createClassy({ component: true, warn: spy });
-    const out = c(
-      'flex',
-      'flex-col',
-      'inline-flex',
-      'grid',
-      'grid-cols-3',
-      'gap-4',
-      'space-x-2',
-      'p-4',
-      'px-6',
-      'py-2',
-      'm-4',
-      'mx-auto',
-      'my-8',
-      'items-center',
-      'justify-between',
-      'self-start',
-      'bg-primary',
-      'text-sm',
-      'border',
-    );
-    // Only non-layout classes survive
-    expect(out).toBe('bg-primary text-sm border');
-  });
-
-  it('handles modifiers on layout utilities', () => {
-    const spy = vi.fn();
-    const c = createClassy({ component: true, warn: spy });
-    const out = c('hover:flex', 'md:gap-4', 'bg-primary');
-    // Modifiers on layout utilities are still layout
-    expect(out).toBe('bg-primary');
-  });
-
-  it('allows semantic color classes on components', () => {
-    const spy = vi.fn();
-    const c = createClassy({ component: true, warn: spy });
-    const out = c('bg-primary', 'text-destructive', 'border-success');
-    expect(out).toBe('bg-primary text-destructive border-success');
+    const out = c('flex', 'gap-4', 'p-4', 'bg-primary');
+    expect(out).toBe('flex gap-4 p-4 bg-primary');
     expect(spy).not.toHaveBeenCalled();
-  });
-
-  it('default classy warns but does not strip', () => {
-    const spy = vi.fn();
-    // Temporarily redirect warn to spy
-    const c = createClassy({ warn: spy });
-    const out = c('flex', 'p-4', 'bg-card');
-    expect(out).toContain('flex');
-    expect(out).toContain('p-4');
-    expect(out).toContain('bg-card');
-    expect(spy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Building a consumer site that uses Rafters floods stdout with hundreds of:

\`\`\`
classy: layout utility 'flex' detected. Container and Grid handle layout in Rafters.
classy: layout utility 'gap-6' detected. Container and Grid handle layout in Rafters.
classy: layout utility 'p-4' detected. Container and Grid handle layout in Rafters.
...
\`\`\`

The warnings fire on Rafters' own layout components -- \`cardHeaderClasses: 'flex flex-col gap-1.5 p-6'\`, \`containerClasses\`, etc. \`classy\` can't distinguish "Rafters internal class map" from "user slop" at runtime because both arrive as strings with no origin.

File-aware enforcement belongs somewhere that knows about files: the pre-edit hook (already has this), and a future build-time source scanner. Not in a runtime string merger.

## Changes

Removes from \`classy.ts\`:
- \`LAYOUT_UTILITY_PATTERNS\` constant
- \`isLayoutUtility\` helper
- The consumer-mode layout warning branch
- The component-mode layout stripping branch (no call sites passed \`component: true\` -- it was dead code)
- \`ClassyOptions.component\` field

Keeps:
- Arbitrary-value blocking (\`w-[10px]\` is unambiguously wrong, no origin problem)
- Token resolution via \`tokenMap\`
- Class deduplication, normalization, merging

Updates test: old "classy - layout utility detection" describe (6 tests) replaced with one "layout utilities pass through silently" test.

Follow-up: strengthen \`plugin/hooks/pre-edit.sh\` to reject layout utilities in consumer-authored \`className=\` and add a build-time source scanner. That's where the actual slop guard lives.

## Test plan

- [x] \`pnpm --filter=@rafters/ui test:unit\` -- 3724 tests pass
- [x] \`pnpm preflight\` -- lint + typecheck + build clean
- [ ] After merge: consumer build (runlegion.dev, rafters.studio) no longer floods stdout