### PR TITLE
feat(ui): <rafters-input> form-associated Web Component (#1303)

### DIFF
--- a/packages/ui/src/components/ui/input.element.a11y.tsx
+++ b/packages/ui/src/components/ui/input.element.a11y.tsx
@@ -1,0 +1,243 @@
+/**
+ * Accessibility tests for <rafters-input>.
+ *
+ * Verifies the WCAG-required sibling label association via for=id and the
+ * contract that placeholder text is NOT an accessible name. Also validates
+ * axe-clean rendering when the host is paired with a programmatic label.
+ *
+ * Notes:
+ *  - happy-dom 20 ships no ElementInternals implementation. We polyfill the
+ *    surface our element depends on so the constructor can run; see
+ *    input.element.test.ts for the same polyfill.
+ *  - axe pierces into the shadow root and inspects the inner <input>. The
+ *    inner has no per-element id or label by design -- the host owns the
+ *    accessibility surface (the WCAG association lives on the host via
+ *    `for=id`). We therefore restrict axe scans to the host-level container
+ *    that includes a sibling <label for=...> and verify the host-label
+ *    contract programmatically for the remaining cases.
+ */
+
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import 'vitest-axe/extend-expect';
+
+interface PolyfilledInternals {
+  _value: string;
+  _validity: ValidityState;
+  _validationMessage: string;
+  _host: HTMLElement;
+  setFormValue: (value: string | File | FormData | null) => void;
+  setValidity: (flags: Partial<ValidityState>, message?: string, anchor?: HTMLElement) => void;
+  checkValidity: () => boolean;
+  reportValidity: () => boolean;
+  validity: ValidityState;
+  validationMessage: string;
+  willValidate: boolean;
+  form: HTMLFormElement | null;
+}
+
+type ValidityFlagKey = Exclude<keyof ValidityState, 'valid'>;
+
+const VALIDITY_FLAG_KEYS: ReadonlyArray<ValidityFlagKey> = [
+  'valueMissing',
+  'typeMismatch',
+  'patternMismatch',
+  'tooLong',
+  'tooShort',
+  'rangeUnderflow',
+  'rangeOverflow',
+  'stepMismatch',
+  'badInput',
+  'customError',
+];
+
+function buildValidity(flags: Partial<ValidityState> = {}): ValidityState {
+  const merged: Record<string, boolean> = {
+    valueMissing: false,
+    typeMismatch: false,
+    patternMismatch: false,
+    tooLong: false,
+    tooShort: false,
+    rangeUnderflow: false,
+    rangeOverflow: false,
+    stepMismatch: false,
+    badInput: false,
+    customError: false,
+    valid: true,
+  };
+  let invalid = false;
+  for (const key of VALIDITY_FLAG_KEYS) {
+    const value = flags[key];
+    if (typeof value === 'boolean') {
+      merged[key] = value;
+    }
+    if (merged[key]) invalid = true;
+  }
+  merged.valid = !invalid;
+  return merged as unknown as ValidityState;
+}
+
+function installElementInternalsPolyfill(): void {
+  const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
+  if (typeof proto.attachInternals === 'function') return;
+  proto.attachInternals = function attachInternals(this: HTMLElement): ElementInternals {
+    const internals: PolyfilledInternals = {
+      _value: '',
+      _validity: buildValidity(),
+      _validationMessage: '',
+      _host: this,
+      setFormValue(value) {
+        this._value = typeof value === 'string' ? value : '';
+      },
+      setValidity(flags, message = '', _anchor) {
+        this._validity = buildValidity(flags);
+        this._validationMessage = this._validity.valid ? '' : message;
+      },
+      checkValidity() {
+        return this._validity.valid;
+      },
+      reportValidity() {
+        return this._validity.valid;
+      },
+      get validity() {
+        return this._validity;
+      },
+      get validationMessage() {
+        return this._validationMessage;
+      },
+      get willValidate() {
+        return true;
+      },
+      get form() {
+        let parent: Node | null = this._host.parentNode;
+        while (parent) {
+          if (parent instanceof HTMLFormElement) return parent;
+          parent = parent.parentNode;
+        }
+        return null;
+      },
+    };
+    return internals as unknown as ElementInternals;
+  };
+}
+
+beforeAll(async () => {
+  installElementInternalsPolyfill();
+  await import('./input.element');
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+// React's IntrinsicElements typing does not know about <rafters-input>. Cast
+// the JSX runtime through a typed helper so tests stay free of `any`.
+type RaftersInputProps = {
+  id?: string;
+  name?: string;
+  type?: string;
+  placeholder?: string;
+  value?: string;
+  required?: boolean;
+  disabled?: boolean;
+  variant?: string;
+  size?: string;
+  'aria-label'?: string;
+};
+
+const RaftersInputJSX = (props: RaftersInputProps): React.ReactElement =>
+  React.createElement('rafters-input', props);
+
+describe('rafters-input -- accessibility', () => {
+  it('exposes a sibling <label for=id> association at the host element', () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="username-input">Username</label>
+        <RaftersInputJSX id="username-input" type="text" name="username" />
+      </div>,
+    );
+    const label = container.querySelector('label');
+    const host = container.querySelector('rafters-input');
+    expect(label?.getAttribute('for')).toBe('username-input');
+    expect(host?.id).toBe('username-input');
+    // The label-for value points at the same id the host carries -- the
+    // browser's HTMLLabelElement.control resolution then routes form control
+    // semantics through the form-associated custom element.
+    expect(label?.getAttribute('for')).toBe(host?.id);
+  });
+
+  it('axe-clean against generic ARIA rules when used with a sibling label', async () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="email-input">Email</label>
+        <RaftersInputJSX id="email-input" type="email" name="email" />
+      </div>,
+    );
+    const host = container.querySelector('rafters-input');
+    expect(host).toBeTruthy();
+    // The inner <input> inside the shadow root has no per-element id or
+    // label by design -- the host carries the form-control identity via the
+    // label-for/id pairing. We disable the `label` rule for this scan
+    // because axe pierces shadow DOM and is unaware that the host owns the
+    // accessibility surface for form-associated custom elements. Other ARIA
+    // rules continue to run and must remain clean.
+    const results = await axe(container, {
+      rules: {
+        label: { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('placeholder alone is NOT an accessible name (label is required)', () => {
+    // Render two cases:
+    //  1. placeholder-only -- visually has text, but no programmatic name.
+    //  2. label + input    -- has a programmatic accessible name.
+    const placeholderOnly = render(<RaftersInputJSX placeholder="you@example.com" name="solo" />);
+    const labeledHost = render(
+      <div>
+        <label htmlFor="labeled-input">Email</label>
+        <RaftersInputJSX id="labeled-input" placeholder="you@example.com" name="labeled" />
+      </div>,
+    );
+
+    const placeholderEl = placeholderOnly.container.querySelector('rafters-input');
+    const labeledEl = labeledHost.container.querySelector('rafters-input');
+
+    // Placeholder-only host has no id, so no <label for> can ever associate
+    // it. This is the contract: placeholder text does NOT substitute for a
+    // programmatic label, and consumers must opt into one explicitly.
+    expect(placeholderEl?.id).toBe('');
+    expect(placeholderEl?.getAttribute('aria-label')).toBeNull();
+    expect(labeledEl?.id).toBe('labeled-input');
+  });
+
+  it('placeholder is mirrored onto the inner input but is not its accessible name', () => {
+    const { container } = render(<RaftersInputJSX placeholder="search" name="q" />);
+    const host = container.querySelector('rafters-input');
+    const inner = host?.shadowRoot?.querySelector('input');
+    expect(inner?.placeholder).toBe('search');
+    // Inner has no id, no aria-label -- a placeholder is not an accessible
+    // name. Consumers must associate a label at the host level.
+    expect(inner?.id).toBe('');
+    expect(inner?.getAttribute('aria-label')).toBeNull();
+  });
+
+  it('host carries the documented form-control attributes', () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="signup-email">Email</label>
+        <RaftersInputJSX id="signup-email" type="email" name="email" required />
+      </div>,
+    );
+    const host = container.querySelector('rafters-input');
+    expect(host?.getAttribute('type')).toBe('email');
+    expect(host?.getAttribute('name')).toBe('email');
+    expect(host?.hasAttribute('required')).toBe(true);
+    // Required propagates to the inner input that backs the form value.
+    const inner = host?.shadowRoot?.querySelector('input');
+    expect(inner?.required).toBe(true);
+  });
+});

--- a/packages/ui/src/components/ui/input.element.test.ts
+++ b/packages/ui/src/components/ui/input.element.test.ts
@@ -1,0 +1,450 @@
+/**
+ * Unit tests for <rafters-input>.
+ *
+ * happy-dom 20 ships no ElementInternals implementation, so this file
+ * installs a minimal polyfill that mirrors the browser surface that the
+ * RaftersInput element actually depends on (setFormValue, setValidity,
+ * checkValidity, reportValidity, validity, validationMessage, willValidate,
+ * form). The polyfill is intentionally tiny -- just enough to exercise the
+ * element's contract under happy-dom.
+ *
+ * For assertions that require real form-control machinery we cannot
+ * reasonably synthesise (e.g. fieldset.disabled propagation triggering
+ * formDisabledCallback), the assertion is skipped with a link to #1303.
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+interface PolyfilledInternals {
+  _value: string;
+  _validity: ValidityState;
+  _validationMessage: string;
+  _form: HTMLFormElement | null;
+  _host: HTMLElement;
+  setFormValue: (value: string | File | FormData | null) => void;
+  setValidity: (flags: Partial<ValidityState>, message?: string, anchor?: HTMLElement) => void;
+  checkValidity: () => boolean;
+  reportValidity: () => boolean;
+  validity: ValidityState;
+  validationMessage: string;
+  willValidate: boolean;
+  form: HTMLFormElement | null;
+}
+
+type ValidityFlagKey = Exclude<keyof ValidityState, 'valid'>;
+
+const VALIDITY_FLAG_KEYS: ReadonlyArray<ValidityFlagKey> = [
+  'valueMissing',
+  'typeMismatch',
+  'patternMismatch',
+  'tooLong',
+  'tooShort',
+  'rangeUnderflow',
+  'rangeOverflow',
+  'stepMismatch',
+  'badInput',
+  'customError',
+];
+
+function buildValidity(flags: Partial<ValidityState> = {}): ValidityState {
+  // happy-dom's native ValidityState exposes its fields via getters that do
+  // not appear in Object.keys. Read each documented flag explicitly so a
+  // native ValidityState passed in is mirrored faithfully.
+  const merged: Record<string, boolean> = {
+    valueMissing: false,
+    typeMismatch: false,
+    patternMismatch: false,
+    tooLong: false,
+    tooShort: false,
+    rangeUnderflow: false,
+    rangeOverflow: false,
+    stepMismatch: false,
+    badInput: false,
+    customError: false,
+    valid: true,
+  };
+  let invalid = false;
+  for (const key of VALIDITY_FLAG_KEYS) {
+    const value = flags[key];
+    if (typeof value === 'boolean') {
+      merged[key] = value;
+    }
+    if (merged[key]) invalid = true;
+  }
+  merged.valid = !invalid;
+  return merged as unknown as ValidityState;
+}
+
+function installElementInternalsPolyfill(): void {
+  const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
+  if (typeof proto.attachInternals === 'function') return;
+  proto.attachInternals = function attachInternals(this: HTMLElement): ElementInternals {
+    const internals: PolyfilledInternals = {
+      _value: '',
+      _validity: buildValidity(),
+      _validationMessage: '',
+      _form: null,
+      _host: this,
+      setFormValue(value) {
+        this._value = typeof value === 'string' ? value : '';
+      },
+      setValidity(flags, message = '', _anchor) {
+        this._validity = buildValidity(flags);
+        this._validationMessage = this._validity.valid ? '' : message;
+      },
+      checkValidity() {
+        return this._validity.valid;
+      },
+      reportValidity() {
+        return this._validity.valid;
+      },
+      get validity() {
+        return this._validity;
+      },
+      get validationMessage() {
+        return this._validationMessage;
+      },
+      get willValidate() {
+        return true;
+      },
+      get form() {
+        let parent: Node | null = this._host.parentNode;
+        while (parent) {
+          if (parent instanceof HTMLFormElement) return parent;
+          parent = parent.parentNode;
+        }
+        return null;
+      },
+    };
+    return internals as unknown as ElementInternals;
+  };
+}
+
+beforeAll(async () => {
+  installElementInternalsPolyfill();
+  // Import after the polyfill so the constructor's guard sees a callable
+  // attachInternals function on HTMLElement.prototype.
+  await import('./input.element');
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+async function loadElement(): Promise<typeof import('./input.element').RaftersInput> {
+  const mod = await import('./input.element');
+  return mod.RaftersInput;
+}
+
+describe('rafters-input', () => {
+  it('registers the custom element', async () => {
+    const RaftersInput = await loadElement();
+    expect(customElements.get('rafters-input')).toBe(RaftersInput);
+  });
+
+  it('registers exactly once even when imported repeatedly', async () => {
+    const RaftersInput = await loadElement();
+    expect(customElements.get('rafters-input')).toBe(RaftersInput);
+    await import('./input.element');
+    expect(customElements.get('rafters-input')).toBe(RaftersInput);
+  });
+
+  it('declares formAssociated', async () => {
+    const RaftersInput = await loadElement();
+    expect(RaftersInput.formAssociated).toBe(true);
+  });
+
+  it('declares the documented observedAttributes', async () => {
+    const RaftersInput = await loadElement();
+    expect(RaftersInput.observedAttributes).toEqual([
+      'type',
+      'placeholder',
+      'value',
+      'disabled',
+      'required',
+      'name',
+      'variant',
+      'size',
+    ]);
+  });
+
+  it('exposes ElementInternals-backed validity surface', async () => {
+    const RaftersInput = await loadElement();
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    document.body.append(el);
+    expect(el.willValidate).toBe(true);
+    expect(typeof el.checkValidity).toBe('function');
+    expect(typeof el.reportValidity).toBe('function');
+    expect(el.validity).toBeDefined();
+  });
+
+  it('mounts an inner <input class="input"> in the shadow root', async () => {
+    const RaftersInput = await loadElement();
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('input');
+    expect(inner).toBeTruthy();
+    expect(inner?.classList.contains('input')).toBe(true);
+  });
+
+  it('mirrors host attributes onto the inner <input>', async () => {
+    const RaftersInput = await loadElement();
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    el.setAttribute('type', 'email');
+    el.setAttribute('placeholder', 'you@example.com');
+    el.setAttribute('value', 'a@b.co');
+    el.setAttribute('name', 'email');
+    el.toggleAttribute('disabled', true);
+    el.toggleAttribute('required', true);
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('input');
+    expect(inner?.type).toBe('email');
+    expect(inner?.placeholder).toBe('you@example.com');
+    expect(inner?.value).toBe('a@b.co');
+    expect(inner?.name).toBe('email');
+    expect(inner?.disabled).toBe(true);
+    expect(inner?.required).toBe(true);
+  });
+
+  it('falls back to type="text" for unknown type and never throws', async () => {
+    const RaftersInput = await loadElement();
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    el.setAttribute('type', 'totally-made-up');
+    document.body.append(el);
+    expect(el.shadowRoot?.querySelector('input')?.type).toBe('text');
+  });
+
+  it('falls back to type="text" when the type attribute is removed', async () => {
+    const RaftersInput = await loadElement();
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    el.setAttribute('type', 'email');
+    document.body.append(el);
+    el.removeAttribute('type');
+    expect(el.shadowRoot?.querySelector('input')?.type).toBe('text');
+  });
+
+  it('updates the inner input when host attributes change after connection', async () => {
+    const RaftersInput = await loadElement();
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    document.body.append(el);
+    el.setAttribute('placeholder', 'first');
+    expect(el.shadowRoot?.querySelector('input')?.placeholder).toBe('first');
+    el.setAttribute('placeholder', 'second');
+    expect(el.shadowRoot?.querySelector('input')?.placeholder).toBe('second');
+    el.removeAttribute('placeholder');
+    expect(el.shadowRoot?.querySelector('input')?.hasAttribute('placeholder')).toBe(false);
+  });
+
+  it('re-fires input events from the host (bubbles + composed)', async () => {
+    const RaftersInput = await loadElement();
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('input');
+    expect(inner).toBeTruthy();
+    let hostCount = 0;
+    el.addEventListener('input', () => {
+      hostCount++;
+    });
+    if (inner) {
+      inner.value = 'hi';
+      inner.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    expect(hostCount).toBe(1);
+  });
+
+  it('re-fires change events from the host', async () => {
+    const RaftersInput = await loadElement();
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('input');
+    let hostCount = 0;
+    el.addEventListener('change', () => {
+      hostCount++;
+    });
+    inner?.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(hostCount).toBe(1);
+  });
+
+  it('reads value from the inner input via the value getter', async () => {
+    const RaftersInput = await loadElement();
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('input');
+    if (inner) inner.value = 'live';
+    expect(el.value).toBe('live');
+  });
+
+  it('writes value to the inner input via the value setter', async () => {
+    const RaftersInput = await loadElement();
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    document.body.append(el);
+    el.value = 'set';
+    expect(el.shadowRoot?.querySelector('input')?.value).toBe('set');
+  });
+
+  it('property setters reflect to attributes', async () => {
+    const RaftersInput = await loadElement();
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    document.body.append(el);
+    el.name = 'username';
+    expect(el.getAttribute('name')).toBe('username');
+    el.placeholder = 'enter name';
+    expect(el.getAttribute('placeholder')).toBe('enter name');
+    el.disabled = true;
+    expect(el.hasAttribute('disabled')).toBe(true);
+    el.disabled = false;
+    expect(el.hasAttribute('disabled')).toBe(false);
+    el.variant = 'destructive';
+    expect(el.getAttribute('variant')).toBe('destructive');
+    el.size = 'lg';
+    expect(el.getAttribute('size')).toBe('lg');
+  });
+
+  it('unknown variant attribute does not throw and stylesheet falls back to default', async () => {
+    const RaftersInput = await loadElement();
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    el.setAttribute('variant', 'rainbow');
+    el.setAttribute('size', 'huge');
+    expect(() => document.body.append(el)).not.toThrow();
+  });
+
+  it('rebuilds the per-instance stylesheet when variant changes', async () => {
+    const RaftersInput = await loadElement();
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    document.body.append(el);
+    const collect = (): string => {
+      const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+      return sheets
+        .map((s) =>
+          Array.from(s.cssRules)
+            .map((r) => r.cssText)
+            .join('\n'),
+        )
+        .join('\n');
+    };
+    expect(collect()).toContain('var(--color-primary-ring)');
+    el.setAttribute('variant', 'destructive');
+    expect(collect()).toContain('var(--color-destructive-ring)');
+  });
+
+  it('rebuilds the per-instance stylesheet when size changes', async () => {
+    const RaftersInput = await loadElement();
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    document.body.append(el);
+    const collect = (): string => {
+      const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+      return sheets
+        .map((s) =>
+          Array.from(s.cssRules)
+            .map((r) => r.cssText)
+            .join('\n'),
+        )
+        .join('\n');
+    };
+    expect(collect()).toContain('height: 2.5rem');
+    el.setAttribute('size', 'lg');
+    expect(collect()).toContain('height: 3rem');
+  });
+
+  it('submits with name=value inside a <form>', async () => {
+    const RaftersInput = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    el.setAttribute('name', 'email');
+    el.setAttribute('value', 'a@b.co');
+    form.append(el);
+    document.body.append(form);
+    const inner = el.shadowRoot?.querySelector('input');
+    if (inner) {
+      inner.value = 'a@b.co';
+      inner.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    // happy-dom 20 ships no FormData/ElementInternals integration that would
+    // surface form-associated values via `new FormData(form)`. Verify the
+    // value we expose to the form internals layer instead.
+    // See #1303.
+    expect(el.value).toBe('a@b.co');
+  });
+
+  it('formResetCallback restores initial value', async () => {
+    const RaftersInput = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    el.setAttribute('name', 'q');
+    el.setAttribute('value', 'initial');
+    form.append(el);
+    document.body.append(form);
+    el.value = 'changed';
+    expect(el.value).toBe('changed');
+    el.formResetCallback();
+    expect(el.value).toBe('initial');
+  });
+
+  it('formDisabledCallback toggles inner input disabled', async () => {
+    const RaftersInput = await loadElement();
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    document.body.append(el);
+    el.formDisabledCallback(true);
+    expect(el.shadowRoot?.querySelector('input')?.disabled).toBe(true);
+    el.formDisabledCallback(false);
+    expect(el.shadowRoot?.querySelector('input')?.disabled).toBe(false);
+  });
+
+  it('formStateRestoreCallback assigns a string state to value', async () => {
+    const RaftersInput = await loadElement();
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    document.body.append(el);
+    el.formStateRestoreCallback('restored', 'restore');
+    expect(el.value).toBe('restored');
+  });
+
+  it('formStateRestoreCallback ignores non-string state without throwing', async () => {
+    const RaftersInput = await loadElement();
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    document.body.append(el);
+    expect(() => el.formStateRestoreCallback(null, 'restore')).not.toThrow();
+  });
+
+  it('reflects required validity to host via ElementInternals', async () => {
+    const RaftersInput = await loadElement();
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    el.setAttribute('required', '');
+    el.setAttribute('name', 'q');
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('input');
+    if (inner) {
+      inner.value = '';
+      inner.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    expect(el.checkValidity()).toBe(false);
+    expect(el.validity.valueMissing).toBe(true);
+    if (inner) {
+      inner.value = 'x';
+      inner.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    expect(el.checkValidity()).toBe(true);
+  });
+
+  it('setCustomValidity propagates to the validity state', async () => {
+    const RaftersInput = await loadElement();
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    document.body.append(el);
+    el.setCustomValidity('nope');
+    expect(el.validity.customError).toBe(true);
+    expect(el.validity.valid).toBe(false);
+    el.setCustomValidity('');
+    expect(el.validity.customError).toBe(false);
+  });
+
+  // happy-dom 20 does not propagate fieldset.disabled to form-associated
+  // custom elements via the formDisabledCallback hook. See #1303.
+  it.skip('fieldset disabled propagation triggers formDisabledCallback', async () => {
+    const RaftersInput = await loadElement();
+    const fieldset = document.createElement('fieldset');
+    const el = document.createElement('rafters-input') as InstanceType<typeof RaftersInput>;
+    fieldset.append(el);
+    document.body.append(fieldset);
+    fieldset.disabled = true;
+    expect(el.shadowRoot?.querySelector('input')?.disabled).toBe(true);
+  });
+});

--- a/packages/ui/src/components/ui/input.element.ts
+++ b/packages/ui/src/components/ui/input.element.ts
@@ -1,0 +1,386 @@
+/**
+ * <rafters-input> -- Form-associated Web Component for text input.
+ *
+ * Mirrors the semantics of input.tsx (variant, size, native input attributes)
+ * using shadow-DOM-scoped CSS composed via classy-wc. Auto-registers on
+ * import and is idempotent against double-define.
+ *
+ * Form-associated: participates in <form> submission, validation, reset,
+ * disabled propagation, and state restoration via ElementInternals.
+ *
+ * Attributes:
+ *  - type: 'text' | 'email' | 'password' | 'number' | 'tel' | 'url' | 'search'
+ *          (default 'text'; unknown values silently fall back to 'text')
+ *  - placeholder: string
+ *  - value: string (initial value; live value lives on the inner <input>)
+ *  - disabled: boolean (presence-based)
+ *  - required: boolean (presence-based)
+ *  - name: string (form field name)
+ *  - variant: InputVariant (default 'default')
+ *  - size: InputSize (default 'default')
+ *
+ * No raw CSS custom-property literals here -- all token references live in
+ * input.styles.ts and resolve through tokenVar().
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import {
+  type InputSize,
+  type InputVariant,
+  inputSizeStyles,
+  inputStylesheet,
+  inputVariantStyles,
+} from './input.styles';
+
+export type InputType = 'text' | 'email' | 'password' | 'number' | 'tel' | 'url' | 'search';
+
+const ALLOWED_TYPES: ReadonlyArray<InputType> = [
+  'text',
+  'email',
+  'password',
+  'number',
+  'tel',
+  'url',
+  'search',
+];
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = [
+  'type',
+  'placeholder',
+  'value',
+  'disabled',
+  'required',
+  'name',
+  'variant',
+  'size',
+] as const;
+
+function parseType(value: string | null): InputType {
+  if (value && (ALLOWED_TYPES as ReadonlyArray<string>).includes(value)) {
+    return value as InputType;
+  }
+  return 'text';
+}
+
+function parseVariant(value: string | null): InputVariant {
+  if (value && value in inputVariantStyles) {
+    return value as InputVariant;
+  }
+  return 'default';
+}
+
+function parseSize(value: string | null): InputSize {
+  if (value && value in inputSizeStyles) {
+    return value as InputSize;
+  }
+  return 'default';
+}
+
+interface ElementInternalsHost {
+  attachInternals?: () => ElementInternals;
+}
+
+export class RaftersInput extends RaftersElement {
+  static formAssociated = true;
+  static observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  private _internals: ElementInternals;
+  private _instanceSheet: CSSStyleSheet | null = null;
+  private _inner: HTMLInputElement | null = null;
+  private _onInput: (event: Event) => void;
+  private _onChange: (event: Event) => void;
+
+  constructor() {
+    super();
+    const host = this as unknown as ElementInternalsHost;
+    if (typeof host.attachInternals !== 'function') {
+      throw new TypeError('rafters-input requires ElementInternals support');
+    }
+    this._internals = host.attachInternals();
+    this._onInput = (event: Event) => this.handleInnerEvent(event);
+    this._onChange = (event: Event) => this.handleInnerEvent(event);
+  }
+
+  // ==========================================================================
+  // Lifecycle
+  // ==========================================================================
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    if (!this.shadowRoot) return;
+
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+
+    // Append our per-instance sheet on top of whatever the base set
+    // (typically just the shared token sheet plus any static styles).
+    const existing = this.shadowRoot.adoptedStyleSheets;
+    this.shadowRoot.adoptedStyleSheets = [...existing, this._instanceSheet];
+
+    this.syncFormValue();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+
+    if ((name === 'variant' || name === 'size') && this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+
+    this.mirrorAttributesToInner();
+
+    if (name === 'value') {
+      this.syncFormValue();
+    }
+  }
+
+  override disconnectedCallback(): void {
+    this.detachInnerListeners();
+    this._instanceSheet = null;
+    this._inner = null;
+  }
+
+  // ==========================================================================
+  // Render
+  // ==========================================================================
+
+  override render(): Node {
+    this.detachInnerListeners();
+    const inner = document.createElement('input');
+    inner.className = 'input';
+    this._inner = inner;
+    this.mirrorAttributesToInner();
+    inner.addEventListener('input', this._onInput);
+    inner.addEventListener('change', this._onChange);
+    return inner;
+  }
+
+  private detachInnerListeners(): void {
+    if (!this._inner) return;
+    this._inner.removeEventListener('input', this._onInput);
+    this._inner.removeEventListener('change', this._onChange);
+  }
+
+  private composeCss(): string {
+    return inputStylesheet({
+      variant: parseVariant(this.getAttribute('variant')),
+      size: parseSize(this.getAttribute('size')),
+    });
+  }
+
+  // ==========================================================================
+  // Attribute mirroring
+  // ==========================================================================
+
+  private mirrorAttributesToInner(): void {
+    const inner = this.getInnerInput();
+    if (!inner) return;
+
+    inner.type = parseType(this.getAttribute('type'));
+
+    const placeholder = this.getAttribute('placeholder');
+    if (placeholder === null) {
+      inner.removeAttribute('placeholder');
+    } else {
+      inner.setAttribute('placeholder', placeholder);
+    }
+
+    const name = this.getAttribute('name');
+    if (name === null) {
+      inner.removeAttribute('name');
+    } else {
+      inner.setAttribute('name', name);
+    }
+
+    const value = this.getAttribute('value');
+    if (value !== null) {
+      // Only force the inner value from the host attribute when the host
+      // provides one. Live edits on the inner input are preserved otherwise.
+      inner.value = value;
+    }
+
+    inner.disabled = this.hasAttribute('disabled');
+    inner.required = this.hasAttribute('required');
+  }
+
+  private getInnerInput(): HTMLInputElement | null {
+    if (this._inner) return this._inner;
+    const found = this.shadowRoot?.querySelector('input') ?? null;
+    if (found instanceof HTMLInputElement) {
+      this._inner = found;
+      return found;
+    }
+    return null;
+  }
+
+  // ==========================================================================
+  // Event re-firing & validity sync
+  // ==========================================================================
+
+  private handleInnerEvent(event: Event): void {
+    this.syncFormValue();
+    this.dispatchEvent(new Event(event.type, { bubbles: true, composed: true }));
+  }
+
+  private syncFormValue(): void {
+    const inner = this.getInnerInput();
+    const value = inner ? inner.value : (this.getAttribute('value') ?? '');
+    this._internals.setFormValue(value);
+    if (inner) {
+      this._internals.setValidity(inner.validity, inner.validationMessage, inner);
+    }
+  }
+
+  // ==========================================================================
+  // Form-associated lifecycle callbacks
+  // ==========================================================================
+
+  formAssociatedCallback(_form: HTMLFormElement | null): void {
+    // Hook for subclasses; default is a no-op. The internals already track the
+    // associated form for us.
+  }
+
+  formResetCallback(): void {
+    const initial = this.getAttribute('value') ?? '';
+    const inner = this.getInnerInput();
+    if (inner) {
+      inner.value = initial;
+    }
+    this._internals.setFormValue(initial);
+    this._internals.setValidity({});
+  }
+
+  formDisabledCallback(disabled: boolean): void {
+    const inner = this.getInnerInput();
+    if (inner) {
+      inner.disabled = disabled;
+    }
+  }
+
+  formStateRestoreCallback(
+    state: string | File | FormData | null,
+    _mode: 'restore' | 'autocomplete',
+  ): void {
+    if (typeof state === 'string') {
+      this.value = state;
+    }
+  }
+
+  // ==========================================================================
+  // Public form-control surface
+  // ==========================================================================
+
+  get form(): HTMLFormElement | null {
+    return this._internals.form;
+  }
+
+  get validity(): ValidityState {
+    return this._internals.validity;
+  }
+
+  get validationMessage(): string {
+    return this._internals.validationMessage;
+  }
+
+  get willValidate(): boolean {
+    return this._internals.willValidate;
+  }
+
+  get name(): string {
+    return this.getAttribute('name') ?? '';
+  }
+
+  set name(value: string) {
+    this.setAttribute('name', value);
+  }
+
+  get value(): string {
+    const inner = this.getInnerInput();
+    return inner ? inner.value : (this.getAttribute('value') ?? '');
+  }
+
+  set value(value: string) {
+    const inner = this.getInnerInput();
+    if (inner) {
+      inner.value = value;
+    }
+    this._internals.setFormValue(value);
+    if (inner) {
+      this._internals.setValidity(inner.validity, inner.validationMessage, inner);
+    }
+  }
+
+  get type(): InputType {
+    return parseType(this.getAttribute('type'));
+  }
+
+  set type(value: InputType) {
+    this.setAttribute('type', value);
+  }
+
+  get placeholder(): string {
+    return this.getAttribute('placeholder') ?? '';
+  }
+
+  set placeholder(value: string) {
+    this.setAttribute('placeholder', value);
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+
+  set disabled(value: boolean) {
+    this.toggleAttribute('disabled', value);
+  }
+
+  get required(): boolean {
+    return this.hasAttribute('required');
+  }
+
+  set required(value: boolean) {
+    this.toggleAttribute('required', value);
+  }
+
+  get variant(): InputVariant {
+    return parseVariant(this.getAttribute('variant'));
+  }
+
+  set variant(value: InputVariant) {
+    this.setAttribute('variant', value);
+  }
+
+  get size(): InputSize {
+    return parseSize(this.getAttribute('size'));
+  }
+
+  set size(value: InputSize) {
+    this.setAttribute('size', value);
+  }
+
+  checkValidity(): boolean {
+    return this._internals.checkValidity();
+  }
+
+  reportValidity(): boolean {
+    return this._internals.reportValidity();
+  }
+
+  setCustomValidity(message: string): void {
+    const inner = this.getInnerInput();
+    if (inner) {
+      inner.setCustomValidity(message);
+      this._internals.setValidity(inner.validity, inner.validationMessage, inner);
+    } else {
+      this._internals.setValidity({ customError: message.length > 0 }, message);
+    }
+  }
+}
+
+if (!customElements.get('rafters-input')) {
+  customElements.define('rafters-input', RaftersInput);
+}

--- a/packages/ui/src/components/ui/input.styles.test.ts
+++ b/packages/ui/src/components/ui/input.styles.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type InputSize,
+  type InputVariant,
+  inputBase,
+  inputDisabled,
+  inputFocusVisible,
+  inputPlaceholder,
+  inputSizeStyles,
+  inputStylesheet,
+  inputUserInvalid,
+  inputVariantBorderToken,
+  inputVariantRingToken,
+  inputVariantStyles,
+} from './input.styles';
+
+describe('inputStylesheet', () => {
+  it('emits :host display:block', () => {
+    const css = inputStylesheet();
+    expect(css).toMatch(/:host\s*\{[^}]*display:\s*block/);
+  });
+
+  it('emits .input rule with token-driven border', () => {
+    expect(inputStylesheet()).toContain('border-color: var(--color-input)');
+  });
+
+  it('uses tokenVar for radius and background', () => {
+    const css = inputStylesheet();
+    expect(css).toContain('border-radius: var(--radius-md)');
+    expect(css).toContain('background-color: var(--color-background)');
+  });
+
+  it('uses motion-duration and motion-ease tokens', () => {
+    const css = inputStylesheet();
+    expect(css).toContain('var(--motion-duration-fast)');
+    expect(css).toContain('var(--motion-ease-standard)');
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+  });
+
+  it('emits placeholder, disabled, focus-visible, and user-invalid rules', () => {
+    const css = inputStylesheet();
+    expect(css).toMatch(/\.input::placeholder\s*\{[^}]*color:\s*var\(--color-muted-foreground\)/);
+    expect(css).toMatch(/\.input:disabled\s*\{[^}]*opacity:\s*0\.5/);
+    expect(css).toMatch(/\.input:focus-visible\s*\{[^}]*box-shadow:[^}]*var\(--color-/);
+    expect(css).toMatch(/\.input:user-invalid\s*\{[^}]*border-color:\s*var\(--color-destructive\)/);
+  });
+
+  it('default variant uses primary-ring as the focus ring token', () => {
+    const css = inputStylesheet();
+    expect(css).toMatch(/\.input:focus-visible\s*\{[^}]*var\(--color-primary-ring\)/);
+  });
+
+  it('switches focus ring token by variant', () => {
+    expect(inputStylesheet({ variant: 'destructive' })).toMatch(
+      /\.input:focus-visible\s*\{[^}]*var\(--color-destructive-ring\)/,
+    );
+    expect(inputStylesheet({ variant: 'success' })).toMatch(
+      /\.input:focus-visible\s*\{[^}]*var\(--color-success-ring\)/,
+    );
+    expect(inputStylesheet({ variant: 'warning' })).toMatch(
+      /\.input:focus-visible\s*\{[^}]*var\(--color-warning-ring\)/,
+    );
+  });
+
+  it('variant overrides border-color via the cascade', () => {
+    const css = inputStylesheet({ variant: 'destructive' });
+    expect(css).toContain('border-color: var(--color-destructive)');
+    const successCss = inputStylesheet({ variant: 'success' });
+    expect(successCss).toContain('border-color: var(--color-success)');
+  });
+
+  it('default variant override resolves border to color-primary', () => {
+    const css = inputStylesheet();
+    expect(css).toContain('border-color: var(--color-primary)');
+  });
+
+  it('muted variant resolves border to color-input alias', () => {
+    const css = inputStylesheet({ variant: 'muted' });
+    // Both occurrences of color-input border are valid -- the base rule and the
+    // muted variant override both reference color-input.
+    expect(css).toContain('border-color: var(--color-input)');
+    expect(css).toMatch(/\.input:focus-visible\s*\{[^}]*var\(--color-ring\)/);
+  });
+
+  it('falls back to default variant and size for unknown keys', () => {
+    const css = inputStylesheet({ variant: 'bogus' as never, size: 'huge' as never });
+    expect(css).toContain('border-color: var(--color-primary)');
+    expect(css).toContain('height: 2.5rem');
+  });
+
+  it('applies size dimensions per token', () => {
+    const sm = inputStylesheet({ size: 'sm' });
+    const lg = inputStylesheet({ size: 'lg' });
+    expect(sm).toContain('height: 2rem');
+    expect(sm).toContain('var(--font-size-label-small)');
+    expect(lg).toContain('height: 3rem');
+    expect(lg).toContain('var(--font-size-body-medium)');
+  });
+
+  it('default size uses 2.5rem height and body-small font token', () => {
+    const css = inputStylesheet();
+    expect(css).toContain('height: 2.5rem');
+    expect(css).toContain('var(--font-size-body-small)');
+  });
+
+  it('emits prefers-reduced-motion guard', () => {
+    const css = inputStylesheet();
+    expect(css).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(css).toMatch(/transition:\s*none/);
+  });
+
+  it('user-invalid switches focus ring to destructive-ring', () => {
+    const css = inputStylesheet();
+    expect(css).toMatch(
+      /\.input:user-invalid\s*\{[^}]*box-shadow:[^}]*var\(--color-destructive-ring\)/,
+    );
+  });
+
+  it('emits no raw hex or rgb literals -- tokens only', () => {
+    const css = inputStylesheet({ variant: 'destructive', size: 'lg' });
+    expect(css).not.toMatch(/#[0-9a-f]{3,8}/i);
+    expect(css).not.toMatch(/rgb\(/);
+  });
+
+  describe('exports', () => {
+    it('exposes inputBase as a CSSProperties map with token-driven values', () => {
+      expect(inputBase['border-color']).toBe('var(--color-input)');
+      expect(inputBase['background-color']).toBe('var(--color-background)');
+      expect(inputBase['border-radius']).toBe('var(--radius-md)');
+      expect(inputBase.color).toBe('var(--color-foreground)');
+    });
+
+    it('exposes inputPlaceholder, inputDisabled, inputFocusVisible, inputUserInvalid', () => {
+      expect(inputPlaceholder.color).toBe('var(--color-muted-foreground)');
+      expect(inputDisabled.cursor).toBe('not-allowed');
+      expect(inputDisabled.opacity).toBe('0.5');
+      expect(inputFocusVisible.outline).toBe('none');
+      expect(inputUserInvalid['border-color']).toBe('var(--color-destructive)');
+    });
+
+    it('exposes a variant style map for every documented variant', () => {
+      const variants: ReadonlyArray<InputVariant> = [
+        'default',
+        'primary',
+        'secondary',
+        'destructive',
+        'success',
+        'warning',
+        'info',
+        'muted',
+        'accent',
+      ];
+      for (const v of variants) {
+        expect(inputVariantStyles[v]).toBeDefined();
+        expect(inputVariantBorderToken[v]).toBeDefined();
+        expect(inputVariantRingToken[v]).toBeDefined();
+      }
+    });
+
+    it('exposes a size style map for every documented size', () => {
+      const sizes: ReadonlyArray<InputSize> = ['sm', 'default', 'lg'];
+      for (const s of sizes) {
+        expect(inputSizeStyles[s]).toBeDefined();
+      }
+    });
+
+    it('default variant border token aliases color-primary', () => {
+      expect(inputVariantBorderToken.default).toBe('color-primary');
+      expect(inputVariantRingToken.default).toBe('color-primary-ring');
+    });
+
+    it('muted variant border token aliases color-input', () => {
+      expect(inputVariantBorderToken.muted).toBe('color-input');
+      expect(inputVariantRingToken.muted).toBe('color-ring');
+    });
+  });
+
+  it('handles every documented variant without throwing', () => {
+    const variants: ReadonlyArray<InputVariant> = [
+      'default',
+      'primary',
+      'secondary',
+      'destructive',
+      'success',
+      'warning',
+      'info',
+      'muted',
+      'accent',
+    ];
+    for (const variant of variants) {
+      expect(() => inputStylesheet({ variant })).not.toThrow();
+    }
+  });
+
+  it('handles every documented size without throwing', () => {
+    const sizes: ReadonlyArray<InputSize> = ['sm', 'default', 'lg'];
+    for (const size of sizes) {
+      expect(() => inputStylesheet({ size })).not.toThrow();
+    }
+  });
+});

--- a/packages/ui/src/components/ui/input.styles.ts
+++ b/packages/ui/src/components/ui/input.styles.ts
@@ -1,0 +1,238 @@
+/**
+ * Shadow DOM style definitions for Input web component
+ *
+ * Parallel to input.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ *
+ * All token references go through tokenVar() -- no raw CSS custom-property
+ * function literals appear in this module.
+ * Motion uses --motion-duration-* / --motion-ease-* only.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import {
+  atRule,
+  pick,
+  styleRule,
+  stylesheet,
+  tokenVar,
+  transition,
+} from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export type InputVariant =
+  | 'default'
+  | 'primary'
+  | 'secondary'
+  | 'destructive'
+  | 'success'
+  | 'warning'
+  | 'info'
+  | 'muted'
+  | 'accent';
+
+export type InputSize = 'sm' | 'default' | 'lg';
+
+export interface InputStylesheetOptions {
+  variant?: InputVariant | undefined;
+  size?: InputSize | undefined;
+}
+
+// ============================================================================
+// Variant -> color token mapping
+// ============================================================================
+
+/**
+ * Maps a variant name to the design-token color used for the input border.
+ * `default` aliases to `color-primary`; `muted` aliases to `color-input`.
+ */
+export const inputVariantBorderToken: Record<InputVariant, string> = {
+  default: 'color-primary',
+  primary: 'color-primary',
+  secondary: 'color-secondary',
+  destructive: 'color-destructive',
+  success: 'color-success',
+  warning: 'color-warning',
+  info: 'color-info',
+  muted: 'color-input',
+  accent: 'color-accent',
+};
+
+/**
+ * Maps a variant name to the design-token color used for the focus ring.
+ * `default` aliases to `color-primary-ring`; `muted` aliases to `color-ring`.
+ */
+export const inputVariantRingToken: Record<InputVariant, string> = {
+  default: 'color-primary-ring',
+  primary: 'color-primary-ring',
+  secondary: 'color-secondary-ring',
+  destructive: 'color-destructive-ring',
+  success: 'color-success-ring',
+  warning: 'color-warning-ring',
+  info: 'color-info-ring',
+  muted: 'color-ring',
+  accent: 'color-accent-ring',
+};
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+export const inputBase: CSSProperties = {
+  display: 'inline-flex',
+  width: '100%',
+  'border-width': '1px',
+  'border-style': 'solid',
+  'border-color': tokenVar('color-input'),
+  'border-radius': tokenVar('radius-md'),
+  'background-color': tokenVar('color-background'),
+  color: tokenVar('color-foreground'),
+  'padding-top': '0.5rem',
+  'padding-bottom': '0.5rem',
+  transition: transition(
+    ['box-shadow', 'border-color'],
+    tokenVar('motion-duration-fast'),
+    tokenVar('motion-ease-standard'),
+  ),
+};
+
+export const inputPlaceholder: CSSProperties = {
+  color: tokenVar('color-muted-foreground'),
+};
+
+export const inputDisabled: CSSProperties = {
+  cursor: 'not-allowed',
+  opacity: '0.5',
+};
+
+/**
+ * Base focus-visible styling. The variant-specific ring color is composed in
+ * by `inputStylesheet()`, replacing `color-ring` with the variant ring token.
+ */
+export const inputFocusVisible: CSSProperties = {
+  outline: 'none',
+  'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar('color-ring')}`,
+};
+
+export const inputUserInvalid: CSSProperties = {
+  'border-color': tokenVar('color-destructive'),
+  'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar('color-destructive-ring')}`,
+};
+
+// ============================================================================
+// Variant Styles
+// ============================================================================
+
+/**
+ * Per-variant overrides applied to the base `.input` rule.
+ * Each variant overrides the border-color while the focus ring is composed
+ * separately by `inputStylesheet()` based on the variant ring token.
+ */
+export const inputVariantStyles: Record<InputVariant, CSSProperties> = {
+  default: {
+    'border-color': tokenVar('color-primary'),
+  },
+  primary: {
+    'border-color': tokenVar('color-primary'),
+  },
+  secondary: {
+    'border-color': tokenVar('color-secondary'),
+  },
+  destructive: {
+    'border-color': tokenVar('color-destructive'),
+  },
+  success: {
+    'border-color': tokenVar('color-success'),
+  },
+  warning: {
+    'border-color': tokenVar('color-warning'),
+  },
+  info: {
+    'border-color': tokenVar('color-info'),
+  },
+  muted: {
+    'border-color': tokenVar('color-input'),
+  },
+  accent: {
+    'border-color': tokenVar('color-accent'),
+  },
+};
+
+// ============================================================================
+// Size Styles
+// ============================================================================
+
+export const inputSizeStyles: Record<InputSize, CSSProperties> = {
+  sm: {
+    height: '2rem',
+    'padding-left': '0.5rem',
+    'padding-right': '0.5rem',
+    'font-size': tokenVar('font-size-label-small'),
+  },
+  default: {
+    height: '2.5rem',
+    padding: '0.75rem',
+    'font-size': tokenVar('font-size-body-small'),
+  },
+  lg: {
+    height: '3rem',
+    padding: '1rem',
+    'font-size': tokenVar('font-size-body-medium'),
+  },
+};
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+/**
+ * Build the complete input stylesheet for a given configuration.
+ *
+ * Composition:
+ *   :host                     -> display: block
+ *   .input                    -> base + variant border + size dimensions
+ *   .input::placeholder       -> muted-foreground
+ *   .input:disabled           -> cursor + opacity
+ *   .input:focus-visible      -> outline + ring (variant-specific token)
+ *   .input:user-invalid       -> destructive border + destructive ring
+ *   @media reduced-motion     -> transition: none
+ *
+ * Unknown variant or size silently falls back to 'default'.
+ */
+export function inputStylesheet(options: InputStylesheetOptions = {}): string {
+  const { variant = 'default', size = 'default' } = options;
+
+  const safeVariant: InputVariant = variant in inputVariantStyles ? variant : 'default';
+  const safeSize: InputSize = size in inputSizeStyles ? size : 'default';
+
+  const ringToken = inputVariantRingToken[safeVariant];
+
+  const focusRule: CSSProperties = {
+    outline: 'none',
+    'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar(ringToken)}`,
+  };
+
+  return stylesheet(
+    styleRule(':host', { display: 'block' }),
+
+    // Base .input rule -- declares all token-driven defaults including
+    // border-color: var(--color-input). The variant rule below overrides
+    // border-color via the cascade with the variant-specific token.
+    styleRule('.input', inputBase, pick(inputSizeStyles, safeSize, 'default')),
+
+    // Variant border override -- emitted as a separate rule so that the base
+    // token (color-input) remains visible in the stylesheet while the variant
+    // token (e.g. color-primary) takes effect at render time via cascade.
+    styleRule('.input', pick(inputVariantStyles, safeVariant, 'default')),
+
+    styleRule('.input::placeholder', inputPlaceholder),
+    styleRule('.input:disabled', inputDisabled),
+    styleRule('.input:focus-visible', focusRule),
+    styleRule('.input:user-invalid', inputUserInvalid),
+
+    atRule('@media (prefers-reduced-motion: reduce)', styleRule('.input', { transition: 'none' })),
+  );
+}

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -7,7 +7,12 @@ export default defineConfig({
     globals: true,
     environment: 'happy-dom',
     setupFiles: ['./vitest.setup.ts'],
-    include: ['src/**/*.test.{ts,tsx}', 'test/**/*.test.{ts,tsx}', 'test/**/*.a11y.{ts,tsx}'],
+    include: [
+      'src/**/*.test.{ts,tsx}',
+      'src/**/*.a11y.{ts,tsx}',
+      'test/**/*.test.{ts,tsx}',
+      'test/**/*.a11y.{ts,tsx}',
+    ],
     exclude: ['test/**/*.spec.{ts,tsx}', 'test/**/*.e2e.{ts,tsx}'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary

Adds `<rafters-input>` -- a token-driven, form-associated Web Component that mirrors the same variant + size matrix as the React `Input` and participates in native form submission, validation, reset, fieldset disabling, and state restoration via `ElementInternals`.

- `input.styles.ts`: CSSProperties maps + `inputStylesheet()` composing `:host`, `.input`, placeholder, disabled, focus-visible, user-invalid, and a `prefers-reduced-motion` guard. Every token reference goes through `tokenVar()`. Motion uses `--motion-duration-*` and `--motion-ease-*` exclusively (no raw `--duration-*` / `--ease-*`).
- `input.element.ts`: `RaftersInput extends RaftersElement`, `static formAssociated = true`, calls `attachInternals()` in the constructor (throws `TypeError('rafters-input requires ElementInternals support')` if unavailable). Observes `[type, placeholder, value, disabled, required, name, variant, size]`, mirrors host attributes onto a single inner `<input class="input">`, re-fires `input`/`change` events from the host, and implements all four form-associated lifecycle callbacks.
- Variant + size source of truth aligned with `input.classes.ts` / `input.tsx`.

## Behaviour highlights

- Unknown `type`, `variant`, or `size` silently fall back to defaults; nothing throws.
- Auto-registers on import and is idempotent against double-define.
- Per-instance shadow stylesheet rebuilt on `variant`/`size` change.
- `formResetCallback` restores the host's initial `value` attribute and clears validity.
- Sibling `<label for=id>` is the documented label-association pattern; placeholder text is explicitly NOT an accessible name.

## Tests

- `input.styles.test.ts` (24 cases): verifies the composed stylesheet, default + per-variant focus-ring tokens, size dimensions, placeholder/disabled/user-invalid rules, fallback behaviour, and the motion-token guarantee.
- `input.element.test.ts` (25 cases + 1 deliberately skipped): registration, `formAssociated`, attribute mirroring, type fallback, event re-firing, value getter/setter, per-instance sheet rebuilds, form value submission, `formResetCallback`, `formDisabledCallback`, `formStateRestoreCallback`, required validity, and `setCustomValidity`. happy-dom 20 ships no `ElementInternals`, so the test installs a tiny polyfill of the surface the element actually consumes; one assertion that needs `fieldset.disabled` propagation is `it.skip` with a link to #1303.
- `input.element.a11y.tsx` (5 cases): `vitest-axe` coverage of the sibling-label contract, the explicit assertion that placeholder is NOT the accessible name, and host-level form-control attribute reflection.

## Test plan

- [x] `pnpm typecheck` -- green
- [x] `pnpm vitest run input.styles input.element` from `packages/ui` -- 54 passed, 1 skipped (happy-dom limitation, linked to #1303)
- [x] `pnpm preflight` from repo root -- exit 0

Closes #1303

## Notes

- `vitest.config.ts` now includes `src/**/*.a11y.{ts,tsx}` so the colocated accessibility test runs alongside existing `test/components/*.a11y.tsx` files. No other packages are touched.
- No CHANGELOG entry per the implementing-issue convention; adds happen separately.