### PR TITLE
feat(ui): <rafters-breadcrumb> Web Component (#1322)

### DIFF
--- a/packages/ui/src/components/ui/breadcrumb.element.test.ts
+++ b/packages/ui/src/components/ui/breadcrumb.element.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import './breadcrumb.element';
+import { RaftersBreadcrumb } from './breadcrumb.element';
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+function mount(): HTMLElement {
+  const el = document.createElement('rafters-breadcrumb');
+  document.body.appendChild(el);
+  return el;
+}
+
+function adoptedCssText(el: Element): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  const blocks: string[] = [];
+  for (const sheet of sheets) {
+    const rules: string[] = [];
+    for (const rule of Array.from(sheet.cssRules)) {
+      rules.push(rule.cssText);
+    }
+    blocks.push(rules.join('\n'));
+  }
+  return blocks.join('\n');
+}
+
+describe('<rafters-breadcrumb>', () => {
+  it('registers the rafters-breadcrumb tag on import', () => {
+    expect(customElements.get('rafters-breadcrumb')).toBe(RaftersBreadcrumb);
+  });
+
+  it('does not throw when the module is imported twice', async () => {
+    await expect(import('./breadcrumb.element')).resolves.toBeDefined();
+    await expect(import('./breadcrumb.element')).resolves.toBeDefined();
+    expect(customElements.get('rafters-breadcrumb')).toBe(RaftersBreadcrumb);
+  });
+
+  it('renders a single nav.breadcrumb[aria-label="Breadcrumb"] containing a slot', () => {
+    const el = mount();
+    const navs = el.shadowRoot?.querySelectorAll('nav.breadcrumb') ?? [];
+    expect(navs.length).toBe(1);
+    const nav = navs[0];
+    expect(nav?.getAttribute('aria-label')).toBe('Breadcrumb');
+    expect(nav?.children.length).toBe(1);
+    expect(nav?.firstElementChild?.tagName.toLowerCase()).toBe('slot');
+  });
+
+  it('observedAttributes is empty', () => {
+    expect(RaftersBreadcrumb.observedAttributes).toEqual([]);
+  });
+
+  it('adopts the breadcrumb stylesheet on connect', () => {
+    const el = mount();
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    expect(sheets.length).toBeGreaterThanOrEqual(1);
+    const css = adoptedCssText(el);
+    expect(css).toMatch(/\.breadcrumb\b/);
+    expect(css).toMatch(/\.breadcrumb-list\b/);
+    expect(css).toMatch(/\.breadcrumb-item\b/);
+    expect(css).toMatch(/\.breadcrumb-link\b/);
+    expect(css).toMatch(/\.breadcrumb-page\b/);
+    expect(css).toMatch(/\.breadcrumb-separator\b/);
+    expect(css).toMatch(/\.breadcrumb-ellipsis\b/);
+  });
+
+  it('stylesheet uses only --motion-duration / --motion-ease tokens', () => {
+    const el = mount();
+    const css = adoptedCssText(el);
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+  });
+
+  it('source contains no direct var() references', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const source = await fs.readFile(path.resolve(__dirname, 'breadcrumb.element.ts'), 'utf-8');
+    expect(source).not.toMatch(/[^a-zA-Z_]var\(/);
+  });
+});

