### PR TITLE
feat(ui): <rafters-spinner> Web Component (#1329)

### DIFF
--- a/packages/ui/src/components/ui/spinner.element.test.ts
+++ b/packages/ui/src/components/ui/spinner.element.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import './spinner.element';
+import { RaftersSpinner } from './spinner.element';
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+function mount(attrs: Record<string, string> = {}): HTMLElement {
+  const el = document.createElement('rafters-spinner');
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.appendChild(el);
+  return el;
+}
+
+function adoptedCssText(el: Element): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  const blocks: string[] = [];
+  for (const sheet of sheets) {
+    const rules: string[] = [];
+    for (const rule of Array.from(sheet.cssRules)) {
+      rules.push(rule.cssText);
+    }
+    blocks.push(rules.join('\n'));
+  }
+  return blocks.join('\n');
+}
+
+describe('<rafters-spinner>', () => {
+  it('registers the rafters-spinner tag on import', () => {
+    expect(customElements.get('rafters-spinner')).toBe(RaftersSpinner);
+  });
+
+  it('does not throw when the module is imported twice', async () => {
+    await expect(import('./spinner.element')).resolves.toBeDefined();
+    await expect(import('./spinner.element')).resolves.toBeDefined();
+    expect(customElements.get('rafters-spinner')).toBe(RaftersSpinner);
+  });
+
+  it('renders an output.spinner[aria-label=Loading] with a sr-only Loading span', () => {
+    const el = mount();
+    const root = el.shadowRoot;
+    expect(root).not.toBeNull();
+    const output = root?.querySelector('output.spinner');
+    expect(output).not.toBeNull();
+    expect(output?.getAttribute('aria-label')).toBe('Loading');
+    const sr = output?.querySelector('span.sr-only');
+    expect(sr).not.toBeNull();
+    expect(sr?.textContent).toBe('Loading');
+    // Output hosts exactly one child: the sr-only span.
+    expect(output?.children.length).toBe(1);
+    // Shadow root hosts exactly one top-level element.
+    expect(root?.childNodes.length).toBe(1);
+  });
+
+  it('falls back to default size/variant for unknown values', () => {
+    const el = mount({ size: 'gigantic', variant: 'nonsense' });
+    const css = adoptedCssText(el);
+    // Default variant: color-primary border-color.
+    expect(css).toContain('color-primary');
+    // Default size: 1.5rem height (default), 2px border width.
+    expect(css).toContain('height: 1.5rem');
+    expect(css).toContain('border-width: 2px');
+  });
+
+  it('reflects size attribute changes to the adopted stylesheet', () => {
+    const el = mount();
+    el.setAttribute('size', 'lg');
+    const css = adoptedCssText(el);
+    expect(css).toContain('height: 2rem');
+    expect(css).toContain('border-width: 3px');
+  });
+
+  it('reflects variant attribute changes to the adopted stylesheet', () => {
+    const el = mount();
+    el.setAttribute('variant', 'destructive');
+    const css = adoptedCssText(el);
+    expect(css).toContain('color-destructive');
+  });
+
+  it('source contains no direct var() references', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const source = await fs.readFile(path.resolve(__dirname, 'spinner.element.ts'), 'utf-8');
+    expect(source).not.toMatch(/[^a-zA-Z_]var\(/);
+  });
+
+  it('observedAttributes matches the documented contract', () => {
+    expect(RaftersSpinner.observedAttributes).toEqual(['size', 'variant']);
+  });
+
+  it('shadow root adopts the per-instance stylesheet', () => {
+    const el = mount();
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    expect(sheets.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('stylesheet uses only --motion-duration / --motion-ease tokens', () => {
+    const el = mount();
+    const css = adoptedCssText(el);
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+  });
+
+  it('stylesheet includes a prefers-reduced-motion rule that disables animation', () => {
+    const el = mount();
+    const css = adoptedCssText(el);
+    expect(css).toMatch(/prefers-reduced-motion:\s*reduce/);
+    expect(css).toMatch(/animation:\s*none/);
+  });
+
+  it('stylesheet includes sr-only visually-hidden declarations', () => {
+    const el = mount();
+    const css = adoptedCssText(el);
+    expect(css).toMatch(/\.sr-only/);
+    expect(css).toMatch(/position:\s*absolute/);
+    expect(css).toMatch(/clip:\s*rect\(0,\s*0,\s*0,\s*0\)/);
+  });
+});

--- a/packages/ui/src/components/ui/spinner.element.ts
+++ b/packages/ui/src/components/ui/spinner.element.ts
@@ -1,0 +1,128 @@
+/**
+ * <rafters-spinner> -- Web Component loading spinner.
+ *
+ * Mirrors the semantics of spinner.tsx (size, variant) using shadow-DOM-scoped
+ * CSS composed via classy-wc. Auto-registers on import and is idempotent
+ * against double-define.
+ *
+ * Attributes:
+ *  - size:    'sm' | 'default' | 'lg'  (default 'default')
+ *  - variant: 'default' | 'primary' | 'secondary' | 'destructive' | 'success'
+ *             | 'warning' | 'info' | 'accent' | 'muted'  (default 'default')
+ *
+ * Shadow DOM structure:
+ *   <output class="spinner" aria-label="Loading">
+ *     <span class="sr-only">Loading</span>
+ *   </output>
+ *
+ * Unknown attribute values fall back to 'default' silently. This matches the
+ * React target's runtime behaviour of
+ * `spinnerVariantClasses[variant] ?? default`.
+ *
+ * DOM APIs only -- never innerHTML. Styling comes exclusively from
+ * spinnerStylesheet(...) adopted as the per-instance stylesheet. The
+ * `.sr-only` helper is defined inside the component stylesheet because the
+ * shadow DOM has no access to the global Tailwind utility.
+ *
+ * The spin animation respects prefers-reduced-motion via an `@media` block
+ * emitted by spinnerStylesheet().
+ *
+ * @cognitive-load 2/10
+ * @accessibility role=status implied by <output>, aria-label announces
+ *                "Loading" to assistive tech; sr-only text carries the same
+ *                phrase for screen readers that favour text content.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import { type SpinnerSize, type SpinnerVariant, spinnerStylesheet } from './spinner.styles';
+
+const ALLOWED_SIZES: ReadonlyArray<SpinnerSize> = ['sm', 'default', 'lg'];
+
+const ALLOWED_VARIANTS: ReadonlyArray<SpinnerVariant> = [
+  'default',
+  'primary',
+  'secondary',
+  'destructive',
+  'success',
+  'warning',
+  'info',
+  'accent',
+  'muted',
+];
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = ['size', 'variant'] as const;
+
+function parseSize(value: string | null): SpinnerSize {
+  if (value && (ALLOWED_SIZES as ReadonlyArray<string>).includes(value)) {
+    return value as SpinnerSize;
+  }
+  return 'default';
+}
+
+function parseVariant(value: string | null): SpinnerVariant {
+  if (value && (ALLOWED_VARIANTS as ReadonlyArray<string>).includes(value)) {
+    return value as SpinnerVariant;
+  }
+  return 'default';
+}
+
+export class RaftersSpinner extends RaftersElement {
+  static readonly observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  /** Per-instance stylesheet rebuilt on size/variant changes. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  override connectedCallback(): void {
+    if (!this.shadowRoot) return;
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+    this.shadowRoot.adoptedStyleSheets = [this._instanceSheet];
+    this.update();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+    if ((name === 'size' || name === 'variant') && this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+    this.update();
+  }
+
+  override disconnectedCallback(): void {
+    this._instanceSheet = null;
+  }
+
+  /**
+   * Build the CSS string for the current size/variant attributes.
+   */
+  private composeCss(): string {
+    return spinnerStylesheet({
+      size: parseSize(this.getAttribute('size')),
+      variant: parseVariant(this.getAttribute('variant')),
+    });
+  }
+
+  /**
+   * Render an <output class="spinner" aria-label="Loading"> containing a
+   * .sr-only span for redundant screen-reader text. DOM APIs only -- never
+   * innerHTML.
+   */
+  override render(): Node {
+    const output = document.createElement('output');
+    output.className = 'spinner';
+    output.setAttribute('aria-label', 'Loading');
+    const srText = document.createElement('span');
+    srText.className = 'sr-only';
+    srText.textContent = 'Loading';
+    output.appendChild(srText);
+    return output;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-spinner')) {
+  customElements.define('rafters-spinner', RaftersSpinner);
+}

--- a/packages/ui/src/components/ui/spinner.styles.ts
+++ b/packages/ui/src/components/ui/spinner.styles.ts
@@ -1,0 +1,183 @@
+/**
+ * Shadow DOM style definitions for Spinner web component
+ *
+ * Parallel to spinner.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ * Token values via var() from the shared token stylesheet.
+ *
+ * All token references go through tokenVar(); no raw var() literals.
+ * Motion uses --motion-duration-* / --motion-ease-* only.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import { atRule, pick, styleRule, stylesheet, tokenVar } from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export type SpinnerSize = 'sm' | 'default' | 'lg';
+
+export type SpinnerVariant =
+  | 'default'
+  | 'primary'
+  | 'secondary'
+  | 'destructive'
+  | 'success'
+  | 'warning'
+  | 'info'
+  | 'accent'
+  | 'muted';
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+/**
+ * Base spinner declarations shared across every variant and size.
+ * Mirrors spinnerBaseClasses from spinner.classes.ts:
+ * inline-block + rounded-full + animate-spin. The visible ring comes from
+ * a solid border with the right side transparent, so rotation produces the
+ * familiar partial-circle sweep.
+ */
+export const spinnerBase: CSSProperties = {
+  display: 'inline-block',
+  'border-radius': '9999px',
+  'border-style': 'solid',
+  'border-right-color': 'transparent',
+  animation: `rafters-spinner-spin ${tokenVar('motion-duration-slower')} ${tokenVar('motion-ease-standard')} infinite`,
+};
+
+// ============================================================================
+// Variant Styles
+// ============================================================================
+
+/**
+ * Variant border-color per spinner. The right border is forced transparent
+ * by spinnerBase to produce the partial-ring sweep; the remaining three
+ * borders carry the variant color.
+ */
+export const spinnerVariantStyles: Record<SpinnerVariant, CSSProperties> = {
+  default: {
+    'border-color': tokenVar('color-primary'),
+  },
+  primary: {
+    'border-color': tokenVar('color-primary'),
+  },
+  secondary: {
+    'border-color': tokenVar('color-secondary'),
+  },
+  destructive: {
+    'border-color': tokenVar('color-destructive'),
+  },
+  success: {
+    'border-color': tokenVar('color-success'),
+  },
+  warning: {
+    'border-color': tokenVar('color-warning'),
+  },
+  info: {
+    'border-color': tokenVar('color-info'),
+  },
+  accent: {
+    'border-color': tokenVar('color-accent'),
+  },
+  muted: {
+    'border-color': tokenVar('color-muted-foreground'),
+  },
+};
+
+// ============================================================================
+// Size Styles
+// ============================================================================
+
+/**
+ * Size declarations map explicit heights, widths, and border widths.
+ * Mirrors spinnerSizeClasses from spinner.classes.ts:
+ * sm -> 1rem / 2px border, default -> 1.5rem / 2px, lg -> 2rem / 3px.
+ */
+export const spinnerSizeStyles: Record<SpinnerSize, CSSProperties> = {
+  sm: {
+    height: '1rem',
+    width: '1rem',
+    'border-width': '2px',
+  },
+  default: {
+    height: '1.5rem',
+    width: '1.5rem',
+    'border-width': '2px',
+  },
+  lg: {
+    height: '2rem',
+    width: '2rem',
+    'border-width': '3px',
+  },
+};
+
+// ============================================================================
+// Visually-Hidden Styles
+// ============================================================================
+
+/**
+ * Standard visually-hidden-but-accessible declarations for .sr-only in the
+ * shadow DOM. The shadow root has no global Tailwind classes, so these must
+ * live inside the component stylesheet itself.
+ */
+export const srOnly: CSSProperties = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: '0',
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  'white-space': 'nowrap',
+  'border-width': '0',
+};
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+export interface SpinnerStylesheetOptions {
+  size?: SpinnerSize | undefined;
+  variant?: SpinnerVariant | undefined;
+}
+
+/**
+ * Build the complete spinner stylesheet for a given configuration.
+ *
+ * Unknown size/variant keys fall back to 'default' via pick(). Never throws.
+ * Emits:
+ *   - `:host` display inline-block
+ *   - `.spinner` base + variant + size rule
+ *   - `.sr-only` visually-hidden helper rule
+ *   - `@keyframes rafters-spinner-spin` for rotation
+ *   - `@media (prefers-reduced-motion: reduce)` block that neutralises
+ *     the animation.
+ */
+export function spinnerStylesheet(options: SpinnerStylesheetOptions = {}): string {
+  const { size, variant } = options;
+
+  return stylesheet(
+    styleRule(':host', { display: 'inline-block' }),
+
+    styleRule(
+      '.spinner',
+      spinnerBase,
+      pick(spinnerVariantStyles, variant, 'default'),
+      pick(spinnerSizeStyles, size, 'default'),
+      // Re-assert border-right-color after variant application so the
+      // transparent edge survives the border-color shorthand.
+      { 'border-right-color': 'transparent' },
+    ),
+
+    styleRule('.sr-only', srOnly),
+
+    `@keyframes rafters-spinner-spin {
+  to { transform: rotate(360deg); }
+}`,
+
+    atRule('@media (prefers-reduced-motion: reduce)', styleRule('.spinner', { animation: 'none' })),
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `<rafters-spinner>` Web Component target parallel to `spinner.tsx` (React) and `spinner.astro` (Astro).
- Authors `spinner.styles.ts` with `SpinnerSize`/`SpinnerVariant` types and a `spinnerStylesheet({ size, variant })` builder that emits shadow-DOM-scoped CSS via classy-wc.
- `spinner.element.ts` auto-registers `<rafters-spinner>` idempotently, observes `['size', 'variant']`, and silently falls back to `'default'` on unknown values.
- Per-instance `CSSStyleSheet` rebuilt on attribute change via `replaceSync`.
- `.sr-only` declarations live inside the component stylesheet since shadow DOM has no global `.sr-only`.
- Spin animation keyed to `--motion-duration-slower` + `--motion-ease-standard`; `@media (prefers-reduced-motion: reduce)` disables the animation.
- No raw `var()` literal in the element file; all token refs go through `tokenVar()`.
- DOM APIs only (never `innerHTML`); shadow DOM is `<output class="spinner" aria-label="Loading"><span class="sr-only">Loading</span></output>`.

Closes #1329

## Test plan

- [x] `pnpm --filter=@rafters/ui test spinner` -- 30/30 passing (12 new element tests + existing React/Astro)
- [x] `pnpm typecheck` clean across workspace
- [x] `pnpm preflight` clean (typecheck + lint + test:unit + test:a11y + build)
- [x] Quality gate recorded clean via `legion quality-gate record`
- [x] Functional tests cover: registration, idempotent import, shadow DOM shape, unknown-value fallback, size/variant attribute reflection, no direct `var()` in source