### PR TITLE
feat(ui): <rafters-label> Web Component (#1326)

### DIFF
--- a/packages/ui/src/components/ui/label.element.test.ts
+++ b/packages/ui/src/components/ui/label.element.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import './label.element';
+import { RaftersLabel } from './label.element';
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+function adoptedCssText(el: Element): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  const blocks: string[] = [];
+  for (const sheet of sheets) {
+    const rules: string[] = [];
+    for (const rule of Array.from(sheet.cssRules)) {
+      rules.push(rule.cssText);
+    }
+    blocks.push(rules.join('\n'));
+  }
+  return blocks.join('\n');
+}
+
+describe('<rafters-label>', () => {
+  it('registers the rafters-label tag on import', () => {
+    expect(customElements.get('rafters-label')).toBe(RaftersLabel);
+  });
+
+  it('does not throw when the module is imported twice', async () => {
+    await expect(import('./label.element')).resolves.toBeDefined();
+    await expect(import('./label.element')).resolves.toBeDefined();
+    expect(customElements.get('rafters-label')).toBe(RaftersLabel);
+  });
+
+  it('renders a single label.label containing a slot', () => {
+    const el = document.createElement('rafters-label');
+    document.body.appendChild(el);
+    const inner = el.shadowRoot?.querySelector('label.label');
+    expect(inner).not.toBeNull();
+    expect(inner?.tagName.toLowerCase()).toBe('label');
+    expect(inner?.children.length).toBe(1);
+    expect(inner?.firstElementChild?.tagName.toLowerCase()).toBe('slot');
+  });
+
+  it('falls back to default variant for unknown values', () => {
+    const el = document.createElement('rafters-label');
+    el.setAttribute('variant', 'nonsense');
+    document.body.appendChild(el);
+    const defaultEl = document.createElement('rafters-label');
+    document.body.appendChild(defaultEl);
+    expect(adoptedCssText(el)).toBe(adoptedCssText(defaultEl));
+    expect(adoptedCssText(el)).toContain('color-foreground');
+  });
+
+  it('reflects variant attribute changes to the adopted stylesheet', () => {
+    const el = document.createElement('rafters-label');
+    document.body.appendChild(el);
+    el.setAttribute('variant', 'destructive');
+    expect(adoptedCssText(el)).toContain('color-destructive');
+  });
+
+  it('forwards the for attribute to the inner label element', () => {
+    const el = document.createElement('rafters-label');
+    el.setAttribute('for', 'email');
+    document.body.appendChild(el);
+    const inner = el.shadowRoot?.querySelector('label.label');
+    expect(inner?.getAttribute('for')).toBe('email');
+  });
+
+  it('updates the inner for attribute when the host attribute changes', () => {
+    const el = document.createElement('rafters-label');
+    document.body.appendChild(el);
+    const inner = el.shadowRoot?.querySelector('label.label');
+    expect(inner?.getAttribute('for')).toBeNull();
+    el.setAttribute('for', 'email');
+    expect(inner?.getAttribute('for')).toBe('email');
+    el.removeAttribute('for');
+    expect(inner?.getAttribute('for')).toBeNull();
+  });
+
+  it('source contains no direct var() references', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const source = await fs.readFile(path.resolve(__dirname, 'label.element.ts'), 'utf-8');
+    expect(source).not.toMatch(/var\(/);
+  });
+
+  it('observedAttributes matches the documented contract', () => {
+    expect(RaftersLabel.observedAttributes).toEqual(['variant', 'for']);
+  });
+});

