### PR TITLE
feat(ui): <rafters-item> Web Component (#1324)

### DIFF
--- a/packages/ui/src/components/ui/item.element.test.ts
+++ b/packages/ui/src/components/ui/item.element.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import './item.element';
+import { RaftersItem } from './item.element';
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+function mount(attrs: Record<string, string> = {}): HTMLElement {
+  const el = document.createElement('rafters-item');
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.appendChild(el);
+  return el;
+}
+
+function adoptedCssText(el: Element): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  const blocks: string[] = [];
+  for (const sheet of sheets) {
+    const rules: string[] = [];
+    for (const rule of Array.from(sheet.cssRules)) {
+      rules.push(rule.cssText);
+    }
+    blocks.push(rules.join('\n'));
+  }
+  return blocks.join('\n');
+}
+
+describe('<rafters-item>', () => {
+  it('registers the rafters-item tag on import', () => {
+    expect(customElements.get('rafters-item')).toBe(RaftersItem);
+  });
+
+  it('does not throw when the module is imported twice', async () => {
+    await expect(import('./item.element')).resolves.toBeDefined();
+    await expect(import('./item.element')).resolves.toBeDefined();
+    expect(customElements.get('rafters-item')).toBe(RaftersItem);
+  });
+
+  it('renders a div.item[role=option] with icon + default + description slots', () => {
+    const el = mount();
+    const inner = el.shadowRoot?.querySelector('div.item');
+    expect(inner).not.toBeNull();
+    expect(inner?.getAttribute('role')).toBe('option');
+    const slots = Array.from(el.shadowRoot?.querySelectorAll('slot') ?? []);
+    const slotNames = slots.map((s) => s.getAttribute('name'));
+    expect(slotNames).toContain('icon');
+    expect(slotNames).toContain('description');
+    expect(slotNames).toContain(null);
+  });
+
+  it('falls back to default size for unknown values', () => {
+    const el = mount({ size: 'huge' });
+    expect(adoptedCssText(el)).toContain('font-size-body-small');
+  });
+
+  it('reflects selected attribute to aria-selected and data-selected on inner div', () => {
+    const el = mount();
+    el.setAttribute('selected', '');
+    const inner = el.shadowRoot?.querySelector('div.item');
+    expect(inner?.getAttribute('aria-selected')).toBe('true');
+    expect(inner?.hasAttribute('data-selected')).toBe(true);
+  });
+
+  it('reflects disabled attribute to aria-disabled, data-disabled, and tabIndex -1', () => {
+    const el = mount();
+    el.setAttribute('disabled', '');
+    const inner = el.shadowRoot?.querySelector('div.item');
+    expect(inner?.getAttribute('aria-disabled')).toBe('true');
+    expect(inner?.hasAttribute('data-disabled')).toBe(true);
+    expect((inner as HTMLElement | null)?.tabIndex).toBe(-1);
+  });
+
+  it('source contains no direct var() references', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const source = await fs.readFile(path.resolve(__dirname, 'item.element.ts'), 'utf-8');
+    expect(source).not.toMatch(/[^a-zA-Z_]var\(/);
+  });
+
+  it('observedAttributes matches the documented contract', () => {
+    expect(RaftersItem.observedAttributes).toEqual(['size', 'selected', 'disabled']);
+  });
+
+  it('sets aria-selected="false" and tabIndex=0 by default', () => {
+    const el = mount();
+    const inner = el.shadowRoot?.querySelector('div.item');
+    expect(inner?.getAttribute('aria-selected')).toBe('false');
+    expect((inner as HTMLElement | null)?.tabIndex).toBe(0);
+    expect(inner?.hasAttribute('aria-disabled')).toBe(false);
+    expect(inner?.hasAttribute('data-selected')).toBe(false);
+    expect(inner?.hasAttribute('data-disabled')).toBe(false);
+  });
+
+  it('re-resolves adopted stylesheet when size attribute changes', () => {
+    const el = mount();
+    el.setAttribute('size', 'lg');
+    expect(adoptedCssText(el)).toContain('font-size-body-medium');
+    el.setAttribute('size', 'sm');
+    expect(adoptedCssText(el)).toContain('font-size-label-small');
+  });
+
+  it('removes data-selected when selected attribute is removed', () => {
+    const el = mount({ selected: '' });
+    let inner = el.shadowRoot?.querySelector('div.item');
+    expect(inner?.hasAttribute('data-selected')).toBe(true);
+    el.removeAttribute('selected');
+    inner = el.shadowRoot?.querySelector('div.item');
+    expect(inner?.hasAttribute('data-selected')).toBe(false);
+    expect(inner?.getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('removes data-disabled and restores tabIndex=0 when disabled is removed', () => {
+    const el = mount({ disabled: '' });
+    let inner = el.shadowRoot?.querySelector('div.item');
+    expect((inner as HTMLElement | null)?.tabIndex).toBe(-1);
+    el.removeAttribute('disabled');
+    inner = el.shadowRoot?.querySelector('div.item');
+    expect((inner as HTMLElement | null)?.tabIndex).toBe(0);
+    expect(inner?.hasAttribute('aria-disabled')).toBe(false);
+    expect(inner?.hasAttribute('data-disabled')).toBe(false);
+  });
+
+  it('shadow root adopts the per-instance stylesheet', () => {
+    const el = mount();
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    expect(sheets.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('stylesheet uses only --motion-duration / --motion-ease tokens', () => {
+    const el = mount();
+    const css = adoptedCssText(el);
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+  });
+});

--- a/packages/ui/src/components/ui/item.element.ts
+++ b/packages/ui/src/components/ui/item.element.ts
@@ -1,0 +1,147 @@
+/**
+ * <rafters-item> -- Web Component list/menu item primitive.
+ *
+ * Mirrors the semantics of item.tsx (size, selected, disabled) using
+ * shadow-DOM-scoped CSS composed via classy-wc. Auto-registers on import
+ * and is idempotent against double-define.
+ *
+ * Attributes:
+ *  - size:     'default' | 'sm' | 'lg'  (default 'default')
+ *  - selected: boolean (presence-based)
+ *  - disabled: boolean (presence-based)
+ *
+ * Shadow DOM structure:
+ *   <div class="item" role="option" ...>
+ *     <span class="item-icon" aria-hidden="true">
+ *       <slot name="icon"></slot>
+ *     </span>
+ *     <span class="item-content">
+ *       <span class="item-label"><slot></slot></span>
+ *       <span class="item-description"><slot name="description"></slot></span>
+ *     </span>
+ *   </div>
+ *
+ * The inner <div> mirrors the React `tabIndex` / `aria-selected` /
+ * `aria-disabled` / `data-selected` / `data-disabled` semantics from
+ * item.tsx and is rebuilt on every attribute change.
+ *
+ * Click and keyboard activation of slotted interactive content is the
+ * consumer's responsibility -- this element is a visual and semantic
+ * primitive only.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import { type ItemSize, itemStylesheet } from './item.styles';
+
+const ALLOWED_SIZES: ReadonlyArray<ItemSize> = ['default', 'sm', 'lg'];
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = ['size', 'selected', 'disabled'] as const;
+
+function parseSize(value: string | null): ItemSize {
+  if (value && (ALLOWED_SIZES as ReadonlyArray<string>).includes(value)) {
+    return value as ItemSize;
+  }
+  return 'default';
+}
+
+export class RaftersItem extends RaftersElement {
+  static readonly observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  /** Per-instance stylesheet rebuilt on every attribute change. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  override connectedCallback(): void {
+    if (!this.shadowRoot) return;
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+    this.shadowRoot.adoptedStyleSheets = [this._instanceSheet];
+    this.update();
+  }
+
+  override attributeChangedCallback(
+    _name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+    if (this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+    this.update();
+  }
+
+  override disconnectedCallback(): void {
+    this._instanceSheet = null;
+  }
+
+  /**
+   * Build the CSS string for the current attribute values.
+   */
+  private composeCss(): string {
+    return itemStylesheet({
+      size: parseSize(this.getAttribute('size')),
+      selected: this.hasAttribute('selected'),
+      disabled: this.hasAttribute('disabled'),
+    });
+  }
+
+  /**
+   * Render the inner semantic <div role="option"> with three slots:
+   * a named `icon` slot, the default (label) slot, and a named
+   * `description` slot. DOM APIs only -- never innerHTML.
+   *
+   * tabIndex / aria-* / data-* attributes mirror the React semantics
+   * of item.tsx and are re-applied on every attributeChangedCallback
+   * because update() calls render() to replace shadow children.
+   */
+  override render(): Node {
+    const selected = this.hasAttribute('selected');
+    const disabled = this.hasAttribute('disabled');
+
+    const inner = document.createElement('div');
+    inner.className = 'item';
+    inner.setAttribute('role', 'option');
+    inner.tabIndex = disabled ? -1 : 0;
+    inner.setAttribute('aria-selected', String(selected));
+    if (disabled) {
+      inner.setAttribute('aria-disabled', 'true');
+      inner.setAttribute('data-disabled', '');
+    }
+    if (selected) {
+      inner.setAttribute('data-selected', '');
+    }
+
+    const iconWrap = document.createElement('span');
+    iconWrap.className = 'item-icon';
+    iconWrap.setAttribute('aria-hidden', 'true');
+    const iconSlot = document.createElement('slot');
+    iconSlot.setAttribute('name', 'icon');
+    iconWrap.appendChild(iconSlot);
+
+    const content = document.createElement('span');
+    content.className = 'item-content';
+
+    const labelWrap = document.createElement('span');
+    labelWrap.className = 'item-label';
+    const labelSlot = document.createElement('slot');
+    labelWrap.appendChild(labelSlot);
+
+    const descWrap = document.createElement('span');
+    descWrap.className = 'item-description';
+    const descSlot = document.createElement('slot');
+    descSlot.setAttribute('name', 'description');
+    descWrap.appendChild(descSlot);
+
+    content.appendChild(labelWrap);
+    content.appendChild(descWrap);
+
+    inner.appendChild(iconWrap);
+    inner.appendChild(content);
+
+    return inner;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-item')) {
+  customElements.define('rafters-item', RaftersItem);
+}

--- a/packages/ui/src/components/ui/item.styles.ts
+++ b/packages/ui/src/components/ui/item.styles.ts
@@ -1,0 +1,212 @@
+/**
+ * Shadow DOM style definitions for Item web component
+ *
+ * Parallel to item.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ * Token values via var() from the shared token stylesheet.
+ *
+ * All token references go through tokenVar(); no raw var() literals.
+ * Motion uses --motion-duration-* / --motion-ease-* only.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import {
+  atRule,
+  pick,
+  styleRule,
+  stylesheet,
+  tokenVar,
+  transition,
+  when,
+} from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export type ItemSize = 'default' | 'sm' | 'lg';
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+/**
+ * Base item declarations shared across every size.
+ * Mirrors itemBaseClasses from item.classes.ts.
+ */
+export const itemBase: CSSProperties = {
+  display: 'flex',
+  'align-items': 'center',
+  gap: '0.75rem',
+  'border-radius': tokenVar('radius-md'),
+  cursor: 'default',
+  'user-select': 'none',
+  outline: 'none',
+  'background-color': 'transparent',
+  color: tokenVar('color-foreground'),
+  transition: transition(
+    ['background-color', 'color'],
+    tokenVar('motion-duration-fast'),
+    tokenVar('motion-ease-standard'),
+  ),
+};
+
+/**
+ * Hover-state declarations applied when neither selected nor disabled.
+ */
+export const itemHover: CSSProperties = {
+  'background-color': tokenVar('color-accent'),
+  color: tokenVar('color-accent-foreground'),
+};
+
+/**
+ * Selected-state declarations. Applied to the inner .item element when the
+ * host carries the `selected` attribute.
+ */
+export const itemSelected: CSSProperties = {
+  'background-color': tokenVar('color-accent'),
+  color: tokenVar('color-accent-foreground'),
+};
+
+/**
+ * Disabled-state declarations. Applied to the inner .item element when the
+ * host carries the `disabled` attribute.
+ */
+export const itemDisabled: CSSProperties = {
+  opacity: '0.5',
+  'pointer-events': 'none',
+  color: tokenVar('color-muted-foreground'),
+};
+
+/**
+ * Focus-visible ring declarations for keyboard navigation. Uses accent
+ * background plus a double-ring box-shadow for visibility on any surface.
+ */
+export const itemFocusVisible: CSSProperties = {
+  'background-color': tokenVar('color-accent'),
+  color: tokenVar('color-accent-foreground'),
+  outline: 'none',
+  'box-shadow': `0 0 0 1px ${tokenVar('color-background')}, 0 0 0 3px ${tokenVar('color-ring')}`,
+};
+
+// ============================================================================
+// Size Styles
+// ============================================================================
+
+/**
+ * Size declarations map per-size padding pairs and font-size tokens.
+ * Mirrors itemSizeClasses from item.classes.ts.
+ */
+export const itemSizeStyles: Record<ItemSize, CSSProperties> = {
+  default: {
+    'padding-left': '0.75rem',
+    'padding-right': '0.75rem',
+    'padding-top': '0.5rem',
+    'padding-bottom': '0.5rem',
+    'font-size': tokenVar('font-size-body-small'),
+  },
+  sm: {
+    'padding-left': '0.5rem',
+    'padding-right': '0.5rem',
+    'padding-top': '0.375rem',
+    'padding-bottom': '0.375rem',
+    'font-size': tokenVar('font-size-label-small'),
+  },
+  lg: {
+    'padding-left': '1rem',
+    'padding-right': '1rem',
+    'padding-top': '0.75rem',
+    'padding-bottom': '0.75rem',
+    'font-size': tokenVar('font-size-body-medium'),
+  },
+};
+
+// ============================================================================
+// Sub-part Styles
+// ============================================================================
+
+/**
+ * Icon slot wrapper -- prevents icon shrink and inherits text color.
+ */
+export const itemIcon: CSSProperties = {
+  'flex-shrink': '0',
+  color: 'currentColor',
+  display: 'inline-flex',
+  'align-items': 'center',
+};
+
+/**
+ * Content wrapper -- stacks label and description vertically.
+ */
+export const itemContent: CSSProperties = {
+  display: 'flex',
+  'flex-direction': 'column',
+  'min-width': '0',
+  flex: '1 1 0%',
+};
+
+/**
+ * Label slot -- truncates overflowing text.
+ */
+export const itemLabel: CSSProperties = {
+  overflow: 'hidden',
+  'text-overflow': 'ellipsis',
+  'white-space': 'nowrap',
+};
+
+/**
+ * Description slot -- muted, smaller text with top spacing.
+ */
+export const itemDescription: CSSProperties = {
+  overflow: 'hidden',
+  'text-overflow': 'ellipsis',
+  'white-space': 'nowrap',
+  color: tokenVar('color-muted-foreground'),
+  'font-size': tokenVar('font-size-label-small'),
+  'margin-top': '0.125rem',
+};
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+export interface ItemStylesheetOptions {
+  size?: ItemSize | undefined;
+  selected?: boolean | undefined;
+  disabled?: boolean | undefined;
+}
+
+/**
+ * Build the complete item stylesheet for a given configuration.
+ *
+ * Unknown size keys fall back to 'default' via pick(). Never throws.
+ * Emits a hover rule scoped to `.item:not([data-selected]):not([data-disabled]):hover`,
+ * a focus-visible ring, selected and disabled state rules, and a
+ * prefers-reduced-motion block that neutralises the transition.
+ */
+export function itemStylesheet(options: ItemStylesheetOptions = {}): string {
+  const { size, selected, disabled } = options;
+
+  return stylesheet(
+    styleRule(':host', { display: 'block' }),
+
+    styleRule(
+      '.item',
+      itemBase,
+      pick(itemSizeStyles, size, 'default'),
+      when(selected, itemSelected),
+      when(disabled, itemDisabled),
+    ),
+
+    styleRule('.item:not([data-selected]):not([data-disabled]):hover', itemHover),
+
+    styleRule('.item:focus-visible', itemFocusVisible),
+
+    styleRule('.item-icon', itemIcon),
+    styleRule('.item-content', itemContent),
+    styleRule('.item-label', itemLabel),
+    styleRule('.item-description', itemDescription),
+
+    atRule('@media (prefers-reduced-motion: reduce)', styleRule('.item', { transition: 'none' })),
+  );
+}


### PR DESCRIPTION
## Summary

Adds the third framework target for the generic list/menu item primitive:
`<rafters-item>` custom element, parallel to `item.tsx` (React) and
`item.astro` (Astro). Ships `item.element.ts` alongside a new
`item.styles.ts` authored in the same commit.

- Attributes: `size` (`default | sm | lg`), presence-based `selected`, presence-based `disabled`.
- Shadow DOM: `<div class="item" role="option">` with `<slot name="icon">`, default slot (label), `<slot name="description">`. DOM APIs only; no `innerHTML`.
- Mirrors `item.tsx` semantics: `tabIndex = disabled ? -1 : 0`, `aria-selected`, `aria-disabled`, `data-selected`, `data-disabled` re-applied on every `attributeChangedCallback`.
- Per-instance `CSSStyleSheet` pattern (matches `button.element.ts`): one sheet created in `connectedCallback`, `replaceSync` on attribute changes.
- Unknown `size` values silently fall back to `'default'`. Never throws.
- Auto-registers `rafters-item`, idempotent via `customElements.get` guard.
- No raw `var()` in the element file; all tokens through `tokenVar()`.
- Motion uses `--motion-duration-*` / `--motion-ease-*` tokens only.

Closes #1324.

## Test plan

- [x] `pnpm --filter=@rafters/ui test item` -- 48 tests across 3 files pass
- [x] `pnpm typecheck` clean across workspace
- [x] `pnpm preflight` clean (typecheck + lint + unit + a11y + build)
- [x] Test file covers: registration, double-import idempotence, shape check, unknown-size fallback, selected attr reflection, disabled attr reflection, no `var()` in source, observedAttributes contract, default aria/tabIndex, attribute toggles, adopted sheet presence, motion namespace discipline