### PR TITLE
feat(ui): <rafters-image> Web Component (#1332)

### DIFF
--- a/packages/ui/src/components/ui/image.classes.ts
+++ b/packages/ui/src/components/ui/image.classes.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared image size and alignment class definitions
+ *
+ * Parallel to badge.classes.ts and button.classes.ts. Captures the Tailwind
+ * class mapping for the image size + alignment matrix so every framework
+ * target (React, Astro, WC) renders visually identical output.
+ *
+ * The React target at image.tsx currently spells these classes inline; this
+ * module pulls them out so image.astro and image.styles.ts can mirror the
+ * same decisions without duplication.
+ */
+
+export type ImageSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'full';
+
+export type ImageAlignment = 'left' | 'center' | 'right';
+
+/** Size preset to Tailwind max-width class mapping. */
+export const imageSizeClasses: Record<ImageSize, string> = {
+  xs: 'max-w-xs',
+  sm: 'max-w-sm',
+  md: 'max-w-md',
+  lg: 'max-w-lg',
+  xl: 'max-w-xl',
+  '2xl': 'max-w-2xl',
+  full: 'w-full',
+};
+
+/** Horizontal alignment class mapping. */
+export const imageAlignmentClasses: Record<ImageAlignment, string> = {
+  left: 'mr-auto',
+  center: 'mx-auto',
+  right: 'ml-auto',
+};
+
+/** Base classes always applied to the figure wrapper. */
+export const imageBaseClasses = 'relative';
+
+/** Classes applied to the inner image element. */
+export const imageImgClasses = 'block w-full h-auto';
+
+/** Classes applied to the optional caption. */
+export const imageCaptionClasses = 'mt-2 text-center text-sm text-muted-foreground';

--- a/packages/ui/src/components/ui/image.element.test.ts
+++ b/packages/ui/src/components/ui/image.element.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import './image.element';
+import { RaftersImage } from './image.element';
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+function mount(attrs: Record<string, string> = {}): HTMLElement {
+  const el = document.createElement('rafters-image');
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.appendChild(el);
+  return el;
+}
+
+function adoptedCssText(el: Element): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  const blocks: string[] = [];
+  for (const sheet of sheets) {
+    const rules: string[] = [];
+    for (const rule of Array.from(sheet.cssRules)) {
+      rules.push(rule.cssText);
+    }
+    blocks.push(rules.join('\n'));
+  }
+  return blocks.join('\n');
+}
+
+const SAMPLE_SRC = 'https://example.com/photo.jpg';
+const SAMPLE_SRC_ALT = 'https://example.com/other.jpg';
+
+describe('<rafters-image>', () => {
+  it('registers the rafters-image tag on import', () => {
+    expect(customElements.get('rafters-image')).toBe(RaftersImage);
+  });
+
+  it('does not throw when the module is imported twice', async () => {
+    await expect(import('./image.element')).resolves.toBeDefined();
+    await expect(import('./image.element')).resolves.toBeDefined();
+    expect(customElements.get('rafters-image')).toBe(RaftersImage);
+  });
+
+  it('renders a figure.image with an img child when src is set', () => {
+    const el = mount({ src: SAMPLE_SRC, alt: 'A sunset' });
+    const figure = el.shadowRoot?.querySelector('figure.image');
+    expect(figure).not.toBeNull();
+    const img = figure?.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toBe(SAMPLE_SRC);
+    expect(img?.getAttribute('alt')).toBe('A sunset');
+  });
+
+  it('renders an empty figure when src attribute is absent', () => {
+    const el = mount();
+    const figure = el.shadowRoot?.querySelector('figure.image');
+    expect(figure).not.toBeNull();
+    expect(figure?.querySelector('img')).toBeNull();
+  });
+
+  it('does not throw when rendered without any attributes', () => {
+    expect(() => mount()).not.toThrow();
+  });
+
+  it('defaults alt to empty string when attribute is absent', () => {
+    const el = mount({ src: SAMPLE_SRC });
+    const img = el.shadowRoot?.querySelector('img');
+    expect(img?.getAttribute('alt')).toBe('');
+  });
+
+  it('falls back to full size and center alignment for unknown values', () => {
+    const el = mount({ src: SAMPLE_SRC, size: 'gigantic', alignment: 'diagonal' });
+    const css = adoptedCssText(el);
+    // full -> max-width: 100%
+    expect(css).toContain('max-width: 100%');
+    // center -> margin-left: auto; margin-right: auto (jsdom serialises to
+    // the `margin` shorthand "0px auto").
+    expect(css).toMatch(/margin:\s*0px\s+auto/);
+  });
+
+  it('applies the requested size when valid', () => {
+    const el = mount({ src: SAMPLE_SRC, size: 'md' });
+    expect(adoptedCssText(el)).toContain('max-width: 28rem');
+  });
+
+  it('applies the requested alignment when valid', () => {
+    const el = mount({ src: SAMPLE_SRC, alignment: 'left' });
+    const css = adoptedCssText(el);
+    // left -> margin-left: 0; margin-right: auto (jsdom shorthand
+    // "0px auto 0px 0px": top right bottom left).
+    expect(css).toMatch(/margin:\s*0px\s+auto\s+0px\s+0px/);
+  });
+
+  it('reflects size changes on the adopted stylesheet', () => {
+    const el = mount({ src: SAMPLE_SRC });
+    expect(adoptedCssText(el)).toContain('max-width: 100%');
+    el.setAttribute('size', 'lg');
+    expect(adoptedCssText(el)).toContain('max-width: 32rem');
+  });
+
+  it('reflects alignment changes on the adopted stylesheet', () => {
+    const el = mount({ src: SAMPLE_SRC });
+    el.setAttribute('alignment', 'right');
+    const css = adoptedCssText(el);
+    // right -> margin-left: auto; margin-right: 0 (jsdom shorthand
+    // "0px 0px 0px auto": top right bottom left).
+    expect(css).toMatch(/margin:\s*0px\s+0px\s+0px\s+auto/);
+  });
+
+  it('reflects alt attribute changes to the img element', () => {
+    const el = mount({ src: SAMPLE_SRC, alt: 'Initial' });
+    el.setAttribute('alt', 'A sunset');
+    const img = el.shadowRoot?.querySelector('img');
+    expect(img?.alt).toBe('A sunset');
+  });
+
+  it('reflects src attribute changes to the img element', () => {
+    const el = mount({ src: SAMPLE_SRC });
+    el.setAttribute('src', SAMPLE_SRC_ALT);
+    const img = el.shadowRoot?.querySelector('img');
+    expect(img?.getAttribute('src')).toBe(SAMPLE_SRC_ALT);
+  });
+
+  it('reflects caption attribute changes to the figcaption textContent', () => {
+    const el = mount({ src: SAMPLE_SRC });
+    // No caption yet, no figcaption in DOM.
+    expect(el.shadowRoot?.querySelector('figcaption')).toBeNull();
+
+    // Setting caption inserts the figcaption with matching textContent.
+    el.setAttribute('caption', 'Photo by John');
+    const first = el.shadowRoot?.querySelector('figcaption');
+    expect(first).not.toBeNull();
+    expect(first?.textContent).toBe('Photo by John');
+
+    // Updating caption updates the same node's textContent.
+    el.setAttribute('caption', 'Updated');
+    const second = el.shadowRoot?.querySelector('figcaption');
+    expect(second?.textContent).toBe('Updated');
+
+    // Removing caption drops the figcaption from the DOM.
+    el.removeAttribute('caption');
+    expect(el.shadowRoot?.querySelector('figcaption')).toBeNull();
+  });
+
+  it('renders an initial figcaption when caption attribute is set at mount', () => {
+    const el = mount({ src: SAMPLE_SRC, caption: 'Initial caption' });
+    const figcaption = el.shadowRoot?.querySelector('figcaption.image-caption');
+    expect(figcaption?.textContent).toBe('Initial caption');
+  });
+
+  it('observedAttributes matches the documented contract', () => {
+    expect(RaftersImage.observedAttributes).toEqual(['src', 'alt', 'size', 'alignment', 'caption']);
+  });
+
+  it('uses only --motion-duration / --motion-ease tokens (never bare --duration/--ease)', () => {
+    const el = mount({ src: SAMPLE_SRC });
+    const css = adoptedCssText(el);
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+  });
+
+  it('source contains no direct var() references', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const source = await fs.readFile(path.resolve(__dirname, 'image.element.ts'), 'utf-8');
+    expect(source).not.toMatch(/[^a-zA-Z_]var\(/);
+  });
+});