--- a/packages/ui/src/components/ui/breadcrumb.element.ts
+++ b/packages/ui/src/components/ui/breadcrumb.element.ts
@@ -1,0 +1,66 @@
+/**
+ * <rafters-breadcrumb> -- Web Component wayfinding container.
+ *
+ * Framework-target for the Breadcrumb outer <nav> wrapper, parallel to
+ * breadcrumb.tsx (React) and breadcrumb.astro (Astro). Scope is limited
+ * to the outer container; the list/item/link/page/separator/ellipsis
+ * children are deferred to a follow-up issue -- consumers compose plain
+ * semantic children into the default slot for now.
+ *
+ * Shadow DOM structure:
+ *   <nav class="breadcrumb" aria-label="Breadcrumb"><slot></slot></nav>
+ *
+ * Attributes: none. No attribute-driven variants on the outer nav.
+ *
+ * Auto-registers on import and is idempotent against double-define.
+ * Styling comes exclusively from breadcrumbStylesheet() adopted as the
+ * per-instance stylesheet. No raw custom-property literals live in this
+ * file; every token reference resolves through tokenVar() inside
+ * breadcrumb.styles.ts. No innerHTML is used either. The per-instance
+ * CSSStyleSheet pattern avoids the static styles mutation bug from PR #1308.
+ *
+ * @cognitive-load 2/10
+ * @accessibility aria-label="Breadcrumb" on the nav element; slotted
+ *                children retain their own semantic roles in the light tree.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import { breadcrumbStylesheet } from './breadcrumb.styles';
+
+export class RaftersBreadcrumb extends RaftersElement {
+  static readonly observedAttributes: ReadonlyArray<string> = [];
+
+  /** Per-instance stylesheet created on connect. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  override connectedCallback(): void {
+    if (!this.shadowRoot) return;
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(breadcrumbStylesheet());
+    this.shadowRoot.adoptedStyleSheets = [this._instanceSheet];
+    this.update();
+  }
+
+  override disconnectedCallback(): void {
+    this._instanceSheet = null;
+  }
+
+  /**
+   * Render the semantic <nav aria-label="Breadcrumb"> wrapper with a single
+   * default <slot>. DOM APIs only -- never innerHTML. The outer nav carries
+   * only the `.breadcrumb` class so visual state comes exclusively from the
+   * per-instance stylesheet.
+   */
+  override render(): Node {
+    const nav = document.createElement('nav');
+    nav.className = 'breadcrumb';
+    nav.setAttribute('aria-label', 'Breadcrumb');
+    const slot = document.createElement('slot');
+    nav.appendChild(slot);
+    return nav;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-breadcrumb')) {
+  customElements.define('rafters-breadcrumb', RaftersBreadcrumb);
+}

