### PR TITLE
feat(ui): <rafters-aspect-ratio> Web Component (#1330)

### DIFF
--- a/packages/ui/src/components/ui/aspect-ratio.classes.ts
+++ b/packages/ui/src/components/ui/aspect-ratio.classes.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared aspect-ratio class definitions
+ *
+ * Imported by aspect-ratio.tsx (React) and any future aspect-ratio.astro
+ * target to ensure visual parity across framework targets.
+ *
+ * These classes cover the outer wrapper only. The `aspect-ratio` CSS
+ * property itself is applied inline via the React `style` prop because
+ * the value is data-driven and not a fixed token. The Web Component
+ * target (aspect-ratio.element.ts) encodes the ratio into its per-instance
+ * stylesheet instead of an inline style so shadow-DOM consumers keep a
+ * style-attribute-free surface.
+ */
+
+export const aspectRatioBaseClasses = 'relative w-full';
+
+export const aspectRatioChildFillClasses = '[&>*]:absolute [&>*]:inset-0 [&>*]:h-full [&>*]:w-full';

--- a/packages/ui/src/components/ui/aspect-ratio.element.test.ts
+++ b/packages/ui/src/components/ui/aspect-ratio.element.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import './aspect-ratio.element';
+import { RaftersAspectRatio } from './aspect-ratio.element';
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+function mount(attrs: Record<string, string> = {}): HTMLElement {
+  const el = document.createElement('rafters-aspect-ratio');
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.appendChild(el);
+  return el;
+}
+
+function adoptedCssText(el: Element): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  const blocks: string[] = [];
+  for (const sheet of sheets) {
+    const rules: string[] = [];
+    for (const rule of Array.from(sheet.cssRules)) {
+      rules.push(rule.cssText);
+    }
+    blocks.push(rules.join('\n'));
+  }
+  return blocks.join('\n');
+}
+
+describe('<rafters-aspect-ratio>', () => {
+  it('registers the rafters-aspect-ratio tag on import', () => {
+    expect(customElements.get('rafters-aspect-ratio')).toBe(RaftersAspectRatio);
+  });
+
+  it('does not throw when the module is imported twice', async () => {
+    await expect(import('./aspect-ratio.element')).resolves.toBeDefined();
+    await expect(import('./aspect-ratio.element')).resolves.toBeDefined();
+    expect(customElements.get('rafters-aspect-ratio')).toBe(RaftersAspectRatio);
+  });
+
+  it('renders a single div.aspect-ratio containing a slot', () => {
+    const el = mount();
+    const root = el.shadowRoot;
+    expect(root).not.toBeNull();
+    // Exactly one top-level child in the shadow root.
+    expect(root?.childNodes.length).toBe(1);
+    const inner = root?.querySelector('div.aspect-ratio');
+    expect(inner).not.toBeNull();
+    expect(inner?.children.length).toBe(1);
+    expect(inner?.firstElementChild?.tagName.toLowerCase()).toBe('slot');
+  });
+
+  it('falls back to ratio 1 for missing, non-numeric, or non-positive values', () => {
+    // Missing attribute.
+    const missing = mount();
+    expect(adoptedCssText(missing)).toMatch(/aspect-ratio:\s*1(?!\.)/);
+
+    // Non-numeric string.
+    const nonNumeric = mount({ ratio: 'foo' });
+    expect(adoptedCssText(nonNumeric)).toMatch(/aspect-ratio:\s*1(?!\.)/);
+
+    // Negative number.
+    const negative = mount({ ratio: '-1' });
+    expect(adoptedCssText(negative)).toMatch(/aspect-ratio:\s*1(?!\.)/);
+
+    // Zero.
+    const zero = mount({ ratio: '0' });
+    expect(adoptedCssText(zero)).toMatch(/aspect-ratio:\s*1(?!\.)/);
+  });
+
+  it('parses fractional ratio strings like "16/9"', () => {
+    const el = mount({ ratio: '16/9' });
+    const css = adoptedCssText(el);
+    // 16 / 9 = 1.7777777777777777
+    expect(css).toContain(`aspect-ratio: ${String(16 / 9)}`);
+  });
+
+  it('reflects ratio attribute changes to the adopted stylesheet', () => {
+    const el = mount({ ratio: '1' });
+    expect(adoptedCssText(el)).toMatch(/aspect-ratio:\s*1(?!\.)/);
+    el.setAttribute('ratio', '4/3');
+    const css = adoptedCssText(el);
+    expect(css).toContain(`aspect-ratio: ${String(4 / 3)}`);
+    expect(css).not.toMatch(/aspect-ratio:\s*1;/);
+  });
+
+  it('source contains no direct var() references', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const source = await fs.readFile(path.resolve(__dirname, 'aspect-ratio.element.ts'), 'utf-8');
+    expect(source).not.toMatch(/[^a-zA-Z_]var\(/);
+  });
+});

