### PR TITLE
feat(ui): <rafters-alert> Web Component (#1320)

### DIFF
--- a/packages/ui/src/components/ui/alert.element.test.ts
+++ b/packages/ui/src/components/ui/alert.element.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import './alert.element';
+import { RaftersAlert } from './alert.element';
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+function mount(attrs: Record<string, string> = {}): HTMLElement {
+  const el = document.createElement('rafters-alert');
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.appendChild(el);
+  return el;
+}
+
+function adoptedCss(el: HTMLElement): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  return sheets
+    .map((s) =>
+      Array.from(s.cssRules)
+        .map((r) => r.cssText)
+        .join('\n'),
+    )
+    .join('\n');
+}
+
+describe('rafters-alert', () => {
+  it('registers the rafters-alert tag on import', () => {
+    expect(customElements.get('rafters-alert')).toBe(RaftersAlert);
+  });
+
+  it('does not throw when the module is imported twice', async () => {
+    await expect(import('./alert.element')).resolves.toBeDefined();
+    await expect(import('./alert.element')).resolves.toBeDefined();
+    expect(customElements.get('rafters-alert')).toBe(RaftersAlert);
+  });
+
+  it('renders a single div.alert[role=alert] containing a slot', () => {
+    const el = mount();
+    const root = el.shadowRoot;
+    expect(root).not.toBeNull();
+    const divs = root?.querySelectorAll('div') ?? [];
+    expect(divs.length).toBe(1);
+    const wrapper = divs[0];
+    expect(wrapper?.className).toBe('alert');
+    expect(wrapper?.getAttribute('role')).toBe('alert');
+    const slot = wrapper?.querySelector('slot');
+    expect(slot).not.toBeNull();
+  });
+
+  it('falls back to default variant for unknown values', () => {
+    const el = mount({ variant: 'nonsense' });
+    const css = adoptedCss(el);
+    expect(css).toContain('color-primary-subtle');
+    expect(css).toContain('color-primary-foreground');
+    expect(css).toContain('color-primary-border');
+  });
+
+  it('reflects variant attribute changes to the adopted stylesheet', () => {
+    const el = mount();
+    el.setAttribute('variant', 'destructive');
+    const css = adoptedCss(el);
+    expect(css).toContain('color-destructive');
+  });
+
+  it('source contains no direct var() references', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const source = await fs.readFile(path.resolve(__dirname, 'alert.element.ts'), 'utf-8');
+    expect(source).not.toMatch(/[^a-zA-Z_]var\(/);
+  });
+
+  it('observedAttributes contains only variant', () => {
+    expect(RaftersAlert.observedAttributes).toEqual(['variant']);
+  });
+
+  it('adopts a per-instance stylesheet on connect', () => {
+    const el = mount();
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    expect(sheets.length).toBe(1);
+  });
+
+  it('stylesheet uses only --motion-duration / --motion-ease tokens', () => {
+    const el = mount();
+    const css = adoptedCss(el);
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+  });
+
+  it('falls back silently without throwing for unknown variant', () => {
+    expect(() => mount({ variant: 'made-up' })).not.toThrow();
+  });
+});

