### PR TITLE
feat(ui): <rafters-badge> Web Component (#1297)

### DIFF
--- a/apps/registry/src/lib/registry/componentService.ts
+++ b/apps/registry/src/lib/registry/componentService.ts
@@ -72,14 +72,16 @@ function getCompositesPath(): string {
 /**
  * Component file extensions to discover.
  * The .tsx file is the primary; others are framework-specific variants.
+ * .element.ts is the Web Component target, parallel to .tsx/.astro/.vue/.svelte.
  */
-const COMPONENT_EXTENSIONS = ['.tsx', '.astro', '.vue', '.svelte'];
+const COMPONENT_EXTENSIONS = ['.tsx', '.astro', '.vue', '.svelte', '.element.ts'];
 
 /**
  * Shared auxiliary file suffixes bundled with components.
- * These provide class maps, types, or constants shared across framework variants.
+ * These provide class maps, types, constants, or shadow-DOM styles shared
+ * across framework variants.
  */
-const SHARED_SUFFIXES = ['.classes.ts', '.types.ts', '.constants.ts'];
+const SHARED_SUFFIXES = ['.classes.ts', '.types.ts', '.constants.ts', '.styles.ts'];
 
 /** Regex matching import statements -- shared across extraction functions */
 const IMPORT_REGEX =

--- a/apps/website/src/lib/registry/componentService.ts
+++ b/apps/website/src/lib/registry/componentService.ts
@@ -72,14 +72,16 @@ function getCompositesPath(): string {
 /**
  * Component file extensions to discover.
  * The .tsx file is the primary; others are framework-specific variants.
+ * .element.ts is the Web Component target, parallel to .tsx/.astro/.vue/.svelte.
  */
-const COMPONENT_EXTENSIONS = ['.tsx', '.astro', '.vue', '.svelte'];
+const COMPONENT_EXTENSIONS = ['.tsx', '.astro', '.vue', '.svelte', '.element.ts'];
 
 /**
  * Shared auxiliary file suffixes bundled with components.
- * These provide class maps, types, or constants shared across framework variants.
+ * These provide class maps, types, constants, or shadow-DOM styles shared
+ * across framework variants.
  */
-const SHARED_SUFFIXES = ['.classes.ts', '.types.ts', '.constants.ts'];
+const SHARED_SUFFIXES = ['.classes.ts', '.types.ts', '.constants.ts', '.styles.ts'];
 
 /**
  * List all available component names.

--- a/packages/ui/src/components/ui/badge.element.test.ts
+++ b/packages/ui/src/components/ui/badge.element.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { RaftersBadge } from './badge.element';
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+function adoptedCssText(el: Element): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  const blocks: string[] = [];
+  for (const sheet of sheets) {
+    const rules: string[] = [];
+    for (const rule of Array.from(sheet.cssRules)) {
+      rules.push(rule.cssText);
+    }
+    blocks.push(rules.join('\n'));
+  }
+  return blocks.join('\n');
+}
+
+describe('<rafters-badge>', () => {
+  it('registers the rafters-badge tag on import', () => {
+    expect(customElements.get('rafters-badge')).toBe(RaftersBadge);
+  });
+
+  it('does not throw when the module is imported twice', async () => {
+    await expect(import('./badge.element')).resolves.toBeDefined();
+    await expect(import('./badge.element')).resolves.toBeDefined();
+    expect(customElements.get('rafters-badge')).toBe(RaftersBadge);
+  });
+
+  it('renders a single span.badge containing a slot', () => {
+    const el = document.createElement('rafters-badge');
+    document.body.appendChild(el);
+    const span = el.shadowRoot?.querySelector('span.badge');
+    expect(span).not.toBeNull();
+    expect(span?.children.length).toBe(1);
+    expect(span?.firstElementChild?.tagName.toLowerCase()).toBe('slot');
+  });
+
+  it('falls back to default variant for unknown values', () => {
+    const el = document.createElement('rafters-badge');
+    el.setAttribute('variant', 'nonsense');
+    document.body.appendChild(el);
+    expect(adoptedCssText(el)).toContain('color-primary');
+  });
+
+  it('falls back to default size for unknown values', () => {
+    const el = document.createElement('rafters-badge');
+    el.setAttribute('size', 'gigantic');
+    document.body.appendChild(el);
+    expect(adoptedCssText(el)).toContain('font-size-label-small');
+  });
+
+  it('reflects variant attribute changes to the adopted stylesheet', () => {
+    const el = document.createElement('rafters-badge');
+    document.body.appendChild(el);
+    el.setAttribute('variant', 'destructive');
+    expect(adoptedCssText(el)).toContain('color-destructive');
+  });
+
+  it('reflects size attribute changes to the adopted stylesheet', () => {
+    const el = document.createElement('rafters-badge');
+    document.body.appendChild(el);
+    el.setAttribute('size', 'lg');
+    expect(adoptedCssText(el)).toContain('font-size-label-medium');
+  });
+
+  it('source contains no direct var() references', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const source = await fs.readFile(path.resolve(__dirname, 'badge.element.ts'), 'utf-8');
+    expect(source).not.toMatch(/var\(/);
+  });
+});

--- a/packages/ui/src/components/ui/badge.element.ts
+++ b/packages/ui/src/components/ui/badge.element.ts
@@ -1,0 +1,117 @@
+/**
+ * <rafters-badge> Web Component
+ *
+ * Framework-target for the Badge component, parallel to badge.tsx (React)
+ * and badge.astro (Astro). Consumes badgeStylesheet() from badge.styles.ts
+ * to guarantee visual parity across framework targets.
+ *
+ * Shadow DOM structure:
+ *   <span class="badge"><slot></slot></span>
+ *
+ * Attributes:
+ *   variant  default | primary | secondary | destructive | success | warning
+ *            | info | muted | accent | outline | ghost
+ *   size     sm | default | lg
+ *
+ * Unknown attribute values fall back to 'default' silently. This matches the
+ * React target's runtime behaviour of `badgeVariantClasses[variant] ?? default`.
+ *
+ * @cognitive-load 2/10
+ * @accessibility Semantic generic span, slotted text remains in the light tree.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import { type BadgeSize, type BadgeVariant, badgeStylesheet } from './badge.styles';
+
+const BADGE_VARIANTS: ReadonlyArray<BadgeVariant> = [
+  'default',
+  'primary',
+  'secondary',
+  'destructive',
+  'success',
+  'warning',
+  'info',
+  'muted',
+  'accent',
+  'outline',
+  'ghost',
+];
+
+const BADGE_SIZES: ReadonlyArray<BadgeSize> = ['sm', 'default', 'lg'];
+
+function isBadgeVariant(value: string | null): value is BadgeVariant {
+  if (value === null) return false;
+  for (const v of BADGE_VARIANTS) {
+    if (v === value) return true;
+  }
+  return false;
+}
+
+function isBadgeSize(value: string | null): value is BadgeSize {
+  if (value === null) return false;
+  for (const s of BADGE_SIZES) {
+    if (s === value) return true;
+  }
+  return false;
+}
+
+export class RaftersBadge extends RaftersElement {
+  static override styles = badgeStylesheet();
+
+  static readonly observedAttributes: ReadonlyArray<string> = ['variant', 'size'];
+
+  private composeStyles(): string {
+    const rawVariant = this.getAttribute('variant');
+    const rawSize = this.getAttribute('size');
+    const variant: BadgeVariant = isBadgeVariant(rawVariant) ? rawVariant : 'default';
+    const size: BadgeSize = isBadgeSize(rawSize) ? rawSize : 'default';
+    const css = badgeStylesheet({ variant, size });
+    (this.constructor as typeof RaftersBadge).styles = css;
+    return css;
+  }
+
+  override connectedCallback(): void {
+    this.composeStyles();
+    super.connectedCallback();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+    if (name === 'variant' || name === 'size') {
+      const css = this.composeStyles();
+      const root = this.shadowRoot;
+      if (root) {
+        const sheets: CSSStyleSheet[] = [];
+        for (const existing of root.adoptedStyleSheets) {
+          sheets.push(existing);
+        }
+        const componentSheet = new CSSStyleSheet();
+        componentSheet.replaceSync(css);
+        // Replace the last sheet (component sheet) if one exists; otherwise append.
+        if (sheets.length > 0) {
+          sheets[sheets.length - 1] = componentSheet;
+        } else {
+          sheets.push(componentSheet);
+        }
+        root.adoptedStyleSheets = sheets;
+      }
+    }
+    super.attributeChangedCallback(name, oldValue, newValue);
+  }
+
+  override render(): Node {
+    const span = document.createElement('span');
+    span.className = 'badge';
+    const slot = document.createElement('slot');
+    span.appendChild(slot);
+    return span;
+  }
+}
+
+if (!customElements.get('rafters-badge')) {
+  customElements.define('rafters-badge', RaftersBadge);
+}

--- a/packages/ui/test/components/badge.element.a11y.ts
+++ b/packages/ui/test/components/badge.element.a11y.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import '../../src/components/ui/badge.element';
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+describe('<rafters-badge> a11y', () => {
+  it('has no accessibility violations in default state', async () => {
+    const el = document.createElement('rafters-badge');
+    el.textContent = 'New';
+    document.body.appendChild(el);
+    // The region rule fires on standalone harness bodies lacking a landmark;
+    // the badge itself has no landmark responsibilities, mirroring badge.tsx.
+    const results = await axe(document.body, { rules: { region: { enabled: false } } });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('matches the semantic role of badge.tsx (generic span, no implicit role)', () => {
+    const el = document.createElement('rafters-badge');
+    el.textContent = 'Active';
+    document.body.appendChild(el);
+    const span = el.shadowRoot?.querySelector('span.badge');
+    expect(span).not.toBeNull();
+    expect(span?.getAttribute('role')).toBeNull();
+    expect(el.getAttribute('role')).toBeNull();
+  });
+
+  it('exposes slotted text content to assistive technology', () => {
+    const el = document.createElement('rafters-badge');
+    el.textContent = 'Pending';
+    document.body.appendChild(el);
+    expect(el.textContent).toBe('Pending');
+  });
+});


### PR DESCRIPTION
Closes #1297.

Ships the Web Component framework target for badge, parallel to `badge.tsx` (React) and `badge.astro` (Astro). The element consumes `badgeStylesheet()` from `badge.styles.ts`, guaranteeing visual parity across all three targets.

## What shipped

- `packages/ui/src/components/ui/badge.element.ts` -- `<rafters-badge>` custom element extending `RaftersElement`
- `packages/ui/src/components/ui/badge.element.test.ts` -- functional tests (registration, render tree, fallback, attribute reflection, no-var invariant)
- `packages/ui/test/components/badge.element.a11y.ts` -- axe-clean + generic-span role parity with `badge.tsx`
- `apps/website/src/lib/registry/componentService.ts` and `apps/registry/src/lib/registry/componentService.ts` -- teach the registry scanner about `.element.ts` variants and `.styles.ts` shared files so the Web Component target ships alongside React and Astro sources

## Behaviour

- `connectedCallback` composes `static styles` from `badgeStylesheet()` before delegating to `super`, so the base class picks up the latest stylesheet
- `attributeChangedCallback` recomposes styles on `variant`/`size` changes and swaps the component sheet in `adoptedStyleSheets`, preserving the shared token sheet
- Unknown attribute values fall back to `'default'` silently, matching the React target's `?? default` behaviour
- Registration is idempotent via `customElements.get` guard; a second import never throws `NotSupportedError`
- Shadow tree built with `document.createElement` + `appendChild`; no `innerHTML` interpolation
- No `var()` literal anywhere in the element file; all token references live in `badge.styles.ts` via `tokenVar()`

## Quality gates

- 11 tests passing (8 functional + 3 a11y)
- `pnpm typecheck` clean
- `pnpm preflight` exit 0
- Registry JSON now lists five files for the badge: `.tsx`, `.astro`, `.classes.ts`, `.element.ts`, `.styles.ts`

Version bump is intentionally deferred -- a separate release PR will roll up all Web Component features together.