### PR TITLE
feat(ui): <rafters-separator> Web Component (#1333)

### DIFF
--- a/packages/ui/src/components/ui/separator.classes.ts
+++ b/packages/ui/src/components/ui/separator.classes.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared separator orientation class definitions
+ *
+ * Imported by both separator.tsx (React) and separator.astro (Astro)
+ * to ensure visual parity across framework targets.
+ */
+
+export const separatorOrientationClasses: Record<string, string> = {
+  horizontal: 'h-px w-full',
+  vertical: 'h-full w-px',
+};
+
+export const separatorBaseClasses = 'shrink-0 bg-border';

--- a/packages/ui/src/components/ui/separator.element.test.ts
+++ b/packages/ui/src/components/ui/separator.element.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import './separator.element';
+import { RaftersSeparator } from './separator.element';
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+function mount(attrs: Record<string, string> = {}): HTMLElement {
+  const el = document.createElement('rafters-separator');
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.appendChild(el);
+  return el;
+}
+
+function adoptedCssText(el: Element): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  const blocks: string[] = [];
+  for (const sheet of sheets) {
+    const rules: string[] = [];
+    for (const rule of Array.from(sheet.cssRules)) {
+      rules.push(rule.cssText);
+    }
+    blocks.push(rules.join('\n'));
+  }
+  return blocks.join('\n');
+}
+
+describe('<rafters-separator>', () => {
+  it('registers the rafters-separator tag on import', () => {
+    expect(customElements.get('rafters-separator')).toBe(RaftersSeparator);
+  });
+
+  it('does not throw when the module is imported twice', async () => {
+    await expect(import('./separator.element')).resolves.toBeDefined();
+    await expect(import('./separator.element')).resolves.toBeDefined();
+    expect(customElements.get('rafters-separator')).toBe(RaftersSeparator);
+  });
+
+  it('renders a single div.separator with role="none" by default (decorative)', () => {
+    const el = mount();
+    const inner = el.shadowRoot?.querySelector('div.separator');
+    expect(inner).not.toBeNull();
+    expect(inner?.getAttribute('role')).toBe('none');
+    expect(inner?.hasAttribute('aria-orientation')).toBe(false);
+    expect(inner?.classList.contains('orientation-horizontal')).toBe(true);
+    // Separator has no slotted content.
+    expect(el.shadowRoot?.querySelector('slot')).toBeNull();
+  });
+
+  it('falls back to horizontal orientation for unknown values', () => {
+    const el = mount({ orientation: 'diagonal' });
+    const inner = el.shadowRoot?.querySelector('div.separator');
+    expect(inner?.classList.contains('orientation-horizontal')).toBe(true);
+    const css = adoptedCssText(el);
+    expect(css).toMatch(/height:\s*1px/);
+    expect(css).toMatch(/width:\s*100%/);
+  });
+
+  it('reflects orientation changes to class and adopted stylesheet', () => {
+    const el = mount();
+    el.setAttribute('orientation', 'vertical');
+    const inner = el.shadowRoot?.querySelector('div.separator');
+    expect(inner?.classList.contains('orientation-vertical')).toBe(true);
+    expect(inner?.classList.contains('orientation-horizontal')).toBe(false);
+    const css = adoptedCssText(el);
+    expect(css).toMatch(/height:\s*100%/);
+    expect(css).toMatch(/width:\s*1px/);
+  });
+
+  it('reflects decorative="false" by setting role="separator" and aria-orientation', () => {
+    const el = mount();
+    el.setAttribute('decorative', 'false');
+    // `decorative="false"` keeps the separator decorative (aria-hidden from AT).
+    const innerAfterFalse = el.shadowRoot?.querySelector('div.separator');
+    expect(innerAfterFalse?.getAttribute('role')).toBe('none');
+    expect(innerAfterFalse?.hasAttribute('aria-orientation')).toBe(false);
+
+    // Setting decorative to any non-"false" value (including empty string)
+    // opts into the non-decorative role/aria-orientation pair.
+    el.setAttribute('decorative', '');
+    const innerAfterPresent = el.shadowRoot?.querySelector('div.separator');
+    expect(innerAfterPresent?.getAttribute('role')).toBe('separator');
+    expect(innerAfterPresent?.getAttribute('aria-orientation')).toBe('horizontal');
+
+    // aria-orientation mirrors the current orientation.
+    el.setAttribute('orientation', 'vertical');
+    const innerVertical = el.shadowRoot?.querySelector('div.separator');
+    expect(innerVertical?.getAttribute('role')).toBe('separator');
+    expect(innerVertical?.getAttribute('aria-orientation')).toBe('vertical');
+  });
+
+  it('observedAttributes matches the documented contract', () => {
+    expect(RaftersSeparator.observedAttributes).toEqual(['orientation', 'decorative']);
+  });
+
+  it('shadow root adopts the per-instance stylesheet', () => {
+    const el = mount();
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    expect(sheets.length).toBe(1);
+  });
+
+  it('stylesheet uses only --motion-duration / --motion-ease tokens', () => {
+    const el = mount();
+    const css = adoptedCssText(el);
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+  });
+
+  it('source contains no direct var() references', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const source = await fs.readFile(path.resolve(__dirname, 'separator.element.ts'), 'utf-8');
+    expect(source).not.toMatch(/[^a-zA-Z_]var\(/);
+  });
+});