--- a/packages/ui/src/components/ui/alert.element.ts
+++ b/packages/ui/src/components/ui/alert.element.ts
@@ -1,0 +1,100 @@
+/**
+ * <rafters-alert> -- Web Component alert primitive.
+ *
+ * Mirrors the semantics of alert.tsx (variant) using shadow-DOM-scoped CSS
+ * composed via classy-wc. Auto-registers on import and is idempotent
+ * against double-define.
+ *
+ * Attributes:
+ *  - variant: 'default' | 'primary' | 'secondary' | 'destructive' | 'success'
+ *             | 'warning' | 'info' | 'muted' | 'accent'  (default 'default')
+ *
+ * The inner <div class="alert" role="alert"> is plain shadow-DOM markup --
+ * NO Tailwind classes. Styling comes exclusively from alertStylesheet(...)
+ * adopted as the per-instance stylesheet.
+ *
+ * Unknown variant values fall back to 'default' silently and NEVER throw.
+ * Subcomponents (title/description/action) are out of scope -- consumers
+ * compose with plain slotted elements.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import { type AlertVariant, alertStylesheet } from './alert.styles';
+
+const ALLOWED_VARIANTS: ReadonlyArray<AlertVariant> = [
+  'default',
+  'primary',
+  'secondary',
+  'destructive',
+  'success',
+  'warning',
+  'info',
+  'muted',
+  'accent',
+];
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = ['variant'] as const;
+
+function parseVariant(value: string | null): AlertVariant {
+  if (value && (ALLOWED_VARIANTS as ReadonlyArray<string>).includes(value)) {
+    return value as AlertVariant;
+  }
+  return 'default';
+}
+
+export class RaftersAlert extends RaftersElement {
+  static readonly observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  /** Per-instance stylesheet rebuilt on every attribute change. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  override connectedCallback(): void {
+    if (!this.shadowRoot) return;
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+    this.shadowRoot.adoptedStyleSheets = [this._instanceSheet];
+    this.update();
+  }
+
+  override attributeChangedCallback(
+    _name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+    if (this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+    this.update();
+  }
+
+  override disconnectedCallback(): void {
+    this._instanceSheet = null;
+  }
+
+  /**
+   * Build the CSS string for the current attribute values.
+   */
+  private composeCss(): string {
+    return alertStylesheet({
+      variant: parseVariant(this.getAttribute('variant')),
+    });
+  }
+
+  /**
+   * Render the semantic <div class="alert" role="alert"> with a single
+   * default <slot>. DOM APIs only -- never innerHTML.
+   */
+  override render(): Node {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'alert';
+    wrapper.setAttribute('role', 'alert');
+    const slot = document.createElement('slot');
+    wrapper.appendChild(slot);
+    return wrapper;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-alert')) {
+  customElements.define('rafters-alert', RaftersAlert);
+}