--- a/packages/ui/src/components/ui/aspect-ratio.element.ts
+++ b/packages/ui/src/components/ui/aspect-ratio.element.ts
@@ -1,0 +1,95 @@
+/**
+ * <rafters-aspect-ratio> -- Web Component aspect-ratio container.
+ *
+ * Mirrors the semantics of aspect-ratio.tsx (ratio) using shadow-DOM-scoped
+ * CSS composed via classy-wc. Auto-registers on import and is idempotent
+ * against double-define.
+ *
+ * Attributes:
+ *  - ratio: positive number. Accepted formats:
+ *      - "16/9"   (fraction string, split-and-divide)
+ *      - "1.778"  (decimal string, Number())
+ *      - "1"      (integer string, Number())
+ *    Non-positive or non-numeric values fall back to 1 silently.
+ *
+ * Shadow DOM structure:
+ *   <div class="aspect-ratio"><slot></slot></div>
+ *
+ * The `aspect-ratio` CSS property is set on the `.aspect-ratio` rule via
+ * the per-instance stylesheet, NOT via an inline style attribute. This
+ * keeps the element file free of style-attribute manipulation.
+ *
+ * Slotted children (<img>, <iframe>, ...) fill the container via a
+ * `::slotted(*)` rule inside aspectRatioStylesheet(). The React target's
+ * `[&>*]:absolute` Tailwind selectors cannot cross the shadow boundary,
+ * so the shadow-DOM surface encodes the same behaviour natively.
+ *
+ * DOM APIs only -- never innerHTML. NEVER a raw CSS custom-property function
+ * literal in this file; token references live in aspect-ratio.styles.ts.
+ * Motion tokens use --motion-duration-* / --motion-ease-* only.
+ *
+ * @cognitive-load 1/10
+ * @accessibility Layout utility; slotted content carries its own semantics.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import { aspectRatioStylesheet } from './aspect-ratio.styles';
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = ['ratio'] as const;
+
+export class RaftersAspectRatio extends RaftersElement {
+  static readonly observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  /** Per-instance stylesheet rebuilt on ratio changes. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  override connectedCallback(): void {
+    if (!this.shadowRoot) return;
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+    this.shadowRoot.adoptedStyleSheets = [this._instanceSheet];
+    this.update();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+    if (name === 'ratio' && this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+    this.update();
+  }
+
+  override disconnectedCallback(): void {
+    this._instanceSheet = null;
+  }
+
+  /**
+   * Build the CSS string for the current ratio attribute. Delegates to
+   * aspectRatioStylesheet(), which parses and falls back on invalid input.
+   */
+  private composeCss(): string {
+    return aspectRatioStylesheet({ ratio: this.getAttribute('ratio') });
+  }
+
+  /**
+   * Render a single .aspect-ratio wrapper with one default <slot>.
+   * DOM APIs only -- never innerHTML. The wrapper carries NO inline
+   * style; the `aspect-ratio` CSS property comes from the per-instance
+   * stylesheet instead.
+   */
+  override render(): Node {
+    const inner = document.createElement('div');
+    inner.className = 'aspect-ratio';
+    const slot = document.createElement('slot');
+    inner.appendChild(slot);
+    return inner;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-aspect-ratio')) {
+  customElements.define('rafters-aspect-ratio', RaftersAspectRatio);
+}