--- a/packages/ui/src/components/ui/label.element.ts
+++ b/packages/ui/src/components/ui/label.element.ts
@@ -1,0 +1,130 @@
+/**
+ * <rafters-label> -- Web Component form label primitive.
+ *
+ * Mirrors the semantics of label.tsx (variant, htmlFor) using shadow-DOM-scoped
+ * CSS composed via classy-wc. Auto-registers on import and is idempotent
+ * against double-define.
+ *
+ * Attributes:
+ *  - variant: 'default' | 'primary' | 'secondary' | 'destructive' | 'success'
+ *             | 'warning' | 'info' | 'muted' | 'accent'   (default 'default')
+ *  - for:     string -- forwarded to the inner <label>'s `for` attribute so
+ *             consumers in the light tree can associate the label with a
+ *             control via id reference.
+ *
+ * The inner <label> carries only `.label` as its className -- NO Tailwind
+ * classes. Styling comes exclusively from labelStylesheet(...) adopted as
+ * the per-instance stylesheet.
+ *
+ * NOTE: The Tailwind `peer-disabled:` utilities from label.classes.ts are
+ * intentionally not replicated inside the shadow root. Those selectors
+ * depend on a sibling <input> in the light tree and the shadow boundary
+ * breaks that targeting. Consumers must mirror disabled/required state on
+ * the <rafters-label> host or outside the shadow root.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import { type LabelVariant, labelStylesheet } from './label.styles';
+
+const ALLOWED_VARIANTS: ReadonlyArray<LabelVariant> = [
+  'default',
+  'primary',
+  'secondary',
+  'destructive',
+  'success',
+  'warning',
+  'info',
+  'muted',
+  'accent',
+];
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = ['variant', 'for'] as const;
+
+function parseVariant(value: string | null): LabelVariant {
+  if (value && (ALLOWED_VARIANTS as ReadonlyArray<string>).includes(value)) {
+    return value as LabelVariant;
+  }
+  return 'default';
+}
+
+export class RaftersLabel extends RaftersElement {
+  static observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  /** Per-instance stylesheet rebuilt on every variant change. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  override connectedCallback(): void {
+    if (!this.shadowRoot) return;
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+    this.shadowRoot.adoptedStyleSheets = [this._instanceSheet];
+    this.update();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+    if (name === 'variant' && this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+    if (name === 'for') {
+      this.syncForAttribute();
+      return;
+    }
+    this.update();
+  }
+
+  override disconnectedCallback(): void {
+    this._instanceSheet = null;
+  }
+
+  /**
+   * Build the CSS string for the current attribute values.
+   */
+  private composeCss(): string {
+    return labelStylesheet({
+      variant: parseVariant(this.getAttribute('variant')),
+    });
+  }
+
+  /**
+   * Forward the host's `for` attribute to the inner <label> without
+   * re-rendering the DOM tree. When the attribute is absent, clear it on
+   * the inner element.
+   */
+  private syncForAttribute(): void {
+    const inner = this.shadowRoot?.querySelector('label.label');
+    if (!inner) return;
+    const forValue = this.getAttribute('for');
+    if (forValue === null) {
+      inner.removeAttribute('for');
+    } else {
+      inner.setAttribute('for', forValue);
+    }
+  }
+
+  /**
+   * Render the inner semantic <label> with a single default <slot>.
+   * DOM APIs only -- never innerHTML. The inner label carries only the
+   * `.label` class so visual state comes exclusively from the per-instance
+   * stylesheet.
+   */
+  override render(): Node {
+    const inner = document.createElement('label');
+    inner.className = 'label';
+    const forValue = this.getAttribute('for');
+    if (forValue !== null) {
+      inner.setAttribute('for', forValue);
+    }
+    const slot = document.createElement('slot');
+    inner.appendChild(slot);
+    return inner;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-label')) {
+  customElements.define('rafters-label', RaftersLabel);
+}

