### PR TITLE
fix(ui): silence classy layout-utility warning + v0.0.50

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rafters
 
+## 0.0.50
+
+### Patch Changes
+
+- fix(ui): `classy` no longer warns on every layout utility. It had no runtime way to distinguish Rafters-internal class maps (Container, Grid, Card internals) from user slop -- both arrive as strings -- so SSR builds flooded logs with hundreds of false positives from `cardHeaderClasses`, `cardContentClasses`, etc. File-aware enforcement belongs in the pre-edit hook and a future build-time source scanner, not in classy. Removes `LAYOUT_UTILITY_PATTERNS`, `isLayoutUtility`, the consumer-mode warning, the dead component-mode strip path, and `ClassyOptions.component`. Keeps arbitrary-value blocking (unambiguous) and token resolution.
+
 ## 0.0.49
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "description": "CLI for Rafters design system - scaffold tokens and add components",
   "license": "MIT",
   "type": "module",

--- a/packages/ui/src/primitives/classy.ts
+++ b/packages/ui/src/primitives/classy.ts
@@ -34,8 +34,6 @@ export interface ClassyOptions {
   tokenMap?: TokenMap;
   /** Allow arbitrary values like w-[10px] (default: false) */
   allowArbitrary?: boolean;
-  /** Component context: strip layout utilities (default: false, warn instead) */
-  component?: boolean;
   /** Custom warning handler */
   warn?: (msg: string) => void;
   /** Custom class normalization */
@@ -166,49 +164,6 @@ function defaultWarn(msg: string) {
   }
 }
 
