### PR TITLE
feat(mcp): monorepo workspace support + v0.0.52

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rafters
 
+## 0.0.52
+
+### Minor Changes
+
+- feat(mcp): monorepo workspace support. `rafters mcp` now reads `pnpm-workspace.yaml` (and `package.json#workspaces` for npm/yarn/bun) when started from a monorepo root, discovers every workspace package containing `.rafters/config.rafters.json`, and addresses them by directory name. Every existing tool (`rafters_composite`, `rafters_rule`, `rafters_pattern`, `rafters_component`) accepts an optional `workspace` parameter. New `rafters_workspaces` tool lists what's available and which one is the default for unscoped calls. Falls back to single-root mode when no monorepo manifest is present, preserving existing behavior.
+
 ## 0.0.51
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "description": "CLI for Rafters design system - scaffold tokens and add components",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -2,21 +2,29 @@
  * rafters mcp
  *
  * Starts MCP server for AI agent access (stdio transport).
- * Discovers the project root by walking up from cwd to find .rafters/,
- * or uses --project-root if provided.
+ *
+ * Discovery:
+ *   - With no `--project-root`, walks up from cwd looking for a monorepo
+ *     manifest (pnpm-workspace.yaml or package.json#workspaces). Each
+ *     workspace package with a `.rafters/config.rafters.json` becomes an
+ *     addressable workspace; the agent picks one per tool call via the
+ *     `workspace` parameter.
+ *   - Falls back to single-root mode when no monorepo manifest is found.
+ *   - With `--project-root`, scopes the server to that one workspace.
  */
 
 import { existsSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { basename, join, resolve } from 'node:path';
 import { startMcpServer } from '../mcp/server.js';
-import { discoverProjectRoot } from '../utils/discover.js';
+import { discoverWorkspaces, pickDefaultWorkspace, type Workspace } from '../utils/workspaces.js';
 
 interface McpOptions {
   projectRoot?: string;
 }
 
 export async function mcp(options: McpOptions): Promise<void> {
-  let projectRoot: string | null;
+  let workspaces: Workspace[];
+  let defaultWorkspace: Workspace | null;
 
   if (options.projectRoot) {
     const explicit = resolve(options.projectRoot);
@@ -25,13 +33,17 @@ export async function mcp(options: McpOptions): Promise<void> {
       process.stderr.write(
         `--project-root ${explicit} does not contain .rafters/config.rafters.json\n`,
       );
-      projectRoot = null;
+      workspaces = [];
+      defaultWorkspace = null;
     } else {
-      projectRoot = explicit;
+      const ws: Workspace = { name: basename(explicit), root: explicit };
+      workspaces = [ws];
+      defaultWorkspace = ws;
     }
   } else {
-    projectRoot = discoverProjectRoot(process.cwd());
+    workspaces = discoverWorkspaces(process.cwd());
+    defaultWorkspace = pickDefaultWorkspace(workspaces, process.cwd());
   }
 
-  await startMcpServer(projectRoot);
+  await startMcpServer(workspaces, defaultWorkspace);
 }

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -8,14 +8,24 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import type { Workspace } from '../utils/workspaces.js';
 import { RaftersToolHandler, TOOL_DEFINITIONS } from './tools.js';
 
 /**
  * Create and start the MCP server.
- * @param projectRoot - Discovered project root, or null if no .rafters/ found
+ *
+ * @param workspaces - Every rafters-initialised workspace reachable from cwd.
+ *                     Empty when no monorepo manifest and no `.rafters/` is found.
+ * @param defaultWorkspace - The workspace used when a tool call omits the
+ *                           `workspace` parameter. Null when there are zero
+ *                           workspaces, or when there are multiple and none
+ *                           contains the cwd.
  */
-export async function startMcpServer(projectRoot: string | null): Promise<void> {
-  const toolHandler = new RaftersToolHandler(projectRoot);
+export async function startMcpServer(
+  workspaces: Workspace[],
+  defaultWorkspace: Workspace | null,
+): Promise<void> {
+  const toolHandler = new RaftersToolHandler(workspaces, defaultWorkspace);
 
   // Create MCP server
   const server = new Server(

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -26,10 +26,29 @@ import {
 } from '@rafters/composites';
 import { registryClient } from '../registry/client.js';
 import { getRaftersPaths } from '../utils/paths.js';
+import { resolveWorkspace, type Workspace } from '../utils/workspaces.js';
+
+const WORKSPACE_PARAM = {
+  workspace: {
+    type: 'string',
+    description:
+      'Workspace name (directory basename). Required when the MCP session has multiple workspaces and none matches cwd. Call rafters_workspaces to list options.',
+  },
+} as const;
 
 // ==================== Tool Definitions ====================
 
 export const TOOL_DEFINITIONS = [
+  {
+    name: 'rafters_workspaces',
+    description:
+      'List rafters workspaces visible to this MCP session. Returns name, path, and which one is the default for unscoped tool calls. Call this first when the project might be a monorepo.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {},
+      required: [],
+    },
+  },
   {
     name: 'rafters_composite',
     description:
@@ -37,6 +56,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object' as const,
       properties: {
+        ...WORKSPACE_PARAM,
         id: { type: 'string', description: 'Get a specific composite by ID' },
         query: { type: 'string', description: 'Fuzzy search by name/keywords' },
         category: { type: 'string', description: 'Filter by category' },
@@ -51,6 +71,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object' as const,
       properties: {
+        ...WORKSPACE_PARAM,
         name: { type: 'string', description: 'Get a specific rule by name' },
         query: { type: 'string', description: 'Search rules by name/description' },
         create: {
@@ -74,6 +95,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object' as const,
       properties: {
+        ...WORKSPACE_PARAM,
         solves: {
           type: 'string',
           description: 'What problem the pattern solves (searches composite solves field)',
@@ -93,6 +115,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object' as const,
       properties: {
+        ...WORKSPACE_PARAM,
         name: {
           type: 'string',
           description: 'Component name (e.g., "button", "dialog", "card")',
@@ -106,28 +129,35 @@ export const TOOL_DEFINITIONS = [
 // ==================== Tool Handler ====================
 
 export class RaftersToolHandler {
-  private projectRoot: string | null;
-  private compositesLoaded = false;
+  private workspaces: Workspace[];
+  private defaultWorkspace: Workspace | null;
+  /** Tracks per-workspace composite loading so we only read from disk once. */
+  private compositesLoadedFor = new Set<string>();
+  /** Tracks built-in composite loading separately (loaded once globally). */
+  private builtInCompositesLoaded = false;
 
-  constructor(projectRoot: string | null) {
-    this.projectRoot = projectRoot;
+  constructor(workspaces: Workspace[], defaultWorkspace: Workspace | null) {
+    this.workspaces = workspaces;
+    this.defaultWorkspace = defaultWorkspace;
   }
 
   async handleToolCall(name: string, args: Record<string, unknown>): Promise<CallToolResult> {
     switch (name) {
+      case 'rafters_workspaces':
+        return this.handleWorkspaces();
       case 'rafters_composite':
         return this.handleComposite(args);
       case 'rafters_rule':
         return this.handleRule(args);
       case 'rafters_pattern':
-        return this.handlePattern(args as { solves?: string; query?: string });
+        return this.handlePattern(args as { solves?: string; query?: string; workspace?: string });
       case 'rafters_component':
         return this.handleComponent(args.name as string);
       default: {
         const suggestion =
           name === 'rafters_onboard'
             ? 'rafters_onboard was removed. Token import is now a CLI operation: run `rafters init` (auto-detects and prompts) or `rafters import` (standalone).'
-            : 'Available tools: rafters_composite, rafters_rule, rafters_pattern, rafters_component.';
+            : 'Available tools: rafters_workspaces, rafters_composite, rafters_rule, rafters_pattern, rafters_component.';
         return {
           content: [
             { type: 'text', text: JSON.stringify({ error: `Unknown tool: ${name}`, suggestion }) },
@@ -135,6 +165,58 @@ export class RaftersToolHandler {
         };
       }
     }
+  }
+
+  /**
+   * Resolve the requested workspace, returning a structured error result when
+   * the agent didn't pick one and there's no default. Returns the default
+   * workspace (which may itself be null when no `.rafters/` exists at all)
+   * for tools that read agent-shipped data and can degrade gracefully.
+   */
+  private resolve(name: string | undefined): Workspace | null {
+    return resolveWorkspace(this.workspaces, this.defaultWorkspace, name);
+  }
+
+  /**
+   * Build a structured error response listing the available workspaces.
+   * Use this when a tool requires a workspace and the agent didn't pick one.
+   */
+  private workspaceRequiredError(): CallToolResult {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            error: 'workspace parameter required',
+            suggestion:
+              'Multiple workspaces are available. Pass `workspace` with one of the names below.',
+            workspaces: this.workspaces.map((w) => ({ name: w.name, root: w.root })),
+          }),
+        },
+      ],
+    };
+  }
+
+  private async handleWorkspaces(): Promise<CallToolResult> {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              workspaces: this.workspaces.map((w) => ({
+                name: w.name,
+                root: w.root,
+                isDefault: w.name === this.defaultWorkspace?.name,
+              })),
+              defaultWorkspace: this.defaultWorkspace?.name ?? null,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
   }
 
   private async loadCompositesFromDir(dir: string): Promise<void> {
@@ -164,30 +246,38 @@ export class RaftersToolHandler {
     }
   }
 
-  private async ensureCompositesLoaded(): Promise<void> {
-    if (this.compositesLoaded) return;
-
-    // Load built-in composites from @rafters/composites
-    const builtInDirs = ['typography'];
-    for (const dir of builtInDirs) {
-      await this.loadCompositesFromDir(
-        join(process.cwd(), 'node_modules/@rafters/composites/src', dir),
-      );
+  private async ensureCompositesLoaded(workspace: Workspace | null): Promise<void> {
+    if (!this.builtInCompositesLoaded) {
+      const builtInDirs = ['typography'];
+      for (const dir of builtInDirs) {
+        await this.loadCompositesFromDir(
+          join(process.cwd(), 'node_modules/@rafters/composites/src', dir),
+        );
+      }
+      this.builtInCompositesLoaded = true;
     }
 
-    // Load project composites if available
-    if (this.projectRoot) {
-      const paths = getRaftersPaths(this.projectRoot);
+    if (workspace && !this.compositesLoadedFor.has(workspace.root)) {
+      const paths = getRaftersPaths(workspace.root);
       await this.loadCompositesFromDir(join(paths.root, 'composites'));
+      this.compositesLoadedFor.add(workspace.root);
     }
-
-    this.compositesLoaded = true;
   }
 
   private async handleComposite(args: Record<string, unknown>): Promise<CallToolResult> {
-    await this.ensureCompositesLoaded();
+    const { id, query, category, workspace } = args as {
+      id?: string;
+      query?: string;
+      category?: string;
+      workspace?: string;
+    };
 
-    const { id, query, category } = args as { id?: string; query?: string; category?: string };
+    const resolved = this.resolve(workspace);
+    if (workspace && !resolved) {
+      return this.workspaceRequiredError();
+    }
+
+    await this.ensureCompositesLoaded(resolved);
 
     let composites: CompositeFile[];
 
@@ -270,10 +360,19 @@ export class RaftersToolHandler {
     return { content: [{ type: 'text', text: JSON.stringify({ rules }, null, 2) }] };
   }
 
-  private async handlePattern(args: { solves?: string; query?: string }): Promise<CallToolResult> {
-    await this.ensureCompositesLoaded();
+  private async handlePattern(args: {
+    solves?: string;
+    query?: string;
+    workspace?: string;
+  }): Promise<CallToolResult> {
+    const { solves, query, workspace } = args;
 
-    const { solves, query } = args;
+    const resolved = this.resolve(workspace);
+    if (workspace && !resolved) {
+      return this.workspaceRequiredError();
+    }
+
+    await this.ensureCompositesLoaded(resolved);
     let composites: CompositeFile[];
 
     if (solves) {

--- a/packages/cli/src/utils/workspaces.ts
+++ b/packages/cli/src/utils/workspaces.ts
@@ -1,0 +1,256 @@
+/**
+ * Workspace discovery for monorepo support.
+ *
+ * The MCP server can be started from a monorepo root that contains multiple
+ * workspaces, each with its own `.rafters/config.rafters.json`. The agent
+ * picks one workspace per tool call via the `workspace` parameter.
+ *
+ * Discovery order:
+ *   1. Walk up from `startDir` looking for `pnpm-workspace.yaml` or
+ *      `package.json` with a `workspaces` field. That directory is the
+ *      monorepo root.
+ *   2. If found, expand workspace globs and filter to those containing
+ *      `.rafters/config.rafters.json`.
+ *   3. If not found, fall back to single-root mode -- walk up looking for
+ *      `.rafters/config.rafters.json` and return that as a single-element list.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+import { discoverProjectRoot } from './discover.js';
+
+export interface Workspace {
+  /** Directory name -- agent uses this to scope tool calls. */
+  name: string;
+  /** Absolute path to the workspace root. */
+  root: string;
+}
+
+interface MonorepoLayout {
+  /** Absolute path to the monorepo root. */
+  root: string;
+  /** Workspace glob patterns from pnpm-workspace.yaml or package.json. */
+  patterns: string[];
+}
+
+/**
+ * Walk up from startDir to find a monorepo root.
+ * Returns null if no pnpm-workspace.yaml or package.json#workspaces is found.
+ *
+ * If `boundary` is provided, the walk stops once it reaches that directory
+ * (used by tests so they can isolate from the surrounding repo).
+ */
+function findMonorepoRoot(startDir: string, boundary?: string): MonorepoLayout | null {
+  let current = resolve(startDir);
+  const stopAt = boundary ? resolve(boundary) : null;
+
+  for (;;) {
+    const pnpmWorkspace = join(current, 'pnpm-workspace.yaml');
+    if (existsSync(pnpmWorkspace)) {
+      const patterns = parsePnpmWorkspaceYaml(readFileSync(pnpmWorkspace, 'utf-8'));
+      if (patterns.length > 0) {
+        return { root: current, patterns };
+      }
+    }
+
+    const pkgJson = join(current, 'package.json');
+    if (existsSync(pkgJson)) {
+      const patterns = parsePackageJsonWorkspaces(readFileSync(pkgJson, 'utf-8'));
+      if (patterns.length > 0) {
+        return { root: current, patterns };
+      }
+    }
+
+    if (stopAt && current === stopAt) return null;
+
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+/**
+ * Parse the `packages:` array from pnpm-workspace.yaml.
+ * Minimal YAML parser sufficient for the standard pnpm-workspace shape.
+ */
+function parsePnpmWorkspaceYaml(content: string): string[] {
+  const lines = content.split('\n');
+  const patterns: string[] = [];
+  let inPackages = false;
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/#.*$/, '').trimEnd();
+    if (!line.trim()) continue;
+
+    if (/^packages\s*:/.test(line)) {
+      inPackages = true;
+      continue;
+    }
+
+    if (inPackages) {
+      const itemMatch = line.match(/^\s*-\s*(?:["']?)([^"'\s]+)(?:["']?)\s*$/);
+      if (itemMatch?.[1]) {
+        patterns.push(itemMatch[1]);
+        continue;
+      }
+      // A non-list, non-empty line at column 0 ends the packages block.
+      if (!/^\s/.test(line)) {
+        inPackages = false;
+      }
+    }
+  }
+
+  return patterns;
+}
+
+/**
+ * Parse the `workspaces` field from package.json (npm/yarn/bun shape).
+ * Accepts both `workspaces: ["..."]` and `workspaces: { packages: ["..."] }`.
+ */
+function parsePackageJsonWorkspaces(content: string): string[] {
+  try {
+    const pkg = JSON.parse(content);
+    const ws = pkg.workspaces;
+    if (Array.isArray(ws)) {
+      return ws.filter((p): p is string => typeof p === 'string');
+    }
+    if (ws && typeof ws === 'object' && Array.isArray(ws.packages)) {
+      return ws.packages.filter((p: unknown): p is string => typeof p === 'string');
+    }
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Expand a workspace glob pattern (only the trailing `*` form is supported,
+ * matching the patterns pnpm and npm actually accept in practice).
+ *
+ * Supported:
+ *   - `apps/*`        -> every direct subdirectory of `apps/`
+ *   - `sites/*`       -> every direct subdirectory of `sites/`
+ *   - `packages/cli`  -> the literal directory
+ *
+ * Not supported (would require a real glob library):
+ *   - `**`, `{a,b}`, character classes, etc.
+ */
+function expandPattern(monorepoRoot: string, pattern: string): string[] {
+  const trimmed = pattern.replace(/\/+$/, '');
+
+  if (trimmed.endsWith('/*')) {
+    const parentRel = trimmed.slice(0, -2);
+    const parent = join(monorepoRoot, parentRel);
+    if (!existsSync(parent)) return [];
+    return readdirSync(parent)
+      .map((entry) => join(parent, entry))
+      .filter((path) => {
+        try {
+          return statSync(path).isDirectory();
+        } catch {
+          return false;
+        }
+      });
+  }
+
+  const literal = join(monorepoRoot, trimmed);
+  if (existsSync(literal)) {
+    try {
+      if (statSync(literal).isDirectory()) return [literal];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+export interface DiscoverOptions {
+  /**
+   * Stop the walk-up search at this directory (inclusive). When `discoverWorkspaces`
+   * is called inside a wider monorepo (the rafters repo itself, the test
+   * sandbox), `boundary` keeps discovery scoped to the intended subtree.
+   */
+  boundary?: string;
+}
+
+/**
+ * Discover all workspaces with a `.rafters/config.rafters.json`.
+ *
+ * If `startDir` is inside a monorepo, returns every workspace package that
+ * has been initialised with rafters. If not in a monorepo, returns at most
+ * one workspace (the nearest ancestor with `.rafters/`).
+ */
+export function discoverWorkspaces(
+  startDir: string = process.cwd(),
+  options: DiscoverOptions = {},
+): Workspace[] {
+  const layout = findMonorepoRoot(startDir, options.boundary);
+
+  if (!layout) {
+    const single = discoverProjectRoot(startDir);
+    if (!single) return [];
+    if (options.boundary && !single.startsWith(resolve(options.boundary))) return [];
+    return [{ name: basename(single), root: single }];
+  }
+
+  const seen = new Set<string>();
+  const workspaces: Workspace[] = [];
+
+  for (const pattern of layout.patterns) {
+    for (const dir of expandPattern(layout.root, pattern)) {
+      if (seen.has(dir)) continue;
+      seen.add(dir);
+      const config = join(dir, '.rafters', 'config.rafters.json');
+      if (existsSync(config)) {
+        workspaces.push({ name: basename(dir), root: dir });
+      }
+    }
+  }
+
+  // Some setups also keep a `.rafters/` at the monorepo root itself
+  // (shared system used by every workspace). Include it if present and
+  // not already covered by a pattern.
+  const rootConfig = join(layout.root, '.rafters', 'config.rafters.json');
+  if (existsSync(rootConfig) && !seen.has(layout.root)) {
+    workspaces.unshift({ name: basename(layout.root), root: layout.root });
+  }
+
+  return workspaces;
+}
+
+/**
+ * Pick the default workspace for an MCP session started in `startDir`.
+ *
+ * Rules:
+ *   - If `startDir` is inside one of the discovered workspaces, that one wins.
+ *   - Otherwise, if there is exactly one workspace, use it.
+ *   - Otherwise, no default (caller must require a `workspace` parameter).
+ */
+export function pickDefaultWorkspace(
+  workspaces: Workspace[],
+  startDir: string = process.cwd(),
+): Workspace | null {
+  if (workspaces.length === 0) return null;
+
+  const cwd = resolve(startDir);
+  const containing = workspaces.find((ws) => cwd === ws.root || cwd.startsWith(`${ws.root}/`));
+  if (containing) return containing;
+
+  if (workspaces.length === 1) return workspaces[0] ?? null;
+  return null;
+}
+
+/**
+ * Resolve a workspace name to its root, or fall back to the default.
+ * Returns null when no workspace is named and no default is set.
+ */
+export function resolveWorkspace(
+  workspaces: Workspace[],
+  defaultWorkspace: Workspace | null,
+  name: string | undefined,
+): Workspace | null {
+  if (name) {
+    return workspaces.find((ws) => ws.name === name) ?? null;
+  }
+  return defaultWorkspace;
+}

--- a/packages/cli/test/integration/mcp-server.integration.test.ts
+++ b/packages/cli/test/integration/mcp-server.integration.test.ts
@@ -22,7 +22,10 @@ afterEach(async () => {
 describe('MCP tools against initialized project', () => {
   it('rafters_pattern returns patterns from composites', async () => {
     fixturePath = await createInitializedFixture('nextjs-shadcn-v4');
-    const handler = new RaftersToolHandler(fixturePath);
+    const handler = new RaftersToolHandler([{ name: 'fixture', root: fixturePath }], {
+      name: 'fixture',
+      root: fixturePath,
+    });
 
     const result = await handler.handleToolCall('rafters_pattern', {
       solves: 'hierarchy',
@@ -37,7 +40,10 @@ describe('MCP tools against initialized project', () => {
 
   it('rafters_pattern searches by query', async () => {
     fixturePath = await createInitializedFixture('vite-no-shadcn');
-    const handler = new RaftersToolHandler(fixturePath);
+    const handler = new RaftersToolHandler([{ name: 'fixture', root: fixturePath }], {
+      name: 'fixture',
+      root: fixturePath,
+    });
 
     const result = await handler.handleToolCall('rafters_pattern', {
       query: 'heading',
@@ -50,7 +56,10 @@ describe('MCP tools against initialized project', () => {
 
   it('rafters_rule lists built-in rules', async () => {
     fixturePath = await createInitializedFixture('nextjs-shadcn-v4');
-    const handler = new RaftersToolHandler(fixturePath);
+    const handler = new RaftersToolHandler([{ name: 'fixture', root: fixturePath }], {
+      name: 'fixture',
+      root: fixturePath,
+    });
 
     const result = await handler.handleToolCall('rafters_rule', {});
 
@@ -65,7 +74,10 @@ describe('MCP tools against initialized project', () => {
 
   it('rafters_rule filters by name', async () => {
     fixturePath = await createInitializedFixture('vite-no-shadcn');
-    const handler = new RaftersToolHandler(fixturePath);
+    const handler = new RaftersToolHandler([{ name: 'fixture', root: fixturePath }], {
+      name: 'fixture',
+      root: fixturePath,
+    });
 
     const result = await handler.handleToolCall('rafters_rule', { name: 'email' });
 
@@ -76,7 +88,10 @@ describe('MCP tools against initialized project', () => {
 
   it('rafters_composite returns composites list', async () => {
     fixturePath = await createInitializedFixture('nextjs-shadcn-v4');
-    const handler = new RaftersToolHandler(fixturePath);
+    const handler = new RaftersToolHandler([{ name: 'fixture', root: fixturePath }], {
+      name: 'fixture',
+      root: fixturePath,
+    });
 
     const result = await handler.handleToolCall('rafters_composite', {});
 
@@ -89,7 +104,10 @@ describe('MCP tools against initialized project', () => {
 
   it('rafters_component fetches component details', async () => {
     fixturePath = await createInitializedFixture('nextjs-shadcn-v4');
-    const handler = new RaftersToolHandler(fixturePath);
+    const handler = new RaftersToolHandler([{ name: 'fixture', root: fixturePath }], {
+      name: 'fixture',
+      root: fixturePath,
+    });
 
     const result = await handler.handleToolCall('rafters_component', {
       name: 'button',
@@ -103,7 +121,7 @@ describe('MCP tools against initialized project', () => {
 
 describe('MCP tools with null project root', () => {
   it('rafters_pattern works without a project root', async () => {
-    const handler = new RaftersToolHandler(null);
+    const handler = new RaftersToolHandler([], null);
 
     const result = await handler.handleToolCall('rafters_pattern', {});
 
@@ -114,7 +132,7 @@ describe('MCP tools with null project root', () => {
   });
 
   it('rafters_rule works without a project root', async () => {
-    const handler = new RaftersToolHandler(null);
+    const handler = new RaftersToolHandler([], null);
 
     const result = await handler.handleToolCall('rafters_rule', {});
 
@@ -124,7 +142,7 @@ describe('MCP tools with null project root', () => {
   });
 
   it('rafters_composite returns empty array without a project root', async () => {
-    const handler = new RaftersToolHandler(null);
+    const handler = new RaftersToolHandler([], null);
 
     const result = await handler.handleToolCall('rafters_composite', {});
 
@@ -137,7 +155,7 @@ describe('MCP tools with null project root', () => {
 
 describe('unknown tool', () => {
   it('returns error for unknown tool', async () => {
-    const handler = new RaftersToolHandler(null);
+    const handler = new RaftersToolHandler([], null);
     const result = await handler.handleToolCall('unknown_tool', {});
 
     const data = JSON.parse(result.content[0].text as string);

--- a/packages/cli/test/mcp/tools.test.ts
+++ b/packages/cli/test/mcp/tools.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, it } from 'vitest';
 import { RaftersToolHandler, TOOL_DEFINITIONS } from '../../src/mcp/tools.js';
 
 describe('TOOL_DEFINITIONS', () => {
-  it('should define 4 tools', () => {
-    expect(TOOL_DEFINITIONS).toHaveLength(4);
+  it('should define 5 tools', () => {
+    expect(TOOL_DEFINITIONS).toHaveLength(5);
   });
 
   it('should have correct tool names', () => {
     const names = TOOL_DEFINITIONS.map((t) => t.name);
+    expect(names).toContain('rafters_workspaces');
     expect(names).toContain('rafters_composite');
     expect(names).toContain('rafters_rule');
     expect(names).toContain('rafters_pattern');
@@ -37,7 +38,7 @@ describe('TOOL_DEFINITIONS', () => {
 describe('RaftersToolHandler', () => {
   describe('rafters_pattern', () => {
     it('should return patterns from composites with usagePatterns', async () => {
-      const handler = new RaftersToolHandler(null);
+      const handler = new RaftersToolHandler([], null);
       const result = await handler.handleToolCall('rafters_pattern', {});
 
       expect(result.content).toHaveLength(1);
@@ -47,7 +48,7 @@ describe('RaftersToolHandler', () => {
     });
 
     it('should search by solves field', async () => {
-      const handler = new RaftersToolHandler(null);
+      const handler = new RaftersToolHandler([], null);
       const result = await handler.handleToolCall('rafters_pattern', {
         solves: 'hierarchy',
       });
@@ -59,7 +60,7 @@ describe('RaftersToolHandler', () => {
     });
 
     it('should search by query', async () => {
-      const handler = new RaftersToolHandler(null);
+      const handler = new RaftersToolHandler([], null);
       const result = await handler.handleToolCall('rafters_pattern', {
         query: 'heading',
       });
@@ -72,7 +73,7 @@ describe('RaftersToolHandler', () => {
 
   describe('rafters_rule', () => {
     it('should list built-in rules', async () => {
-      const handler = new RaftersToolHandler(null);
+      const handler = new RaftersToolHandler([], null);
       const result = await handler.handleToolCall('rafters_rule', {});
 
       const data = JSON.parse(result.content[0].text as string);
@@ -82,7 +83,7 @@ describe('RaftersToolHandler', () => {
     });
 
     it('should filter rules by name', async () => {
-      const handler = new RaftersToolHandler(null);
+      const handler = new RaftersToolHandler([], null);
       const result = await handler.handleToolCall('rafters_rule', { name: 'email' });
 
       const data = JSON.parse(result.content[0].text as string);
@@ -93,7 +94,7 @@ describe('RaftersToolHandler', () => {
 
   describe('rafters_composite', () => {
     it('should return empty array when no composites loaded', async () => {
-      const handler = new RaftersToolHandler(null);
+      const handler = new RaftersToolHandler([], null);
       const result = await handler.handleToolCall('rafters_composite', {});
 
       const data = JSON.parse(result.content[0].text as string);
@@ -102,9 +103,58 @@ describe('RaftersToolHandler', () => {
     });
   });
 
+  describe('rafters_workspaces', () => {
+    it('returns the empty list and null default when nothing is configured', async () => {
+      const handler = new RaftersToolHandler([], null);
+      const result = await handler.handleToolCall('rafters_workspaces', {});
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.workspaces).toEqual([]);
+      expect(data.defaultWorkspace).toBeNull();
+    });
+
+    it('lists every workspace with its default flag', async () => {
+      const a = { name: 'a', root: '/repo/sites/a' };
+      const b = { name: 'b', root: '/repo/sites/b' };
+      const handler = new RaftersToolHandler([a, b], a);
+      const result = await handler.handleToolCall('rafters_workspaces', {});
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.workspaces).toEqual([
+        { name: 'a', root: '/repo/sites/a', isDefault: true },
+        { name: 'b', root: '/repo/sites/b', isDefault: false },
+      ]);
+      expect(data.defaultWorkspace).toBe('a');
+    });
+  });
+
+  describe('workspace routing', () => {
+    it('returns a workspace-required error when the named workspace is unknown', async () => {
+      const a = { name: 'a', root: '/repo/sites/a' };
+      const handler = new RaftersToolHandler([a], a);
+      const result = await handler.handleToolCall('rafters_composite', {
+        workspace: 'does-not-exist',
+      });
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.error).toBe('workspace parameter required');
+      expect(data.workspaces).toEqual([{ name: 'a', root: '/repo/sites/a' }]);
+    });
+
+    it('uses the default workspace when none is named', async () => {
+      const a = { name: 'a', root: '/repo/sites/a' };
+      const handler = new RaftersToolHandler([a], a);
+      const result = await handler.handleToolCall('rafters_pattern', {});
+
+      const data = JSON.parse(result.content[0].text as string);
+      // Should not be a workspace error -- handler proceeded with default.
+      expect(data.error).not.toBe('workspace parameter required');
+    });
+  });
+
   describe('unknown tool', () => {
     it('should return error for unknown tool', async () => {
-      const handler = new RaftersToolHandler(null);
+      const handler = new RaftersToolHandler([], null);
       const result = await handler.handleToolCall('unknown_tool', {});
 
       const data = JSON.parse(result.content[0].text as string);
@@ -113,7 +163,7 @@ describe('RaftersToolHandler', () => {
     });
 
     it('should point rafters_onboard callers to the CLI', async () => {
-      const handler = new RaftersToolHandler(null);
+      const handler = new RaftersToolHandler([], null);
       const result = await handler.handleToolCall('rafters_onboard', {});
 
       const data = JSON.parse(result.content[0].text as string);

--- a/packages/cli/test/utils/workspaces.test.ts
+++ b/packages/cli/test/utils/workspaces.test.ts
@@ -1,0 +1,167 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  discoverWorkspaces,
+  pickDefaultWorkspace,
+  resolveWorkspace,
+  type Workspace,
+} from '../../src/utils/workspaces.js';
+
+const SCRATCH = join(process.cwd(), '.scratch', 'workspaces-test');
+
+function mkRafters(dir: string): void {
+  mkdirSync(join(dir, '.rafters'), { recursive: true });
+  writeFileSync(join(dir, '.rafters', 'config.rafters.json'), '{}');
+}
+
+beforeEach(() => {
+  rmSync(SCRATCH, { recursive: true, force: true });
+  mkdirSync(SCRATCH, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(SCRATCH, { recursive: true, force: true });
+});
+
+describe('discoverWorkspaces - pnpm-workspace.yaml', () => {
+  it('discovers workspaces under sites/* matching shingle layout', () => {
+    writeFileSync(join(SCRATCH, 'pnpm-workspace.yaml'), 'packages:\n  - sites/*\n');
+    mkdirSync(join(SCRATCH, 'sites', 'a'), { recursive: true });
+    mkdirSync(join(SCRATCH, 'sites', 'b'), { recursive: true });
+    mkdirSync(join(SCRATCH, 'sites', 'c'), { recursive: true });
+    mkRafters(join(SCRATCH, 'sites', 'a'));
+    mkRafters(join(SCRATCH, 'sites', 'b'));
+    // c has no .rafters - should be excluded
+
+    const result = discoverWorkspaces(SCRATCH, { boundary: SCRATCH });
+    expect(result.map((w) => w.name).sort()).toEqual(['a', 'b']);
+  });
+
+  it('handles literal workspace patterns (packages/cli style)', () => {
+    writeFileSync(
+      join(SCRATCH, 'pnpm-workspace.yaml'),
+      'packages:\n  - packages/cli\n  - packages/ui\n',
+    );
+    mkdirSync(join(SCRATCH, 'packages', 'cli'), { recursive: true });
+    mkdirSync(join(SCRATCH, 'packages', 'ui'), { recursive: true });
+    mkRafters(join(SCRATCH, 'packages', 'cli'));
+
+    const result = discoverWorkspaces(SCRATCH, { boundary: SCRATCH });
+    expect(result.map((w) => w.name)).toEqual(['cli']);
+  });
+
+  it('combines apps/* and packages/* with quoted patterns', () => {
+    writeFileSync(
+      join(SCRATCH, 'pnpm-workspace.yaml'),
+      'packages:\n  - "apps/*"\n  - \'packages/*\'\n',
+    );
+    mkdirSync(join(SCRATCH, 'apps', 'web'), { recursive: true });
+    mkdirSync(join(SCRATCH, 'packages', 'ui'), { recursive: true });
+    mkRafters(join(SCRATCH, 'apps', 'web'));
+    mkRafters(join(SCRATCH, 'packages', 'ui'));
+
+    const result = discoverWorkspaces(SCRATCH, { boundary: SCRATCH });
+    expect(result.map((w) => w.name).sort()).toEqual(['ui', 'web']);
+  });
+
+  it('includes the monorepo root when it has its own .rafters/', () => {
+    writeFileSync(join(SCRATCH, 'pnpm-workspace.yaml'), 'packages:\n  - sites/*\n');
+    mkdirSync(join(SCRATCH, 'sites', 'one'), { recursive: true });
+    mkRafters(join(SCRATCH, 'sites', 'one'));
+    mkRafters(SCRATCH);
+
+    const result = discoverWorkspaces(SCRATCH, { boundary: SCRATCH });
+    const names = result.map((w) => w.name);
+    expect(names).toContain('one');
+    expect(names).toContain('workspaces-test'); // basename of SCRATCH
+  });
+});
+
+describe('discoverWorkspaces - package.json#workspaces', () => {
+  it('reads the array form', () => {
+    writeFileSync(
+      join(SCRATCH, 'package.json'),
+      JSON.stringify({ name: 'mono', workspaces: ['apps/*'] }),
+    );
+    mkdirSync(join(SCRATCH, 'apps', 'one'), { recursive: true });
+    mkRafters(join(SCRATCH, 'apps', 'one'));
+
+    const result = discoverWorkspaces(SCRATCH, { boundary: SCRATCH });
+    expect(result.map((w) => w.name)).toEqual(['one']);
+  });
+
+  it('reads the { packages: [] } object form', () => {
+    writeFileSync(
+      join(SCRATCH, 'package.json'),
+      JSON.stringify({ name: 'mono', workspaces: { packages: ['apps/*'] } }),
+    );
+    mkdirSync(join(SCRATCH, 'apps', 'two'), { recursive: true });
+    mkRafters(join(SCRATCH, 'apps', 'two'));
+
+    const result = discoverWorkspaces(SCRATCH, { boundary: SCRATCH });
+    expect(result.map((w) => w.name)).toEqual(['two']);
+  });
+});
+
+describe('discoverWorkspaces - single-root fallback', () => {
+  it('returns one workspace when no monorepo manifest is present', () => {
+    mkRafters(SCRATCH);
+    const result = discoverWorkspaces(SCRATCH, { boundary: SCRATCH });
+    expect(result).toEqual([{ name: 'workspaces-test', root: SCRATCH }]);
+  });
+
+  it('returns empty when neither monorepo nor .rafters/ is found', () => {
+    const result = discoverWorkspaces(SCRATCH, { boundary: SCRATCH });
+    expect(result).toEqual([]);
+  });
+});
+
+describe('pickDefaultWorkspace', () => {
+  const workspaces: Workspace[] = [
+    { name: 'a', root: '/repo/sites/a' },
+    { name: 'b', root: '/repo/sites/b' },
+  ];
+
+  it('returns the workspace containing cwd', () => {
+    const picked = pickDefaultWorkspace(workspaces, '/repo/sites/a/src');
+    expect(picked?.name).toBe('a');
+  });
+
+  it('returns null when cwd is the monorepo root and there are multiple workspaces', () => {
+    expect(pickDefaultWorkspace(workspaces, '/repo')).toBeNull();
+  });
+
+  it('returns the only workspace when there is exactly one', () => {
+    const single: Workspace[] = [{ name: 'solo', root: '/repo/solo' }];
+    expect(pickDefaultWorkspace(single, '/repo')?.name).toBe('solo');
+  });
+
+  it('returns null for empty workspace list', () => {
+    expect(pickDefaultWorkspace([], '/repo')).toBeNull();
+  });
+});
+
+describe('resolveWorkspace', () => {
+  const workspaces: Workspace[] = [
+    { name: 'a', root: '/repo/sites/a' },
+    { name: 'b', root: '/repo/sites/b' },
+  ];
+  const defaultWs = workspaces[0] ?? null;
+
+  it('returns the named workspace when it exists', () => {
+    expect(resolveWorkspace(workspaces, defaultWs, 'b')?.name).toBe('b');
+  });
+
+  it('returns null for an unknown workspace name', () => {
+    expect(resolveWorkspace(workspaces, defaultWs, 'nope')).toBeNull();
+  });
+
+  it('returns the default when no name is given', () => {
+    expect(resolveWorkspace(workspaces, defaultWs, undefined)?.name).toBe('a');
+  });
+
+  it('returns null when no name and no default', () => {
+    expect(resolveWorkspace(workspaces, null, undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
`rafters mcp` now works in a monorepo. When started from a root with `pnpm-workspace.yaml` or `package.json#workspaces`, every workspace package containing `.rafters/config.rafters.json` is addressable by directory name.

- Every existing tool gains an optional `workspace` parameter.
- New `rafters_workspaces` tool lists what's available + which is the default.
- Default workspace = the one containing cwd; or the only one; otherwise none (tools return a structured error listing names).
- Single-root behavior preserved when there's no monorepo manifest.

Concretely fixes the shingle case: 5 sites under `sites/*`, no root `.rafters/`. Before this change `rafters mcp` from shingle root returned a null project root and every tool failed.

## Changes
- `packages/cli/src/utils/workspaces.ts` -- new discovery + default-pick + resolve helpers
- `packages/cli/src/commands/mcp.ts` -- discover workspaces, pass to server
- `packages/cli/src/mcp/server.ts` -- accept `workspaces` + `defaultWorkspace`
- `packages/cli/src/mcp/tools.ts` -- workspace param on every tool, new `rafters_workspaces`, structured error listing names when an unknown workspace is requested
- 16 new unit tests for discovery/defaulting/resolve
- 5 new tests for the workspace-routing handler behavior
- All existing handler tests updated to new constructor signature
- v0.0.52 + CHANGELOG in the same commit

## Test plan
- [x] `pnpm preflight` passes
- [x] `pnpm vitest run` -- 21 files, 324 passed, 12 skipped
- [x] Workspace discovery against the actual shingle layout (sites/* with mixed `.rafters/` presence) covered by unit tests