--- a/packages/ui/src/components/ui/image.element.ts
+++ b/packages/ui/src/components/ui/image.element.ts
@@ -1,0 +1,216 @@
+/**
+ * <rafters-image> -- Web Component for static image display.
+ *
+ * Framework-target for the Image component, parallel to image.tsx (React).
+ * Scope is intentionally REDUCED relative to the React target: the WC
+ * covers the static display path only -- a `<figure>` with `<img>` and
+ * an optional `<figcaption>`. The editable mode (upload, drag-drop, paste,
+ * alignment toolbar, loading/error overlays, contentEditable caption) is a
+ * React-only concern and is NOT in this file.
+ *
+ * Shadow DOM structure (src present):
+ *   <figure class="image"><img src alt /></figure>
+ *
+ * Shadow DOM structure (src present, caption present):
+ *   <figure class="image">
+ *     <img src alt />
+ *     <figcaption class="image-caption">{caption}</figcaption>
+ *   </figure>
+ *
+ * Shadow DOM structure (src absent):
+ *   <figure class="image"></figure>
+ *
+ * Attributes:
+ *   src        Image URL. When absent, render an empty `<figure>` (no
+ *              `<img>`) and NEVER throw.
+ *   alt        Alt text forwarded to the inner `<img>`. Defaults to ""
+ *              when absent, matching the HTML spec for decorative images.
+ *   size       xs | sm | md | lg | xl | 2xl | full. Unknown or missing
+ *              values fall back to 'full' silently.
+ *   alignment  left | center | right. Unknown or missing values fall
+ *              back to 'center' silently.
+ *   caption    Optional text below the image. When present, render a
+ *              `<figcaption>` with the text assigned via `textContent`.
+ *              Never `innerHTML`.
+ *
+ * Behaviour:
+ *   - Auto-registers on import, idempotent via customElements.get guard.
+ *   - Per-instance CSSStyleSheet pattern: connectedCallback creates one
+ *     sheet, replaceSync(imageStylesheet(...)), adoptedStyleSheets = [sheet].
+ *     On `size` / `alignment` change, replaceSync the SAME sheet.
+ *   - On `src` / `alt` / `caption` change, update the inner DOM
+ *     (img.src, img.alt, figcaption.textContent) WITHOUT rebuilding the
+ *     whole subtree.
+ *   - DOM APIs only (document.createElement + setAttribute + appendChild);
+ *     NEVER innerHTML.
+ *   - NEVER raw CSS custom-property literal in this file; token references
+ *     live in image.styles.ts.
+ *   - Motion tokens use --motion-duration-* / --motion-ease-* only.
+ *
+ * @cognitive-load 2/10
+ * @accessibility `<img>` always carries an `alt` attribute; defaults to ""
+ *   when absent to match the HTML spec for decorative images.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import { type ImageAlignment, type ImageSize, imageStylesheet } from './image.styles';
+
+const ALLOWED_SIZES: ReadonlyArray<ImageSize> = ['xs', 'sm', 'md', 'lg', 'xl', '2xl', 'full'];
+
+const ALLOWED_ALIGNMENTS: ReadonlyArray<ImageAlignment> = ['left', 'center', 'right'];
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = [
+  'src',
+  'alt',
+  'size',
+  'alignment',
+  'caption',
+] as const;
+
+function parseSize(value: string | null): ImageSize {
+  if (value && (ALLOWED_SIZES as ReadonlyArray<string>).includes(value)) {
+    return value as ImageSize;
+  }
+  return 'full';
+}
+
+function parseAlignment(value: string | null): ImageAlignment {
+  if (value && (ALLOWED_ALIGNMENTS as ReadonlyArray<string>).includes(value)) {
+    return value as ImageAlignment;
+  }
+  return 'center';
+}
+
+export class RaftersImage extends RaftersElement {
+  static readonly observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  /** Per-instance stylesheet rebuilt when size or alignment changes. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  /** Stable reference to the rendered `<figure>` wrapper. */
+  private _figure: HTMLElement | null = null;
+
+  /** Stable reference to the rendered `<img>` (when src is present). */
+  private _img: HTMLImageElement | null = null;
+
+  /** Stable reference to the rendered `<figcaption>` (when caption present). */
+  private _caption: HTMLElement | null = null;
+
+  override connectedCallback(): void {
+    if (!this.shadowRoot) return;
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+    this.shadowRoot.adoptedStyleSheets = [this._instanceSheet];
+    this.update();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+
+    // size / alignment map onto the adopted stylesheet only; the DOM shape
+    // is unchanged so no re-render is needed.
+    if (name === 'size' || name === 'alignment') {
+      if (this._instanceSheet) {
+        this._instanceSheet.replaceSync(this.composeCss());
+      }
+      return;
+    }
+
+    // src, alt, caption map onto inner DOM state. Prefer the surgical
+    // update path when the figure exists and the transition does not
+    // require adding/removing a child element. Otherwise re-render.
+    if (name === 'alt' && this._img) {
+      this._img.alt = newValue ?? '';
+      return;
+    }
+
+    if (name === 'src' && this._figure && this._img && newValue) {
+      this._img.src = newValue;
+      return;
+    }
+
+    if (name === 'caption' && this._figure) {
+      if (newValue == null) {
+        if (this._caption) {
+          this._caption.remove();
+          this._caption = null;
+        }
+        return;
+      }
+      if (this._caption) {
+        this._caption.textContent = newValue;
+        return;
+      }
+      this._caption = document.createElement('figcaption');
+      this._caption.className = 'image-caption';
+      this._caption.textContent = newValue;
+      this._figure.appendChild(this._caption);
+      return;
+    }
+
+    // Fall back to a full re-render for transitions that change the DOM
+    // shape (e.g. src toggling between absent/present).
+    this.update();
+  }
+
+  override disconnectedCallback(): void {
+    this._instanceSheet = null;
+    this._figure = null;
+    this._img = null;
+    this._caption = null;
+  }
+
+  /**
+   * Build the CSS string for the current size / alignment attributes.
+   */
+  private composeCss(): string {
+    return imageStylesheet({
+      size: parseSize(this.getAttribute('size')),
+      alignment: parseAlignment(this.getAttribute('alignment')),
+    });
+  }
+
+  /**
+   * Render the inner semantic `<figure>` with an optional `<img>` and an
+   * optional `<figcaption>`. DOM APIs only -- never innerHTML.
+   *
+   * The figure always gets `.image`. The img (when present) carries no
+   * classes; styling comes from the adopted stylesheet via `.image img`.
+   * The caption (when present) gets `.image-caption`.
+   */
+  override render(): Node {
+    const figure = document.createElement('figure');
+    figure.className = 'image';
+    this._figure = figure;
+    this._img = null;
+    this._caption = null;
+
+    const src = this.getAttribute('src');
+    if (src) {
+      const img = document.createElement('img');
+      img.setAttribute('src', src);
+      img.setAttribute('alt', this.getAttribute('alt') ?? '');
+      figure.appendChild(img);
+      this._img = img;
+    }
+
+    const caption = this.getAttribute('caption');
+    if (caption != null) {
+      const captionEl = document.createElement('figcaption');
+      captionEl.className = 'image-caption';
+      captionEl.textContent = caption;
+      figure.appendChild(captionEl);
+      this._caption = captionEl;
+    }
+
+    return figure;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-image')) {
+  customElements.define('rafters-image', RaftersImage);
+}

