### PR TITLE
feat(ui): <rafters-avatar> Web Component (#1321)

### DIFF
--- a/packages/ui/src/components/ui/avatar.element.test.ts
+++ b/packages/ui/src/components/ui/avatar.element.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import './avatar.element';
+import { RaftersAvatar } from './avatar.element';
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+function mount(attrs: Record<string, string> = {}): HTMLElement {
+  const el = document.createElement('rafters-avatar');
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.appendChild(el);
+  return el;
+}
+
+function collectCss(el: HTMLElement): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  return sheets
+    .map((s) =>
+      Array.from(s.cssRules)
+        .map((r) => r.cssText)
+        .join('\n'),
+    )
+    .join('\n');
+}
+
+describe('<rafters-avatar>', () => {
+  it('registers the rafters-avatar tag on import', () => {
+    expect(customElements.get('rafters-avatar')).toBe(RaftersAvatar);
+  });
+
+  it('does not throw when the module is imported twice', async () => {
+    await expect(import('./avatar.element')).resolves.toBeDefined();
+    await expect(import('./avatar.element')).resolves.toBeDefined();
+    expect(customElements.get('rafters-avatar')).toBe(RaftersAvatar);
+  });
+
+  it('renders a single span.avatar containing a slot', () => {
+    const el = mount();
+    const span = el.shadowRoot?.querySelector('span.avatar');
+    expect(span).not.toBeNull();
+    expect(span?.children.length).toBe(1);
+    expect(span?.firstElementChild?.tagName.toLowerCase()).toBe('slot');
+  });
+
+  it('falls back to default size md for unknown values', () => {
+    const el = mount({ size: 'mega' });
+    expect(collectCss(el)).toContain('spacing-10');
+  });
+
+  it('reflects size attribute changes to the adopted stylesheet', () => {
+    const el = mount();
+    el.setAttribute('size', 'xl');
+    expect(collectCss(el)).toContain('spacing-16');
+  });
+
+  it('source contains no direct var() references', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const source = await fs.readFile(path.resolve(__dirname, 'avatar.element.ts'), 'utf-8');
+    expect(source).not.toMatch(/var\(/);
+  });
+});

--- a/packages/ui/src/components/ui/avatar.element.ts
+++ b/packages/ui/src/components/ui/avatar.element.ts
@@ -1,0 +1,89 @@
+/**
+ * <rafters-avatar> -- Web Component avatar primitive.
+ *
+ * Mirrors the outer container semantics of avatar.tsx (React) and
+ * avatar.astro (Astro) using shadow-DOM-scoped CSS composed via classy-wc.
+ * Auto-registers on import and is idempotent against double-define.
+ *
+ * This issue scopes to the OUTER <rafters-avatar> only. The inner
+ * <rafters-avatar-image> and <rafters-avatar-fallback> subcomponents require
+ * image-load status coordination and are deferred to a follow-up.
+ *
+ * Attributes:
+ *  - size: 'xs' | 'sm' | 'md' | 'lg' | 'xl'  (default 'md')
+ *
+ * The inner <span> is plain shadow-DOM markup -- NO Tailwind classes.
+ * Styling comes exclusively from avatarStylesheet(...) adopted as the
+ * per-instance stylesheet. Unknown size values fall back to 'md' silently
+ * and NEVER throw.
+ *
+ * @cognitive-load 2/10
+ * @accessibility Semantic generic span; slotted content remains in the light tree.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import { type AvatarSize, avatarStylesheet, isAvatarSize } from './avatar.styles';
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = ['size'] as const;
+
+function parseSize(value: string | null): AvatarSize {
+  return isAvatarSize(value) ? value : 'md';
+}
+
+export class RaftersAvatar extends RaftersElement {
+  static observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  /** Per-instance stylesheet rebuilt on every attribute change. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  override connectedCallback(): void {
+    if (!this.shadowRoot) return;
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+    this.shadowRoot.adoptedStyleSheets = [this._instanceSheet];
+    this.update();
+  }
+
+  override attributeChangedCallback(
+    _name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+    if (this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+    this.update();
+  }
+
+  override disconnectedCallback(): void {
+    this._instanceSheet = null;
+  }
+
+  /**
+   * Build the CSS string for the current attribute values.
+   */
+  private composeCss(): string {
+    return avatarStylesheet({
+      size: parseSize(this.getAttribute('size')),
+    });
+  }
+
+  /**
+   * Render a single <span class="avatar"> containing a default <slot>.
+   * DOM APIs only -- never innerHTML. The inner span carries NO classes
+   * other than `.avatar` so visual state comes exclusively from the
+   * per-instance stylesheet.
+   */
+  override render(): Node {
+    const inner = document.createElement('span');
+    inner.className = 'avatar';
+    const slot = document.createElement('slot');
+    inner.appendChild(slot);
+    return inner;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-avatar')) {
+  customElements.define('rafters-avatar', RaftersAvatar);
+}

