### PR TITLE
feat(ui): <rafters-toggle> form-associated Web Component (#1343)

### DIFF
--- a/packages/ui/src/components/ui/embed.classes.ts
+++ b/packages/ui/src/components/ui/embed.classes.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared embed class definitions
+ *
+ * Parallel to embed.styles.ts. Tailwind class strings for the React target
+ * (embed.tsx) and any future embed.astro target so visual parity holds
+ * across framework targets.
+ *
+ * Scope covers the iframe display path only -- the Twitter-widget flow,
+ * editable URL input, drag/drop upload, and alignment toolbar remain
+ * React-target concerns and do not appear here.
+ */
+
+/**
+ * Outer container wrapping the iframe. Matches the React target's
+ * "relative overflow-hidden rounded-lg bg-muted" container div.
+ */
+export const embedContainerClasses = 'relative overflow-hidden rounded-lg bg-muted';
+
+/**
+ * Iframe positioning. Matches the React target's
+ * "absolute inset-0 h-full w-full border-0" iframe styling.
+ */
+export const embedIframeClasses = 'absolute inset-0 h-full w-full border-0';
+
+/**
+ * Fallback container shown for missing or disallowed URLs. Matches the
+ * React target's EmbedFallback wrapper chrome.
+ */
+export const embedFallbackClasses =
+  'flex flex-col items-center justify-center rounded-lg border-2 border-dashed border-muted-foreground/25 bg-muted/50 p-8 text-center';
+
+/**
+ * Fallback message text styling.
+ */
+export const embedFallbackMessageClasses =
+  'mb-2 text-label-small font-medium text-muted-foreground';
+
+/**
+ * Fallback external link styling (Open in new tab).
+ */
+export const embedFallbackLinkClasses =
+  'text-label-small text-primary underline underline-offset-4 hover:text-primary/80';
+
+/**
+ * Accepted aspect-ratio keys shared across framework targets. Mirrors the
+ * AspectRatio type exported from embed.tsx and the AspectRatioKey contract
+ * in embed.styles.ts.
+ */
+export type AspectRatio = '16:9' | '4:3' | '1:1' | '9:16';

--- a/packages/ui/src/components/ui/embed.element.test.ts
+++ b/packages/ui/src/components/ui/embed.element.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import './embed.element';
+import { RaftersEmbed } from './embed.element';
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+function mount(attrs: Record<string, string> = {}): HTMLElement {
+  const el = document.createElement('rafters-embed');
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.appendChild(el);
+  return el;
+}
+
+function adoptedCssText(el: Element): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  const blocks: string[] = [];
+  for (const sheet of sheets) {
+    const rules: string[] = [];
+    for (const rule of Array.from(sheet.cssRules)) {
+      rules.push(rule.cssText);
+    }
+    blocks.push(rules.join('\n'));
+  }
+  return blocks.join('\n');
+}
+
+const YOUTUBE_URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+const YOUTUBE_URL_ALT = 'https://www.youtube.com/watch?v=9bZkp7q19f0';
+const DISALLOWED_URL = 'https://example.com/video/123';
+
+describe('<rafters-embed>', () => {
+  it('registers the rafters-embed tag on import', () => {
+    expect(customElements.get('rafters-embed')).toBe(RaftersEmbed);
+  });
+
+  it('does not throw when the module is imported twice', async () => {
+    await expect(import('./embed.element')).resolves.toBeDefined();
+    await expect(import('./embed.element')).resolves.toBeDefined();
+    expect(customElements.get('rafters-embed')).toBe(RaftersEmbed);
+  });
+
+  it('renders a fallback div when url attribute is absent', () => {
+    const el = mount();
+    const iframe = el.shadowRoot?.querySelector('iframe');
+    expect(iframe).toBeNull();
+    const fallback = el.shadowRoot?.querySelector('.embed-fallback');
+    expect(fallback).not.toBeNull();
+  });
+
+  it('renders an iframe with correct src/allow/allowfullscreen/loading/referrerpolicy when url is a valid YouTube URL', () => {
+    const el = mount({ url: YOUTUBE_URL });
+    const iframe = el.shadowRoot?.querySelector('iframe');
+    expect(iframe).not.toBeNull();
+    expect(iframe?.getAttribute('src')).toBe('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ');
+    expect(iframe?.getAttribute('allow')).toContain('accelerometer');
+    expect(iframe?.getAttribute('allow')).toContain('autoplay');
+    expect(iframe?.getAttribute('allow')).toContain('clipboard-write');
+    expect(iframe?.getAttribute('allow')).toContain('encrypted-media');
+    expect(iframe?.getAttribute('allow')).toContain('gyroscope');
+    expect(iframe?.getAttribute('allow')).toContain('picture-in-picture');
+    expect(iframe?.getAttribute('allow')).toContain('web-share');
+    expect(iframe?.hasAttribute('allowfullscreen')).toBe(true);
+    expect(iframe?.getAttribute('loading')).toBe('lazy');
+    expect(iframe?.getAttribute('referrerpolicy')).toBe('strict-origin-when-cross-origin');
+    expect(iframe?.getAttribute('title')).toBe('youtube embed');
+  });
+
+  it('uses a provided title attribute on the iframe', () => {
+    const el = mount({ url: YOUTUBE_URL, title: 'Rick roll' });
+    const iframe = el.shadowRoot?.querySelector('iframe');
+    expect(iframe?.getAttribute('title')).toBe('Rick roll');
+  });
+
+  it('renders a fallback when url is on a disallowed domain', () => {
+    const el = mount({ url: DISALLOWED_URL });
+    const iframe = el.shadowRoot?.querySelector('iframe');
+    expect(iframe).toBeNull();
+    const fallback = el.shadowRoot?.querySelector('.embed-fallback');
+    expect(fallback).not.toBeNull();
+    const link = fallback?.querySelector('a');
+    expect(link?.getAttribute('href')).toBe(DISALLOWED_URL);
+    expect(link?.getAttribute('target')).toBe('_blank');
+    expect(link?.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+
+  it('falls back to 16:9 aspect ratio for unknown values', () => {
+    const el = mount({ url: YOUTUBE_URL, 'aspect-ratio': 'wide' });
+    const css = adoptedCssText(el);
+    expect(css).toContain('aspect-ratio: 16 / 9');
+  });
+
+  it('applies the requested aspect-ratio when valid', () => {
+    const el = mount({ url: YOUTUBE_URL, 'aspect-ratio': '4:3' });
+    expect(adoptedCssText(el)).toContain('aspect-ratio: 4 / 3');
+  });
+
+  it('reflects url changes by re-rendering the inner DOM', () => {
+    const el = mount({ url: YOUTUBE_URL });
+    const first = el.shadowRoot?.querySelector('iframe');
+    expect(first?.getAttribute('src')).toContain('dQw4w9WgXcQ');
+
+    el.setAttribute('url', YOUTUBE_URL_ALT);
+    const second = el.shadowRoot?.querySelector('iframe');
+    expect(second?.getAttribute('src')).toContain('9bZkp7q19f0');
+  });
+
+  it('reflects aspect-ratio changes on the adopted stylesheet', () => {
+    const el = mount({ url: YOUTUBE_URL });
+    expect(adoptedCssText(el)).toContain('aspect-ratio: 16 / 9');
+    el.setAttribute('aspect-ratio', '9:16');
+    expect(adoptedCssText(el)).toContain('aspect-ratio: 9 / 16');
+  });
+
+  it('observedAttributes matches the documented contract', () => {
+    expect(RaftersEmbed.observedAttributes).toEqual(['url', 'provider', 'aspect-ratio', 'title']);
+  });
+
+  it('never renders an iframe for a Twitter URL (widget out of scope)', () => {
+    const el = mount({ url: 'https://twitter.com/jack/status/20' });
+    expect(el.shadowRoot?.querySelector('iframe')).toBeNull();
+    expect(el.shadowRoot?.querySelector('.embed-fallback')).not.toBeNull();
+  });
+
+  it('source contains no direct var() references', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const source = await fs.readFile(path.resolve(__dirname, 'embed.element.ts'), 'utf-8');
+    expect(source).not.toMatch(/[^a-zA-Z_]var\(/);
+  });
+});

--- a/packages/ui/src/components/ui/embed.element.ts
+++ b/packages/ui/src/components/ui/embed.element.ts
@@ -1,0 +1,207 @@
+/**
+ * <rafters-embed> -- Web Component for external embedded content.
+ *
+ * Framework-target for the Embed component, parallel to embed.tsx (React).
+ * Scope is intentionally REDUCED relative to the React target: the WC
+ * covers the iframe provider path only (YouTube, Vimeo, Twitch, generic).
+ * The Twitter-widget flow, editable URL input, drag/drop file upload,
+ * and alignment toolbar are React-only concerns and are NOT in this file.
+ *
+ * Shadow DOM structure (URL present, domain allowed, provider detected):
+ *   <div class="embed"><iframe ... /></div>
+ *
+ * Shadow DOM structure (URL missing or domain disallowed):
+ *   <div class="embed-fallback">...</div>
+ *
+ * Attributes:
+ *   url           URL of the content to embed. Required.
+ *   provider      Override auto-detected provider: youtube | vimeo | twitch
+ *                 | generic. Unknown values fall back to auto-detection.
+ *   aspect-ratio  16:9 | 4:3 | 1:1 | 9:16. Unknown values fall back to
+ *                 '16:9' silently.
+ *   title         Forwarded to the inner iframe's `title` attribute for
+ *                 accessibility. Default: "{provider} embed".
+ *
+ * Behaviour:
+ *   - Auto-registers on import, idempotent via customElements.get guard.
+ *   - When `url` is absent, renders a fallback div and NEVER throws.
+ *   - When `isAllowedEmbedDomain(url)` returns false, renders a fallback
+ *     div with an <a> link to the original URL. NEVER renders an iframe
+ *     to an unallowed domain.
+ *   - Twitter-provider URLs fall through to the fallback case because
+ *     the widget-based flow is out of scope.
+ *   - DOM APIs only (document.createElement + setAttribute + appendChild);
+ *     NEVER innerHTML.
+ *   - Per-instance CSSStyleSheet pattern: connectedCallback creates one
+ *     sheet, replaceSync(embedStylesheet(...)), adoptedStyleSheets = [sheet].
+ *     On attribute change, re-render the inner DOM AND replaceSync the
+ *     same sheet when `aspect-ratio` changed.
+ *   - NEVER a raw CSS custom-property function literal in this file;
+ *     token references live in embed.styles.ts.
+ *   - Motion tokens use --motion-duration-* / --motion-ease-* only.
+ *
+ * @cognitive-load 3/10
+ * @accessibility iframe carries a `title` attribute; fallback exposes an
+ *   <a> link to the original URL for recovery.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import { type AspectRatioKey, embedStylesheet } from './embed.styles';
+import { detectEmbedProvider, type EmbedProvider, isAllowedEmbedDomain } from './embed-utils';
+
+const ALLOWED_ASPECT_RATIOS: ReadonlyArray<AspectRatioKey> = ['16:9', '4:3', '1:1', '9:16'];
+
+const ALLOWED_PROVIDERS: ReadonlyArray<EmbedProvider> = ['youtube', 'vimeo', 'twitch', 'generic'];
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = [
+  'url',
+  'provider',
+  'aspect-ratio',
+  'title',
+] as const;
+
+const IFRAME_ALLOW =
+  'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';
+
+const IFRAME_REFERRER_POLICY = 'strict-origin-when-cross-origin';
+
+const FALLBACK_MESSAGE_MISSING_URL = 'No URL provided';
+const FALLBACK_MESSAGE_DISALLOWED_DOMAIN = 'This URL is not from a supported embed provider';
+const FALLBACK_LINK_TEXT = 'Open in new tab';
+
+function parseAspectRatio(value: string | null): AspectRatioKey {
+  if (value && (ALLOWED_ASPECT_RATIOS as ReadonlyArray<string>).includes(value)) {
+    return value as AspectRatioKey;
+  }
+  return '16:9';
+}
+
+function parseProviderOverride(value: string | null): EmbedProvider | null {
+  if (value && (ALLOWED_PROVIDERS as ReadonlyArray<string>).includes(value)) {
+    return value as EmbedProvider;
+  }
+  return null;
+}
+
+export class RaftersEmbed extends RaftersElement {
+  static readonly observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  /** Per-instance stylesheet rebuilt when aspect-ratio changes. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  override connectedCallback(): void {
+    if (!this.shadowRoot) return;
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+    this.shadowRoot.adoptedStyleSheets = [this._instanceSheet];
+    this.update();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+    if (name === 'aspect-ratio' && this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+    this.update();
+  }
+
+  override disconnectedCallback(): void {
+    this._instanceSheet = null;
+  }
+
+  /**
+   * Build the CSS string for the current aspect-ratio attribute.
+   */
+  private composeCss(): string {
+    return embedStylesheet({
+      aspectRatio: parseAspectRatio(this.getAttribute('aspect-ratio')),
+    });
+  }
+
+  /**
+   * Render the inner DOM for the current attribute state. DOM APIs only
+   * -- never innerHTML. Returns a `.embed` wrapper with an `<iframe>` when
+   * the URL is present, on an allowed domain, and resolves to a supported
+   * non-Twitter provider; otherwise returns a `.embed-fallback` wrapper.
+   */
+  override render(): Node {
+    const url = this.getAttribute('url');
+
+    if (!url) {
+      return this.renderFallback('', FALLBACK_MESSAGE_MISSING_URL, false);
+    }
+
+    if (!isAllowedEmbedDomain(url)) {
+      return this.renderFallback(url, FALLBACK_MESSAGE_DISALLOWED_DOMAIN, true);
+    }
+
+    const detected = detectEmbedProvider(url);
+    if (!detected) {
+      return this.renderFallback(url, FALLBACK_MESSAGE_DISALLOWED_DOMAIN, true);
+    }
+
+    // Twitter falls through to the fallback: widget flow is out of scope.
+    if (detected.provider === 'twitter') {
+      return this.renderFallback(url, FALLBACK_MESSAGE_DISALLOWED_DOMAIN, true);
+    }
+
+    const providerOverride = parseProviderOverride(this.getAttribute('provider'));
+    const provider: EmbedProvider = providerOverride ?? detected.provider;
+    const iframeTitle = this.getAttribute('title') ?? `${provider} embed`;
+
+    return this.renderIframe(detected.embedUrl, iframeTitle);
+  }
+
+  /**
+   * Create the iframe branch of the render tree.
+   */
+  private renderIframe(src: string, title: string): Node {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'embed';
+
+    const iframe = document.createElement('iframe');
+    iframe.setAttribute('src', src);
+    iframe.setAttribute('title', title);
+    iframe.setAttribute('allow', IFRAME_ALLOW);
+    iframe.setAttribute('allowfullscreen', '');
+    iframe.setAttribute('loading', 'lazy');
+    iframe.setAttribute('referrerpolicy', IFRAME_REFERRER_POLICY);
+
+    wrapper.appendChild(iframe);
+    return wrapper;
+  }
+
+  /**
+   * Create the fallback branch of the render tree. When `includeLink` is
+   * true, append an <a> pointing at `url` so consumers can recover.
+   */
+  private renderFallback(url: string, message: string, includeLink: boolean): Node {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'embed-fallback';
+
+    const messageEl = document.createElement('p');
+    messageEl.className = 'embed-fallback__message';
+    messageEl.textContent = message;
+    wrapper.appendChild(messageEl);
+
+    if (includeLink && url) {
+      const link = document.createElement('a');
+      link.className = 'embed-fallback__link';
+      link.setAttribute('href', url);
+      link.setAttribute('target', '_blank');
+      link.setAttribute('rel', 'noopener noreferrer');
+      link.textContent = FALLBACK_LINK_TEXT;
+      wrapper.appendChild(link);
+    }
+
+    return wrapper;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-embed')) {
+  customElements.define('rafters-embed', RaftersEmbed);
+}

--- a/packages/ui/src/components/ui/embed.styles.ts
+++ b/packages/ui/src/components/ui/embed.styles.ts
@@ -1,0 +1,177 @@
+/**
+ * Shadow DOM style definitions for Embed web component
+ *
+ * Parallel to embed.classes.ts. Same semantic structure for the iframe
+ * display path, CSS property maps instead of Tailwind class strings.
+ *
+ * Scope is reduced relative to the React target: the WC covers the iframe
+ * provider path (YouTube, Vimeo, Twitch, generic) plus a fallback. The
+ * Twitter-widget flow, editable URL input, drag/drop upload, and alignment
+ * toolbar are React-only concerns and do NOT appear in this file.
+ *
+ * All token references go through tokenVar(); no raw var() literals appear
+ * outside the classy-wc primitives. Motion tokens use --motion-duration-*
+ * / --motion-ease-* only.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import { styleRule, stylesheet, tokenVar } from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+/**
+ * Accepted aspect-ratio keys for the <rafters-embed> host attribute.
+ *
+ * Unknown values fall back to '16:9' silently at the stylesheet boundary
+ * (never throw).
+ */
+export type AspectRatioKey = '16:9' | '4:3' | '1:1' | '9:16';
+
+// ============================================================================
+// Aspect Ratio Map
+// ============================================================================
+
+/**
+ * CSS aspect-ratio values keyed by AspectRatioKey. The CSS `aspect-ratio`
+ * property accepts the `<width> / <height>` two-number syntax directly, so
+ * these values are passed through to the `.embed` rule.
+ */
+export const aspectRatioValues: Record<AspectRatioKey, string> = {
+  '16:9': '16 / 9',
+  '4:3': '4 / 3',
+  '1:1': '1 / 1',
+  '9:16': '9 / 16',
+};
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+/**
+ * Outer `.embed` wrapper base. Mirrors embedContainerClasses:
+ *   "relative overflow-hidden rounded-lg bg-muted"
+ *
+ * Width fills the host; height comes from the aspect-ratio property set
+ * on the same rule.
+ */
+export const embedBase: CSSProperties = {
+  position: 'relative',
+  overflow: 'hidden',
+  'border-radius': tokenVar('radius-lg'),
+  'background-color': tokenVar('color-muted'),
+  width: '100%',
+};
+
+/**
+ * Inner `<iframe>` positioning. Mirrors embedIframeClasses:
+ *   "absolute inset-0 h-full w-full border-0"
+ */
+export const embedIframeBase: CSSProperties = {
+  position: 'absolute',
+  top: '0',
+  right: '0',
+  bottom: '0',
+  left: '0',
+  width: '100%',
+  height: '100%',
+  'border-width': '0',
+  'border-style': 'solid',
+  'border-color': 'transparent',
+};
+
+/**
+ * Fallback wrapper base. Mirrors embedFallbackClasses:
+ *   "flex flex-col items-center justify-center rounded-lg border-2
+ *    border-dashed border-muted-foreground/25 bg-muted/50 p-8 text-center"
+ *
+ * Note: the shadow-DOM surface cannot reference the half-opacity Tailwind
+ * utilities directly; opacity pairs are resolved via color tokens with
+ * `-muted-foreground` / `-muted` whole-token references. Parity with the
+ * React target's opacity nuance is handled at the token layer, not here.
+ */
+export const embedFallbackBase: CSSProperties = {
+  display: 'flex',
+  'flex-direction': 'column',
+  'align-items': 'center',
+  'justify-content': 'center',
+  'border-radius': tokenVar('radius-lg'),
+  'border-width': '2px',
+  'border-style': 'dashed',
+  'border-color': tokenVar('color-muted-foreground'),
+  'background-color': tokenVar('color-muted'),
+  padding: '2rem',
+  'text-align': 'center',
+};
+
+/**
+ * Fallback message text. Mirrors embedFallbackMessageClasses:
+ *   "mb-2 text-label-small font-medium text-muted-foreground"
+ */
+export const embedFallbackMessage: CSSProperties = {
+  'margin-bottom': '0.5rem',
+  'font-size': tokenVar('font-size-label-small'),
+  'font-weight': '500',
+  color: tokenVar('color-muted-foreground'),
+};
+
+/**
+ * Fallback external link. Mirrors embedFallbackLinkClasses:
+ *   "text-label-small text-primary underline underline-offset-4"
+ */
+export const embedFallbackLink: CSSProperties = {
+  'font-size': tokenVar('font-size-label-small'),
+  color: tokenVar('color-primary'),
+  'text-decoration': 'underline',
+  'text-underline-offset': '4px',
+};
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+export interface EmbedStylesheetOptions {
+  aspectRatio?: AspectRatioKey | undefined;
+}
+
+/**
+ * Build the complete embed stylesheet for a given configuration.
+ *
+ * Unknown aspectRatio keys fall back to '16:9' via pick(). Never throws.
+ * Emits:
+ *   - `:host` block layout so the embed takes full width by default
+ *   - `.embed` outer wrapper with the resolved aspect-ratio
+ *   - `.embed iframe` absolute-fill positioning
+ *   - `.embed-fallback` fallback wrapper chrome
+ *   - `.embed-fallback__message` fallback text styling
+ *   - `.embed-fallback__link` fallback link styling
+ */
+export function embedStylesheet(options: EmbedStylesheetOptions = {}): string {
+  const { aspectRatio } = options;
+
+  return stylesheet(
+    styleRule(':host', { display: 'block', width: '100%' }),
+
+    styleRule('.embed', embedBase, {
+      'aspect-ratio': pickAspectRatio(aspectRatio),
+    }),
+
+    styleRule('.embed iframe', embedIframeBase),
+
+    styleRule('.embed-fallback', embedFallbackBase),
+
+    styleRule('.embed-fallback__message', embedFallbackMessage),
+
+    styleRule('.embed-fallback__link', embedFallbackLink),
+  );
+}
+
+/**
+ * Resolve an aspect-ratio input into its CSS value. Unknown keys fall
+ * back to '16:9' silently. Never throws.
+ */
+function pickAspectRatio(key: AspectRatioKey | undefined): string {
+  if (key && key in aspectRatioValues) return aspectRatioValues[key];
+  return aspectRatioValues['16:9'];
+}

--- a/packages/ui/src/components/ui/toggle.element.a11y.tsx
+++ b/packages/ui/src/components/ui/toggle.element.a11y.tsx
@@ -1,0 +1,244 @@
+/**
+ * Accessibility tests for <rafters-toggle>.
+ *
+ * Verifies that axe has no complaints when the host is used as a press-toggle
+ * button with either a visible label, an aria-label, or an icon+aria-label
+ * pair, and across every documented variant/size combination.
+ *
+ * happy-dom 20 ships no ElementInternals implementation. We polyfill the
+ * surface our element depends on so the constructor can run; see
+ * toggle.element.test.ts for the same polyfill.
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import 'vitest-axe/extend-expect';
+
+interface PolyfilledInternals {
+  _value: string | null;
+  _validity: ValidityState;
+  _validationMessage: string;
+  _host: HTMLElement;
+  setFormValue: (value: string | File | FormData | null) => void;
+  setValidity: (flags: Partial<ValidityState>, message?: string, anchor?: HTMLElement) => void;
+  checkValidity: () => boolean;
+  reportValidity: () => boolean;
+  validity: ValidityState;
+  validationMessage: string;
+  willValidate: boolean;
+  form: HTMLFormElement | null;
+}
+
+type ValidityFlagKey = Exclude<keyof ValidityState, 'valid'>;
+
+const VALIDITY_FLAG_KEYS: ReadonlyArray<ValidityFlagKey> = [
+  'valueMissing',
+  'typeMismatch',
+  'patternMismatch',
+  'tooLong',
+  'tooShort',
+  'rangeUnderflow',
+  'rangeOverflow',
+  'stepMismatch',
+  'badInput',
+  'customError',
+];
+
+function buildValidity(flags: Partial<ValidityState> = {}): ValidityState {
+  const merged: Record<string, boolean> = {
+    valueMissing: false,
+    typeMismatch: false,
+    patternMismatch: false,
+    tooLong: false,
+    tooShort: false,
+    rangeUnderflow: false,
+    rangeOverflow: false,
+    stepMismatch: false,
+    badInput: false,
+    customError: false,
+    valid: true,
+  };
+  let invalid = false;
+  for (const key of VALIDITY_FLAG_KEYS) {
+    const value = flags[key];
+    if (typeof value === 'boolean') {
+      merged[key] = value;
+    }
+    if (merged[key]) invalid = true;
+  }
+  merged.valid = !invalid;
+  return merged as unknown as ValidityState;
+}
+
+function installElementInternalsPolyfill(): void {
+  const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
+  if (typeof proto.attachInternals === 'function') return;
+  proto.attachInternals = function attachInternals(this: HTMLElement): ElementInternals {
+    const internals: PolyfilledInternals = {
+      _value: null,
+      _validity: buildValidity(),
+      _validationMessage: '',
+      _host: this,
+      setFormValue(value) {
+        this._value = typeof value === 'string' ? value : value === null ? null : '';
+      },
+      setValidity(flags, message = '', _anchor) {
+        this._validity = buildValidity(flags);
+        this._validationMessage = this._validity.valid ? '' : message;
+      },
+      checkValidity() {
+        return this._validity.valid;
+      },
+      reportValidity() {
+        return this._validity.valid;
+      },
+      get validity() {
+        return this._validity;
+      },
+      get validationMessage() {
+        return this._validationMessage;
+      },
+      get willValidate() {
+        return true;
+      },
+      get form() {
+        let parent: Node | null = this._host.parentNode;
+        while (parent) {
+          if (parent instanceof HTMLFormElement) return parent;
+          parent = parent.parentNode;
+        }
+        return null;
+      },
+    };
+    return internals as unknown as ElementInternals;
+  };
+}
+
+beforeAll(async () => {
+  installElementInternalsPolyfill();
+  await import('./toggle.element');
+});
+
+let container: HTMLElement;
+
+function mountContainer(): HTMLElement {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  return container;
+}
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+function buildToggle(
+  attrs: Record<string, string> = {},
+  text: string | null = 'Toggle',
+): HTMLElement {
+  const host = document.createElement('rafters-toggle');
+  for (const [k, v] of Object.entries(attrs)) host.setAttribute(k, v);
+  if (text !== null) host.textContent = text;
+  container.appendChild(host);
+  return host;
+}
+
+const VARIANTS = [
+  'default',
+  'primary',
+  'secondary',
+  'destructive',
+  'success',
+  'warning',
+  'info',
+  'accent',
+  'outline',
+  'ghost',
+] as const;
+
+const SIZES = ['sm', 'default', 'lg'] as const;
+
+describe('<rafters-toggle> - Accessibility', () => {
+  it('has no violations with default configuration (visible text label)', async () => {
+    mountContainer();
+    buildToggle({}, 'Bold');
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations when aria-label provides the accessible name', async () => {
+    mountContainer();
+    buildToggle({ 'aria-label': 'Toggle bold' }, 'B');
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations in pressed state', async () => {
+    mountContainer();
+    buildToggle({ pressed: '' }, 'Bold');
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations when disabled', async () => {
+    mountContainer();
+    buildToggle({ disabled: '' }, 'Bold');
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations across every variant', async () => {
+    for (const variant of VARIANTS) {
+      mountContainer();
+      buildToggle({ variant }, 'Bold');
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+      while (document.body.firstChild) {
+        document.body.removeChild(document.body.firstChild);
+      }
+    }
+  });
+
+  it('has no violations across every size', async () => {
+    for (const size of SIZES) {
+      mountContainer();
+      buildToggle({ size }, 'Bold');
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+      while (document.body.firstChild) {
+        document.body.removeChild(document.body.firstChild);
+      }
+    }
+  });
+
+  it('has no violations when placed inside a <form> with name + value', async () => {
+    mountContainer();
+    const form = document.createElement('form');
+    const host = document.createElement('rafters-toggle');
+    host.setAttribute('name', 'bold');
+    host.setAttribute('value', 'yes');
+    host.textContent = 'Bold';
+    form.appendChild(host);
+    container.appendChild(form);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations for a toolbar of toggles', async () => {
+    mountContainer();
+    const toolbar = document.createElement('div');
+    toolbar.setAttribute('role', 'toolbar');
+    toolbar.setAttribute('aria-label', 'Text formatting');
+
+    for (const label of ['Bold', 'Italic', 'Underline']) {
+      const host = document.createElement('rafters-toggle');
+      host.textContent = label;
+      toolbar.appendChild(host);
+    }
+
+    container.appendChild(toolbar);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/ui/src/components/ui/toggle.element.test.ts
+++ b/packages/ui/src/components/ui/toggle.element.test.ts
@@ -1,0 +1,502 @@
+/**
+ * Unit tests for <rafters-toggle>.
+ *
+ * happy-dom 20 ships no ElementInternals implementation, so this file
+ * installs a minimal polyfill that mirrors the browser surface that the
+ * RaftersToggle element actually depends on (setFormValue, setValidity,
+ * checkValidity, reportValidity, validity, validationMessage, willValidate,
+ * form). The polyfill also bridges `setFormValue` into the form's FormData
+ * enumeration so `new FormData(form)` reflects pressed/unpressed state the
+ * way a browser with real form-associated custom element support would.
+ *
+ * For assertions that require real form-control machinery we cannot
+ * reasonably synthesise (e.g. fieldset.disabled propagation triggering
+ * formDisabledCallback), the assertion is skipped with a link to #1303.
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+interface PolyfilledInternals {
+  _value: string | null;
+  _validity: ValidityState;
+  _validationMessage: string;
+  _host: HTMLElement;
+  setFormValue: (value: string | File | FormData | null) => void;
+  setValidity: (flags: Partial<ValidityState>, message?: string, anchor?: HTMLElement) => void;
+  checkValidity: () => boolean;
+  reportValidity: () => boolean;
+  validity: ValidityState;
+  validationMessage: string;
+  willValidate: boolean;
+  form: HTMLFormElement | null;
+}
+
+type ValidityFlagKey = Exclude<keyof ValidityState, 'valid'>;
+
+const VALIDITY_FLAG_KEYS: ReadonlyArray<ValidityFlagKey> = [
+  'valueMissing',
+  'typeMismatch',
+  'patternMismatch',
+  'tooLong',
+  'tooShort',
+  'rangeUnderflow',
+  'rangeOverflow',
+  'stepMismatch',
+  'badInput',
+  'customError',
+];
+
+function buildValidity(flags: Partial<ValidityState> = {}): ValidityState {
+  const merged: Record<string, boolean> = {
+    valueMissing: false,
+    typeMismatch: false,
+    patternMismatch: false,
+    tooLong: false,
+    tooShort: false,
+    rangeUnderflow: false,
+    rangeOverflow: false,
+    stepMismatch: false,
+    badInput: false,
+    customError: false,
+    valid: true,
+  };
+  let invalid = false;
+  for (const key of VALIDITY_FLAG_KEYS) {
+    const value = flags[key];
+    if (typeof value === 'boolean') {
+      merged[key] = value;
+    }
+    if (merged[key]) invalid = true;
+  }
+  merged.valid = !invalid;
+  return merged as unknown as ValidityState;
+}
+
+const FORM_VALUE_REGISTRY: WeakMap<HTMLElement, string | null> = new WeakMap();
+
+function installElementInternalsPolyfill(): void {
+  const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
+  if (typeof proto.attachInternals !== 'function') {
+    proto.attachInternals = function attachInternals(this: HTMLElement): ElementInternals {
+      const internals: PolyfilledInternals = {
+        _value: null,
+        _validity: buildValidity(),
+        _validationMessage: '',
+        _host: this,
+        setFormValue(value) {
+          const resolved = typeof value === 'string' ? value : value === null ? null : '';
+          this._value = resolved;
+          FORM_VALUE_REGISTRY.set(this._host, resolved);
+        },
+        setValidity(flags, message = '', _anchor) {
+          this._validity = buildValidity(flags);
+          this._validationMessage = this._validity.valid ? '' : message;
+        },
+        checkValidity() {
+          return this._validity.valid;
+        },
+        reportValidity() {
+          return this._validity.valid;
+        },
+        get validity() {
+          return this._validity;
+        },
+        get validationMessage() {
+          return this._validationMessage;
+        },
+        get willValidate() {
+          return true;
+        },
+        get form() {
+          let parent: Node | null = this._host.parentNode;
+          while (parent) {
+            if (parent instanceof HTMLFormElement) return parent;
+            parent = parent.parentNode;
+          }
+          return null;
+        },
+      };
+      return internals as unknown as ElementInternals;
+    };
+  }
+
+  // happy-dom 20 does not enumerate form-associated custom elements into
+  // FormData. Monkey-patch FormData's constructor and `get` to consult the
+  // FORM_VALUE_REGISTRY for any rafters-toggle descendants of the form.
+  const OriginalFormData = globalThis.FormData;
+  if (
+    OriginalFormData &&
+    !(OriginalFormData as unknown as { __raftersPatched?: boolean }).__raftersPatched
+  ) {
+    const patched = function PatchedFormData(form?: HTMLFormElement): FormData {
+      const instance = new OriginalFormData(form);
+      if (form) {
+        const hosts = form.querySelectorAll('rafters-toggle');
+        for (const host of Array.from(hosts)) {
+          const name = host.getAttribute('name');
+          if (!name) continue;
+          const value = FORM_VALUE_REGISTRY.get(host as HTMLElement);
+          if (value != null) {
+            instance.append(name, value);
+          }
+        }
+      }
+      return instance;
+    } as unknown as typeof FormData;
+    (patched as unknown as { __raftersPatched?: boolean }).__raftersPatched = true;
+    patched.prototype = OriginalFormData.prototype;
+    globalThis.FormData = patched;
+  }
+}
+
+beforeAll(async () => {
+  installElementInternalsPolyfill();
+  // Import after the polyfill so the constructor's guard sees a callable
+  // attachInternals function on HTMLElement.prototype.
+  await import('./toggle.element');
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+async function loadElement(): Promise<typeof import('./toggle.element').RaftersToggle> {
+  const mod = await import('./toggle.element');
+  return mod.RaftersToggle;
+}
+
+function collectCss(el: HTMLElement): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  return sheets
+    .map((s) =>
+      Array.from(s.cssRules)
+        .map((r) => r.cssText)
+        .join('\n'),
+    )
+    .join('\n');
+}
+
+describe('rafters-toggle', () => {
+  it('registers the custom element', async () => {
+    const RaftersToggle = await loadElement();
+    expect(customElements.get('rafters-toggle')).toBe(RaftersToggle);
+  });
+
+  it('registers idempotently on re-import', async () => {
+    const RaftersToggle = await loadElement();
+    expect(customElements.get('rafters-toggle')).toBe(RaftersToggle);
+    await import('./toggle.element');
+    expect(customElements.get('rafters-toggle')).toBe(RaftersToggle);
+  });
+
+  it('declares formAssociated', async () => {
+    const RaftersToggle = await loadElement();
+    expect(RaftersToggle.formAssociated).toBe(true);
+  });
+
+  it('declares the documented observedAttributes', async () => {
+    const RaftersToggle = await loadElement();
+    expect(RaftersToggle.observedAttributes).toEqual([
+      'pressed',
+      'disabled',
+      'name',
+      'value',
+      'variant',
+      'size',
+    ]);
+  });
+
+  it('mounts an inner <button class="toggle"> with type=button', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('button');
+    expect(inner).toBeTruthy();
+    expect(inner?.className).toBe('toggle');
+    expect(inner?.getAttribute('type')).toBe('button');
+  });
+
+  it('renders a slot for consumer content', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    document.body.append(el);
+    const slot = el.shadowRoot?.querySelector('slot');
+    expect(slot).toBeTruthy();
+  });
+
+  it('toggles pressed on click and reflects aria-pressed', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('button');
+    expect(inner).toBeTruthy();
+    inner?.click();
+    expect(el.pressed).toBe(true);
+    expect(inner?.getAttribute('aria-pressed')).toBe('true');
+    expect(inner?.getAttribute('data-state')).toBe('on');
+    inner?.click();
+    expect(el.pressed).toBe(false);
+    expect(inner?.getAttribute('aria-pressed')).toBe('false');
+    expect(inner?.getAttribute('data-state')).toBe('off');
+  });
+
+  it('initial pressed attribute renders as pressed', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    el.setAttribute('pressed', '');
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('button');
+    expect(inner?.getAttribute('aria-pressed')).toBe('true');
+    expect(inner?.getAttribute('data-state')).toBe('on');
+  });
+
+  it('dispatches change event on toggle (bubbles + composed)', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    document.body.append(el);
+    let changes = 0;
+    el.addEventListener('change', () => {
+      changes += 1;
+    });
+    el.shadowRoot?.querySelector('button')?.click();
+    expect(changes).toBe(1);
+    el.shadowRoot?.querySelector('button')?.click();
+    expect(changes).toBe(2);
+  });
+
+  it('change event escapes the shadow root (composed)', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    document.body.append(el);
+    let bodyReceived = 0;
+    document.body.addEventListener('change', () => {
+      bodyReceived += 1;
+    });
+    el.shadowRoot?.querySelector('button')?.click();
+    expect(bodyReceived).toBe(1);
+  });
+
+  it('does not toggle when disabled', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    el.toggleAttribute('disabled', true);
+    document.body.append(el);
+    el.shadowRoot?.querySelector('button')?.click();
+    expect(el.pressed).toBe(false);
+  });
+
+  it('reflects disabled to the inner button', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    el.toggleAttribute('disabled', true);
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('button');
+    expect(inner?.disabled).toBe(true);
+    el.removeAttribute('disabled');
+    expect(inner?.disabled).toBe(false);
+  });
+
+  it('submits name=value when pressed inside <form>', async () => {
+    const RaftersToggle = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    el.setAttribute('name', 'bold');
+    el.setAttribute('value', 'yes');
+    form.append(el);
+    document.body.append(form);
+    el.pressed = true;
+    expect(new FormData(form).get('bold')).toBe('yes');
+  });
+
+  it('defaults submitted value to "on" when no value attribute is set', async () => {
+    const RaftersToggle = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    el.setAttribute('name', 'italic');
+    form.append(el);
+    document.body.append(form);
+    el.pressed = true;
+    expect(new FormData(form).get('italic')).toBe('on');
+  });
+
+  it('omits unpressed value from FormData', async () => {
+    const RaftersToggle = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    el.setAttribute('name', 'bold');
+    form.append(el);
+    document.body.append(form);
+    expect(new FormData(form).get('bold')).toBeNull();
+  });
+
+  it('formResetCallback restores initial pressed', async () => {
+    const RaftersToggle = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    el.setAttribute('pressed', '');
+    form.append(el);
+    document.body.append(form);
+    el.pressed = false;
+    el.formResetCallback();
+    expect(el.pressed).toBe(true);
+  });
+
+  it('formResetCallback with no initial pressed restores to unpressed', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    document.body.append(el);
+    el.pressed = true;
+    el.formResetCallback();
+    expect(el.pressed).toBe(false);
+  });
+
+  it('formDisabledCallback toggles inner button disabled', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    document.body.append(el);
+    el.formDisabledCallback(true);
+    expect(el.shadowRoot?.querySelector('button')?.disabled).toBe(true);
+    el.formDisabledCallback(false);
+    expect(el.shadowRoot?.querySelector('button')?.disabled).toBe(false);
+  });
+
+  it('formStateRestoreCallback restores pressed when state is non-null', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    document.body.append(el);
+    el.formStateRestoreCallback('on', 'restore');
+    expect(el.pressed).toBe(true);
+  });
+
+  it('formStateRestoreCallback unsets pressed when state is null', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    el.setAttribute('pressed', '');
+    document.body.append(el);
+    el.formStateRestoreCallback(null, 'restore');
+    expect(el.pressed).toBe(false);
+  });
+
+  it('falls back to default variant/size on unknown values', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    el.setAttribute('variant', 'weird');
+    el.setAttribute('size', 'huge');
+    expect(() => document.body.append(el)).not.toThrow();
+    expect(el.variant).toBe('default');
+    expect(el.size).toBe('default');
+  });
+
+  it('property setters reflect to attributes', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    document.body.append(el);
+    el.name = 'bold';
+    expect(el.getAttribute('name')).toBe('bold');
+    el.value = 'yes';
+    expect(el.getAttribute('value')).toBe('yes');
+    el.disabled = true;
+    expect(el.hasAttribute('disabled')).toBe(true);
+    el.disabled = false;
+    expect(el.hasAttribute('disabled')).toBe(false);
+    el.pressed = true;
+    expect(el.hasAttribute('pressed')).toBe(true);
+    el.variant = 'destructive';
+    expect(el.getAttribute('variant')).toBe('destructive');
+    el.size = 'lg';
+    expect(el.getAttribute('size')).toBe('lg');
+  });
+
+  it('pressed getter reads the attribute', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    document.body.append(el);
+    expect(el.pressed).toBe(false);
+    el.setAttribute('pressed', '');
+    expect(el.pressed).toBe(true);
+  });
+
+  it('value defaults to "on" when no attribute is set', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    document.body.append(el);
+    expect(el.value).toBe('on');
+  });
+
+  it('rebuilds the per-instance stylesheet when variant changes', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    document.body.append(el);
+    expect(collectCss(el)).toContain('var(--color-primary)');
+    el.setAttribute('variant', 'destructive');
+    expect(collectCss(el)).toContain('var(--color-destructive)');
+  });
+
+  it('rebuilds the per-instance stylesheet when size changes', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    document.body.append(el);
+    expect(collectCss(el)).toContain('height: 2.5rem');
+    el.setAttribute('size', 'lg');
+    expect(collectCss(el)).toContain('height: 2.75rem');
+  });
+
+  it('exposes ElementInternals-backed validity surface', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    document.body.append(el);
+    expect(el.willValidate).toBe(true);
+    expect(typeof el.checkValidity).toBe('function');
+    expect(typeof el.reportValidity).toBe('function');
+    expect(el.validity).toBeDefined();
+  });
+
+  it('setCustomValidity propagates to the validity state', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    document.body.append(el);
+    el.setCustomValidity('nope');
+    expect(el.validity.customError).toBe(true);
+    expect(el.validity.valid).toBe(false);
+    el.setCustomValidity('');
+    expect(el.validity.customError).toBe(false);
+  });
+
+  it('shadow root adopts the per-instance stylesheet', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    document.body.append(el);
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    expect(sheets.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('stylesheet uses only --motion-duration / --motion-ease tokens', async () => {
+    const RaftersToggle = await loadElement();
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    document.body.append(el);
+    const css = collectCss(el);
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+  });
+
+  it('source contains no direct var() literals in either .ts file', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const elementSource = await fs.readFile(path.resolve(__dirname, 'toggle.element.ts'), 'utf-8');
+    expect(elementSource).not.toMatch(/[^a-zA-Z_]var\(/);
+    const stylesSource = await fs.readFile(path.resolve(__dirname, 'toggle.styles.ts'), 'utf-8');
+    expect(stylesSource).not.toMatch(/[^a-zA-Z_]var\(/);
+  });
+
+  // happy-dom 20 does not propagate fieldset.disabled to form-associated
+  // custom elements via the formDisabledCallback hook. See #1303.
+  it.skip('fieldset disabled propagation triggers formDisabledCallback', async () => {
+    const RaftersToggle = await loadElement();
+    const fieldset = document.createElement('fieldset');
+    const el = document.createElement('rafters-toggle') as InstanceType<typeof RaftersToggle>;
+    fieldset.append(el);
+    document.body.append(fieldset);
+    fieldset.disabled = true;
+    expect(el.shadowRoot?.querySelector('button')?.disabled).toBe(true);
+  });
+});

--- a/packages/ui/src/components/ui/toggle.element.ts
+++ b/packages/ui/src/components/ui/toggle.element.ts
@@ -1,0 +1,350 @@
+/**
+ * <rafters-toggle> -- Form-associated Web Component for press-toggle buttons.
+ *
+ * Mirrors the semantics of toggle.tsx (variant, size, pressed state) using
+ * shadow-DOM-scoped CSS composed via classy-wc. Auto-registers on import and
+ * is idempotent against double-define.
+ *
+ * Form-associated: participates in <form> submission, reset, disabled
+ * propagation, and state restoration via ElementInternals. When pressed,
+ * contributes `name=value` to FormData; when unpressed, contributes nothing.
+ *
+ * Attributes:
+ *  - pressed:  boolean (presence-based; mirrors to aria-pressed + data-state)
+ *  - disabled: boolean (presence-based)
+ *  - name:     string  (form field name)
+ *  - value:    string  (form-submitted value when pressed; defaults to 'on')
+ *  - variant:  ToggleVariant (default 'default')
+ *  - size:     ToggleSize    (default 'default')
+ *
+ * Interaction model:
+ *  - Click on the inner <button> flips `pressed` (unless disabled).
+ *  - Space/Enter keys are handled by the native button (click synthesis).
+ *  - After a state change, dispatches `change` at the host (bubbles/composed).
+ *
+ * No raw CSS custom-property literals here -- all token references live in
+ * toggle.styles.ts and resolve through tokenVar().
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import {
+  type ToggleSize,
+  type ToggleVariant,
+  toggleSizeStyles,
+  toggleStylesheet,
+  toggleVariantStyles,
+} from './toggle.styles';
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = [
+  'pressed',
+  'disabled',
+  'name',
+  'value',
+  'variant',
+  'size',
+] as const;
+
+function parseVariant(value: string | null): ToggleVariant {
+  if (value && value in toggleVariantStyles) {
+    return value as ToggleVariant;
+  }
+  return 'default';
+}
+
+function parseSize(value: string | null): ToggleSize {
+  if (value && value in toggleSizeStyles) {
+    return value as ToggleSize;
+  }
+  return 'default';
+}
+
+interface ElementInternalsHost {
+  attachInternals?: () => ElementInternals;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Form-associated Web Component backing `<rafters-toggle>`.
+ */
+export class RaftersToggle extends RaftersElement {
+  static formAssociated = true;
+  static observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  private _internals: ElementInternals;
+  private _instanceSheet: CSSStyleSheet | null = null;
+  private _inner: HTMLButtonElement | null = null;
+  private _onClick: (event: Event) => void;
+  private _initialPressed: boolean;
+
+  constructor() {
+    super();
+    const host = this as unknown as ElementInternalsHost;
+    if (typeof host.attachInternals !== 'function') {
+      throw new TypeError('rafters-toggle requires ElementInternals support');
+    }
+    this._internals = host.attachInternals();
+    this._onClick = (event: Event) => this.handleInnerClick(event);
+    // Remember the initial pressed state declared via markup so formResetCallback
+    // can restore it. Updated only on connection when the element is first
+    // inserted; explicit property/attribute mutations post-connect do not change
+    // the "declared" starting value.
+    this._initialPressed = this.hasAttribute('pressed');
+  }
+
+  // ==========================================================================
+  // Lifecycle
+  // ==========================================================================
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    if (!this.shadowRoot) return;
+
+    // Re-capture the declared initial state in case the element was
+    // constructed programmatically and had its `pressed` attribute set
+    // before the first connection.
+    this._initialPressed = this.hasAttribute('pressed');
+
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+
+    const existing = this.shadowRoot.adoptedStyleSheets;
+    this.shadowRoot.adoptedStyleSheets = [...existing, this._instanceSheet];
+
+    this.syncFormValue();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+
+    if (
+      (name === 'variant' || name === 'size' || name === 'pressed' || name === 'disabled') &&
+      this._instanceSheet
+    ) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+
+    this.mirrorStateToInner();
+
+    if (name === 'pressed' || name === 'value' || name === 'name') {
+      this.syncFormValue();
+    }
+  }
+
+  override disconnectedCallback(): void {
+    this.detachInnerListeners();
+    this._instanceSheet = null;
+    this._inner = null;
+  }
+
+  // ==========================================================================
+  // Render
+  // ==========================================================================
+
+  override render(): Node {
+    this.detachInnerListeners();
+    const inner = document.createElement('button');
+    inner.className = 'toggle';
+    inner.setAttribute('type', 'button');
+    this._inner = inner;
+
+    const slot = document.createElement('slot');
+    inner.appendChild(slot);
+
+    this.mirrorStateToInner();
+    inner.addEventListener('click', this._onClick);
+    return inner;
+  }
+
+  private detachInnerListeners(): void {
+    if (!this._inner) return;
+    this._inner.removeEventListener('click', this._onClick);
+  }
+
+  private composeCss(): string {
+    return toggleStylesheet({
+      variant: parseVariant(this.getAttribute('variant')),
+      size: parseSize(this.getAttribute('size')),
+      pressed: this.hasAttribute('pressed'),
+      disabled: this.hasAttribute('disabled'),
+    });
+  }
+
+  // ==========================================================================
+  // State mirroring
+  // ==========================================================================
+
+  private mirrorStateToInner(): void {
+    const inner = this.getInnerButton();
+    if (!inner) return;
+    const pressed = this.hasAttribute('pressed');
+    inner.setAttribute('aria-pressed', pressed ? 'true' : 'false');
+    inner.setAttribute('data-state', pressed ? 'on' : 'off');
+    inner.disabled = this.hasAttribute('disabled');
+  }
+
+  private getInnerButton(): HTMLButtonElement | null {
+    if (this._inner) return this._inner;
+    const found = this.shadowRoot?.querySelector('button') ?? null;
+    if (found instanceof HTMLButtonElement) {
+      this._inner = found;
+      return found;
+    }
+    return null;
+  }
+
+  // ==========================================================================
+  // Interaction
+  // ==========================================================================
+
+  private handleInnerClick(_event: Event): void {
+    if (this.hasAttribute('disabled')) return;
+    const next = !this.hasAttribute('pressed');
+    this.toggleAttribute('pressed', next);
+    this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+  }
+
+  private syncFormValue(): void {
+    const pressed = this.hasAttribute('pressed');
+    if (pressed) {
+      const value = this.getAttribute('value') ?? 'on';
+      this._internals.setFormValue(value);
+    } else {
+      this._internals.setFormValue(null);
+    }
+  }
+
+  // ==========================================================================
+  // Form-associated lifecycle callbacks
+  // ==========================================================================
+
+  formAssociatedCallback(_form: HTMLFormElement | null): void {
+    // Hook for subclasses; default is a no-op. The internals already track the
+    // associated form for us.
+  }
+
+  formResetCallback(): void {
+    this.toggleAttribute('pressed', this._initialPressed);
+    this.syncFormValue();
+  }
+
+  formDisabledCallback(disabled: boolean): void {
+    const inner = this.getInnerButton();
+    if (inner) {
+      inner.disabled = disabled;
+    }
+  }
+
+  formStateRestoreCallback(
+    state: string | File | FormData | null,
+    _mode: 'restore' | 'autocomplete',
+  ): void {
+    // A non-null state means the toggle was pressed when the state was
+    // captured. Null means it was unpressed.
+    this.toggleAttribute('pressed', state !== null);
+  }
+
+  // ==========================================================================
+  // Public form-control surface
+  // ==========================================================================
+
+  /**
+   * The ElementInternals instance bound to this host. Exposed read-only so
+   * consumers (and tests) can inspect form association without
+   * monkey-patching. Mutation is intentionally not supported -- use the
+   * setCustomValidity and form lifecycle methods instead.
+   */
+  get internals(): ElementInternals {
+    return this._internals;
+  }
+
+  get pressed(): boolean {
+    return this.hasAttribute('pressed');
+  }
+
+  set pressed(next: boolean) {
+    this.toggleAttribute('pressed', next);
+  }
+
+  get name(): string {
+    return this.getAttribute('name') ?? '';
+  }
+
+  set name(value: string) {
+    this.setAttribute('name', value);
+  }
+
+  get value(): string {
+    return this.getAttribute('value') ?? 'on';
+  }
+
+  set value(next: string) {
+    this.setAttribute('value', next);
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+
+  set disabled(value: boolean) {
+    this.toggleAttribute('disabled', value);
+  }
+
+  get variant(): ToggleVariant {
+    return parseVariant(this.getAttribute('variant'));
+  }
+
+  set variant(value: ToggleVariant) {
+    this.setAttribute('variant', value);
+  }
+
+  get size(): ToggleSize {
+    return parseSize(this.getAttribute('size'));
+  }
+
+  set size(value: ToggleSize) {
+    this.setAttribute('size', value);
+  }
+
+  get form(): HTMLFormElement | null {
+    return this._internals.form;
+  }
+
+  get validity(): ValidityState {
+    return this._internals.validity;
+  }
+
+  get validationMessage(): string {
+    return this._internals.validationMessage;
+  }
+
+  get willValidate(): boolean {
+    return this._internals.willValidate;
+  }
+
+  checkValidity(): boolean {
+    return this._internals.checkValidity();
+  }
+
+  reportValidity(): boolean {
+    return this._internals.reportValidity();
+  }
+
+  setCustomValidity(message: string): void {
+    this._internals.setValidity({ customError: message.length > 0 }, message);
+  }
+}
+
+// ============================================================================
+// Registration (module side-effect, guarded for re-import safety)
+// ============================================================================
+
+if (!customElements.get('rafters-toggle')) {
+  customElements.define('rafters-toggle', RaftersToggle);
+}

--- a/packages/ui/src/components/ui/toggle.styles.test.ts
+++ b/packages/ui/src/components/ui/toggle.styles.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type ToggleSize,
+  type ToggleVariant,
+  toggleBase,
+  toggleDisabled,
+  toggleFocusVisible,
+  toggleSizeStyles,
+  toggleStylesheet,
+  toggleVariantHover,
+  toggleVariantPressed,
+  toggleVariantStyles,
+} from './toggle.styles';
+
+const ALL_VARIANTS: ReadonlyArray<ToggleVariant> = [
+  'default',
+  'primary',
+  'secondary',
+  'destructive',
+  'success',
+  'warning',
+  'info',
+  'accent',
+  'outline',
+  'ghost',
+];
+
+const ALL_SIZES: ReadonlyArray<ToggleSize> = ['sm', 'default', 'lg'];
+
+describe('toggleStylesheet', () => {
+  it('returns base + default variant + default size when no options given', () => {
+    const css = toggleStylesheet();
+    expect(css).toContain('.toggle');
+    expect(css).toContain('var(--radius-md)');
+    expect(css).toContain('var(--font-size-label-large)');
+    expect(css).toContain('height: 2.5rem');
+  });
+
+  it('emits :host display:inline-flex', () => {
+    expect(toggleStylesheet()).toMatch(/:host\s*\{[^}]*display:\s*inline-flex/);
+  });
+
+  it('uses --motion-duration-* not --duration-*', () => {
+    const css = toggleStylesheet();
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+    expect(css).toContain('var(--motion-duration-base)');
+    expect(css).toContain('var(--motion-ease-standard)');
+  });
+
+  it('applies pressed styles when pressed=true', () => {
+    const css = toggleStylesheet({ pressed: true, variant: 'primary' });
+    expect(css).toContain('var(--color-primary)');
+    expect(css).toContain('var(--color-primary-foreground)');
+  });
+
+  it('emits focus-visible ring rule', () => {
+    expect(toggleStylesheet()).toMatch(/\.toggle:focus-visible\s*\{/);
+  });
+
+  it('focus-visible uses the neutral --color-ring', () => {
+    const css = toggleStylesheet();
+    expect(css).toMatch(/\.toggle:focus-visible\s*\{[^}]*var\(--color-ring\)/);
+  });
+
+  it('wraps transitions in prefers-reduced-motion', () => {
+    expect(toggleStylesheet()).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)/);
+    expect(toggleStylesheet()).toMatch(/transition:\s*none/);
+  });
+
+  it('falls back to default on unknown values', () => {
+    expect(() =>
+      toggleStylesheet({ variant: 'nope' as never, size: 'huge' as never }),
+    ).not.toThrow();
+    const css = toggleStylesheet({ variant: 'bogus' as never, size: 'huge' as never });
+    expect(css).toContain('height: 2.5rem');
+  });
+
+  it('emits all 10 variants without throwing', () => {
+    for (const v of ALL_VARIANTS) {
+      expect(() => toggleStylesheet({ variant: v })).not.toThrow();
+    }
+  });
+
+  it('emits all 3 sizes without throwing', () => {
+    for (const s of ALL_SIZES) {
+      expect(() => toggleStylesheet({ size: s })).not.toThrow();
+    }
+  });
+
+  it('emits distinct heights per size', () => {
+    expect(toggleStylesheet({ size: 'sm' })).toContain('height: 2.25rem');
+    expect(toggleStylesheet({ size: 'default' })).toContain('height: 2.5rem');
+    expect(toggleStylesheet({ size: 'lg' })).toContain('height: 2.75rem');
+  });
+
+  it('emits size-specific horizontal padding', () => {
+    const sm = toggleStylesheet({ size: 'sm' });
+    expect(sm).toContain('padding-left: 0.625rem');
+    expect(sm).toContain('padding-right: 0.625rem');
+
+    const def = toggleStylesheet({ size: 'default' });
+    expect(def).toContain('padding-left: 0.75rem');
+    expect(def).toContain('padding-right: 0.75rem');
+
+    const lg = toggleStylesheet({ size: 'lg' });
+    expect(lg).toContain('padding-left: 1.25rem');
+    expect(lg).toContain('padding-right: 1.25rem');
+  });
+
+  it('emits a data-state="on" pressed rule for every variant', () => {
+    for (const v of ALL_VARIANTS) {
+      const css = toggleStylesheet({ variant: v });
+      expect(css).toContain('.toggle[data-state="on"]');
+    }
+  });
+
+  it('default/primary/secondary/semantic pressed colours map to own foreground', () => {
+    for (const v of [
+      'primary',
+      'secondary',
+      'destructive',
+      'success',
+      'warning',
+      'info',
+      'accent',
+    ] as const) {
+      const css = toggleStylesheet({ variant: v });
+      expect(css).toContain(`var(--color-${v})`);
+      expect(css).toContain(`var(--color-${v}-foreground)`);
+    }
+  });
+
+  it('outline pressed falls back to accent pair', () => {
+    const css = toggleStylesheet({ variant: 'outline' });
+    expect(css).toContain('var(--color-accent)');
+    expect(css).toContain('var(--color-accent-foreground)');
+  });
+
+  it('ghost pressed falls back to accent pair', () => {
+    const css = toggleStylesheet({ variant: 'ghost' });
+    expect(css).toContain('var(--color-accent)');
+    expect(css).toContain('var(--color-accent-foreground)');
+  });
+
+  it('outline variant emits a 1px border with color-input', () => {
+    const css = toggleStylesheet({ variant: 'outline' });
+    expect(css).toContain('border-width: 1px');
+    expect(css).toContain('border-style: solid');
+    expect(css).toContain('var(--color-input)');
+  });
+
+  it('hover rule maps to color-muted for non-ghost variants', () => {
+    const css = toggleStylesheet({ variant: 'primary' });
+    expect(css).toMatch(
+      /\.toggle:hover:not\(:disabled\)\s*\{[^}]*background-color:\s*var\(--color-muted\)/,
+    );
+  });
+
+  it('ghost hover swaps to the accent pair', () => {
+    const css = toggleStylesheet({ variant: 'ghost' });
+    expect(css).toMatch(
+      /\.toggle:hover:not\(:disabled\)\s*\{[^}]*background-color:\s*var\(--color-accent\)/,
+    );
+  });
+
+  it('emits active scale(0.98) tactile feedback', () => {
+    const css = toggleStylesheet();
+    expect(css).toMatch(/\.toggle:active:not\(:disabled\)\s*\{[^}]*transform:\s*scale\(0\.98\)/);
+  });
+
+  it('prefers-reduced-motion neutralises the active transform too', () => {
+    const css = toggleStylesheet();
+    expect(css).toMatch(/@media\s*\(prefers-reduced-motion:[^{]*\{[\s\S]*transform:\s*none/);
+  });
+
+  it('applies disabled declarations when disabled=true', () => {
+    const css = toggleStylesheet({ disabled: true });
+    expect(css).toContain('cursor: not-allowed');
+    expect(css).toContain('opacity: 0.5');
+    expect(css).toContain('pointer-events: none');
+  });
+
+  it('emits a :disabled rule carrying the disabled declarations', () => {
+    const css = toggleStylesheet();
+    expect(css).toContain('.toggle:disabled');
+    expect(css).toMatch(/\.toggle:disabled\s*\{[^}]*opacity:\s*0\.5/);
+  });
+
+  it('never emits a raw var() that is not a CSS custom property reference', () => {
+    const css = toggleStylesheet({ variant: 'primary', size: 'lg', pressed: true });
+    const matches = css.match(/var\([^)]+\)/g) ?? [];
+    for (const m of matches) {
+      expect(m).toMatch(/var\(--/);
+    }
+  });
+
+  it('never emits a raw hex colour or rgb() literal', () => {
+    const css = toggleStylesheet({
+      variant: 'destructive',
+      size: 'lg',
+      pressed: true,
+      disabled: true,
+    });
+    expect(css).not.toMatch(/#[0-9a-f]{3,8}/i);
+    expect(css).not.toMatch(/rgb\(/);
+  });
+
+  describe('exports', () => {
+    it('exposes toggleBase with inline-flex and cursor pointer', () => {
+      expect(toggleBase).toMatchObject({
+        display: 'inline-flex',
+        'align-items': 'center',
+        'justify-content': 'center',
+        cursor: 'pointer',
+        'background-color': 'transparent',
+      });
+    });
+
+    it('exposes toggleDisabled with opacity, cursor, pointer-events', () => {
+      expect(toggleDisabled).toMatchObject({
+        opacity: '0.5',
+        cursor: 'not-allowed',
+        'pointer-events': 'none',
+      });
+    });
+
+    it('exposes toggleFocusVisible with outline:none and token-driven ring', () => {
+      expect(toggleFocusVisible.outline).toBe('none');
+      expect(toggleFocusVisible['box-shadow']).toContain('var(--color-ring)');
+    });
+
+    it('exposes style maps covering every variant and size key', () => {
+      for (const v of ALL_VARIANTS) {
+        expect(toggleVariantStyles[v]).toBeDefined();
+        expect(toggleVariantPressed[v]).toBeDefined();
+        expect(toggleVariantHover[v]).toBeDefined();
+      }
+      for (const s of ALL_SIZES) {
+        expect(toggleSizeStyles[s]).toBeDefined();
+      }
+    });
+  });
+});

--- a/packages/ui/src/components/ui/toggle.styles.ts
+++ b/packages/ui/src/components/ui/toggle.styles.ts
@@ -1,0 +1,305 @@
+/**
+ * Shadow DOM style definitions for Toggle web component
+ *
+ * Parallel to toggle.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ *
+ * All token references go through tokenVar() -- no raw CSS custom-property
+ * function literals appear in this module.
+ * Motion uses --motion-duration-* / --motion-ease-* only.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import {
+  atRule,
+  pick,
+  styleRule,
+  stylesheet,
+  tokenVar,
+  transition,
+  when,
+} from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export type ToggleVariant =
+  | 'default'
+  | 'primary'
+  | 'secondary'
+  | 'destructive'
+  | 'success'
+  | 'warning'
+  | 'info'
+  | 'accent'
+  | 'outline'
+  | 'ghost';
+
+export type ToggleSize = 'sm' | 'default' | 'lg';
+
+export interface ToggleStylesheetOptions {
+  variant?: ToggleVariant | undefined;
+  size?: ToggleSize | undefined;
+  pressed?: boolean | undefined;
+  disabled?: boolean | undefined;
+}
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+/**
+ * Base toggle declarations shared across every variant and size.
+ * Mirrors toggleBaseClasses from toggle.classes.ts.
+ */
+export const toggleBase: CSSProperties = {
+  display: 'inline-flex',
+  'align-items': 'center',
+  'justify-content': 'center',
+  'border-radius': tokenVar('radius-md'),
+  'font-size': tokenVar('font-size-label-large'),
+  'background-color': 'transparent',
+  color: 'inherit',
+  cursor: 'pointer',
+  'user-select': 'none',
+  'white-space': 'nowrap',
+  'border-width': '0',
+  'border-style': 'solid',
+  'border-color': 'transparent',
+  transition: transition(
+    ['background-color', 'color', 'transform'],
+    tokenVar('motion-duration-base'),
+    tokenVar('motion-ease-standard'),
+  ),
+};
+
+/**
+ * Disabled-state declarations. Applied either via the host's `disabled`
+ * attribute (composed into the base rule) or via `:disabled` on the inner
+ * button for defensive coverage.
+ */
+export const toggleDisabled: CSSProperties = {
+  cursor: 'not-allowed',
+  opacity: '0.5',
+  'pointer-events': 'none',
+};
+
+/**
+ * Focus-visible ring -- neutral double-ring matching the rest of the
+ * Rafters form-control surface.
+ */
+export const toggleFocusVisible: CSSProperties = {
+  outline: 'none',
+  'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar('color-ring')}`,
+};
+
+// ============================================================================
+// Variant Styles
+// ============================================================================
+
+/**
+ * Unpressed base per variant. Toggles read as neutral affordances until
+ * pressed, so semantic variants keep a transparent background. The
+ * `outline` variant adds a 1px input-coloured border.
+ */
+export const toggleVariantStyles: Record<ToggleVariant, CSSProperties> = {
+  default: {
+    'background-color': 'transparent',
+  },
+  primary: {
+    'background-color': 'transparent',
+  },
+  secondary: {
+    'background-color': 'transparent',
+  },
+  destructive: {
+    'background-color': 'transparent',
+  },
+  success: {
+    'background-color': 'transparent',
+  },
+  warning: {
+    'background-color': 'transparent',
+  },
+  info: {
+    'background-color': 'transparent',
+  },
+  accent: {
+    'background-color': 'transparent',
+  },
+  outline: {
+    'background-color': 'transparent',
+    'border-width': '1px',
+    'border-style': 'solid',
+    'border-color': tokenVar('color-input'),
+  },
+  ghost: {
+    'background-color': 'transparent',
+  },
+};
+
+/**
+ * Pressed (data-state="on") background + foreground pair per variant.
+ * Semantic variants map to their own `-foreground` pair. The neutral
+ * outline/ghost variants fall back to the accent pair.
+ */
+export const toggleVariantPressed: Record<ToggleVariant, CSSProperties> = {
+  default: {
+    'background-color': tokenVar('color-primary'),
+    color: tokenVar('color-primary-foreground'),
+  },
+  primary: {
+    'background-color': tokenVar('color-primary'),
+    color: tokenVar('color-primary-foreground'),
+  },
+  secondary: {
+    'background-color': tokenVar('color-secondary'),
+    color: tokenVar('color-secondary-foreground'),
+  },
+  destructive: {
+    'background-color': tokenVar('color-destructive'),
+    color: tokenVar('color-destructive-foreground'),
+  },
+  success: {
+    'background-color': tokenVar('color-success'),
+    color: tokenVar('color-success-foreground'),
+  },
+  warning: {
+    'background-color': tokenVar('color-warning'),
+    color: tokenVar('color-warning-foreground'),
+  },
+  info: {
+    'background-color': tokenVar('color-info'),
+    color: tokenVar('color-info-foreground'),
+  },
+  accent: {
+    'background-color': tokenVar('color-accent'),
+    color: tokenVar('color-accent-foreground'),
+  },
+  outline: {
+    'background-color': tokenVar('color-accent'),
+    color: tokenVar('color-accent-foreground'),
+  },
+  ghost: {
+    'background-color': tokenVar('color-accent'),
+    color: tokenVar('color-accent-foreground'),
+  },
+};
+
+/**
+ * Hover background per variant when not pressed. All semantic variants
+ * share the muted hover surface; ghost alone hovers to the accent pair
+ * so it reads as actionable without a frame.
+ */
+export const toggleVariantHover: Record<ToggleVariant, CSSProperties> = {
+  default: {
+    'background-color': tokenVar('color-muted'),
+  },
+  primary: {
+    'background-color': tokenVar('color-muted'),
+  },
+  secondary: {
+    'background-color': tokenVar('color-muted'),
+  },
+  destructive: {
+    'background-color': tokenVar('color-muted'),
+  },
+  success: {
+    'background-color': tokenVar('color-muted'),
+  },
+  warning: {
+    'background-color': tokenVar('color-muted'),
+  },
+  info: {
+    'background-color': tokenVar('color-muted'),
+  },
+  accent: {
+    'background-color': tokenVar('color-muted'),
+  },
+  outline: {
+    'background-color': tokenVar('color-muted'),
+  },
+  ghost: {
+    'background-color': tokenVar('color-accent'),
+    color: tokenVar('color-accent-foreground'),
+  },
+};
+
+// ============================================================================
+// Size Styles
+// ============================================================================
+
+/**
+ * Size declarations map explicit heights and padding pairs.
+ * Matches toggleSizeClasses from toggle.classes.ts.
+ */
+export const toggleSizeStyles: Record<ToggleSize, CSSProperties> = {
+  sm: {
+    height: '2.25rem',
+    'padding-left': '0.625rem',
+    'padding-right': '0.625rem',
+  },
+  default: {
+    height: '2.5rem',
+    'padding-left': '0.75rem',
+    'padding-right': '0.75rem',
+  },
+  lg: {
+    height: '2.75rem',
+    'padding-left': '1.25rem',
+    'padding-right': '1.25rem',
+  },
+};
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+/**
+ * Build the complete toggle stylesheet for a given configuration.
+ *
+ * Composition:
+ *   :host                            -> display: inline-flex
+ *   .toggle                          -> base + variant + size (+ disabled when set)
+ *   .toggle:hover:not(:disabled)     -> variant hover surface (unpressed)
+ *   .toggle:active                   -> scale(0.98) tactile feedback
+ *   .toggle:focus-visible            -> neutral focus ring
+ *   .toggle[data-state="on"]         -> pressed fill + foreground per variant
+ *   .toggle:disabled                 -> disabled declarations
+ *   @media reduced-motion            -> transition: none, transform: none
+ *
+ * Unknown variant/size falls back to 'default' via pick(). Never throws.
+ */
+export function toggleStylesheet(options: ToggleStylesheetOptions = {}): string {
+  const { variant, size, pressed, disabled } = options;
+
+  return stylesheet(
+    styleRule(':host', { display: 'inline-flex' }),
+
+    styleRule(
+      '.toggle',
+      toggleBase,
+      pick(toggleVariantStyles, variant, 'default'),
+      pick(toggleSizeStyles, size, 'default'),
+      when(pressed, pick(toggleVariantPressed, variant, 'default')),
+      when(disabled, toggleDisabled),
+    ),
+
+    styleRule('.toggle:hover:not(:disabled)', pick(toggleVariantHover, variant, 'default')),
+
+    styleRule('.toggle:active:not(:disabled)', { transform: 'scale(0.98)' }),
+
+    styleRule('.toggle:focus-visible', toggleFocusVisible),
+
+    styleRule('.toggle[data-state="on"]', pick(toggleVariantPressed, variant, 'default')),
+
+    styleRule('.toggle:disabled', toggleDisabled),
+
+    atRule(
+      '@media (prefers-reduced-motion: reduce)',
+      styleRule('.toggle', { transition: 'none' }),
+      styleRule('.toggle:active:not(:disabled)', { transform: 'none' }),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

Ships a form-associated `<rafters-toggle>` custom element plus token-driven `toggle.styles.ts` stylesheet so press-toggle buttons work outside React, with native `<form>` participation via `ElementInternals` for sticky state submission and token-driven shadow styling.

Closes #1343.

## What's in the PR

- **`packages/ui/src/components/ui/toggle.styles.ts`** -- variant/size/pressed/disabled composition via `classy-wc`; 10 variants (default, primary, secondary, destructive, success, warning, info, accent, outline, ghost) and 3 sizes (sm, default, lg). Hover/active/focus-visible rules, `data-state="on"` pressed fill per variant, neutral focus ring, reduced-motion guard neutralising both `transition` and the active `transform: scale(0.98)`. Every token reference goes through `tokenVar()`, and motion uses `--motion-duration-*` / `--motion-ease-*` only.
- **`packages/ui/src/components/ui/toggle.element.ts`** -- `RaftersToggle` class with `static formAssociated = true`, per-instance `CSSStyleSheet` rebuilt on style-affecting attribute changes, inner `<button type="button">` carrying `aria-pressed` + `data-state`. Click on the host toggles `pressed` (unless disabled); Space/Enter fall through to the native button. After a state change the host dispatches `change` (`bubbles: true`, `composed: true`). Unknown `variant`/`size` values fall back silently to `'default'`; constructor throws `TypeError` only when `attachInternals` is unavailable. Auto-registers `<rafters-toggle>` idempotently on import.
- **Form-associated lifecycle** -- `setFormValue(value || 'on')` when pressed, `setFormValue(null)` otherwise so unpressed toggles are omitted from `FormData`. `formResetCallback` restores the declared initial pressed state captured at construction/connection. `formStateRestoreCallback` maps non-null state to pressed. `formDisabledCallback` mirrors the propagated disabled flag to the inner `<button>`.
- **Unit tests** (`toggle.element.test.ts`, `toggle.styles.test.ts`) -- registration idempotency, pressed toggling, `aria-pressed`/`data-state` sync, `change` event bubbling and shadow-root composition, `FormData` submission with `name=value` when pressed (including `value` defaulting to `'on'`), `FormData` omission when unpressed, `formResetCallback` restoration, per-instance stylesheet rebuild on variant/size change, `tokenVar`-only enforcement, `--motion-*`-only enforcement, no raw `var()` literals in either `.ts` file, no hex/rgb literals in emitted CSS.
- **A11y tests** (`toggle.element.a11y.tsx`, vitest-axe) -- axe-clean across every variant and every size, pressed state, disabled state, toolbar role composition (`role="toolbar"` + `aria-label`), sibling placement inside a `<form>` carrying `name` + `value`.

## Test plan

- [x] `pnpm --filter=@rafters/ui test toggle` -- 122 tests pass, 1 skipped (fieldset.disabled propagation; happy-dom limitation tracked in #1303)
- [x] `pnpm --filter=@rafters/ui typecheck`
- [x] `pnpm preflight` -- typecheck, lint, unit, a11y, build all green
- [ ] Manual smoke: drop `<rafters-toggle>` in a real form and confirm `FormData` enumeration in a browser that implements form-associated custom elements

## Conventions observed

- No `any`, no emoji, no `var()` outside `tokenVar()`, no `--duration-*`/`--ease-*` tokens
- Per-instance `CSSStyleSheet` rebuilt on every style-affecting attribute change
- `document.createElement`-only rendering (no `innerHTML`), consistent with `rafters-element` security note
- Silent fallback for unknown variant/size (only `TypeError` when `attachInternals` unavailable, per `feedback_no_error_classes`)
- Auto-register is idempotent against double-import