### PR TITLE
feat(ui): <rafters-grid> Web Component with container-query responsive cols (#1300)

### DIFF
--- a/packages/ui/src/components/ui/grid.element.test.ts
+++ b/packages/ui/src/components/ui/grid.element.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import './grid.element';
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+describe('rafters-grid', () => {
+  it('auto-registers on import', () => {
+    expect(customElements.get('rafters-grid')).toBeDefined();
+  });
+
+  it('renders a div.grid containing a slot', () => {
+    const host = document.createElement('rafters-grid');
+    document.body.appendChild(host);
+    const grid = host.shadowRoot?.querySelector('div.grid');
+    expect(grid).not.toBeNull();
+    expect(grid?.querySelector('slot')).not.toBeNull();
+  });
+
+  it('defaults to cols=1, gap=4, flow=row', () => {
+    const host = document.createElement('rafters-grid');
+    document.body.appendChild(host);
+    const sheet = host.shadowRoot?.adoptedStyleSheets.at(-1);
+    const css = Array.from(sheet?.cssRules ?? [])
+      .map((r) => r.cssText)
+      .join('\n');
+    expect(css).toContain('repeat(1, minmax(0, 1fr))');
+    expect(css).toContain('var(--spacing-4)');
+    expect(css).toContain('grid-auto-flow: row');
+  });
+
+  it('regenerates stylesheet when cols changes, without rebuilding DOM', () => {
+    const host = document.createElement('rafters-grid');
+    document.body.appendChild(host);
+    const initialDiv = host.shadowRoot?.querySelector('div.grid');
+    host.setAttribute('cols', '6');
+    const finalDiv = host.shadowRoot?.querySelector('div.grid');
+    expect(finalDiv).toBe(initialDiv);
+    const sheet = host.shadowRoot?.adoptedStyleSheets.at(-1);
+    const css = Array.from(sheet?.cssRules ?? [])
+      .map((r) => r.cssText)
+      .join('\n');
+    expect(css).toContain('@container (min-width: 80rem)');
+    expect(css).toContain('repeat(6, minmax(0, 1fr))');
+  });
+
+  it('falls back to defaults for invalid attribute values without throwing', () => {
+    const host = document.createElement('rafters-grid');
+    expect(() => {
+      host.setAttribute('cols', 'banana');
+      host.setAttribute('gap', '999');
+      host.setAttribute('flow', 'sideways');
+      document.body.appendChild(host);
+    }).not.toThrow();
+    const sheet = host.shadowRoot?.adoptedStyleSheets.at(-1);
+    const css = Array.from(sheet?.cssRules ?? [])
+      .map((r) => r.cssText)
+      .join('\n');
+    expect(css).toContain('repeat(1, minmax(0, 1fr))');
+  });
+
+  it('does not throw when module is re-imported', async () => {
+    await expect(import('./grid.element')).resolves.toBeDefined();
+  });
+});

--- a/packages/ui/src/components/ui/grid.element.ts
+++ b/packages/ui/src/components/ui/grid.element.ts
@@ -1,0 +1,142 @@
+/**
+ * <rafters-grid> Web Component
+ *
+ * Framework-target for the Grid component, parallel to grid.tsx (React) and
+ * grid.astro (Astro). Consumes gridStylesheet() from grid.styles.ts so visual
+ * parity is guaranteed across framework targets.
+ *
+ * Shadow DOM structure:
+ *   <div class="grid"><slot></slot></div>
+ *
+ * Attributes:
+ *   cols  1 | 2 | 3 | 4 | 6 | 12          (default 1)
+ *   gap   0 | 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12 | 16  (default 4)
+ *   flow  row | col | dense                (default row)
+ *
+ * Unknown attribute values fall back to defaults silently.
+ *
+ * Container queries (NOT viewport media queries) drive responsive column
+ * counts so the grid responds to its parent container's inline size, not
+ * the viewport.
+ *
+ * Attribute changes regenerate the per-instance stylesheet only; the DOM
+ * tree (the wrapping `<div class="grid">` and its slot) is a stable
+ * reference for the lifetime of the element.
+ *
+ * @cognitive-load 4/10
+ * @accessibility Layout-only container; consumers may set role on the host
+ *                element when interactive grid semantics are required.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import {
+  DEFAULT_GRID_COLS,
+  DEFAULT_GRID_FLOW,
+  DEFAULT_GRID_GAP,
+  GRID_COLS_VALUES,
+  GRID_FLOW_VALUES,
+  GRID_GAP_VALUES,
+  gridStylesheet,
+} from './grid.styles';
+
+function parseEnumInt<T extends number>(raw: string | null, allowed: readonly T[], fallback: T): T {
+  if (raw === null) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed)) return fallback;
+  for (const candidate of allowed) {
+    if (candidate === parsed) return candidate;
+  }
+  return fallback;
+}
+
+function parseEnumString<T extends string>(
+  raw: string | null,
+  allowed: readonly T[],
+  fallback: T,
+): T {
+  if (raw === null) return fallback;
+  for (const candidate of allowed) {
+    if (candidate === raw) return candidate;
+  }
+  return fallback;
+}
+
+export class RaftersGrid extends RaftersElement {
+  /**
+   * Static styles intentionally empty -- per-instance stylesheet is composed
+   * from current attributes in connectedCallback so attribute changes can
+   * swap the sheet without rebuilding the DOM tree.
+   */
+  static override styles = '';
+
+  static readonly observedAttributes: ReadonlyArray<string> = ['cols', 'gap', 'flow'];
+
+  /** Stable per-instance component stylesheet, swapped in place on attr change. */
+  private instanceSheet: CSSStyleSheet | null = null;
+
+  /** Stable per-instance grid wrapper. Built once, reused across attr changes. */
+  private gridRoot: HTMLDivElement | null = null;
+
+  private composeStyles(): string {
+    const cols = parseEnumInt(this.getAttribute('cols'), GRID_COLS_VALUES, DEFAULT_GRID_COLS);
+    const gap = parseEnumInt(this.getAttribute('gap'), GRID_GAP_VALUES, DEFAULT_GRID_GAP);
+    const flow = parseEnumString(this.getAttribute('flow'), GRID_FLOW_VALUES, DEFAULT_GRID_FLOW);
+    return gridStylesheet({ cols, gap, flow });
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+
+    const root = this.shadowRoot;
+    if (!root) return;
+
+    if (!this.instanceSheet) {
+      this.instanceSheet = new CSSStyleSheet();
+    }
+    this.instanceSheet.replaceSync(this.composeStyles());
+
+    const sheets: CSSStyleSheet[] = [];
+    for (const existing of root.adoptedStyleSheets) {
+      if (existing !== this.instanceSheet) sheets.push(existing);
+    }
+    sheets.push(this.instanceSheet);
+    root.adoptedStyleSheets = sheets;
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+    if (name !== 'cols' && name !== 'gap' && name !== 'flow') return;
+
+    if (!this.instanceSheet) return; // pre-connect: connectedCallback will compose.
+
+    this.instanceSheet.replaceSync(this.composeStyles());
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    // Keep gridRoot and instanceSheet so reconnects preserve stable references.
+  }
+
+  override render(): Node {
+    if (!this.gridRoot) {
+      this.gridRoot = this.buildGridRoot();
+    }
+    return this.gridRoot;
+  }
+
+  private buildGridRoot(): HTMLDivElement {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'grid';
+    const slot = document.createElement('slot');
+    wrapper.appendChild(slot);
+    return wrapper;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-grid')) {
+  customElements.define('rafters-grid', RaftersGrid);
+}

--- a/packages/ui/src/components/ui/grid.styles.test.ts
+++ b/packages/ui/src/components/ui/grid.styles.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_GRID_COLS,
+  DEFAULT_GRID_FLOW,
+  DEFAULT_GRID_GAP,
+  GRID_COLS_VALUES,
+  gridStylesheet,
+} from './grid.styles';
+
+describe('gridStylesheet defaults', () => {
+  it('uses cols=1, gap=4, flow=row when no options passed', () => {
+    expect(DEFAULT_GRID_COLS).toBe(1);
+    expect(DEFAULT_GRID_GAP).toBe(4);
+    expect(DEFAULT_GRID_FLOW).toBe('row');
+    const css = gridStylesheet();
+    expect(css).toContain(':host {');
+    expect(css).toContain('display: block;');
+    expect(css).toContain('container-type: inline-size;');
+    expect(css).toContain('display: grid');
+    expect(css).toContain('grid-template-columns: repeat(1, minmax(0, 1fr))');
+    expect(css).toContain('gap: var(--spacing-4)');
+    expect(css).toContain('grid-auto-flow: row');
+  });
+});
+
+describe('gridStylesheet container queries', () => {
+  it('emits @container (min-width: 30rem) only when cols >= 2', () => {
+    expect(gridStylesheet({ cols: 1 })).not.toContain('@container (min-width: 30rem)');
+    expect(gridStylesheet({ cols: 2 })).toContain('@container (min-width: 30rem)');
+  });
+
+  it('never emits viewport media queries', () => {
+    for (const cols of GRID_COLS_VALUES) {
+      const css = gridStylesheet({ cols });
+      expect(css).not.toMatch(/@media\s*\(/);
+    }
+  });
+
+  it('emits all step-up breakpoints for cols=12', () => {
+    const css = gridStylesheet({ cols: 12 });
+    expect(css).toContain('@container (min-width: 30rem)');
+    expect(css).toContain('@container (min-width: 48rem)');
+    expect(css).toContain('@container (min-width: 64rem)');
+    expect(css).toContain('@container (min-width: 80rem)');
+    expect(css).toContain('@container (min-width: 96rem)');
+    expect(css).toContain('repeat(12, minmax(0, 1fr))');
+  });
+
+  it('keeps mobile-first base at 1 column even when target cols=6', () => {
+    const css = gridStylesheet({ cols: 6 });
+    const baseRuleMatch = css.match(/\.grid\s*\{[\s\S]*?\}/);
+    expect(baseRuleMatch).not.toBeNull();
+    expect(baseRuleMatch?.[0]).toContain('grid-template-columns: repeat(1, minmax(0, 1fr))');
+  });
+});
+
+describe('gridStylesheet gap token resolution', () => {
+  it('renders gap via tokenVar(spacing-N)', () => {
+    expect(gridStylesheet({ gap: 8 })).toContain('gap: var(--spacing-8)');
+    expect(gridStylesheet({ gap: 0 })).toContain('gap: var(--spacing-0)');
+    expect(gridStylesheet({ gap: 16 })).toContain('gap: var(--spacing-16)');
+  });
+});
+
+describe('gridStylesheet unknown value fallback', () => {
+  it('falls back to defaults for unknown cols/gap/flow without throwing', () => {
+    const css = gridStylesheet({ cols: 7 as never, gap: 99 as never, flow: 'sideways' as never });
+    expect(css).toContain('grid-template-columns: repeat(1, minmax(0, 1fr))');
+    expect(css).toContain('gap: var(--spacing-4)');
+    expect(css).toContain('grid-auto-flow: row');
+  });
+});
+
+describe('gridStylesheet flow', () => {
+  it('renders col -> grid-auto-flow: column', () => {
+    expect(gridStylesheet({ flow: 'col' })).toContain('grid-auto-flow: column');
+  });
+
+  it('renders dense -> grid-auto-flow: row dense', () => {
+    expect(gridStylesheet({ flow: 'dense' })).toContain('grid-auto-flow: row dense');
+  });
+});
+
+describe('gridStylesheet purity', () => {
+  it('returns identical output for identical inputs', () => {
+    const a = gridStylesheet({ cols: 4, gap: 6, flow: 'row' });
+    const b = gridStylesheet({ cols: 4, gap: 6, flow: 'row' });
+    expect(a).toBe(b);
+  });
+});

--- a/packages/ui/src/components/ui/grid.styles.ts
+++ b/packages/ui/src/components/ui/grid.styles.ts
@@ -1,0 +1,131 @@
+/**
+ * Shadow DOM style definitions for Grid web component
+ *
+ * Parallel to grid.classes.ts. Same semantic structure,
+ * CSS property maps + container queries instead of Tailwind utilities.
+ *
+ * Mobile-first: the base rule always declares a single column. Container
+ * queries (NOT viewport media queries) step the column count up at increasing
+ * container widths so that the grid responds to the size of its parent
+ * surface, not the viewport.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import { atRule, styleRule, stylesheet, tokenVar } from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export type GridCols = 1 | 2 | 3 | 4 | 6 | 12;
+export type GridGap = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12 | 16;
+export type GridFlow = 'row' | 'col' | 'dense';
+
+export const GRID_COLS_VALUES: readonly GridCols[] = [1, 2, 3, 4, 6, 12];
+export const GRID_GAP_VALUES: readonly GridGap[] = [0, 1, 2, 3, 4, 5, 6, 8, 10, 12, 16];
+export const GRID_FLOW_VALUES: readonly GridFlow[] = ['row', 'col', 'dense'];
+
+export const DEFAULT_GRID_COLS: GridCols = 1;
+export const DEFAULT_GRID_GAP: GridGap = 4;
+export const DEFAULT_GRID_FLOW: GridFlow = 'row';
+
+export interface GridStylesheetOptions {
+  cols?: GridCols;
+  gap?: GridGap;
+  flow?: GridFlow;
+}
+
+// ============================================================================
+// Internal Helpers
+// ============================================================================
+
+function isMember<T>(allowed: readonly T[], value: unknown): value is T {
+  for (const candidate of allowed) {
+    if ((candidate as unknown) === value) return true;
+  }
+  return false;
+}
+
+function flowDeclaration(flow: GridFlow): string {
+  if (flow === 'col') return 'column';
+  if (flow === 'dense') return 'row dense';
+  return 'row';
+}
+
+function templateColumns(count: number): string {
+  return `repeat(${count}, minmax(0, 1fr))`;
+}
+
+/**
+ * Container-query step-ups. Each entry promotes the column count to
+ * `min(target, cap)` once the container is at least `min` wide. Mobile-first:
+ * the base rule always renders a single column.
+ */
+interface ContainerStep {
+  min: string;
+  cap: number;
+}
+
+const CONTAINER_STEPS: readonly ContainerStep[] = [
+  { min: '30rem', cap: 2 },
+  { min: '48rem', cap: 3 },
+  { min: '64rem', cap: 4 },
+  { min: '80rem', cap: 6 },
+  { min: '96rem', cap: 12 },
+];
+
+// ============================================================================
+// Base Style Maps
+// ============================================================================
+
+export const gridHostBase: CSSProperties = {
+  display: 'block',
+  'container-type': 'inline-size',
+};
+
+export function gridBase(gap: GridGap, flow: GridFlow): CSSProperties {
+  return {
+    display: 'grid',
+    'grid-template-columns': templateColumns(1),
+    'grid-auto-flow': flowDeclaration(flow),
+    gap: tokenVar(`spacing-${gap}`),
+  };
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Build the complete grid stylesheet for a given configuration.
+ *
+ * Pure: identical options always yield identical output.
+ * Unknown / out-of-range values fall back to defaults silently.
+ */
+export function gridStylesheet(options: GridStylesheetOptions = {}): string {
+  const cols: GridCols = isMember(GRID_COLS_VALUES, options.cols)
+    ? options.cols
+    : DEFAULT_GRID_COLS;
+  const gap: GridGap = isMember(GRID_GAP_VALUES, options.gap) ? options.gap : DEFAULT_GRID_GAP;
+  const flow: GridFlow = isMember(GRID_FLOW_VALUES, options.flow)
+    ? options.flow
+    : DEFAULT_GRID_FLOW;
+
+  const stepRules: string[] = [];
+  for (const step of CONTAINER_STEPS) {
+    if (cols < step.cap) continue;
+    const count = Math.min(cols, step.cap);
+    stepRules.push(
+      atRule(
+        `@container (min-width: ${step.min})`,
+        styleRule('.grid', { 'grid-template-columns': templateColumns(count) }),
+      ),
+    );
+  }
+
+  return stylesheet(
+    styleRule(':host', gridHostBase),
+    styleRule('.grid', gridBase(gap, flow)),
+    ...stepRules,
+  );
+}


### PR DESCRIPTION
## Summary

- Ship `<rafters-grid>` as a token-aware Web Component (`grid.element.ts`) backed by a CSS property map module (`grid.styles.ts`) so non-React/Astro contexts can compose responsive grids without Tailwind.
- Container queries (NOT viewport media queries) drive responsive column counts: mobile-first base of `repeat(1, ...)`, with step-ups at 30/48/64/80/96rem capped at the requested `cols` (1, 2, 3, 4, 6, 12).
- Gap renders through `tokenVar('spacing-N')` so spacing follows the design-token system; never raw `var()`.

## Behavior

- Attributes: `cols`, `gap`, `flow`. Unknown / out-of-range values silently fall back to `cols=1`, `gap=4`, `flow=row`.
- Auto-registers `<rafters-grid>` (idempotent, SSR-safe).
- Shadow DOM (`<div class=\"grid\"><slot></slot></div>`) is a stable reference for the lifetime of the element. Attribute changes only swap the per-instance adopted stylesheet contents -- never rebuild the DOM tree.
- `gridStylesheet({ cols, gap, flow })` is pure: identical options yield identical strings.

## What is NOT in this PR

Per spec scope: no bento/golden/linear preset porting, no `<rafters-grid-item>`, no editable mode / drop zones, no auto-fit/auto-fill heuristics, no padding attribute, no auto-spacing container-query gap scaling. No edits to `grid.tsx`, `grid.classes.ts`, the React component, or design-tokens.

## Test plan

- [x] `pnpm vitest run grid.styles grid.element` from `packages/ui` -- 16/16 pass
- [x] `pnpm typecheck` -- green
- [x] `pnpm preflight` from repo root -- exit 0 (171 ui test files / 3740 tests pass)
- [x] Quality gate (legion-simplify) -- clean, 0 findings
- [x] No raw `var()` in element source; only via `tokenVar()`
- [x] No viewport `@media` queries -- container queries only
- [x] `customElements.get('rafters-grid')` defined after import; idempotent under double import

Closes #1300