### PR TITLE
feat(ui): <rafters-embed> Web Component (#1331)

### DIFF
--- a/packages/ui/src/components/ui/embed.classes.ts
+++ b/packages/ui/src/components/ui/embed.classes.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared embed class definitions
+ *
+ * Parallel to embed.styles.ts. Tailwind class strings for the React target
+ * (embed.tsx) and any future embed.astro target so visual parity holds
+ * across framework targets.
+ *
+ * Scope covers the iframe display path only -- the Twitter-widget flow,
+ * editable URL input, drag/drop upload, and alignment toolbar remain
+ * React-target concerns and do not appear here.
+ */
+
+/**
+ * Outer container wrapping the iframe. Matches the React target's
+ * "relative overflow-hidden rounded-lg bg-muted" container div.
+ */
+export const embedContainerClasses = 'relative overflow-hidden rounded-lg bg-muted';
+
+/**
+ * Iframe positioning. Matches the React target's
+ * "absolute inset-0 h-full w-full border-0" iframe styling.
+ */
+export const embedIframeClasses = 'absolute inset-0 h-full w-full border-0';
+
+/**
+ * Fallback container shown for missing or disallowed URLs. Matches the
+ * React target's EmbedFallback wrapper chrome.
+ */
+export const embedFallbackClasses =
+  'flex flex-col items-center justify-center rounded-lg border-2 border-dashed border-muted-foreground/25 bg-muted/50 p-8 text-center';
+
+/**
+ * Fallback message text styling.
+ */
+export const embedFallbackMessageClasses =
+  'mb-2 text-label-small font-medium text-muted-foreground';
+
+/**
+ * Fallback external link styling (Open in new tab).
+ */
+export const embedFallbackLinkClasses =
+  'text-label-small text-primary underline underline-offset-4 hover:text-primary/80';
+
+/**
+ * Accepted aspect-ratio keys shared across framework targets. Mirrors the
+ * AspectRatio type exported from embed.tsx and the AspectRatioKey contract
+ * in embed.styles.ts.
+ */
+export type AspectRatio = '16:9' | '4:3' | '1:1' | '9:16';

--- a/packages/ui/src/components/ui/embed.element.test.ts
+++ b/packages/ui/src/components/ui/embed.element.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import './embed.element';
+import { RaftersEmbed } from './embed.element';
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+function mount(attrs: Record<string, string> = {}): HTMLElement {
+  const el = document.createElement('rafters-embed');
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.appendChild(el);
+  return el;
+}
+
+function adoptedCssText(el: Element): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  const blocks: string[] = [];
+  for (const sheet of sheets) {
+    const rules: string[] = [];
+    for (const rule of Array.from(sheet.cssRules)) {
+      rules.push(rule.cssText);
+    }
+    blocks.push(rules.join('\n'));
+  }
+  return blocks.join('\n');
+}
+
+const YOUTUBE_URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+const YOUTUBE_URL_ALT = 'https://www.youtube.com/watch?v=9bZkp7q19f0';
+const DISALLOWED_URL = 'https://example.com/video/123';
+
+describe('<rafters-embed>', () => {
+  it('registers the rafters-embed tag on import', () => {
+    expect(customElements.get('rafters-embed')).toBe(RaftersEmbed);
+  });
+
+  it('does not throw when the module is imported twice', async () => {
+    await expect(import('./embed.element')).resolves.toBeDefined();
+    await expect(import('./embed.element')).resolves.toBeDefined();
+    expect(customElements.get('rafters-embed')).toBe(RaftersEmbed);
+  });
+
+  it('renders a fallback div when url attribute is absent', () => {
+    const el = mount();
+    const iframe = el.shadowRoot?.querySelector('iframe');
+    expect(iframe).toBeNull();
+    const fallback = el.shadowRoot?.querySelector('.embed-fallback');
+    expect(fallback).not.toBeNull();
+  });
+
+  it('renders an iframe with correct src/allow/allowfullscreen/loading/referrerpolicy when url is a valid YouTube URL', () => {
+    const el = mount({ url: YOUTUBE_URL });
+    const iframe = el.shadowRoot?.querySelector('iframe');
+    expect(iframe).not.toBeNull();
+    expect(iframe?.getAttribute('src')).toBe('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ');
+    expect(iframe?.getAttribute('allow')).toContain('accelerometer');
+    expect(iframe?.getAttribute('allow')).toContain('autoplay');
+    expect(iframe?.getAttribute('allow')).toContain('clipboard-write');
+    expect(iframe?.getAttribute('allow')).toContain('encrypted-media');
+    expect(iframe?.getAttribute('allow')).toContain('gyroscope');
+    expect(iframe?.getAttribute('allow')).toContain('picture-in-picture');
+    expect(iframe?.getAttribute('allow')).toContain('web-share');
+    expect(iframe?.hasAttribute('allowfullscreen')).toBe(true);
+    expect(iframe?.getAttribute('loading')).toBe('lazy');
+    expect(iframe?.getAttribute('referrerpolicy')).toBe('strict-origin-when-cross-origin');
+    expect(iframe?.getAttribute('title')).toBe('youtube embed');
+  });
+
+  it('uses a provided title attribute on the iframe', () => {
+    const el = mount({ url: YOUTUBE_URL, title: 'Rick roll' });
+    const iframe = el.shadowRoot?.querySelector('iframe');
+    expect(iframe?.getAttribute('title')).toBe('Rick roll');
+  });
+
+  it('renders a fallback when url is on a disallowed domain', () => {
+    const el = mount({ url: DISALLOWED_URL });
+    const iframe = el.shadowRoot?.querySelector('iframe');
+    expect(iframe).toBeNull();
+    const fallback = el.shadowRoot?.querySelector('.embed-fallback');
+    expect(fallback).not.toBeNull();
+    const link = fallback?.querySelector('a');
+    expect(link?.getAttribute('href')).toBe(DISALLOWED_URL);
+    expect(link?.getAttribute('target')).toBe('_blank');
+    expect(link?.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+
+  it('falls back to 16:9 aspect ratio for unknown values', () => {
+    const el = mount({ url: YOUTUBE_URL, 'aspect-ratio': 'wide' });
+    const css = adoptedCssText(el);
+    expect(css).toContain('aspect-ratio: 16 / 9');
+  });
+
+  it('applies the requested aspect-ratio when valid', () => {
+    const el = mount({ url: YOUTUBE_URL, 'aspect-ratio': '4:3' });
+    expect(adoptedCssText(el)).toContain('aspect-ratio: 4 / 3');
+  });
+
+  it('reflects url changes by re-rendering the inner DOM', () => {
+    const el = mount({ url: YOUTUBE_URL });
+    const first = el.shadowRoot?.querySelector('iframe');
+    expect(first?.getAttribute('src')).toContain('dQw4w9WgXcQ');
+
+    el.setAttribute('url', YOUTUBE_URL_ALT);
+    const second = el.shadowRoot?.querySelector('iframe');
+    expect(second?.getAttribute('src')).toContain('9bZkp7q19f0');
+  });
+
+  it('reflects aspect-ratio changes on the adopted stylesheet', () => {
+    const el = mount({ url: YOUTUBE_URL });
+    expect(adoptedCssText(el)).toContain('aspect-ratio: 16 / 9');
+    el.setAttribute('aspect-ratio', '9:16');
+    expect(adoptedCssText(el)).toContain('aspect-ratio: 9 / 16');
+  });
+
+  it('observedAttributes matches the documented contract', () => {
+    expect(RaftersEmbed.observedAttributes).toEqual(['url', 'provider', 'aspect-ratio', 'title']);
+  });
+
+  it('never renders an iframe for a Twitter URL (widget out of scope)', () => {
+    const el = mount({ url: 'https://twitter.com/jack/status/20' });
+    expect(el.shadowRoot?.querySelector('iframe')).toBeNull();
+    expect(el.shadowRoot?.querySelector('.embed-fallback')).not.toBeNull();
+  });
+
+  it('source contains no direct var() references', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const source = await fs.readFile(path.resolve(__dirname, 'embed.element.ts'), 'utf-8');
+    expect(source).not.toMatch(/[^a-zA-Z_]var\(/);
+  });
+});

--- a/packages/ui/src/components/ui/embed.element.ts
+++ b/packages/ui/src/components/ui/embed.element.ts
@@ -1,0 +1,207 @@
+/**
+ * <rafters-embed> -- Web Component for external embedded content.
+ *
+ * Framework-target for the Embed component, parallel to embed.tsx (React).
+ * Scope is intentionally REDUCED relative to the React target: the WC
+ * covers the iframe provider path only (YouTube, Vimeo, Twitch, generic).
+ * The Twitter-widget flow, editable URL input, drag/drop file upload,
+ * and alignment toolbar are React-only concerns and are NOT in this file.
+ *
+ * Shadow DOM structure (URL present, domain allowed, provider detected):
+ *   <div class="embed"><iframe ... /></div>
+ *
+ * Shadow DOM structure (URL missing or domain disallowed):
+ *   <div class="embed-fallback">...</div>
+ *
+ * Attributes:
+ *   url           URL of the content to embed. Required.
+ *   provider      Override auto-detected provider: youtube | vimeo | twitch
+ *                 | generic. Unknown values fall back to auto-detection.
+ *   aspect-ratio  16:9 | 4:3 | 1:1 | 9:16. Unknown values fall back to
+ *                 '16:9' silently.
+ *   title         Forwarded to the inner iframe's `title` attribute for
+ *                 accessibility. Default: "{provider} embed".
+ *
+ * Behaviour:
+ *   - Auto-registers on import, idempotent via customElements.get guard.
+ *   - When `url` is absent, renders a fallback div and NEVER throws.
+ *   - When `isAllowedEmbedDomain(url)` returns false, renders a fallback
+ *     div with an <a> link to the original URL. NEVER renders an iframe
+ *     to an unallowed domain.
+ *   - Twitter-provider URLs fall through to the fallback case because
+ *     the widget-based flow is out of scope.
+ *   - DOM APIs only (document.createElement + setAttribute + appendChild);
+ *     NEVER innerHTML.
+ *   - Per-instance CSSStyleSheet pattern: connectedCallback creates one
+ *     sheet, replaceSync(embedStylesheet(...)), adoptedStyleSheets = [sheet].
+ *     On attribute change, re-render the inner DOM AND replaceSync the
+ *     same sheet when `aspect-ratio` changed.
+ *   - NEVER a raw CSS custom-property function literal in this file;
+ *     token references live in embed.styles.ts.
+ *   - Motion tokens use --motion-duration-* / --motion-ease-* only.
+ *
+ * @cognitive-load 3/10
+ * @accessibility iframe carries a `title` attribute; fallback exposes an
+ *   <a> link to the original URL for recovery.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import { type AspectRatioKey, embedStylesheet } from './embed.styles';
+import { detectEmbedProvider, type EmbedProvider, isAllowedEmbedDomain } from './embed-utils';
+
+const ALLOWED_ASPECT_RATIOS: ReadonlyArray<AspectRatioKey> = ['16:9', '4:3', '1:1', '9:16'];
+
+const ALLOWED_PROVIDERS: ReadonlyArray<EmbedProvider> = ['youtube', 'vimeo', 'twitch', 'generic'];
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = [
+  'url',
+  'provider',
+  'aspect-ratio',
+  'title',
+] as const;
+
+const IFRAME_ALLOW =
+  'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';
+
+const IFRAME_REFERRER_POLICY = 'strict-origin-when-cross-origin';
+
+const FALLBACK_MESSAGE_MISSING_URL = 'No URL provided';
+const FALLBACK_MESSAGE_DISALLOWED_DOMAIN = 'This URL is not from a supported embed provider';
+const FALLBACK_LINK_TEXT = 'Open in new tab';
+
+function parseAspectRatio(value: string | null): AspectRatioKey {
+  if (value && (ALLOWED_ASPECT_RATIOS as ReadonlyArray<string>).includes(value)) {
+    return value as AspectRatioKey;
+  }
+  return '16:9';
+}
+
+function parseProviderOverride(value: string | null): EmbedProvider | null {
+  if (value && (ALLOWED_PROVIDERS as ReadonlyArray<string>).includes(value)) {
+    return value as EmbedProvider;
+  }
+  return null;
+}
+
+export class RaftersEmbed extends RaftersElement {
+  static readonly observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  /** Per-instance stylesheet rebuilt when aspect-ratio changes. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  override connectedCallback(): void {
+    if (!this.shadowRoot) return;
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+    this.shadowRoot.adoptedStyleSheets = [this._instanceSheet];
+    this.update();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+    if (name === 'aspect-ratio' && this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+    this.update();
+  }
+
+  override disconnectedCallback(): void {
+    this._instanceSheet = null;
+  }
+
+  /**
+   * Build the CSS string for the current aspect-ratio attribute.
+   */
+  private composeCss(): string {
+    return embedStylesheet({
+      aspectRatio: parseAspectRatio(this.getAttribute('aspect-ratio')),
+    });
+  }
+
+  /**
+   * Render the inner DOM for the current attribute state. DOM APIs only
+   * -- never innerHTML. Returns a `.embed` wrapper with an `<iframe>` when
+   * the URL is present, on an allowed domain, and resolves to a supported
+   * non-Twitter provider; otherwise returns a `.embed-fallback` wrapper.
+   */
+  override render(): Node {
+    const url = this.getAttribute('url');
+
+    if (!url) {
+      return this.renderFallback('', FALLBACK_MESSAGE_MISSING_URL, false);
+    }
+
+    if (!isAllowedEmbedDomain(url)) {
+      return this.renderFallback(url, FALLBACK_MESSAGE_DISALLOWED_DOMAIN, true);
+    }
+
+    const detected = detectEmbedProvider(url);
+    if (!detected) {
+      return this.renderFallback(url, FALLBACK_MESSAGE_DISALLOWED_DOMAIN, true);
+    }
+
+    // Twitter falls through to the fallback: widget flow is out of scope.
+    if (detected.provider === 'twitter') {
+      return this.renderFallback(url, FALLBACK_MESSAGE_DISALLOWED_DOMAIN, true);
+    }
+
+    const providerOverride = parseProviderOverride(this.getAttribute('provider'));
+    const provider: EmbedProvider = providerOverride ?? detected.provider;
+    const iframeTitle = this.getAttribute('title') ?? `${provider} embed`;
+
+    return this.renderIframe(detected.embedUrl, iframeTitle);
+  }
+
+  /**
+   * Create the iframe branch of the render tree.
+   */
+  private renderIframe(src: string, title: string): Node {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'embed';
+
+    const iframe = document.createElement('iframe');
+    iframe.setAttribute('src', src);
+    iframe.setAttribute('title', title);
+    iframe.setAttribute('allow', IFRAME_ALLOW);
+    iframe.setAttribute('allowfullscreen', '');
+    iframe.setAttribute('loading', 'lazy');
+    iframe.setAttribute('referrerpolicy', IFRAME_REFERRER_POLICY);
+
+    wrapper.appendChild(iframe);
+    return wrapper;
+  }
+
+  /**
+   * Create the fallback branch of the render tree. When `includeLink` is
+   * true, append an <a> pointing at `url` so consumers can recover.
+   */
+  private renderFallback(url: string, message: string, includeLink: boolean): Node {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'embed-fallback';
+
+    const messageEl = document.createElement('p');
+    messageEl.className = 'embed-fallback__message';
+    messageEl.textContent = message;
+    wrapper.appendChild(messageEl);
+
+    if (includeLink && url) {
+      const link = document.createElement('a');
+      link.className = 'embed-fallback__link';
+      link.setAttribute('href', url);
+      link.setAttribute('target', '_blank');
+      link.setAttribute('rel', 'noopener noreferrer');
+      link.textContent = FALLBACK_LINK_TEXT;
+      wrapper.appendChild(link);
+    }
+
+    return wrapper;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-embed')) {
+  customElements.define('rafters-embed', RaftersEmbed);
+}

--- a/packages/ui/src/components/ui/embed.styles.ts
+++ b/packages/ui/src/components/ui/embed.styles.ts
@@ -1,0 +1,177 @@
+/**
+ * Shadow DOM style definitions for Embed web component
+ *
+ * Parallel to embed.classes.ts. Same semantic structure for the iframe
+ * display path, CSS property maps instead of Tailwind class strings.
+ *
+ * Scope is reduced relative to the React target: the WC covers the iframe
+ * provider path (YouTube, Vimeo, Twitch, generic) plus a fallback. The
+ * Twitter-widget flow, editable URL input, drag/drop upload, and alignment
+ * toolbar are React-only concerns and do NOT appear in this file.
+ *
+ * All token references go through tokenVar(); no raw var() literals appear
+ * outside the classy-wc primitives. Motion tokens use --motion-duration-*
+ * / --motion-ease-* only.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import { styleRule, stylesheet, tokenVar } from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+/**
+ * Accepted aspect-ratio keys for the <rafters-embed> host attribute.
+ *
+ * Unknown values fall back to '16:9' silently at the stylesheet boundary
+ * (never throw).
+ */
+export type AspectRatioKey = '16:9' | '4:3' | '1:1' | '9:16';
+
+// ============================================================================
+// Aspect Ratio Map
+// ============================================================================
+
+/**
+ * CSS aspect-ratio values keyed by AspectRatioKey. The CSS `aspect-ratio`
+ * property accepts the `<width> / <height>` two-number syntax directly, so
+ * these values are passed through to the `.embed` rule.
+ */
+export const aspectRatioValues: Record<AspectRatioKey, string> = {
+  '16:9': '16 / 9',
+  '4:3': '4 / 3',
+  '1:1': '1 / 1',
+  '9:16': '9 / 16',
+};
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+/**
+ * Outer `.embed` wrapper base. Mirrors embedContainerClasses:
+ *   "relative overflow-hidden rounded-lg bg-muted"
+ *
+ * Width fills the host; height comes from the aspect-ratio property set
+ * on the same rule.
+ */
+export const embedBase: CSSProperties = {
+  position: 'relative',
+  overflow: 'hidden',
+  'border-radius': tokenVar('radius-lg'),
+  'background-color': tokenVar('color-muted'),
+  width: '100%',
+};
+
+/**
+ * Inner `<iframe>` positioning. Mirrors embedIframeClasses:
+ *   "absolute inset-0 h-full w-full border-0"
+ */
+export const embedIframeBase: CSSProperties = {
+  position: 'absolute',
+  top: '0',
+  right: '0',
+  bottom: '0',
+  left: '0',
+  width: '100%',
+  height: '100%',
+  'border-width': '0',
+  'border-style': 'solid',
+  'border-color': 'transparent',
+};
+
+/**
+ * Fallback wrapper base. Mirrors embedFallbackClasses:
+ *   "flex flex-col items-center justify-center rounded-lg border-2
+ *    border-dashed border-muted-foreground/25 bg-muted/50 p-8 text-center"
+ *
+ * Note: the shadow-DOM surface cannot reference the half-opacity Tailwind
+ * utilities directly; opacity pairs are resolved via color tokens with
+ * `-muted-foreground` / `-muted` whole-token references. Parity with the
+ * React target's opacity nuance is handled at the token layer, not here.
+ */
+export const embedFallbackBase: CSSProperties = {
+  display: 'flex',
+  'flex-direction': 'column',
+  'align-items': 'center',
+  'justify-content': 'center',
+  'border-radius': tokenVar('radius-lg'),
+  'border-width': '2px',
+  'border-style': 'dashed',
+  'border-color': tokenVar('color-muted-foreground'),
+  'background-color': tokenVar('color-muted'),
+  padding: '2rem',
+  'text-align': 'center',
+};
+
+/**
+ * Fallback message text. Mirrors embedFallbackMessageClasses:
+ *   "mb-2 text-label-small font-medium text-muted-foreground"
+ */
+export const embedFallbackMessage: CSSProperties = {
+  'margin-bottom': '0.5rem',
+  'font-size': tokenVar('font-size-label-small'),
+  'font-weight': '500',
+  color: tokenVar('color-muted-foreground'),
+};
+
+/**
+ * Fallback external link. Mirrors embedFallbackLinkClasses:
+ *   "text-label-small text-primary underline underline-offset-4"
+ */
+export const embedFallbackLink: CSSProperties = {
+  'font-size': tokenVar('font-size-label-small'),
+  color: tokenVar('color-primary'),
+  'text-decoration': 'underline',
+  'text-underline-offset': '4px',
+};
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+export interface EmbedStylesheetOptions {
+  aspectRatio?: AspectRatioKey | undefined;
+}
+
+/**
+ * Build the complete embed stylesheet for a given configuration.
+ *
+ * Unknown aspectRatio keys fall back to '16:9' via pick(). Never throws.
+ * Emits:
+ *   - `:host` block layout so the embed takes full width by default
+ *   - `.embed` outer wrapper with the resolved aspect-ratio
+ *   - `.embed iframe` absolute-fill positioning
+ *   - `.embed-fallback` fallback wrapper chrome
+ *   - `.embed-fallback__message` fallback text styling
+ *   - `.embed-fallback__link` fallback link styling
+ */
+export function embedStylesheet(options: EmbedStylesheetOptions = {}): string {
+  const { aspectRatio } = options;
+
+  return stylesheet(
+    styleRule(':host', { display: 'block', width: '100%' }),
+
+    styleRule('.embed', embedBase, {
+      'aspect-ratio': pickAspectRatio(aspectRatio),
+    }),
+
+    styleRule('.embed iframe', embedIframeBase),
+
+    styleRule('.embed-fallback', embedFallbackBase),
+
+    styleRule('.embed-fallback__message', embedFallbackMessage),
+
+    styleRule('.embed-fallback__link', embedFallbackLink),
+  );
+}
+
+/**
+ * Resolve an aspect-ratio input into its CSS value. Unknown keys fall
+ * back to '16:9' silently. Never throws.
+ */
+function pickAspectRatio(key: AspectRatioKey | undefined): string {
+  if (key && key in aspectRatioValues) return aspectRatioValues[key];
+  return aspectRatioValues['16:9'];
+}


### PR DESCRIPTION
## Summary

Adds `<rafters-embed>` as the framework-target Web Component parallel to `embed.tsx` for external embedded content. Closes #1331.

Scope is reduced relative to the React target: the WC covers iframe providers only (YouTube, Vimeo, Twitch, generic). The following React-only concerns are explicitly **out of scope** for this issue:

- Twitter widget integration (requires external script + React state)
- Editable mode with URL input form
- Drag / drop / paste file upload
- Alignment toolbar
- Provider badge chrome

## What shipped

- `packages/ui/src/components/ui/embed.classes.ts` -- Tailwind class strings for React/Astro parity (iframe display path only).
- `packages/ui/src/components/ui/embed.styles.ts` -- CSS property maps for shadow DOM. Exports `AspectRatioKey` type and `embedStylesheet({ aspectRatio })`.
- `packages/ui/src/components/ui/embed.element.ts` -- `RaftersEmbed` custom element, auto-registers `<rafters-embed>` idempotently.
- `packages/ui/src/components/ui/embed.element.test.ts` -- 13 functional tests.

## Behaviour

- `observedAttributes = ['url', 'provider', 'aspect-ratio', 'title']`.
- Missing `url` -> `.embed-fallback` with "No URL provided". Never throws.
- Domain outside `isAllowedEmbedDomain()` -> `.embed-fallback` with `<a>` link to the original URL. No iframe ever renders to a disallowed domain.
- Twitter URLs fall through to the fallback (widget flow is out of scope).
- Unknown `aspect-ratio` -> silent fallback to `16:9`.
- Unknown `provider` override -> silent fallback to `detectEmbedProvider()`.
- Iframe attributes: `src`, `title`, `allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"`, `allowfullscreen`, `loading="lazy"`, `referrerpolicy="strict-origin-when-cross-origin"`.
- Per-instance `CSSStyleSheet` adopted on `connectedCallback`, `replaceSync` on `aspect-ratio` change.
- DOM APIs only (`document.createElement` + `setAttribute` + `appendChild`); never `innerHTML`.
- `tokenVar()` only, never raw `var()` literal in the element file.
- `--motion-duration-*` / `--motion-ease-*` tokens only.
- Reuses existing `embed-utils.ts` for `detectEmbedProvider` and `isAllowedEmbedDomain`.

## Test plan

- [x] `registers the rafters-embed tag on import`
- [x] `does not throw when the module is imported twice`
- [x] `renders a fallback div when url attribute is absent`
- [x] `renders an iframe with correct src/allow/allowfullscreen/loading/referrerpolicy for a valid YouTube URL`
- [x] `uses a provided title attribute on the iframe`
- [x] `renders a fallback when url is on a disallowed domain`
- [x] `falls back to 16:9 aspect ratio for unknown values`
- [x] `applies the requested aspect-ratio when valid`
- [x] `reflects url changes by re-rendering the inner DOM`
- [x] `reflects aspect-ratio changes on the adopted stylesheet`
- [x] `observedAttributes matches the documented contract`
- [x] `never renders an iframe for a Twitter URL (widget out of scope)`
- [x] `source contains no direct var() references`
- [x] `pnpm --filter=@rafters/ui typecheck` passes
- [x] `pnpm --filter=@rafters/ui test embed` passes (39 tests across React + WC suites)
- [x] `pnpm preflight` passes end-to-end (typecheck, lint, unit, a11y, build)

No version bump, no CHANGELOG entry in this PR per instructions.