--- a/packages/ui/src/components/ui/avatar.styles.ts
+++ b/packages/ui/src/components/ui/avatar.styles.ts
@@ -1,0 +1,115 @@
+/**
+ * Shadow DOM style definitions for Avatar web component
+ *
+ * Parallel to avatar.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ * Token values via var() from the shared token stylesheet.
+ *
+ * All token references resolve through tokenVar(); no raw var() literals
+ * appear in this module.
+ * Motion uses --motion-duration-* / --motion-ease-* only.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import { pick, styleRule, stylesheet, tokenVar } from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export type AvatarSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+// ============================================================================
+// Allowed Value Sets (for validation / fallback)
+// ============================================================================
+
+export const AVATAR_SIZES: ReadonlyArray<AvatarSize> = ['xs', 'sm', 'md', 'lg', 'xl'];
+
+export function isAvatarSize(value: unknown): value is AvatarSize {
+  return typeof value === 'string' && (AVATAR_SIZES as ReadonlyArray<string>).includes(value);
+}
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+/**
+ * Base avatar declarations shared across every size.
+ * Mirrors avatarBaseClasses from avatar.classes.ts: relative flex shrink-0
+ * overflow-hidden rounded-full.
+ */
+export const avatarBase: CSSProperties = {
+  display: 'inline-flex',
+  'align-items': 'center',
+  'justify-content': 'center',
+  'flex-shrink': '0',
+  overflow: 'hidden',
+  'border-radius': '9999px',
+  'background-color': tokenVar('color-muted'),
+  color: tokenVar('color-muted-foreground'),
+};
+
+// ============================================================================
+// Size Styles
+// ============================================================================
+
+/**
+ * Size declarations map explicit square dimensions (height === width) plus
+ * per-size font-size tokens. Mirrors avatarSizeClasses from avatar.classes.ts.
+ *
+ *   xs: h-6 w-6 text-xs    -> spacing-6  + font-size-label-small
+ *   sm: h-8 w-8 text-sm    -> spacing-8  + font-size-label-small
+ *   md: h-10 w-10 text-base -> spacing-10 + font-size-label-medium
+ *   lg: h-12 w-12 text-lg   -> spacing-12 + font-size-label-large
+ *   xl: h-16 w-16 text-xl   -> spacing-16 + font-size-title-medium
+ */
+export const avatarSizeStyles: Record<AvatarSize, CSSProperties> = {
+  xs: {
+    height: tokenVar('spacing-6'),
+    width: tokenVar('spacing-6'),
+    'font-size': tokenVar('font-size-label-small'),
+  },
+  sm: {
+    height: tokenVar('spacing-8'),
+    width: tokenVar('spacing-8'),
+    'font-size': tokenVar('font-size-label-small'),
+  },
+  md: {
+    height: tokenVar('spacing-10'),
+    width: tokenVar('spacing-10'),
+    'font-size': tokenVar('font-size-label-medium'),
+  },
+  lg: {
+    height: tokenVar('spacing-12'),
+    width: tokenVar('spacing-12'),
+    'font-size': tokenVar('font-size-label-large'),
+  },
+  xl: {
+    height: tokenVar('spacing-16'),
+    width: tokenVar('spacing-16'),
+    'font-size': tokenVar('font-size-title-medium'),
+  },
+};
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+export interface AvatarStylesheetOptions {
+  size?: AvatarSize | undefined;
+}
+
+/**
+ * Build the complete avatar stylesheet for a given configuration.
+ *
+ * Unknown size keys fall back to 'md' via pick(). Never throws.
+ */
+export function avatarStylesheet(options: AvatarStylesheetOptions = {}): string {
+  const { size } = options;
+
+  return stylesheet(
+    styleRule(':host', { display: 'inline-flex' }),
+
+    styleRule('.avatar', avatarBase, pick(avatarSizeStyles, size, 'md')),
+  );
+}


### PR DESCRIPTION
## Summary

Adds the `<rafters-avatar>` custom element as the Web Component framework target for avatar, parallel to `avatar.tsx` (React) and `avatar.astro` (Astro). Ships `avatar.element.ts` alongside a new `avatar.styles.ts` that exports the `AvatarSize` union and an `avatarStylesheet({ size })` composer.

Scopes to the OUTER `<rafters-avatar>` container only. The inner `<rafters-avatar-image>` and `<rafters-avatar-fallback>` subcomponents require image-load status coordination across the pair and are deferred to a follow-up issue.

## Contract

- Auto-register on import, idempotent via `customElements.get` guard
- `observedAttributes`: `['size']`
- `size` parsed against `AvatarSize` (`xs | sm | md | lg | xl`); unknown values fall back to `'md'` silently and never throw
- `render()` returns `<span class="avatar"><slot></slot></span>` using DOM APIs only; never `innerHTML`
- Per-instance CSSStyleSheet: `connectedCallback` creates one sheet, `replaceSync(avatarStylesheet({ size }))`; `attributeChangedCallback` `replaceSync`-es the same sheet
- All token references resolve via `tokenVar()` in `avatar.styles.ts`; no raw `var()` literal appears in `avatar.element.ts`
- Motion namespace kept: only `--motion-duration-*` / `--motion-ease-*` (avatar styles use no motion, leaving the door open for future size transitions)

## Token Mapping

| Size | Dimension | Font size |
|------|-----------|-----------|
| xs   | `spacing-6`  | `font-size-label-small`  |
| sm   | `spacing-8`  | `font-size-label-small`  |
| md   | `spacing-10` | `font-size-label-medium` |
| lg   | `spacing-12` | `font-size-label-large`  |
| xl   | `spacing-16` | `font-size-title-medium` |

Parallels the Tailwind `h-* w-* text-*` classes in `avatar.classes.ts`.

## Test plan

- [x] Registers the `rafters-avatar` tag on import
- [x] Double-import is idempotent (no redefine throw)
- [x] Shadow DOM shape: single `span.avatar` containing exactly one `<slot>`
- [x] Unknown `size` values fall back to `md` (adopted CSS contains `spacing-10`)
- [x] Attribute change reflects to the adopted stylesheet (xl -> `spacing-16`)
- [x] Source contains no direct `var()` references in `avatar.element.ts`
- [x] `pnpm typecheck` clean
- [x] `pnpm --filter=@rafters/ui test avatar` all passing (43 tests: 37 React + 6 WC)
- [x] `pnpm preflight` clean

Closes #1321