--- a/packages/ui/src/components/ui/image.styles.ts
+++ b/packages/ui/src/components/ui/image.styles.ts
@@ -1,0 +1,180 @@
+/**
+ * Shadow DOM style definitions for Image web component
+ *
+ * Parallel to image.classes.ts. Same semantic structure for the static
+ * display path (figure + img + optional figcaption), CSS property maps
+ * instead of Tailwind class strings.
+ *
+ * Scope is reduced relative to the React target: the WC covers the static
+ * display surface only. Upload/drag-drop/paste handlers, loading and error
+ * overlays, the alignment toolbar, and the contentEditable caption are
+ * React-only concerns and do NOT appear in this file.
+ *
+ * All token references go through tokenVar(); no raw var() literals appear
+ * outside the classy-wc primitives. Motion tokens use --motion-duration-*
+ * / --motion-ease-* only.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import { pick, styleRule, stylesheet, tokenVar } from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+/**
+ * Token-based image size presets. Matches image.tsx / image.classes.ts.
+ *
+ * Unknown values fall back to 'full' silently at the stylesheet boundary
+ * (never throw).
+ */
+export type ImageSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'full';
+
+/**
+ * Horizontal alignment options for the figure. Matches image.tsx /
+ * image.classes.ts.
+ *
+ * Unknown values fall back to 'center' silently at the stylesheet
+ * boundary (never throw).
+ */
+export type ImageAlignment = 'left' | 'center' | 'right';
+
+// ============================================================================
+// Size Map
+// ============================================================================
+
+/**
+ * Image size preset to max-width value. Values mirror the Tailwind
+ * `max-w-*` scale consumed by image.classes.ts:
+ *   xs  -> 20rem, sm  -> 24rem, md  -> 28rem, lg  -> 32rem,
+ *   xl  -> 36rem, 2xl -> 42rem, full -> 100%
+ */
+export const imageSizeValues: Record<ImageSize, string> = {
+  xs: '20rem',
+  sm: '24rem',
+  md: '28rem',
+  lg: '32rem',
+  xl: '36rem',
+  '2xl': '42rem',
+  full: '100%',
+};
+
+// ============================================================================
+// Alignment Map
+// ============================================================================
+
+/**
+ * Horizontal alignment rules expressed as auto-margin CSS properties.
+ * Mirrors the Tailwind `mr-auto` / `mx-auto` / `ml-auto` utilities from
+ * image.classes.ts.
+ */
+export const imageAlignmentStyles: Record<ImageAlignment, CSSProperties> = {
+  left: {
+    'margin-left': '0',
+    'margin-right': 'auto',
+  },
+  center: {
+    'margin-left': 'auto',
+    'margin-right': 'auto',
+  },
+  right: {
+    'margin-left': 'auto',
+    'margin-right': '0',
+  },
+};
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+/**
+ * Outer `<figure>` base. Mirrors imageBaseClasses + responsive width.
+ * The `max-width` declaration is filled in per-instance by imageStylesheet()
+ * based on the resolved size. The `margin` pair is filled in from
+ * imageAlignmentStyles.
+ */
+export const imageFigureBase: CSSProperties = {
+  position: 'relative',
+  'border-width': '0',
+  'border-style': 'solid',
+  'border-color': 'transparent',
+  'margin-top': '0',
+  'margin-bottom': '0',
+};
+
+/**
+ * Inner `<img>` element. Mirrors imageImgClasses:
+ *   "block w-full h-auto"
+ *
+ * A rounded corner on the image wrapper would require an extra DOM node;
+ * the React target wraps the img in a `relative overflow-hidden rounded-lg`
+ * div to enable that. The WC omits the wrapper div to keep the DOM minimal
+ * for the static display path.
+ */
+export const imageImgBase: CSSProperties = {
+  display: 'block',
+  width: '100%',
+  height: 'auto',
+  'border-radius': tokenVar('radius-lg'),
+};
+
+/**
+ * Optional `<figcaption>`. Mirrors imageCaptionClasses:
+ *   "mt-2 text-center text-sm text-muted-foreground"
+ */
+export const imageCaptionBase: CSSProperties = {
+  'margin-top': '0.5rem',
+  'text-align': 'center',
+  'font-size': tokenVar('font-size-label-small'),
+  color: tokenVar('color-muted-foreground'),
+};
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+export interface ImageStylesheetOptions {
+  size?: ImageSize | undefined;
+  alignment?: ImageAlignment | undefined;
+}
+
+/**
+ * Build the complete image stylesheet for a given configuration.
+ *
+ * Unknown size keys fall back to 'full' silently; unknown alignment keys
+ * fall back to 'center' silently. Never throws. Emits:
+ *   - `:host` block layout so the figure resolves its own max-width
+ *   - `.image` figure wrapper with the resolved max-width and alignment
+ *     auto-margins
+ *   - `.image img` inner image scaling
+ *   - `.image-caption` caption text styling
+ */
+export function imageStylesheet(options: ImageStylesheetOptions = {}): string {
+  const { size, alignment } = options;
+
+  return stylesheet(
+    styleRule(':host', { display: 'block', width: '100%' }),
+
+    styleRule(
+      '.image',
+      imageFigureBase,
+      {
+        'max-width': pickSize(size),
+      },
+      pick(imageAlignmentStyles, alignment, 'center'),
+    ),
+
+    styleRule('.image img', imageImgBase),
+
+    styleRule('.image-caption', imageCaptionBase),
+  );
+}
+
+/**
+ * Resolve a size input into its CSS max-width value. Unknown keys fall
+ * back to 'full' silently. Never throws.
+ */
+function pickSize(key: ImageSize | undefined): string {
+  if (key && key in imageSizeValues) return imageSizeValues[key];
+  return imageSizeValues.full;
+}


