### PR TITLE
feat(ui): <rafters-button> Web Component with full variant matrix (#1302)

### DIFF
--- a/packages/ui/src/components/ui/button.element.a11y.tsx
+++ b/packages/ui/src/components/ui/button.element.a11y.tsx
@@ -1,0 +1,190 @@
+/**
+ * Accessibility tests for <rafters-button>.
+ *
+ * Rendering path is plain DOM -- the component lives in its shadow root,
+ * so we create host elements inside a scoped container div and run
+ * vitest-axe against that container. axe-core >= 4 descends into open
+ * shadow roots automatically.
+ *
+ * Scoping to a container (rather than document.body) avoids axe's
+ * document-level "region" rule from firing on every component test.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+// Side-effect import: augments `Assertion` with axe matchers (toHaveNoViolations).
+import 'vitest-axe/extend-expect';
+import './button.element';
+
+let container: HTMLElement;
+
+function mountContainer(): HTMLElement {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  return container;
+}
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+/**
+ * Helper: build a <rafters-button> with attributes and default slot text,
+ * appended to the current scoped container. Returns the host element.
+ */
+function buildButton(attrs: Record<string, string> = {}, text = 'Action'): HTMLElement {
+  const host = document.createElement('rafters-button');
+  for (const [k, v] of Object.entries(attrs)) host.setAttribute(k, v);
+  host.textContent = text;
+  container.appendChild(host);
+  return host;
+}
+
+const VARIANTS = [
+  'default',
+  'primary',
+  'secondary',
+  'destructive',
+  'success',
+  'warning',
+  'info',
+  'muted',
+  'accent',
+  'outline',
+  'ghost',
+  'link',
+] as const;
+
+const SIZES = ['default', 'xs', 'sm', 'lg', 'icon', 'icon-xs', 'icon-sm', 'icon-lg'] as const;
+
+describe('<rafters-button> - Accessibility', () => {
+  it('has no violations with default configuration', async () => {
+    mountContainer();
+    buildButton();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations across every variant', async () => {
+    for (const variant of VARIANTS) {
+      mountContainer();
+      buildButton({ variant }, 'Action');
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+      while (document.body.firstChild) {
+        document.body.removeChild(document.body.firstChild);
+      }
+    }
+  });
+
+  it('has no violations across every size', async () => {
+    for (const size of SIZES) {
+      mountContainer();
+      const isIcon = size.startsWith('icon');
+      if (isIcon) {
+        buildButton({ size, 'aria-label': 'Close dialog' }, 'X');
+      } else {
+        buildButton({ size }, 'Action');
+      }
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+      while (document.body.firstChild) {
+        document.body.removeChild(document.body.firstChild);
+      }
+    }
+  });
+
+  it('has no violations when disabled', async () => {
+    mountContainer();
+    buildButton({ disabled: '' }, 'Disabled');
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with type=submit inside a form', async () => {
+    mountContainer();
+    const form = document.createElement('form');
+
+    const label = document.createElement('label');
+    label.setAttribute('for', 'email');
+    label.textContent = 'Email';
+    form.appendChild(label);
+
+    const input = document.createElement('input');
+    input.id = 'email';
+    input.type = 'email';
+    form.appendChild(input);
+
+    const host = document.createElement('rafters-button');
+    host.setAttribute('type', 'submit');
+    host.textContent = 'Submit';
+    form.appendChild(host);
+
+    container.appendChild(form);
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations for icon button with aria-label', async () => {
+    mountContainer();
+    buildButton({ size: 'icon', 'aria-label': 'Close dialog' }, 'X');
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations when combining variants and sizes', async () => {
+    mountContainer();
+    const configs: Array<{ variant: string; size: string; label: string }> = [
+      { variant: 'default', size: 'sm', label: 'Small Default' },
+      { variant: 'secondary', size: 'lg', label: 'Large Secondary' },
+      { variant: 'outline', size: 'default', label: 'Outline' },
+      { variant: 'ghost', size: 'sm', label: 'Ghost' },
+    ];
+    for (const c of configs) {
+      const host = document.createElement('rafters-button');
+      host.setAttribute('variant', c.variant);
+      host.setAttribute('size', c.size);
+      host.textContent = c.label;
+      container.appendChild(host);
+    }
+    const icon = document.createElement('rafters-button');
+    icon.setAttribute('variant', 'destructive');
+    icon.setAttribute('size', 'icon');
+    icon.setAttribute('aria-label', 'Delete');
+    icon.textContent = 'X';
+    container.appendChild(icon);
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations inside an aria-labelled group', async () => {
+    mountContainer();
+    const group = document.createElement('div');
+    group.setAttribute('role', 'group');
+    group.setAttribute('aria-label', 'Actions');
+
+    const save = document.createElement('rafters-button');
+    save.setAttribute('variant', 'default');
+    save.textContent = 'Save';
+    group.appendChild(save);
+
+    const cancel = document.createElement('rafters-button');
+    cancel.setAttribute('variant', 'outline');
+    cancel.textContent = 'Cancel';
+    group.appendChild(cancel);
+
+    const del = document.createElement('rafters-button');
+    del.setAttribute('variant', 'destructive');
+    del.textContent = 'Delete';
+    group.appendChild(del);
+
+    container.appendChild(group);
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/ui/src/components/ui/button.element.test.ts
+++ b/packages/ui/src/components/ui/button.element.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import './button.element';
+import { RaftersButton } from './button.element';
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+function mount(attrs: Record<string, string> = {}): HTMLElement {
+  const el = document.createElement('rafters-button');
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.appendChild(el);
+  return el;
+}
+
+function collectCss(el: HTMLElement): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  return sheets
+    .map((s) =>
+      Array.from(s.cssRules)
+        .map((r) => r.cssText)
+        .join('\n'),
+    )
+    .join('\n');
+}
+
+describe('rafters-button', () => {
+  it('registers as a custom element', () => {
+    expect(customElements.get('rafters-button')).toBeDefined();
+  });
+
+  it('exports RaftersButton as the registered constructor', () => {
+    expect(customElements.get('rafters-button')).toBe(RaftersButton);
+  });
+
+  it('renders an inner <button> with type="button" by default', () => {
+    const el = mount();
+    const inner = el.shadowRoot?.querySelector('button');
+    expect(inner).toBeTruthy();
+    expect(inner?.getAttribute('type')).toBe('button');
+  });
+
+  it('inner <button> carries only the .button class (no Tailwind)', () => {
+    const el = mount();
+    const inner = el.shadowRoot?.querySelector('button');
+    expect(inner?.className).toBe('button');
+  });
+
+  it('reflects disabled to the inner button', () => {
+    const el = mount({ disabled: '' });
+    const inner = el.shadowRoot?.querySelector('button');
+    expect(inner?.disabled).toBe(true);
+
+    el.removeAttribute('disabled');
+    const refreshed = el.shadowRoot?.querySelector('button');
+    expect(refreshed?.disabled).toBe(false);
+  });
+
+  it('applies type=submit when attribute is set', () => {
+    const el = mount({ type: 'submit' });
+    expect(el.shadowRoot?.querySelector('button')?.getAttribute('type')).toBe('submit');
+  });
+
+  it('applies type=reset when attribute is set', () => {
+    const el = mount({ type: 'reset' });
+    expect(el.shadowRoot?.querySelector('button')?.getAttribute('type')).toBe('reset');
+  });
+
+  it('falls back to type=button for unknown type values', () => {
+    const el = mount({ type: 'bogus' });
+    expect(el.shadowRoot?.querySelector('button')?.getAttribute('type')).toBe('button');
+  });
+
+  it('falls back to default variant/size for unknown values without throwing', () => {
+    expect(() => mount({ variant: 'made-up', size: 'enormous' })).not.toThrow();
+  });
+
+  it('bubbles click events from inner button to host', () => {
+    const el = mount();
+    let received = 0;
+    el.addEventListener('click', () => {
+      received += 1;
+    });
+    el.shadowRoot?.querySelector('button')?.click();
+    expect(received).toBe(1);
+  });
+
+  it('does not fire click when disabled', () => {
+    const el = mount({ disabled: '' });
+    let received = 0;
+    el.addEventListener('click', () => {
+      received += 1;
+    });
+    el.shadowRoot?.querySelector('button')?.click();
+    expect(received).toBe(0);
+  });
+
+  it('renders a default <slot> for consumer content', () => {
+    const el = mount();
+    el.textContent = 'Save';
+    const slot = el.shadowRoot?.querySelector('slot');
+    expect(slot).toBeTruthy();
+  });
+
+  it('updates stylesheet when variant attribute changes', () => {
+    const el = mount();
+    el.setAttribute('variant', 'destructive');
+    const css = collectCss(el);
+    expect(css).toContain('var(--color-destructive)');
+  });
+
+  it('updates stylesheet when size attribute changes', () => {
+    const el = mount();
+    el.setAttribute('size', 'lg');
+    const css = collectCss(el);
+    expect(css).toContain('height: 3rem');
+  });
+
+  it('updates stylesheet when disabled is toggled', () => {
+    const el = mount();
+    expect(collectCss(el)).not.toMatch(/\.button\s*\{[^}]*opacity:\s*0\.5/);
+    el.setAttribute('disabled', '');
+    expect(collectCss(el)).toMatch(/opacity:\s*0\.5/);
+    el.removeAttribute('disabled');
+    const after = collectCss(el);
+    // :disabled rule still emits disabled styles, but the base rule should not.
+    expect(after).toMatch(/\.button:disabled\s*\{[^}]*opacity:\s*0\.5/);
+  });
+
+  it('rebuilds inner button type when type attribute changes', () => {
+    const el = mount();
+    expect(el.shadowRoot?.querySelector('button')?.getAttribute('type')).toBe('button');
+    el.setAttribute('type', 'submit');
+    expect(el.shadowRoot?.querySelector('button')?.getAttribute('type')).toBe('submit');
+    el.setAttribute('type', 'bogus');
+    expect(el.shadowRoot?.querySelector('button')?.getAttribute('type')).toBe('button');
+  });
+
+  it('observedAttributes matches the documented contract', () => {
+    expect(RaftersButton.observedAttributes).toEqual(['variant', 'size', 'disabled', 'type']);
+  });
+
+  it('importing the module twice does not throw', async () => {
+    await import('./button.element');
+    await import('./button.element');
+    expect(customElements.get('rafters-button')).toBe(RaftersButton);
+  });
+
+  it('shadow root adopts the per-instance stylesheet', () => {
+    const el = mount();
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    expect(sheets.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('stylesheet uses only --motion-duration / --motion-ease tokens', () => {
+    const el = mount();
+    const css = collectCss(el);
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+  });
+
+  it('source contains no direct var() literals in either .ts file', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const elementSource = await fs.readFile(path.resolve(__dirname, 'button.element.ts'), 'utf-8');
+    expect(elementSource).not.toMatch(/[^a-zA-Z_]var\(/);
+  });
+});

--- a/packages/ui/src/components/ui/button.element.ts
+++ b/packages/ui/src/components/ui/button.element.ts
@@ -1,0 +1,141 @@
+/**
+ * <rafters-button> -- Web Component button primitive.
+ *
+ * Mirrors the semantics of button.tsx (variant, size, disabled, type) using
+ * shadow-DOM-scoped CSS composed via classy-wc. Auto-registers on import and
+ * is idempotent against double-define.
+ *
+ * Attributes:
+ *  - variant: 'default' | 'primary' | 'secondary' | 'destructive' | 'success'
+ *             | 'warning' | 'info' | 'muted' | 'accent' | 'outline' | 'ghost'
+ *             | 'link'  (default 'default')
+ *  - size:    'default' | 'xs' | 'sm' | 'lg' | 'icon' | 'icon-xs'
+ *             | 'icon-sm' | 'icon-lg'  (default 'default')
+ *  - disabled: boolean (presence-based)
+ *  - type:    'button' | 'submit' | 'reset'  (default 'button')
+ *
+ * The inner <button> is plain shadow-DOM markup -- NO Tailwind classes.
+ * Styling comes exclusively from buttonStylesheet(...) adopted as the
+ * per-instance stylesheet.
+ *
+ * Click events bubble naturally from the inner <button> to the host.
+ * Default type MUST be 'button' to prevent accidental form submission.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import { type ButtonSize, type ButtonVariant, buttonStylesheet } from './button.styles';
+
+export type ButtonType = 'button' | 'submit' | 'reset';
+
+const ALLOWED_VARIANTS: ReadonlyArray<ButtonVariant> = [
+  'default',
+  'primary',
+  'secondary',
+  'destructive',
+  'success',
+  'warning',
+  'info',
+  'muted',
+  'accent',
+  'outline',
+  'ghost',
+  'link',
+];
+
+const ALLOWED_SIZES: ReadonlyArray<ButtonSize> = [
+  'default',
+  'xs',
+  'sm',
+  'lg',
+  'icon',
+  'icon-xs',
+  'icon-sm',
+  'icon-lg',
+];
+
+const ALLOWED_TYPES: ReadonlyArray<ButtonType> = ['button', 'submit', 'reset'];
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = ['variant', 'size', 'disabled', 'type'] as const;
+
+function parseVariant(value: string | null): ButtonVariant {
+  if (value && (ALLOWED_VARIANTS as ReadonlyArray<string>).includes(value)) {
+    return value as ButtonVariant;
+  }
+  return 'default';
+}
+
+function parseSize(value: string | null): ButtonSize {
+  if (value && (ALLOWED_SIZES as ReadonlyArray<string>).includes(value)) {
+    return value as ButtonSize;
+  }
+  return 'default';
+}
+
+function parseType(value: string | null): ButtonType {
+  if (value && (ALLOWED_TYPES as ReadonlyArray<string>).includes(value)) {
+    return value as ButtonType;
+  }
+  return 'button';
+}
+
+export class RaftersButton extends RaftersElement {
+  static observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  /** Per-instance stylesheet rebuilt on every attribute change. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  override connectedCallback(): void {
+    if (!this.shadowRoot) return;
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+    this.shadowRoot.adoptedStyleSheets = [this._instanceSheet];
+    this.update();
+  }
+
+  override attributeChangedCallback(
+    _name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+    if (this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+    this.update();
+  }
+
+  override disconnectedCallback(): void {
+    this._instanceSheet = null;
+  }
+
+  /**
+   * Build the CSS string for the current attribute values.
+   */
+  private composeCss(): string {
+    return buttonStylesheet({
+      variant: parseVariant(this.getAttribute('variant')),
+      size: parseSize(this.getAttribute('size')),
+      disabled: this.hasAttribute('disabled'),
+    });
+  }
+
+  /**
+   * Render the inner semantic <button> with a single default <slot>.
+   * DOM APIs only -- never innerHTML. The inner button carries NO classes
+   * other than `.button` so visual state comes exclusively from the
+   * per-instance stylesheet.
+   */
+  override render(): Node {
+    const inner = document.createElement('button');
+    inner.className = 'button';
+    inner.setAttribute('type', parseType(this.getAttribute('type')));
+    inner.disabled = this.hasAttribute('disabled');
+    const slot = document.createElement('slot');
+    inner.appendChild(slot);
+    return inner;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-button')) {
+  customElements.define('rafters-button', RaftersButton);
+}

--- a/packages/ui/src/components/ui/button.styles.test.ts
+++ b/packages/ui/src/components/ui/button.styles.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type ButtonSize,
+  type ButtonVariant,
+  buttonBase,
+  buttonDisabled,
+  buttonSizeStyles,
+  buttonStylesheet,
+  buttonVariantActive,
+  buttonVariantFocusRing,
+  buttonVariantHover,
+  buttonVariantStyles,
+} from './button.styles';
+
+const ALL_VARIANTS: ReadonlyArray<ButtonVariant> = [
+  'default',
+  'primary',
+  'secondary',
+  'destructive',
+  'success',
+  'warning',
+  'info',
+  'muted',
+  'accent',
+  'outline',
+  'ghost',
+  'link',
+];
+
+const ALL_SIZES: ReadonlyArray<ButtonSize> = [
+  'default',
+  'xs',
+  'sm',
+  'lg',
+  'icon',
+  'icon-xs',
+  'icon-sm',
+  'icon-lg',
+];
+
+describe('buttonStylesheet', () => {
+  it('returns base + default variant + default size when no options given', () => {
+    const css = buttonStylesheet();
+    expect(css).toContain('.button');
+    expect(css).toContain('var(--color-primary)');
+    expect(css).toContain('var(--color-primary-foreground)');
+    expect(css).toContain('height: 2.5rem');
+  });
+
+  it('emits all 12 variants without throwing', () => {
+    for (const v of ALL_VARIANTS) {
+      expect(() => buttonStylesheet({ variant: v })).not.toThrow();
+    }
+  });
+
+  it('emits all 8 sizes without throwing', () => {
+    for (const s of ALL_SIZES) {
+      expect(() => buttonStylesheet({ size: s })).not.toThrow();
+    }
+  });
+
+  it('uses tokenVar() for all token references (no --duration/--ease)', () => {
+    const css = buttonStylesheet({ variant: 'primary' });
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+    expect(css).toMatch(/var\(--motion-duration-/);
+    expect(css).toMatch(/var\(--motion-ease-/);
+  });
+
+  it('applies disabled styles when disabled=true', () => {
+    const css = buttonStylesheet({ disabled: true });
+    expect(css).toContain('opacity: 0.5');
+    expect(css).toContain('cursor: not-allowed');
+    expect(css).toContain('pointer-events: none');
+  });
+
+  it('falls back to default for unknown variant/size', () => {
+    const css = buttonStylesheet({
+      variant: 'bogus' as never,
+      size: 'huge' as never,
+    });
+    expect(css).toContain('var(--color-primary)');
+    expect(css).toContain('height: 2.5rem');
+  });
+
+  it('emits focus-visible ring rule using the destructive-ring token', () => {
+    const css = buttonStylesheet({ variant: 'destructive' });
+    expect(css).toContain('.button:focus-visible');
+    expect(css).toContain('var(--color-destructive-ring)');
+  });
+
+  it('emits hover and active rules for semantic variants', () => {
+    const css = buttonStylesheet({ variant: 'primary' });
+    expect(css).toContain('.button:hover:not(:disabled)');
+    expect(css).toContain('var(--color-primary-hover)');
+    expect(css).toContain('.button:active:not(:disabled)');
+    expect(css).toContain('var(--color-primary-active)');
+  });
+
+  it('emits a prefers-reduced-motion at-rule that kills transitions', () => {
+    const css = buttonStylesheet();
+    expect(css).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(css).toContain('transition: none');
+  });
+
+  it('never emits a raw var() that is not a CSS custom property reference', () => {
+    const css = buttonStylesheet({ variant: 'primary', size: 'lg' });
+    // Every var() must start with --
+    const matches = css.match(/var\([^)]+\)/g) ?? [];
+    for (const m of matches) {
+      expect(m).toMatch(/var\(--/);
+    }
+  });
+
+  it('uses only --motion-duration-* and --motion-ease-* motion tokens', () => {
+    const css = buttonStylesheet({
+      variant: 'destructive',
+      size: 'lg',
+      disabled: true,
+    });
+    expect(css).toMatch(/var\(--motion-duration-fast\)/);
+    expect(css).toMatch(/var\(--motion-ease-standard\)/);
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+  });
+
+  it('emits :host display: inline-flex', () => {
+    const css = buttonStylesheet();
+    expect(css).toMatch(/:host\s*\{[^}]*display:\s*inline-flex/);
+  });
+
+  it('link variant emits transparent background and primary color', () => {
+    const css = buttonStylesheet({ variant: 'link' });
+    expect(css).toContain('background-color: transparent');
+    expect(css).toContain('var(--color-primary)');
+  });
+
+  it('outline variant emits a 1px solid border with color-input', () => {
+    const css = buttonStylesheet({ variant: 'outline' });
+    expect(css).toContain('border-width: 1px');
+    expect(css).toContain('border-style: solid');
+    expect(css).toContain('var(--color-input)');
+  });
+
+  it('ghost variant emits transparent background with foreground color', () => {
+    const css = buttonStylesheet({ variant: 'ghost' });
+    expect(css).toContain('background-color: transparent');
+    expect(css).toContain('var(--color-foreground)');
+  });
+
+  it('link hover adds text-decoration: underline', () => {
+    const css = buttonStylesheet({ variant: 'link' });
+    expect(css).toContain('text-decoration: underline');
+  });
+
+  it('semantic hover/active tokens cover every semantic variant', () => {
+    const semantic: ReadonlyArray<ButtonVariant> = [
+      'default',
+      'primary',
+      'secondary',
+      'destructive',
+      'success',
+      'warning',
+      'info',
+      'muted',
+      'accent',
+    ];
+    for (const v of semantic) {
+      const css = buttonStylesheet({ variant: v });
+      // muted hover/active uses its own tokens too
+      const normalized = v === 'default' ? 'primary' : v;
+      expect(css).toContain(`var(--color-${normalized}-hover)`);
+      expect(css).toContain(`var(--color-${normalized}-active)`);
+    }
+  });
+
+  it('focus ring uses the neutral --color-ring for outline/ghost/muted/link', () => {
+    for (const v of ['outline', 'ghost', 'muted', 'link'] as const) {
+      const css = buttonStylesheet({ variant: v });
+      expect(css).toContain('var(--color-ring)');
+    }
+  });
+
+  it('emits distinct heights per size', () => {
+    expect(buttonStylesheet({ size: 'default' })).toContain('height: 2.5rem');
+    expect(buttonStylesheet({ size: 'xs' })).toContain('height: 1.5rem');
+    expect(buttonStylesheet({ size: 'sm' })).toContain('height: 2rem');
+    expect(buttonStylesheet({ size: 'lg' })).toContain('height: 3rem');
+  });
+
+  it('icon sizes set both height and width', () => {
+    const iconCss = buttonStylesheet({ size: 'icon' });
+    expect(iconCss).toContain('height: 2.5rem');
+    expect(iconCss).toContain('width: 2.5rem');
+
+    const iconXsCss = buttonStylesheet({ size: 'icon-xs' });
+    expect(iconXsCss).toContain('height: 1.5rem');
+    expect(iconXsCss).toContain('width: 1.5rem');
+
+    const iconSmCss = buttonStylesheet({ size: 'icon-sm' });
+    expect(iconSmCss).toContain('height: 2rem');
+    expect(iconSmCss).toContain('width: 2rem');
+
+    const iconLgCss = buttonStylesheet({ size: 'icon-lg' });
+    expect(iconLgCss).toContain('height: 3rem');
+    expect(iconLgCss).toContain('width: 3rem');
+  });
+
+  it('uses label font-size tokens per size', () => {
+    expect(buttonStylesheet({ size: 'xs' })).toContain('var(--font-size-label-small)');
+    expect(buttonStylesheet({ size: 'sm' })).toContain('var(--font-size-label-small)');
+    expect(buttonStylesheet({ size: 'default' })).toContain('var(--font-size-label-medium)');
+    expect(buttonStylesheet({ size: 'lg' })).toContain('var(--font-size-label-large)');
+  });
+
+  it('emits a :disabled rule that carries the disabled declarations', () => {
+    const css = buttonStylesheet();
+    expect(css).toContain('.button:disabled');
+    // Closing match on the opacity declaration for defensive scoping.
+    expect(css).toMatch(/\.button:disabled\s*\{[^}]*opacity:\s*0\.5/);
+  });
+
+  it('exports buttonBase with inline-flex and cursor pointer', () => {
+    expect(buttonBase).toMatchObject({
+      display: 'inline-flex',
+      'align-items': 'center',
+      'justify-content': 'center',
+      cursor: 'pointer',
+    });
+  });
+
+  it('exports buttonDisabled with opacity, cursor, and pointer-events', () => {
+    expect(buttonDisabled).toMatchObject({
+      opacity: '0.5',
+      cursor: 'not-allowed',
+      'pointer-events': 'none',
+    });
+  });
+
+  it('exports style maps covering every variant/size key', () => {
+    for (const v of ALL_VARIANTS) {
+      expect(buttonVariantStyles[v]).toBeDefined();
+      expect(buttonVariantHover[v]).toBeDefined();
+      expect(buttonVariantActive[v]).toBeDefined();
+      expect(buttonVariantFocusRing[v]).toBeDefined();
+    }
+    for (const s of ALL_SIZES) {
+      expect(buttonSizeStyles[s]).toBeDefined();
+    }
+  });
+
+  it('never emits a raw hex colour or rgb() literal', () => {
+    const css = buttonStylesheet({
+      variant: 'destructive',
+      size: 'lg',
+      disabled: true,
+    });
+    expect(css).not.toMatch(/#[0-9a-f]{3,8}/i);
+    expect(css).not.toMatch(/rgb\(/);
+  });
+});

--- a/packages/ui/src/components/ui/button.styles.ts
+++ b/packages/ui/src/components/ui/button.styles.ts
@@ -1,0 +1,399 @@
+/**
+ * Shadow DOM style definitions for Button web component
+ *
+ * Parallel to button.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ * Token values via var() from the shared token stylesheet.
+ *
+ * All token references go through tokenVar(); no raw var() literals.
+ * Motion uses --motion-duration-* / --motion-ease-* only.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import {
+  atRule,
+  mixin,
+  pick,
+  styleRule,
+  stylesheet,
+  tokenVar,
+  transition,
+  when,
+} from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export type ButtonVariant =
+  | 'default'
+  | 'primary'
+  | 'secondary'
+  | 'destructive'
+  | 'success'
+  | 'warning'
+  | 'info'
+  | 'muted'
+  | 'accent'
+  | 'outline'
+  | 'ghost'
+  | 'link';
+
+export type ButtonSize =
+  | 'default'
+  | 'xs'
+  | 'sm'
+  | 'lg'
+  | 'icon'
+  | 'icon-xs'
+  | 'icon-sm'
+  | 'icon-lg';
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+/**
+ * Base button declarations shared across every variant and size.
+ * Mirrors buttonBaseClasses from button.classes.ts.
+ */
+export const buttonBase: CSSProperties = {
+  display: 'inline-flex',
+  'align-items': 'center',
+  'justify-content': 'center',
+  gap: '0.5rem',
+  'border-radius': tokenVar('radius-md'),
+  'font-weight': '500',
+  cursor: 'pointer',
+  'user-select': 'none',
+  'white-space': 'nowrap',
+  'border-width': '0',
+  'border-style': 'solid',
+  'border-color': 'transparent',
+  'background-color': 'transparent',
+  color: 'inherit',
+  transition: transition(
+    ['background-color', 'color', 'border-color', 'box-shadow', 'opacity'],
+    tokenVar('motion-duration-fast'),
+    tokenVar('motion-ease-standard'),
+  ),
+};
+
+/**
+ * Disabled-state declarations. Applied either via the host's `disabled`
+ * attribute (composed into the base rule) or via `:disabled` on the inner
+ * button for defensive coverage.
+ */
+export const buttonDisabled: CSSProperties = {
+  opacity: '0.5',
+  cursor: 'not-allowed',
+  'pointer-events': 'none',
+};
+
+// ============================================================================
+// Variant Styles
+// ============================================================================
+
+/**
+ * Base background + foreground pair for every variant.
+ * Semantic variants carry solid fills; outline/ghost/link use transparent base.
+ */
+export const buttonVariantStyles: Record<ButtonVariant, CSSProperties> = {
+  default: {
+    'background-color': tokenVar('color-primary'),
+    color: tokenVar('color-primary-foreground'),
+  },
+  primary: {
+    'background-color': tokenVar('color-primary'),
+    color: tokenVar('color-primary-foreground'),
+  },
+  secondary: {
+    'background-color': tokenVar('color-secondary'),
+    color: tokenVar('color-secondary-foreground'),
+  },
+  destructive: {
+    'background-color': tokenVar('color-destructive'),
+    color: tokenVar('color-destructive-foreground'),
+  },
+  success: {
+    'background-color': tokenVar('color-success'),
+    color: tokenVar('color-success-foreground'),
+  },
+  warning: {
+    'background-color': tokenVar('color-warning'),
+    color: tokenVar('color-warning-foreground'),
+  },
+  info: {
+    'background-color': tokenVar('color-info'),
+    color: tokenVar('color-info-foreground'),
+  },
+  muted: {
+    'background-color': tokenVar('color-muted'),
+    color: tokenVar('color-muted-foreground'),
+  },
+  accent: {
+    'background-color': tokenVar('color-accent'),
+    color: tokenVar('color-accent-foreground'),
+  },
+  outline: {
+    'background-color': 'transparent',
+    'border-width': '1px',
+    'border-style': 'solid',
+    'border-color': tokenVar('color-input'),
+    color: tokenVar('color-foreground'),
+  },
+  ghost: {
+    'background-color': 'transparent',
+    color: tokenVar('color-foreground'),
+  },
+  link: {
+    'background-color': 'transparent',
+    color: tokenVar('color-primary'),
+    'text-underline-offset': '4px',
+  },
+};
+
+/**
+ * Hover-state background override per variant.
+ * Semantic variants flip to their `-hover` token. outline/ghost hover to
+ * the accent pair. link adds underline without changing background.
+ */
+export const buttonVariantHover: Record<ButtonVariant, CSSProperties> = {
+  default: {
+    'background-color': tokenVar('color-primary-hover'),
+  },
+  primary: {
+    'background-color': tokenVar('color-primary-hover'),
+  },
+  secondary: {
+    'background-color': tokenVar('color-secondary-hover'),
+  },
+  destructive: {
+    'background-color': tokenVar('color-destructive-hover'),
+  },
+  success: {
+    'background-color': tokenVar('color-success-hover'),
+  },
+  warning: {
+    'background-color': tokenVar('color-warning-hover'),
+  },
+  info: {
+    'background-color': tokenVar('color-info-hover'),
+  },
+  muted: {
+    'background-color': tokenVar('color-muted-hover'),
+  },
+  accent: {
+    'background-color': tokenVar('color-accent-hover'),
+  },
+  outline: {
+    'background-color': tokenVar('color-accent'),
+    color: tokenVar('color-accent-foreground'),
+  },
+  ghost: {
+    'background-color': tokenVar('color-accent'),
+    color: tokenVar('color-accent-foreground'),
+  },
+  link: {
+    'text-decoration': 'underline',
+  },
+};
+
+/**
+ * Active-state (press) background override per variant.
+ * Semantic variants flip to their `-active` token.
+ * outline/ghost fall back to the accent pair; link is unchanged.
+ */
+export const buttonVariantActive: Record<ButtonVariant, CSSProperties> = {
+  default: {
+    'background-color': tokenVar('color-primary-active'),
+  },
+  primary: {
+    'background-color': tokenVar('color-primary-active'),
+  },
+  secondary: {
+    'background-color': tokenVar('color-secondary-active'),
+  },
+  destructive: {
+    'background-color': tokenVar('color-destructive-active'),
+  },
+  success: {
+    'background-color': tokenVar('color-success-active'),
+  },
+  warning: {
+    'background-color': tokenVar('color-warning-active'),
+  },
+  info: {
+    'background-color': tokenVar('color-info-active'),
+  },
+  muted: {
+    'background-color': tokenVar('color-muted-active'),
+  },
+  accent: {
+    'background-color': tokenVar('color-accent-active'),
+  },
+  outline: {
+    'background-color': tokenVar('color-accent'),
+    color: tokenVar('color-accent-foreground'),
+  },
+  ghost: {
+    'background-color': tokenVar('color-accent'),
+    color: tokenVar('color-accent-foreground'),
+  },
+  link: {
+    'text-decoration': 'underline',
+  },
+};
+
+/**
+ * Focus-visible ring mixin factory. Double-ring (background offset + color-ring)
+ * gives the ring space on any background.
+ */
+function focusRingFor(ringToken: string): CSSProperties {
+  return mixin({
+    outline: 'none',
+    'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar(ringToken)}`,
+  });
+}
+
+/**
+ * Focus-visible ring styles per variant. Semantic variants use their
+ * `-ring` token. muted/outline/ghost/link share the neutral `color-ring`.
+ */
+export const buttonVariantFocusRing: Record<ButtonVariant, CSSProperties> = {
+  default: focusRingFor('color-primary-ring'),
+  primary: focusRingFor('color-primary-ring'),
+  secondary: focusRingFor('color-secondary-ring'),
+  destructive: focusRingFor('color-destructive-ring'),
+  success: focusRingFor('color-success-ring'),
+  warning: focusRingFor('color-warning-ring'),
+  info: focusRingFor('color-info-ring'),
+  muted: focusRingFor('color-ring'),
+  accent: focusRingFor('color-accent-ring'),
+  outline: focusRingFor('color-ring'),
+  ghost: focusRingFor('color-ring'),
+  link: focusRingFor('color-ring'),
+};
+
+// ============================================================================
+// Size Styles
+// ============================================================================
+
+/**
+ * Size declarations map explicit heights (with matching widths on icon sizes)
+ * plus padding pairs and per-size label font-size tokens.
+ */
+export const buttonSizeStyles: Record<ButtonSize, CSSProperties> = {
+  default: {
+    height: '2.5rem',
+    'padding-left': '1rem',
+    'padding-right': '1rem',
+    'padding-top': '0.5rem',
+    'padding-bottom': '0.5rem',
+    'font-size': tokenVar('font-size-label-medium'),
+  },
+  xs: {
+    height: '1.5rem',
+    'padding-left': '0.5rem',
+    'padding-right': '0.5rem',
+    'padding-top': '0',
+    'padding-bottom': '0',
+    'font-size': tokenVar('font-size-label-small'),
+  },
+  sm: {
+    height: '2rem',
+    'padding-left': '0.75rem',
+    'padding-right': '0.75rem',
+    'padding-top': '0',
+    'padding-bottom': '0',
+    'font-size': tokenVar('font-size-label-small'),
+  },
+  lg: {
+    height: '3rem',
+    'padding-left': '1.5rem',
+    'padding-right': '1.5rem',
+    'padding-top': '0.5rem',
+    'padding-bottom': '0.5rem',
+    'font-size': tokenVar('font-size-label-large'),
+  },
+  icon: {
+    height: '2.5rem',
+    width: '2.5rem',
+    'padding-left': '0',
+    'padding-right': '0',
+    'padding-top': '0',
+    'padding-bottom': '0',
+    'font-size': tokenVar('font-size-label-medium'),
+  },
+  'icon-xs': {
+    height: '1.5rem',
+    width: '1.5rem',
+    'padding-left': '0',
+    'padding-right': '0',
+    'padding-top': '0',
+    'padding-bottom': '0',
+    'font-size': tokenVar('font-size-label-small'),
+  },
+  'icon-sm': {
+    height: '2rem',
+    width: '2rem',
+    'padding-left': '0',
+    'padding-right': '0',
+    'padding-top': '0',
+    'padding-bottom': '0',
+    'font-size': tokenVar('font-size-label-small'),
+  },
+  'icon-lg': {
+    height: '3rem',
+    width: '3rem',
+    'padding-left': '0',
+    'padding-right': '0',
+    'padding-top': '0',
+    'padding-bottom': '0',
+    'font-size': tokenVar('font-size-label-large'),
+  },
+};
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+export interface ButtonStylesheetOptions {
+  variant?: ButtonVariant | undefined;
+  size?: ButtonSize | undefined;
+  disabled?: boolean | undefined;
+}
+
+/**
+ * Build the complete button stylesheet for a given configuration.
+ *
+ * Unknown variant/size keys fall back to 'default' via pick(). Never throws.
+ * Emits hover/active rules scoped to `.button:hover:not(:disabled)` and
+ * `.button:active:not(:disabled)`, a focus-visible ring, a :disabled rule,
+ * and a prefers-reduced-motion block that neutralises the transition.
+ */
+export function buttonStylesheet(options: ButtonStylesheetOptions = {}): string {
+  const { variant, size, disabled } = options;
+
+  return stylesheet(
+    styleRule(':host', { display: 'inline-flex' }),
+
+    styleRule(
+      '.button',
+      buttonBase,
+      pick(buttonVariantStyles, variant, 'default'),
+      pick(buttonSizeStyles, size, 'default'),
+      when(disabled, buttonDisabled),
+    ),
+
+    styleRule('.button:hover:not(:disabled)', pick(buttonVariantHover, variant, 'default')),
+
+    styleRule('.button:active:not(:disabled)', pick(buttonVariantActive, variant, 'default')),
+
+    styleRule('.button:focus-visible', pick(buttonVariantFocusRing, variant, 'default')),
+
+    styleRule('.button:disabled', buttonDisabled),
+
+    atRule('@media (prefers-reduced-motion: reduce)', styleRule('.button', { transition: 'none' })),
+  );
+}

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -7,7 +7,12 @@ export default defineConfig({
     globals: true,
     environment: 'happy-dom',
     setupFiles: ['./vitest.setup.ts'],
-    include: ['src/**/*.test.{ts,tsx}', 'test/**/*.test.{ts,tsx}', 'test/**/*.a11y.{ts,tsx}'],
+    include: [
+      'src/**/*.test.{ts,tsx}',
+      'src/**/*.a11y.{ts,tsx}',
+      'test/**/*.test.{ts,tsx}',
+      'test/**/*.a11y.{ts,tsx}',
+    ],
     exclude: ['test/**/*.spec.{ts,tsx}', 'test/**/*.e2e.{ts,tsx}'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary

Ships `<rafters-button>` as a token-driven Web Component mirroring the React
`Button` across **all 12 variants**, **8 sizes**, and hover/active/focus-visible/
disabled states. Styling lives entirely inside the shadow root via
`buttonStylesheet(...)` composed with `classy-wc` helpers -- no Tailwind
dependency reaches the shadow DOM and **no raw `var()` literals** appear in
source. Every token reference flows through `tokenVar()` and all motion goes
through `--motion-duration-*` / `--motion-ease-*`.

Closes #1302.

## What ships

- `packages/ui/src/components/ui/button.styles.ts` -- CSS property maps for
  all 12 variants + 8 sizes + hover/active/focus-visible/disabled, plus the
  `buttonStylesheet({ variant, size, disabled })` builder.
- `packages/ui/src/components/ui/button.element.ts` -- `RaftersButton`
  custom element. Auto-registers `<rafters-button>` (idempotent guard),
  inner `<button type=button|submit|reset>`, click events bubble, per-
  instance stylesheet rebuilds on observed attribute changes.
- Unit tests: `button.styles.test.ts` and `button.element.test.ts`.
- A11y tests: `button.element.a11y.tsx` (vitest-axe, 8 cases covering
  every variant, every size, disabled, submit-in-form, icon-with-label,
  and an aria-labelled group).
- `packages/ui/vitest.config.ts` now includes `src/**/*.a11y.{ts,tsx}`
  so the mandatory a11y test beside the implementation is discovered.

## Key decisions

- **Default `type="button"`** prevents accidental form submission.
  `submit` / `reset` accepted; anything else silently falls back.
- **Unknown variant/size attributes** resolve to `'default'` via
  `pick(map, key, 'default')`. Never throws, never logs.
- **Per-instance `CSSStyleSheet`** rebuilds on every observed attribute
  change so hover/active/focus tokens stay in sync with the host.
- **Focus ring** uses a double-layer box-shadow (background offset +
  color-ring) seeded from `color-{variant}-ring` for semantics and the
  neutral `color-ring` for muted/outline/ghost/link.
- **Prefers-reduced-motion** kills the transition via `@media` at-rule.

## What's out of scope (per spec)

- `loading` state (needs separate `<rafters-spinner>`).
- `asChild`, button-group context, `data-icon`.
- Astro/React wrappers.
- MCP component metadata update.
- Version bump and CHANGELOG entry (spec explicitly disallows).

## Test plan

- [x] `pnpm typecheck` -- green across the monorepo.
- [x] `pnpm vitest run button.styles button.element` -- 55 tests green.
- [x] `pnpm test run button` -- 122 tests across 7 files green.
- [x] `pnpm preflight` -- exit 0.
- [x] Quality gate recorded clean (0 findings).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>