-/**
- * Layout utilities that Container and Grid handle.
- * Components should never receive these. Consumer code gets a warning.
- */
-const LAYOUT_UTILITY_PATTERNS = [
-  /^flex$/,
-  /^flex-(col|row|wrap|nowrap|1|auto|initial|none)$/,
-  /^inline-flex$/,
-  /^grid$/,
-  /^grid-cols-/,
-  /^grid-rows-/,
-  /^col-span-/,
-  /^row-span-/,
-  /^gap-/,
-  /^space-(x|y)-/,
-  /^p-/,
-  /^px-/,
-  /^py-/,
-  /^pt-/,
-  /^pr-/,
-  /^pb-/,
-  /^pl-/,
-  /^m-/,
-  /^mx-/,
-  /^my-/,
-  /^mt-/,
-  /^mr-/,
-  /^mb-/,
-  /^ml-/,
-  /^items-/,
-  /^justify-/,
-  /^self-/,
-  /^place-/,
-  /^content-/,
-];
-
-/**
- * Check if a utility (without modifiers) is a layout utility
- */
-function isLayoutUtility(utility: string): boolean {
-  return LAYOUT_UTILITY_PATTERNS.some((pattern) => pattern.test(utility));
-}
-
 function flatten(inputs: ClassInput[], out: unknown[] = []): unknown[] {
   for (const i of inputs) {
     if (i == null || i === false) continue;
@@ -228,31 +183,16 @@ function flatten(inputs: ClassInput[], out: unknown[] = []): unknown[] {
 export function createClassy(options?: ClassyOptions) {
   const tokenMap = options?.tokenMap;
   const allowArbitrary = options?.allowArbitrary ?? false;
-  const isComponent = options?.component ?? false;
   const warn = options?.warn ?? defaultWarn;
   const normalize = options?.normalize ?? ((s: string) => s);
 
   /**
-   * Process a single class string, checking for arbitrary values and layout utilities
+   * Process a single class string, checking for arbitrary values
    */
   function processClass(cls: string, seen: Set<string>, out: string[]): void {
     if (!allowArbitrary && hasArbitraryValue(cls)) {
       warn(`classy: arbitrary value '${cls}' skipped`);
       return;
-    }
-
-    // Check for layout utilities that Container and Grid handle
-    const parsed = parseTailwindClass(cls);
-    if (parsed.isValid && isLayoutUtility(parsed.utility)) {
-      if (isComponent) {
-        // Components: strip layout utilities silently -- they handle their own layout
-        warn(`classy: layout utility '${cls}' stripped from component. Use Container and Grid.`);
-        return;
-      }
-      // Consumer code: warn but allow
-      warn(
-        `classy: layout utility '${cls}' detected. Container and Grid handle layout in Rafters.`,
-      );
     }
 
     const norm = normalize(cls);

--- a/packages/ui/test/primitives/classy.test.ts
+++ b/packages/ui/test/primitives/classy.test.ts
@@ -53,80 +53,12 @@ describe('classy - bracket blocking', () => {
   });
 });
 
-describe('classy - layout utility detection', () => {
-  it('warns on layout utilities in consumer code but keeps them', () => {
+describe('classy - layout utilities pass through', () => {
+  it('passes layout utilities through silently', () => {
     const spy = vi.fn();
     const c = createClassy({ warn: spy });
-    const out = c('flex', 'gap-4', 'bg-primary');
-    // Consumer: warns but allows
-    expect(out).toBe('flex gap-4 bg-primary');
-    expect(spy).toHaveBeenCalledTimes(2);
-    expect(spy.mock.calls[0][0]).toContain('layout utility');
-    expect(spy.mock.calls[1][0]).toContain('layout utility');
-  });
-
-  it('strips layout utilities in component context', () => {
-    const spy = vi.fn();
-    const c = createClassy({ component: true, warn: spy });
-    const out = c('flex', 'gap-4', 'bg-primary');
-    // Component: strips layout, keeps color
-    expect(out).toBe('bg-primary');
-    expect(spy).toHaveBeenCalledTimes(2);
-    expect(spy.mock.calls[0][0]).toContain('stripped');
-  });
-
-  it('detects all layout utility patterns', () => {
-    const spy = vi.fn();
-    const c = createClassy({ component: true, warn: spy });
-    const out = c(
-      'flex',
-      'flex-col',
-      'inline-flex',
-      'grid',
-      'grid-cols-3',
-      'gap-4',
-      'space-x-2',
-      'p-4',
-      'px-6',
-      'py-2',
-      'm-4',
-      'mx-auto',
-      'my-8',
-      'items-center',
-      'justify-between',
-      'self-start',
-      'bg-primary',
-      'text-sm',
-      'border',
-    );
-    // Only non-layout classes survive
-    expect(out).toBe('bg-primary text-sm border');
-  });
-
-  it('handles modifiers on layout utilities', () => {
-    const spy = vi.fn();
-    const c = createClassy({ component: true, warn: spy });
-    const out = c('hover:flex', 'md:gap-4', 'bg-primary');
-    // Modifiers on layout utilities are still layout
-    expect(out).toBe('bg-primary');
-  });
-
-  it('allows semantic color classes on components', () => {
-    const spy = vi.fn();
-    const c = createClassy({ component: true, warn: spy });
-    const out = c('bg-primary', 'text-destructive', 'border-success');
-    expect(out).toBe('bg-primary text-destructive border-success');
+    const out = c('flex', 'gap-4', 'p-4', 'bg-primary');
+    expect(out).toBe('flex gap-4 p-4 bg-primary');
     expect(spy).not.toHaveBeenCalled();
-  });
-
-  it('default classy warns but does not strip', () => {
-    const spy = vi.fn();
-    // Temporarily redirect warn to spy
-    const c = createClassy({ warn: spy });
-    const out = c('flex', 'p-4', 'bg-card');
-    expect(out).toContain('flex');
-    expect(out).toContain('p-4');
-    expect(out).toContain('bg-card');
-    expect(spy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- `classy` no longer warns on every layout utility from internal class maps (Container, Grid, Card internals). SSR builds were flooding logs with hundreds of false-positive warnings.
- Removes `LAYOUT_UTILITY_PATTERNS`, `isLayoutUtility`, the consumer-mode warning, the dead component-mode strip path, and `ClassyOptions.component`.
- Keeps arbitrary-value blocking (unambiguous) and token resolution.
- File-aware enforcement belongs in the pre-edit hook + a future build-time source scanner, not in classy.

## Release
- v0.0.50 patch bump
- CHANGELOG entry in same PR

## Test plan
- [x] `pnpm preflight` passes (exit 0)
- [x] `classy.test.ts` updated and green