--- a/packages/ui/src/components/ui/breadcrumb.styles.ts
+++ b/packages/ui/src/components/ui/breadcrumb.styles.ts
@@ -1,0 +1,152 @@
+/**
+ * Shadow DOM style definitions for Breadcrumb web component
+ *
+ * Parallel to breadcrumb.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ *
+ * Scope: styles the outer `<nav class="breadcrumb">` container plus the
+ * list/item/link/page/separator/ellipsis descendant selectors so future
+ * child components (or light-DOM composition via ::slotted) inherit the
+ * correct visual rhythm.
+ *
+ * Token references go exclusively through tokenVar(). Motion tokens are
+ * the --motion-duration-* / --motion-ease-* namespace only.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import { atRule, styleRule, stylesheet, tokenVar, transition } from '../../primitives/classy-wc';
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+/**
+ * Outer <nav class="breadcrumb"> container. Semantic wrapper only.
+ */
+export const breadcrumbBase: CSSProperties = {
+  display: 'block',
+  color: tokenVar('color-muted-foreground'),
+};
+
+/**
+ * <ol class="breadcrumb-list"> -- horizontal list of breadcrumb items.
+ * Mirrors breadcrumbListClasses from breadcrumb.classes.ts.
+ */
+export const breadcrumbList: CSSProperties = {
+  display: 'flex',
+  'flex-wrap': 'wrap',
+  'align-items': 'center',
+  gap: '0.375rem',
+  'word-break': 'break-word',
+  'font-size': tokenVar('font-size-label-medium'),
+  color: tokenVar('color-muted-foreground'),
+  'list-style': 'none',
+  margin: '0',
+  padding: '0',
+};
+
+/**
+ * <li class="breadcrumb-item"> -- individual trail entry.
+ */
+export const breadcrumbItem: CSSProperties = {
+  display: 'inline-flex',
+  'align-items': 'center',
+  gap: '0.375rem',
+};
+
+/**
+ * <a class="breadcrumb-link"> -- navigable ancestor link.
+ * Hover flips color to foreground; focus-visible paints a double ring.
+ */
+export const breadcrumbLink: CSSProperties = {
+  color: 'inherit',
+  'text-decoration': 'none',
+  transition: transition(
+    ['color'],
+    tokenVar('motion-duration-fast'),
+    tokenVar('motion-ease-standard'),
+  ),
+};
+
+export const breadcrumbLinkHover: CSSProperties = {
+  color: tokenVar('color-foreground'),
+};
+
+export const breadcrumbLinkFocusVisible: CSSProperties = {
+  outline: 'none',
+  'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar('color-ring')}`,
+};
+
+/**
+ * <span class="breadcrumb-page"> -- non-interactive current page token.
+ */
+export const breadcrumbPage: CSSProperties = {
+  color: tokenVar('color-foreground'),
+  'font-weight': '400',
+};
+
+/**
+ * <li class="breadcrumb-separator"> -- visual divider between trail items.
+ * Svg sizing matches the React target (size-3.5).
+ */
+export const breadcrumbSeparator: CSSProperties = {
+  display: 'inline-flex',
+  'align-items': 'center',
+  'pointer-events': 'none',
+};
+
+export const breadcrumbSeparatorSvg: CSSProperties = {
+  width: '0.875rem',
+  height: '0.875rem',
+};
+
+/**
+ * <span class="breadcrumb-ellipsis"> -- collapsed-segment affordance.
+ */
+export const breadcrumbEllipsis: CSSProperties = {
+  display: 'inline-flex',
+  'align-items': 'center',
+  'justify-content': 'center',
+  width: '2.25rem',
+  height: '2.25rem',
+};
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+/**
+ * Build the complete breadcrumb stylesheet.
+ *
+ * The outer container has no variants, so this is a zero-arg factory.
+ * Emits base rules for the nav plus every documented descendant selector
+ * so slotted children or future child Web Components inherit consistent
+ * visual rhythm under the host shadow root.
+ */
+export function breadcrumbStylesheet(): string {
+  return stylesheet(
+    styleRule(':host', { display: 'block' }),
+
+    styleRule('.breadcrumb', breadcrumbBase),
+
+    styleRule('.breadcrumb-list', breadcrumbList),
+
+    styleRule('.breadcrumb-item', breadcrumbItem),
+
+    styleRule('.breadcrumb-link', breadcrumbLink),
+    styleRule('.breadcrumb-link:hover', breadcrumbLinkHover),
+    styleRule('.breadcrumb-link:focus-visible', breadcrumbLinkFocusVisible),
+
+    styleRule('.breadcrumb-page', breadcrumbPage),
+
+    styleRule('.breadcrumb-separator', breadcrumbSeparator),
+    styleRule('.breadcrumb-separator > svg', breadcrumbSeparatorSvg),
+
+    styleRule('.breadcrumb-ellipsis', breadcrumbEllipsis),
+
+    atRule(
+      '@media (prefers-reduced-motion: reduce)',
+      styleRule('.breadcrumb-link', { transition: 'none' }),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

Ships the outer `<nav>` framework target for the breadcrumb triad, parallel to `breadcrumb.tsx` (React) and `breadcrumb.astro` (Astro). Scope is limited to the semantic wrapper; list/item/link/page/separator/ellipsis children are deferred to a follow-up -- consumers compose plain semantic children into the default slot.

- New `breadcrumb.styles.ts` exports `breadcrumbStylesheet()` covering the outer `.breadcrumb` plus the `.breadcrumb-list`, `.breadcrumb-item`, `.breadcrumb-link`, `.breadcrumb-page`, `.breadcrumb-separator`, and `.breadcrumb-ellipsis` selectors so slotted descendants inherit consistent visual rhythm.
- New `breadcrumb.element.ts` defines `RaftersBreadcrumb` with empty `observedAttributes`, per-instance `CSSStyleSheet` created on connect, and DOM-only rendering of `<nav class="breadcrumb" aria-label="Breadcrumb">` with a single default `<slot>`. Auto-registers `<rafters-breadcrumb>` via an idempotent `customElements.define` guard.
- All token references flow through `tokenVar()`; motion uses the `--motion-duration-*` / `--motion-ease-*` namespace only. No direct `var()` literal in the element file; no `innerHTML`; no emoji; no `any`.

## Test Plan

- [x] `pnpm --filter=@rafters/ui test breadcrumb` -- 60 tests pass (7 new WC tests + 53 existing React tests)
- [x] `pnpm typecheck` -- clean across the workspace
- [x] `pnpm lint` -- biome clean after format
- [x] `pnpm preflight` -- green end-to-end
- [x] Shadow DOM shape check: `nav.breadcrumb[aria-label="Breadcrumb"]` containing a single `<slot>`
- [x] Adopted-stylesheet coverage test asserts every child selector
- [x] Motion-namespace purity test rejects `--duration-*` / `--ease-*`
- [x] Source-grep test confirms no direct `var()` literal in the element file

Closes #1322