### PR TITLE
feat(ui): <rafters-progress> Web Component (#1327)

### DIFF
--- a/packages/ui/src/components/ui/progress.element.test.ts
+++ b/packages/ui/src/components/ui/progress.element.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import './progress.element';
+import { RaftersProgress } from './progress.element';
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+function mount(attrs: Record<string, string> = {}): HTMLElement {
+  const el = document.createElement('rafters-progress');
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.appendChild(el);
+  return el;
+}
+
+function adoptedCssText(el: Element): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  const blocks: string[] = [];
+  for (const sheet of sheets) {
+    const rules: string[] = [];
+    for (const rule of Array.from(sheet.cssRules)) {
+      rules.push(rule.cssText);
+    }
+    blocks.push(rules.join('\n'));
+  }
+  return blocks.join('\n');
+}
+
+describe('<rafters-progress>', () => {
+  it('registers the rafters-progress tag on import', () => {
+    expect(customElements.get('rafters-progress')).toBe(RaftersProgress);
+  });
+
+  it('does not throw when the module is imported twice', async () => {
+    await expect(import('./progress.element')).resolves.toBeDefined();
+    await expect(import('./progress.element')).resolves.toBeDefined();
+    expect(customElements.get('rafters-progress')).toBe(RaftersProgress);
+  });
+
+  it('renders a div.progress > div.progress-indicator structure', () => {
+    const el = mount();
+    const track = el.shadowRoot?.querySelector('div.progress');
+    expect(track).not.toBeNull();
+    expect(track?.getAttribute('role')).toBe('progressbar');
+    const indicator = track?.querySelector('div.progress-indicator');
+    expect(indicator).not.toBeNull();
+  });
+
+  it('falls back to default variant/size for unknown values', () => {
+    const el = mount({ variant: 'nonsense', size: 'gigantic' });
+    const css = adoptedCssText(el);
+    // default variant = color-primary, default size = 0.5rem track height
+    expect(css).toContain('color-primary');
+    expect(css).toMatch(/height:\s*0\.5rem/);
+  });
+
+  it('reflects value changes to indicator inline width and aria-valuenow', () => {
+    const el = mount();
+    el.setAttribute('value', '33');
+    const indicator = el.shadowRoot?.querySelector('div.progress-indicator');
+    const track = el.shadowRoot?.querySelector('div.progress');
+    expect((indicator as HTMLElement | null)?.style.width).toBe('33%');
+    expect(track?.getAttribute('aria-valuenow')).toBe('33');
+    expect(track?.getAttribute('aria-valuetext')).toBe('33%');
+    expect(el.hasAttribute('aria-busy')).toBe(false);
+  });
+
+  it('falls back to indeterminate when value is absent or non-numeric', () => {
+    const el = mount();
+    expect(el.getAttribute('aria-busy')).toBe('true');
+    const indicator = el.shadowRoot?.querySelector('div.progress-indicator');
+    expect((indicator as HTMLElement | null)?.style.width).toBe('');
+    expect(indicator?.hasAttribute('data-indeterminate')).toBe(true);
+
+    const el2 = mount({ value: 'not-a-number' });
+    expect(el2.getAttribute('aria-busy')).toBe('true');
+    const indicator2 = el2.shadowRoot?.querySelector('div.progress-indicator');
+    expect((indicator2 as HTMLElement | null)?.style.width).toBe('');
+    expect(indicator2?.hasAttribute('data-indeterminate')).toBe(true);
+  });
+
+  it('source contains no direct var() references', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const source = await fs.readFile(path.resolve(__dirname, 'progress.element.ts'), 'utf-8');
+    expect(source).not.toMatch(/[^a-zA-Z_]var\(/);
+  });
+
+  it('observedAttributes matches the documented contract', () => {
+    expect(RaftersProgress.observedAttributes).toEqual(['value', 'max', 'variant', 'size']);
+  });
+
+  it('emits aria-valuemin=0 and aria-valuemax=max on the track', () => {
+    const el = mount({ max: '250', value: '50' });
+    const track = el.shadowRoot?.querySelector('div.progress');
+    expect(track?.getAttribute('aria-valuemin')).toBe('0');
+    expect(track?.getAttribute('aria-valuemax')).toBe('250');
+    expect(track?.getAttribute('aria-valuenow')).toBe('50');
+  });
+
+  it('clamps value to [0, max]', () => {
+    const el = mount({ value: '200', max: '100' });
+    const indicator = el.shadowRoot?.querySelector('div.progress-indicator');
+    const track = el.shadowRoot?.querySelector('div.progress');
+    expect((indicator as HTMLElement | null)?.style.width).toBe('100%');
+    expect(track?.getAttribute('aria-valuenow')).toBe('100');
+
+    const el2 = mount({ value: '-50' });
+    const indicator2 = el2.shadowRoot?.querySelector('div.progress-indicator');
+    const track2 = el2.shadowRoot?.querySelector('div.progress');
+    expect((indicator2 as HTMLElement | null)?.style.width).toBe('0%');
+    expect(track2?.getAttribute('aria-valuenow')).toBe('0');
+  });
+
+  it('falls back to max=100 when max is non-numeric or non-positive', () => {
+    const el = mount({ max: 'abc', value: '50' });
+    const track = el.shadowRoot?.querySelector('div.progress');
+    expect(track?.getAttribute('aria-valuemax')).toBe('100');
+
+    const el2 = mount({ max: '0', value: '50' });
+    const track2 = el2.shadowRoot?.querySelector('div.progress');
+    expect(track2?.getAttribute('aria-valuemax')).toBe('100');
+
+    const el3 = mount({ max: '-10', value: '50' });
+    const track3 = el3.shadowRoot?.querySelector('div.progress');
+    expect(track3?.getAttribute('aria-valuemax')).toBe('100');
+  });
+
+  it('reflects variant attribute changes to the adopted stylesheet', () => {
+    const el = mount();
+    el.setAttribute('variant', 'destructive');
+    expect(adoptedCssText(el)).toContain('color-destructive');
+  });
+
+  it('reflects size attribute changes to the adopted stylesheet', () => {
+    const el = mount();
+    el.setAttribute('size', 'lg');
+    expect(adoptedCssText(el)).toMatch(/height:\s*0\.75rem/);
+    el.setAttribute('size', 'sm');
+    expect(adoptedCssText(el)).toMatch(/height:\s*0\.25rem/);
+  });
+
+  it('removes aria-busy and data-indeterminate when value becomes numeric', () => {
+    const el = mount();
+    expect(el.getAttribute('aria-busy')).toBe('true');
+    el.setAttribute('value', '42');
+    expect(el.hasAttribute('aria-busy')).toBe(false);
+    const indicator = el.shadowRoot?.querySelector('div.progress-indicator');
+    expect(indicator?.hasAttribute('data-indeterminate')).toBe(false);
+    expect((indicator as HTMLElement | null)?.style.width).toBe('42%');
+  });
+
+  it('re-enters indeterminate when value is removed', () => {
+    const el = mount({ value: '50' });
+    expect(el.hasAttribute('aria-busy')).toBe(false);
+    el.removeAttribute('value');
+    expect(el.getAttribute('aria-busy')).toBe('true');
+    const indicator = el.shadowRoot?.querySelector('div.progress-indicator');
+    expect(indicator?.hasAttribute('data-indeterminate')).toBe(true);
+    expect((indicator as HTMLElement | null)?.style.width).toBe('');
+  });
+
+  it('shadow root adopts the per-instance stylesheet', () => {
+    const el = mount();
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    expect(sheets.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('stylesheet uses only --motion-duration / --motion-ease tokens', () => {
+    const el = mount();
+    const css = adoptedCssText(el);
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+  });
+});

--- a/packages/ui/src/components/ui/progress.element.ts
+++ b/packages/ui/src/components/ui/progress.element.ts
@@ -1,0 +1,172 @@
+/**
+ * <rafters-progress> -- Web Component progress primitive.
+ *
+ * Mirrors the semantics of progress.tsx (value, max, variant, size) using
+ * shadow-DOM-scoped CSS composed via classy-wc. Auto-registers on import and
+ * is idempotent against double-define.
+ *
+ * Attributes:
+ *  - value:   number in [0, max] (default: absent = indeterminate)
+ *  - max:     number > 0 (default 100; non-numeric or non-positive falls back to 100)
+ *  - variant: 'default' | 'primary' | 'secondary' | 'destructive'
+ *             | 'success' | 'warning' | 'info' | 'accent' (default 'default')
+ *  - size:    'sm' | 'default' | 'lg' (default 'default')
+ *
+ * Shadow DOM structure:
+ *   <div class="progress" role="progressbar" aria-valuemin="0" aria-valuemax=max
+ *        [aria-valuenow=clampedValue] [aria-valuetext="N%"]>
+ *     <div class="progress-indicator" style="width: N%">
+ *   </div>
+ *
+ * When indeterminate the host gets `aria-busy="true"`, the indicator
+ * carries a `data-indeterminate` attribute (used by the stylesheet to
+ * apply the slide animation), and no inline width is set.
+ *
+ * DOM APIs only -- never innerHTML. Styling comes exclusively from
+ * progressStylesheet(...) adopted as the per-instance stylesheet.
+ *
+ * @cognitive-load 4/10
+ * @accessibility role="progressbar" with aria-valuemin/max/now/text.
+ *                Host aria-busy="true" when indeterminate.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import { type ProgressSize, type ProgressVariant, progressStylesheet } from './progress.styles';
+
+const ALLOWED_VARIANTS: ReadonlyArray<ProgressVariant> = [
+  'default',
+  'primary',
+  'secondary',
+  'destructive',
+  'success',
+  'warning',
+  'info',
+  'accent',
+];
+
+const ALLOWED_SIZES: ReadonlyArray<ProgressSize> = ['sm', 'default', 'lg'];
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = ['value', 'max', 'variant', 'size'] as const;
+
+function parseVariant(value: string | null): ProgressVariant {
+  if (value && (ALLOWED_VARIANTS as ReadonlyArray<string>).includes(value)) {
+    return value as ProgressVariant;
+  }
+  return 'default';
+}
+
+function parseSize(value: string | null): ProgressSize {
+  if (value && (ALLOWED_SIZES as ReadonlyArray<string>).includes(value)) {
+    return value as ProgressSize;
+  }
+  return 'default';
+}
+
+function parseMax(raw: string | null): number {
+  if (raw === null) return 100;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return 100;
+  return n;
+}
+
+interface ParsedValue {
+  indeterminate: boolean;
+  clamped: number;
+}
+
+function parseValue(raw: string | null, max: number): ParsedValue {
+  if (raw === null) return { indeterminate: true, clamped: 0 };
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return { indeterminate: true, clamped: 0 };
+  const clamped = Math.min(Math.max(n, 0), max);
+  return { indeterminate: false, clamped };
+}
+
+export class RaftersProgress extends RaftersElement {
+  static readonly observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  /** Per-instance stylesheet rebuilt on variant/size changes. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  override connectedCallback(): void {
+    if (!this.shadowRoot) return;
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+    this.shadowRoot.adoptedStyleSheets = [this._instanceSheet];
+    this.update();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+    if ((name === 'variant' || name === 'size') && this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+    this.update();
+  }
+
+  override disconnectedCallback(): void {
+    this._instanceSheet = null;
+  }
+
+  /**
+   * Build the CSS string for the current variant/size attributes.
+   */
+  private composeCss(): string {
+    return progressStylesheet({
+      variant: parseVariant(this.getAttribute('variant')),
+      size: parseSize(this.getAttribute('size')),
+    });
+  }
+
+  /**
+   * Render the track + indicator. DOM APIs only -- never innerHTML.
+   *
+   * Host ARIA attributes are written on `this` so they surface on the
+   * custom element itself (light DOM side). The inner track carries the
+   * role="progressbar" and aria-value* attributes so assistive tech that
+   * pierces through to the shadow DOM still finds a compliant node.
+   */
+  override render(): Node {
+    const max = parseMax(this.getAttribute('max'));
+    const { indeterminate, clamped } = parseValue(this.getAttribute('value'), max);
+
+    // Host-level ARIA state for screen readers that read the light tree.
+    if (indeterminate) {
+      this.setAttribute('aria-busy', 'true');
+    } else {
+      this.removeAttribute('aria-busy');
+    }
+
+    const track = document.createElement('div');
+    track.className = 'progress';
+    track.setAttribute('role', 'progressbar');
+    track.setAttribute('aria-valuemin', '0');
+    track.setAttribute('aria-valuemax', String(max));
+
+    if (!indeterminate) {
+      track.setAttribute('aria-valuenow', String(clamped));
+      const percent = Math.round((clamped / max) * 100);
+      track.setAttribute('aria-valuetext', `${percent}%`);
+    }
+
+    const indicator = document.createElement('div');
+    indicator.className = 'progress-indicator';
+    if (indeterminate) {
+      indicator.setAttribute('data-indeterminate', '');
+    } else {
+      const percent = (clamped / max) * 100;
+      indicator.setAttribute('style', `width: ${percent}%`);
+    }
+
+    track.appendChild(indicator);
+    return track;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-progress')) {
+  customElements.define('rafters-progress', RaftersProgress);
+}

--- a/packages/ui/src/components/ui/progress.styles.ts
+++ b/packages/ui/src/components/ui/progress.styles.ts
@@ -1,0 +1,177 @@
+/**
+ * Shadow DOM style definitions for Progress web component
+ *
+ * Parallel to progress.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ * Token values via var() from the shared token stylesheet.
+ *
+ * All token references go through tokenVar(); no raw var() literals.
+ * Motion uses --motion-duration-* / --motion-ease-* only.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import {
+  atRule,
+  pick,
+  styleRule,
+  stylesheet,
+  tokenVar,
+  transition,
+} from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export type ProgressVariant =
+  | 'default'
+  | 'primary'
+  | 'secondary'
+  | 'destructive'
+  | 'success'
+  | 'warning'
+  | 'info'
+  | 'accent';
+
+export type ProgressSize = 'sm' | 'default' | 'lg';
+
+// ============================================================================
+// Container (Track) Styles
+// ============================================================================
+
+/**
+ * Base track declarations shared across every variant and size.
+ * Mirrors progressContainerClasses from progress.classes.ts.
+ */
+export const progressContainerBase: CSSProperties = {
+  position: 'relative',
+  width: '100%',
+  overflow: 'hidden',
+  'border-radius': '9999px',
+  'background-color': tokenVar('color-muted'),
+};
+
+/**
+ * Size declarations map explicit track heights.
+ * Mirrors progressSizeClasses from progress.classes.ts.
+ */
+export const progressSizeStyles: Record<ProgressSize, CSSProperties> = {
+  sm: {
+    height: '0.25rem',
+  },
+  default: {
+    height: '0.5rem',
+  },
+  lg: {
+    height: '0.75rem',
+  },
+};
+
+// ============================================================================
+// Indicator Styles
+// ============================================================================
+
+/**
+ * Base indicator declarations shared across every variant.
+ * Mirrors progressIndicatorBaseClasses from progress.classes.ts.
+ * Width is set by the element via inline style when determinate.
+ */
+export const progressIndicatorBase: CSSProperties = {
+  height: '100%',
+  transition: transition(
+    ['width'],
+    tokenVar('motion-duration-normal'),
+    tokenVar('motion-ease-standard'),
+  ),
+};
+
+/**
+ * Variant background color per indicator.
+ * Semantic variants carry solid fills from their token pair.
+ */
+export const progressVariantStyles: Record<ProgressVariant, CSSProperties> = {
+  default: {
+    'background-color': tokenVar('color-primary'),
+  },
+  primary: {
+    'background-color': tokenVar('color-primary'),
+  },
+  secondary: {
+    'background-color': tokenVar('color-secondary'),
+  },
+  destructive: {
+    'background-color': tokenVar('color-destructive'),
+  },
+  success: {
+    'background-color': tokenVar('color-success'),
+  },
+  warning: {
+    'background-color': tokenVar('color-warning'),
+  },
+  info: {
+    'background-color': tokenVar('color-info'),
+  },
+  accent: {
+    'background-color': tokenVar('color-accent'),
+  },
+};
+
+/**
+ * Indeterminate indicator declarations. When no numeric value is known
+ * the indicator shrinks to a third of the track and animates horizontally
+ * via the @keyframes defined below.
+ */
+export const progressIndeterminateStyles: CSSProperties = {
+  width: '33%',
+  animation: `rafters-progress-indeterminate ${tokenVar('motion-duration-slow')} ${tokenVar('motion-ease-standard')} infinite`,
+};
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+export interface ProgressStylesheetOptions {
+  variant?: ProgressVariant | undefined;
+  size?: ProgressSize | undefined;
+}
+
+/**
+ * Build the complete progress stylesheet for a given configuration.
+ *
+ * Unknown variant/size keys fall back to 'default' via pick(). Never throws.
+ * Emits:
+ *   - `:host` display block
+ *   - `.progress` track rule (container base + size)
+ *   - `.progress-indicator` base + variant rule
+ *   - `.progress-indicator[data-indeterminate]` indeterminate animation rule
+ *   - `@keyframes rafters-progress-indeterminate` for the slide animation
+ *   - `@media (prefers-reduced-motion: reduce)` block that neutralises
+ *     indicator transition and animation.
+ */
+export function progressStylesheet(options: ProgressStylesheetOptions = {}): string {
+  const { variant, size } = options;
+
+  return stylesheet(
+    styleRule(':host', { display: 'block' }),
+
+    styleRule('.progress', progressContainerBase, pick(progressSizeStyles, size, 'default')),
+
+    styleRule(
+      '.progress-indicator',
+      progressIndicatorBase,
+      pick(progressVariantStyles, variant, 'default'),
+    ),
+
+    styleRule('.progress-indicator[data-indeterminate]', progressIndeterminateStyles),
+
+    `@keyframes rafters-progress-indeterminate {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(400%); }
+}`,
+
+    atRule(
+      '@media (prefers-reduced-motion: reduce)',
+      styleRule('.progress-indicator', { transition: 'none', animation: 'none' }),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

Adds the Web Component framework target for progress, parallel to `progress.tsx` (React) and `progress.astro` (Astro). Ships `progress.element.ts` alongside a new `progress.styles.ts` that expresses the track + indicator as token-resolved CSS property maps composed via `classy-wc`.

## Behavior

- `RaftersProgress` observes `value`, `max`, `variant`, `size`.
- Unknown `variant` / `size` values silently fall back to `'default'`.
- Non-numeric or non-positive `max` falls back to `100`.
- Absent or non-numeric `value` renders indeterminate: host gets `aria-busy="true"` and the indicator carries `data-indeterminate` (consumed by the stylesheet's slide animation).
- Numeric `value` clamps to `[0, max]`, writes the percentage to the indicator `style="width: N%"`, and sets `aria-valuenow` + `aria-valuetext="N%"` on the track.
- Track is `role="progressbar"` with `aria-valuemin="0"` and `aria-valuemax=max`.

## Implementation notes

- Per-instance `CSSStyleSheet`: `connectedCallback` builds once; `variant` / `size` changes `replaceSync` the same sheet; `value` / `max` changes only rerender.
- DOM APIs only -- never `innerHTML`.
- All tokens via `tokenVar()`. No raw `var()` literals in the element file.
- Motion uses `--motion-duration-normal` / `--motion-duration-slow` and `--motion-ease-standard` only.
- Auto-registers `<rafters-progress>`, idempotent against double-define.
- `@media (prefers-reduced-motion: reduce)` neutralises transition and animation.

## Test plan

- [x] `registers the rafters-progress tag on import`
- [x] `does not throw when the module is imported twice`
- [x] `renders a div.progress > div.progress-indicator structure`
- [x] `falls back to default variant/size for unknown values`
- [x] `reflects value changes to indicator inline width and aria-valuenow`
- [x] `falls back to indeterminate when value is absent or non-numeric`
- [x] `source contains no direct var() references`
- [x] `observedAttributes matches the documented contract`
- [x] `emits aria-valuemin=0 and aria-valuemax=max on the track`
- [x] `clamps value to [0, max]`
- [x] `falls back to max=100 when max is non-numeric or non-positive`
- [x] `reflects variant attribute changes to the adopted stylesheet`
- [x] `reflects size attribute changes to the adopted stylesheet`
- [x] `removes aria-busy and data-indeterminate when value becomes numeric`
- [x] `re-enters indeterminate when value is removed`
- [x] `shadow root adopts the per-instance stylesheet`
- [x] `stylesheet uses only --motion-duration / --motion-ease tokens`
- [x] Full preflight (`pnpm preflight`) clean

Closes #1327