### PR TITLE
feat(ui): typography.styles.ts and <rafters-typography> Web Component (#1301)

### DIFF
--- a/packages/ui/src/components/ui/typography.element.test.ts
+++ b/packages/ui/src/components/ui/typography.element.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Tests for <rafters-typography> Web Component.
+ *
+ * Uses happy-dom (vitest default for this workspace). Shadow DOM and
+ * adoptedStyleSheets are both supported.
+ *
+ * Assertions check rendered semantic tag per variant, fallback behavior,
+ * idempotent registration, and that TypographyTokenProps attributes inject
+ * token references into the shadow stylesheet (values need not resolve --
+ * resolver work is tracked separately).
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import './typography.element';
+import { RaftersTypography } from './typography.element';
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+describe('rafters-typography', () => {
+  it('registers as rafters-typography', () => {
+    expect(customElements.get('rafters-typography')).toBeDefined();
+  });
+
+  it('registered constructor is RaftersTypography', () => {
+    expect(customElements.get('rafters-typography')).toBe(RaftersTypography);
+  });
+
+  it('idempotent registration -- second import does not throw', async () => {
+    await expect(import('./typography.element')).resolves.toBeDefined();
+  });
+
+  it('defaults to <p> when variant attribute is absent', () => {
+    const el = document.createElement('rafters-typography');
+    document.body.appendChild(el);
+    expect(el.shadowRoot?.querySelector('p')).not.toBeNull();
+  });
+
+  it('renders <h1> when variant="h1"', () => {
+    const el = document.createElement('rafters-typography');
+    el.setAttribute('variant', 'h1');
+    document.body.appendChild(el);
+    expect(el.shadowRoot?.querySelector('h1')).not.toBeNull();
+  });
+
+  it('renders <h2> when variant="h2"', () => {
+    const el = document.createElement('rafters-typography');
+    el.setAttribute('variant', 'h2');
+    document.body.appendChild(el);
+    expect(el.shadowRoot?.querySelector('h2')).not.toBeNull();
+  });
+
+  it('renders <h3> when variant="h3"', () => {
+    const el = document.createElement('rafters-typography');
+    el.setAttribute('variant', 'h3');
+    document.body.appendChild(el);
+    expect(el.shadowRoot?.querySelector('h3')).not.toBeNull();
+  });
+
+  it('renders <h4> when variant="h4"', () => {
+    const el = document.createElement('rafters-typography');
+    el.setAttribute('variant', 'h4');
+    document.body.appendChild(el);
+    expect(el.shadowRoot?.querySelector('h4')).not.toBeNull();
+  });
+
+  it('renders <small> when variant="small"', () => {
+    const el = document.createElement('rafters-typography');
+    el.setAttribute('variant', 'small');
+    document.body.appendChild(el);
+    expect(el.shadowRoot?.querySelector('small')).not.toBeNull();
+  });
+
+  it('renders <code> when variant="code"', () => {
+    const el = document.createElement('rafters-typography');
+    el.setAttribute('variant', 'code');
+    document.body.appendChild(el);
+    expect(el.shadowRoot?.querySelector('code')).not.toBeNull();
+  });
+
+  it('renders <blockquote> when variant="blockquote"', () => {
+    const el = document.createElement('rafters-typography');
+    el.setAttribute('variant', 'blockquote');
+    document.body.appendChild(el);
+    expect(el.shadowRoot?.querySelector('blockquote')).not.toBeNull();
+  });
+
+  it('renders <ul> when variant="ul"', () => {
+    const el = document.createElement('rafters-typography');
+    el.setAttribute('variant', 'ul');
+    document.body.appendChild(el);
+    expect(el.shadowRoot?.querySelector('ul')).not.toBeNull();
+  });
+
+  it('renders <ol> when variant="ol"', () => {
+    const el = document.createElement('rafters-typography');
+    el.setAttribute('variant', 'ol');
+    document.body.appendChild(el);
+    expect(el.shadowRoot?.querySelector('ol')).not.toBeNull();
+  });
+
+  it('renders <li> when variant="li"', () => {
+    const el = document.createElement('rafters-typography');
+    el.setAttribute('variant', 'li');
+    document.body.appendChild(el);
+    expect(el.shadowRoot?.querySelector('li')).not.toBeNull();
+  });
+
+  it('renders <mark> when variant="mark"', () => {
+    const el = document.createElement('rafters-typography');
+    el.setAttribute('variant', 'mark');
+    document.body.appendChild(el);
+    expect(el.shadowRoot?.querySelector('mark')).not.toBeNull();
+  });
+
+  it('renders <abbr> when variant="abbr"', () => {
+    const el = document.createElement('rafters-typography');
+    el.setAttribute('variant', 'abbr');
+    document.body.appendChild(el);
+    expect(el.shadowRoot?.querySelector('abbr')).not.toBeNull();
+  });
+
+  it('renders <p> when variant is one of the paragraph-based variants', () => {
+    for (const variant of ['lead', 'large', 'muted']) {
+      const el = document.createElement('rafters-typography');
+      el.setAttribute('variant', variant);
+      document.body.appendChild(el);
+      expect(el.shadowRoot?.querySelector('p')).not.toBeNull();
+      document.body.removeChild(el);
+    }
+  });
+
+  it('renders pre>code when variant="codeblock"', () => {
+    const el = document.createElement('rafters-typography');
+    el.setAttribute('variant', 'codeblock');
+    document.body.appendChild(el);
+    const pre = el.shadowRoot?.querySelector('pre');
+    expect(pre).not.toBeNull();
+    expect(pre?.querySelector('code')).not.toBeNull();
+  });
+
+  it('codeblock contains a <slot> inside the <code> element', () => {
+    const el = document.createElement('rafters-typography');
+    el.setAttribute('variant', 'codeblock');
+    document.body.appendChild(el);
+    const code = el.shadowRoot?.querySelector('pre > code');
+    expect(code).not.toBeNull();
+    expect(code?.querySelector('slot')).not.toBeNull();
+  });
+
+  it('falls back to <p> on unknown variant', () => {
+    const el = document.createElement('rafters-typography');
+    el.setAttribute('variant', 'totally-bogus');
+    document.body.appendChild(el);
+    expect(el.shadowRoot?.querySelector('p')).not.toBeNull();
+    expect(el.shadowRoot?.querySelector('h1')).toBeNull();
+  });
+
+  it('does not throw on unknown variant', () => {
+    const el = document.createElement('rafters-typography');
+    expect(() => {
+      el.setAttribute('variant', 'nonsense');
+      document.body.appendChild(el);
+    }).not.toThrow();
+  });
+
+  it('rerenders semantic tag when variant attribute changes', () => {
+    const el = document.createElement('rafters-typography');
+    el.setAttribute('variant', 'h1');
+    document.body.appendChild(el);
+    expect(el.shadowRoot?.querySelector('h1')).not.toBeNull();
+    el.setAttribute('variant', 'h2');
+    expect(el.shadowRoot?.querySelector('h1')).toBeNull();
+    expect(el.shadowRoot?.querySelector('h2')).not.toBeNull();
+  });
+
+  it('contains a single <slot> for projected children (non-codeblock variants)', () => {
+    const el = document.createElement('rafters-typography');
+    document.body.appendChild(el);
+    expect(el.shadowRoot?.querySelectorAll('slot').length).toBe(1);
+  });
+
+  it('observes all TypographyTokenProps attributes', () => {
+    const ctor = customElements.get('rafters-typography') as typeof HTMLElement & {
+      observedAttributes: string[];
+    };
+    const observed = ctor.observedAttributes;
+    for (const attr of [
+      'variant',
+      'size',
+      'weight',
+      'color',
+      'line',
+      'tracking',
+      'family',
+      'align',
+      'transform',
+    ]) {
+      expect(observed).toContain(attr);
+    }
+  });
+
+  it('size attribute injects font-size override into shadow stylesheet', () => {
+    const el = document.createElement('rafters-typography');
+    el.setAttribute('size', 'xl');
+    document.body.appendChild(el);
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    const allCss = sheets
+      .map((s) =>
+        Array.from(s.cssRules)
+          .map((r) => r.cssText)
+          .join('\n'),
+      )
+      .join('\n');
+    expect(allCss).toContain('var(--font-size-xl)');
+  });
+
+  it('color attribute injects color override into shadow stylesheet', () => {
+    const el = document.createElement('rafters-typography');
+    el.setAttribute('color', 'muted-foreground');
+    document.body.appendChild(el);
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    const allCss = sheets
+      .map((s) =>
+        Array.from(s.cssRules)
+          .map((r) => r.cssText)
+          .join('\n'),
+      )
+      .join('\n');
+    expect(allCss).toContain('var(--color-muted-foreground)');
+  });
+
+  it('h1 variant emits display-large composite token references', () => {
+    const el = document.createElement('rafters-typography');
+    el.setAttribute('variant', 'h1');
+    document.body.appendChild(el);
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    const allCss = sheets
+      .map((s) =>
+        Array.from(s.cssRules)
+          .map((r) => r.cssText)
+          .join('\n'),
+      )
+      .join('\n');
+    expect(allCss).toContain('var(--font-display-large-size)');
+  });
+
+  it('align attribute emits a literal text-align value into the shadow stylesheet', () => {
+    const el = document.createElement('rafters-typography');
+    el.setAttribute('align', 'center');
+    document.body.appendChild(el);
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    const allCss = sheets
+      .map((s) =>
+        Array.from(s.cssRules)
+          .map((r) => r.cssText)
+          .join('\n'),
+      )
+      .join('\n');
+    expect(allCss).toContain('text-align: center');
+  });
+
+  it('transform attribute emits a literal text-transform value into the shadow stylesheet', () => {
+    const el = document.createElement('rafters-typography');
+    el.setAttribute('transform', 'uppercase');
+    document.body.appendChild(el);
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    const allCss = sheets
+      .map((s) =>
+        Array.from(s.cssRules)
+          .map((r) => r.cssText)
+          .join('\n'),
+      )
+      .join('\n');
+    expect(allCss).toContain('text-transform: uppercase');
+  });
+
+  it('changing a TypographyTokenProps attribute updates the shadow stylesheet', () => {
+    const el = document.createElement('rafters-typography');
+    document.body.appendChild(el);
+
+    let sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    let allCss = sheets
+      .map((s) =>
+        Array.from(s.cssRules)
+          .map((r) => r.cssText)
+          .join('\n'),
+      )
+      .join('\n');
+    expect(allCss).not.toContain('var(--font-weight-bold)');
+
+    el.setAttribute('weight', 'bold');
+    sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    allCss = sheets
+      .map((s) =>
+        Array.from(s.cssRules)
+          .map((r) => r.cssText)
+          .join('\n'),
+      )
+      .join('\n');
+    expect(allCss).toContain('var(--font-weight-bold)');
+  });
+});

--- a/packages/ui/src/components/ui/typography.element.ts
+++ b/packages/ui/src/components/ui/typography.element.ts
@@ -1,0 +1,143 @@
+/**
+ * <rafters-typography> -- token-aware typography Web Component
+ *
+ * Renders any of 17 variants (h1-h4, p, lead, large, small, muted, code,
+ * blockquote, ul, ol, li, codeblock, mark, abbr) inside shadow DOM.
+ *
+ * The variant attribute drives both the rendered tag AND the composite role
+ * (see variantToCompositeRole in ./typography.styles). TypographyTokenProps
+ * attributes (size/weight/color/line/tracking/family/align/transform) override
+ * variant defaults by injecting bare token references into the shadow stylesheet.
+ *
+ * Auto-registers as 'rafters-typography' on import. Registration is idempotent.
+ * Unknown variants silently fall back to 'p' -- NEVER throws.
+ *
+ * DOM is built via document.createElement / appendChild. No innerHTML.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import {
+  resolveVariant,
+  type TypographyTokenOverrides,
+  type TypographyVariant,
+  typographyStylesheet,
+  variantToTag,
+} from './typography.styles';
+
+// ============================================================================
+// Observed Attributes
+// ============================================================================
+
+/** Attribute names that map to TypographyTokenOverrides keys. */
+const OVERRIDE_ATTRIBUTES = [
+  'size',
+  'weight',
+  'color',
+  'line',
+  'tracking',
+  'family',
+  'align',
+  'transform',
+] as const;
+
+type OverrideAttribute = (typeof OVERRIDE_ATTRIBUTES)[number];
+
+/** All attributes the element observes. Variant is first; overrides follow. */
+const OBSERVED_ATTRIBUTES = ['variant', ...OVERRIDE_ATTRIBUTES] as const;
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export class RaftersTypography extends RaftersElement {
+  static observedAttributes: readonly string[] = OBSERVED_ATTRIBUTES;
+
+  /** Per-instance stylesheet carrying the variant + overrides CSS. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  /**
+   * Read all TypographyTokenOverrides attributes off the element, omitting
+   * absent entries so tokenOverridesToProperties skips them cleanly.
+   */
+  private readOverrides(): TypographyTokenOverrides {
+    const out: TypographyTokenOverrides = {};
+    for (const attr of OVERRIDE_ATTRIBUTES) {
+      const value = this.getAttribute(attr);
+      if (value !== null && value.length > 0) {
+        out[attr satisfies OverrideAttribute] = value;
+      }
+    }
+    return out;
+  }
+
+  /** Resolve the current variant from the `variant` attribute. */
+  private currentVariant(): TypographyVariant {
+    return resolveVariant(this.getAttribute('variant'));
+  }
+
+  /** Build the CSS text for this instance's current state. */
+  protected currentStylesheet(): string {
+    return typographyStylesheet({
+      variant: this.currentVariant(),
+      overrides: this.readOverrides(),
+    });
+  }
+
+  /**
+   * Rebuild the instance stylesheet and the shadow DOM on any state change.
+   * Called by RaftersElement.connectedCallback and attributeChangedCallback.
+   */
+  override update(): void {
+    if (!this.shadowRoot) return;
+
+    // Rebuild the per-instance stylesheet from current variant + overrides.
+    const css = this.currentStylesheet();
+    if (!this._instanceSheet) {
+      this._instanceSheet = new CSSStyleSheet();
+    }
+    this._instanceSheet.replaceSync(css);
+
+    // Compose adopted sheets: keep any inherited sheets, then append ours.
+    const existing = this.shadowRoot.adoptedStyleSheets;
+    const next: CSSStyleSheet[] = [];
+    for (const sheet of existing) {
+      if (sheet !== this._instanceSheet) next.push(sheet);
+    }
+    next.push(this._instanceSheet);
+    this.shadowRoot.adoptedStyleSheets = next;
+
+    // Replace content. render() builds a fresh subtree.
+    this.shadowRoot.replaceChildren(this.render());
+  }
+
+  /**
+   * Build the semantic tag tree for the current variant.
+   * codeblock -> <pre><code><slot/></code></pre>
+   * All other variants -> <tag><slot/></tag>
+   */
+  override render(): Node {
+    const variant = this.currentVariant();
+    const tag = variantToTag[variant];
+    const root = document.createElement(tag);
+
+    if (variant === 'codeblock') {
+      const code = document.createElement('code');
+      const slot = document.createElement('slot');
+      code.appendChild(slot);
+      root.appendChild(code);
+      return root;
+    }
+
+    root.appendChild(document.createElement('slot'));
+    return root;
+  }
+}
+
+// ============================================================================
+// Auto-registration (idempotent)
+// ============================================================================
+
+const TAG_NAME = 'rafters-typography';
+if (typeof customElements !== 'undefined' && !customElements.get(TAG_NAME)) {
+  customElements.define(TAG_NAME, RaftersTypography);
+}

--- a/packages/ui/src/components/ui/typography.styles.test.ts
+++ b/packages/ui/src/components/ui/typography.styles.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Tests for typography.styles.ts
+ *
+ * Assertions target the CSS text produced by typographyStylesheet -- we
+ * verify the var() references exist, not that they resolve to real values.
+ * Resolver wiring lives in resolve-tokens.ts and is covered separately.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  resolveVariant,
+  type TypographyVariant,
+  tokenOverridesToProperties,
+  typographyStylesheet,
+  variantToCompositeRole,
+  variantToTag,
+} from './typography.styles';
+
+describe('typographyStylesheet', () => {
+  it('defaults to variant p when no options provided', () => {
+    const css = typographyStylesheet();
+    expect(css).toContain(':host {');
+    expect(css).toContain('display: block');
+    expect(css).toContain('var(--font-body-medium-size)');
+  });
+
+  it('emits :host display block for h1', () => {
+    expect(typographyStylesheet({ variant: 'h1' })).toContain('display: block');
+  });
+
+  it('emits :host display inline for small', () => {
+    expect(typographyStylesheet({ variant: 'small' })).toContain('display: inline');
+  });
+
+  it('emits :host display inline for code, mark, abbr', () => {
+    for (const variant of ['code', 'mark', 'abbr'] as const) {
+      expect(typographyStylesheet({ variant })).toContain('display: inline');
+    }
+  });
+
+  it('emits :host display block for p, h2, h3, h4, blockquote, ul, ol, li, codeblock, lead, large, muted', () => {
+    for (const variant of [
+      'p',
+      'h2',
+      'h3',
+      'h4',
+      'blockquote',
+      'ul',
+      'ol',
+      'li',
+      'codeblock',
+      'lead',
+      'large',
+      'muted',
+    ] as const) {
+      expect(typographyStylesheet({ variant })).toContain('display: block');
+    }
+  });
+
+  it('h1 references display-large composite tokens', () => {
+    const css = typographyStylesheet({ variant: 'h1' });
+    expect(css).toContain('var(--font-display-large-family)');
+    expect(css).toContain('var(--font-display-large-size)');
+    expect(css).toContain('var(--font-display-large-weight)');
+    expect(css).toContain('var(--font-display-large-line-height)');
+    expect(css).toContain('var(--font-display-large-letter-spacing)');
+  });
+
+  it('h2 references display-medium composite tokens', () => {
+    const css = typographyStylesheet({ variant: 'h2' });
+    expect(css).toContain('var(--font-display-medium-family)');
+    expect(css).toContain('var(--font-display-medium-size)');
+    expect(css).toContain('var(--font-display-medium-weight)');
+    expect(css).toContain('var(--font-display-medium-line-height)');
+    expect(css).toContain('var(--font-display-medium-letter-spacing)');
+  });
+
+  it('h3 references title-large composite tokens', () => {
+    const css = typographyStylesheet({ variant: 'h3' });
+    expect(css).toContain('var(--font-title-large-family)');
+    expect(css).toContain('var(--font-title-large-size)');
+  });
+
+  it('h4 references title-medium composite tokens', () => {
+    const css = typographyStylesheet({ variant: 'h4' });
+    expect(css).toContain('var(--font-title-medium-family)');
+    expect(css).toContain('var(--font-title-medium-size)');
+  });
+
+  it('lead references body-large composite tokens and uses muted foreground', () => {
+    const css = typographyStylesheet({ variant: 'lead' });
+    expect(css).toContain('var(--font-body-large-size)');
+    expect(css).toContain('var(--color-muted-foreground)');
+  });
+
+  it('large references body-large composite tokens with semibold weight override', () => {
+    const css = typographyStylesheet({ variant: 'large' });
+    expect(css).toContain('var(--font-body-large-size)');
+    expect(css).toContain('var(--font-weight-semibold)');
+  });
+
+  it('small references body-small composite tokens with medium weight override', () => {
+    const css = typographyStylesheet({ variant: 'small' });
+    expect(css).toContain('var(--font-body-small-size)');
+    expect(css).toContain('var(--font-weight-medium)');
+  });
+
+  it('muted references body-small composite tokens and uses muted foreground', () => {
+    const css = typographyStylesheet({ variant: 'muted' });
+    expect(css).toContain('var(--font-body-small-size)');
+    expect(css).toContain('var(--color-muted-foreground)');
+  });
+
+  it('code references code-small composite tokens and emits muted background', () => {
+    const css = typographyStylesheet({ variant: 'code' });
+    expect(css).toContain('var(--font-code-small-size)');
+    expect(css).toContain('var(--color-muted)');
+  });
+
+  it('blockquote variant adds border-left and italic', () => {
+    const css = typographyStylesheet({ variant: 'blockquote' });
+    expect(css).toContain('font-style: italic');
+    expect(css).toContain('border-left');
+    expect(css).toContain('var(--color-border)');
+  });
+
+  it('ul variant sets list-style-type disc', () => {
+    const css = typographyStylesheet({ variant: 'ul' });
+    expect(css).toContain('list-style-type: disc');
+  });
+
+  it('ol variant sets list-style-type decimal', () => {
+    const css = typographyStylesheet({ variant: 'ol' });
+    expect(css).toContain('list-style-type: decimal');
+  });
+
+  it('li variant references body-medium composite tokens', () => {
+    const css = typographyStylesheet({ variant: 'li' });
+    expect(css).toContain('var(--font-body-medium-size)');
+  });
+
+  it('codeblock variant uses pre styling with overflow', () => {
+    const css = typographyStylesheet({ variant: 'codeblock' });
+    expect(css).toContain('overflow-x: auto');
+    expect(css).toContain('var(--color-muted)');
+  });
+
+  it('mark variant uses accent background', () => {
+    const css = typographyStylesheet({ variant: 'mark' });
+    expect(css).toContain('var(--color-accent)');
+    expect(css).toContain('var(--color-accent-foreground)');
+  });
+
+  it('abbr variant sets cursor help and dotted underline', () => {
+    const css = typographyStylesheet({ variant: 'abbr' });
+    expect(css).toContain('cursor: help');
+    expect(css).toContain('text-decoration-style: dotted');
+  });
+
+  it('size override emits font-size after the composite block', () => {
+    const css = typographyStylesheet({ variant: 'p', overrides: { size: 'xl' } });
+    const composite = css.indexOf('var(--font-body-medium-size)');
+    const override = css.lastIndexOf('var(--font-size-xl)');
+    expect(composite).toBeGreaterThanOrEqual(0);
+    expect(override).toBeGreaterThan(composite);
+  });
+
+  it('weight override resolves to font-weight token reference', () => {
+    const css = typographyStylesheet({ variant: 'p', overrides: { weight: 'bold' } });
+    expect(css).toContain('var(--font-weight-bold)');
+  });
+
+  it('color override resolves bare token names', () => {
+    const css = typographyStylesheet({ variant: 'p', overrides: { color: 'muted-foreground' } });
+    expect(css).toContain('var(--color-muted-foreground)');
+  });
+
+  it('line override resolves to line-height token reference', () => {
+    const css = typographyStylesheet({ variant: 'p', overrides: { line: 'relaxed' } });
+    expect(css).toContain('var(--line-height-relaxed)');
+  });
+
+  it('tracking override resolves to letter-spacing token reference', () => {
+    const css = typographyStylesheet({ variant: 'p', overrides: { tracking: 'tight' } });
+    expect(css).toContain('var(--letter-spacing-tight)');
+  });
+
+  it('family override resolves to font-{role} token reference', () => {
+    const css = typographyStylesheet({ variant: 'p', overrides: { family: 'heading' } });
+    expect(css).toContain('var(--font-heading)');
+  });
+
+  it('align override emits literal text-align value, not a token reference', () => {
+    const css = typographyStylesheet({ variant: 'p', overrides: { align: 'center' } });
+    expect(css).toContain('text-align: center');
+    expect(css).not.toContain('var(--text-align');
+  });
+
+  it('transform override emits literal text-transform value', () => {
+    const css = typographyStylesheet({ variant: 'p', overrides: { transform: 'uppercase' } });
+    expect(css).toContain('text-transform: uppercase');
+    expect(css).not.toContain('var(--text-transform');
+  });
+
+  it('variantToCompositeRole maps every variant to a non-empty role', () => {
+    for (const role of Object.values(variantToCompositeRole)) {
+      expect(role).toBeTruthy();
+    }
+  });
+
+  it('variantToCompositeRole covers every declared variant', () => {
+    const variants: TypographyVariant[] = [
+      'h1',
+      'h2',
+      'h3',
+      'h4',
+      'p',
+      'lead',
+      'large',
+      'small',
+      'muted',
+      'code',
+      'blockquote',
+      'ul',
+      'ol',
+      'li',
+      'codeblock',
+      'mark',
+      'abbr',
+    ];
+    for (const v of variants) {
+      expect(variantToCompositeRole[v]).toBeTruthy();
+      expect(variantToTag[v]).toBeTruthy();
+    }
+  });
+
+  it('unknown variant falls back to p without throwing', () => {
+    // Cast guards exist for runtime safety -- we test that path directly.
+    const css = typographyStylesheet({ variant: 'bogus' as unknown as TypographyVariant });
+    expect(css).toContain('var(--font-body-medium-size)');
+    expect(css).toContain('display: block');
+  });
+
+  it('codeblock variant picks <pre> tag in variantToTag', () => {
+    expect(variantToTag.codeblock).toBe('pre');
+  });
+
+  it('emits CSS without any raw --duration-* or --ease-* references', () => {
+    const variants: TypographyVariant[] = [
+      'h1',
+      'h2',
+      'h3',
+      'h4',
+      'p',
+      'lead',
+      'large',
+      'small',
+      'muted',
+      'code',
+      'blockquote',
+      'ul',
+      'ol',
+      'li',
+      'codeblock',
+      'mark',
+      'abbr',
+    ];
+    for (const v of variants) {
+      const css = typographyStylesheet({ variant: v });
+      expect(css).not.toMatch(/var\(--duration-/);
+      expect(css).not.toMatch(/var\(--ease-/);
+    }
+  });
+});
+
+describe('resolveVariant', () => {
+  it('returns p for null', () => {
+    expect(resolveVariant(null)).toBe('p');
+  });
+
+  it('returns p for empty string', () => {
+    expect(resolveVariant('')).toBe('p');
+  });
+
+  it('returns p for unknown variant', () => {
+    expect(resolveVariant('totally-bogus')).toBe('p');
+  });
+
+  it('returns the variant when known', () => {
+    expect(resolveVariant('h1')).toBe('h1');
+    expect(resolveVariant('codeblock')).toBe('codeblock');
+  });
+
+  it('never throws on unknown input', () => {
+    expect(() => resolveVariant(undefined)).not.toThrow();
+    expect(() => resolveVariant(42)).not.toThrow();
+    expect(() => resolveVariant({})).not.toThrow();
+  });
+});
+
+describe('tokenOverridesToProperties', () => {
+  it('emits no properties for empty overrides', () => {
+    const props = tokenOverridesToProperties({});
+    expect(Object.keys(props).length).toBe(0);
+  });
+
+  it('maps all six token-backed keys to var() references', () => {
+    const props = tokenOverridesToProperties({
+      size: 'lg',
+      weight: 'semibold',
+      color: 'primary',
+      line: 'relaxed',
+      tracking: 'tight',
+      family: 'heading',
+    });
+    expect(props['font-size']).toBe('var(--font-size-lg)');
+    expect(props['font-weight']).toBe('var(--font-weight-semibold)');
+    expect(props.color).toBe('var(--color-primary)');
+    expect(props['line-height']).toBe('var(--line-height-relaxed)');
+    expect(props['letter-spacing']).toBe('var(--letter-spacing-tight)');
+    expect(props['font-family']).toBe('var(--font-heading)');
+  });
+
+  it('emits align and transform as literal values (no var())', () => {
+    const props = tokenOverridesToProperties({ align: 'right', transform: 'lowercase' });
+    expect(props['text-align']).toBe('right');
+    expect(props['text-transform']).toBe('lowercase');
+  });
+});

--- a/packages/ui/src/components/ui/typography.styles.ts
+++ b/packages/ui/src/components/ui/typography.styles.ts
@@ -1,0 +1,321 @@
+/**
+ * Shadow DOM style definitions for Typography web component
+ *
+ * Parallel to typography.classes.ts (React variant). CSS property maps
+ * instead of Tailwind class strings. Each variant references a single
+ * composite typography role via --font-{role}-{family|size|weight|line-height|letter-spacing}
+ * custom properties. The resolver in resolve-tokens.ts is responsible for
+ * producing those values; this module only emits the var() references.
+ *
+ * TypographyTokenOverrides mirrors the shape of TypographyTokenProps from
+ * typography.classes.ts. Each override resolves to a bare token reference
+ * via tokenVar() (size/weight/color/line/tracking/family), or emits a
+ * literal CSS value (align/transform). No raw var() calls -- always
+ * through tokenVar(). No --duration-* or --ease-* -- always
+ * --motion-duration-* and --motion-ease-* when motion is needed.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import { styleRule, stylesheet, tokenVar } from '../../primitives/classy-wc';
+
+// ============================================================================
+// Variant Surface
+// ============================================================================
+
+export type TypographyVariant =
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'p'
+  | 'lead'
+  | 'large'
+  | 'small'
+  | 'muted'
+  | 'code'
+  | 'blockquote'
+  | 'ul'
+  | 'ol'
+  | 'li'
+  | 'codeblock'
+  | 'mark'
+  | 'abbr';
+
+/**
+ * Variant -> composite typography role.
+ * The role name drives the --font-{role}-{dimension} custom property
+ * references emitted by compositeRoleProperties().
+ */
+export const variantToCompositeRole: Record<TypographyVariant, string> = {
+  h1: 'display-large',
+  h2: 'display-medium',
+  h3: 'title-large',
+  h4: 'title-medium',
+  p: 'body-medium',
+  lead: 'body-large',
+  large: 'body-large',
+  small: 'body-small',
+  muted: 'body-small',
+  code: 'code-small',
+  blockquote: 'body-medium',
+  ul: 'body-medium',
+  ol: 'body-medium',
+  li: 'body-medium',
+  codeblock: 'code-small',
+  mark: 'body-medium',
+  abbr: 'body-medium',
+};
+
+/**
+ * Variant -> semantic HTML tag (the element rendered inside shadow DOM).
+ * Unknown variants fall back to 'p' at the caller layer -- NEVER throw.
+ */
+export const variantToTag: Record<TypographyVariant, string> = {
+  h1: 'h1',
+  h2: 'h2',
+  h3: 'h3',
+  h4: 'h4',
+  p: 'p',
+  lead: 'p',
+  large: 'p',
+  small: 'small',
+  muted: 'p',
+  code: 'code',
+  blockquote: 'blockquote',
+  ul: 'ul',
+  ol: 'ol',
+  li: 'li',
+  codeblock: 'pre',
+  mark: 'mark',
+  abbr: 'abbr',
+};
+
+// ============================================================================
+// Per-variant :host Display
+// ============================================================================
+
+/**
+ * Headings, paragraphs, lists, blockquote, and codeblock flow as blocks.
+ * small/code/mark/abbr are inline phrasing content.
+ */
+const INLINE_VARIANTS = new Set<TypographyVariant>(['small', 'code', 'mark', 'abbr']);
+
+function hostDisplay(variant: TypographyVariant): CSSProperties {
+  return { display: INLINE_VARIANTS.has(variant) ? 'inline' : 'block' };
+}
+
+// ============================================================================
+// Composite Role Property Map
+// ============================================================================
+
+/**
+ * Build the five composite dimension var() references for a role.
+ * Each variant references these -- the resolver populates the real values.
+ */
+function compositeRoleProperties(role: string): CSSProperties {
+  return {
+    'font-family': tokenVar(`font-${role}-family`),
+    'font-size': tokenVar(`font-${role}-size`),
+    'font-weight': tokenVar(`font-${role}-weight`),
+    'line-height': tokenVar(`font-${role}-line-height`),
+    'letter-spacing': tokenVar(`font-${role}-letter-spacing`),
+  };
+}
+
+// ============================================================================
+// Variant Style Extensions (beyond the composite role defaults)
+// ============================================================================
+
+/**
+ * Per-variant style extensions. These layer on top of the composite
+ * role properties. Keys that also appear in the composite role map
+ * (e.g. color) override for this variant.
+ */
+export const typographyVariantStyles: Record<TypographyVariant, CSSProperties> = {
+  h1: {
+    color: tokenVar('color-foreground'),
+    margin: '0',
+  },
+  h2: {
+    color: tokenVar('color-foreground'),
+    margin: '0',
+  },
+  h3: {
+    color: tokenVar('color-foreground'),
+    margin: '0',
+  },
+  h4: {
+    color: tokenVar('color-foreground'),
+    margin: '0',
+  },
+  p: {
+    color: tokenVar('color-foreground'),
+    margin: '0',
+  },
+  lead: {
+    color: tokenVar('color-muted-foreground'),
+    margin: '0',
+  },
+  large: {
+    'font-weight': tokenVar('font-weight-semibold'),
+    color: tokenVar('color-foreground'),
+    margin: '0',
+  },
+  small: {
+    'font-weight': tokenVar('font-weight-medium'),
+    color: tokenVar('color-foreground'),
+  },
+  muted: {
+    color: tokenVar('color-muted-foreground'),
+    margin: '0',
+  },
+  code: {
+    'background-color': tokenVar('color-muted'),
+    color: tokenVar('color-foreground'),
+    'border-radius': tokenVar('radius-sm'),
+    'padding-left': tokenVar('spacing-1'),
+    'padding-right': tokenVar('spacing-1'),
+    'padding-top': tokenVar('spacing-0-5'),
+    'padding-bottom': tokenVar('spacing-0-5'),
+  },
+  blockquote: {
+    color: tokenVar('color-foreground'),
+    'border-left-width': '2px',
+    'border-left-style': 'solid',
+    'border-left-color': tokenVar('color-border'),
+    'padding-left': tokenVar('spacing-6'),
+    'font-style': 'italic',
+    margin: '0',
+  },
+  ul: {
+    color: tokenVar('color-foreground'),
+    'list-style-type': 'disc',
+    'margin-top': tokenVar('spacing-6'),
+    'margin-bottom': tokenVar('spacing-6'),
+    'margin-left': tokenVar('spacing-6'),
+    'padding-left': '0',
+  },
+  ol: {
+    color: tokenVar('color-foreground'),
+    'list-style-type': 'decimal',
+    'margin-top': tokenVar('spacing-6'),
+    'margin-bottom': tokenVar('spacing-6'),
+    'margin-left': tokenVar('spacing-6'),
+    'padding-left': '0',
+  },
+  li: {
+    color: tokenVar('color-foreground'),
+    'margin-top': tokenVar('spacing-2'),
+  },
+  codeblock: {
+    color: tokenVar('color-foreground'),
+    'background-color': tokenVar('color-muted'),
+    'border-radius': tokenVar('radius-lg'),
+    padding: tokenVar('spacing-4'),
+    'overflow-x': 'auto',
+    margin: '0',
+  },
+  mark: {
+    'background-color': tokenVar('color-accent'),
+    color: tokenVar('color-accent-foreground'),
+    'border-radius': tokenVar('radius-sm'),
+    'padding-left': tokenVar('spacing-1'),
+    'padding-right': tokenVar('spacing-1'),
+  },
+  abbr: {
+    cursor: 'help',
+    'text-decoration-line': 'underline',
+    'text-decoration-style': 'dotted',
+    'text-underline-offset': tokenVar('spacing-1'),
+  },
+};
+
+// ============================================================================
+// TypographyTokenOverrides
+// ============================================================================
+
+/**
+ * Token-level overrides. Mirrors TypographyTokenProps from typography.classes.ts.
+ * Each override has an explicit mapping to a CSS property:
+ *   size -> font-size -> var(--font-size-{value})
+ *   weight -> font-weight -> var(--font-weight-{value})
+ *   color -> color -> var(--color-{value})
+ *   line -> line-height -> var(--line-height-{value})
+ *   tracking -> letter-spacing -> var(--letter-spacing-{value})
+ *   family -> font-family -> var(--font-{value})
+ *   align -> text-align -> literal value ({value})
+ *   transform -> text-transform -> literal value ({value})
+ */
+export interface TypographyTokenOverrides {
+  size?: string;
+  weight?: string;
+  color?: string;
+  line?: string;
+  tracking?: string;
+  family?: string;
+  align?: string;
+  transform?: string;
+}
+
+/**
+ * Convert override keys to CSS property assignments.
+ * Size/weight/color/line/tracking/family resolve via tokenVar().
+ * Align/transform emit the literal CSS value (per spec).
+ */
+export function tokenOverridesToProperties(overrides: TypographyTokenOverrides): CSSProperties {
+  const out: CSSProperties = {};
+  if (overrides.size) out['font-size'] = tokenVar(`font-size-${overrides.size}`);
+  if (overrides.weight) out['font-weight'] = tokenVar(`font-weight-${overrides.weight}`);
+  if (overrides.color) out.color = tokenVar(`color-${overrides.color}`);
+  if (overrides.line) out['line-height'] = tokenVar(`line-height-${overrides.line}`);
+  if (overrides.tracking) out['letter-spacing'] = tokenVar(`letter-spacing-${overrides.tracking}`);
+  if (overrides.family) out['font-family'] = tokenVar(`font-${overrides.family}`);
+  if (overrides.align) out['text-align'] = overrides.align;
+  if (overrides.transform) out['text-transform'] = overrides.transform;
+  return out;
+}
+
+// ============================================================================
+// Stylesheet Assembly
+// ============================================================================
+
+/**
+ * Build the complete typography stylesheet for a given variant + overrides.
+ *
+ * Emission order is deliberate -- later rules override earlier ones per the
+ * CSS cascade. We split into three :host rules so every earlier reference
+ * remains visible in the output even when a later layer overrides the same
+ * property:
+ *   1. Composite role references (--font-{role}-*)
+ *   2. Per-variant style extensions (color, borders, padding, etc.)
+ *   3. TypographyTokenOverrides (size/weight/color/line/tracking/family/align/transform)
+ *
+ * Unknown variants coerce to 'p'. NEVER throws.
+ */
+export function typographyStylesheet(
+  options: { variant?: TypographyVariant; overrides?: TypographyTokenOverrides } = {},
+): string {
+  const variant = resolveVariant(options.variant);
+  const overrides = options.overrides ?? {};
+  const role = variantToCompositeRole[variant];
+  const overrideProps = tokenOverridesToProperties(overrides);
+  const hasOverrides = Object.keys(overrideProps).length > 0;
+
+  return stylesheet(
+    styleRule(':host', hostDisplay(variant)),
+    styleRule(':host', compositeRoleProperties(role)),
+    styleRule(':host', typographyVariantStyles[variant]),
+    hasOverrides ? styleRule(':host', overrideProps) : '',
+  );
+}
+
+/**
+ * Coerce an arbitrary string to a known variant. Unknown values fall back
+ * to 'p'. NEVER throws. Used by both typographyStylesheet and the
+ * RaftersTypography element.
+ */
+export function resolveVariant(value: unknown): TypographyVariant {
+  if (typeof value !== 'string' || value.length === 0) return 'p';
+  if (value in variantToCompositeRole) return value as TypographyVariant;
+  return 'p';
+}


### PR DESCRIPTION
## Summary

Ships the token-aware `<rafters-typography>` Web Component that renders any of 17 variants (h1-h4, p, lead, large, small, muted, code, blockquote, ul, ol, li, codeblock, mark, abbr) inside shadow DOM. Each variant references a single composite typography role via `--font-{role}-{family|size|weight|line-height|letter-spacing}` custom properties, and TypographyTokenOverrides attributes layer as later `:host` rules so override cascade is deterministic and each composite reference stays visible in the output.

- `packages/ui/src/components/ui/typography.styles.ts` -- `variantToCompositeRole`, `variantToTag`, `typographyVariantStyles`, `TypographyTokenOverrides`, `tokenOverridesToProperties`, `typographyStylesheet`, `resolveVariant`. Composite references emitted via `tokenVar()` only -- no raw `var()`. No `--duration-*` / `--ease-*`.
- `packages/ui/src/components/ui/typography.element.ts` -- `RaftersTypography extends RaftersElement`; auto-registers `<rafters-typography>` idempotently; observes `variant` plus all 8 TypographyTokenProps attributes; rebuilds a per-instance `CSSStyleSheet` on every update; `codeblock` renders `<pre><code><slot/></code></pre>` via `document.createElement`/`appendChild` (no `innerHTML`).
- Unknown variants silently fall back to `p` -- never throws.
- `:host` display is `block` for headings/p/lists/blockquote/codeblock, `inline` for small/code/mark/abbr.
- `align` and `transform` overrides emit literal CSS values; size/weight/color/line/tracking/family resolve to bare `var()` references.

The composite token resolver that populates `--font-{role}-*` at runtime is tracked separately; this component emits the `var()` references and tolerates missing values via CSS `initial` fallback.

## Test plan

- [x] `pnpm typecheck` green across the workspace
- [x] `pnpm vitest run typography.styles typography.element` from `packages/ui` -- 72 tests pass (42 styles + 30 element)
- [x] `pnpm preflight` exits 0 (typecheck, lint, unit, a11y, build)
- [x] Every variant renders the correct semantic tag; unknown variants fall back to `<p>` without throwing
- [x] `size="xl"` attribute injects `var(--font-size-xl)` into the adopted shadow stylesheet
- [x] `h1` variant's shadow stylesheet contains `var(--font-display-large-*)` references for all five composite dimensions
- [x] `align="center"` / `transform="uppercase"` emit literal CSS values, not token references
- [x] Double-import of `./typography.element` does not throw (idempotent registration)

Closes #1301