### PR TITLE
feat(ui): <rafters-radio-group> form-associated Web Component (#1341)

### DIFF
--- a/packages/ui/src/components/ui/radio-group.element.a11y.tsx
+++ b/packages/ui/src/components/ui/radio-group.element.a11y.tsx
@@ -1,0 +1,383 @@
+/**
+ * Accessibility tests for <rafters-radio-group> + <rafters-radio-item>.
+ *
+ * Validates:
+ *  - role="radiogroup" / role="radio" semantics pierce through
+ *    axe-core's shadow DOM descent.
+ *  - aria-orientation reflects the group orientation.
+ *  - Arrow-key navigation wiring produces a roving tabindex surface
+ *    (exactly one non-disabled item carries tabindex=0 at any time).
+ *  - Disabled items participate in ARIA semantics but not focus.
+ *  - Required group with missing value triggers axe-clean fieldset
+ *    labelling.
+ *
+ * Notes:
+ *  - happy-dom 20 ships no ElementInternals implementation. Polyfill
+ *    the surface the element depends on so the constructor can run;
+ *    mirror the polyfill used in radio-group.element.test.ts.
+ *  - axe pierces into shadow roots. The inner <button> inside each
+ *    item has no per-element label by design -- the host carries the
+ *    label via sibling <label for=id> pairing on the host element.
+ *    Disable the `label` rule on scans that include custom-element
+ *    shadow trees so axe does not flag the inner button.
+ */
+
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import 'vitest-axe/extend-expect';
+
+interface PolyfilledInternals {
+  _value: string | null;
+  _validity: ValidityState;
+  _validationMessage: string;
+  _host: HTMLElement;
+  setFormValue: (value: string | File | FormData | null) => void;
+  setValidity: (flags: Partial<ValidityState>, message?: string, anchor?: HTMLElement) => void;
+  checkValidity: () => boolean;
+  reportValidity: () => boolean;
+  validity: ValidityState;
+  validationMessage: string;
+  willValidate: boolean;
+  form: HTMLFormElement | null;
+}
+
+type ValidityFlagKey = Exclude<keyof ValidityState, 'valid'>;
+
+const VALIDITY_FLAG_KEYS: ReadonlyArray<ValidityFlagKey> = [
+  'valueMissing',
+  'typeMismatch',
+  'patternMismatch',
+  'tooLong',
+  'tooShort',
+  'rangeUnderflow',
+  'rangeOverflow',
+  'stepMismatch',
+  'badInput',
+  'customError',
+];
+
+function buildValidity(flags: Partial<ValidityState> = {}): ValidityState {
+  const merged: Record<string, boolean> = {
+    valueMissing: false,
+    typeMismatch: false,
+    patternMismatch: false,
+    tooLong: false,
+    tooShort: false,
+    rangeUnderflow: false,
+    rangeOverflow: false,
+    stepMismatch: false,
+    badInput: false,
+    customError: false,
+    valid: true,
+  };
+  let invalid = false;
+  for (const key of VALIDITY_FLAG_KEYS) {
+    const value = flags[key];
+    if (typeof value === 'boolean') {
+      merged[key] = value;
+    }
+    if (merged[key]) invalid = true;
+  }
+  merged.valid = !invalid;
+  return merged as unknown as ValidityState;
+}
+
+function installElementInternalsPolyfill(): void {
+  const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
+  if (typeof proto.attachInternals === 'function') return;
+  proto.attachInternals = function attachInternals(this: HTMLElement): ElementInternals {
+    const internals: PolyfilledInternals = {
+      _value: null,
+      _validity: buildValidity(),
+      _validationMessage: '',
+      _host: this,
+      setFormValue(value) {
+        if (value === null) {
+          this._value = null;
+        } else if (typeof value === 'string') {
+          this._value = value;
+        } else {
+          this._value = '';
+        }
+      },
+      setValidity(flags, message = '', _anchor) {
+        this._validity = buildValidity(flags);
+        this._validationMessage = this._validity.valid ? '' : message;
+      },
+      checkValidity() {
+        return this._validity.valid;
+      },
+      reportValidity() {
+        return this._validity.valid;
+      },
+      get validity() {
+        return this._validity;
+      },
+      get validationMessage() {
+        return this._validationMessage;
+      },
+      get willValidate() {
+        return true;
+      },
+      get form() {
+        let parent: Node | null = this._host.parentNode;
+        while (parent) {
+          if (parent instanceof HTMLFormElement) return parent;
+          parent = parent.parentNode;
+        }
+        return null;
+      },
+    };
+    return internals as unknown as ElementInternals;
+  };
+}
+
+beforeAll(async () => {
+  installElementInternalsPolyfill();
+  await import('./radio-group.element');
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+// React's IntrinsicElements typing does not know about rafters-* custom
+// elements. Render through typed helpers so tests stay free of `any`.
+
+type RaftersRadioGroupProps = {
+  id?: string;
+  name?: string;
+  value?: string;
+  required?: boolean;
+  disabled?: boolean;
+  orientation?: string;
+  'aria-labelledby'?: string;
+  children?: React.ReactNode;
+};
+
+type RaftersRadioItemProps = {
+  id?: string;
+  value?: string;
+  disabled?: boolean;
+  children?: React.ReactNode;
+};
+
+const RaftersRadioGroupJSX = (props: RaftersRadioGroupProps): React.ReactElement =>
+  React.createElement('rafters-radio-group', props);
+
+const RaftersRadioItemJSX = (props: RaftersRadioItemProps): React.ReactElement =>
+  React.createElement('rafters-radio-item', props);
+
+describe('rafters-radio-group -- accessibility', () => {
+  it('exposes role=radiogroup and role=radio semantics', () => {
+    const { container } = render(
+      <RaftersRadioGroupJSX name="pref" aria-labelledby="group-label">
+        <RaftersRadioItemJSX value="a" />
+        <RaftersRadioItemJSX value="b" />
+      </RaftersRadioGroupJSX>,
+    );
+    const group = container.querySelector('rafters-radio-group');
+    const items = container.querySelectorAll('rafters-radio-item');
+    expect(group?.getAttribute('role')).toBe('radiogroup');
+    expect(items).toHaveLength(2);
+    for (const item of Array.from(items)) {
+      expect(item.getAttribute('role')).toBe('radio');
+    }
+  });
+
+  it('axe-clean when paired with a heading label via aria-labelledby', async () => {
+    const { container } = render(
+      <div>
+        <span id="color-label">Favorite color</span>
+        <RaftersRadioGroupJSX name="color" aria-labelledby="color-label">
+          <RaftersRadioItemJSX value="red" />
+          <RaftersRadioItemJSX value="blue" />
+        </RaftersRadioGroupJSX>
+      </div>,
+    );
+    // Shadow DOM inner buttons have no per-element label -- the host
+    // owns the accessibility surface. Disable the `label` rule so axe
+    // does not flag the inner <button> inside each item.
+    const results = await axe(container, {
+      rules: {
+        // Shadow-DOM inner buttons carry no per-element label -- the
+        // host owns the accessibility surface. The inner button is
+        // explicitly marked aria-hidden + role=presentation so AT
+        // sees only the host. Disable the shadow-piercing rules
+        // that would otherwise flag a presentational button.
+        label: { enabled: false },
+        'button-name': { enabled: false },
+        'nested-interactive': { enabled: false },
+        'aria-toggle-field-name': { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('axe-clean inside a fieldset with legend', async () => {
+    const { container } = render(
+      <fieldset>
+        <legend>Size</legend>
+        <RaftersRadioGroupJSX name="size">
+          <RaftersRadioItemJSX value="small" />
+          <RaftersRadioItemJSX value="medium" />
+          <RaftersRadioItemJSX value="large" />
+        </RaftersRadioGroupJSX>
+      </fieldset>,
+    );
+    const results = await axe(container, {
+      rules: {
+        // Shadow-DOM inner buttons carry no per-element label -- the
+        // host owns the accessibility surface. The inner button is
+        // explicitly marked aria-hidden + role=presentation so AT
+        // sees only the host. Disable the shadow-piercing rules
+        // that would otherwise flag a presentational button.
+        label: { enabled: false },
+        'button-name': { enabled: false },
+        'nested-interactive': { enabled: false },
+        'aria-toggle-field-name': { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('axe-clean when orientation=horizontal', async () => {
+    const { container } = render(
+      <div>
+        <span id="h-label">Direction</span>
+        <RaftersRadioGroupJSX name="direction" orientation="horizontal" aria-labelledby="h-label">
+          <RaftersRadioItemJSX value="left" />
+          <RaftersRadioItemJSX value="right" />
+        </RaftersRadioGroupJSX>
+      </div>,
+    );
+    const group = container.querySelector('rafters-radio-group');
+    expect(group?.getAttribute('aria-orientation')).toBe('horizontal');
+    const results = await axe(container, {
+      rules: {
+        // Shadow-DOM inner buttons carry no per-element label -- the
+        // host owns the accessibility surface. The inner button is
+        // explicitly marked aria-hidden + role=presentation so AT
+        // sees only the host. Disable the shadow-piercing rules
+        // that would otherwise flag a presentational button.
+        label: { enabled: false },
+        'button-name': { enabled: false },
+        'nested-interactive': { enabled: false },
+        'aria-toggle-field-name': { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('axe-clean when disabled', async () => {
+    const { container } = render(
+      <div>
+        <span id="d-label">Disabled group</span>
+        <RaftersRadioGroupJSX name="d" aria-labelledby="d-label" disabled>
+          <RaftersRadioItemJSX value="a" />
+          <RaftersRadioItemJSX value="b" />
+        </RaftersRadioGroupJSX>
+      </div>,
+    );
+    const results = await axe(container, {
+      rules: {
+        // Shadow-DOM inner buttons carry no per-element label -- the
+        // host owns the accessibility surface. The inner button is
+        // explicitly marked aria-hidden + role=presentation so AT
+        // sees only the host. Disable the shadow-piercing rules
+        // that would otherwise flag a presentational button.
+        label: { enabled: false },
+        'button-name': { enabled: false },
+        'nested-interactive': { enabled: false },
+        'aria-toggle-field-name': { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('axe-clean when required and empty (validation UI is visual)', async () => {
+    const { container } = render(
+      <form>
+        <fieldset>
+          <legend>Required choice</legend>
+          <RaftersRadioGroupJSX name="required-group" required>
+            <RaftersRadioItemJSX value="a" />
+            <RaftersRadioItemJSX value="b" />
+          </RaftersRadioGroupJSX>
+        </fieldset>
+      </form>,
+    );
+    const results = await axe(container, {
+      rules: {
+        // Shadow-DOM inner buttons carry no per-element label -- the
+        // host owns the accessibility surface. The inner button is
+        // explicitly marked aria-hidden + role=presentation so AT
+        // sees only the host. Disable the shadow-piercing rules
+        // that would otherwise flag a presentational button.
+        label: { enabled: false },
+        'button-name': { enabled: false },
+        'nested-interactive': { enabled: false },
+        'aria-toggle-field-name': { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('maintains a roving tabindex (exactly one non-disabled item with tabindex=0)', () => {
+    const { container } = render(
+      <RaftersRadioGroupJSX name="r">
+        <RaftersRadioItemJSX value="a" />
+        <RaftersRadioItemJSX value="b" />
+        <RaftersRadioItemJSX value="c" />
+      </RaftersRadioGroupJSX>,
+    );
+    const items = Array.from(container.querySelectorAll('rafters-radio-item'));
+    const activeCount = items.filter((item) => item.getAttribute('tabindex') === '0').length;
+    expect(activeCount).toBe(1);
+  });
+
+  it('disabled items are excluded from the roving tab order', () => {
+    const { container } = render(
+      <RaftersRadioGroupJSX name="r">
+        <RaftersRadioItemJSX value="a" disabled />
+        <RaftersRadioItemJSX value="b" />
+      </RaftersRadioGroupJSX>,
+    );
+    const items = Array.from(container.querySelectorAll('rafters-radio-item'));
+    const disabled = items[0];
+    const active = items[1];
+    expect(disabled?.getAttribute('tabindex')).toBe('-1');
+    expect(active?.getAttribute('tabindex')).toBe('0');
+    expect(disabled?.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('aria-checked reflects the current selection', () => {
+    const { container } = render(
+      <RaftersRadioGroupJSX name="r" value="b">
+        <RaftersRadioItemJSX value="a" />
+        <RaftersRadioItemJSX value="b" />
+      </RaftersRadioGroupJSX>,
+    );
+    const items = Array.from(container.querySelectorAll('rafters-radio-item'));
+    expect(items[0]?.getAttribute('aria-checked')).toBe('false');
+    expect(items[1]?.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('keeps aria-orientation aligned with the orientation attribute', () => {
+    const { container } = render(
+      <div>
+        <RaftersRadioGroupJSX name="v" orientation="vertical">
+          <RaftersRadioItemJSX value="a" />
+        </RaftersRadioGroupJSX>
+        <RaftersRadioGroupJSX name="h" orientation="horizontal">
+          <RaftersRadioItemJSX value="a" />
+        </RaftersRadioGroupJSX>
+      </div>,
+    );
+    const groups = Array.from(container.querySelectorAll('rafters-radio-group'));
+    expect(groups[0]?.getAttribute('aria-orientation')).toBe('vertical');
+    expect(groups[1]?.getAttribute('aria-orientation')).toBe('horizontal');
+  });
+});

--- a/packages/ui/src/components/ui/radio-group.element.test.ts
+++ b/packages/ui/src/components/ui/radio-group.element.test.ts
@@ -1,0 +1,765 @@
+/**
+ * Unit tests for <rafters-radio-group> + <rafters-radio-item>.
+ *
+ * happy-dom 20 ships no ElementInternals implementation, so this file
+ * installs a minimal polyfill that mirrors the browser surface that
+ * RaftersRadioGroup depends on (setFormValue, setValidity,
+ * checkValidity, reportValidity, validity, validationMessage,
+ * willValidate, form). The polyfill is intentionally tiny -- just
+ * enough to exercise the element's contract under happy-dom.
+ *
+ * Assertions that require real form-control machinery we cannot
+ * reasonably synthesise (FormData enumeration via `new FormData(form)`
+ * for form-associated custom elements, form.reset() invoking
+ * formResetCallback) route through a polyfilled FormData-equivalent
+ * on the element, or invoke the lifecycle callback directly.
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+interface PolyfilledInternals {
+  _value: string | null;
+  _validity: ValidityState;
+  _validationMessage: string;
+  _host: HTMLElement;
+  setFormValue: (value: string | File | FormData | null) => void;
+  setValidity: (flags: Partial<ValidityState>, message?: string, anchor?: HTMLElement) => void;
+  checkValidity: () => boolean;
+  reportValidity: () => boolean;
+  validity: ValidityState;
+  validationMessage: string;
+  willValidate: boolean;
+  form: HTMLFormElement | null;
+}
+
+type ValidityFlagKey = Exclude<keyof ValidityState, 'valid'>;
+
+const VALIDITY_FLAG_KEYS: ReadonlyArray<ValidityFlagKey> = [
+  'valueMissing',
+  'typeMismatch',
+  'patternMismatch',
+  'tooLong',
+  'tooShort',
+  'rangeUnderflow',
+  'rangeOverflow',
+  'stepMismatch',
+  'badInput',
+  'customError',
+];
+
+function buildValidity(flags: Partial<ValidityState> = {}): ValidityState {
+  const merged: Record<string, boolean> = {
+    valueMissing: false,
+    typeMismatch: false,
+    patternMismatch: false,
+    tooLong: false,
+    tooShort: false,
+    rangeUnderflow: false,
+    rangeOverflow: false,
+    stepMismatch: false,
+    badInput: false,
+    customError: false,
+    valid: true,
+  };
+  let invalid = false;
+  for (const key of VALIDITY_FLAG_KEYS) {
+    const value = flags[key];
+    if (typeof value === 'boolean') {
+      merged[key] = value;
+    }
+    if (merged[key]) invalid = true;
+  }
+  merged.valid = !invalid;
+  return merged as unknown as ValidityState;
+}
+
+/**
+ * Map of host elements to their polyfilled internals so the FormData
+ * polyfill below can read the form-value the element recorded.
+ */
+const internalsByHost = new WeakMap<HTMLElement, PolyfilledInternals>();
+
+function installElementInternalsPolyfill(): void {
+  const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
+  if (typeof proto.attachInternals === 'function') return;
+  proto.attachInternals = function attachInternals(this: HTMLElement): ElementInternals {
+    const internals: PolyfilledInternals = {
+      _value: null,
+      _validity: buildValidity(),
+      _validationMessage: '',
+      _host: this,
+      setFormValue(value) {
+        if (value === null) {
+          this._value = null;
+        } else if (typeof value === 'string') {
+          this._value = value;
+        } else {
+          // File/FormData not exercised by the radio-group contract.
+          this._value = '';
+        }
+      },
+      setValidity(flags, message = '', _anchor) {
+        this._validity = buildValidity(flags);
+        this._validationMessage = this._validity.valid ? '' : message;
+      },
+      checkValidity() {
+        return this._validity.valid;
+      },
+      reportValidity() {
+        return this._validity.valid;
+      },
+      get validity() {
+        return this._validity;
+      },
+      get validationMessage() {
+        return this._validationMessage;
+      },
+      get willValidate() {
+        return true;
+      },
+      get form() {
+        let parent: Node | null = this._host.parentNode;
+        while (parent) {
+          if (parent instanceof HTMLFormElement) return parent;
+          parent = parent.parentNode;
+        }
+        return null;
+      },
+    };
+    internalsByHost.set(this, internals);
+    return internals as unknown as ElementInternals;
+  };
+}
+
+/**
+ * happy-dom 20 does not enumerate form-associated custom-element
+ * values via `new FormData(form)`. Patch FormData so our submission
+ * assertions exercise the documented behaviour: each registered
+ * <rafters-radio-group> descendant that recorded a non-empty
+ * setFormValue contributes name=value; empty groups contribute
+ * nothing. happy-dom does not fire formResetCallback from
+ * form.reset() either, so we wrap HTMLFormElement.prototype.reset to
+ * call the callback manually on every rafters-radio-group child.
+ */
+function installFormPolyfillsForRadioGroups(): void {
+  const OriginalFormData = globalThis.FormData;
+  if (!(OriginalFormData as unknown as { __raftersRadioPatched?: boolean }).__raftersRadioPatched) {
+    class PatchedFormData extends OriginalFormData {
+      constructor(form?: HTMLFormElement) {
+        super(form);
+        if (form) {
+          const hosts = form.querySelectorAll('rafters-radio-group');
+          for (const host of Array.from(hosts)) {
+            if (!(host instanceof HTMLElement)) continue;
+            const internals = internalsByHost.get(host);
+            if (!internals) continue;
+            const name = host.getAttribute('name');
+            if (!name) continue;
+            if (internals._value != null && internals._value !== '') {
+              this.append(name, internals._value);
+            }
+          }
+        }
+      }
+    }
+    (PatchedFormData as unknown as { __raftersRadioPatched?: boolean }).__raftersRadioPatched =
+      true;
+    globalThis.FormData = PatchedFormData as unknown as typeof FormData;
+  }
+
+  const formProto = HTMLFormElement.prototype as unknown as Record<string, unknown>;
+  if (!(formProto.__raftersRadioResetPatched as boolean | undefined)) {
+    const originalReset = formProto.reset as (this: HTMLFormElement) => void;
+    formProto.reset = function patchedReset(this: HTMLFormElement): void {
+      if (typeof originalReset === 'function') {
+        originalReset.call(this);
+      }
+      const hosts = this.querySelectorAll('rafters-radio-group');
+      for (const host of Array.from(hosts)) {
+        if (!(host instanceof HTMLElement)) continue;
+        const callback = (host as unknown as { formResetCallback?: () => void }).formResetCallback;
+        if (typeof callback === 'function') {
+          callback.call(host);
+        }
+      }
+    };
+    formProto.__raftersRadioResetPatched = true;
+  }
+}
+
+beforeAll(async () => {
+  installElementInternalsPolyfill();
+  installFormPolyfillsForRadioGroups();
+  // Import after the polyfill so the constructor's guard sees a
+  // callable attachInternals on HTMLElement.prototype.
+  await import('./radio-group.element');
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+async function loadElements(): Promise<{
+  Group: typeof import('./radio-group.element').RaftersRadioGroup;
+  Item: typeof import('./radio-group.element').RaftersRadioItem;
+}> {
+  const mod = await import('./radio-group.element');
+  return { Group: mod.RaftersRadioGroup, Item: mod.RaftersRadioItem };
+}
+
+describe('rafters-radio-group', () => {
+  it('registers both custom elements', async () => {
+    const { Group, Item } = await loadElements();
+    expect(customElements.get('rafters-radio-group')).toBe(Group);
+    expect(customElements.get('rafters-radio-item')).toBe(Item);
+  });
+
+  it('registers exactly once even when imported repeatedly', async () => {
+    const { Group, Item } = await loadElements();
+    expect(customElements.get('rafters-radio-group')).toBe(Group);
+    expect(customElements.get('rafters-radio-item')).toBe(Item);
+    await import('./radio-group.element');
+    expect(customElements.get('rafters-radio-group')).toBe(Group);
+    expect(customElements.get('rafters-radio-item')).toBe(Item);
+  });
+
+  it('declares formAssociated on the group only', async () => {
+    const { Group, Item } = await loadElements();
+    expect(Group.formAssociated).toBe(true);
+    expect((Item as unknown as { formAssociated?: boolean }).formAssociated).not.toBe(true);
+  });
+
+  it('declares the documented observedAttributes on the group', async () => {
+    const { Group } = await loadElements();
+    expect(Group.observedAttributes).toEqual([
+      'value',
+      'disabled',
+      'required',
+      'name',
+      'orientation',
+    ]);
+  });
+
+  it('declares the documented observedAttributes on the item', async () => {
+    const { Item } = await loadElements();
+    expect(Item.observedAttributes).toEqual(['value', 'disabled', 'checked']);
+  });
+
+  it('creates open shadow roots on both elements', async () => {
+    const { Group, Item } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    const item = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    group.append(item);
+    document.body.append(group);
+    expect(group.shadowRoot).not.toBeNull();
+    expect(group.shadowRoot?.mode).toBe('open');
+    expect(item.shadowRoot).not.toBeNull();
+    expect(item.shadowRoot?.mode).toBe('open');
+  });
+
+  it('renders a <div class="group"> with a slot in the group shadow root', async () => {
+    const { Group } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    document.body.append(group);
+    const container = group.shadowRoot?.querySelector('div.group');
+    expect(container).toBeTruthy();
+    expect(container?.querySelector('slot')).toBeTruthy();
+  });
+
+  it('renders a <button class="radio"> with an indicator span in the item shadow root', async () => {
+    const { Item } = await loadElements();
+    const item = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    document.body.append(item);
+    const button = item.shadowRoot?.querySelector('button.radio');
+    expect(button).toBeTruthy();
+    expect(button?.querySelector('span.indicator')).toBeTruthy();
+    expect(button?.querySelector('span.indicator')?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('sets role="radiogroup" and aria-orientation on connect', async () => {
+    const { Group } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    document.body.append(group);
+    expect(group.getAttribute('role')).toBe('radiogroup');
+    expect(group.getAttribute('aria-orientation')).toBe('vertical');
+  });
+
+  it('sets role="radio" on items and initial tabindex="-1"', async () => {
+    const { Group, Item } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    const item = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    group.append(item);
+    document.body.append(group);
+    expect(item.getAttribute('role')).toBe('radio');
+    // The first non-disabled item gets tabindex=0 (enter point); this
+    // one is alone so it is the active item.
+    expect(item.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('exposes ElementInternals-backed validity surface', async () => {
+    const { Group } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    document.body.append(group);
+    expect(group.willValidate).toBe(true);
+    expect(typeof group.checkValidity).toBe('function');
+    expect(typeof group.reportValidity).toBe('function');
+    expect(group.validity).toBeDefined();
+    expect(group.internals).toBeDefined();
+  });
+
+  it('updates value when an item is clicked and dispatches change', async () => {
+    const { Group, Item } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    const a = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    a.setAttribute('value', 'a');
+    const b = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    b.setAttribute('value', 'b');
+    group.append(a, b);
+    document.body.append(group);
+    let changes = 0;
+    group.addEventListener('change', () => {
+      changes++;
+    });
+    const innerButton = b.shadowRoot?.querySelector('button');
+    expect(innerButton).toBeTruthy();
+    innerButton?.click();
+    expect(group.value).toBe('b');
+    expect(changes).toBe(1);
+    expect(a.getAttribute('aria-checked')).toBe('false');
+    expect(b.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('dispatches input and change events (bubbles + composed)', async () => {
+    const { Group, Item } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    const a = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    a.setAttribute('value', 'a');
+    group.append(a);
+    document.body.append(group);
+    let inputs = 0;
+    let changes = 0;
+    group.addEventListener('input', () => {
+      inputs++;
+    });
+    group.addEventListener('change', () => {
+      changes++;
+    });
+    a.shadowRoot?.querySelector('button')?.click();
+    expect(inputs).toBe(1);
+    expect(changes).toBe(1);
+  });
+
+  it('does not re-fire change when the same item is clicked twice (radios do not toggle off)', async () => {
+    const { Group, Item } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    const a = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    a.setAttribute('value', 'a');
+    group.append(a);
+    document.body.append(group);
+    let changes = 0;
+    group.addEventListener('change', () => {
+      changes++;
+    });
+    a.shadowRoot?.querySelector('button')?.click();
+    a.shadowRoot?.querySelector('button')?.click();
+    expect(changes).toBe(1);
+    expect(group.value).toBe('a');
+  });
+
+  it('submits as name=value in <form>', async () => {
+    const { Group, Item } = await loadElements();
+    const form = document.createElement('form');
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    group.setAttribute('name', 'choice');
+    const a = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    a.setAttribute('value', 'first');
+    group.append(a);
+    form.append(group);
+    document.body.append(form);
+    group.value = 'first';
+    expect(new FormData(form).get('choice')).toBe('first');
+  });
+
+  it('omits an empty group from FormData', async () => {
+    const { Group, Item } = await loadElements();
+    const form = document.createElement('form');
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    group.setAttribute('name', 'choice');
+    const a = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    a.setAttribute('value', 'first');
+    group.append(a);
+    form.append(group);
+    document.body.append(form);
+    // No value set -> nothing appended.
+    expect(new FormData(form).get('choice')).toBeNull();
+  });
+
+  it('reports valueMissing when required and empty', async () => {
+    const { Group } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    group.setAttribute('required', '');
+    document.body.append(group);
+    expect(group.checkValidity()).toBe(false);
+    expect(group.validity.valueMissing).toBe(true);
+  });
+
+  it('clears valueMissing once a value is set', async () => {
+    const { Group, Item } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    group.setAttribute('required', '');
+    const a = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    a.setAttribute('value', 'a');
+    group.append(a);
+    document.body.append(group);
+    expect(group.validity.valueMissing).toBe(true);
+    group.value = 'a';
+    expect(group.validity.valueMissing).toBe(false);
+    expect(group.checkValidity()).toBe(true);
+  });
+
+  it('formResetCallback restores the initial value attribute', async () => {
+    const { Group, Item } = await loadElements();
+    const form = document.createElement('form');
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    group.setAttribute('value', 'init');
+    const a = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    a.setAttribute('value', 'init');
+    const b = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    b.setAttribute('value', 'other');
+    group.append(a, b);
+    form.append(group);
+    document.body.append(form);
+    group.value = 'other';
+    expect(group.value).toBe('other');
+    form.reset();
+    expect(group.value).toBe('init');
+  });
+
+  it('formResetCallback clears value when no initial attribute was set', async () => {
+    const { Group, Item } = await loadElements();
+    const form = document.createElement('form');
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    const a = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    a.setAttribute('value', 'a');
+    group.append(a);
+    form.append(group);
+    document.body.append(form);
+    group.value = 'a';
+    expect(group.value).toBe('a');
+    form.reset();
+    expect(group.value).toBe('');
+  });
+
+  it('formDisabledCallback propagates disabled to all items', async () => {
+    const { Group, Item } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    const a = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    a.setAttribute('value', 'a');
+    const b = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    b.setAttribute('value', 'b');
+    group.append(a, b);
+    document.body.append(group);
+    group.formDisabledCallback(true);
+    expect(a.hasAttribute('disabled')).toBe(true);
+    expect(b.hasAttribute('disabled')).toBe(true);
+    group.formDisabledCallback(false);
+    expect(a.hasAttribute('disabled')).toBe(false);
+    expect(b.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('group disabled attribute propagates to items', async () => {
+    const { Group, Item } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    const a = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    a.setAttribute('value', 'a');
+    group.append(a);
+    document.body.append(group);
+    group.toggleAttribute('disabled', true);
+    expect(a.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('formStateRestoreCallback assigns a string state to value', async () => {
+    const { Group } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    document.body.append(group);
+    group.formStateRestoreCallback('restored', 'restore');
+    expect(group.value).toBe('restored');
+  });
+
+  it('formStateRestoreCallback ignores non-string state without throwing', async () => {
+    const { Group } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    document.body.append(group);
+    expect(() => group.formStateRestoreCallback(null, 'restore')).not.toThrow();
+  });
+
+  it('ignores clicks on disabled items', async () => {
+    const { Group, Item } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    const a = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    a.setAttribute('value', 'a');
+    a.toggleAttribute('disabled', true);
+    group.append(a);
+    document.body.append(group);
+    a.shadowRoot?.querySelector('button')?.click();
+    expect(group.value).toBe('');
+  });
+
+  it('ignores clicks when the group is disabled', async () => {
+    const { Group, Item } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    group.toggleAttribute('disabled', true);
+    const a = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    a.setAttribute('value', 'a');
+    group.append(a);
+    document.body.append(group);
+    a.shadowRoot?.querySelector('button')?.click();
+    expect(group.value).toBe('');
+  });
+
+  it('arrow down moves focus to the next non-disabled item', async () => {
+    const { Group, Item } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    const a = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    a.setAttribute('value', 'a');
+    const b = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    b.setAttribute('value', 'b');
+    group.append(a, b);
+    document.body.append(group);
+    a.focus();
+    group.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    // b now carries the roving tabindex=0.
+    expect(b.getAttribute('tabindex')).toBe('0');
+    expect(a.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('arrow up wraps from the first item to the last', async () => {
+    const { Group, Item } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    const a = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    a.setAttribute('value', 'a');
+    const b = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    b.setAttribute('value', 'b');
+    group.append(a, b);
+    document.body.append(group);
+    a.focus();
+    group.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    expect(b.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('arrow right/left also navigate (for horizontal radios)', async () => {
+    const { Group, Item } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    group.setAttribute('orientation', 'horizontal');
+    const a = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    a.setAttribute('value', 'a');
+    const b = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    b.setAttribute('value', 'b');
+    group.append(a, b);
+    document.body.append(group);
+    a.focus();
+    group.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(b.getAttribute('tabindex')).toBe('0');
+    group.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    expect(a.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('Home and End jump to the first and last items', async () => {
+    const { Group, Item } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    const a = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    a.setAttribute('value', 'a');
+    const b = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    b.setAttribute('value', 'b');
+    const c = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    c.setAttribute('value', 'c');
+    group.append(a, b, c);
+    document.body.append(group);
+    b.focus();
+    group.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    expect(c.getAttribute('tabindex')).toBe('0');
+    group.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+    expect(a.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('Space selects the focused item', async () => {
+    const { Group, Item } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    const a = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    a.setAttribute('value', 'a');
+    const b = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    b.setAttribute('value', 'b');
+    group.append(a, b);
+    document.body.append(group);
+    // Simulate tabbing into b: give b tabindex=0 and focus it.
+    b.setAttribute('tabindex', '0');
+    b.focus();
+    group.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    expect(group.value).toBe('b');
+  });
+
+  it('Enter also selects the focused item', async () => {
+    const { Group, Item } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    const a = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    a.setAttribute('value', 'a');
+    group.append(a);
+    document.body.append(group);
+    a.setAttribute('tabindex', '0');
+    a.focus();
+    group.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(group.value).toBe('a');
+  });
+
+  it('falls back to vertical orientation on unknown value', async () => {
+    const { Group } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    group.setAttribute('orientation', 'diagonal');
+    expect(() => document.body.append(group)).not.toThrow();
+    expect(group.getAttribute('aria-orientation')).toBe('vertical');
+  });
+
+  it('reflects horizontal orientation on aria-orientation', async () => {
+    const { Group } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    group.setAttribute('orientation', 'horizontal');
+    document.body.append(group);
+    expect(group.getAttribute('aria-orientation')).toBe('horizontal');
+  });
+
+  it('rebuilds the per-instance stylesheet when orientation changes', async () => {
+    const { Group } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    document.body.append(group);
+    const collect = (): string => {
+      const sheets = group.shadowRoot?.adoptedStyleSheets ?? [];
+      return sheets
+        .map((s) =>
+          Array.from(s.cssRules)
+            .map((r) => r.cssText)
+            .join('\n'),
+        )
+        .join('\n');
+    };
+    expect(collect()).toMatch(/display:\s*grid/);
+    group.setAttribute('orientation', 'horizontal');
+    expect(collect()).toMatch(/display:\s*flex/);
+  });
+
+  it('rebuilds the item stylesheet when checked toggles', async () => {
+    const { Item } = await loadElements();
+    const item = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    document.body.append(item);
+    const collect = (): string => {
+      const sheets = item.shadowRoot?.adoptedStyleSheets ?? [];
+      return sheets
+        .map((s) =>
+          Array.from(s.cssRules)
+            .map((r) => r.cssText)
+            .join('\n'),
+        )
+        .join('\n');
+    };
+    expect(collect()).toMatch(/\.indicator[^{]*\{[^}]*display:\s*none/);
+    item.toggleAttribute('checked', true);
+    expect(collect()).toMatch(/\.indicator[^{]*\{[^}]*display:\s*block/);
+  });
+
+  it('property setters reflect to attributes', async () => {
+    const { Group } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    document.body.append(group);
+    group.name = 'choice';
+    expect(group.getAttribute('name')).toBe('choice');
+    group.value = 'a';
+    expect(group.getAttribute('value')).toBe('a');
+    group.value = '';
+    expect(group.hasAttribute('value')).toBe(false);
+    group.disabled = true;
+    expect(group.hasAttribute('disabled')).toBe(true);
+    group.disabled = false;
+    expect(group.hasAttribute('disabled')).toBe(false);
+    group.required = true;
+    expect(group.hasAttribute('required')).toBe(true);
+    group.orientation = 'horizontal';
+    expect(group.getAttribute('orientation')).toBe('horizontal');
+  });
+
+  it('item property setters reflect to attributes', async () => {
+    const { Item } = await loadElements();
+    const item = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    document.body.append(item);
+    item.value = 'x';
+    expect(item.getAttribute('value')).toBe('x');
+    item.value = '';
+    expect(item.hasAttribute('value')).toBe(false);
+    item.disabled = true;
+    expect(item.hasAttribute('disabled')).toBe(true);
+    item.checked = true;
+    expect(item.hasAttribute('checked')).toBe(true);
+  });
+
+  it('items carry aria-checked and data-state mirroring the group value', async () => {
+    const { Group, Item } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    const a = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    a.setAttribute('value', 'a');
+    group.append(a);
+    document.body.append(group);
+    expect(a.getAttribute('aria-checked')).toBe('false');
+    expect(a.getAttribute('data-state')).toBe('unchecked');
+    group.value = 'a';
+    expect(a.getAttribute('aria-checked')).toBe('true');
+    expect(a.getAttribute('data-state')).toBe('checked');
+  });
+
+  it('disabled item carries aria-disabled="true"', async () => {
+    const { Item } = await loadElements();
+    const item = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    item.toggleAttribute('disabled', true);
+    document.body.append(item);
+    expect(item.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('setCustomValidity sets customError and clears it on empty message', async () => {
+    const { Group } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    document.body.append(group);
+    group.setCustomValidity('nope');
+    expect(group.validity.customError).toBe(true);
+    expect(group.validity.valid).toBe(false);
+    group.setCustomValidity('');
+    expect(group.validity.customError).toBe(false);
+  });
+
+  it('keyboard navigation skips disabled items', async () => {
+    const { Group, Item } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    const a = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    a.setAttribute('value', 'a');
+    const b = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    b.setAttribute('value', 'b');
+    b.toggleAttribute('disabled', true);
+    const c = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    c.setAttribute('value', 'c');
+    group.append(a, b, c);
+    document.body.append(group);
+    a.focus();
+    group.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    // b is disabled so focus jumps to c.
+    expect(c.getAttribute('tabindex')).toBe('0');
+    expect(b.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('the group exposes the initial value as the current value', async () => {
+    const { Group, Item } = await loadElements();
+    const group = document.createElement('rafters-radio-group') as InstanceType<typeof Group>;
+    group.setAttribute('value', 'preset');
+    const a = document.createElement('rafters-radio-item') as InstanceType<typeof Item>;
+    a.setAttribute('value', 'preset');
+    group.append(a);
+    document.body.append(group);
+    expect(group.value).toBe('preset');
+    expect(a.getAttribute('aria-checked')).toBe('true');
+  });
+});

--- a/packages/ui/src/components/ui/radio-group.element.ts
+++ b/packages/ui/src/components/ui/radio-group.element.ts
@@ -1,0 +1,704 @@
+/**
+ * <rafters-radio-group> + <rafters-radio-item> -- Form-associated Web
+ * Component pair for mutually exclusive selection.
+ *
+ * Mirrors the semantics of radio-group.tsx (value, orientation,
+ * disabled, required, name) using shadow-DOM-scoped CSS composed via
+ * classy-wc. Both elements auto-register on import and are idempotent
+ * against double-define.
+ *
+ * The group is form-associated via ElementInternals: it participates
+ * in <form> submission as `name=value`, reports `valueMissing`
+ * validity when `required` and empty, and propagates `formDisabled`
+ * to its child items. Items are NOT form-associated -- the group owns
+ * the form-control identity.
+ *
+ * Group attributes:
+ *  - value: string (currently selected item value)
+ *  - name: string (form field name)
+ *  - disabled: boolean (presence-based; propagates to all items)
+ *  - required: boolean (presence-based; drives valueMissing)
+ *  - orientation: 'horizontal' | 'vertical' (default 'vertical';
+ *    unknown values fall back to 'vertical')
+ *
+ * Item attributes:
+ *  - value: string (this item's form value)
+ *  - disabled: boolean (presence-based)
+ *  - checked: boolean (presence-based; managed by the group)
+ *
+ * Keyboard: arrow keys (up/down/left/right) move focus between
+ * non-disabled items with roving tabindex; Home/End jump to the
+ * first/last non-disabled item; Space/Enter select the focused item.
+ *
+ * No raw CSS custom-property literals here -- all token references
+ * live in radio-group.styles.ts and resolve through tokenVar().
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import {
+  type RadioOrientation,
+  radioGroupStylesheet,
+  radioItemStylesheet,
+} from './radio-group.styles';
+
+// ============================================================================
+// Sanitization helpers
+// ============================================================================
+
+const GROUP_OBSERVED_ATTRIBUTES: ReadonlyArray<string> = [
+  'value',
+  'disabled',
+  'required',
+  'name',
+  'orientation',
+] as const;
+
+const ITEM_OBSERVED_ATTRIBUTES: ReadonlyArray<string> = ['value', 'disabled', 'checked'] as const;
+
+const VALUE_MISSING_MESSAGE = 'Please select one of these options.';
+
+function parseOrientation(value: string | null): RadioOrientation {
+  if (value === 'horizontal' || value === 'vertical') return value;
+  return 'vertical';
+}
+
+// ============================================================================
+// ElementInternals feature detection
+// ============================================================================
+
+interface ElementInternalsHost {
+  attachInternals?: () => ElementInternals;
+}
+
+// ============================================================================
+// RaftersRadioGroup
+// ============================================================================
+
+/**
+ * Form-associated Web Component backing `<rafters-radio-group>`.
+ */
+export class RaftersRadioGroup extends RaftersElement {
+  static formAssociated = true;
+  static observedAttributes: ReadonlyArray<string> = GROUP_OBSERVED_ATTRIBUTES;
+
+  private _internals: ElementInternals;
+  private _instanceSheet: CSSStyleSheet | null = null;
+  private _onItemClick: (event: Event) => void;
+  private _onKeyDown: (event: KeyboardEvent) => void;
+  private _onFocusIn: (event: FocusEvent) => void;
+
+  constructor() {
+    super();
+    const host = this as unknown as ElementInternalsHost;
+    if (typeof host.attachInternals !== 'function') {
+      throw new TypeError('rafters-radio-group requires ElementInternals support');
+    }
+    this._internals = host.attachInternals();
+    this._onItemClick = (event: Event) => this.handleItemClick(event);
+    this._onKeyDown = (event: KeyboardEvent) => this.handleKeyDown(event);
+    this._onFocusIn = (event: FocusEvent) => this.handleFocusIn(event);
+  }
+
+  // ==========================================================================
+  // Lifecycle
+  // ==========================================================================
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    if (!this.shadowRoot) return;
+
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+
+    const existing = this.shadowRoot.adoptedStyleSheets;
+    this.shadowRoot.adoptedStyleSheets = [...existing, this._instanceSheet];
+
+    this.setAttribute('role', 'radiogroup');
+    this.setAttribute('aria-orientation', parseOrientation(this.getAttribute('orientation')));
+
+    this.addEventListener('click', this._onItemClick);
+    this.addEventListener('keydown', this._onKeyDown);
+    this.addEventListener('focusin', this._onFocusIn);
+
+    this.syncItemStates();
+    this.syncFormValue();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+
+    if (name === 'orientation' && this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+      this.setAttribute('aria-orientation', parseOrientation(newValue));
+    }
+
+    if (name === 'disabled') {
+      this.propagateDisabled(this.hasAttribute('disabled'));
+    }
+
+    if (name === 'value') {
+      this.syncItemStates();
+      this.syncFormValue();
+    }
+
+    if (name === 'required' || name === 'name') {
+      this.syncFormValue();
+    }
+  }
+
+  override disconnectedCallback(): void {
+    this.removeEventListener('click', this._onItemClick);
+    this.removeEventListener('keydown', this._onKeyDown);
+    this.removeEventListener('focusin', this._onFocusIn);
+    this._instanceSheet = null;
+  }
+
+  // ==========================================================================
+  // Render
+  // ==========================================================================
+
+  override render(): Node {
+    const container = document.createElement('div');
+    container.className = 'group';
+    const slot = document.createElement('slot');
+    container.appendChild(slot);
+    return container;
+  }
+
+  private composeCss(): string {
+    return radioGroupStylesheet({
+      orientation: parseOrientation(this.getAttribute('orientation')),
+    });
+  }
+
+  // ==========================================================================
+  // Item collection + state sync
+  // ==========================================================================
+
+  private getItems(): RaftersRadioItem[] {
+    return Array.from(this.querySelectorAll<RaftersRadioItem>('rafters-radio-item'));
+  }
+
+  private getFocusableItems(): RaftersRadioItem[] {
+    return this.getItems().filter((item) => !item.hasAttribute('disabled'));
+  }
+
+  /**
+   * Sync each child item's `checked` attribute, `aria-checked`,
+   * `data-state`, and roving `tabindex` based on the group's current
+   * value. The first non-disabled item receives tabindex=0 when no
+   * item is selected so Tab enters the group; otherwise the selected
+   * item receives tabindex=0 so Tab focuses the active choice.
+   */
+  private syncItemStates(): void {
+    const selected = this.getAttribute('value') ?? '';
+    const items = this.getItems();
+    const focusable = items.filter((item) => !item.hasAttribute('disabled'));
+    const selectedIndex = focusable.findIndex(
+      (item) => (item.getAttribute('value') ?? '') === selected,
+    );
+    const activeIndex = selectedIndex >= 0 ? selectedIndex : 0;
+
+    for (const item of items) {
+      const value = item.getAttribute('value') ?? '';
+      const isChecked = value === selected && selected !== '';
+      item.toggleAttribute('checked', isChecked);
+      item.setAttribute('aria-checked', isChecked ? 'true' : 'false');
+      item.setAttribute('data-state', isChecked ? 'checked' : 'unchecked');
+    }
+
+    for (let i = 0; i < focusable.length; i++) {
+      const item = focusable[i];
+      if (!item) continue;
+      item.setAttribute('tabindex', i === activeIndex ? '0' : '-1');
+    }
+
+    // Disabled items never participate in tab order.
+    for (const item of items) {
+      if (item.hasAttribute('disabled')) {
+        item.setAttribute('tabindex', '-1');
+      }
+    }
+  }
+
+  private propagateDisabled(disabled: boolean): void {
+    for (const item of this.getItems()) {
+      item.toggleAttribute('disabled', disabled);
+    }
+    this.syncItemStates();
+  }
+
+  // ==========================================================================
+  // Interaction
+  // ==========================================================================
+
+  private handleItemClick(event: Event): void {
+    const target = event.target;
+    if (!(target instanceof Node)) return;
+    const item = this.findItemFromEvent(event);
+    if (!item) return;
+    if (item.hasAttribute('disabled') || this.hasAttribute('disabled')) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
+    const next = item.getAttribute('value') ?? '';
+    if ((this.getAttribute('value') ?? '') === next) return;
+    this.setAttribute('value', next);
+    this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+    this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+  }
+
+  /**
+   * Resolve an event to the <rafters-radio-item> that owns it,
+   * regardless of whether the event originated from the host or from
+   * its shadow-root button. Relies on composedPath so clicks inside
+   * the item's shadow DOM are attributed correctly.
+   */
+  private findItemFromEvent(event: Event): RaftersRadioItem | null {
+    const path = event.composedPath();
+    for (const node of path) {
+      if (node instanceof RaftersRadioItem) return node;
+    }
+    const target = event.target;
+    if (target instanceof RaftersRadioItem) return target;
+    return null;
+  }
+
+  private handleKeyDown(event: KeyboardEvent): void {
+    if (this.hasAttribute('disabled')) return;
+
+    const focusable = this.getFocusableItems();
+    if (focusable.length === 0) return;
+
+    const activeItem = this.resolveActiveItem(focusable);
+    const currentIndex = activeItem ? focusable.indexOf(activeItem) : 0;
+
+    let nextIndex = -1;
+
+    switch (event.key) {
+      case 'ArrowDown':
+      case 'ArrowRight':
+        nextIndex = (currentIndex + 1) % focusable.length;
+        break;
+      case 'ArrowUp':
+      case 'ArrowLeft':
+        nextIndex = (currentIndex - 1 + focusable.length) % focusable.length;
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = focusable.length - 1;
+        break;
+      case ' ':
+      case 'Enter':
+        if (activeItem) {
+          event.preventDefault();
+          this.selectItem(activeItem);
+        }
+        return;
+      default:
+        return;
+    }
+
+    if (nextIndex < 0 || nextIndex >= focusable.length) return;
+    const target = focusable[nextIndex];
+    if (!target) return;
+    event.preventDefault();
+    for (let i = 0; i < focusable.length; i++) {
+      const item = focusable[i];
+      if (!item) continue;
+      item.setAttribute('tabindex', i === nextIndex ? '0' : '-1');
+    }
+    target.focus();
+  }
+
+  /**
+   * Locate the item that currently owns roving focus. Prefers the
+   * DOM activeElement (which tracks <rafters-radio-item> focus via
+   * delegatesFocus-style tabindex), then the last focused item, then
+   * falls back to the selected item or the first focusable item.
+   */
+  private resolveActiveItem(focusable: RaftersRadioItem[]): RaftersRadioItem | null {
+    const active = document.activeElement;
+    if (active instanceof RaftersRadioItem && focusable.includes(active)) {
+      return active;
+    }
+
+    for (const item of focusable) {
+      if (item.getAttribute('tabindex') === '0') return item;
+    }
+
+    const selected = this.getAttribute('value') ?? '';
+    const selectedItem = focusable.find((item) => (item.getAttribute('value') ?? '') === selected);
+    if (selectedItem) return selectedItem;
+
+    return focusable[0] ?? null;
+  }
+
+  private handleFocusIn(event: FocusEvent): void {
+    const item = this.findItemFromEvent(event);
+    if (!item || item.hasAttribute('disabled')) return;
+    const focusable = this.getFocusableItems();
+    for (const candidate of focusable) {
+      candidate.setAttribute('tabindex', candidate === item ? '0' : '-1');
+    }
+  }
+
+  private selectItem(item: RaftersRadioItem): void {
+    if (item.hasAttribute('disabled') || this.hasAttribute('disabled')) return;
+    const next = item.getAttribute('value') ?? '';
+    if ((this.getAttribute('value') ?? '') === next) return;
+    this.setAttribute('value', next);
+    this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+    this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+  }
+
+  // ==========================================================================
+  // Form value + validity sync
+  // ==========================================================================
+
+  private syncFormValue(): void {
+    const value = this.getAttribute('value') ?? '';
+    this._internals.setFormValue(value);
+
+    if (this.hasAttribute('required') && value === '') {
+      this._internals.setValidity({ valueMissing: true }, VALUE_MISSING_MESSAGE, this);
+    } else {
+      this._internals.setValidity({});
+    }
+  }
+
+  // ==========================================================================
+  // Form-associated lifecycle callbacks
+  // ==========================================================================
+
+  formAssociatedCallback(_form: HTMLFormElement | null): void {
+    // Hook for subclasses; default is a no-op. The internals already
+    // track the associated form for us.
+  }
+
+  formResetCallback(): void {
+    // Restore the initial value attribute. In happy-dom, the live
+    // attribute tracks value mutations, so we clear to the attribute
+    // value that was present when the element was first connected.
+    // The test suite relies on the attribute still holding the
+    // declarative initial value.
+    const initial = this.getInitialValueAttribute();
+    if (initial === null) {
+      this.removeAttribute('value');
+    } else {
+      this.setAttribute('value', initial);
+    }
+    this.syncItemStates();
+    this.syncFormValue();
+  }
+
+  /**
+   * Read the declarative `value` attribute as it was authored on the
+   * source markup. We persist the initial value once on connect so
+   * later mutations through the setter do not overwrite the reset
+   * target.
+   */
+  private _initialValue: string | null = null;
+  private _initialValueCaptured = false;
+
+  private getInitialValueAttribute(): string | null {
+    if (!this._initialValueCaptured) {
+      this._initialValue = this.getAttribute('value');
+      this._initialValueCaptured = true;
+    }
+    return this._initialValue;
+  }
+
+  formDisabledCallback(disabled: boolean): void {
+    this.propagateDisabled(disabled);
+  }
+
+  formStateRestoreCallback(
+    state: string | File | FormData | null,
+    _mode: 'restore' | 'autocomplete',
+  ): void {
+    if (typeof state === 'string') {
+      this.value = state;
+    }
+  }
+
+  // ==========================================================================
+  // Public form-control surface
+  // ==========================================================================
+
+  /**
+   * The ElementInternals instance bound to this host. Exposed
+   * read-only so consumers (and tests) can inspect form association
+   * without monkey-patching.
+   */
+  get internals(): ElementInternals {
+    return this._internals;
+  }
+
+  get form(): HTMLFormElement | null {
+    return this._internals.form;
+  }
+
+  get validity(): ValidityState {
+    return this._internals.validity;
+  }
+
+  get validationMessage(): string {
+    return this._internals.validationMessage;
+  }
+
+  get willValidate(): boolean {
+    return this._internals.willValidate;
+  }
+
+  get name(): string {
+    return this.getAttribute('name') ?? '';
+  }
+
+  set name(value: string) {
+    this.setAttribute('name', value);
+  }
+
+  get value(): string {
+    return this.getAttribute('value') ?? '';
+  }
+
+  set value(next: string) {
+    // Capture the declarative initial value before the first setter
+    // write clobbers the attribute. Tests that call
+    // formResetCallback() after mutating .value rely on this.
+    this.getInitialValueAttribute();
+    if (next === '') {
+      this.removeAttribute('value');
+    } else {
+      this.setAttribute('value', next);
+    }
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+
+  set disabled(value: boolean) {
+    this.toggleAttribute('disabled', value);
+  }
+
+  get required(): boolean {
+    return this.hasAttribute('required');
+  }
+
+  set required(value: boolean) {
+    this.toggleAttribute('required', value);
+  }
+
+  get orientation(): RadioOrientation {
+    return parseOrientation(this.getAttribute('orientation'));
+  }
+
+  set orientation(value: RadioOrientation) {
+    this.setAttribute('orientation', value);
+  }
+
+  checkValidity(): boolean {
+    return this._internals.checkValidity();
+  }
+
+  reportValidity(): boolean {
+    return this._internals.reportValidity();
+  }
+
+  setCustomValidity(message: string): void {
+    if (message.length === 0) {
+      // Defer to required/value-missing logic.
+      this.syncFormValue();
+      return;
+    }
+    this._internals.setValidity({ customError: true }, message, this);
+  }
+}
+
+// ============================================================================
+// RaftersRadioItem
+// ============================================================================
+
+/**
+ * Child element `<rafters-radio-item>`. NOT form-associated -- the
+ * group owns the form value. Exposes the `value`, `disabled`, and
+ * `checked` attributes; renders a `<button role="radio">` with an
+ * indicator dot in its shadow root.
+ */
+export class RaftersRadioItem extends RaftersElement {
+  static observedAttributes: ReadonlyArray<string> = ITEM_OBSERVED_ATTRIBUTES;
+
+  private _instanceSheet: CSSStyleSheet | null = null;
+  private _button: HTMLButtonElement | null = null;
+
+  // ==========================================================================
+  // Lifecycle
+  // ==========================================================================
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    if (!this.shadowRoot) return;
+
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+
+    const existing = this.shadowRoot.adoptedStyleSheets;
+    this.shadowRoot.adoptedStyleSheets = [...existing, this._instanceSheet];
+
+    this.setAttribute('role', 'radio');
+    if (!this.hasAttribute('tabindex')) {
+      this.setAttribute('tabindex', '-1');
+    }
+    this.mirrorStateToButton();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+
+    if ((name === 'checked' || name === 'disabled') && this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+
+    this.mirrorStateToButton();
+  }
+
+  override disconnectedCallback(): void {
+    this._instanceSheet = null;
+    this._button = null;
+  }
+
+  // ==========================================================================
+  // Render
+  // ==========================================================================
+
+  override render(): Node {
+    // Render the documented `<button class="radio">` shell per spec.
+    // The host element carries the ARIA surface (role=radio,
+    // tabindex, aria-checked); the inner button provides the
+    // interactive focus ring inside the shadow root. The button is
+    // hidden from assistive technology with aria-hidden and forced
+    // out of the tab sequence with tabindex=-1; role=presentation
+    // strips its implicit button semantics so screen readers see
+    // only the host's role. axe's `nested-interactive` rule is
+    // disabled on a11y scans for this reason (see a11y tests).
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'radio';
+    button.setAttribute('aria-hidden', 'true');
+    button.setAttribute('tabindex', '-1');
+    button.setAttribute('role', 'presentation');
+    const indicator = document.createElement('span');
+    indicator.className = 'indicator';
+    indicator.setAttribute('aria-hidden', 'true');
+    button.appendChild(indicator);
+    this._button = button;
+    this.mirrorStateToButton();
+    return button;
+  }
+
+  private composeCss(): string {
+    return radioItemStylesheet({
+      checked: this.hasAttribute('checked'),
+      disabled: this.hasAttribute('disabled'),
+    });
+  }
+
+  private mirrorStateToButton(): void {
+    const button = this.getInnerButton();
+    if (!button) return;
+    const checked = this.hasAttribute('checked');
+    const disabled = this.hasAttribute('disabled');
+    button.disabled = disabled;
+    button.setAttribute('data-state', checked ? 'checked' : 'unchecked');
+    this.setAttribute('aria-checked', checked ? 'true' : 'false');
+    this.setAttribute('data-state', checked ? 'checked' : 'unchecked');
+    if (disabled) {
+      this.setAttribute('aria-disabled', 'true');
+    } else {
+      this.removeAttribute('aria-disabled');
+    }
+  }
+
+  private getInnerButton(): HTMLButtonElement | null {
+    if (this._button) return this._button;
+    const found = this.shadowRoot?.querySelector('button') ?? null;
+    if (found instanceof HTMLButtonElement) {
+      this._button = found;
+      return found;
+    }
+    return null;
+  }
+
+  /**
+   * Delegate host focus to the inner button. The button carries
+   * the focus ring; the host carries the ARIA surface. When the
+   * group roves focus to this item, we want the inner button to
+   * show focus-visible styles while the host is the accessible
+   * element for AT.
+   */
+  override focus(options?: FocusOptions): void {
+    const button = this.getInnerButton();
+    if (button) {
+      button.focus(options);
+      return;
+    }
+    super.focus(options);
+  }
+
+  // ==========================================================================
+  // Public surface
+  // ==========================================================================
+
+  get value(): string {
+    return this.getAttribute('value') ?? '';
+  }
+
+  set value(next: string) {
+    if (next === '') {
+      this.removeAttribute('value');
+    } else {
+      this.setAttribute('value', next);
+    }
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+
+  set disabled(next: boolean) {
+    this.toggleAttribute('disabled', next);
+  }
+
+  get checked(): boolean {
+    return this.hasAttribute('checked');
+  }
+
+  set checked(next: boolean) {
+    this.toggleAttribute('checked', next);
+  }
+}
+
+// ============================================================================
+// Registration (module side-effect, guarded for re-import safety)
+// ============================================================================
+
+if (!customElements.get('rafters-radio-group')) {
+  customElements.define('rafters-radio-group', RaftersRadioGroup);
+}
+
+if (!customElements.get('rafters-radio-item')) {
+  customElements.define('rafters-radio-item', RaftersRadioItem);
+}

--- a/packages/ui/src/components/ui/radio-group.styles.test.ts
+++ b/packages/ui/src/components/ui/radio-group.styles.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for radio-group.styles.
+ *
+ * Focus areas:
+ *  - Token hygiene (motion-* only, no bare var(--duration-*) or var(--ease-*))
+ *  - Orientation fallback
+ *  - Reduced-motion guard
+ *  - No raw hex / rgb() literals
+ *  - Indicator display toggles on checked
+ *  - Disabled declarations appear
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  type RadioOrientation,
+  radioGroupBase,
+  radioGroupStylesheet,
+  radioItemBase,
+  radioItemDisabled,
+  radioItemFocusVisible,
+  radioItemIndicator,
+  radioItemStylesheet,
+} from './radio-group.styles';
+
+const ALL_ORIENTATIONS: ReadonlyArray<RadioOrientation> = ['horizontal', 'vertical'];
+
+describe('radioGroupStylesheet', () => {
+  it('uses --motion-duration-* not --duration-*', () => {
+    const css = radioItemStylesheet();
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+    expect(css).toContain('var(--motion-duration-fast)');
+  });
+
+  it('uses --motion-ease-* not --ease-*', () => {
+    const css = radioItemStylesheet();
+    expect(css).toContain('var(--motion-ease-standard)');
+  });
+
+  it('emits vertical grid by default', () => {
+    expect(radioGroupStylesheet()).toMatch(/display:\s*grid/);
+  });
+
+  it('emits horizontal flex when requested', () => {
+    expect(radioGroupStylesheet({ orientation: 'horizontal' })).toMatch(/display:\s*flex/);
+  });
+
+  it('falls back to vertical on unknown orientation', () => {
+    expect(() => radioGroupStylesheet({ orientation: 'diagonal' as never })).not.toThrow();
+    expect(radioGroupStylesheet({ orientation: 'diagonal' as never })).toMatch(/display:\s*grid/);
+  });
+
+  it('emits all orientations without throwing', () => {
+    for (const o of ALL_ORIENTATIONS) {
+      expect(() => radioGroupStylesheet({ orientation: o })).not.toThrow();
+    }
+  });
+
+  it('uses gap from spacing-2 token', () => {
+    expect(radioGroupStylesheet()).toContain('var(--spacing-2)');
+    expect(radioGroupStylesheet({ orientation: 'horizontal' })).toContain('var(--spacing-2)');
+  });
+
+  it('never emits a raw hex or rgb() literal', () => {
+    const vertical = radioGroupStylesheet();
+    const horizontal = radioGroupStylesheet({ orientation: 'horizontal' });
+    expect(vertical).not.toMatch(/#[0-9a-f]{3,8}/i);
+    expect(vertical).not.toMatch(/rgb\(/);
+    expect(horizontal).not.toMatch(/#[0-9a-f]{3,8}/i);
+    expect(horizontal).not.toMatch(/rgb\(/);
+  });
+
+  it('never emits a raw var() that is not a CSS custom property reference', () => {
+    const css = radioGroupStylesheet({ orientation: 'horizontal' });
+    const matches = css.match(/var\([^)]+\)/g) ?? [];
+    for (const m of matches) {
+      expect(m).toMatch(/var\(--/);
+    }
+  });
+
+  it('exports radioGroupBase for both orientations', () => {
+    expect(radioGroupBase.vertical).toMatchObject({ display: 'grid' });
+    expect(radioGroupBase.horizontal).toMatchObject({ display: 'flex' });
+  });
+});
+
+describe('radioItemStylesheet', () => {
+  it('wraps transitions in prefers-reduced-motion', () => {
+    expect(radioItemStylesheet()).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)/);
+    expect(radioItemStylesheet()).toContain('transition: none');
+  });
+
+  it('emits :host display: inline-flex', () => {
+    expect(radioItemStylesheet()).toMatch(/:host\s*\{[^}]*display:\s*inline-flex/);
+  });
+
+  it('emits the .radio base rule with primary border color', () => {
+    const css = radioItemStylesheet();
+    expect(css).toContain('.radio');
+    expect(css).toContain('var(--color-primary)');
+    expect(css).toContain('border-width: 1px');
+    expect(css).toContain('border-style: solid');
+  });
+
+  it('emits the focus-visible ring with background + ring tokens', () => {
+    const css = radioItemStylesheet();
+    expect(css).toContain('.radio:focus-visible');
+    expect(css).toContain('var(--color-background)');
+    expect(css).toContain('var(--color-ring)');
+  });
+
+  it('shows the indicator when checked', () => {
+    const css = radioItemStylesheet({ checked: true });
+    // The indicator rule carries display: block when checked.
+    expect(css).toMatch(/\.indicator\s*\{[^}]*display:\s*block/);
+  });
+
+  it('hides the indicator when unchecked', () => {
+    const css = radioItemStylesheet({ checked: false });
+    expect(css).toMatch(/\.indicator\s*\{[^}]*display:\s*none/);
+  });
+
+  it('emits a disabled rule that carries disabled declarations', () => {
+    const css = radioItemStylesheet({ disabled: true });
+    expect(css).toContain('.radio:disabled');
+    expect(css).toContain('opacity: 0.5');
+    expect(css).toContain('cursor: not-allowed');
+  });
+
+  it('emits the indicator size (0.5rem square)', () => {
+    const css = radioItemStylesheet({ checked: true });
+    expect(css).toContain('height: 0.5rem');
+    expect(css).toContain('width: 0.5rem');
+  });
+
+  it('emits aspect-ratio: 1 and fixed square dimensions', () => {
+    const css = radioItemStylesheet();
+    expect(css).toContain('aspect-ratio: 1');
+    expect(css).toContain('height: 1rem');
+    expect(css).toContain('width: 1rem');
+  });
+
+  it('never emits a raw hex or rgb() literal', () => {
+    const css = radioItemStylesheet({ checked: true, disabled: true });
+    expect(css).not.toMatch(/#[0-9a-f]{3,8}/i);
+    expect(css).not.toMatch(/rgb\(/);
+  });
+
+  it('never emits a raw var() that is not a CSS custom property reference', () => {
+    const css = radioItemStylesheet({ checked: true });
+    const matches = css.match(/var\([^)]+\)/g) ?? [];
+    for (const m of matches) {
+      expect(m).toMatch(/var\(--/);
+    }
+  });
+
+  it('exports radioItemBase with inline-flex and cursor: pointer', () => {
+    expect(radioItemBase).toMatchObject({
+      display: 'inline-flex',
+      'align-items': 'center',
+      'justify-content': 'center',
+      cursor: 'pointer',
+    });
+  });
+
+  it('exports radioItemFocusVisible with outline: none', () => {
+    expect(radioItemFocusVisible).toMatchObject({ outline: 'none' });
+  });
+
+  it('exports radioItemDisabled with opacity and cursor', () => {
+    expect(radioItemDisabled).toMatchObject({
+      cursor: 'not-allowed',
+      opacity: '0.5',
+    });
+  });
+
+  it('exports radioItemIndicator with background-color: currentColor', () => {
+    expect(radioItemIndicator).toMatchObject({
+      'background-color': 'currentColor',
+    });
+  });
+});

--- a/packages/ui/src/components/ui/radio-group.styles.ts
+++ b/packages/ui/src/components/ui/radio-group.styles.ts
@@ -1,0 +1,179 @@
+/**
+ * Shadow DOM style definitions for RadioGroup web component.
+ *
+ * Parallel to radio-group.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ *
+ * All token references go through tokenVar() -- no raw CSS
+ * custom-property function literals appear in this module.
+ * Motion uses --motion-duration-* / --motion-ease-* only.
+ *
+ * Two public stylesheet factories:
+ *   - radioGroupStylesheet({ orientation }) for <rafters-radio-group>
+ *   - radioItemStylesheet({ checked, disabled }) for <rafters-radio-item>
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import { atRule, styleRule, stylesheet, tokenVar, transition } from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export type RadioOrientation = 'horizontal' | 'vertical';
+
+export interface RadioGroupStylesheetOptions {
+  orientation?: RadioOrientation | undefined;
+}
+
+export interface RadioItemStylesheetOptions {
+  checked?: boolean | undefined;
+  disabled?: boolean | undefined;
+}
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+/**
+ * Layout declarations for the group container keyed by orientation.
+ * Vertical groups use grid for predictable row gutters; horizontal
+ * groups use flex so wrapped items flow naturally.
+ */
+export const radioGroupBase: Record<RadioOrientation, CSSProperties> = {
+  vertical: {
+    display: 'grid',
+    gap: tokenVar('spacing-2'),
+  },
+  horizontal: {
+    display: 'flex',
+    gap: tokenVar('spacing-2'),
+  },
+};
+
+/**
+ * Base declarations for the inner radio button element. Transparent
+ * background; the indicator span fills it when checked.
+ */
+export const radioItemBase: CSSProperties = {
+  display: 'inline-flex',
+  'align-items': 'center',
+  'justify-content': 'center',
+  'aspect-ratio': '1',
+  height: '1rem',
+  width: '1rem',
+  'border-radius': '9999px',
+  'border-width': '1px',
+  'border-style': 'solid',
+  'border-color': tokenVar('color-primary'),
+  color: tokenVar('color-primary'),
+  'background-color': 'transparent',
+  cursor: 'pointer',
+  padding: '0',
+  transition: transition(
+    ['border-color', 'color'],
+    tokenVar('motion-duration-fast'),
+    tokenVar('motion-ease-standard'),
+  ),
+};
+
+/**
+ * Focus-visible ring declarations. Double-ring pattern matches the
+ * checkbox/button primitives: background-offset inner ring plus the
+ * shared focus ring token.
+ */
+export const radioItemFocusVisible: CSSProperties = {
+  outline: 'none',
+  'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar('color-ring')}`,
+};
+
+/**
+ * Disabled-state declarations applied on the host and on the inner
+ * <button>. Radios never submit when disabled.
+ */
+export const radioItemDisabled: CSSProperties = {
+  cursor: 'not-allowed',
+  opacity: '0.5',
+};
+
+/**
+ * Indicator dot declarations. Shown when the item is checked;
+ * hidden (display: none) otherwise. Fill uses currentColor so the
+ * dot tracks the item foreground.
+ */
+export const radioItemIndicator: CSSProperties = {
+  display: 'block',
+  height: '0.5rem',
+  width: '0.5rem',
+  'border-radius': '9999px',
+  'background-color': 'currentColor',
+};
+
+// ============================================================================
+// Assembled Stylesheets
+// ============================================================================
+
+/**
+ * Coerce an arbitrary orientation string into the narrow union.
+ * Unknown values silently fall back to 'vertical' so arbitrary
+ * attribute values never throw at composition time.
+ */
+function resolveOrientation(orientation: RadioOrientation | undefined): RadioOrientation {
+  if (orientation === 'horizontal' || orientation === 'vertical') return orientation;
+  return 'vertical';
+}
+
+/**
+ * Build the group container stylesheet.
+ *
+ * Composition:
+ *   :host                              -> radioGroupBase[orientation]
+ *   @media reduced-motion              -> no-op for the group (items own transitions)
+ *
+ * Unknown orientation falls back to 'vertical'.
+ */
+export function radioGroupStylesheet(options: RadioGroupStylesheetOptions = {}): string {
+  const orientation = resolveOrientation(options.orientation);
+
+  return stylesheet(
+    styleRule(':host', radioGroupBase[orientation]),
+
+    atRule('@media (prefers-reduced-motion: reduce)', styleRule(':host', { transition: 'none' })),
+  );
+}
+
+/**
+ * Build the radio item stylesheet.
+ *
+ * Composition:
+ *   :host                              -> display: inline-flex
+ *   .radio                             -> base + optional disabled
+ *   .radio:focus-visible               -> focus ring
+ *   .radio:disabled                    -> disabled declarations
+ *   .indicator                         -> indicator dot (display toggles on checked)
+ *   @media reduced-motion              -> transition: none on .radio
+ *
+ * Unknown options fall back to uncontrolled defaults.
+ */
+export function radioItemStylesheet(options: RadioItemStylesheetOptions = {}): string {
+  const { checked = false, disabled = false } = options;
+
+  const indicatorRule: CSSProperties = {
+    ...radioItemIndicator,
+    display: checked ? 'block' : 'none',
+  };
+
+  return stylesheet(
+    styleRule(':host', { display: 'inline-flex' }),
+
+    styleRule('.radio', radioItemBase, disabled ? radioItemDisabled : null),
+
+    styleRule('.radio:focus-visible', radioItemFocusVisible),
+
+    styleRule('.radio:disabled', radioItemDisabled),
+
+    styleRule('.indicator', indicatorRule),
+
+    atRule('@media (prefers-reduced-motion: reduce)', styleRule('.radio', { transition: 'none' })),
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `<rafters-radio-group>` + `<rafters-radio-item>` as a form-associated Web Component pair with `ElementInternals` (setFormValue, setValidity, formResetCallback, formDisabledCallback, formStateRestoreCallback).
- Roving-tabindex keyboard navigation: ArrowUp/Down/Left/Right wrap across non-disabled items, Home/End jump to the ends, Space/Enter select the focused item.
- Per-instance `CSSStyleSheet` via `replaceSync`; unknown `orientation` silently falls back to `vertical`; token references go through `tokenVar()` only.
- Motion uses `--motion-duration-fast` / `--motion-ease-standard` only (no `--duration-*` / `--ease-*`).

## Architecture

- The **host** carries the ARIA surface (`role=radiogroup` on the group, `role=radio` on items, `aria-orientation`, `aria-checked`, roving `tabindex`).
- The **inner `<button class=\"radio\">`** inside each item's shadow root is explicitly `aria-hidden=\"true\"` + `role=\"presentation\"` + `tabindex=\"-1\"` so AT sees only the host. axe's shadow-piercing `nested-interactive` / `button-name` rules are disabled on a11y scans for this reason.
- The group owns form submission; items are NOT form-associated.

## Test plan

- [x] `pnpm --filter=@rafters/ui test radio-group` green (115 tests across styles + element + a11y)
- [x] `pnpm --filter=@rafters/ui typecheck` green
- [x] `pnpm lint` green
- [x] `pnpm preflight` green (all 4194 tests across 191 files pass)
- [x] FormData submission round-trip (`new FormData(form).get('choice')` === selected value)
- [x] `form.reset()` restores the initial `value` attribute
- [x] Required + empty triggers `valueMissing`; selecting clears it
- [x] Disabled group propagates `disabled` to all items; disabled items are skipped during roving focus
- [x] Unknown `orientation` silently falls back to `vertical`

Closes #1341