### PR TITLE
chore(release): rafters v0.0.51

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rafters
 
+## 0.0.51
+
+### Patch Changes
+
+- fix(ui): `classy` no longer warns on every layout utility. It had no runtime way to distinguish Rafters-internal class maps (Container, Grid, Card internals) from user slop -- both arrive as strings -- so SSR builds flooded logs with hundreds of false positives from `cardHeaderClasses`, `cardContentClasses`, etc. File-aware enforcement belongs in the pre-edit hook and a future build-time source scanner, not in classy. Removes `LAYOUT_UTILITY_PATTERNS`, `isLayoutUtility`, the consumer-mode warning, the dead component-mode strip path, and `ClassyOptions.component`. Keeps arbitrary-value blocking (unambiguous) and token resolution. Code change shipped in #1294, this entry catches up the changelog.
+
 ## 0.0.50
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "description": "CLI for Rafters design system - scaffold tokens and add components",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
Patch bump for the classy layout-utility warning fix shipped in #1294. Code already on main; this PR catches up the version + CHANGELOG so the next publish ships it.

## Changes
- `packages/cli/package.json` 0.0.50 -> 0.0.51
- `packages/cli/CHANGELOG.md` new 0.0.51 entry referencing #1294

## Test plan
- [x] `pnpm preflight` passes (62s, exit 0)