--- a/packages/ui/src/components/ui/separator.element.ts
+++ b/packages/ui/src/components/ui/separator.element.ts
@@ -1,0 +1,116 @@
+/**
+ * <rafters-separator> -- Web Component separator primitive.
+ *
+ * Mirrors the semantics of separator.tsx (orientation, decorative) using
+ * shadow-DOM-scoped CSS composed via classy-wc. Auto-registers on import
+ * and is idempotent against double-define.
+ *
+ * Attributes:
+ *  - orientation: 'horizontal' | 'vertical'  (default 'horizontal')
+ *  - decorative:  presence-based. ABSENT = decorative (matches React's
+ *                 default of true). PRESENT and not exactly "false" =
+ *                 non-decorative. `<rafters-separator decorative="false">`
+ *                 turns non-decorative OFF (i.e. remains decorative).
+ *
+ * Shadow DOM structure:
+ *   <div class="separator orientation-{orientation}" role=... aria-orientation=...>
+ *
+ * Accessibility:
+ *  - Decorative: role="none" on the inner div, no aria-orientation.
+ *  - Non-decorative: role="separator" on the inner div, aria-orientation
+ *    mirrors the current orientation.
+ *
+ * Rendering:
+ *  - No <slot>; separator has no slotted content.
+ *  - DOM APIs only; never innerHTML.
+ *
+ * @cognitive-load 0/10
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import { type SeparatorOrientation, separatorStylesheet } from './separator.styles';
+
+const ALLOWED_ORIENTATIONS: ReadonlyArray<SeparatorOrientation> = ['horizontal', 'vertical'];
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = ['orientation', 'decorative'] as const;
+
+function parseOrientation(value: string | null): SeparatorOrientation {
+  if (value && (ALLOWED_ORIENTATIONS as ReadonlyArray<string>).includes(value)) {
+    return value as SeparatorOrientation;
+  }
+  return 'horizontal';
+}
+
+export class RaftersSeparator extends RaftersElement {
+  static readonly observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  /** Per-instance stylesheet mutated in place on every attribute change. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  override connectedCallback(): void {
+    if (!this.shadowRoot) return;
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+    this.shadowRoot.adoptedStyleSheets = [this._instanceSheet];
+    this.update();
+  }
+
+  override attributeChangedCallback(
+    _name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+    if (this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+    this.update();
+  }
+
+  override disconnectedCallback(): void {
+    this._instanceSheet = null;
+  }
+
+  /**
+   * Whether the separator should expose a non-decorative `role="separator"`
+   * with `aria-orientation`. Presence-based: absent = decorative, present
+   * and not the literal string "false" = non-decorative.
+   */
+  private isNonDecorative(): boolean {
+    return this.hasAttribute('decorative') && this.getAttribute('decorative') !== 'false';
+  }
+
+  /**
+   * Build the CSS string for the current attribute values.
+   */
+  private composeCss(): string {
+    return separatorStylesheet({
+      orientation: parseOrientation(this.getAttribute('orientation')),
+    });
+  }
+
+  /**
+   * Render the inner `<div.separator>` with orientation-specific class and
+   * ARIA attributes. DOM APIs only -- never innerHTML.
+   */
+  override render(): Node {
+    const orientation = parseOrientation(this.getAttribute('orientation'));
+    const nonDecorative = this.isNonDecorative();
+
+    const inner = document.createElement('div');
+    inner.className = `separator orientation-${orientation}`;
+
+    if (nonDecorative) {
+      inner.setAttribute('role', 'separator');
+      inner.setAttribute('aria-orientation', orientation);
+    } else {
+      inner.setAttribute('role', 'none');
+    }
+
+    return inner;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-separator')) {
+  customElements.define('rafters-separator', RaftersSeparator);
+}