--- a/packages/ui/src/components/ui/label.styles.ts
+++ b/packages/ui/src/components/ui/label.styles.ts
@@ -1,0 +1,113 @@
+/**
+ * Shadow DOM style definitions for Label web component
+ *
+ * Parallel to label.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ * Token values via tokenVar() from the shared token stylesheet.
+ *
+ * All token references go through tokenVar(); no raw var() literals.
+ *
+ * NOTE: Tailwind's `peer-disabled:` pseudo-selectors from label.classes.ts
+ * intentionally do NOT appear here. Those selectors depend on a sibling
+ * <input> in the light tree; the shadow boundary breaks that association.
+ * Consumers are responsible for reflecting disabled/required state outside
+ * the shadow root.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import { pick, styleRule, stylesheet, tokenVar } from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export type LabelVariant =
+  | 'default'
+  | 'primary'
+  | 'secondary'
+  | 'destructive'
+  | 'success'
+  | 'warning'
+  | 'info'
+  | 'muted'
+  | 'accent';
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+/**
+ * Base label declarations shared across every variant.
+ * Mirrors labelBaseClasses from label.classes.ts:
+ *   - text-label-medium        -> font-size: var(--font-size-label-medium)
+ *   - leading-none             -> line-height: 1
+ *
+ * The Tailwind `peer-disabled:` utilities are intentionally omitted; see the
+ * file header for the rationale.
+ */
+export const labelBase: CSSProperties = {
+  'font-size': tokenVar('font-size-label-medium'),
+  'line-height': '1',
+};
+
+// ============================================================================
+// Variant Styles
+// ============================================================================
+
+/**
+ * Per-variant foreground colour, mirroring labelVariantClasses.
+ * `muted` intentionally uses `color-muted-foreground` to match Tailwind's
+ * `text-muted-foreground` utility.
+ */
+export const labelVariantStyles: Record<LabelVariant, CSSProperties> = {
+  default: {
+    color: tokenVar('color-foreground'),
+  },
+  primary: {
+    color: tokenVar('color-primary'),
+  },
+  secondary: {
+    color: tokenVar('color-secondary'),
+  },
+  destructive: {
+    color: tokenVar('color-destructive'),
+  },
+  success: {
+    color: tokenVar('color-success'),
+  },
+  warning: {
+    color: tokenVar('color-warning'),
+  },
+  info: {
+    color: tokenVar('color-info'),
+  },
+  muted: {
+    color: tokenVar('color-muted-foreground'),
+  },
+  accent: {
+    color: tokenVar('color-accent'),
+  },
+};
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+export interface LabelStylesheetOptions {
+  variant?: LabelVariant | undefined;
+}
+
+/**
+ * Build the complete label stylesheet for a given configuration.
+ *
+ * Unknown variant keys fall back to 'default' via pick(). Never throws.
+ */
+export function labelStylesheet(options: LabelStylesheetOptions = {}): string {
+  const { variant } = options;
+
+  return stylesheet(
+    styleRule(':host', { display: 'inline-block' }),
+
+    styleRule('.label', labelBase, pick(labelVariantStyles, variant, 'default')),
+  );
+}


### PR DESCRIPTION
## Summary

Adds `<rafters-label>` as the Web Component framework target for the form label, parallel to `label.tsx` (React) and `label.astro` (Astro). Ships `label.element.ts` alongside a new `label.styles.ts` mapping `label.classes.ts` variants to CSS property maps composed via `classy-wc`.

- `RaftersLabel` extends `RaftersElement` with a per-instance `CSSStyleSheet` rebuilt on variant change via `replaceSync` on the same sheet.
- `observedAttributes = ['variant', 'for']`. Unknown variant values fall back to `default` silently.
- The `for` attribute is forwarded to the inner `<label>` so consumers preserve form-control association across the shadow boundary.
- Inner `<label class="label"><slot></slot>` built via DOM APIs; never `innerHTML`.
- Token references only via `tokenVar()`; no raw `var()` literals in the element source.
- Auto-registers on import, idempotent via `customElements.get`.
- Tailwind `peer-disabled:` utilities are intentionally not replicated inside the shadow root; documented in both files (the shadow boundary breaks `peer` targeting; consumers must mirror disabled/required state outside the shadow root).

Closes #1326

## Test plan

- [x] `pnpm --filter=@rafters/ui test label.element` -- 9 tests pass
- [x] `pnpm typecheck` clean
- [x] `pnpm preflight` clean (typecheck, biome lint, 4125 UI unit tests, 662 a11y tests, builds)
- [x] Source free of direct `var()` literals (asserted by test)
- [x] Source free of `--duration-*` / `--ease-*` (motion uses `tokenVar`-only composition; label does not reference motion tokens)