### PR TITLE
feat(ui): <rafters-skeleton> Web Component (#1328)

### DIFF
--- a/packages/ui/src/components/ui/skeleton.element.test.ts
+++ b/packages/ui/src/components/ui/skeleton.element.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import './skeleton.element';
+import { RaftersSkeleton } from './skeleton.element';
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+function mount(attrs: Record<string, string> = {}): HTMLElement {
+  const el = document.createElement('rafters-skeleton');
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.appendChild(el);
+  return el;
+}
+
+function adoptedCssText(el: Element): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  const blocks: string[] = [];
+  for (const sheet of sheets) {
+    const rules: string[] = [];
+    for (const rule of Array.from(sheet.cssRules)) {
+      rules.push(rule.cssText);
+    }
+    blocks.push(rules.join('\n'));
+  }
+  return blocks.join('\n');
+}
+
+describe('<rafters-skeleton>', () => {
+  it('registers the rafters-skeleton tag on import', () => {
+    expect(customElements.get('rafters-skeleton')).toBe(RaftersSkeleton);
+  });
+
+  it('does not throw when the module is imported twice', async () => {
+    await expect(import('./skeleton.element')).resolves.toBeDefined();
+    await expect(import('./skeleton.element')).resolves.toBeDefined();
+    expect(customElements.get('rafters-skeleton')).toBe(RaftersSkeleton);
+  });
+
+  it('renders a single div.skeleton[aria-hidden=true] with no slot', () => {
+    const el = mount();
+    const root = el.shadowRoot;
+    expect(root).not.toBeNull();
+    const div = root?.querySelector('div.skeleton');
+    expect(div).not.toBeNull();
+    expect(div?.getAttribute('aria-hidden')).toBe('true');
+    // No slot element anywhere in the shadow tree
+    expect(root?.querySelector('slot')).toBeNull();
+    // Single child on the shadow root
+    expect(root?.childNodes.length).toBe(1);
+    // The skeleton div itself has no children
+    expect(div?.children.length).toBe(0);
+  });
+
+  it('falls back to default variant for unknown values', () => {
+    const el = mount({ variant: 'nonsense' });
+    // Default variant background is color-muted
+    const css = adoptedCssText(el);
+    expect(css).toContain('color-muted');
+    expect(css).not.toContain('color-primary-subtle');
+    expect(css).not.toContain('color-destructive-subtle');
+  });
+
+  it('reflects variant attribute changes to the adopted stylesheet', () => {
+    const el = mount();
+    el.setAttribute('variant', 'destructive');
+    const css = adoptedCssText(el);
+    expect(css).toContain('color-destructive-subtle');
+  });
+
+  it('source contains no direct var() references', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const source = await fs.readFile(path.resolve(__dirname, 'skeleton.element.ts'), 'utf-8');
+    expect(source).not.toMatch(/[^a-zA-Z_]var\(/);
+  });
+
+  it('observedAttributes matches the documented contract', () => {
+    expect(RaftersSkeleton.observedAttributes).toEqual(['variant']);
+  });
+
+  it('shadow root adopts the per-instance stylesheet', () => {
+    const el = mount();
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    expect(sheets.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('stylesheet uses only --motion-duration / --motion-ease tokens', () => {
+    const el = mount();
+    const css = adoptedCssText(el);
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+  });
+
+  it('stylesheet includes a prefers-reduced-motion rule that disables animation', () => {
+    const el = mount();
+    const css = adoptedCssText(el);
+    expect(css).toMatch(/prefers-reduced-motion:\s*reduce/);
+    expect(css).toMatch(/animation:\s*none/);
+  });
+
+  it('reflects primary variant to the primary-subtle background', () => {
+    const el = mount({ variant: 'primary' });
+    const css = adoptedCssText(el);
+    expect(css).toContain('color-primary-subtle');
+  });
+});

--- a/packages/ui/src/components/ui/skeleton.element.ts
+++ b/packages/ui/src/components/ui/skeleton.element.ts
@@ -1,0 +1,104 @@
+/**
+ * <rafters-skeleton> -- Web Component skeleton loader.
+ *
+ * Mirrors the semantics of skeleton.tsx (variant) using shadow-DOM-scoped
+ * CSS composed via classy-wc. Auto-registers on import and is idempotent
+ * against double-define.
+ *
+ * Attributes:
+ *  - variant: 'default' | 'primary' | 'secondary' | 'destructive' | 'success'
+ *             | 'warning' | 'info' | 'muted' | 'accent' (default 'default')
+ *
+ * Shadow DOM structure:
+ *   <div class="skeleton" aria-hidden="true">
+ *
+ * No slot -- skeleton is purely decorative with no slotted content.
+ * Unknown variant values fall back to 'default' silently. This matches the
+ * React target's runtime behaviour of `skeletonVariantClasses[variant] ?? default`.
+ *
+ * DOM APIs only -- never innerHTML. Styling comes exclusively from
+ * skeletonStylesheet(...) adopted as the per-instance stylesheet.
+ *
+ * @cognitive-load 1/10
+ * @accessibility aria-hidden decorative placeholder.
+ *                Animation respects prefers-reduced-motion.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import { type SkeletonVariant, skeletonStylesheet } from './skeleton.styles';
+
+const ALLOWED_VARIANTS: ReadonlyArray<SkeletonVariant> = [
+  'default',
+  'primary',
+  'secondary',
+  'destructive',
+  'success',
+  'warning',
+  'info',
+  'muted',
+  'accent',
+];
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = ['variant'] as const;
+
+function parseVariant(value: string | null): SkeletonVariant {
+  if (value && (ALLOWED_VARIANTS as ReadonlyArray<string>).includes(value)) {
+    return value as SkeletonVariant;
+  }
+  return 'default';
+}
+
+export class RaftersSkeleton extends RaftersElement {
+  static readonly observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  /** Per-instance stylesheet rebuilt on variant changes. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  override connectedCallback(): void {
+    if (!this.shadowRoot) return;
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+    this.shadowRoot.adoptedStyleSheets = [this._instanceSheet];
+    this.update();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+    if (name === 'variant' && this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+    this.update();
+  }
+
+  override disconnectedCallback(): void {
+    this._instanceSheet = null;
+  }
+
+  /**
+   * Build the CSS string for the current variant attribute.
+   */
+  private composeCss(): string {
+    return skeletonStylesheet({
+      variant: parseVariant(this.getAttribute('variant')),
+    });
+  }
+
+  /**
+   * Render a single decorative div with aria-hidden. No slot -- skeleton
+   * is purely a loading placeholder. DOM APIs only -- never innerHTML.
+   */
+  override render(): Node {
+    const inner = document.createElement('div');
+    inner.className = 'skeleton';
+    inner.setAttribute('aria-hidden', 'true');
+    return inner;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-skeleton')) {
+  customElements.define('rafters-skeleton', RaftersSkeleton);
+}

--- a/packages/ui/src/components/ui/skeleton.styles.ts
+++ b/packages/ui/src/components/ui/skeleton.styles.ts
@@ -1,0 +1,123 @@
+/**
+ * Shadow DOM style definitions for Skeleton web component
+ *
+ * Parallel to skeleton.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ * Token values via var() from the shared token stylesheet.
+ *
+ * All token references go through tokenVar(); no raw var() literals.
+ * Motion uses --motion-duration-* / --motion-ease-* only.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import { atRule, pick, styleRule, stylesheet, tokenVar } from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export type SkeletonVariant =
+  | 'default'
+  | 'primary'
+  | 'secondary'
+  | 'destructive'
+  | 'success'
+  | 'warning'
+  | 'info'
+  | 'muted'
+  | 'accent';
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+/**
+ * Base skeleton declarations shared across every variant.
+ * Mirrors skeletonBaseClasses from skeleton.classes.ts:
+ * rounded-md + animate-pulse. Consumers control size via inline styles
+ * or CSS on the host element.
+ */
+export const skeletonBase: CSSProperties = {
+  display: 'block',
+  'border-radius': tokenVar('radius-md'),
+  animation: `rafters-skeleton-pulse ${tokenVar('motion-duration-slower')} ${tokenVar('motion-ease-standard')} infinite`,
+};
+
+// ============================================================================
+// Variant Styles
+// ============================================================================
+
+/**
+ * Variant background per skeleton. Subtle backgrounds match
+ * skeletonVariantClasses from skeleton.classes.ts. `default` and `muted`
+ * both fall through to the muted token; other semantic variants use
+ * their `-subtle` token pair.
+ */
+export const skeletonVariantStyles: Record<SkeletonVariant, CSSProperties> = {
+  default: {
+    'background-color': tokenVar('color-muted'),
+  },
+  primary: {
+    'background-color': tokenVar('color-primary-subtle'),
+  },
+  secondary: {
+    'background-color': tokenVar('color-secondary-subtle'),
+  },
+  destructive: {
+    'background-color': tokenVar('color-destructive-subtle'),
+  },
+  success: {
+    'background-color': tokenVar('color-success-subtle'),
+  },
+  warning: {
+    'background-color': tokenVar('color-warning-subtle'),
+  },
+  info: {
+    'background-color': tokenVar('color-info-subtle'),
+  },
+  muted: {
+    'background-color': tokenVar('color-muted'),
+  },
+  accent: {
+    'background-color': tokenVar('color-accent-subtle'),
+  },
+};
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+export interface SkeletonStylesheetOptions {
+  variant?: SkeletonVariant | undefined;
+}
+
+/**
+ * Build the complete skeleton stylesheet for a given configuration.
+ *
+ * Unknown variant keys fall back to 'default' via pick(). Never throws.
+ * Emits:
+ *   - `:host` display block
+ *   - `.skeleton` base + variant rule
+ *   - `@keyframes rafters-skeleton-pulse` for the pulse animation
+ *   - `@media (prefers-reduced-motion: reduce)` block that neutralises
+ *     the animation.
+ */
+export function skeletonStylesheet(options: SkeletonStylesheetOptions = {}): string {
+  const { variant } = options;
+
+  return stylesheet(
+    styleRule(':host', { display: 'block' }),
+
+    styleRule('.skeleton', skeletonBase, pick(skeletonVariantStyles, variant, 'default')),
+
+    `@keyframes rafters-skeleton-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}`,
+
+    atRule(
+      '@media (prefers-reduced-motion: reduce)',
+      styleRule('.skeleton', { animation: 'none' }),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

Ships the Web Component framework target for skeleton loaders, parallel to `skeleton.tsx` (React) and `skeleton.astro` (Astro). Adds `<rafters-skeleton>` with variant parity against the React target, composed via `classy-wc` into a per-instance shadow-DOM stylesheet.

- `packages/ui/src/components/ui/skeleton.styles.ts` -- CSS property maps plus `skeletonStylesheet()` that composes `:host`, `.skeleton`, a `@keyframes rafters-skeleton-pulse` animation, and a `prefers-reduced-motion` block that disables the animation. All token references go through `tokenVar()` and motion uses `--motion-duration-*` / `--motion-ease-*` only. Unknown variant values silently fall back to `default`.
- `packages/ui/src/components/ui/skeleton.element.ts` -- `RaftersSkeleton` custom element that renders a single decorative `<div class="skeleton" aria-hidden="true">` with no slot (skeleton is purely decorative). `observedAttributes=['variant']`. Per-instance `CSSStyleSheet` pattern: `connectedCallback` creates a new sheet and `replaceSync()`s the composed CSS; `attributeChangedCallback` calls `replaceSync` on the same sheet when `variant` changes. Auto-registers `<rafters-skeleton>` idempotently via the `customElements.get` guard. DOM APIs only -- never `innerHTML`. No raw `var()` literal in the element file.

## Test plan

- [x] `pnpm --filter=@rafters/ui test skeleton` -- 19 tests passing (includes 11 skeleton.element tests)
- [x] `pnpm --filter=@rafters/ui typecheck` -- clean
- [x] `pnpm biome check` on new files -- clean
- [x] `pnpm preflight` -- clean

Closes #1328