--- a/packages/ui/src/components/ui/separator.styles.ts
+++ b/packages/ui/src/components/ui/separator.styles.ts
@@ -1,0 +1,83 @@
+/**
+ * Shadow DOM style definitions for Separator web component
+ *
+ * Parallel to separator.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ * Token values via tokenVar() from the shared token stylesheet.
+ *
+ * All token references go through tokenVar(); no raw var() literals.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import { pick, styleRule, stylesheet, tokenVar } from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export type SeparatorOrientation = 'horizontal' | 'vertical';
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+/**
+ * Base separator declarations shared across both orientations.
+ * Mirrors separatorBaseClasses from separator.classes.ts
+ * (`shrink-0 bg-border`).
+ */
+export const separatorBase: CSSProperties = {
+  'flex-shrink': '0',
+  'background-color': tokenVar('color-border'),
+};
+
+// ============================================================================
+// Orientation Styles
+// ============================================================================
+
+/**
+ * Orientation-driven sizing declarations.
+ * horizontal = 1px tall, fills available width.
+ * vertical   = fills available height, 1px wide.
+ */
+export const separatorOrientationStyles: Record<SeparatorOrientation, CSSProperties> = {
+  horizontal: {
+    height: '1px',
+    width: '100%',
+  },
+  vertical: {
+    height: '100%',
+    width: '1px',
+  },
+};
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+export interface SeparatorStylesheetOptions {
+  orientation?: SeparatorOrientation | undefined;
+}
+
+/**
+ * Build the complete separator stylesheet for a given configuration.
+ *
+ * Unknown orientation keys fall back to 'horizontal' via pick(). Never throws.
+ * The inner `.separator` div carries both the base color and orientation
+ * sizing rules. `:host` is block-level by default; orientation-specific
+ * host sizing is left to the consumer so vertical separators stretch to
+ * fill their flex/grid parent naturally.
+ */
+export function separatorStylesheet(options: SeparatorStylesheetOptions = {}): string {
+  const { orientation } = options;
+
+  return stylesheet(
+    styleRule(':host', { display: 'block' }),
+
+    styleRule(
+      '.separator',
+      separatorBase,
+      pick(separatorOrientationStyles, orientation, 'horizontal'),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

Adds the Web Component framework-target for the visual separator, parallel to `separator.tsx` (React) and `separator.astro` (Astro). Ships three new files in `packages/ui/src/components/ui/`:

- `separator.classes.ts` -- shared Tailwind class map (`separatorBaseClasses`, `separatorOrientationClasses`) for future React/Astro deduplication.
- `separator.styles.ts` -- `SeparatorOrientation` type and `separatorStylesheet({ orientation })` composer built on `classy-wc` (`tokenVar`, `styleRule`, `pick`, `stylesheet`). No raw `var()` literals.
- `separator.element.ts` -- `RaftersSeparator` (auto-registers as `<rafters-separator>`, idempotent via `customElements.get` guard).

### Attribute contract

- `orientation`: `'horizontal' | 'vertical'`, default `'horizontal'`. Unknown values fall back silently.
- `decorative`: presence-driven. ABSENT keeps the React default of `decorative = true` (`role="none"`, no `aria-orientation`). PRESENT with any value that is **not** the literal string `"false"` flips to `role="separator"` with `aria-orientation` mirroring the current orientation. `<rafters-separator decorative="false">` therefore turns non-decorative OFF.

### Rendering

- Shadow root: `<div class="separator orientation-{orientation}" role=... aria-orientation=...>`.
- No `<slot>` (separator carries no content).
- DOM APIs only, never `innerHTML`.
- Per-instance `CSSStyleSheet` created once on connect and `replaceSync`'d in place on every `attributeChangedCallback`, so the adopted stylesheet slot is stable across orientation flips.

Closes #1333

## Test plan

- [x] 10 new tests in `separator.element.test.ts` covering registration, double-import idempotency, default decorative shape (`role="none"`, no `aria-orientation`, no slot), unknown-orientation fallback, orientation reflection (class + adopted CSS), `decorative="false"` kept decorative vs `decorative=""` flipping to `role="separator"` + `aria-orientation`, `observedAttributes` contract, adopted-stylesheet count, motion-namespace enforcement, and source-has-no-`var()` literal.
- [x] `pnpm --filter=@rafters/ui test separator` -- 20/20 passing (separator.element + tsx + astro).
- [x] `pnpm --filter=@rafters/ui typecheck` clean.
- [x] `pnpm preflight` clean (typecheck, lint, unit, a11y, build).
- [x] Pre-push hook preflight passed in 86.5s.

No version bump, no CHANGELOG, no barrel re-exports, no React/Astro changes.