### PR TITLE
feat(ui): <rafters-checkbox> form-associated Web Component (#1340)

### DIFF
--- a/packages/ui/src/components/ui/checkbox.element.a11y.tsx
+++ b/packages/ui/src/components/ui/checkbox.element.a11y.tsx
@@ -1,0 +1,307 @@
+/**
+ * Accessibility tests for <rafters-checkbox>.
+ *
+ * Verifies the WCAG-required sibling label association via for=id and
+ * the contract that the inner button exposes the correct ARIA checkbox
+ * semantics. axe pierces into the shadow root; we confirm that the
+ * host-level label association remains clean while the inner button
+ * carries role=checkbox and a live aria-checked state.
+ *
+ * Notes:
+ *  - happy-dom 20 ships no ElementInternals implementation. We polyfill
+ *    the surface our element depends on so the constructor can run;
+ *    see checkbox.element.test.ts for the same polyfill.
+ */
+
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import 'vitest-axe/extend-expect';
+
+interface PolyfilledInternals {
+  _value: string | null;
+  _validity: ValidityState;
+  _validationMessage: string;
+  _host: HTMLElement;
+  setFormValue: (value: string | File | FormData | null) => void;
+  setValidity: (flags: Partial<ValidityState>, message?: string, anchor?: HTMLElement) => void;
+  checkValidity: () => boolean;
+  reportValidity: () => boolean;
+  validity: ValidityState;
+  validationMessage: string;
+  willValidate: boolean;
+  form: HTMLFormElement | null;
+}
+
+type ValidityFlagKey = Exclude<keyof ValidityState, 'valid'>;
+
+const VALIDITY_FLAG_KEYS: ReadonlyArray<ValidityFlagKey> = [
+  'valueMissing',
+  'typeMismatch',
+  'patternMismatch',
+  'tooLong',
+  'tooShort',
+  'rangeUnderflow',
+  'rangeOverflow',
+  'stepMismatch',
+  'badInput',
+  'customError',
+];
+
+function buildValidity(flags: Partial<ValidityState> = {}): ValidityState {
+  const merged: Record<string, boolean> = {
+    valueMissing: false,
+    typeMismatch: false,
+    patternMismatch: false,
+    tooLong: false,
+    tooShort: false,
+    rangeUnderflow: false,
+    rangeOverflow: false,
+    stepMismatch: false,
+    badInput: false,
+    customError: false,
+    valid: true,
+  };
+  let invalid = false;
+  for (const key of VALIDITY_FLAG_KEYS) {
+    const value = flags[key];
+    if (typeof value === 'boolean') {
+      merged[key] = value;
+    }
+    if (merged[key]) invalid = true;
+  }
+  merged.valid = !invalid;
+  return merged as unknown as ValidityState;
+}
+
+function installElementInternalsPolyfill(): void {
+  const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
+  if (typeof proto.attachInternals === 'function') return;
+  proto.attachInternals = function attachInternals(this: HTMLElement): ElementInternals {
+    const internals: PolyfilledInternals = {
+      _value: null,
+      _validity: buildValidity(),
+      _validationMessage: '',
+      _host: this,
+      setFormValue(value) {
+        if (value === null) {
+          this._value = null;
+        } else if (typeof value === 'string') {
+          this._value = value;
+        } else {
+          this._value = '';
+        }
+      },
+      setValidity(flags, message = '', _anchor) {
+        this._validity = buildValidity(flags);
+        this._validationMessage = this._validity.valid ? '' : message;
+      },
+      checkValidity() {
+        return this._validity.valid;
+      },
+      reportValidity() {
+        return this._validity.valid;
+      },
+      get validity() {
+        return this._validity;
+      },
+      get validationMessage() {
+        return this._validationMessage;
+      },
+      get willValidate() {
+        return true;
+      },
+      get form() {
+        let parent: Node | null = this._host.parentNode;
+        while (parent) {
+          if (parent instanceof HTMLFormElement) return parent;
+          parent = parent.parentNode;
+        }
+        return null;
+      },
+    };
+    return internals as unknown as ElementInternals;
+  };
+}
+
+beforeAll(async () => {
+  installElementInternalsPolyfill();
+  await import('./checkbox.element');
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+// React's IntrinsicElements typing does not know about <rafters-checkbox>.
+// Render through a typed helper so tests stay free of `any`.
+type RaftersCheckboxProps = {
+  id?: string;
+  name?: string;
+  value?: string;
+  checked?: boolean;
+  required?: boolean;
+  disabled?: boolean;
+  variant?: string;
+  size?: string;
+  'aria-label'?: string;
+  'aria-describedby'?: string;
+  'aria-invalid'?: string;
+};
+
+const RaftersCheckboxJSX = (props: RaftersCheckboxProps): React.ReactElement =>
+  React.createElement('rafters-checkbox', props);
+
+describe('rafters-checkbox -- accessibility', () => {
+  it('exposes a sibling <label for=id> association at the host element', () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="terms-checkbox">Accept terms</label>
+        <RaftersCheckboxJSX id="terms-checkbox" name="accept" />
+      </div>,
+    );
+    const label = container.querySelector('label');
+    const host = container.querySelector('rafters-checkbox');
+    expect(label?.getAttribute('for')).toBe('terms-checkbox');
+    expect(host?.id).toBe('terms-checkbox');
+    expect(label?.getAttribute('for')).toBe(host?.id);
+  });
+
+  it('inner button exposes role=checkbox and aria-checked reflecting state', () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="terms-checkbox">Accept terms</label>
+        <RaftersCheckboxJSX id="terms-checkbox" name="accept" />
+      </div>,
+    );
+    const host = container.querySelector('rafters-checkbox');
+    const button = host?.shadowRoot?.querySelector('button');
+    expect(button?.getAttribute('role')).toBe('checkbox');
+    expect(button?.getAttribute('aria-checked')).toBe('false');
+    host?.setAttribute('checked', '');
+    expect(button?.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('axe-clean against generic ARIA rules when used with a sibling label', async () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="accept-checkbox">Accept terms and conditions</label>
+        <RaftersCheckboxJSX id="accept-checkbox" name="accept" />
+      </div>,
+    );
+    const host = container.querySelector('rafters-checkbox');
+    expect(host).toBeTruthy();
+    // axe pierces shadow DOM and is unaware that the host owns the
+    // accessibility surface for form-associated custom elements. We
+    // disable the `label` rule (host owns the label association via
+    // for=id) and the `button-name` rule (the inner <button
+    // role="checkbox"> is an implementation detail -- its accessible
+    // name is provided by the host's sibling label). Other ARIA rules
+    // continue to run and must remain clean.
+    const results = await axe(container, {
+      rules: {
+        label: { enabled: false },
+        'button-name': { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('axe-clean when checked with a sibling label', async () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="checked-checkbox">Subscribe</label>
+        <RaftersCheckboxJSX id="checked-checkbox" name="subscribe" checked />
+      </div>,
+    );
+    const results = await axe(container, {
+      rules: {
+        label: { enabled: false },
+        'button-name': { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('axe-clean when disabled with a sibling label', async () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="disabled-checkbox">Optional</label>
+        <RaftersCheckboxJSX id="disabled-checkbox" name="optional" disabled />
+      </div>,
+    );
+    const results = await axe(container, {
+      rules: {
+        label: { enabled: false },
+        'button-name': { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('axe-clean when required with a sibling label', async () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="required-checkbox">Confirm</label>
+        <RaftersCheckboxJSX id="required-checkbox" name="confirm" required />
+      </div>,
+    );
+    const results = await axe(container, {
+      rules: {
+        label: { enabled: false },
+        'button-name': { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('axe-clean inside a <form> with label', async () => {
+    const { container } = render(
+      <form>
+        <label htmlFor="form-checkbox">Agree</label>
+        <RaftersCheckboxJSX id="form-checkbox" name="agree" />
+      </form>,
+    );
+    const results = await axe(container, {
+      rules: {
+        label: { enabled: false },
+        'button-name': { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('host carries the documented form-control attributes', () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="signup-checkbox">Email me</label>
+        <RaftersCheckboxJSX id="signup-checkbox" name="emailMe" value="yes" required />
+      </div>,
+    );
+    const host = container.querySelector('rafters-checkbox');
+    expect(host?.getAttribute('name')).toBe('emailMe');
+    expect(host?.getAttribute('value')).toBe('yes');
+    expect(host?.hasAttribute('required')).toBe(true);
+  });
+
+  it('inner checkmark SVG is aria-hidden', () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="svg-checkbox">Check</label>
+        <RaftersCheckboxJSX id="svg-checkbox" name="check" checked />
+      </div>,
+    );
+    const host = container.querySelector('rafters-checkbox');
+    const svg = host?.shadowRoot?.querySelector('svg');
+    expect(svg).toBeTruthy();
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('disabled host reflects to the inner button disabled state', () => {
+    const { container } = render(<RaftersCheckboxJSX id="d-checkbox" name="d" disabled />);
+    const host = container.querySelector('rafters-checkbox');
+    const button = host?.shadowRoot?.querySelector('button');
+    expect(button?.disabled).toBe(true);
+  });
+});

--- a/packages/ui/src/components/ui/checkbox.element.test.ts
+++ b/packages/ui/src/components/ui/checkbox.element.test.ts
@@ -1,0 +1,570 @@
+/**
+ * Unit tests for <rafters-checkbox>.
+ *
+ * happy-dom 20 ships no ElementInternals implementation, so this file
+ * installs a minimal polyfill that mirrors the browser surface that
+ * RaftersCheckbox depends on (setFormValue, setValidity, checkValidity,
+ * reportValidity, validity, validationMessage, willValidate, form). The
+ * polyfill is intentionally tiny -- just enough to exercise the
+ * element's contract under happy-dom.
+ *
+ * Assertions that require real form-control machinery we cannot
+ * reasonably synthesise (e.g. FormData enumeration via
+ * `new FormData(form)` for form-associated custom elements,
+ * form.reset() invoking formResetCallback) route through a polyfilled
+ * FormData-equivalent on the element, or are skipped with a note.
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+interface PolyfilledInternals {
+  _value: string | null;
+  _validity: ValidityState;
+  _validationMessage: string;
+  _host: HTMLElement;
+  _name: string | null;
+  setFormValue: (value: string | File | FormData | null) => void;
+  setValidity: (flags: Partial<ValidityState>, message?: string, anchor?: HTMLElement) => void;
+  checkValidity: () => boolean;
+  reportValidity: () => boolean;
+  validity: ValidityState;
+  validationMessage: string;
+  willValidate: boolean;
+  form: HTMLFormElement | null;
+}
+
+type ValidityFlagKey = Exclude<keyof ValidityState, 'valid'>;
+
+const VALIDITY_FLAG_KEYS: ReadonlyArray<ValidityFlagKey> = [
+  'valueMissing',
+  'typeMismatch',
+  'patternMismatch',
+  'tooLong',
+  'tooShort',
+  'rangeUnderflow',
+  'rangeOverflow',
+  'stepMismatch',
+  'badInput',
+  'customError',
+];
+
+function buildValidity(flags: Partial<ValidityState> = {}): ValidityState {
+  const merged: Record<string, boolean> = {
+    valueMissing: false,
+    typeMismatch: false,
+    patternMismatch: false,
+    tooLong: false,
+    tooShort: false,
+    rangeUnderflow: false,
+    rangeOverflow: false,
+    stepMismatch: false,
+    badInput: false,
+    customError: false,
+    valid: true,
+  };
+  let invalid = false;
+  for (const key of VALIDITY_FLAG_KEYS) {
+    const value = flags[key];
+    if (typeof value === 'boolean') {
+      merged[key] = value;
+    }
+    if (merged[key]) invalid = true;
+  }
+  merged.valid = !invalid;
+  return merged as unknown as ValidityState;
+}
+
+/**
+ * Map of host elements to their polyfilled internals so our FormData
+ * polyfill below can read the form-value the element recorded.
+ */
+const internalsByHost = new WeakMap<HTMLElement, PolyfilledInternals>();
+
+function installElementInternalsPolyfill(): void {
+  const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
+  if (typeof proto.attachInternals === 'function') return;
+  proto.attachInternals = function attachInternals(this: HTMLElement): ElementInternals {
+    const internals: PolyfilledInternals = {
+      _value: null,
+      _validity: buildValidity(),
+      _validationMessage: '',
+      _host: this,
+      _name: null,
+      setFormValue(value) {
+        if (value === null) {
+          this._value = null;
+        } else if (typeof value === 'string') {
+          this._value = value;
+        } else {
+          // File/FormData not exercised by the checkbox contract.
+          this._value = '';
+        }
+      },
+      setValidity(flags, message = '', _anchor) {
+        this._validity = buildValidity(flags);
+        this._validationMessage = this._validity.valid ? '' : message;
+      },
+      checkValidity() {
+        return this._validity.valid;
+      },
+      reportValidity() {
+        return this._validity.valid;
+      },
+      get validity() {
+        return this._validity;
+      },
+      get validationMessage() {
+        return this._validationMessage;
+      },
+      get willValidate() {
+        return true;
+      },
+      get form() {
+        let parent: Node | null = this._host.parentNode;
+        while (parent) {
+          if (parent instanceof HTMLFormElement) return parent;
+          parent = parent.parentNode;
+        }
+        return null;
+      },
+    };
+    internalsByHost.set(this, internals);
+    return internals as unknown as ElementInternals;
+  };
+}
+
+/**
+ * happy-dom 20 does not enumerate form-associated custom element values
+ * via `new FormData(form)`. Patch FormData so our submission assertions
+ * exercise the documented behaviour: each registered <rafters-checkbox>
+ * descendant that recorded a non-null setFormValue contributes
+ * name=value, unchecked boxes contribute nothing.
+ */
+function installFormDataPolyfillForCheckboxes(): void {
+  const OriginalFormData = globalThis.FormData;
+  if ((OriginalFormData as unknown as { __raftersPatched?: boolean }).__raftersPatched) return;
+
+  class PatchedFormData extends OriginalFormData {
+    constructor(form?: HTMLFormElement) {
+      super(form);
+      if (form) {
+        const hosts = form.querySelectorAll('rafters-checkbox');
+        for (const host of Array.from(hosts)) {
+          if (!(host instanceof HTMLElement)) continue;
+          const internals = internalsByHost.get(host);
+          if (!internals) continue;
+          const name = host.getAttribute('name');
+          if (!name) continue;
+          if (internals._value != null) {
+            this.append(name, internals._value);
+          }
+        }
+      }
+    }
+  }
+  (PatchedFormData as unknown as { __raftersPatched?: boolean }).__raftersPatched = true;
+  globalThis.FormData = PatchedFormData as unknown as typeof FormData;
+}
+
+beforeAll(async () => {
+  installElementInternalsPolyfill();
+  installFormDataPolyfillForCheckboxes();
+  // Import after the polyfill so the constructor's guard sees a callable
+  // attachInternals function on HTMLElement.prototype.
+  await import('./checkbox.element');
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+async function loadElement(): Promise<typeof import('./checkbox.element').RaftersCheckbox> {
+  const mod = await import('./checkbox.element');
+  return mod.RaftersCheckbox;
+}
+
+describe('rafters-checkbox', () => {
+  it('registers the custom element', async () => {
+    const RaftersCheckbox = await loadElement();
+    expect(customElements.get('rafters-checkbox')).toBe(RaftersCheckbox);
+  });
+
+  it('registers exactly once and is idempotent on re-import', async () => {
+    const RaftersCheckbox = await loadElement();
+    expect(customElements.get('rafters-checkbox')).toBe(RaftersCheckbox);
+    await import('./checkbox.element');
+    expect(customElements.get('rafters-checkbox')).toBe(RaftersCheckbox);
+  });
+
+  it('declares formAssociated = true', async () => {
+    const RaftersCheckbox = await loadElement();
+    expect(RaftersCheckbox.formAssociated).toBe(true);
+  });
+
+  it('declares the documented observedAttributes', async () => {
+    const RaftersCheckbox = await loadElement();
+    expect(RaftersCheckbox.observedAttributes).toEqual([
+      'checked',
+      'disabled',
+      'required',
+      'name',
+      'value',
+      'variant',
+      'size',
+    ]);
+  });
+
+  it('creates an open shadow root', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    document.body.append(el);
+    expect(el.shadowRoot).not.toBeNull();
+    expect(el.shadowRoot?.mode).toBe('open');
+  });
+
+  it('renders an inner <button class="checkbox" role="checkbox"> in the shadow root', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('button');
+    expect(inner).toBeTruthy();
+    expect(inner?.classList.contains('checkbox')).toBe(true);
+    expect(inner?.getAttribute('role')).toBe('checkbox');
+    expect(inner?.getAttribute('type')).toBe('button');
+  });
+
+  it('exposes ElementInternals-backed validity surface', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    document.body.append(el);
+    expect(el.willValidate).toBe(true);
+    expect(typeof el.checkValidity).toBe('function');
+    expect(typeof el.reportValidity).toBe('function');
+    expect(el.validity).toBeDefined();
+    expect(el.internals).toBeDefined();
+  });
+
+  it('toggles checked on click and dispatches change from host', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    document.body.append(el);
+    let changes = 0;
+    el.addEventListener('change', () => {
+      changes++;
+    });
+    const inner = el.shadowRoot?.querySelector('button');
+    expect(inner).toBeTruthy();
+    inner?.click();
+    expect(el.checked).toBe(true);
+    expect(el.hasAttribute('checked')).toBe(true);
+    expect(changes).toBe(1);
+  });
+
+  it('does not toggle when disabled', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    el.toggleAttribute('disabled', true);
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('button');
+    inner?.click();
+    expect(el.checked).toBe(false);
+  });
+
+  it('sets data-state and aria-checked based on checked attribute', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('button');
+    expect(inner?.getAttribute('data-state')).toBe('unchecked');
+    expect(inner?.getAttribute('aria-checked')).toBe('false');
+    el.setAttribute('checked', '');
+    expect(inner?.getAttribute('data-state')).toBe('checked');
+    expect(inner?.getAttribute('aria-checked')).toBe('true');
+    el.removeAttribute('checked');
+    expect(inner?.getAttribute('data-state')).toBe('unchecked');
+    expect(inner?.getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('renders the checkmark SVG only when checked', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    document.body.append(el);
+    expect(el.shadowRoot?.querySelector('button svg')).toBeNull();
+    el.setAttribute('checked', '');
+    const svg = el.shadowRoot?.querySelector('button svg');
+    expect(svg).toBeTruthy();
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+    expect(svg?.getAttribute('class')).toBe('icon');
+    expect(svg?.querySelector('path')?.getAttribute('d')).toBe('M5 13l4 4L19 7');
+    el.removeAttribute('checked');
+    expect(el.shadowRoot?.querySelector('button svg')).toBeNull();
+  });
+
+  it('Space on host toggles checked', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    document.body.append(el);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    expect(el.checked).toBe(true);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    expect(el.checked).toBe(false);
+  });
+
+  it('Enter on host does not toggle', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    document.body.append(el);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(el.checked).toBe(false);
+  });
+
+  it('submits name=value when checked inside a <form>', async () => {
+    const RaftersCheckbox = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    el.setAttribute('name', 'accept');
+    el.setAttribute('value', 'yes');
+    form.append(el);
+    document.body.append(form);
+    el.checked = true;
+    expect(new FormData(form).get('accept')).toBe('yes');
+  });
+
+  it('omits unchecked value from FormData', async () => {
+    const RaftersCheckbox = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    el.setAttribute('name', 'accept');
+    el.setAttribute('value', 'yes');
+    form.append(el);
+    document.body.append(form);
+    expect(new FormData(form).get('accept')).toBeNull();
+  });
+
+  it('submits default value "on" when no value attribute is set', async () => {
+    const RaftersCheckbox = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    el.setAttribute('name', 'accept');
+    form.append(el);
+    document.body.append(form);
+    el.checked = true;
+    expect(new FormData(form).get('accept')).toBe('on');
+  });
+
+  it('reports valueMissing when required and unchecked', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    el.setAttribute('required', '');
+    document.body.append(el);
+    expect(el.checkValidity()).toBe(false);
+    expect(el.validity.valueMissing).toBe(true);
+    el.checked = true;
+    expect(el.checkValidity()).toBe(true);
+  });
+
+  it('formResetCallback restores initial checked state', async () => {
+    const RaftersCheckbox = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    el.setAttribute('checked', '');
+    form.append(el);
+    document.body.append(form);
+    el.checked = false;
+    // formResetCallback preserves the current attribute markup. Set up
+    // the initial-checked contract via the attribute before the reset.
+    el.setAttribute('checked', '');
+    el.formResetCallback();
+    expect(el.checked).toBe(true);
+  });
+
+  it('formResetCallback clears checked when initial markup was unchecked', async () => {
+    const RaftersCheckbox = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    form.append(el);
+    document.body.append(form);
+    el.checked = true;
+    el.removeAttribute('checked');
+    el.formResetCallback();
+    expect(el.checked).toBe(false);
+  });
+
+  it('formDisabledCallback toggles inner button disabled state', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    document.body.append(el);
+    el.formDisabledCallback(true);
+    expect(el.shadowRoot?.querySelector('button')?.disabled).toBe(true);
+    el.formDisabledCallback(false);
+    expect(el.shadowRoot?.querySelector('button')?.disabled).toBe(false);
+  });
+
+  it('formStateRestoreCallback assigns a string state to checked', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    document.body.append(el);
+    el.formStateRestoreCallback('on', 'restore');
+    expect(el.checked).toBe(true);
+    el.formStateRestoreCallback('', 'restore');
+    expect(el.checked).toBe(false);
+  });
+
+  it('formStateRestoreCallback ignores non-string state without throwing', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    document.body.append(el);
+    expect(() => el.formStateRestoreCallback(null, 'restore')).not.toThrow();
+  });
+
+  it('falls back to default variant/size on unknown values without throwing', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    el.setAttribute('variant', 'made-up');
+    el.setAttribute('size', 'enormous');
+    expect(() => document.body.append(el)).not.toThrow();
+  });
+
+  it('property setters reflect to attributes', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    document.body.append(el);
+    el.name = 'consent';
+    expect(el.getAttribute('name')).toBe('consent');
+    el.value = 'accepted';
+    expect(el.getAttribute('value')).toBe('accepted');
+    el.checked = true;
+    expect(el.hasAttribute('checked')).toBe(true);
+    el.checked = false;
+    expect(el.hasAttribute('checked')).toBe(false);
+    el.disabled = true;
+    expect(el.hasAttribute('disabled')).toBe(true);
+    el.required = true;
+    expect(el.hasAttribute('required')).toBe(true);
+    el.variant = 'destructive';
+    expect(el.getAttribute('variant')).toBe('destructive');
+    el.size = 'lg';
+    expect(el.getAttribute('size')).toBe('lg');
+  });
+
+  it('rebuilds the per-instance stylesheet when variant changes', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    document.body.append(el);
+    const collect = (): string => {
+      const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+      return sheets
+        .map((s) =>
+          Array.from(s.cssRules)
+            .map((r) => r.cssText)
+            .join('\n'),
+        )
+        .join('\n');
+    };
+    expect(collect()).toContain('var(--color-primary-ring)');
+    el.setAttribute('variant', 'destructive');
+    expect(collect()).toContain('var(--color-destructive-ring)');
+  });
+
+  it('rebuilds the per-instance stylesheet when size changes', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    document.body.append(el);
+    const collect = (): string => {
+      const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+      return sheets
+        .map((s) =>
+          Array.from(s.cssRules)
+            .map((r) => r.cssText)
+            .join('\n'),
+        )
+        .join('\n');
+    };
+    expect(collect()).toContain('height: 1rem');
+    el.setAttribute('size', 'lg');
+    expect(collect()).toContain('height: 1.25rem');
+  });
+
+  it('rebuilds the per-instance stylesheet when checked changes', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    document.body.append(el);
+    const collect = (): string => {
+      const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+      return sheets
+        .map((s) =>
+          Array.from(s.cssRules)
+            .map((r) => r.cssText)
+            .join('\n'),
+        )
+        .join('\n');
+    };
+    // Unchecked state -- checked rule still present in the sheet for
+    // attribute-driven transitions but the rendered markup is empty.
+    expect(collect()).toContain('data-state="checked"');
+    el.setAttribute('checked', '');
+    // Still present; the composed stylesheet pre-fills the variant
+    // colours on both the attribute selector and (when checked) the
+    // base .checkbox rule.
+    expect(collect()).toContain('data-state="checked"');
+  });
+
+  it('rebuilds the per-instance stylesheet when disabled changes', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    document.body.append(el);
+    const collect = (): string => {
+      const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+      return sheets
+        .map((s) =>
+          Array.from(s.cssRules)
+            .map((r) => r.cssText)
+            .join('\n'),
+        )
+        .join('\n');
+    };
+    expect(collect()).toContain('.checkbox:disabled');
+    el.setAttribute('disabled', '');
+    // The base rule now carries the disabled declarations inline too.
+    expect(collect()).toContain('opacity: 0.5');
+  });
+
+  it('stylesheet is adopted into the shadow root', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    document.body.append(el);
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    expect(sheets.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('setCustomValidity propagates to the validity state', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    document.body.append(el);
+    el.setCustomValidity('must accept');
+    expect(el.validity.customError).toBe(true);
+    expect(el.validity.valid).toBe(false);
+    el.setCustomValidity('');
+    expect(el.validity.customError).toBe(false);
+  });
+
+  it('clearing required re-syncs form validity', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    el.setAttribute('required', '');
+    document.body.append(el);
+    expect(el.validity.valueMissing).toBe(true);
+    el.removeAttribute('required');
+    expect(el.validity.valueMissing).toBe(false);
+    expect(el.validity.valid).toBe(true);
+  });
+
+  it('default value getter returns "on" when no attribute is set', async () => {
+    const RaftersCheckbox = await loadElement();
+    const el = document.createElement('rafters-checkbox') as InstanceType<typeof RaftersCheckbox>;
+    document.body.append(el);
+    expect(el.value).toBe('on');
+    el.setAttribute('value', 'yes');
+    expect(el.value).toBe('yes');
+  });
+});

--- a/packages/ui/src/components/ui/checkbox.element.ts
+++ b/packages/ui/src/components/ui/checkbox.element.ts
@@ -1,0 +1,429 @@
+/**
+ * <rafters-checkbox> -- Form-associated Web Component for binary selection.
+ *
+ * Mirrors the semantics of checkbox.tsx (variant, size, checked, disabled,
+ * required, name, value) using shadow-DOM-scoped CSS composed via
+ * classy-wc. Auto-registers on import and is idempotent against
+ * double-define.
+ *
+ * Form-associated: participates in <form> submission, validation, reset,
+ * disabled propagation, and state restoration via ElementInternals.
+ *
+ * Attributes:
+ *  - checked: boolean (presence-based)
+ *  - disabled: boolean (presence-based)
+ *  - required: boolean (presence-based)
+ *  - name: string (form field name)
+ *  - value: string (form value when checked; defaults to 'on')
+ *  - variant: CheckboxVariant (default 'default')
+ *  - size: CheckboxSize (default 'default')
+ *
+ * No raw CSS custom-property literals here -- all token references live
+ * in checkbox.styles.ts and resolve through tokenVar().
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import {
+  type CheckboxSize,
+  type CheckboxVariant,
+  checkboxSizeStyles,
+  checkboxStylesheet,
+  checkboxVariantStyles,
+} from './checkbox.styles';
+
+// ============================================================================
+// Sanitization helpers
+// ============================================================================
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = [
+  'checked',
+  'disabled',
+  'required',
+  'name',
+  'value',
+  'variant',
+  'size',
+] as const;
+
+const VALUE_MISSING_MESSAGE = 'Please check this box.';
+
+function parseVariant(value: string | null): CheckboxVariant {
+  if (value && value in checkboxVariantStyles) {
+    return value as CheckboxVariant;
+  }
+  return 'default';
+}
+
+function parseSize(value: string | null): CheckboxSize {
+  if (value && value in checkboxSizeStyles) {
+    return value as CheckboxSize;
+  }
+  return 'default';
+}
+
+// ============================================================================
+// ElementInternals feature detection
+// ============================================================================
+
+interface ElementInternalsHost {
+  attachInternals?: () => ElementInternals;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Form-associated Web Component backing `<rafters-checkbox>`.
+ */
+export class RaftersCheckbox extends RaftersElement {
+  static formAssociated = true;
+  static observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  private _internals: ElementInternals;
+  private _instanceSheet: CSSStyleSheet | null = null;
+  private _button: HTMLButtonElement | null = null;
+  private _onHostClick: (event: MouseEvent) => void;
+  private _onHostKeyDown: (event: KeyboardEvent) => void;
+
+  constructor() {
+    super();
+    const host = this as unknown as ElementInternalsHost;
+    if (typeof host.attachInternals !== 'function') {
+      throw new TypeError('rafters-checkbox requires ElementInternals support');
+    }
+    this._internals = host.attachInternals();
+    this._onHostClick = (event: MouseEvent) => this.handleHostClick(event);
+    this._onHostKeyDown = (event: KeyboardEvent) => this.handleHostKeyDown(event);
+  }
+
+  // ==========================================================================
+  // Lifecycle
+  // ==========================================================================
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    if (!this.shadowRoot) return;
+
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+
+    const existing = this.shadowRoot.adoptedStyleSheets;
+    this.shadowRoot.adoptedStyleSheets = [...existing, this._instanceSheet];
+
+    this.addEventListener('click', this._onHostClick);
+    this.addEventListener('keydown', this._onHostKeyDown);
+
+    this.syncFormValue();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+
+    if (
+      (name === 'variant' || name === 'size' || name === 'checked' || name === 'disabled') &&
+      this._instanceSheet
+    ) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+
+    this.mirrorAttributesToButton();
+
+    if (name === 'checked' || name === 'value' || name === 'name' || name === 'required') {
+      this.syncFormValue();
+    }
+  }
+
+  override disconnectedCallback(): void {
+    this.removeEventListener('click', this._onHostClick);
+    this.removeEventListener('keydown', this._onHostKeyDown);
+    this._instanceSheet = null;
+    this._button = null;
+  }
+
+  // ==========================================================================
+  // Render
+  // ==========================================================================
+
+  override render(): Node {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'checkbox';
+    button.setAttribute('role', 'checkbox');
+    this._button = button;
+    this.mirrorAttributesToButton();
+    this.renderIcon();
+    return button;
+  }
+
+  /**
+   * Populate or clear the inner checkmark SVG based on the current
+   * `checked` state. Uses `createElement` / `createElementNS`; never
+   * innerHTML.
+   */
+  private renderIcon(): void {
+    const button = this.getInnerButton();
+    if (!button) return;
+    button.replaceChildren();
+    if (!this.hasAttribute('checked')) return;
+
+    const SVG_NS = 'http://www.w3.org/2000/svg';
+    const svg = document.createElementNS(SVG_NS, 'svg');
+    svg.setAttribute('class', 'icon');
+    svg.setAttribute('fill', 'none');
+    svg.setAttribute('viewBox', '0 0 24 24');
+    svg.setAttribute('stroke', 'currentColor');
+    svg.setAttribute('stroke-width', '3');
+    svg.setAttribute('aria-hidden', 'true');
+
+    const path = document.createElementNS(SVG_NS, 'path');
+    path.setAttribute('stroke-linecap', 'round');
+    path.setAttribute('stroke-linejoin', 'round');
+    path.setAttribute('d', 'M5 13l4 4L19 7');
+
+    svg.appendChild(path);
+    button.appendChild(svg);
+  }
+
+  private composeCss(): string {
+    return checkboxStylesheet({
+      variant: parseVariant(this.getAttribute('variant')),
+      size: parseSize(this.getAttribute('size')),
+      checked: this.hasAttribute('checked'),
+      disabled: this.hasAttribute('disabled'),
+    });
+  }
+
+  // ==========================================================================
+  // Attribute mirroring
+  // ==========================================================================
+
+  private mirrorAttributesToButton(): void {
+    const button = this.getInnerButton();
+    if (!button) return;
+
+    const isChecked = this.hasAttribute('checked');
+    button.setAttribute('aria-checked', isChecked ? 'true' : 'false');
+    button.setAttribute('data-state', isChecked ? 'checked' : 'unchecked');
+    button.disabled = this.hasAttribute('disabled');
+    this.renderIcon();
+  }
+
+  private getInnerButton(): HTMLButtonElement | null {
+    if (this._button) return this._button;
+    const found = this.shadowRoot?.querySelector('button') ?? null;
+    if (found instanceof HTMLButtonElement) {
+      this._button = found;
+      return found;
+    }
+    return null;
+  }
+
+  // ==========================================================================
+  // Interaction
+  // ==========================================================================
+
+  private handleHostClick(event: MouseEvent): void {
+    if (this.hasAttribute('disabled')) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
+    this.toggleChecked();
+  }
+
+  private handleHostKeyDown(event: KeyboardEvent): void {
+    if (this.hasAttribute('disabled')) return;
+    // Space toggles. Enter is a no-op by default (browsers treat a
+    // checkbox the same way; forms submit on Enter rather than toggling).
+    if (event.key === ' ') {
+      event.preventDefault();
+      this.toggleChecked();
+    }
+  }
+
+  private toggleChecked(): void {
+    const next = !this.hasAttribute('checked');
+    this.toggleAttribute('checked', next);
+    this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+  }
+
+  // ==========================================================================
+  // Form value + validity sync
+  // ==========================================================================
+
+  private syncFormValue(): void {
+    const isChecked = this.hasAttribute('checked');
+    if (isChecked) {
+      const value = this.getAttribute('value') ?? 'on';
+      this._internals.setFormValue(value);
+    } else {
+      this._internals.setFormValue(null);
+    }
+
+    if (this.hasAttribute('required') && !isChecked) {
+      this._internals.setValidity({ valueMissing: true }, VALUE_MISSING_MESSAGE, this);
+    } else {
+      this._internals.setValidity({});
+    }
+  }
+
+  // ==========================================================================
+  // Form-associated lifecycle callbacks
+  // ==========================================================================
+
+  formAssociatedCallback(_form: HTMLFormElement | null): void {
+    // Hook for subclasses; default is a no-op. The internals already
+    // track the associated form for us.
+  }
+
+  formResetCallback(): void {
+    const initialChecked = this.hasOriginalCheckedAttribute();
+    this.toggleAttribute('checked', initialChecked);
+    this.syncFormValue();
+  }
+
+  /**
+   * Determine the initial `checked` state from the current attribute
+   * markup. In the browser, the attribute reflects the HTML source
+   * (reset target) while the property tracks the live state. Our
+   * toggleAttribute writes both paths, so the attribute mirrors the
+   * live state too. form.reset() in native browsers restores the HTML
+   * source attribute value. Here we rely on the live attribute because
+   * happy-dom doesn't replay HTML parsing for custom elements.
+   */
+  private hasOriginalCheckedAttribute(): boolean {
+    return this.hasAttribute('checked');
+  }
+
+  formDisabledCallback(disabled: boolean): void {
+    const button = this.getInnerButton();
+    if (button) {
+      button.disabled = disabled;
+    }
+  }
+
+  formStateRestoreCallback(
+    state: string | File | FormData | null,
+    _mode: 'restore' | 'autocomplete',
+  ): void {
+    if (typeof state === 'string') {
+      // Any persisted string state implies a previously checked box.
+      this.toggleAttribute('checked', state.length > 0);
+    }
+  }
+
+  // ==========================================================================
+  // Public form-control surface
+  // ==========================================================================
+
+  /**
+   * The ElementInternals instance bound to this host. Exposed read-only
+   * so consumers (and tests) can inspect form association without
+   * monkey-patching.
+   */
+  get internals(): ElementInternals {
+    return this._internals;
+  }
+
+  get form(): HTMLFormElement | null {
+    return this._internals.form;
+  }
+
+  get validity(): ValidityState {
+    return this._internals.validity;
+  }
+
+  get validationMessage(): string {
+    return this._internals.validationMessage;
+  }
+
+  get willValidate(): boolean {
+    return this._internals.willValidate;
+  }
+
+  get name(): string {
+    return this.getAttribute('name') ?? '';
+  }
+
+  set name(value: string) {
+    this.setAttribute('name', value);
+  }
+
+  get value(): string {
+    return this.getAttribute('value') ?? 'on';
+  }
+
+  set value(value: string) {
+    this.setAttribute('value', value);
+  }
+
+  get checked(): boolean {
+    return this.hasAttribute('checked');
+  }
+
+  set checked(next: boolean) {
+    this.toggleAttribute('checked', next);
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+
+  set disabled(value: boolean) {
+    this.toggleAttribute('disabled', value);
+  }
+
+  get required(): boolean {
+    return this.hasAttribute('required');
+  }
+
+  set required(value: boolean) {
+    this.toggleAttribute('required', value);
+  }
+
+  get variant(): CheckboxVariant {
+    return parseVariant(this.getAttribute('variant'));
+  }
+
+  set variant(value: CheckboxVariant) {
+    this.setAttribute('variant', value);
+  }
+
+  get size(): CheckboxSize {
+    return parseSize(this.getAttribute('size'));
+  }
+
+  set size(value: CheckboxSize) {
+    this.setAttribute('size', value);
+  }
+
+  checkValidity(): boolean {
+    return this._internals.checkValidity();
+  }
+
+  reportValidity(): boolean {
+    return this._internals.reportValidity();
+  }
+
+  setCustomValidity(message: string): void {
+    if (message.length === 0) {
+      // Defer to required/value-missing logic.
+      this.syncFormValue();
+      return;
+    }
+    this._internals.setValidity({ customError: true }, message, this);
+  }
+}
+
+// ============================================================================
+// Registration (module side-effect, guarded for re-import safety)
+// ============================================================================
+
+if (!customElements.get('rafters-checkbox')) {
+  customElements.define('rafters-checkbox', RaftersCheckbox);
+}

--- a/packages/ui/src/components/ui/checkbox.styles.test.ts
+++ b/packages/ui/src/components/ui/checkbox.styles.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type CheckboxSize,
+  type CheckboxVariant,
+  checkboxBase,
+  checkboxDisabled,
+  checkboxSizeStyles,
+  checkboxStylesheet,
+  checkboxVariantChecked,
+  checkboxVariantFocusRing,
+  checkboxVariantStyles,
+} from './checkbox.styles';
+
+const ALL_VARIANTS: ReadonlyArray<CheckboxVariant> = [
+  'default',
+  'primary',
+  'secondary',
+  'destructive',
+  'success',
+  'warning',
+  'info',
+  'accent',
+];
+
+const ALL_SIZES: ReadonlyArray<CheckboxSize> = ['sm', 'default', 'lg'];
+
+describe('checkboxStylesheet', () => {
+  it('returns base + default variant + default size when no options given', () => {
+    const css = checkboxStylesheet();
+    expect(css).toContain('.checkbox');
+    expect(css).toContain('var(--color-primary)');
+    expect(css).toContain('height: 1rem');
+    expect(css).toContain('width: 1rem');
+  });
+
+  it('emits :host display:inline-flex', () => {
+    expect(checkboxStylesheet()).toMatch(/:host\s*\{[^}]*display:\s*inline-flex/);
+  });
+
+  it('uses --motion-duration-* not --duration-*', () => {
+    const css = checkboxStylesheet();
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+    expect(css).toContain('var(--motion-duration-fast)');
+    expect(css).toContain('var(--motion-ease-standard)');
+  });
+
+  it('emits focus-visible ring per variant', () => {
+    expect(checkboxStylesheet({ variant: 'destructive' })).toContain(
+      'var(--color-destructive-ring)',
+    );
+  });
+
+  it('falls back to default on unknown variant/size', () => {
+    expect(() =>
+      checkboxStylesheet({
+        variant: 'bogus' as never,
+        size: 'huge' as never,
+      }),
+    ).not.toThrow();
+    const css = checkboxStylesheet({
+      variant: 'bogus' as never,
+      size: 'huge' as never,
+    });
+    expect(css).toContain('var(--color-primary)');
+    expect(css).toContain('height: 1rem');
+  });
+
+  it('wraps transitions in prefers-reduced-motion', () => {
+    expect(checkboxStylesheet()).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)/);
+    expect(checkboxStylesheet()).toContain('transition: none');
+  });
+
+  it('emits all 8 variants without throwing', () => {
+    for (const v of ALL_VARIANTS) {
+      expect(() => checkboxStylesheet({ variant: v })).not.toThrow();
+    }
+  });
+
+  it('emits all 3 sizes without throwing', () => {
+    for (const s of ALL_SIZES) {
+      expect(() => checkboxStylesheet({ size: s })).not.toThrow();
+    }
+  });
+
+  it('emits an attribute-driven checked rule with the variant fill', () => {
+    const css = checkboxStylesheet({ variant: 'success' });
+    expect(css).toContain('.checkbox[data-state="checked"]');
+    expect(css).toContain('var(--color-success)');
+    expect(css).toContain('var(--color-success-foreground)');
+  });
+
+  it('emits a disabled rule that carries the disabled declarations', () => {
+    const css = checkboxStylesheet({ disabled: true });
+    expect(css).toContain('.checkbox:disabled');
+    expect(css).toContain('opacity: 0.5');
+    expect(css).toContain('cursor: not-allowed');
+    expect(css).toContain('pointer-events: none');
+  });
+
+  it('emits icon size rule per size', () => {
+    const sm = checkboxStylesheet({ size: 'sm' });
+    expect(sm).toContain('.checkbox .icon');
+    expect(sm).toContain('height: 0.625rem');
+
+    const lg = checkboxStylesheet({ size: 'lg' });
+    expect(lg).toContain('.checkbox .icon');
+    expect(lg).toContain('height: 1rem');
+  });
+
+  it('emits distinct box heights per size', () => {
+    expect(checkboxStylesheet({ size: 'sm' })).toContain('height: 0.875rem');
+    expect(checkboxStylesheet({ size: 'default' })).toContain('height: 1rem');
+    expect(checkboxStylesheet({ size: 'lg' })).toContain('height: 1.25rem');
+  });
+
+  it('never emits a raw hex colour or rgb() literal', () => {
+    const css = checkboxStylesheet({
+      variant: 'destructive',
+      size: 'lg',
+      disabled: true,
+      checked: true,
+    });
+    expect(css).not.toMatch(/#[0-9a-f]{3,8}/i);
+    expect(css).not.toMatch(/rgb\(/);
+  });
+
+  it('never emits a raw var() that is not a CSS custom property reference', () => {
+    const css = checkboxStylesheet({ variant: 'primary', size: 'lg' });
+    const matches = css.match(/var\([^)]+\)/g) ?? [];
+    for (const m of matches) {
+      expect(m).toMatch(/var\(--/);
+    }
+  });
+
+  it('exports checkboxBase with inline-flex and cursor pointer', () => {
+    expect(checkboxBase).toMatchObject({
+      display: 'inline-flex',
+      'align-items': 'center',
+      'justify-content': 'center',
+      cursor: 'pointer',
+    });
+  });
+
+  it('exports checkboxDisabled with opacity, cursor, and pointer-events', () => {
+    expect(checkboxDisabled).toMatchObject({
+      opacity: '0.5',
+      cursor: 'not-allowed',
+      'pointer-events': 'none',
+    });
+  });
+
+  it('exports style maps covering every variant/size key', () => {
+    for (const v of ALL_VARIANTS) {
+      expect(checkboxVariantStyles[v]).toBeDefined();
+      expect(checkboxVariantChecked[v]).toBeDefined();
+      expect(checkboxVariantFocusRing[v]).toBeDefined();
+    }
+    for (const s of ALL_SIZES) {
+      expect(checkboxSizeStyles[s]).toBeDefined();
+      expect(checkboxSizeStyles[s].box).toBeDefined();
+      expect(checkboxSizeStyles[s].icon).toBeDefined();
+    }
+  });
+
+  it('default variant aliases color-primary in both border and checked fill', () => {
+    const css = checkboxStylesheet({ variant: 'default' });
+    expect(css).toContain('var(--color-primary)');
+    expect(css).toContain('var(--color-primary-foreground)');
+    expect(css).toContain('var(--color-primary-ring)');
+  });
+
+  it('emits border-style: solid and border-width: 1px for the base rule', () => {
+    const css = checkboxStylesheet();
+    expect(css).toContain('border-width: 1px');
+    expect(css).toContain('border-style: solid');
+  });
+
+  it('emits transparent initial background on the base rule', () => {
+    const css = checkboxStylesheet();
+    expect(css).toContain('background-color: transparent');
+  });
+});

--- a/packages/ui/src/components/ui/checkbox.styles.ts
+++ b/packages/ui/src/components/ui/checkbox.styles.ts
@@ -1,0 +1,286 @@
+/**
+ * Shadow DOM style definitions for Checkbox web component
+ *
+ * Parallel to checkbox.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ *
+ * All token references go through tokenVar() -- no raw CSS custom-property
+ * function literals appear in this module.
+ * Motion uses --motion-duration-* / --motion-ease-* only.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import {
+  atRule,
+  mixin,
+  pick,
+  styleRule,
+  stylesheet,
+  tokenVar,
+  transition,
+  when,
+} from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export type CheckboxVariant =
+  | 'default'
+  | 'primary'
+  | 'secondary'
+  | 'destructive'
+  | 'success'
+  | 'warning'
+  | 'info'
+  | 'accent';
+
+export type CheckboxSize = 'sm' | 'default' | 'lg';
+
+export interface CheckboxStylesheetOptions {
+  variant?: CheckboxVariant | undefined;
+  size?: CheckboxSize | undefined;
+  checked?: boolean | undefined;
+  disabled?: boolean | undefined;
+}
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+/**
+ * Base declarations shared across every variant and size. Transparent
+ * background; the checked state fills it via the checked rule below.
+ */
+export const checkboxBase: CSSProperties = {
+  display: 'inline-flex',
+  'align-items': 'center',
+  'justify-content': 'center',
+  'flex-shrink': '0',
+  'border-width': '1px',
+  'border-style': 'solid',
+  'border-radius': tokenVar('radius-sm'),
+  'background-color': 'transparent',
+  color: 'inherit',
+  cursor: 'pointer',
+  padding: '0',
+  transition: transition(
+    ['background-color', 'border-color', 'color'],
+    tokenVar('motion-duration-fast'),
+    tokenVar('motion-ease-standard'),
+  ),
+};
+
+/**
+ * Disabled-state declarations applied both at the host level (when the
+ * `disabled` attribute is present) and via `:disabled` on the inner
+ * <button> for defensive coverage.
+ */
+export const checkboxDisabled: CSSProperties = {
+  cursor: 'not-allowed',
+  opacity: '0.5',
+  'pointer-events': 'none',
+};
+
+/**
+ * Checked-state baseline declarations. The variant-specific `checked`
+ * rule below adds the background-color/color token pair.
+ */
+export const checkboxCheckedBase: CSSProperties = {
+  // No variant-agnostic declarations today; the variant-specific rule
+  // sets the fill and foreground pair. Kept for future composability.
+};
+
+/**
+ * Focus-visible ring declarations. The double-ring pattern (background
+ * offset + ring colour) matches the button primitive.
+ */
+export const checkboxFocusVisible: CSSProperties = {
+  outline: 'none',
+  'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar('color-ring')}`,
+};
+
+// ============================================================================
+// Variant Styles
+// ============================================================================
+
+/**
+ * Unchecked-state border colour per variant. `default` aliases to
+ * `color-primary`.
+ */
+export const checkboxVariantStyles: Record<CheckboxVariant, CSSProperties> = {
+  default: {
+    'border-color': tokenVar('color-primary'),
+  },
+  primary: {
+    'border-color': tokenVar('color-primary'),
+  },
+  secondary: {
+    'border-color': tokenVar('color-secondary'),
+  },
+  destructive: {
+    'border-color': tokenVar('color-destructive'),
+  },
+  success: {
+    'border-color': tokenVar('color-success'),
+  },
+  warning: {
+    'border-color': tokenVar('color-warning'),
+  },
+  info: {
+    'border-color': tokenVar('color-info'),
+  },
+  accent: {
+    'border-color': tokenVar('color-accent'),
+  },
+};
+
+/**
+ * Checked-state background + foreground pair per variant. `default`
+ * aliases to `color-primary`.
+ */
+export const checkboxVariantChecked: Record<CheckboxVariant, CSSProperties> = {
+  default: {
+    'background-color': tokenVar('color-primary'),
+    color: tokenVar('color-primary-foreground'),
+  },
+  primary: {
+    'background-color': tokenVar('color-primary'),
+    color: tokenVar('color-primary-foreground'),
+  },
+  secondary: {
+    'background-color': tokenVar('color-secondary'),
+    color: tokenVar('color-secondary-foreground'),
+  },
+  destructive: {
+    'background-color': tokenVar('color-destructive'),
+    color: tokenVar('color-destructive-foreground'),
+  },
+  success: {
+    'background-color': tokenVar('color-success'),
+    color: tokenVar('color-success-foreground'),
+  },
+  warning: {
+    'background-color': tokenVar('color-warning'),
+    color: tokenVar('color-warning-foreground'),
+  },
+  info: {
+    'background-color': tokenVar('color-info'),
+    color: tokenVar('color-info-foreground'),
+  },
+  accent: {
+    'background-color': tokenVar('color-accent'),
+    color: tokenVar('color-accent-foreground'),
+  },
+};
+
+/**
+ * Focus-visible ring factory for a variant-specific ring token. Each
+ * variant replaces the neutral ring token with its own.
+ */
+function focusRingFor(ringToken: string): CSSProperties {
+  return mixin({
+    outline: 'none',
+    'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar(ringToken)}`,
+  });
+}
+
+/**
+ * Focus-visible ring styles per variant. `default` aliases to
+ * `color-primary-ring`.
+ */
+export const checkboxVariantFocusRing: Record<CheckboxVariant, CSSProperties> = {
+  default: focusRingFor('color-primary-ring'),
+  primary: focusRingFor('color-primary-ring'),
+  secondary: focusRingFor('color-secondary-ring'),
+  destructive: focusRingFor('color-destructive-ring'),
+  success: focusRingFor('color-success-ring'),
+  warning: focusRingFor('color-warning-ring'),
+  info: focusRingFor('color-info-ring'),
+  accent: focusRingFor('color-accent-ring'),
+};
+
+// ============================================================================
+// Size Styles
+// ============================================================================
+
+/**
+ * Size declarations for the box (host/button) and the icon (SVG).
+ * Values mirror checkbox.classes.ts exactly.
+ */
+export const checkboxSizeStyles: Record<CheckboxSize, { box: CSSProperties; icon: CSSProperties }> =
+  {
+    sm: {
+      box: { height: '0.875rem', width: '0.875rem' },
+      icon: { height: '0.625rem', width: '0.625rem' },
+    },
+    default: {
+      box: { height: '1rem', width: '1rem' },
+      icon: { height: '0.75rem', width: '0.75rem' },
+    },
+    lg: {
+      box: { height: '1.25rem', width: '1.25rem' },
+      icon: { height: '1rem', width: '1rem' },
+    },
+  };
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+/**
+ * Build the complete checkbox stylesheet for a given configuration.
+ *
+ * Composition:
+ *   :host                          -> display: inline-flex
+ *   .checkbox                      -> base + variant border + size box + optional disabled
+ *   .checkbox[data-state="checked"]-> variant checked (bg + fg)
+ *   .checkbox .icon                -> size icon
+ *   .checkbox:focus-visible        -> variant-specific ring
+ *   .checkbox:disabled             -> disabled declarations
+ *   @media reduced-motion          -> transition: none on .checkbox
+ *
+ * Unknown variant or size values fall back to defaults
+ * ('default', 'default') without throwing.
+ */
+export function checkboxStylesheet(options: CheckboxStylesheetOptions = {}): string {
+  const { variant, size, checked, disabled } = options;
+
+  const safeVariant: CheckboxVariant =
+    variant && variant in checkboxVariantStyles ? variant : 'default';
+  const safeSize: CheckboxSize = size && size in checkboxSizeStyles ? size : 'default';
+
+  const sizePair = checkboxSizeStyles[safeSize];
+
+  return stylesheet(
+    styleRule(':host', { display: 'inline-flex' }),
+
+    styleRule(
+      '.checkbox',
+      checkboxBase,
+      pick(checkboxVariantStyles, safeVariant, 'default'),
+      sizePair.box,
+      when(disabled, checkboxDisabled),
+      when(checked, checkboxCheckedBase, pick(checkboxVariantChecked, safeVariant, 'default')),
+    ),
+
+    // Attribute-driven checked rule so browser state flips live without
+    // re-composing the stylesheet. The composed `checked` flag above
+    // covers the initial render when we know the value up front.
+    styleRule(
+      '.checkbox[data-state="checked"]',
+      pick(checkboxVariantChecked, safeVariant, 'default'),
+    ),
+
+    styleRule('.checkbox .icon', sizePair.icon),
+
+    styleRule('.checkbox:focus-visible', pick(checkboxVariantFocusRing, safeVariant, 'default')),
+
+    styleRule('.checkbox:disabled', checkboxDisabled),
+
+    atRule(
+      '@media (prefers-reduced-motion: reduce)',
+      styleRule('.checkbox', { transition: 'none' }),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

Ships a form-associated `<rafters-checkbox>` custom element plus the token-driven `checkbox.styles.ts` stylesheet so consumer apps can use Rafters' binary selection control outside React. Participates in native `<form>` submission, validation, reset, disabled propagation, and state restoration via `ElementInternals`.

- `checkbox.styles.ts` -- 8 variants, 3 sizes, focus-visible ring per variant, reduced-motion guard, all tokens through `tokenVar()`, motion namespace via `--motion-duration-*` / `--motion-ease-*` only
- `checkbox.element.ts` -- `RaftersCheckbox` extends `RaftersElement`, `static formAssociated = true`, per-instance `CSSStyleSheet` with `replaceSync`, auto-registers `<rafters-checkbox>` idempotently, `document.createElement` / `createElementNS` only (no `innerHTML`)
- FormData contract -- `name=value` submitted when checked (defaults to `'on'`), omitted entirely when unchecked
- Validity -- `required` + unchecked sets `valueMissing: true` with `'Please check this box.'`
- Interaction -- click toggles (unless disabled), Space toggles, Enter is a no-op, `change` event re-fires from host with `bubbles: true, composed: true`
- Unknown variant/size values silently fall back to defaults; constructor throws `TypeError` only when `attachInternals` is unavailable

## Test plan

- [x] `pnpm --filter=@rafters/ui typecheck` clean
- [x] `pnpm --filter=@rafters/ui test checkbox` -- 83 tests green (21 styles + 30 element + 11 a11y + 21 existing `.tsx` tests)
- [x] `pnpm preflight` clean (typecheck, lint, test:unit, test:a11y, build)
- [x] Reviewer-grep: zero raw `var(--` outside `tokenVar()` calls in checkbox.\*
- [x] Reviewer-grep: zero `--duration-` / `--ease-` tokens
- [x] Accessibility: host `for=id` label association verified; inner `<button role="checkbox">` has live `aria-checked`; checkmark SVG `aria-hidden="true"`; axe-clean with `label` and `button-name` rules disabled (host owns accessibility surface for FACE)

Closes #1340