### PR TITLE
feat(ui): <rafters-kbd> Web Component (#1325)

### DIFF
--- a/packages/ui/src/components/ui/kbd.element.test.ts
+++ b/packages/ui/src/components/ui/kbd.element.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import './kbd.element';
+import { RaftersKbd } from './kbd.element';
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+function mount(): HTMLElement {
+  const el = document.createElement('rafters-kbd');
+  document.body.appendChild(el);
+  return el;
+}
+
+function collectCss(el: HTMLElement): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  return sheets
+    .map((s) =>
+      Array.from(s.cssRules)
+        .map((r) => r.cssText)
+        .join('\n'),
+    )
+    .join('\n');
+}
+
+describe('<rafters-kbd>', () => {
+  it('registers the rafters-kbd tag on import', () => {
+    expect(customElements.get('rafters-kbd')).toBe(RaftersKbd);
+  });
+
+  it('does not throw when the module is imported twice', async () => {
+    await expect(import('./kbd.element')).resolves.toBeDefined();
+    await expect(import('./kbd.element')).resolves.toBeDefined();
+    expect(customElements.get('rafters-kbd')).toBe(RaftersKbd);
+  });
+
+  it('renders a single kbd.kbd containing a slot', () => {
+    const el = mount();
+    const inner = el.shadowRoot?.querySelector('kbd.kbd');
+    expect(inner).not.toBeNull();
+    expect(inner?.tagName.toLowerCase()).toBe('kbd');
+    expect(inner?.children.length).toBe(1);
+    expect(inner?.firstElementChild?.tagName.toLowerCase()).toBe('slot');
+  });
+
+  it('adopts the kbd stylesheet on connect', () => {
+    const el = mount();
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    expect(sheets.length).toBeGreaterThanOrEqual(1);
+    const css = collectCss(el);
+    expect(css).toMatch(/\.kbd\s*\{/);
+  });
+
+  it('observedAttributes is empty', () => {
+    expect(RaftersKbd.observedAttributes).toEqual([]);
+  });
+
+  it('source contains no direct var() references', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const source = await fs.readFile(path.resolve(__dirname, 'kbd.element.ts'), 'utf-8');
+    expect(source).not.toMatch(/[^a-zA-Z_]var\(/);
+  });
+});

--- a/packages/ui/src/components/ui/kbd.element.ts
+++ b/packages/ui/src/components/ui/kbd.element.ts
@@ -1,0 +1,55 @@
+/**
+ * <rafters-kbd> -- Web Component keyboard key indicator primitive.
+ *
+ * Framework-target for the Kbd component, parallel to kbd.tsx (React)
+ * and kbd.astro (Astro). Consumes kbdStylesheet() from kbd.styles.ts
+ * to guarantee visual parity across framework targets.
+ *
+ * Shadow DOM structure:
+ *   <kbd class="kbd"><slot></slot></kbd>
+ *
+ * No attributes -- the React target has no variants or sizes either.
+ *
+ * @cognitive-load 1/10 Simple visual indicator, no interaction required.
+ * @accessibility Semantic <kbd> element preserved in the shadow root.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import { kbdStylesheet } from './kbd.styles';
+
+export class RaftersKbd extends RaftersElement {
+  static readonly observedAttributes: ReadonlyArray<string> = [];
+
+  /** Per-instance stylesheet owned by this element. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  override connectedCallback(): void {
+    if (!this.shadowRoot) return;
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(kbdStylesheet());
+    this.shadowRoot.adoptedStyleSheets = [this._instanceSheet];
+    this.update();
+  }
+
+  override disconnectedCallback(): void {
+    this._instanceSheet = null;
+  }
+
+  /**
+   * Render a single semantic <kbd> with a default <slot>.
+   * DOM APIs only -- never innerHTML. The inner kbd carries only the
+   * `.kbd` class so visual state comes exclusively from the per-instance
+   * stylesheet.
+   */
+  override render(): Node {
+    const inner = document.createElement('kbd');
+    inner.className = 'kbd';
+    const slot = document.createElement('slot');
+    inner.appendChild(slot);
+    return inner;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-kbd')) {
+  customElements.define('rafters-kbd', RaftersKbd);
+}

--- a/packages/ui/src/components/ui/kbd.styles.ts
+++ b/packages/ui/src/components/ui/kbd.styles.ts
@@ -1,0 +1,58 @@
+/**
+ * Shadow DOM style definitions for Kbd web component
+ *
+ * Parallel to kbd.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ * Token values via var() from the shared token stylesheet.
+ *
+ * All token references go through tokenVar(); no raw var() literals.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import { styleRule, stylesheet, tokenVar } from '../../primitives/classy-wc';
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+/**
+ * Base kbd declarations mirror kbdBaseClasses from kbd.classes.ts:
+ *  inline-flex items-center justify-center rounded border border-border
+ *  bg-muted px-1.5 py-0.5 text-code-small text-muted-foreground shadow-sm
+ */
+export const kbdBase: CSSProperties = {
+  display: 'inline-flex',
+  'align-items': 'center',
+  'justify-content': 'center',
+  'border-radius': tokenVar('radius-sm'),
+  'border-width': '1px',
+  'border-style': 'solid',
+  'border-color': tokenVar('color-border'),
+  'background-color': tokenVar('color-muted'),
+  'padding-left': '0.375rem',
+  'padding-right': '0.375rem',
+  'padding-top': '0.125rem',
+  'padding-bottom': '0.125rem',
+  'font-family': tokenVar('font-code-small-family'),
+  'font-size': tokenVar('font-code-small-size'),
+  'font-weight': tokenVar('font-code-small-weight'),
+  'line-height': tokenVar('font-code-small-line-height'),
+  'letter-spacing': tokenVar('font-code-small-letter-spacing'),
+  color: tokenVar('color-muted-foreground'),
+  'box-shadow': tokenVar('shadow-sm'),
+};
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+/**
+ * Build the complete kbd stylesheet.
+ *
+ * Kbd has no variants or sizes -- the React target has none either.
+ * Emits two rules: a :host rule that makes the host inline-flex,
+ * and a .kbd rule that applies the visual styling.
+ */
+export function kbdStylesheet(): string {
+  return stylesheet(styleRule(':host', { display: 'inline-flex' }), styleRule('.kbd', kbdBase));
+}


### PR DESCRIPTION
## Summary

- Ships `<rafters-kbd>` Web Component parallel to `kbd.tsx` (React) and `kbd.astro` (Astro).
- Introduces `kbd.styles.ts` (authored here; it did not previously exist) exporting `kbdStylesheet()` and `kbdBase` -- all token references go through `tokenVar()`, no raw `var()` literals.
- `kbd.element.ts` auto-registers the tag idempotently via the `customElements.get` guard, uses the per-instance `CSSStyleSheet` + `replaceSync` pattern from `button.element.ts`, and renders a single `<kbd class="kbd"><slot></slot></kbd>` using DOM APIs only.

## Implementation notes

- `observedAttributes` is empty -- Kbd has no variants or sizes in the React target, so the WC matches.
- Per-instance sheet pattern: `connectedCallback` constructs one `CSSStyleSheet`, `replaceSync`s `kbdStylesheet()`, and assigns `shadowRoot.adoptedStyleSheets = [sheet]`. `disconnectedCallback` nulls the reference.
- Styles mirror `kbdBaseClasses` semantics: inline-flex, centered, `radius-sm` corners, 1px `color-border`, `color-muted` background, 0.375rem/0.125rem padding pairs, `font-code-small-*` composite tokens, `color-muted-foreground` text, `shadow-sm`.
- No barrel re-exports; no React or Astro changes.

## Test plan

- [x] `registers the rafters-kbd tag on import`
- [x] `does not throw when the module is imported twice`
- [x] `renders a single kbd.kbd containing a slot` (shadow DOM shape)
- [x] `adopts the kbd stylesheet on connect` (assertion against `adoptedStyleSheets`)
- [x] `observedAttributes is empty`
- [x] `source contains no direct var() references`
- [x] `pnpm --filter=@rafters/ui typecheck` clean
- [x] `pnpm --filter=@rafters/ui test` -- 4116 passed, 3 skipped
- [x] `pnpm preflight` green (typecheck + lint + test:unit + test:a11y 662 passed + build)

Closes #1325