### PR TITLE
feat(ui): <rafters-empty> Web Component (#1323)

### DIFF
--- a/packages/ui/src/components/ui/empty.element.test.ts
+++ b/packages/ui/src/components/ui/empty.element.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { RaftersEmpty } from './empty.element';
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+function adoptedCssText(el: Element): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  const blocks: string[] = [];
+  for (const sheet of sheets) {
+    const rules: string[] = [];
+    for (const rule of Array.from(sheet.cssRules)) {
+      rules.push(rule.cssText);
+    }
+    blocks.push(rules.join('\n'));
+  }
+  return blocks.join('\n');
+}
+
+describe('<rafters-empty>', () => {
+  it('registers the rafters-empty tag on import', () => {
+    expect(customElements.get('rafters-empty')).toBe(RaftersEmpty);
+  });
+
+  it('does not throw when the module is imported twice', async () => {
+    await expect(import('./empty.element')).resolves.toBeDefined();
+    await expect(import('./empty.element')).resolves.toBeDefined();
+    expect(customElements.get('rafters-empty')).toBe(RaftersEmpty);
+  });
+
+  it('renders a single div.empty containing a slot', () => {
+    const el = document.createElement('rafters-empty');
+    document.body.appendChild(el);
+    const root = el.shadowRoot?.querySelector('div.empty');
+    expect(root).not.toBeNull();
+    expect(root?.children.length).toBe(1);
+    expect(root?.firstElementChild?.tagName.toLowerCase()).toBe('slot');
+  });
+
+  it('observedAttributes is an empty array', () => {
+    expect(Array.from(RaftersEmpty.observedAttributes)).toEqual([]);
+  });
+
+  it('adopts the empty stylesheet on connect', () => {
+    const el = document.createElement('rafters-empty');
+    document.body.appendChild(el);
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    expect(sheets.length).toBeGreaterThanOrEqual(1);
+    const css = adoptedCssText(el);
+    expect(css).toContain('.empty');
+  });
+
+  it('adopted stylesheet resolves token references via var()', () => {
+    const el = document.createElement('rafters-empty');
+    document.body.appendChild(el);
+    const css = adoptedCssText(el);
+    // Base container uses spacing tokens for gap and padding.
+    expect(css).toContain('var(--spacing-4)');
+    expect(css).toContain('var(--spacing-12)');
+  });
+
+  it('stylesheet uses only --motion-duration / --motion-ease tokens', () => {
+    const el = document.createElement('rafters-empty');
+    document.body.appendChild(el);
+    const css = adoptedCssText(el);
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+  });
+
+  it('clears the instance stylesheet on disconnect', () => {
+    const el = document.createElement('rafters-empty');
+    document.body.appendChild(el);
+    el.remove();
+    // After disconnect, re-connecting yields a fresh sheet without throwing.
+    document.body.appendChild(el);
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    expect(sheets.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('source contains no direct var() references', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const source = await fs.readFile(path.resolve(__dirname, 'empty.element.ts'), 'utf-8');
+    expect(source).not.toMatch(/[^a-zA-Z_]var\(/);
+  });
+});

--- a/packages/ui/src/components/ui/empty.element.ts
+++ b/packages/ui/src/components/ui/empty.element.ts
@@ -1,0 +1,61 @@
+/**
+ * <rafters-empty> Web Component
+ *
+ * Framework target for the Empty container, parallel to empty.tsx (React)
+ * and empty.astro (Astro). Consumes emptyStylesheet() from empty.styles.ts.
+ * Auto-registers on import; registration is idempotent under HMR and
+ * double-import.
+ *
+ * Shadow DOM structure:
+ *   <div class="empty"><slot></slot></div>
+ *
+ * Scope note: this issue covers the OUTER <rafters-empty> container only.
+ * The <rafters-empty-icon>, <rafters-empty-title>, <rafters-empty-description>,
+ * and <rafters-empty-action> subcomponents are deferred to a follow-up.
+ *
+ * NEVER: import React, Astro, nanostores, Tailwind; reference CSS custom
+ * properties directly in this file; emit inline CSS strings. All styling
+ * flows from emptyStylesheet() which owns every token reference.
+ *
+ * @cognitive-load 2/10
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import { emptyStylesheet } from './empty.styles';
+
+export class RaftersEmpty extends RaftersElement {
+  static readonly observedAttributes: ReadonlyArray<string> = [];
+
+  /** Per-instance stylesheet. No attributes drive the outer container today,
+   *  so the sheet is built once at connect and held for the life of the
+   *  instance. Kept as a field so disconnectedCallback can clear it. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  override connectedCallback(): void {
+    if (!this.shadowRoot) return;
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(emptyStylesheet());
+    this.shadowRoot.adoptedStyleSheets = [this._instanceSheet];
+    this.update();
+  }
+
+  override disconnectedCallback(): void {
+    this._instanceSheet = null;
+  }
+
+  /**
+   * Render the outer .empty container with a single default slot.
+   * DOM APIs only -- NEVER innerHTML.
+   */
+  override render(): Node {
+    const root = document.createElement('div');
+    root.className = 'empty';
+    const slot = document.createElement('slot');
+    root.appendChild(slot);
+    return root;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-empty')) {
+  customElements.define('rafters-empty', RaftersEmpty);
+}

--- a/packages/ui/src/components/ui/empty.styles.ts
+++ b/packages/ui/src/components/ui/empty.styles.ts
@@ -1,0 +1,109 @@
+/**
+ * Shadow DOM style definitions for Empty web component
+ *
+ * Parallel to empty.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ * Token values via tokenVar() -- never raw var() literals.
+ *
+ * This issue scopes to the outer <rafters-empty> container. The child
+ * selectors (.empty-icon, .empty-title, .empty-description, .empty-action)
+ * are emitted here for future sibling web components or ::slotted targeting
+ * of light-tree children.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import { styleRule, stylesheet, tokenVar } from '../../primitives/classy-wc';
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+/**
+ * Outer container base styles.
+ * Mirrors emptyBaseClasses: flex flex-col items-center justify-center
+ * gap-4 py-12 text-center.
+ */
+export const emptyBase: CSSProperties = {
+  display: 'flex',
+  'flex-direction': 'column',
+  'align-items': 'center',
+  'justify-content': 'center',
+  gap: tokenVar('spacing-4'),
+  'padding-top': tokenVar('spacing-12'),
+  'padding-bottom': tokenVar('spacing-12'),
+  'text-align': 'center',
+};
+
+// ============================================================================
+// Sub-component Styles
+// ============================================================================
+
+/**
+ * Icon wrapper styles.
+ * Mirrors emptyIconClasses: text-muted-foreground [&>svg]:h-12 [&>svg]:w-12.
+ * Descendant-svg sizing uses a child combinator on svg.
+ */
+export const emptyIcon: CSSProperties = {
+  color: tokenVar('color-muted-foreground'),
+};
+
+export const emptyIconSvg: CSSProperties = {
+  height: tokenVar('spacing-12'),
+  width: tokenVar('spacing-12'),
+};
+
+/**
+ * Title styles.
+ * Mirrors emptyTitleClasses: text-title-medium text-foreground.
+ */
+export const emptyTitle: CSSProperties = {
+  'font-size': tokenVar('font-size-title-medium'),
+  color: tokenVar('color-foreground'),
+};
+
+/**
+ * Description styles.
+ * Mirrors emptyDescriptionClasses: max-w-sm text-body-small text-muted-foreground.
+ * Tailwind max-w-sm resolves to 24rem; there is no direct size-* token for
+ * that value, so we emit the literal to preserve visual parity with the React
+ * and Astro targets.
+ */
+export const emptyDescription: CSSProperties = {
+  'max-width': '24rem',
+  'font-size': tokenVar('font-size-body-small'),
+  color: tokenVar('color-muted-foreground'),
+};
+
+/**
+ * Action wrapper styles.
+ * Mirrors emptyActionClasses: empty -- no explicit declarations needed.
+ * Reserved for future sibling web components.
+ */
+export const emptyAction: CSSProperties = {};
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+/**
+ * Build the complete empty stylesheet.
+ *
+ * Emits the outer .empty container plus selectors for future icon/title/
+ * description/action child components. The child selectors are harmless
+ * noise until sibling web components ship, but having them in the adopted
+ * sheet now means consumers can ::slotted() target them without a follow-up.
+ */
+export function emptyStylesheet(): string {
+  return stylesheet(
+    styleRule(':host', { display: 'block' }),
+
+    styleRule('.empty', emptyBase),
+
+    styleRule('.empty-icon', emptyIcon),
+    styleRule('.empty-icon > svg', emptyIconSvg),
+
+    styleRule('.empty-title', emptyTitle),
+
+    styleRule('.empty-description', emptyDescription),
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `empty.styles.ts` authoring the shadow DOM stylesheet via classy-wc composition helpers; every token reference flows through `tokenVar()`, no raw `var()` literals. Emits `.empty` plus forward-compatible `.empty-icon`, `.empty-title`, `.empty-description` selectors so future sibling web components (or `::slotted` usage) already have matching rules in the adopted sheet.
- Adds `empty.element.ts` defining `RaftersEmpty` with the per-instance `CSSStyleSheet` + `replaceSync` pattern (mirrors `button.element.ts`). Auto-registers `<rafters-empty>` idempotently via `customElements.get` guard. `observedAttributes` is empty -- no attribute-driven variants on the outer container.
- `render()` builds `<div class="empty"><slot></slot></div>` through `document.createElement`; never `innerHTML`.
- Child web components (`<rafters-empty-icon>`, `<rafters-empty-title>`, `<rafters-empty-description>`, `<rafters-empty-action>`) are deferred to a follow-up per spec.

Closes #1323

## Test plan

- [x] `pnpm typecheck` green across the monorepo
- [x] `pnpm --filter=@rafters/ui test empty` passes all 54 tests including the three existing empty suites and the new `empty.element.test.ts`
- [x] `pnpm preflight` green (189 UI test files, 4122 passing; 51 a11y suites, 662 passing)
- [x] Asserts registration, idempotent double-import, shadow DOM shape, adopted stylesheet contains `.empty`, motion tokens use `--motion-duration-*` / `--motion-ease-*` only, source contains no direct `var()` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)