### PR DESCRIPTION
## Summary

- Adds `<rafters-image>` custom element as the Web Component target for images, parallel to `image.tsx` (React).
- Scope is intentionally reduced to the static display path: a `<figure>` with `<img>` and an optional `<figcaption>`. The editable mode (upload, drag-drop, paste, alignment toolbar, loading/error overlays, `contentEditable` caption) remains a React-only concern.
- Ships three new files plus functional tests.

## Files

- `packages/ui/src/components/ui/image.classes.ts` -- size + alignment Tailwind class maps lifted out of `image.tsx` so every framework target reads the same decisions.
- `packages/ui/src/components/ui/image.styles.ts` -- `ImageSize` / `ImageAlignment` types and `imageStylesheet({ size, alignment })` composer. Unknown keys fall back silently (`size` -> `'full'`, `alignment` -> `'center'`); never throws.
- `packages/ui/src/components/ui/image.element.ts` -- `RaftersImage` class with `observedAttributes` `['src', 'alt', 'size', 'alignment', 'caption']`. Auto-registers on import and is idempotent via a `customElements.get` guard. Per-instance `CSSStyleSheet` pattern: `size` / `alignment` changes `replaceSync` the same sheet; `src` / `alt` / `caption` changes update the inner DOM surgically without rebuilding the subtree. DOM APIs only, never `innerHTML`.
- `packages/ui/src/components/ui/image.element.test.ts` -- functional tests covering tag registration, idempotent double-import, `figure.image` + `img` shape, empty `figure` when `src` is absent, size / alignment fallback for unknown values, surgical `alt` / `src` / `caption` updates, `figcaption` insertion / removal on caption toggle, `observedAttributes` contract, and a no-`var()` literal guard against the element source.

## Invariants

- No `any` types.
- No raw `var()` literal in the element file; all token references flow through `tokenVar()` in `image.styles.ts`.
- Motion tokens use `--motion-duration-*` / `--motion-ease-*` only.
- Auto-register is idempotent via `customElements.get('rafters-image')` guard.
- DOM construction uses `document.createElement` + `setAttribute` + `appendChild`; caption text assigned via `textContent`.
- Silent fallback on unknown `size` / `alignment` values; never throws.

## Test plan

- [x] `pnpm --filter=@rafters/ui test image` -- 46 / 46 passing (2 files).
- [x] `pnpm --filter=@rafters/ui typecheck` clean.
- [x] `pnpm preflight` exit 0 (typecheck, lint, 4116 `@rafters/ui` unit, 662 a11y, all builds).
- [x] No `var(` literal in `image.element.ts`.
- [x] No `--duration-*` / `--ease-*` in the adopted stylesheet.

Closes #1332