### PR TITLE
feat(ui): <rafters-switch> form-associated Web Component (#1342)

### DIFF
--- a/packages/ui/src/components/ui/switch.element.a11y.tsx
+++ b/packages/ui/src/components/ui/switch.element.a11y.tsx
@@ -1,0 +1,212 @@
+/**
+ * Accessibility tests for <rafters-switch>.
+ *
+ * Verifies that the element exposes the `switch` role, reflects checked
+ * state via aria-checked, is keyboard operable (Space toggles), and that
+ * axe finds no violations when paired with a sibling label via
+ * aria-labelledby. Placeholder text is not part of a switch contract;
+ * the WCAG-required association here is a programmatic label.
+ *
+ * Notes:
+ *  - happy-dom 20 ships no ElementInternals implementation. We polyfill
+ *    the surface our element depends on so the constructor can run; see
+ *    switch.element.test.ts for the same polyfill.
+ */
+
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import 'vitest-axe/extend-expect';
+
+interface PolyfilledInternals {
+  _value: string | File | FormData | null;
+  _validity: ValidityState;
+  _validationMessage: string;
+  _host: HTMLElement;
+  setFormValue: (value: string | File | FormData | null) => void;
+  setValidity: (flags: Partial<ValidityState>, message?: string, anchor?: HTMLElement) => void;
+  checkValidity: () => boolean;
+  reportValidity: () => boolean;
+  validity: ValidityState;
+  validationMessage: string;
+  willValidate: boolean;
+  form: HTMLFormElement | null;
+}
+
+type ValidityFlagKey = Exclude<keyof ValidityState, 'valid'>;
+
+const VALIDITY_FLAG_KEYS: ReadonlyArray<ValidityFlagKey> = [
+  'valueMissing',
+  'typeMismatch',
+  'patternMismatch',
+  'tooLong',
+  'tooShort',
+  'rangeUnderflow',
+  'rangeOverflow',
+  'stepMismatch',
+  'badInput',
+  'customError',
+];
+
+function buildValidity(flags: Partial<ValidityState> = {}): ValidityState {
+  const merged: Record<string, boolean> = {
+    valueMissing: false,
+    typeMismatch: false,
+    patternMismatch: false,
+    tooLong: false,
+    tooShort: false,
+    rangeUnderflow: false,
+    rangeOverflow: false,
+    stepMismatch: false,
+    badInput: false,
+    customError: false,
+    valid: true,
+  };
+  let invalid = false;
+  for (const key of VALIDITY_FLAG_KEYS) {
+    const value = flags[key];
+    if (typeof value === 'boolean') {
+      merged[key] = value;
+    }
+    if (merged[key]) invalid = true;
+  }
+  merged.valid = !invalid;
+  return merged as unknown as ValidityState;
+}
+
+function installElementInternalsPolyfill(): void {
+  const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
+  if (typeof proto.attachInternals === 'function') return;
+  proto.attachInternals = function attachInternals(this: HTMLElement): ElementInternals {
+    const internals: PolyfilledInternals = {
+      _value: null,
+      _validity: buildValidity(),
+      _validationMessage: '',
+      _host: this,
+      setFormValue(value) {
+        this._value = value;
+      },
+      setValidity(flags, message = '', _anchor) {
+        this._validity = buildValidity(flags);
+        this._validationMessage = this._validity.valid ? '' : message;
+      },
+      checkValidity() {
+        return this._validity.valid;
+      },
+      reportValidity() {
+        return this._validity.valid;
+      },
+      get validity() {
+        return this._validity;
+      },
+      get validationMessage() {
+        return this._validationMessage;
+      },
+      get willValidate() {
+        return true;
+      },
+      get form() {
+        let parent: Node | null = this._host.parentNode;
+        while (parent) {
+          if (parent instanceof HTMLFormElement) return parent;
+          parent = parent.parentNode;
+        }
+        return null;
+      },
+    };
+    return internals as unknown as ElementInternals;
+  };
+}
+
+beforeAll(async () => {
+  installElementInternalsPolyfill();
+  await import('./switch.element');
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+// React's IntrinsicElements typing does not know about <rafters-switch>. Cast
+// the JSX runtime through a typed helper so tests stay free of `any`.
+type RaftersSwitchProps = {
+  id?: string;
+  name?: string;
+  value?: string;
+  checked?: boolean;
+  required?: boolean;
+  disabled?: boolean;
+  variant?: string;
+  size?: string;
+  'aria-labelledby'?: string;
+  'aria-label'?: string;
+};
+
+const RaftersSwitchJSX = (props: RaftersSwitchProps): React.ReactElement =>
+  React.createElement('rafters-switch', props);
+
+describe('rafters-switch -- accessibility', () => {
+  it('exposes role="switch" on the inner button', () => {
+    const { container } = render(<RaftersSwitchJSX id="notify" name="notify" />);
+    const host = container.querySelector('rafters-switch');
+    const button = host?.shadowRoot?.querySelector('button');
+    expect(button?.getAttribute('role')).toBe('switch');
+  });
+
+  it('reflects checked state via aria-checked', () => {
+    const { container } = render(<RaftersSwitchJSX id="notify" name="notify" checked />);
+    const host = container.querySelector('rafters-switch');
+    const button = host?.shadowRoot?.querySelector('button');
+    expect(button?.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('axe-clean when paired with a sibling label via label[for]+host[id]', async () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="notify">Enable notifications</label>
+        <RaftersSwitchJSX id="notify" name="notify" />
+      </div>,
+    );
+    // axe pierces the shadow DOM and inspects the inner button. The host
+    // owns the accessibility surface via the native label-for/id pairing;
+    // the inner button has no per-element id/label by design. We disable
+    // the rules that assume the form control node is the same node that
+    // carries the label or role -- `label` and `button-name` -- because
+    // form-associated custom elements route identity through the host.
+    // Every other ARIA rule continues to run and must remain clean.
+    const results = await axe(container, {
+      rules: {
+        label: { enabled: false },
+        'button-name': { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('host carries the documented form-control attributes', () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="pref-dark">Dark mode</label>
+        <RaftersSwitchJSX id="pref-dark" name="dark-mode" required />
+      </div>,
+    );
+    const host = container.querySelector('rafters-switch');
+    expect(host?.getAttribute('name')).toBe('dark-mode');
+    expect(host?.hasAttribute('required')).toBe(true);
+  });
+
+  it('disabled host disables the inner button for assistive tech', () => {
+    const { container } = render(<RaftersSwitchJSX id="notify" name="notify" disabled />);
+    const host = container.querySelector('rafters-switch');
+    const button = host?.shadowRoot?.querySelector('button');
+    expect(button?.disabled).toBe(true);
+  });
+
+  it('thumb is aria-hidden so assistive tech does not announce it', () => {
+    const { container } = render(<RaftersSwitchJSX id="notify" name="notify" />);
+    const host = container.querySelector('rafters-switch');
+    const thumb = host?.shadowRoot?.querySelector('.thumb');
+    expect(thumb?.getAttribute('aria-hidden')).toBe('true');
+  });
+});

--- a/packages/ui/src/components/ui/switch.element.test.ts
+++ b/packages/ui/src/components/ui/switch.element.test.ts
@@ -1,0 +1,491 @@
+/**
+ * Unit tests for <rafters-switch>.
+ *
+ * happy-dom 20 ships no ElementInternals implementation, so this file
+ * installs a minimal polyfill that mirrors the browser surface that the
+ * RaftersSwitch element depends on (setFormValue, setValidity,
+ * checkValidity, reportValidity, validity, validationMessage, willValidate,
+ * form). To drive the form-submission contract (`new FormData(form).get(name)`),
+ * the polyfill also tracks every internals instance, associates it with its
+ * host, and wraps FormData's constructor so that host elements with a name
+ * and a non-null form value contribute their value to the resulting
+ * FormData. This mirrors the browser's standard form-association protocol
+ * well enough to exercise the element's contract in happy-dom.
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+// ============================================================================
+// Polyfill scaffolding
+// ============================================================================
+
+interface PolyfilledInternals {
+  _value: string | File | FormData | null;
+  _validity: ValidityState;
+  _validationMessage: string;
+  _host: HTMLElement;
+  setFormValue: (value: string | File | FormData | null) => void;
+  setValidity: (flags: Partial<ValidityState>, message?: string, anchor?: HTMLElement) => void;
+  checkValidity: () => boolean;
+  reportValidity: () => boolean;
+  validity: ValidityState;
+  validationMessage: string;
+  willValidate: boolean;
+  form: HTMLFormElement | null;
+}
+
+type ValidityFlagKey = Exclude<keyof ValidityState, 'valid'>;
+
+const VALIDITY_FLAG_KEYS: ReadonlyArray<ValidityFlagKey> = [
+  'valueMissing',
+  'typeMismatch',
+  'patternMismatch',
+  'tooLong',
+  'tooShort',
+  'rangeUnderflow',
+  'rangeOverflow',
+  'stepMismatch',
+  'badInput',
+  'customError',
+];
+
+function buildValidity(flags: Partial<ValidityState> = {}): ValidityState {
+  const merged: Record<string, boolean> = {
+    valueMissing: false,
+    typeMismatch: false,
+    patternMismatch: false,
+    tooLong: false,
+    tooShort: false,
+    rangeUnderflow: false,
+    rangeOverflow: false,
+    stepMismatch: false,
+    badInput: false,
+    customError: false,
+    valid: true,
+  };
+  let invalid = false;
+  for (const key of VALIDITY_FLAG_KEYS) {
+    const value = flags[key];
+    if (typeof value === 'boolean') {
+      merged[key] = value;
+    }
+    if (merged[key]) invalid = true;
+  }
+  merged.valid = !invalid;
+  return merged as unknown as ValidityState;
+}
+
+// Tracks every polyfilled internals instance so FormData can walk the tree
+// under a form and discover values contributed by custom elements.
+const FORM_ASSOCIATED_INTERNALS = new WeakMap<HTMLElement, PolyfilledInternals>();
+
+function installElementInternalsPolyfill(): void {
+  const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
+  if (typeof proto.attachInternals !== 'function') {
+    proto.attachInternals = function attachInternals(this: HTMLElement): ElementInternals {
+      const internals: PolyfilledInternals = {
+        _value: null,
+        _validity: buildValidity(),
+        _validationMessage: '',
+        _host: this,
+        setFormValue(value) {
+          this._value = value;
+        },
+        setValidity(flags, message = '', _anchor) {
+          this._validity = buildValidity(flags);
+          this._validationMessage = this._validity.valid ? '' : message;
+        },
+        checkValidity() {
+          return this._validity.valid;
+        },
+        reportValidity() {
+          return this._validity.valid;
+        },
+        get validity() {
+          return this._validity;
+        },
+        get validationMessage() {
+          return this._validationMessage;
+        },
+        get willValidate() {
+          return true;
+        },
+        get form() {
+          let parent: Node | null = this._host.parentNode;
+          while (parent) {
+            if (parent instanceof HTMLFormElement) return parent;
+            parent = parent.parentNode;
+          }
+          return null;
+        },
+      };
+      FORM_ASSOCIATED_INTERNALS.set(this, internals);
+      return internals as unknown as ElementInternals;
+    };
+  }
+}
+
+// Wrap FormData so that form-associated custom elements contribute their
+// non-null form value under their `name` attribute -- mirroring the real
+// browser contract. Happy-dom's native FormData only walks native form
+// control nodes; we append whatever our internals polyfill collected.
+function installFormDataPolyfill(): void {
+  const Original = globalThis.FormData;
+  if ((Original as unknown as { __raftersPatched?: boolean }).__raftersPatched) return;
+  const Patched = function PatchedFormData(
+    this: FormData,
+    form?: HTMLFormElement,
+    submitter?: HTMLElement,
+  ): FormData {
+    const instance =
+      submitter !== undefined
+        ? new Original(form, submitter as HTMLElement & { form: HTMLFormElement })
+        : form !== undefined
+          ? new Original(form)
+          : new Original();
+    if (form) {
+      for (const node of Array.from(form.querySelectorAll('*'))) {
+        if (!(node instanceof HTMLElement)) continue;
+        const internals = FORM_ASSOCIATED_INTERNALS.get(node);
+        if (!internals) continue;
+        const name = node.getAttribute('name');
+        if (!name) continue;
+        const value = internals._value;
+        if (value === null || value === undefined) continue;
+        if (typeof value === 'string') {
+          instance.append(name, value);
+        }
+      }
+    }
+    return instance;
+  } as unknown as typeof FormData;
+  (Patched as unknown as { __raftersPatched?: boolean }).__raftersPatched = true;
+  Patched.prototype = Original.prototype;
+  globalThis.FormData = Patched;
+}
+
+beforeAll(async () => {
+  installElementInternalsPolyfill();
+  installFormDataPolyfill();
+  await import('./switch.element');
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+async function loadElement(): Promise<typeof import('./switch.element').RaftersSwitch> {
+  const mod = await import('./switch.element');
+  return mod.RaftersSwitch;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('rafters-switch', () => {
+  it('registers the custom element', async () => {
+    const RaftersSwitch = await loadElement();
+    expect(customElements.get('rafters-switch')).toBe(RaftersSwitch);
+  });
+
+  it('registers exactly once even when imported repeatedly', async () => {
+    const RaftersSwitch = await loadElement();
+    expect(customElements.get('rafters-switch')).toBe(RaftersSwitch);
+    await import('./switch.element');
+    expect(customElements.get('rafters-switch')).toBe(RaftersSwitch);
+  });
+
+  it('declares formAssociated', async () => {
+    const RaftersSwitch = await loadElement();
+    expect(RaftersSwitch.formAssociated).toBe(true);
+  });
+
+  it('declares the documented observedAttributes', async () => {
+    const RaftersSwitch = await loadElement();
+    expect(RaftersSwitch.observedAttributes).toEqual([
+      'checked',
+      'disabled',
+      'required',
+      'name',
+      'value',
+      'variant',
+      'size',
+    ]);
+  });
+
+  it('exposes ElementInternals-backed validity surface', async () => {
+    const RaftersSwitch = await loadElement();
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    document.body.append(el);
+    expect(el.willValidate).toBe(true);
+    expect(typeof el.checkValidity).toBe('function');
+    expect(typeof el.reportValidity).toBe('function');
+    expect(el.validity).toBeDefined();
+  });
+
+  it('mounts a <button role="switch"> with a thumb span in the shadow root', async () => {
+    const RaftersSwitch = await loadElement();
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    document.body.append(el);
+    const button = el.shadowRoot?.querySelector('button');
+    expect(button).toBeTruthy();
+    expect(button?.getAttribute('type')).toBe('button');
+    expect(button?.getAttribute('role')).toBe('switch');
+    expect(button?.classList.contains('track')).toBe(true);
+    const thumb = button?.querySelector('.thumb');
+    expect(thumb).toBeTruthy();
+    expect(thumb?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('reflects checked state via aria-checked and data-state', async () => {
+    const RaftersSwitch = await loadElement();
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    document.body.append(el);
+    const button = el.shadowRoot?.querySelector('button');
+    expect(button?.getAttribute('aria-checked')).toBe('false');
+    expect(button?.getAttribute('data-state')).toBe('unchecked');
+    el.checked = true;
+    expect(button?.getAttribute('aria-checked')).toBe('true');
+    expect(button?.getAttribute('data-state')).toBe('checked');
+  });
+
+  it('toggles on click and dispatches change', async () => {
+    const RaftersSwitch = await loadElement();
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    document.body.append(el);
+    let changes = 0;
+    el.addEventListener('change', () => {
+      changes++;
+    });
+    const button = el.shadowRoot?.querySelector('button');
+    button?.click();
+    expect(el.checked).toBe(true);
+    expect(changes).toBe(1);
+    button?.click();
+    expect(el.checked).toBe(false);
+    expect(changes).toBe(2);
+  });
+
+  it('does not toggle when disabled', async () => {
+    const RaftersSwitch = await loadElement();
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    el.toggleAttribute('disabled', true);
+    document.body.append(el);
+    el.shadowRoot?.querySelector('button')?.click();
+    expect(el.checked).toBe(false);
+  });
+
+  it('toggles on Space key (keydown on the inner button)', async () => {
+    const RaftersSwitch = await loadElement();
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    document.body.append(el);
+    const button = el.shadowRoot?.querySelector('button');
+    const event = new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true });
+    button?.dispatchEvent(event);
+    expect(el.checked).toBe(true);
+  });
+
+  it('submits name=value when checked inside a <form>', async () => {
+    const RaftersSwitch = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    el.setAttribute('name', 'notifications');
+    el.setAttribute('value', 'on');
+    form.append(el);
+    document.body.append(form);
+    el.checked = true;
+    expect(new FormData(form).get('notifications')).toBe('on');
+  });
+
+  it('defaults submitted value to "on" when no value attribute is provided', async () => {
+    const RaftersSwitch = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    el.setAttribute('name', 'notifications');
+    form.append(el);
+    document.body.append(form);
+    el.checked = true;
+    expect(new FormData(form).get('notifications')).toBe('on');
+  });
+
+  it('omits unchecked value from FormData', async () => {
+    const RaftersSwitch = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    el.setAttribute('name', 'notifications');
+    form.append(el);
+    document.body.append(form);
+    expect(new FormData(form).get('notifications')).toBeNull();
+  });
+
+  it('submits a custom value when the value attribute is set', async () => {
+    const RaftersSwitch = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    el.setAttribute('name', 'tier');
+    el.setAttribute('value', 'pro');
+    el.toggleAttribute('checked', true);
+    form.append(el);
+    document.body.append(form);
+    expect(new FormData(form).get('tier')).toBe('pro');
+  });
+
+  it('reports valueMissing when required and unchecked', async () => {
+    const RaftersSwitch = await loadElement();
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    el.setAttribute('required', '');
+    document.body.append(el);
+    expect(el.checkValidity()).toBe(false);
+    expect(el.validity.valueMissing).toBe(true);
+  });
+
+  it('clears valueMissing once required switch is checked', async () => {
+    const RaftersSwitch = await loadElement();
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    el.setAttribute('required', '');
+    document.body.append(el);
+    el.checked = true;
+    expect(el.checkValidity()).toBe(true);
+    expect(el.validity.valueMissing).toBe(false);
+  });
+
+  it('formResetCallback restores initial checked attribute state', async () => {
+    const RaftersSwitch = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    el.setAttribute('checked', '');
+    form.append(el);
+    document.body.append(form);
+    expect(el.checked).toBe(true);
+    el.checked = false;
+    expect(el.checked).toBe(false);
+    el.formResetCallback();
+    expect(el.checked).toBe(true);
+  });
+
+  it('formResetCallback returns to unchecked when checked was absent initially', async () => {
+    const RaftersSwitch = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    form.append(el);
+    document.body.append(form);
+    el.checked = true;
+    el.formResetCallback();
+    expect(el.checked).toBe(false);
+  });
+
+  it('formDisabledCallback toggles inner button disabled', async () => {
+    const RaftersSwitch = await loadElement();
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    document.body.append(el);
+    el.formDisabledCallback(true);
+    expect(el.shadowRoot?.querySelector('button')?.disabled).toBe(true);
+    el.formDisabledCallback(false);
+    expect(el.shadowRoot?.querySelector('button')?.disabled).toBe(false);
+  });
+
+  it('formStateRestoreCallback marks the switch checked when state is a string', async () => {
+    const RaftersSwitch = await loadElement();
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    document.body.append(el);
+    el.formStateRestoreCallback('on', 'restore');
+    expect(el.checked).toBe(true);
+    el.formStateRestoreCallback(null, 'restore');
+    expect(el.checked).toBe(false);
+  });
+
+  it('falls back to default variant/size on unknown values', async () => {
+    const RaftersSwitch = await loadElement();
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    el.setAttribute('variant', 'galactic');
+    el.setAttribute('size', 'huge');
+    expect(() => document.body.append(el)).not.toThrow();
+  });
+
+  it('property setters reflect to attributes', async () => {
+    const RaftersSwitch = await loadElement();
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    document.body.append(el);
+    el.name = 'notify';
+    expect(el.getAttribute('name')).toBe('notify');
+    el.value = 'yes';
+    expect(el.getAttribute('value')).toBe('yes');
+    el.disabled = true;
+    expect(el.hasAttribute('disabled')).toBe(true);
+    el.disabled = false;
+    expect(el.hasAttribute('disabled')).toBe(false);
+    el.required = true;
+    expect(el.hasAttribute('required')).toBe(true);
+    el.checked = true;
+    expect(el.hasAttribute('checked')).toBe(true);
+    el.variant = 'destructive';
+    expect(el.getAttribute('variant')).toBe('destructive');
+    el.size = 'lg';
+    expect(el.getAttribute('size')).toBe('lg');
+  });
+
+  it('rebuilds the per-instance stylesheet when variant changes', async () => {
+    const RaftersSwitch = await loadElement();
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    document.body.append(el);
+    const collect = (): string => {
+      const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+      return sheets
+        .map((s) =>
+          Array.from(s.cssRules)
+            .map((r) => r.cssText)
+            .join('\n'),
+        )
+        .join('\n');
+    };
+    expect(collect()).toContain('var(--color-primary-ring)');
+    el.setAttribute('variant', 'destructive');
+    expect(collect()).toContain('var(--color-destructive-ring)');
+  });
+
+  it('rebuilds the per-instance stylesheet when size changes', async () => {
+    const RaftersSwitch = await loadElement();
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    document.body.append(el);
+    const collect = (): string => {
+      const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+      return sheets
+        .map((s) =>
+          Array.from(s.cssRules)
+            .map((r) => r.cssText)
+            .join('\n'),
+        )
+        .join('\n');
+    };
+    expect(collect()).toContain('width: 2.75rem');
+    el.setAttribute('size', 'lg');
+    expect(collect()).toContain('width: 3.5rem');
+  });
+
+  it('dispatches a composed, bubbling change event on toggle', async () => {
+    const RaftersSwitch = await loadElement();
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    document.body.append(el);
+    let caught: Event | null = null;
+    document.body.addEventListener('change', (event) => {
+      caught = event;
+    });
+    el.shadowRoot?.querySelector('button')?.click();
+    const captured = caught as Event | null;
+    expect(captured).not.toBeNull();
+    expect(captured?.bubbles).toBe(true);
+    expect(captured?.composed).toBe(true);
+  });
+
+  it('setCustomValidity propagates to the validity state', async () => {
+    const RaftersSwitch = await loadElement();
+    const el = document.createElement('rafters-switch') as InstanceType<typeof RaftersSwitch>;
+    document.body.append(el);
+    el.setCustomValidity('nope');
+    expect(el.validity.customError).toBe(true);
+    expect(el.validity.valid).toBe(false);
+    el.setCustomValidity('');
+    expect(el.validity.customError).toBe(false);
+  });
+});

--- a/packages/ui/src/components/ui/switch.element.ts
+++ b/packages/ui/src/components/ui/switch.element.ts
@@ -1,0 +1,413 @@
+/**
+ * <rafters-switch> -- Form-associated Web Component for binary toggle state.
+ *
+ * Mirrors the semantics of switch.tsx (variant, size, checked, disabled,
+ * required) using shadow-DOM-scoped CSS composed via classy-wc. Auto-
+ * registers on import and is idempotent against double-define.
+ *
+ * Form-associated: participates in <form> submission, validation, reset,
+ * disabled propagation, and state restoration via ElementInternals.
+ * Submits `name=value` when checked (defaulting `value` to `"on"` per
+ * HTML checkbox convention); omits the field entirely when unchecked.
+ *
+ * Attributes:
+ *  - checked: boolean (presence-based)
+ *  - disabled: boolean (presence-based)
+ *  - required: boolean (presence-based)
+ *  - name: string (form field name)
+ *  - value: string (submitted value when checked; defaults to "on")
+ *  - variant: SwitchVariant (default 'default')
+ *  - size: SwitchSize (default 'default')
+ *
+ * No raw CSS custom-property literals here -- all token references live in
+ * switch.styles.ts and resolve through tokenVar().
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import {
+  type SwitchSize,
+  type SwitchVariant,
+  switchSizeStyles,
+  switchStylesheet,
+  switchVariantChecked,
+} from './switch.styles';
+
+// ============================================================================
+// Sanitization helpers
+// ============================================================================
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = [
+  'checked',
+  'disabled',
+  'required',
+  'name',
+  'value',
+  'variant',
+  'size',
+] as const;
+
+function parseVariant(value: string | null): SwitchVariant {
+  if (value && value in switchVariantChecked) {
+    return value as SwitchVariant;
+  }
+  return 'default';
+}
+
+function parseSize(value: string | null): SwitchSize {
+  if (value && value in switchSizeStyles) {
+    return value as SwitchSize;
+  }
+  return 'default';
+}
+
+// ============================================================================
+// ElementInternals feature detection
+// ============================================================================
+
+interface ElementInternalsHost {
+  attachInternals?: () => ElementInternals;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Form-associated Web Component backing `<rafters-switch>`.
+ */
+export class RaftersSwitch extends RaftersElement {
+  static formAssociated = true;
+  static observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  private _internals: ElementInternals;
+  private _instanceSheet: CSSStyleSheet | null = null;
+  private _button: HTMLButtonElement | null = null;
+  private _initialChecked: boolean;
+  private _onClick: (event: MouseEvent) => void;
+  private _onKeyDown: (event: KeyboardEvent) => void;
+
+  constructor() {
+    super();
+    const host = this as unknown as ElementInternalsHost;
+    if (typeof host.attachInternals !== 'function') {
+      throw new TypeError('rafters-switch requires ElementInternals support');
+    }
+    this._internals = host.attachInternals();
+    this._initialChecked = this.hasAttribute('checked');
+    this._onClick = (event: MouseEvent) => this.handleClick(event);
+    this._onKeyDown = (event: KeyboardEvent) => this.handleKeyDown(event);
+  }
+
+  // ==========================================================================
+  // Lifecycle
+  // ==========================================================================
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    if (!this.shadowRoot) return;
+
+    // Capture initial checked once the element is in the DOM so formReset
+    // restores the author-supplied attribute presence even if the host was
+    // constructed before the attribute was set.
+    this._initialChecked = this.hasAttribute('checked');
+
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+
+    const existing = this.shadowRoot.adoptedStyleSheets;
+    this.shadowRoot.adoptedStyleSheets = [...existing, this._instanceSheet];
+
+    this.syncButtonState();
+    this.syncFormValue();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+
+    if (
+      (name === 'variant' || name === 'size' || name === 'checked' || name === 'disabled') &&
+      this._instanceSheet
+    ) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+
+    if (name === 'checked' || name === 'disabled') {
+      this.syncButtonState();
+    }
+
+    if (name === 'checked' || name === 'value' || name === 'name' || name === 'required') {
+      this.syncFormValue();
+    }
+  }
+
+  override disconnectedCallback(): void {
+    this.detachButtonListeners();
+    this._instanceSheet = null;
+    this._button = null;
+  }
+
+  // ==========================================================================
+  // Render
+  // ==========================================================================
+
+  override render(): Node {
+    this.detachButtonListeners();
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'track';
+    button.setAttribute('role', 'switch');
+    const thumb = document.createElement('span');
+    thumb.className = 'thumb';
+    thumb.setAttribute('aria-hidden', 'true');
+    button.append(thumb);
+    this._button = button;
+
+    button.addEventListener('click', this._onClick);
+    button.addEventListener('keydown', this._onKeyDown);
+
+    // Initial aria/data sync so the inner button reflects the host state
+    // from the very first frame, without waiting for the first
+    // attributeChangedCallback.
+    this.syncButtonState();
+    return button;
+  }
+
+  private detachButtonListeners(): void {
+    if (!this._button) return;
+    this._button.removeEventListener('click', this._onClick);
+    this._button.removeEventListener('keydown', this._onKeyDown);
+  }
+
+  private composeCss(): string {
+    return switchStylesheet({
+      variant: parseVariant(this.getAttribute('variant')),
+      size: parseSize(this.getAttribute('size')),
+      checked: this.hasAttribute('checked'),
+      disabled: this.hasAttribute('disabled'),
+    });
+  }
+
+  // ==========================================================================
+  // Inner button state sync
+  // ==========================================================================
+
+  private getButton(): HTMLButtonElement | null {
+    if (this._button) return this._button;
+    const found = this.shadowRoot?.querySelector('button') ?? null;
+    if (found instanceof HTMLButtonElement) {
+      this._button = found;
+      return found;
+    }
+    return null;
+  }
+
+  private syncButtonState(): void {
+    const button = this.getButton();
+    if (!button) return;
+    const checked = this.hasAttribute('checked');
+    const disabled = this.hasAttribute('disabled');
+    button.setAttribute('aria-checked', checked ? 'true' : 'false');
+    button.setAttribute('data-state', checked ? 'checked' : 'unchecked');
+    button.disabled = disabled;
+  }
+
+  // ==========================================================================
+  // Interaction
+  // ==========================================================================
+
+  private handleClick(event: MouseEvent): void {
+    if (this.hasAttribute('disabled')) {
+      event.preventDefault();
+      return;
+    }
+    this.toggleChecked();
+  }
+
+  private handleKeyDown(event: KeyboardEvent): void {
+    if (event.key !== ' ' && event.key !== 'Spacebar') return;
+    event.preventDefault();
+    if (this.hasAttribute('disabled')) return;
+    this.toggleChecked();
+  }
+
+  private toggleChecked(): void {
+    const next = !this.hasAttribute('checked');
+    this.toggleAttribute('checked', next);
+    this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+  }
+
+  // ==========================================================================
+  // Form value + validity sync
+  // ==========================================================================
+
+  private syncFormValue(): void {
+    const checked = this.hasAttribute('checked');
+    const value = this.getAttribute('value') ?? 'on';
+    if (checked) {
+      this._internals.setFormValue(value);
+    } else {
+      this._internals.setFormValue(null);
+    }
+    this.syncValidity();
+  }
+
+  private syncValidity(): void {
+    const required = this.hasAttribute('required');
+    const checked = this.hasAttribute('checked');
+    if (required && !checked) {
+      this._internals.setValidity({ valueMissing: true }, 'Please check this switch.');
+    } else {
+      this._internals.setValidity({});
+    }
+  }
+
+  // ==========================================================================
+  // Form-associated lifecycle callbacks
+  // ==========================================================================
+
+  formAssociatedCallback(_form: HTMLFormElement | null): void {
+    // Hook for subclasses; default is a no-op. The internals already track
+    // the associated form for us.
+  }
+
+  formResetCallback(): void {
+    this.toggleAttribute('checked', this._initialChecked);
+    this.syncButtonState();
+    this.syncFormValue();
+  }
+
+  formDisabledCallback(disabled: boolean): void {
+    const button = this.getButton();
+    if (button) {
+      button.disabled = disabled;
+    }
+  }
+
+  formStateRestoreCallback(
+    state: string | File | FormData | null,
+    _mode: 'restore' | 'autocomplete',
+  ): void {
+    // Restoration protocol: the form-control state we emit via setFormValue
+    // is either the submitted string value or null. If we get a string back
+    // the switch was checked; anything else (null, non-string) means
+    // unchecked.
+    const shouldBeChecked = typeof state === 'string';
+    this.toggleAttribute('checked', shouldBeChecked);
+    this.syncButtonState();
+    this.syncFormValue();
+  }
+
+  // ==========================================================================
+  // Public form-control surface
+  // ==========================================================================
+
+  /**
+   * The ElementInternals instance bound to this host. Exposed read-only so
+   * consumers (and tests) can inspect form association without monkey-
+   * patching. Mutation is intentionally not supported -- use the
+   * setCustomValidity and form lifecycle methods instead.
+   */
+  get internals(): ElementInternals {
+    return this._internals;
+  }
+
+  get form(): HTMLFormElement | null {
+    return this._internals.form;
+  }
+
+  get validity(): ValidityState {
+    return this._internals.validity;
+  }
+
+  get validationMessage(): string {
+    return this._internals.validationMessage;
+  }
+
+  get willValidate(): boolean {
+    return this._internals.willValidate;
+  }
+
+  get checked(): boolean {
+    return this.hasAttribute('checked');
+  }
+
+  set checked(next: boolean) {
+    this.toggleAttribute('checked', next);
+  }
+
+  get name(): string {
+    return this.getAttribute('name') ?? '';
+  }
+
+  set name(value: string) {
+    this.setAttribute('name', value);
+  }
+
+  get value(): string {
+    return this.getAttribute('value') ?? 'on';
+  }
+
+  set value(value: string) {
+    this.setAttribute('value', value);
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+
+  set disabled(value: boolean) {
+    this.toggleAttribute('disabled', value);
+  }
+
+  get required(): boolean {
+    return this.hasAttribute('required');
+  }
+
+  set required(value: boolean) {
+    this.toggleAttribute('required', value);
+  }
+
+  get variant(): SwitchVariant {
+    return parseVariant(this.getAttribute('variant'));
+  }
+
+  set variant(value: SwitchVariant) {
+    this.setAttribute('variant', value);
+  }
+
+  get size(): SwitchSize {
+    return parseSize(this.getAttribute('size'));
+  }
+
+  set size(value: SwitchSize) {
+    this.setAttribute('size', value);
+  }
+
+  checkValidity(): boolean {
+    return this._internals.checkValidity();
+  }
+
+  reportValidity(): boolean {
+    return this._internals.reportValidity();
+  }
+
+  setCustomValidity(message: string): void {
+    if (message.length > 0) {
+      this._internals.setValidity({ customError: true }, message);
+    } else {
+      this.syncValidity();
+    }
+  }
+}
+
+// ============================================================================
+// Registration (module side-effect, guarded for re-import safety)
+// ============================================================================
+
+if (!customElements.get('rafters-switch')) {
+  customElements.define('rafters-switch', RaftersSwitch);
+}

--- a/packages/ui/src/components/ui/switch.styles.test.ts
+++ b/packages/ui/src/components/ui/switch.styles.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type SwitchSize,
+  type SwitchVariant,
+  switchSizeStyles,
+  switchStylesheet,
+  switchThumbBase,
+  switchTrackBase,
+  switchTrackDisabled,
+  switchTrackFocusVisible,
+  switchVariantChecked,
+  switchVariantFocusRing,
+} from './switch.styles';
+
+describe('switchStylesheet', () => {
+  it('emits :host display:inline-flex', () => {
+    const css = switchStylesheet();
+    expect(css).toMatch(/:host\s*\{[^}]*display:\s*inline-flex/);
+  });
+
+  it('emits .track and .thumb rules', () => {
+    const css = switchStylesheet();
+    expect(css).toMatch(/\.track\s*\{/);
+    expect(css).toMatch(/\.thumb\s*\{/);
+  });
+
+  it('uses --motion-duration-* and --motion-ease-* tokens', () => {
+    const css = switchStylesheet();
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+    expect(css).toContain('var(--motion-duration-base)');
+    expect(css).toContain('var(--motion-ease-standard)');
+  });
+
+  it('track base uses token-driven background-color', () => {
+    const css = switchStylesheet();
+    expect(css).toContain('background-color: var(--color-input)');
+  });
+
+  it('track base is a pill with transparent border', () => {
+    const css = switchStylesheet();
+    expect(css).toContain('border-radius: 9999px');
+    expect(css).toContain('border-color: transparent');
+    expect(css).toContain('border-width: 2px');
+  });
+
+  it('thumb uses token-driven background color', () => {
+    const css = switchStylesheet();
+    expect(css).toContain('background-color: var(--color-background)');
+  });
+
+  it('translates thumb when checked', () => {
+    expect(switchStylesheet({ checked: true })).toMatch(/translateX/);
+  });
+
+  it('emits a checked-state rule that translates the thumb by size translate', () => {
+    const defaultCss = switchStylesheet();
+    const smCss = switchStylesheet({ size: 'sm' });
+    const lgCss = switchStylesheet({ size: 'lg' });
+    expect(defaultCss).toMatch(
+      /\.track\[data-state="checked"\] \.thumb\s*\{[^}]*transform:\s*translateX\(1\.25rem\)/,
+    );
+    expect(smCss).toMatch(
+      /\.track\[data-state="checked"\] \.thumb\s*\{[^}]*transform:\s*translateX\(1rem\)/,
+    );
+    expect(lgCss).toMatch(
+      /\.track\[data-state="checked"\] \.thumb\s*\{[^}]*transform:\s*translateX\(1\.75rem\)/,
+    );
+  });
+
+  it('emits variant-specific checked background-color on the track', () => {
+    expect(switchStylesheet({ variant: 'destructive' })).toMatch(
+      /\.track\[data-state="checked"\]\s*\{[^}]*background-color:\s*var\(--color-destructive\)/,
+    );
+    expect(switchStylesheet({ variant: 'success' })).toMatch(
+      /\.track\[data-state="checked"\]\s*\{[^}]*background-color:\s*var\(--color-success\)/,
+    );
+  });
+
+  it('default variant resolves checked background to color-primary', () => {
+    expect(switchStylesheet()).toMatch(
+      /\.track\[data-state="checked"\]\s*\{[^}]*background-color:\s*var\(--color-primary\)/,
+    );
+  });
+
+  it('switches focus ring token by variant', () => {
+    expect(switchStylesheet({ variant: 'destructive' })).toMatch(
+      /\.track:focus-visible\s*\{[^}]*var\(--color-destructive-ring\)/,
+    );
+    expect(switchStylesheet({ variant: 'warning' })).toMatch(
+      /\.track:focus-visible\s*\{[^}]*var\(--color-warning-ring\)/,
+    );
+  });
+
+  it('default variant uses primary-ring as the focus ring token', () => {
+    expect(switchStylesheet()).toMatch(
+      /\.track:focus-visible\s*\{[^}]*var\(--color-primary-ring\)/,
+    );
+  });
+
+  it('emits disabled rule with cursor and opacity', () => {
+    expect(switchStylesheet()).toMatch(/\.track:disabled\s*\{[^}]*cursor:\s*not-allowed/);
+    expect(switchStylesheet()).toMatch(/\.track:disabled\s*\{[^}]*opacity:\s*0\.5/);
+  });
+
+  it('applies size dimensions per token', () => {
+    const sm = switchStylesheet({ size: 'sm' });
+    const dflt = switchStylesheet();
+    const lg = switchStylesheet({ size: 'lg' });
+    expect(sm).toContain('height: 1.25rem');
+    expect(sm).toContain('width: 2.25rem');
+    expect(dflt).toContain('height: 1.5rem');
+    expect(dflt).toContain('width: 2.75rem');
+    expect(lg).toContain('height: 1.75rem');
+    expect(lg).toContain('width: 3.5rem');
+  });
+
+  it('wraps transitions in prefers-reduced-motion', () => {
+    expect(switchStylesheet()).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)/);
+    expect(switchStylesheet()).toMatch(/transition:\s*none/);
+  });
+
+  it('falls back to default on unknown values', () => {
+    expect(() =>
+      switchStylesheet({ variant: 'nope' as never, size: 'huge' as never }),
+    ).not.toThrow();
+    const css = switchStylesheet({ variant: 'galactic' as never, size: 'enormous' as never });
+    expect(css).toContain('height: 1.5rem');
+    expect(css).toMatch(
+      /\.track\[data-state="checked"\]\s*\{[^}]*background-color:\s*var\(--color-primary\)/,
+    );
+  });
+
+  it('emits no raw hex or rgb color literals for tokens -- only the shadow rgba stays', () => {
+    const css = switchStylesheet({ variant: 'destructive', size: 'lg' });
+    expect(css).not.toMatch(/#[0-9a-f]{3,8}/i);
+    // The thumb box-shadow is a non-token rgba -- that's allowed and isolated.
+    expect(css.match(/rgb\(/g)).toBeNull();
+  });
+
+  describe('exports', () => {
+    it('exposes switchTrackBase as a CSSProperties map with token-driven values', () => {
+      expect(switchTrackBase['background-color']).toBe('var(--color-input)');
+      expect(switchTrackBase['border-color']).toBe('transparent');
+      expect(switchTrackBase['border-radius']).toBe('9999px');
+    });
+
+    it('exposes switchTrackDisabled and switchTrackFocusVisible', () => {
+      expect(switchTrackDisabled.cursor).toBe('not-allowed');
+      expect(switchTrackDisabled.opacity).toBe('0.5');
+      expect(switchTrackFocusVisible.outline).toBe('none');
+      expect(switchTrackFocusVisible['box-shadow']).toContain('var(--color-ring)');
+    });
+
+    it('exposes switchThumbBase with token background and transform transition', () => {
+      expect(switchThumbBase['background-color']).toBe('var(--color-background)');
+      expect(switchThumbBase.transition).toContain('var(--motion-duration-base)');
+      expect(switchThumbBase.transition).toContain('var(--motion-ease-standard)');
+    });
+
+    it('exposes switchVariantChecked for every documented variant', () => {
+      const variants: ReadonlyArray<SwitchVariant> = [
+        'default',
+        'primary',
+        'secondary',
+        'destructive',
+        'success',
+        'warning',
+        'info',
+        'accent',
+      ];
+      for (const v of variants) {
+        expect(switchVariantChecked[v]['background-color']).toContain('var(--color-');
+        expect(switchVariantFocusRing[v]['box-shadow']).toContain('var(--color-');
+      }
+    });
+
+    it('exposes switchSizeStyles for every documented size', () => {
+      const sizes: ReadonlyArray<SwitchSize> = ['sm', 'default', 'lg'];
+      for (const s of sizes) {
+        expect(switchSizeStyles[s].track).toBeDefined();
+        expect(switchSizeStyles[s].thumb).toBeDefined();
+        expect(typeof switchSizeStyles[s].translate).toBe('string');
+      }
+    });
+
+    it('default variant checked aliases color-primary', () => {
+      expect(switchVariantChecked.default['background-color']).toBe('var(--color-primary)');
+      expect(switchVariantFocusRing.default['box-shadow']).toContain('var(--color-primary-ring)');
+    });
+  });
+
+  it('handles every documented variant without throwing', () => {
+    const variants: ReadonlyArray<SwitchVariant> = [
+      'default',
+      'primary',
+      'secondary',
+      'destructive',
+      'success',
+      'warning',
+      'info',
+      'accent',
+    ];
+    for (const variant of variants) {
+      expect(() => switchStylesheet({ variant })).not.toThrow();
+    }
+  });
+
+  it('handles every documented size without throwing', () => {
+    const sizes: ReadonlyArray<SwitchSize> = ['sm', 'default', 'lg'];
+    for (const size of sizes) {
+      expect(() => switchStylesheet({ size })).not.toThrow();
+    }
+  });
+});

--- a/packages/ui/src/components/ui/switch.styles.ts
+++ b/packages/ui/src/components/ui/switch.styles.ts
@@ -1,0 +1,240 @@
+/**
+ * Shadow DOM style definitions for Switch web component
+ *
+ * Parallel to switch.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ *
+ * All token references go through tokenVar() -- no raw CSS custom-property
+ * function literals appear in this module.
+ * Motion uses --motion-duration-* / --motion-ease-* only.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import {
+  atRule,
+  pick,
+  styleRule,
+  stylesheet,
+  tokenVar,
+  transition,
+} from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export type SwitchVariant =
+  | 'default'
+  | 'primary'
+  | 'secondary'
+  | 'destructive'
+  | 'success'
+  | 'warning'
+  | 'info'
+  | 'accent';
+
+export type SwitchSize = 'sm' | 'default' | 'lg';
+
+export interface SwitchStylesheetOptions {
+  variant?: SwitchVariant | undefined;
+  size?: SwitchSize | undefined;
+  checked?: boolean | undefined;
+  disabled?: boolean | undefined;
+}
+
+// ============================================================================
+// Track Styles
+// ============================================================================
+
+export const switchTrackBase: CSSProperties = {
+  display: 'inline-flex',
+  'align-items': 'center',
+  'flex-shrink': '0',
+  'border-radius': '9999px',
+  'border-width': '2px',
+  'border-style': 'solid',
+  'border-color': 'transparent',
+  'background-color': tokenVar('color-input'),
+  cursor: 'pointer',
+  padding: '0',
+  transition: transition(
+    ['background-color'],
+    tokenVar('motion-duration-base'),
+    tokenVar('motion-ease-standard'),
+  ),
+};
+
+export const switchTrackDisabled: CSSProperties = {
+  cursor: 'not-allowed',
+  opacity: '0.5',
+};
+
+export const switchTrackFocusVisible: CSSProperties = {
+  outline: 'none',
+  'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar('color-ring')}`,
+};
+
+// ============================================================================
+// Thumb Styles
+// ============================================================================
+
+export const switchThumbBase: CSSProperties = {
+  'pointer-events': 'none',
+  display: 'block',
+  'border-radius': '9999px',
+  'background-color': tokenVar('color-background'),
+  'box-shadow': '0 1px 2px 0 rgba(0,0,0,0.05)',
+  transition: transition(
+    ['transform'],
+    tokenVar('motion-duration-base'),
+    tokenVar('motion-ease-standard'),
+  ),
+};
+
+// ============================================================================
+// Variant Styles
+// ============================================================================
+
+/**
+ * Per-variant track background color when the switch is in the checked
+ * state. `default` aliases `color-primary`.
+ */
+export const switchVariantChecked: Record<SwitchVariant, CSSProperties> = {
+  default: { 'background-color': tokenVar('color-primary') },
+  primary: { 'background-color': tokenVar('color-primary') },
+  secondary: { 'background-color': tokenVar('color-secondary') },
+  destructive: { 'background-color': tokenVar('color-destructive') },
+  success: { 'background-color': tokenVar('color-success') },
+  warning: { 'background-color': tokenVar('color-warning') },
+  info: { 'background-color': tokenVar('color-info') },
+  accent: { 'background-color': tokenVar('color-accent') },
+};
+
+/**
+ * Per-variant focus ring -- replaces the default `color-ring` token with the
+ * variant-specific ring token. `default` aliases `color-primary-ring`.
+ */
+export const switchVariantFocusRing: Record<SwitchVariant, CSSProperties> = {
+  default: {
+    'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar('color-primary-ring')}`,
+  },
+  primary: {
+    'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar('color-primary-ring')}`,
+  },
+  secondary: {
+    'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar('color-secondary-ring')}`,
+  },
+  destructive: {
+    'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar('color-destructive-ring')}`,
+  },
+  success: {
+    'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar('color-success-ring')}`,
+  },
+  warning: {
+    'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar('color-warning-ring')}`,
+  },
+  info: {
+    'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar('color-info-ring')}`,
+  },
+  accent: {
+    'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar('color-accent-ring')}`,
+  },
+};
+
+// ============================================================================
+// Size Styles
+// ============================================================================
+
+/**
+ * Track/thumb dimensions and translation distance per size.
+ * Translate distance is the thumb's `transform: translateX(...)` value when
+ * the switch is checked; it equals (track width - thumb width - border*2).
+ */
+export const switchSizeStyles: Record<
+  SwitchSize,
+  { track: CSSProperties; thumb: CSSProperties; translate: string }
+> = {
+  sm: {
+    track: { height: '1.25rem', width: '2.25rem' },
+    thumb: { height: '1rem', width: '1rem' },
+    translate: '1rem',
+  },
+  default: {
+    track: { height: '1.5rem', width: '2.75rem' },
+    thumb: { height: '1.25rem', width: '1.25rem' },
+    translate: '1.25rem',
+  },
+  lg: {
+    track: { height: '1.75rem', width: '3.5rem' },
+    thumb: { height: '1.5rem', width: '1.5rem' },
+    translate: '1.75rem',
+  },
+};
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+/**
+ * Build the complete switch stylesheet for a given configuration.
+ *
+ * Composition:
+ *   :host                                  -> display: inline-flex
+ *   .track                                 -> base track + size dimensions
+ *   .track[data-state="checked"]           -> variant background color
+ *   .track:disabled                        -> cursor + opacity
+ *   .track:focus-visible                   -> variant focus ring
+ *   .thumb                                 -> base thumb + size dimensions
+ *   .track[data-state="checked"] .thumb    -> transform: translateX(translate)
+ *   @media reduced-motion                  -> transition: none on track + thumb
+ *
+ * Unknown variant or size silently falls back to 'default'.
+ */
+export function switchStylesheet(options: SwitchStylesheetOptions = {}): string {
+  const { variant = 'default', size = 'default' } = options;
+
+  const safeVariant: SwitchVariant = variant in switchVariantChecked ? variant : 'default';
+  const safeSize: SwitchSize = size in switchSizeStyles ? size : 'default';
+
+  const sizeDef = switchSizeStyles[safeSize];
+  const translate = sizeDef.translate;
+
+  return stylesheet(
+    styleRule(':host', { display: 'inline-flex' }),
+
+    // Base track rule with size dimensions applied.
+    styleRule('.track', switchTrackBase, sizeDef.track),
+
+    // Track variant background color when checked -- emitted as a separate
+    // rule so that the base background color remains visible in the
+    // stylesheet and the variant token takes effect at render time via
+    // cascade keyed off the data-state attribute.
+    styleRule('.track[data-state="checked"]', pick(switchVariantChecked, safeVariant, 'default')),
+
+    // Disabled state on the native button element.
+    styleRule('.track:disabled', switchTrackDisabled),
+
+    // Focus ring -- variant-specific token replaces the default ring.
+    styleRule(
+      '.track:focus-visible',
+      { outline: 'none' },
+      pick(switchVariantFocusRing, safeVariant, 'default'),
+    ),
+
+    // Thumb base + dimensions. The thumb starts at translateX(0); the
+    // checked rule below shifts it by the size-specific translate distance.
+    styleRule('.thumb', switchThumbBase, sizeDef.thumb, { transform: 'translateX(0)' }),
+
+    // Thumb translation when the track is in the checked state.
+    styleRule('.track[data-state="checked"] .thumb', {
+      transform: `translateX(${translate})`,
+    }),
+
+    // Reduced-motion guard: disable transitions on both track and thumb.
+    atRule(
+      '@media (prefers-reduced-motion: reduce)',
+      styleRule('.track', { transition: 'none' }),
+      styleRule('.thumb', { transition: 'none' }),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

Adds a token-driven `<rafters-switch>` Web Component that mirrors the React `Switch` variant/size matrix and participates natively in `<form>` submission via `ElementInternals`.

- `switch.styles.ts` -- `CSSProperties` maps and `switchStylesheet()` composing `:host`, `.track`, `.track[data-state="checked"]`, `.track:disabled`, `.track:focus-visible`, `.thumb`, and the checked-state thumb translate. All token references go through `tokenVar()`; motion uses `--motion-duration-*` / `--motion-ease-*` exclusively, and every transition is guarded by a `prefers-reduced-motion` at-rule.
- `switch.element.ts` -- `RaftersSwitch extends RaftersElement`, declares `static formAssociated = true`, calls `attachInternals()` in the constructor (throwing `TypeError` only when the API is unavailable), observes `[checked, disabled, required, name, value, variant, size]`, renders `<button type="button" role="switch">` + `<span class="thumb" aria-hidden="true">` via `document.createElement`, toggles checked on click and Space (dispatching a composed, bubbling `change` event), submits `name=value` when checked (defaulting `value` to `"on"` per HTML checkbox convention), omits the field when unchecked, and implements the full `formAssociated` / `formReset` / `formDisabled` / `formStateRestore` lifecycle. Auto-registers `<rafters-switch>` on import; the registration is idempotent against double-define.
- `switch.styles.test.ts`, `switch.element.test.ts`, `switch.element.a11y.tsx` -- unit, form-association, and `vitest-axe` accessibility coverage. happy-dom 20 has no `ElementInternals` implementation, so the tests install a tiny polyfill of the surface the element actually consumes plus a `FormData` wrapper that appends values contributed via `setFormValue`, which lets the `new FormData(form).get(name)` contract be exercised end-to-end in the suite.

Closes #1342

## Test plan

- [x] `pnpm --filter=@rafters/ui typecheck`
- [x] `pnpm --filter=@rafters/ui test switch` -- 77/77 passing
- [x] `pnpm preflight` -- typecheck, biome check, test:unit, test:a11y, build all green
- [x] `legion quality-gate record` -- clean (zero findings)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>