--- a/packages/ui/src/components/ui/aspect-ratio.styles.ts
+++ b/packages/ui/src/components/ui/aspect-ratio.styles.ts
@@ -1,0 +1,128 @@
+/**
+ * Shadow DOM style definitions for AspectRatio web component
+ *
+ * Parallel to aspect-ratio.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ *
+ * The `aspect-ratio` CSS property is data-driven (caller-supplied number)
+ * so it lives on the `.aspect-ratio` rule composed inside the stylesheet
+ * rather than inline on the element. Slotted descendants receive fill
+ * declarations via `::slotted(*)` because Tailwind's `[&>*]` descendant
+ * selectors from the React/Astro classes.ts cannot cross the shadow
+ * boundary.
+ *
+ * All token references go through tokenVar(); no raw var() literals
+ * appear outside the classy-wc primitives.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import { styleRule, stylesheet } from '../../primitives/classy-wc';
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+/**
+ * Host block layout. AspectRatio is a full-width proportional container.
+ */
+export const aspectRatioHostBase: CSSProperties = {
+  display: 'block',
+  position: 'relative',
+  width: '100%',
+};
+
+/**
+ * Inner wrapper base. Carries the `aspect-ratio` property the consumer
+ * requested. Width is inherited from the host.
+ */
+export const aspectRatioInnerBase: CSSProperties = {
+  position: 'relative',
+  width: '100%',
+};
+
+/**
+ * Slotted-child fill rule -- shadow-DOM equivalent of the React target's
+ * `[&>*]:absolute [&>*]:inset-0 [&>*]:h-full [&>*]:w-full` selectors.
+ * `object-fit: cover` matches the common `<img>` / `<iframe>` use case
+ * documented on aspect-ratio.tsx.
+ */
+export const aspectRatioSlottedFill: CSSProperties = {
+  position: 'absolute',
+  top: '0',
+  right: '0',
+  bottom: '0',
+  left: '0',
+  width: '100%',
+  height: '100%',
+  'object-fit': 'cover',
+};
+
+// ============================================================================
+// Ratio Parsing
+// ============================================================================
+
+/**
+ * Parse a raw ratio input into a positive number.
+ *
+ * Accepted formats:
+ *  - `"16/9"` -> 16 / 9 = 1.7777...
+ *  - `"1.778"` -> 1.778
+ *  - `1` (numeric) -> 1
+ *
+ * Non-positive or non-numeric values silently fall back to 1, matching
+ * the behaviour documented on the React target (`ratio = 1` default).
+ */
+export function parseRatio(input: string | number | null | undefined): number {
+  if (input === null || input === undefined) return 1;
+  if (typeof input === 'number') {
+    return Number.isFinite(input) && input > 0 ? input : 1;
+  }
+  const trimmed = input.trim();
+  if (trimmed === '') return 1;
+  if (trimmed.includes('/')) {
+    const [rawNum, rawDen] = trimmed.split('/');
+    const num = Number(rawNum);
+    const den = Number(rawDen);
+    if (!Number.isFinite(num) || !Number.isFinite(den) || den === 0) return 1;
+    const quotient = num / den;
+    return quotient > 0 ? quotient : 1;
+  }
+  const numeric = Number(trimmed);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : 1;
+}
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+export interface AspectRatioStylesheetOptions {
+  ratio?: string | number | null | undefined;
+}
+
+/**
+ * Build the complete aspect-ratio stylesheet for a given ratio.
+ *
+ * Emits:
+ *   - `:host` host-level block layout
+ *   - `.aspect-ratio` inner wrapper carrying the resolved `aspect-ratio`
+ *     CSS property
+ *   - `::slotted(*)` fill rule so slotted `<img>` / `<iframe>` / other
+ *     children fill the container (shadow-boundary equivalent of the
+ *     React target's `[&>*]` selectors)
+ *
+ * Non-positive or non-numeric ratio values silently fall back to 1.
+ * Never throws.
+ */
+export function aspectRatioStylesheet(options: AspectRatioStylesheetOptions = {}): string {
+  const ratio = parseRatio(options.ratio);
+
+  return stylesheet(
+    styleRule(':host', aspectRatioHostBase),
+
+    styleRule('.aspect-ratio', aspectRatioInnerBase, {
+      'aspect-ratio': String(ratio),
+    }),
+
+    styleRule('::slotted(*)', aspectRatioSlottedFill),
+  );
+}


### PR DESCRIPTION
## Summary

- Add the Web Component framework target for AspectRatio alongside the existing React surface.
- Introduce `aspect-ratio.classes.ts` (shared class strings), `aspect-ratio.styles.ts` (stylesheet builder with ratio parsing), and `aspect-ratio.element.ts` (auto-registering `<rafters-aspect-ratio>`).
- Put `aspect-ratio: N` in the adopted stylesheet (never inline) and fill slotted descendants via `::slotted(*)` rules, because Tailwind's `[&>*]` selectors cannot cross the shadow boundary.

## Behaviour

- `observedAttributes = ['ratio']`.
- Ratio parsing supports `"16/9"` (split and divide), `"1.778"` (decimal), and `"1"` (integer). Non-positive or non-numeric values silently fall back to `1`.
- Per-instance `CSSStyleSheet` created in `connectedCallback`; `replaceSync` reuses the same sheet on attribute changes.
- Registration is idempotent via `customElements.get('rafters-aspect-ratio')` guard.
- No `var()` literal in the element file; all tokens route through `tokenVar()` in `aspect-ratio.styles.ts`.

## Test plan

- [x] `pnpm --filter=@rafters/ui test aspect-ratio` (21 passed across 3 files; 7 new tests in `aspect-ratio.element.test.ts`)
- [x] `pnpm typecheck` clean across the monorepo
- [x] `pnpm preflight` clean (pre-push hook)
- [x] Shadow DOM shape: single `div.aspect-ratio` containing one `<slot>`
- [x] Fallback behaviour covers missing, non-numeric, negative, and zero values
- [x] Fractional strings parse correctly (`16/9` -> `1.777...`)
- [x] Attribute changes reflected in `adoptedStyleSheets`
- [x] Source contains no direct `var()` references

Closes #1330