### PR TITLE
feat(ui): <rafters-container> Web Component with semantic element rendering (#1299)

### DIFF
--- a/packages/ui/src/components/ui/container.element.test.ts
+++ b/packages/ui/src/components/ui/container.element.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import './container.element';
+import { RaftersContainer } from './container.element';
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+function mount(tag: string, attrs: Record<string, string> = {}): HTMLElement {
+  const el = document.createElement(tag);
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.appendChild(el);
+  return el;
+}
+
+function collectCss(el: HTMLElement): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  return sheets
+    .map((s) =>
+      Array.from(s.cssRules)
+        .map((r) => r.cssText)
+        .join('\n'),
+    )
+    .join('\n');
+}
+
+describe('rafters-container', () => {
+  it('registers the custom element', () => {
+    expect(customElements.get('rafters-container')).toBeDefined();
+  });
+
+  it('exports RaftersContainer as the registered constructor', () => {
+    expect(customElements.get('rafters-container')).toBe(RaftersContainer);
+  });
+
+  it('defaults to a div in the shadow root', () => {
+    const el = mount('rafters-container');
+    expect(el.shadowRoot?.firstElementChild?.tagName).toBe('DIV');
+  });
+
+  it('renders the requested semantic element', () => {
+    const el = mount('rafters-container', { as: 'main' });
+    expect(el.shadowRoot?.firstElementChild?.tagName).toBe('MAIN');
+  });
+
+  it('renders section / article / aside semantic elements', () => {
+    expect(
+      mount('rafters-container', { as: 'section' }).shadowRoot?.firstElementChild?.tagName,
+    ).toBe('SECTION');
+    expect(
+      mount('rafters-container', { as: 'article' }).shadowRoot?.firstElementChild?.tagName,
+    ).toBe('ARTICLE');
+    expect(mount('rafters-container', { as: 'aside' }).shadowRoot?.firstElementChild?.tagName).toBe(
+      'ASIDE',
+    );
+  });
+
+  it('falls back to div for unknown as values', () => {
+    const el = mount('rafters-container', { as: 'bogus' });
+    expect(el.shadowRoot?.firstElementChild?.tagName).toBe('DIV');
+  });
+
+  it('exposes a default slot', () => {
+    const el = mount('rafters-container');
+    expect(el.shadowRoot?.querySelector('slot')).toBeTruthy();
+  });
+
+  it('inner element carries the .container class', () => {
+    const el = mount('rafters-container');
+    const inner = el.shadowRoot?.firstElementChild;
+    expect(inner?.classList.contains('container')).toBe(true);
+  });
+
+  it('sets host to inline-size container with width 100 percent', () => {
+    const css = collectCss(mount('rafters-container'));
+    expect(css).toMatch(/:host\s*\{[^}]*display:\s*block/);
+    expect(css).toMatch(/:host\s*\{[^}]*container-type:\s*inline-size/);
+    expect(css).toMatch(/:host\s*\{[^}]*width:\s*100%/);
+  });
+
+  it('applies size max-width via token var', () => {
+    const css = collectCss(mount('rafters-container', { size: '6xl' }));
+    expect(css).toContain('var(--size-container-6xl)');
+    expect(css).toMatch(/margin-inline:\s*auto/);
+  });
+
+  it('full size yields width 100 percent with no max-width', () => {
+    const css = collectCss(mount('rafters-container', { size: 'full' }));
+    expect(css).not.toContain('var(--size-container-full)');
+    expect(css).toMatch(/width:\s*100%/);
+  });
+
+  it('applies padding from spacing scale', () => {
+    expect(collectCss(mount('rafters-container', { padding: '6' }))).toContain('var(--spacing-6)');
+  });
+
+  it('applies gap as flex-column with token spacing', () => {
+    const css = collectCss(mount('rafters-container', { gap: '8' }));
+    expect(css).toContain('var(--spacing-8)');
+    expect(css).toMatch(/display:\s*flex/);
+    expect(css).toMatch(/flex-direction:\s*column/);
+  });
+
+  it('derives gap from size when gap attribute is bare', () => {
+    const css = collectCss(mount('rafters-container', { size: '3xl', gap: '' }));
+    expect(css).toContain('var(--spacing-8)');
+  });
+
+  it('derives default gap of 6 when bare gap and no size', () => {
+    const css = collectCss(mount('rafters-container', { gap: '' }));
+    expect(css).toContain('var(--spacing-6)');
+  });
+
+  it('applies background tokens for known names', () => {
+    const css = collectCss(mount('rafters-container', { background: 'muted' }));
+    expect(css).toContain('var(--color-muted)');
+    expect(css).toContain('var(--color-muted-foreground)');
+  });
+
+  it('unknown background falls back to none', () => {
+    const css = collectCss(mount('rafters-container', { background: 'rainbow' }));
+    expect(css).not.toMatch(/background-color:\s*var\(--color-/);
+  });
+
+  it('explicit none background emits no background-color rule', () => {
+    const css = collectCss(mount('rafters-container', { background: 'none' }));
+    expect(css).not.toMatch(/background-color:\s*var\(--color-/);
+  });
+
+  it('article applies typography to descendant selectors via tokens only', () => {
+    const css = collectCss(mount('rafters-container', { as: 'article' }));
+    expect(css).toMatch(/p\s*\{/);
+    expect(css).toMatch(/h1\s*\{/);
+    expect(css).toMatch(/blockquote\s*\{/);
+    expect(css).not.toMatch(/#[0-9a-f]{3,8}/i);
+    expect(css).not.toMatch(/rgb\(/);
+  });
+
+  it('editable applies dashed outline in muted-foreground at 30 percent', () => {
+    const css = collectCss(mount('rafters-container', { editable: '' }));
+    expect(css).toMatch(/outline-style:\s*dashed/);
+    expect(css).toContain('color-mix(in oklch, var(--color-muted-foreground) 30%, transparent)');
+  });
+
+  it('rebuilds stylesheet when observed attributes change', () => {
+    const el = mount('rafters-container', { size: 'sm' });
+    expect(collectCss(el)).toContain('var(--size-container-sm)');
+    el.setAttribute('size', '4xl');
+    expect(collectCss(el)).toContain('var(--size-container-4xl)');
+  });
+
+  it('rebuilds when as changes (article toggles typography)', () => {
+    const el = mount('rafters-container');
+    expect(collectCss(el)).not.toMatch(/blockquote\s*\{/);
+    el.setAttribute('as', 'article');
+    expect(collectCss(el)).toMatch(/blockquote\s*\{/);
+  });
+
+  it('rebuilds when editable is toggled', () => {
+    const el = mount('rafters-container');
+    expect(collectCss(el)).not.toMatch(/outline-style:\s*dashed/);
+    el.setAttribute('editable', '');
+    expect(collectCss(el)).toMatch(/outline-style:\s*dashed/);
+    el.removeAttribute('editable');
+    expect(collectCss(el)).not.toMatch(/outline-style:\s*dashed/);
+  });
+
+  it('motion uses --motion-duration tokens, never --duration', () => {
+    const css = collectCss(mount('rafters-container'));
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+  });
+
+  it('importing the module twice does not throw', async () => {
+    await import('./container.element');
+    await import('./container.element');
+    expect(customElements.get('rafters-container')).toBe(RaftersContainer);
+  });
+
+  it('observedAttributes contains exactly the documented attributes', () => {
+    expect(RaftersContainer.observedAttributes).toEqual([
+      'as',
+      'size',
+      'padding',
+      'gap',
+      'background',
+      'editable',
+    ]);
+  });
+
+  it('source contains no direct var() references', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const source = await fs.readFile(path.resolve(__dirname, 'container.element.ts'), 'utf-8');
+    expect(source).not.toMatch(/var\(/);
+  });
+});

--- a/packages/ui/src/components/ui/container.element.ts
+++ b/packages/ui/src/components/ui/container.element.ts
@@ -1,0 +1,152 @@
+/**
+ * <rafters-container> -- Web Component layout primitive.
+ *
+ * Mirrors the semantics of container.tsx (size, padding, gap, background,
+ * article typography, editable) using shadow-DOM-scoped CSS composed via
+ * classy-wc. Auto-registers on import and is idempotent against double-define.
+ *
+ * Attributes:
+ *  - as: 'div' | 'main' | 'section' | 'article' | 'aside' (default 'div')
+ *  - size: 'sm'..'7xl' | 'full'
+ *  - padding: '0' | '1' | ... | '24'
+ *  - gap: same as padding scale, OR bare/empty -> derive from size
+ *  - background: 'none' | 'muted' | 'accent' | 'card' | 'primary' | 'secondary'
+ *  - editable: boolean (presence-based)
+ *
+ * No raw CSS custom-property literals here -- all token references live in
+ * container.styles.ts and resolve through tokenVar().
+ * Container queries are always-on via :host { container-type: inline-size }.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import {
+  type ContainerBackground,
+  type ContainerSize,
+  type ContainerSpacing,
+  containerStylesheet,
+  isContainerBackground,
+  isContainerSize,
+  isContainerSpacing,
+} from './container.styles';
+
+export type ContainerAs = 'div' | 'main' | 'section' | 'article' | 'aside';
+
+const ALLOWED_AS: ReadonlyArray<ContainerAs> = ['div', 'main', 'section', 'article', 'aside'];
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = [
+  'as',
+  'size',
+  'padding',
+  'gap',
+  'background',
+  'editable',
+] as const;
+
+function parseAs(value: string | null): ContainerAs {
+  if (value && (ALLOWED_AS as ReadonlyArray<string>).includes(value)) {
+    return value as ContainerAs;
+  }
+  return 'div';
+}
+
+function parseSize(value: string | null): ContainerSize | undefined {
+  return isContainerSize(value) ? value : undefined;
+}
+
+function parsePadding(value: string | null): ContainerSpacing | undefined {
+  return isContainerSpacing(value) ? value : undefined;
+}
+
+function parseBackground(value: string | null): ContainerBackground | undefined {
+  if (!isContainerBackground(value)) return undefined;
+  return value === 'none' ? undefined : value;
+}
+
+/**
+ * Parse the gap attribute.
+ *  - Missing attribute (null): no gap.
+ *  - Bare attribute (empty string): true -> derive from size.
+ *  - Spacing scale value: that value.
+ *  - Unknown string: undefined (silent fallback to no gap).
+ */
+function parseGap(value: string | null): ContainerSpacing | true | undefined {
+  if (value === null) return undefined;
+  if (value === '') return true;
+  return isContainerSpacing(value) ? value : undefined;
+}
+
+export class RaftersContainer extends RaftersElement {
+  static observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  /** Per-instance stylesheet rebuilt on every attribute change. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  override connectedCallback(): void {
+    if (!this.shadowRoot) return;
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+    this.shadowRoot.adoptedStyleSheets = [this._instanceSheet];
+    this.update();
+  }
+
+  override attributeChangedCallback(
+    _name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+    if (this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+    this.update();
+  }
+
+  override disconnectedCallback(): void {
+    this._instanceSheet = null;
+  }
+
+  /**
+   * Resolve the semantic element tag from the `as` attribute, falling back
+   * to `div` for anything outside the allow-list.
+   */
+  getAs(): ContainerAs {
+    return parseAs(this.getAttribute('as'));
+  }
+
+  /**
+   * Build the CSS string for the current attribute values.
+   */
+  private composeCss(): string {
+    const size = parseSize(this.getAttribute('size'));
+    const padding = parsePadding(this.getAttribute('padding'));
+    const gap = parseGap(this.getAttribute('gap'));
+    const background = parseBackground(this.getAttribute('background'));
+    const article = this.getAs() === 'article';
+    const editable = this.hasAttribute('editable');
+
+    return containerStylesheet({
+      size,
+      padding,
+      gap,
+      background,
+      article,
+      editable,
+    });
+  }
+
+  /**
+   * Render the inner semantic element with a single default <slot>.
+   * DOM APIs only -- never innerHTML.
+   */
+  override render(): Node {
+    const inner = document.createElement(this.getAs());
+    inner.className = 'container';
+    const slot = document.createElement('slot');
+    inner.appendChild(slot);
+    return inner;
+  }
+}
+
+if (!customElements.get('rafters-container')) {
+  customElements.define('rafters-container', RaftersContainer);
+}

--- a/packages/ui/src/components/ui/container.styles.test.ts
+++ b/packages/ui/src/components/ui/container.styles.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type ContainerStylesheetOptions,
+  containerBackgroundStyles,
+  containerHostBase,
+  containerSizeGapScale,
+  containerStylesheet,
+  isContainerBackground,
+  isContainerSize,
+  isContainerSpacing,
+  resolveDerivedGap,
+} from './container.styles';
+
+function compose(options: ContainerStylesheetOptions = {}): string {
+  return containerStylesheet(options);
+}
+
+describe('containerStylesheet', () => {
+  describe(':host base', () => {
+    it('always emits display: block', () => {
+      expect(compose()).toMatch(/:host\s*\{[^}]*display:\s*block/);
+    });
+
+    it('always emits container-type: inline-size', () => {
+      expect(compose()).toMatch(/:host\s*\{[^}]*container-type:\s*inline-size/);
+    });
+
+    it('always emits width: 100%', () => {
+      expect(compose()).toMatch(/:host\s*\{[^}]*width:\s*100%/);
+    });
+
+    it('exposes containerHostBase as a CSSProperties map', () => {
+      expect(containerHostBase).toMatchObject({
+        display: 'block',
+        'container-type': 'inline-size',
+        width: '100%',
+      });
+    });
+  });
+
+  describe('size', () => {
+    it('emits max-width via size-container token for sized variants', () => {
+      const css = compose({ size: '6xl' });
+      expect(css).toContain('var(--size-container-6xl)');
+      expect(css).toMatch(/margin-inline:\s*auto/);
+    });
+
+    it('does not emit a size-container-full token for full', () => {
+      const css = compose({ size: 'full' });
+      expect(css).not.toContain('var(--size-container-full)');
+      expect(css).toMatch(/width:\s*100%/);
+    });
+
+    it('handles every documented size without throwing', () => {
+      for (const size of [
+        'sm',
+        'md',
+        'lg',
+        'xl',
+        '2xl',
+        '3xl',
+        '4xl',
+        '5xl',
+        '6xl',
+        '7xl',
+        'full',
+      ] as const) {
+        expect(() => compose({ size })).not.toThrow();
+      }
+    });
+  });
+
+  describe('padding', () => {
+    it('emits spacing token for padding', () => {
+      expect(compose({ padding: '6' })).toContain('var(--spacing-6)');
+    });
+
+    it('handles every documented spacing without throwing', () => {
+      for (const padding of [
+        '0',
+        '1',
+        '2',
+        '3',
+        '4',
+        '5',
+        '6',
+        '8',
+        '10',
+        '12',
+        '16',
+        '20',
+        '24',
+      ] as const) {
+        expect(() => compose({ padding })).not.toThrow();
+      }
+    });
+  });
+
+  describe('gap', () => {
+    it('emits flex column with token spacing for explicit gap', () => {
+      const css = compose({ gap: '8' });
+      expect(css).toContain('var(--spacing-8)');
+      expect(css).toMatch(/display:\s*flex/);
+      expect(css).toMatch(/flex-direction:\s*column/);
+    });
+
+    it('derives gap from size when gap is true', () => {
+      // 3xl -> 8 per containerSizeGapScale
+      expect(compose({ size: '3xl', gap: true })).toContain('var(--spacing-8)');
+    });
+
+    it('falls back to spacing-6 when gap is true and no size set', () => {
+      expect(compose({ gap: true })).toContain('var(--spacing-6)');
+    });
+
+    it('omits flex layout when gap is undefined', () => {
+      const css = compose();
+      expect(css).not.toMatch(/flex-direction:\s*column/);
+    });
+  });
+
+  describe('background', () => {
+    it('emits background tokens for known names', () => {
+      const css = compose({ background: 'muted' });
+      expect(css).toContain('var(--color-muted)');
+      expect(css).toContain('var(--color-muted-foreground)');
+    });
+
+    it('omits background-color rule when background is none', () => {
+      const css = compose({ background: 'none' });
+      expect(css).not.toMatch(/background-color:\s*var\(--color-/);
+    });
+
+    it('omits background-color rule when background is undefined', () => {
+      const css = compose();
+      expect(css).not.toMatch(/background-color:\s*var\(--color-/);
+    });
+
+    it('exposes background style maps for every variant', () => {
+      const variants: ReadonlyArray<keyof typeof containerBackgroundStyles> = [
+        'none',
+        'muted',
+        'accent',
+        'card',
+        'primary',
+        'secondary',
+      ];
+      for (const v of variants) {
+        expect(containerBackgroundStyles[v]).toBeDefined();
+      }
+    });
+  });
+
+  describe('article', () => {
+    it('emits typography rules for descendant selectors', () => {
+      const css = compose({ article: true });
+      expect(css).toMatch(/p\s*\{/);
+      expect(css).toMatch(/h1\s*\{/);
+      expect(css).toMatch(/h2\s*\{/);
+      expect(css).toMatch(/h3\s*\{/);
+      expect(css).toMatch(/h4\s*\{/);
+      expect(css).toMatch(/blockquote\s*\{/);
+      expect(css).toMatch(/code\s*\{/);
+      expect(css).toMatch(/pre\s*\{/);
+      expect(css).toMatch(/ul\s*\{/);
+      expect(css).toMatch(/ol\s*\{/);
+      expect(css).toMatch(/li\s*\{/);
+      expect(css).toMatch(/a\s*\{/);
+      expect(css).toMatch(/hr\s*\{/);
+      expect(css).toMatch(/img\s*\{/);
+      expect(css).toMatch(/table\s*\{/);
+      expect(css).toMatch(/th\s*\{/);
+      expect(css).toMatch(/td\s*\{/);
+    });
+
+    it('uses tokens only -- no raw hex or rgb literals', () => {
+      const css = compose({ article: true });
+      expect(css).not.toMatch(/#[0-9a-f]{3,8}/i);
+      expect(css).not.toMatch(/rgb\(/);
+    });
+
+    it('clamps width to size-prose when article and size unset', () => {
+      const css = compose({ article: true });
+      expect(css).toContain('var(--size-prose, 65ch)');
+    });
+
+    it('does not clamp width to size-prose when size is explicitly set', () => {
+      const css = compose({ article: true, size: '4xl' });
+      expect(css).not.toContain('var(--size-prose');
+      expect(css).toContain('var(--size-container-4xl)');
+    });
+
+    it('omits article rules when article is false', () => {
+      const css = compose();
+      expect(css).not.toMatch(/blockquote\s*\{/);
+    });
+  });
+
+  describe('editable', () => {
+    it('emits dashed outline with color-mix muted-foreground 30%', () => {
+      const css = compose({ editable: true });
+      expect(css).toMatch(/outline-style:\s*dashed/);
+      expect(css).toContain('color-mix(in oklch, var(--color-muted-foreground) 30%, transparent)');
+      expect(css).toMatch(/outline-offset:\s*2px/);
+      expect(css).toMatch(/outline-width:\s*2px/);
+    });
+
+    it('omits outline when editable is false', () => {
+      const css = compose();
+      expect(css).not.toMatch(/outline-style:\s*dashed/);
+    });
+  });
+
+  describe('motion safety', () => {
+    it('never references --duration- or --ease- vars (only --motion-* allowed)', () => {
+      const css = compose({
+        size: '4xl',
+        padding: '6',
+        gap: '8',
+        background: 'muted',
+        article: true,
+        editable: true,
+      });
+      expect(css).not.toMatch(/var\(--duration-/);
+      expect(css).not.toMatch(/var\(--ease-/);
+    });
+
+    it('emits a prefers-reduced-motion media block', () => {
+      const css = compose();
+      expect(css).toMatch(/@media \(prefers-reduced-motion: reduce\)/);
+    });
+  });
+
+  describe('parsers / type guards', () => {
+    it('isContainerSize accepts valid sizes and rejects others', () => {
+      expect(isContainerSize('sm')).toBe(true);
+      expect(isContainerSize('full')).toBe(true);
+      expect(isContainerSize('massive')).toBe(false);
+      expect(isContainerSize(null)).toBe(false);
+      expect(isContainerSize(42)).toBe(false);
+    });
+
+    it('isContainerSpacing accepts valid scale and rejects others', () => {
+      expect(isContainerSpacing('0')).toBe(true);
+      expect(isContainerSpacing('24')).toBe(true);
+      expect(isContainerSpacing('7')).toBe(false);
+      expect(isContainerSpacing('px')).toBe(false);
+    });
+
+    it('isContainerBackground accepts the documented union', () => {
+      for (const bg of ['none', 'muted', 'accent', 'card', 'primary', 'secondary']) {
+        expect(isContainerBackground(bg)).toBe(true);
+      }
+      expect(isContainerBackground('rainbow')).toBe(false);
+    });
+  });
+
+  describe('size-gap derivation', () => {
+    it('contains the documented size-gap mapping', () => {
+      expect(containerSizeGapScale.sm).toBe('3');
+      expect(containerSizeGapScale['3xl']).toBe('8');
+      expect(containerSizeGapScale['7xl']).toBe('12');
+    });
+
+    it('resolveDerivedGap returns the size-mapped value or falls back to 6', () => {
+      expect(resolveDerivedGap('sm')).toBe('3');
+      expect(resolveDerivedGap('3xl')).toBe('8');
+      expect(resolveDerivedGap('full')).toBe('6');
+      expect(resolveDerivedGap(undefined)).toBe('6');
+    });
+  });
+});

--- a/packages/ui/src/components/ui/container.styles.ts
+++ b/packages/ui/src/components/ui/container.styles.ts
@@ -1,0 +1,480 @@
+/**
+ * Shadow DOM style definitions for Container web component
+ *
+ * Parallel to container.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ *
+ * Container queries always-on (:host sets container-type: inline-size).
+ * All token references go through tokenVar() -- no raw CSS custom-property
+ * function literals appear in this module.
+ * Motion uses --motion-duration-* / --motion-ease-* only.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import { atRule, styleRule, stylesheet, tokenVar } from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export type ContainerSize =
+  | 'sm'
+  | 'md'
+  | 'lg'
+  | 'xl'
+  | '2xl'
+  | '3xl'
+  | '4xl'
+  | '5xl'
+  | '6xl'
+  | '7xl'
+  | 'full';
+
+export type ContainerSpacing =
+  | '0'
+  | '1'
+  | '2'
+  | '3'
+  | '4'
+  | '5'
+  | '6'
+  | '8'
+  | '10'
+  | '12'
+  | '16'
+  | '20'
+  | '24';
+
+export type ContainerBackground = 'none' | 'muted' | 'accent' | 'card' | 'primary' | 'secondary';
+
+export interface ContainerStylesheetOptions {
+  size?: ContainerSize | undefined;
+  padding?: ContainerSpacing | undefined;
+  gap?: ContainerSpacing | true | undefined;
+  background?: ContainerBackground | undefined;
+  article?: boolean | undefined;
+  editable?: boolean | undefined;
+}
+
+// ============================================================================
+// Allowed Value Sets (for validation / fallback)
+// ============================================================================
+
+const SIZES: ReadonlyArray<ContainerSize> = [
+  'sm',
+  'md',
+  'lg',
+  'xl',
+  '2xl',
+  '3xl',
+  '4xl',
+  '5xl',
+  '6xl',
+  '7xl',
+  'full',
+];
+
+const SPACING: ReadonlyArray<ContainerSpacing> = [
+  '0',
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '8',
+  '10',
+  '12',
+  '16',
+  '20',
+  '24',
+];
+
+const BACKGROUNDS: ReadonlyArray<ContainerBackground> = [
+  'none',
+  'muted',
+  'accent',
+  'card',
+  'primary',
+  'secondary',
+];
+
+export function isContainerSize(value: unknown): value is ContainerSize {
+  return typeof value === 'string' && (SIZES as ReadonlyArray<string>).includes(value);
+}
+
+export function isContainerSpacing(value: unknown): value is ContainerSpacing {
+  return typeof value === 'string' && (SPACING as ReadonlyArray<string>).includes(value);
+}
+
+export function isContainerBackground(value: unknown): value is ContainerBackground {
+  return typeof value === 'string' && (BACKGROUNDS as ReadonlyArray<string>).includes(value);
+}
+
+// ============================================================================
+// Size-to-Gap Scale (mirrors container.classes.ts)
+// ============================================================================
+
+/**
+ * Walks the spacing scale from component-padding tier into section-padding tier.
+ * Used when `gap` is bare (true / empty) so the gap derives from the container size.
+ */
+export const containerSizeGapScale: Record<Exclude<ContainerSize, 'full'>, ContainerSpacing> = {
+  sm: '3',
+  md: '4',
+  lg: '5',
+  xl: '6',
+  '2xl': '6',
+  '3xl': '8',
+  '4xl': '8',
+  '5xl': '10',
+  '6xl': '10',
+  '7xl': '12',
+};
+
+/**
+ * Resolve the bare-gap default for the given size. Falls back to '6' when no size set.
+ */
+export function resolveDerivedGap(size: ContainerSize | undefined): ContainerSpacing {
+  if (size && size !== 'full') {
+    return containerSizeGapScale[size];
+  }
+  return '6';
+}
+
+// ============================================================================
+// Base Host Styles
+// ============================================================================
+
+/**
+ * Always applied to :host. Container queries are always-on.
+ */
+export const containerHostBase: CSSProperties = {
+  display: 'block',
+  'container-type': 'inline-size',
+  width: '100%',
+};
+
+/**
+ * Locally-scoped CSS custom property name carrying the editable outline color.
+ * Defined on :host so CSSOM implementations that reject unparsed `color-mix()`
+ * values on `outline-color` (notably happy-dom in tests) still preserve the
+ * declaration via the indirection through tokenVar(). The literal
+ * `color-mix()` expression still appears in the final CSS via the host-side
+ * definition.
+ */
+const EDITABLE_OUTLINE_TOKEN = 'rafters-container-editable-outline';
+
+/**
+ * :host-scoped custom-property declaration for the editable outline color.
+ * Only included when `editable` is true.
+ */
+export const containerEditableHost: CSSProperties = {
+  [`--${EDITABLE_OUTLINE_TOKEN}`]: `color-mix(in oklch, ${tokenVar('color-muted-foreground')} 30%, transparent)`,
+};
+
+/**
+ * Editable outline preset on the inner element. Dashed, 30% muted-foreground.
+ */
+export const containerEditable: CSSProperties = {
+  'outline-width': '2px',
+  'outline-style': 'dashed',
+  'outline-color': tokenVar(EDITABLE_OUTLINE_TOKEN),
+  'outline-offset': '2px',
+};
+
+// ============================================================================
+// Background Variants
+// ============================================================================
+
+export const containerBackgroundStyles: Record<ContainerBackground, CSSProperties> = {
+  none: {},
+  muted: {
+    'background-color': tokenVar('color-muted'),
+    color: tokenVar('color-muted-foreground'),
+  },
+  accent: {
+    'background-color': tokenVar('color-accent'),
+    color: tokenVar('color-accent-foreground'),
+  },
+  card: {
+    'background-color': tokenVar('color-card'),
+    color: tokenVar('color-card-foreground'),
+  },
+  primary: {
+    'background-color': tokenVar('color-primary'),
+    color: tokenVar('color-primary-foreground'),
+  },
+  secondary: {
+    'background-color': tokenVar('color-secondary'),
+    color: tokenVar('color-secondary-foreground'),
+  },
+};
+
+// ============================================================================
+// Article Typography Rules
+// ============================================================================
+
+/**
+ * Article typography rules, scoped to descendant selectors inside the shadow root.
+ * Mirrors container.classes.ts containerArticleTypography but uses tokens.
+ */
+function articleTypographyRules(): string {
+  return stylesheet(
+    styleRule('p', {
+      'line-height': tokenVar('line-height-relaxed', '1.625'),
+      'margin-bottom': tokenVar('spacing-4'),
+    }),
+
+    styleRule('p:last-child', {
+      'margin-bottom': '0',
+    }),
+
+    styleRule('h1', {
+      'font-size': tokenVar('font-size-display-medium'),
+      'font-weight': tokenVar('font-weight-bold', '700'),
+      'letter-spacing': tokenVar('letter-spacing-tight', '-0.025em'),
+      'margin-top': '0',
+      'margin-bottom': tokenVar('spacing-4'),
+      color: tokenVar('color-accent-foreground'),
+    }),
+
+    styleRule('h2', {
+      'font-size': tokenVar('font-size-display-small'),
+      'font-weight': tokenVar('font-weight-semibold', '600'),
+      'letter-spacing': tokenVar('letter-spacing-tight', '-0.025em'),
+      'margin-top': tokenVar('spacing-8'),
+      'margin-bottom': tokenVar('spacing-3'),
+      color: tokenVar('color-accent-foreground'),
+    }),
+
+    styleRule('h2:first-child', {
+      'margin-top': '0',
+    }),
+
+    styleRule('h3', {
+      'font-size': tokenVar('font-size-headline-medium'),
+      'font-weight': tokenVar('font-weight-semibold', '600'),
+      'margin-top': tokenVar('spacing-6'),
+      'margin-bottom': tokenVar('spacing-2'),
+      color: tokenVar('color-accent-foreground'),
+    }),
+
+    styleRule('h4', {
+      'font-size': tokenVar('font-size-headline-small'),
+      'font-weight': tokenVar('font-weight-semibold', '600'),
+      'margin-top': tokenVar('spacing-4'),
+      'margin-bottom': tokenVar('spacing-2'),
+      color: tokenVar('color-accent-foreground'),
+    }),
+
+    styleRule('ul', {
+      'list-style-type': 'disc',
+      'padding-left': tokenVar('spacing-6'),
+      'margin-bottom': tokenVar('spacing-4'),
+    }),
+
+    styleRule('ol', {
+      'list-style-type': 'decimal',
+      'padding-left': tokenVar('spacing-6'),
+      'margin-bottom': tokenVar('spacing-4'),
+    }),
+
+    styleRule('li', {
+      'margin-bottom': tokenVar('spacing-1'),
+    }),
+
+    styleRule('a', {
+      color: tokenVar('color-primary'),
+      'text-decoration': 'underline',
+      'text-underline-offset': tokenVar('spacing-1'),
+    }),
+
+    styleRule('a:hover', {
+      color: `color-mix(in oklch, ${tokenVar('color-primary')} 80%, transparent)`,
+    }),
+
+    styleRule('blockquote', {
+      'border-left-width': '4px',
+      'border-left-style': 'solid',
+      'border-left-color': tokenVar('color-muted'),
+      'padding-left': tokenVar('spacing-4'),
+      'font-style': 'italic',
+      'margin-top': tokenVar('spacing-4'),
+      'margin-bottom': tokenVar('spacing-4'),
+    }),
+
+    styleRule('code', {
+      'background-color': tokenVar('color-muted'),
+      'padding-left': tokenVar('spacing-1'),
+      'padding-right': tokenVar('spacing-1'),
+      'padding-top': tokenVar('spacing-0'),
+      'padding-bottom': tokenVar('spacing-0'),
+      'border-radius': tokenVar('radius-sm'),
+      'font-size': tokenVar('font-size-body-small'),
+      'font-family': tokenVar('font-family-mono'),
+    }),
+
+    styleRule('pre', {
+      'background-color': tokenVar('color-muted'),
+      padding: tokenVar('spacing-4'),
+      'border-radius': tokenVar('radius-lg'),
+      'overflow-x': 'auto',
+      'margin-top': tokenVar('spacing-4'),
+      'margin-bottom': tokenVar('spacing-4'),
+    }),
+
+    styleRule('pre code', {
+      'background-color': 'transparent',
+      padding: '0',
+    }),
+
+    styleRule('hr', {
+      'border-color': tokenVar('color-border'),
+      'margin-top': tokenVar('spacing-8'),
+      'margin-bottom': tokenVar('spacing-8'),
+    }),
+
+    styleRule('img', {
+      'border-radius': tokenVar('radius-lg'),
+      'margin-top': tokenVar('spacing-4'),
+      'margin-bottom': tokenVar('spacing-4'),
+    }),
+
+    styleRule('table', {
+      width: '100%',
+      'margin-top': tokenVar('spacing-4'),
+      'margin-bottom': tokenVar('spacing-4'),
+    }),
+
+    styleRule('th', {
+      'border-width': '1px',
+      'border-style': 'solid',
+      'border-color': tokenVar('color-border'),
+      'padding-left': tokenVar('spacing-3'),
+      'padding-right': tokenVar('spacing-3'),
+      'padding-top': tokenVar('spacing-2'),
+      'padding-bottom': tokenVar('spacing-2'),
+      'text-align': 'left',
+      'font-weight': tokenVar('font-weight-semibold', '600'),
+    }),
+
+    styleRule('td', {
+      'border-width': '1px',
+      'border-style': 'solid',
+      'border-color': tokenVar('color-border'),
+      'padding-left': tokenVar('spacing-3'),
+      'padding-right': tokenVar('spacing-3'),
+      'padding-top': tokenVar('spacing-2'),
+      'padding-bottom': tokenVar('spacing-2'),
+    }),
+  );
+}
+
+// ============================================================================
+// Inner Element Style Composition
+// ============================================================================
+
+interface InnerStyles {
+  base: CSSProperties;
+  layout: CSSProperties | null;
+}
+
+/**
+ * Build the property map for the inner semantic element (.container).
+ *
+ * Layered composition:
+ *  - max-width / width based on `size`
+ *  - margin-inline: auto when sized but not full
+ *  - padding when present
+ *  - flex column + gap when gap resolved
+ *  - background pair when present
+ *  - article max-width clamp when article and size unset
+ */
+function innerElementStyles(options: ContainerStylesheetOptions): InnerStyles {
+  const base: CSSProperties = {};
+
+  // Size constraint -- max-width via token, except 'full' (already 100% on host).
+  if (options.size && options.size !== 'full') {
+    base['max-width'] = tokenVar(`size-container-${options.size}`);
+    base['margin-inline'] = 'auto';
+  }
+  if (options.size === 'full') {
+    base.width = '100%';
+  }
+
+  // Article width clamp when no explicit size set.
+  if (options.article && !options.size) {
+    base['max-width'] = tokenVar('size-prose', '65ch');
+    base['margin-inline'] = 'auto';
+  }
+
+  // Padding from spacing scale.
+  if (options.padding) {
+    base.padding = tokenVar(`spacing-${options.padding}`);
+  }
+
+  // Background pair (background-color + foreground color).
+  if (options.background && options.background !== 'none') {
+    const bg = containerBackgroundStyles[options.background];
+    Object.assign(base, bg);
+  }
+
+  // Editable outline.
+  if (options.editable) {
+    Object.assign(base, containerEditable);
+  }
+
+  // Gap -> flex column layout. Resolve true to size-derived default.
+  let gapValue: ContainerSpacing | null = null;
+  if (options.gap === true) {
+    gapValue = resolveDerivedGap(options.size);
+  } else if (typeof options.gap === 'string' && isContainerSpacing(options.gap)) {
+    gapValue = options.gap;
+  }
+
+  let layout: CSSProperties | null = null;
+  if (gapValue !== null) {
+    layout = {
+      display: 'flex',
+      'flex-direction': 'column',
+      gap: tokenVar(`spacing-${gapValue}`),
+    };
+  }
+
+  return { base, layout };
+}
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+/**
+ * Build the complete container stylesheet for a given configuration.
+ *
+ * Returns concatenated CSS rule blocks suitable for adoption by a
+ * CSSStyleSheet inside a shadow root. All token references resolve via the
+ * shared token stylesheet on RaftersElement.
+ */
+export function containerStylesheet(options: ContainerStylesheetOptions = {}): string {
+  const inner = innerElementStyles(options);
+  const article = options.article ? articleTypographyRules() : '';
+
+  // Compose :host declarations -- always include base, optionally include the
+  // editable outline color custom property so the inner outline-color
+  // reference resolves through CSSOM regardless of color-mix parser support.
+  const hostStyles: CSSProperties = {
+    ...containerHostBase,
+    ...(options.editable ? containerEditableHost : {}),
+  };
+
+  return stylesheet(
+    styleRule(':host', hostStyles),
+    styleRule('.container', inner.base, inner.layout),
+    article,
+    atRule(
+      '@media (prefers-reduced-motion: reduce)',
+      styleRule('.container', { transition: 'none' }),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

Ships `<rafters-container>` as the third framework target alongside `container.tsx` (React) and `container.astro` (Astro). The element renders the requested semantic element (`div` / `main` / `section` / `article` / `aside`) into a shadow root and adopts a per-instance stylesheet composed from `containerStylesheet()` in `container.styles.ts`.

Closes #1299.

## Behavior

- Auto-registers `rafters-container` on import; idempotent against double-define.
- `observedAttributes` exactly: `as`, `size`, `padding`, `gap`, `background`, `editable`.
- Container queries always-on via `:host { container-type: inline-size; display: block; width: 100% }`.
- `size` constrains `max-width` via `tokenVar('size-container-{size}')` and centers with `margin-inline: auto`. `size='full'` falls back to `width: 100%` with no max-width.
- `padding` maps to `tokenVar('spacing-{n}')` on the inner element.
- `gap` turns the inner element into a vertical flex column with `gap: tokenVar('spacing-{n}')`. Bare `gap` (empty attribute) derives the spacing from `size` via the documented size-gap scale; defaults to `'6'` when no size is set.
- `background` resolves the legacy enum (`muted` / `accent` / `card` / `primary` / `secondary`) to a paired `background-color` + foreground `color` via `tokenVar()`. Unknown / `none` values silently fall back.
- `as='article'` applies typography rules to descendant selectors (`p`, `h1`-`h4`, `ul`, `ol`, `li`, `a`, `blockquote`, `code`, `pre`, `hr`, `img`, `table`, `th`, `td`) sourced exclusively from tokens. When no explicit `size` is set, article also clamps width to `tokenVar('size-prose', '65ch')`.
- `editable` applies a 2px dashed outline whose color comes from `color-mix(in oklch, var(--color-muted-foreground) 30%, transparent)`. The expression is parked on a `:host`-scoped custom property so CSSOM implementations that cannot parse `color-mix()` (notably happy-dom in tests) still preserve the declaration.

## Conventions

- Motion declarations stay in the `--motion-duration-*` / `--motion-ease-*` namespace; `@media (prefers-reduced-motion: reduce)` disables transitions.
- Every CSS variable reference in `container.styles.ts` and `container.element.ts` goes through `tokenVar()`; no raw `var(...)` literals.
- No Tailwind utility class strings, no `any` types, no emoji, no innerHTML (DOM APIs only).
- Tests live alongside the source per the `packages/ui` vitest include glob.

## Test plan

- [x] `pnpm vitest run container` from `packages/ui` -- 84 passing across 5 files (the four new tests plus the existing React container suites).
- [x] `pnpm typecheck` -- clean.
- [x] `pnpm preflight` from repo root -- exit 0.

NO version bump / NO CHANGELOG entry per the WC fan-out plan; release PR rolls these up later.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>