--- a/packages/ui/src/components/ui/alert.styles.ts
+++ b/packages/ui/src/components/ui/alert.styles.ts
@@ -1,0 +1,146 @@
+/**
+ * Shadow DOM style definitions for Alert web component
+ *
+ * Parallel to alert.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ * Token values via var() from the shared token stylesheet.
+ *
+ * All token references go through tokenVar(); no raw var() literals.
+ * Motion uses --motion-duration-* / --motion-ease-* only.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import {
+  atRule,
+  pick,
+  styleRule,
+  stylesheet,
+  tokenVar,
+  transition,
+} from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export type AlertVariant =
+  | 'default'
+  | 'primary'
+  | 'secondary'
+  | 'destructive'
+  | 'success'
+  | 'warning'
+  | 'info'
+  | 'muted'
+  | 'accent';
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+/**
+ * Base alert declarations shared across every variant.
+ * Mirrors alertBaseClasses from alert.classes.ts:
+ *   relative w-full rounded-lg border p-4
+ * Omits the Tailwind `[&>svg]` adjacency selectors -- consumers compose
+ * slotted content themselves in the shadow DOM target.
+ */
+export const alertBase: CSSProperties = {
+  position: 'relative',
+  width: '100%',
+  'border-radius': tokenVar('radius-lg'),
+  'border-width': '1px',
+  'border-style': 'solid',
+  'border-color': 'transparent',
+  padding: '1rem',
+  transition: transition(
+    ['background-color', 'color', 'border-color'],
+    tokenVar('motion-duration-fast'),
+    tokenVar('motion-ease-standard'),
+  ),
+};
+
+// ============================================================================
+// Variant Styles
+// ============================================================================
+
+/**
+ * Per-variant background/foreground/border triple, mirroring
+ * alertVariantClasses from alert.classes.ts. Semantic variants use
+ * their `-subtle` / `-foreground` / `-border` token trio. muted uses
+ * the flat muted pair with the neutral border token.
+ */
+export const alertVariantStyles: Record<AlertVariant, CSSProperties> = {
+  default: {
+    'background-color': tokenVar('color-primary-subtle'),
+    color: tokenVar('color-primary-foreground'),
+    'border-color': tokenVar('color-primary-border'),
+  },
+  primary: {
+    'background-color': tokenVar('color-primary-subtle'),
+    color: tokenVar('color-primary-foreground'),
+    'border-color': tokenVar('color-primary-border'),
+  },
+  secondary: {
+    'background-color': tokenVar('color-secondary-subtle'),
+    color: tokenVar('color-secondary-foreground'),
+    'border-color': tokenVar('color-secondary-border'),
+  },
+  destructive: {
+    'background-color': tokenVar('color-destructive-subtle'),
+    color: tokenVar('color-destructive-foreground'),
+    'border-color': tokenVar('color-destructive-border'),
+  },
+  success: {
+    'background-color': tokenVar('color-success-subtle'),
+    color: tokenVar('color-success-foreground'),
+    'border-color': tokenVar('color-success-border'),
+  },
+  warning: {
+    'background-color': tokenVar('color-warning-subtle'),
+    color: tokenVar('color-warning-foreground'),
+    'border-color': tokenVar('color-warning-border'),
+  },
+  info: {
+    'background-color': tokenVar('color-info-subtle'),
+    color: tokenVar('color-info-foreground'),
+    'border-color': tokenVar('color-info-border'),
+  },
+  muted: {
+    'background-color': tokenVar('color-muted'),
+    color: tokenVar('color-muted-foreground'),
+    'border-color': tokenVar('color-border'),
+  },
+  accent: {
+    'background-color': tokenVar('color-accent-subtle'),
+    color: tokenVar('color-accent-foreground'),
+    'border-color': tokenVar('color-accent-border'),
+  },
+};
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+export interface AlertStylesheetOptions {
+  variant?: AlertVariant | undefined;
+}
+
+/**
+ * Build the complete alert stylesheet for a given configuration.
+ *
+ * Unknown variant keys fall back to 'default' via pick(). Never throws.
+ * Emits the base `.alert` rule plus a prefers-reduced-motion block that
+ * neutralises the transition.
+ */
+export function alertStylesheet(options: AlertStylesheetOptions = {}): string {
+  const { variant } = options;
+
+  return stylesheet(
+    styleRule(':host', { display: 'block' }),
+
+    styleRule('.alert', alertBase, pick(alertVariantStyles, variant, 'default')),
+
+    atRule('@media (prefers-reduced-motion: reduce)', styleRule('.alert', { transition: 'none' })),
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `<rafters-alert>` custom element as the Web Component framework target for alert, parallel to `alert.tsx` (React) and `alert.astro` (Astro).
- Ships `alert.element.ts` alongside a new `alert.styles.ts` (CSS-in-shadow parallel to `alert.classes.ts`), completing the framework triad.
- Per-instance `CSSStyleSheet` + `replaceSync` + `adoptedStyleSheets` pattern (mirrors `button.element.ts`); never mutates `static styles`, avoiding the PR #1308 ctor bug.
- Auto-registers on import, idempotent via `customElements.get` guard. Unknown `variant` values fall back to `'default'` silently and never throw. DOM via `document.createElement`; never `innerHTML`.
- Token refs only through `tokenVar()` in `alert.styles.ts`; no raw `var()` literal in `alert.element.ts`. Motion uses `--motion-duration-*` / `--motion-ease-*`.

## Test plan

- [x] `pnpm --filter=@rafters/ui test alert.element alert.styles` -- 10/10 pass
- [x] `pnpm typecheck` -- green across workspace
- [x] `pnpm preflight` -- exit 0
- [x] Tests query `shadowRoot.adoptedStyleSheets` for attribute-change assertions (not `ctor.styles`)
- [x] Functional tests cover: registration, idempotent re-import, shadow DOM shape (`div.alert[role=alert]` with single `<slot>`), unknown-variant fallback, attribute-change reflection to adopted sheet, and the source-level `var()` regex grep

Closes #1320