### PR TITLE
feat(ui): <rafters-toggle-group> form-associated Web Component (#1344)

### DIFF
--- a/packages/ui/src/components/ui/toggle-group.element.a11y.tsx
+++ b/packages/ui/src/components/ui/toggle-group.element.a11y.tsx
@@ -1,0 +1,259 @@
+/**
+ * Accessibility tests for <rafters-toggle-group> and
+ * <rafters-toggle-group-item>.
+ *
+ * Verifies that the group exposes role="group", individual items reflect
+ * aria-pressed, and axe reports no violations when paired with a
+ * group-labelling aria-label/aria-labelledby. axe-core descends into open
+ * shadow roots automatically.
+ *
+ * Notes:
+ *  - happy-dom 20 ships no ElementInternals implementation. We polyfill
+ *    the surface our element depends on so the constructor can run; see
+ *    toggle-group.element.test.ts for the same polyfill.
+ */
+
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import 'vitest-axe/extend-expect';
+
+interface PolyfilledInternals {
+  _value: string | File | FormData | null;
+  _validity: ValidityState;
+  _validationMessage: string;
+  _host: HTMLElement;
+  setFormValue: (value: string | File | FormData | null) => void;
+  setValidity: (flags: Partial<ValidityState>, message?: string, anchor?: HTMLElement) => void;
+  checkValidity: () => boolean;
+  reportValidity: () => boolean;
+  validity: ValidityState;
+  validationMessage: string;
+  willValidate: boolean;
+  form: HTMLFormElement | null;
+}
+
+type ValidityFlagKey = Exclude<keyof ValidityState, 'valid'>;
+
+const VALIDITY_FLAG_KEYS: ReadonlyArray<ValidityFlagKey> = [
+  'valueMissing',
+  'typeMismatch',
+  'patternMismatch',
+  'tooLong',
+  'tooShort',
+  'rangeUnderflow',
+  'rangeOverflow',
+  'stepMismatch',
+  'badInput',
+  'customError',
+];
+
+function buildValidity(flags: Partial<ValidityState> = {}): ValidityState {
+  const merged: Record<string, boolean> = {
+    valueMissing: false,
+    typeMismatch: false,
+    patternMismatch: false,
+    tooLong: false,
+    tooShort: false,
+    rangeUnderflow: false,
+    rangeOverflow: false,
+    stepMismatch: false,
+    badInput: false,
+    customError: false,
+    valid: true,
+  };
+  let invalid = false;
+  for (const key of VALIDITY_FLAG_KEYS) {
+    const value = flags[key];
+    if (typeof value === 'boolean') {
+      merged[key] = value;
+    }
+    if (merged[key]) invalid = true;
+  }
+  merged.valid = !invalid;
+  return merged as unknown as ValidityState;
+}
+
+function installElementInternalsPolyfill(): void {
+  const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
+  if (typeof proto.attachInternals === 'function') return;
+  proto.attachInternals = function attachInternals(this: HTMLElement): ElementInternals {
+    const internals: PolyfilledInternals = {
+      _value: null,
+      _validity: buildValidity(),
+      _validationMessage: '',
+      _host: this,
+      setFormValue(value) {
+        this._value = value;
+      },
+      setValidity(flags, message = '', _anchor) {
+        this._validity = buildValidity(flags);
+        this._validationMessage = this._validity.valid ? '' : message;
+      },
+      checkValidity() {
+        return this._validity.valid;
+      },
+      reportValidity() {
+        return this._validity.valid;
+      },
+      get validity() {
+        return this._validity;
+      },
+      get validationMessage() {
+        return this._validationMessage;
+      },
+      get willValidate() {
+        return true;
+      },
+      get form() {
+        let parent: Node | null = this._host.parentNode;
+        while (parent) {
+          if (parent instanceof HTMLFormElement) return parent;
+          parent = parent.parentNode;
+        }
+        return null;
+      },
+    };
+    return internals as unknown as ElementInternals;
+  };
+}
+
+beforeAll(async () => {
+  installElementInternalsPolyfill();
+  await import('./toggle-group.element');
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+// React's IntrinsicElements typing does not know about <rafters-toggle-group>.
+// Cast the JSX runtime through a typed helper so tests stay free of `any`.
+type GroupProps = {
+  id?: string;
+  name?: string;
+  type?: 'single' | 'multiple';
+  value?: string;
+  variant?: string;
+  size?: string;
+  orientation?: 'horizontal' | 'vertical';
+  required?: boolean;
+  disabled?: boolean;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+  children?: React.ReactNode;
+};
+
+type ItemProps = {
+  value: string;
+  pressed?: boolean;
+  disabled?: boolean;
+  children?: React.ReactNode;
+};
+
+const GroupJSX = (props: GroupProps): React.ReactElement =>
+  React.createElement('rafters-toggle-group', props);
+
+const ItemJSX = (props: ItemProps): React.ReactElement =>
+  React.createElement('rafters-toggle-group-item', props);
+
+describe('rafters-toggle-group -- accessibility', () => {
+  it('exposes role="group" on the host', () => {
+    const { container } = render(
+      <GroupJSX aria-label="View mode" type="single">
+        <ItemJSX value="grid">Grid</ItemJSX>
+        <ItemJSX value="list">List</ItemJSX>
+      </GroupJSX>,
+    );
+    const host = container.querySelector('rafters-toggle-group');
+    expect(host?.getAttribute('role')).toBe('group');
+  });
+
+  it('reflects orientation via data-orientation', () => {
+    const { container } = render(
+      <GroupJSX aria-label="View mode" type="single" orientation="vertical">
+        <ItemJSX value="grid">Grid</ItemJSX>
+      </GroupJSX>,
+    );
+    const host = container.querySelector('rafters-toggle-group');
+    expect(host?.getAttribute('data-orientation')).toBe('vertical');
+  });
+
+  it('items expose aria-pressed', () => {
+    const { container } = render(
+      <GroupJSX aria-label="Text formatting" type="multiple">
+        <ItemJSX value="bold">Bold</ItemJSX>
+        <ItemJSX value="italic">Italic</ItemJSX>
+      </GroupJSX>,
+    );
+    const item = container.querySelector('rafters-toggle-group-item');
+    const button = item?.shadowRoot?.querySelector('button');
+    expect(button?.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('axe-clean when labelled with aria-label', async () => {
+    const { container } = render(
+      <GroupJSX aria-label="View mode" type="single">
+        <ItemJSX value="grid">Grid</ItemJSX>
+        <ItemJSX value="list">List</ItemJSX>
+      </GroupJSX>,
+    );
+    const results = await axe(container, {
+      rules: {
+        // Form-associated custom elements route identity through the host,
+        // so the axe label rule (which expects a native control) is disabled.
+        label: { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('axe-clean when labelled via aria-labelledby', async () => {
+    const { container } = render(
+      <div>
+        <span id="fmt-label">Text formatting</span>
+        <GroupJSX aria-labelledby="fmt-label" type="multiple">
+          <ItemJSX value="bold">Bold</ItemJSX>
+          <ItemJSX value="italic">Italic</ItemJSX>
+        </GroupJSX>
+      </div>,
+    );
+    const results = await axe(container, {
+      rules: {
+        label: { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('axe-clean for a required group', async () => {
+    const { container } = render(
+      <GroupJSX aria-label="Priority" type="single" required>
+        <ItemJSX value="low">Low</ItemJSX>
+        <ItemJSX value="high">High</ItemJSX>
+      </GroupJSX>,
+    );
+    const results = await axe(container, {
+      rules: {
+        label: { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('disabled items expose disabled to assistive tech via inner button', () => {
+    const { container } = render(
+      <GroupJSX aria-label="View mode" type="single">
+        <ItemJSX value="grid">Grid</ItemJSX>
+        <ItemJSX value="list" disabled>
+          List
+        </ItemJSX>
+      </GroupJSX>,
+    );
+    const items = container.querySelectorAll('rafters-toggle-group-item');
+    const second = items[1];
+    const button = second?.shadowRoot?.querySelector('button');
+    expect(button?.disabled).toBe(true);
+  });
+});

--- a/packages/ui/src/components/ui/toggle-group.element.test.ts
+++ b/packages/ui/src/components/ui/toggle-group.element.test.ts
@@ -1,0 +1,763 @@
+/**
+ * Unit tests for <rafters-toggle-group> and <rafters-toggle-group-item>.
+ *
+ * happy-dom 20 ships no ElementInternals implementation, so this file
+ * installs a minimal polyfill that mirrors the browser surface that
+ * RaftersToggleGroup depends on (setFormValue, setValidity, checkValidity,
+ * reportValidity, validity, validationMessage, willValidate, form).
+ *
+ * To drive the form-submission contract in multiple mode we also patch
+ * FormData so that form-associated custom elements contribute their
+ * non-null form value (string or FormData) under their `name` attribute
+ * -- mirroring the real browser contract. Happy-dom's native FormData only
+ * walks native form control nodes.
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+// ============================================================================
+// Polyfill scaffolding
+// ============================================================================
+
+interface PolyfilledInternals {
+  _value: string | File | FormData | null;
+  _validity: ValidityState;
+  _validationMessage: string;
+  _host: HTMLElement;
+  setFormValue: (value: string | File | FormData | null) => void;
+  setValidity: (flags: Partial<ValidityState>, message?: string, anchor?: HTMLElement) => void;
+  checkValidity: () => boolean;
+  reportValidity: () => boolean;
+  validity: ValidityState;
+  validationMessage: string;
+  willValidate: boolean;
+  form: HTMLFormElement | null;
+}
+
+type ValidityFlagKey = Exclude<keyof ValidityState, 'valid'>;
+
+const VALIDITY_FLAG_KEYS: ReadonlyArray<ValidityFlagKey> = [
+  'valueMissing',
+  'typeMismatch',
+  'patternMismatch',
+  'tooLong',
+  'tooShort',
+  'rangeUnderflow',
+  'rangeOverflow',
+  'stepMismatch',
+  'badInput',
+  'customError',
+];
+
+function buildValidity(flags: Partial<ValidityState> = {}): ValidityState {
+  const merged: Record<string, boolean> = {
+    valueMissing: false,
+    typeMismatch: false,
+    patternMismatch: false,
+    tooLong: false,
+    tooShort: false,
+    rangeUnderflow: false,
+    rangeOverflow: false,
+    stepMismatch: false,
+    badInput: false,
+    customError: false,
+    valid: true,
+  };
+  let invalid = false;
+  for (const key of VALIDITY_FLAG_KEYS) {
+    const value = flags[key];
+    if (typeof value === 'boolean') {
+      merged[key] = value;
+    }
+    if (merged[key]) invalid = true;
+  }
+  merged.valid = !invalid;
+  return merged as unknown as ValidityState;
+}
+
+const FORM_ASSOCIATED_INTERNALS = new WeakMap<HTMLElement, PolyfilledInternals>();
+
+function installElementInternalsPolyfill(): void {
+  const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
+  if (typeof proto.attachInternals === 'function') return;
+  proto.attachInternals = function attachInternals(this: HTMLElement): ElementInternals {
+    const internals: PolyfilledInternals = {
+      _value: null,
+      _validity: buildValidity(),
+      _validationMessage: '',
+      _host: this,
+      setFormValue(value) {
+        this._value = value;
+      },
+      setValidity(flags, message = '', _anchor) {
+        this._validity = buildValidity(flags);
+        this._validationMessage = this._validity.valid ? '' : message;
+      },
+      checkValidity() {
+        return this._validity.valid;
+      },
+      reportValidity() {
+        return this._validity.valid;
+      },
+      get validity() {
+        return this._validity;
+      },
+      get validationMessage() {
+        return this._validationMessage;
+      },
+      get willValidate() {
+        return true;
+      },
+      get form() {
+        let parent: Node | null = this._host.parentNode;
+        while (parent) {
+          if (parent instanceof HTMLFormElement) return parent;
+          parent = parent.parentNode;
+        }
+        return null;
+      },
+    };
+    FORM_ASSOCIATED_INTERNALS.set(this, internals);
+    return internals as unknown as ElementInternals;
+  };
+}
+
+/**
+ * Wrap FormData so form-associated custom elements contribute their
+ * non-null form value under their `name` attribute. If the value is a
+ * FormData instance we copy each entry; strings contribute a single entry.
+ */
+function installFormDataPolyfill(): void {
+  const Original = globalThis.FormData;
+  if ((Original as unknown as { __raftersPatched?: boolean }).__raftersPatched) return;
+  const Patched = function PatchedFormData(
+    this: FormData,
+    form?: HTMLFormElement,
+    submitter?: HTMLElement,
+  ): FormData {
+    const instance =
+      submitter !== undefined
+        ? new Original(form, submitter as HTMLElement & { form: HTMLFormElement })
+        : form !== undefined
+          ? new Original(form)
+          : new Original();
+    if (form) {
+      for (const node of Array.from(form.querySelectorAll('*'))) {
+        if (!(node instanceof HTMLElement)) continue;
+        const internals = FORM_ASSOCIATED_INTERNALS.get(node);
+        if (!internals) continue;
+        const name = node.getAttribute('name');
+        if (!name) continue;
+        const value = internals._value;
+        if (value === null || value === undefined) continue;
+        if (typeof value === 'string') {
+          instance.append(name, value);
+        } else if (value instanceof FormData) {
+          for (const [entryKey, entryValue] of value.entries()) {
+            // FormData from setFormValue uses the element's name as its key.
+            // We respect whatever keys the element chose when writing.
+            instance.append(entryKey || name, entryValue);
+          }
+        }
+      }
+    }
+    return instance;
+  } as unknown as typeof FormData;
+  (Patched as unknown as { __raftersPatched?: boolean }).__raftersPatched = true;
+  Patched.prototype = Original.prototype;
+  globalThis.FormData = Patched;
+}
+
+beforeAll(async () => {
+  installElementInternalsPolyfill();
+  installFormDataPolyfill();
+  await import('./toggle-group.element');
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+async function loadElements(): Promise<{
+  RaftersToggleGroup: typeof import('./toggle-group.element').RaftersToggleGroup;
+  RaftersToggleGroupItem: typeof import('./toggle-group.element').RaftersToggleGroupItem;
+}> {
+  const mod = await import('./toggle-group.element');
+  return {
+    RaftersToggleGroup: mod.RaftersToggleGroup,
+    RaftersToggleGroupItem: mod.RaftersToggleGroupItem,
+  };
+}
+
+function buildGroup(
+  attrs: Record<string, string> = {},
+): import('./toggle-group.element').RaftersToggleGroup {
+  const group = document.createElement(
+    'rafters-toggle-group',
+  ) as import('./toggle-group.element').RaftersToggleGroup;
+  for (const [k, v] of Object.entries(attrs)) group.setAttribute(k, v);
+  return group;
+}
+
+function buildItem(
+  attrs: Record<string, string> = {},
+): import('./toggle-group.element').RaftersToggleGroupItem {
+  const item = document.createElement(
+    'rafters-toggle-group-item',
+  ) as import('./toggle-group.element').RaftersToggleGroupItem;
+  for (const [k, v] of Object.entries(attrs)) item.setAttribute(k, v);
+  return item;
+}
+
+function innerButton(item: Element): HTMLButtonElement | null {
+  const btn = item.shadowRoot?.querySelector('button') ?? null;
+  return btn instanceof HTMLButtonElement ? btn : null;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('rafters-toggle-group registration', () => {
+  it('registers both custom elements', async () => {
+    const { RaftersToggleGroup, RaftersToggleGroupItem } = await loadElements();
+    expect(customElements.get('rafters-toggle-group')).toBe(RaftersToggleGroup);
+    expect(customElements.get('rafters-toggle-group-item')).toBe(RaftersToggleGroupItem);
+  });
+
+  it('registers idempotently on repeated imports', async () => {
+    const { RaftersToggleGroup, RaftersToggleGroupItem } = await loadElements();
+    await import('./toggle-group.element');
+    expect(customElements.get('rafters-toggle-group')).toBe(RaftersToggleGroup);
+    expect(customElements.get('rafters-toggle-group-item')).toBe(RaftersToggleGroupItem);
+  });
+
+  it('declares formAssociated on the group', async () => {
+    const { RaftersToggleGroup } = await loadElements();
+    expect(RaftersToggleGroup.formAssociated).toBe(true);
+  });
+
+  it('declares the documented observedAttributes on the group', async () => {
+    const { RaftersToggleGroup } = await loadElements();
+    expect(RaftersToggleGroup.observedAttributes).toEqual([
+      'type',
+      'value',
+      'disabled',
+      'required',
+      'name',
+      'variant',
+      'size',
+      'orientation',
+    ]);
+  });
+
+  it('declares the documented observedAttributes on the item', async () => {
+    const { RaftersToggleGroupItem } = await loadElements();
+    expect(RaftersToggleGroupItem.observedAttributes).toEqual(['value', 'pressed', 'disabled']);
+  });
+});
+
+describe('rafters-toggle-group DOM + stylesheet', () => {
+  it('applies role="group" and data-orientation to the host', async () => {
+    await loadElements();
+    const group = buildGroup();
+    document.body.append(group);
+    expect(group.getAttribute('role')).toBe('group');
+    expect(group.getAttribute('data-orientation')).toBe('horizontal');
+  });
+
+  it('reflects vertical orientation on data-orientation', async () => {
+    await loadElements();
+    const group = buildGroup({ orientation: 'vertical' });
+    document.body.append(group);
+    expect(group.getAttribute('data-orientation')).toBe('vertical');
+  });
+
+  it('renders a .group wrapper with a default <slot>', async () => {
+    await loadElements();
+    const group = buildGroup();
+    document.body.append(group);
+    const wrapper = group.shadowRoot?.querySelector('.group');
+    expect(wrapper).toBeTruthy();
+    expect(wrapper?.querySelector('slot')).toBeTruthy();
+  });
+
+  it('adopts a per-instance CSSStyleSheet on the shadow root', async () => {
+    await loadElements();
+    const group = buildGroup();
+    document.body.append(group);
+    const sheets = group.shadowRoot?.adoptedStyleSheets ?? [];
+    const text = sheets
+      .map((sheet) =>
+        Array.from(sheet.cssRules)
+          .map((rule) => rule.cssText)
+          .join('\n'),
+      )
+      .join('\n');
+    expect(text).toContain('var(--radius-lg)');
+  });
+
+  it('rebuilds the stylesheet when variant changes', async () => {
+    await loadElements();
+    const group = buildGroup({ variant: 'default' });
+    document.body.append(group);
+    const collect = (): string => {
+      const sheets = group.shadowRoot?.adoptedStyleSheets ?? [];
+      return sheets
+        .map((sheet) =>
+          Array.from(sheet.cssRules)
+            .map((rule) => rule.cssText)
+            .join('\n'),
+        )
+        .join('\n');
+    };
+    expect(collect()).toContain('var(--color-muted)');
+    group.setAttribute('variant', 'outline');
+    expect(collect()).not.toContain('var(--color-muted)');
+  });
+});
+
+describe('rafters-toggle-group-item DOM + stylesheet', () => {
+  it('renders a <button class="item"> in the shadow root', async () => {
+    await loadElements();
+    const item = buildItem({ value: 'a' });
+    document.body.append(item);
+    const button = innerButton(item);
+    expect(button).toBeTruthy();
+    expect(button?.classList.contains('item')).toBe(true);
+    expect(button?.getAttribute('type')).toBe('button');
+  });
+
+  it('reflects pressed state via aria-pressed and data-state', async () => {
+    await loadElements();
+    const item = buildItem({ value: 'a' });
+    document.body.append(item);
+    const button = innerButton(item);
+    expect(button?.getAttribute('aria-pressed')).toBe('false');
+    expect(button?.getAttribute('data-state')).toBe('off');
+    item.setAttribute('pressed', '');
+    expect(button?.getAttribute('aria-pressed')).toBe('true');
+    expect(button?.getAttribute('data-state')).toBe('on');
+  });
+
+  it('disables the inner button when host is disabled', async () => {
+    await loadElements();
+    const item = buildItem({ value: 'a', disabled: '' });
+    document.body.append(item);
+    expect(innerButton(item)?.disabled).toBe(true);
+  });
+
+  it('adopts a per-instance stylesheet with font-size token', async () => {
+    await loadElements();
+    const item = buildItem({ value: 'a' });
+    document.body.append(item);
+    const sheets = item.shadowRoot?.adoptedStyleSheets ?? [];
+    const text = sheets
+      .map((sheet) =>
+        Array.from(sheet.cssRules)
+          .map((rule) => rule.cssText)
+          .join('\n'),
+      )
+      .join('\n');
+    expect(text).toContain('var(--font-size-label-large)');
+    expect(text).toContain('var(--motion-duration-base)');
+    expect(text).toContain('var(--motion-ease-standard)');
+  });
+});
+
+describe('rafters-toggle-group single-mode selection', () => {
+  it('single mode sets value to clicked item and toggles off on second click', async () => {
+    await loadElements();
+    const group = buildGroup({ type: 'single' });
+    const a = buildItem({ value: 'a' });
+    group.append(a);
+    document.body.append(group);
+    innerButton(a)?.click();
+    expect(group.value).toBe('a');
+    innerButton(a)?.click();
+    expect(group.value).toBe('');
+  });
+
+  it('single mode swaps selection between items', async () => {
+    await loadElements();
+    const group = buildGroup({ type: 'single' });
+    const a = buildItem({ value: 'a' });
+    const b = buildItem({ value: 'b' });
+    group.append(a, b);
+    document.body.append(group);
+    innerButton(a)?.click();
+    expect(group.value).toBe('a');
+    innerButton(b)?.click();
+    expect(group.value).toBe('b');
+    expect(a.pressed).toBe(false);
+    expect(b.pressed).toBe(true);
+  });
+
+  it('ignores clicks on disabled items', async () => {
+    await loadElements();
+    const group = buildGroup({ type: 'single' });
+    const a = buildItem({ value: 'a', disabled: '' });
+    group.append(a);
+    document.body.append(group);
+    innerButton(a)?.click();
+    expect(group.value).toBe('');
+  });
+
+  it('defaults to single when type attribute is missing', async () => {
+    await loadElements();
+    const group = buildGroup();
+    document.body.append(group);
+    expect(group.type).toBe('single');
+  });
+
+  it('falls back to single on unknown type', async () => {
+    await loadElements();
+    const group = buildGroup({ type: 'weird' });
+    document.body.append(group);
+    expect(group.type).toBe('single');
+  });
+});
+
+describe('rafters-toggle-group multiple-mode selection', () => {
+  it('multiple mode toggles item presence', async () => {
+    await loadElements();
+    const group = buildGroup({ type: 'multiple' });
+    const a = buildItem({ value: 'a' });
+    const b = buildItem({ value: 'b' });
+    group.append(a, b);
+    document.body.append(group);
+    innerButton(a)?.click();
+    innerButton(b)?.click();
+    expect(group.value).toContain('a');
+    expect(group.value).toContain('b');
+    innerButton(a)?.click();
+    expect(group.value).not.toContain('a');
+    expect(group.value).toContain('b');
+  });
+
+  it('multiple mode CSV reflects insertion order', async () => {
+    await loadElements();
+    const group = buildGroup({ type: 'multiple' });
+    const a = buildItem({ value: 'bold' });
+    const b = buildItem({ value: 'italic' });
+    group.append(a, b);
+    document.body.append(group);
+    innerButton(b)?.click();
+    innerButton(a)?.click();
+    expect(group.value).toBe('italic,bold');
+  });
+
+  it('multiple mode updates pressed attribute on items', async () => {
+    await loadElements();
+    const group = buildGroup({ type: 'multiple' });
+    const a = buildItem({ value: 'a' });
+    const b = buildItem({ value: 'b' });
+    group.append(a, b);
+    document.body.append(group);
+    innerButton(a)?.click();
+    expect(a.pressed).toBe(true);
+    expect(b.pressed).toBe(false);
+    innerButton(b)?.click();
+    expect(a.pressed).toBe(true);
+    expect(b.pressed).toBe(true);
+  });
+});
+
+describe('rafters-toggle-group events', () => {
+  it('dispatches change and input events on value change', async () => {
+    await loadElements();
+    const group = buildGroup({ type: 'single' });
+    const a = buildItem({ value: 'a' });
+    group.append(a);
+    document.body.append(group);
+    let changes = 0;
+    let inputs = 0;
+    group.addEventListener('change', () => {
+      changes++;
+    });
+    group.addEventListener('input', () => {
+      inputs++;
+    });
+    innerButton(a)?.click();
+    expect(changes).toBe(1);
+    expect(inputs).toBe(1);
+  });
+
+  it('dispatches rafters-toggle-group-change custom event with detail', async () => {
+    await loadElements();
+    const group = buildGroup({ type: 'single' });
+    const a = buildItem({ value: 'hello' });
+    group.append(a);
+    document.body.append(group);
+    let detail: { value: string; type: string } | null = null;
+    group.addEventListener('rafters-toggle-group-change', (event: Event) => {
+      if (event instanceof CustomEvent) {
+        detail = event.detail as { value: string; type: string };
+      }
+    });
+    innerButton(a)?.click();
+    expect(detail).toEqual({ value: 'hello', type: 'single' });
+  });
+});
+
+describe('rafters-toggle-group form submission', () => {
+  it('submits a single value in single mode', async () => {
+    await loadElements();
+    const form = document.createElement('form');
+    const group = buildGroup({ type: 'single', name: 'view' });
+    const a = buildItem({ value: 'grid' });
+    group.append(a);
+    form.append(group);
+    document.body.append(form);
+    innerButton(a)?.click();
+    expect(new FormData(form).get('view')).toBe('grid');
+  });
+
+  it('submits all selected values in multiple mode via getAll', async () => {
+    await loadElements();
+    const form = document.createElement('form');
+    const group = buildGroup({ type: 'multiple', name: 'tools' });
+    const a = buildItem({ value: 'bold' });
+    const b = buildItem({ value: 'italic' });
+    group.append(a, b);
+    form.append(group);
+    document.body.append(form);
+    innerButton(a)?.click();
+    innerButton(b)?.click();
+    const data = new FormData(form);
+    expect(data.getAll('tools')).toEqual(['bold', 'italic']);
+  });
+
+  it('omits unnamed groups from FormData', async () => {
+    await loadElements();
+    const form = document.createElement('form');
+    const group = buildGroup({ type: 'single' });
+    const a = buildItem({ value: 'grid' });
+    group.append(a);
+    form.append(group);
+    document.body.append(form);
+    innerButton(a)?.click();
+    expect(new FormData(form).get('view')).toBeNull();
+  });
+});
+
+describe('rafters-toggle-group validity', () => {
+  it('reports valueMissing when required and empty', async () => {
+    await loadElements();
+    const group = buildGroup();
+    group.setAttribute('required', '');
+    document.body.append(group);
+    expect(group.checkValidity()).toBe(false);
+    expect(group.validity.valueMissing).toBe(true);
+  });
+
+  it('clears valueMissing once a value is selected', async () => {
+    await loadElements();
+    const group = buildGroup({ type: 'single' });
+    group.setAttribute('required', '');
+    const a = buildItem({ value: 'a' });
+    group.append(a);
+    document.body.append(group);
+    innerButton(a)?.click();
+    expect(group.checkValidity()).toBe(true);
+    expect(group.validity.valueMissing).toBe(false);
+  });
+
+  it('exposes willValidate, checkValidity, reportValidity, validationMessage', async () => {
+    await loadElements();
+    const group = buildGroup();
+    document.body.append(group);
+    expect(group.willValidate).toBe(true);
+    expect(typeof group.checkValidity).toBe('function');
+    expect(typeof group.reportValidity).toBe('function');
+    expect(typeof group.validationMessage).toBe('string');
+  });
+
+  it('setCustomValidity records a custom error', async () => {
+    await loadElements();
+    const group = buildGroup();
+    document.body.append(group);
+    group.setCustomValidity('nope');
+    expect(group.checkValidity()).toBe(false);
+    expect(group.validity.customError).toBe(true);
+  });
+});
+
+describe('rafters-toggle-group form lifecycle', () => {
+  it('formResetCallback restores initial value attribute', async () => {
+    await loadElements();
+    const form = document.createElement('form');
+    const group = buildGroup({ type: 'single', value: 'init' });
+    form.append(group);
+    document.body.append(form);
+    group.value = 'changed';
+    group.formResetCallback();
+    expect(group.value).toBe('init');
+  });
+
+  it('formResetCallback resets multi-mode groups too', async () => {
+    await loadElements();
+    const form = document.createElement('form');
+    const group = buildGroup({ type: 'multiple', value: 'a,b' });
+    const a = buildItem({ value: 'a' });
+    const b = buildItem({ value: 'b' });
+    group.append(a, b);
+    form.append(group);
+    document.body.append(form);
+    group.value = 'a';
+    group.formResetCallback();
+    expect(group.value).toBe('a,b');
+  });
+
+  it('formDisabledCallback propagates disabled to items', async () => {
+    await loadElements();
+    const group = buildGroup();
+    const a = buildItem({ value: 'a' });
+    group.append(a);
+    document.body.append(group);
+    group.formDisabledCallback(true);
+    expect(a.hasAttribute('data-group-disabled')).toBe(true);
+    expect(innerButton(a)?.disabled).toBe(true);
+    group.formDisabledCallback(false);
+    expect(a.hasAttribute('data-group-disabled')).toBe(false);
+  });
+
+  it('formStateRestoreCallback assigns value from string state', async () => {
+    await loadElements();
+    const group = buildGroup({ type: 'single' });
+    document.body.append(group);
+    group.formStateRestoreCallback('a', 'restore');
+    expect(group.value).toBe('a');
+    group.formStateRestoreCallback(null, 'restore');
+    expect(group.value).toBe('');
+  });
+});
+
+describe('rafters-toggle-group keyboard navigation', () => {
+  it('ArrowRight moves focus to the next item when horizontal', async () => {
+    await loadElements();
+    const group = buildGroup({ orientation: 'horizontal' });
+    const a = buildItem({ value: 'a' });
+    const b = buildItem({ value: 'b' });
+    group.append(a, b);
+    document.body.append(group);
+    a.focus();
+    group.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(document.activeElement).toBe(b);
+  });
+
+  it('ArrowDown moves focus when vertical', async () => {
+    await loadElements();
+    const group = buildGroup({ orientation: 'vertical' });
+    const a = buildItem({ value: 'a' });
+    const b = buildItem({ value: 'b' });
+    group.append(a, b);
+    document.body.append(group);
+    a.focus();
+    group.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    expect(document.activeElement).toBe(b);
+  });
+
+  it('ArrowLeft loops to the last item when at the first', async () => {
+    await loadElements();
+    const group = buildGroup();
+    const a = buildItem({ value: 'a' });
+    const b = buildItem({ value: 'b' });
+    group.append(a, b);
+    document.body.append(group);
+    a.focus();
+    group.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    expect(document.activeElement).toBe(b);
+  });
+
+  it('Space toggles the focused item', async () => {
+    await loadElements();
+    const group = buildGroup({ type: 'single' });
+    const a = buildItem({ value: 'a' });
+    group.append(a);
+    document.body.append(group);
+    a.focus();
+    group.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    expect(group.value).toBe('a');
+  });
+
+  it('Enter toggles the focused item', async () => {
+    await loadElements();
+    const group = buildGroup({ type: 'single' });
+    const a = buildItem({ value: 'a' });
+    group.append(a);
+    document.body.append(group);
+    a.focus();
+    group.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(group.value).toBe('a');
+  });
+
+  it('skips disabled items during arrow navigation', async () => {
+    await loadElements();
+    const group = buildGroup();
+    const a = buildItem({ value: 'a' });
+    const b = buildItem({ value: 'b', disabled: '' });
+    const c = buildItem({ value: 'c' });
+    group.append(a, b, c);
+    document.body.append(group);
+    a.focus();
+    group.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(document.activeElement).toBe(c);
+  });
+});
+
+describe('rafters-toggle-group property surface', () => {
+  it('property setters reflect to attributes', async () => {
+    await loadElements();
+    const group = buildGroup();
+    document.body.append(group);
+    group.type = 'multiple';
+    expect(group.getAttribute('type')).toBe('multiple');
+    group.value = 'a,b';
+    expect(group.getAttribute('value')).toBe('a,b');
+    group.name = 'tools';
+    expect(group.getAttribute('name')).toBe('tools');
+    group.disabled = true;
+    expect(group.hasAttribute('disabled')).toBe(true);
+    group.disabled = false;
+    expect(group.hasAttribute('disabled')).toBe(false);
+    group.required = true;
+    expect(group.hasAttribute('required')).toBe(true);
+    group.variant = 'outline';
+    expect(group.getAttribute('variant')).toBe('outline');
+    group.size = 'lg';
+    expect(group.getAttribute('size')).toBe('lg');
+    group.orientation = 'vertical';
+    expect(group.getAttribute('orientation')).toBe('vertical');
+  });
+
+  it('item property setters reflect to attributes', async () => {
+    await loadElements();
+    const item = buildItem();
+    document.body.append(item);
+    item.value = 'x';
+    expect(item.getAttribute('value')).toBe('x');
+    item.pressed = true;
+    expect(item.hasAttribute('pressed')).toBe(true);
+    item.pressed = false;
+    expect(item.hasAttribute('pressed')).toBe(false);
+    item.disabled = true;
+    expect(item.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('exposes the ElementInternals instance on the group', async () => {
+    await loadElements();
+    const group = buildGroup();
+    document.body.append(group);
+    expect(group.internals).toBeDefined();
+  });
+
+  it('falls back to default on unknown variant/size/orientation', async () => {
+    await loadElements();
+    const group = buildGroup({ variant: 'neon', size: 'huge', orientation: 'diagonal' });
+    expect(() => document.body.append(group)).not.toThrow();
+    expect(group.variant).toBe('default');
+    expect(group.size).toBe('default');
+    expect(group.orientation).toBe('horizontal');
+  });
+});

--- a/packages/ui/src/components/ui/toggle-group.element.ts
+++ b/packages/ui/src/components/ui/toggle-group.element.ts
@@ -1,0 +1,746 @@
+/**
+ * <rafters-toggle-group> and <rafters-toggle-group-item> --
+ * Form-associated Web Component pair for grouped toggle selections.
+ *
+ * Mirrors the semantics of toggle-group.tsx (type, variant, size, pressed)
+ * using shadow-DOM-scoped CSS composed via classy-wc. Auto-registers on
+ * import and is idempotent against double-define.
+ *
+ * The group (`<rafters-toggle-group>`) owns form submission via
+ * ElementInternals. Individual items (`<rafters-toggle-group-item>`) are
+ * not form-associated -- they bubble clicks to the group, which updates
+ * its `value` attribute and calls `setFormValue` appropriately.
+ *
+ * Attributes (group):
+ *  - type:        'single' | 'multiple' (default 'single'; unknown -> 'single')
+ *  - value:       string (single: the selected item's value; multiple: CSV)
+ *  - disabled:    boolean (presence-based)
+ *  - required:    boolean (presence-based)
+ *  - name:        string (form field name)
+ *  - variant:     ToggleGroupVariant (default 'default')
+ *  - size:        ToggleGroupSize    (default 'default')
+ *  - orientation: ToggleGroupOrientation (default 'horizontal')
+ *
+ * Attributes (item):
+ *  - value:    string (identifies this item within its group)
+ *  - pressed:  boolean (presence-based; mirrors to aria-pressed + data-state)
+ *  - disabled: boolean (presence-based)
+ *
+ * Keyboard (roving focus on the group):
+ *  - ArrowRight/ArrowDown moves focus to the next enabled item (loops).
+ *  - ArrowLeft/ArrowUp moves to the previous enabled item (loops).
+ *  - Space/Enter toggles the focused item (via native button click synthesis).
+ *
+ * No raw CSS custom-property literals here -- all token references live in
+ * toggle-group.styles.ts and resolve through tokenVar().
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import {
+  type ToggleGroupOrientation,
+  type ToggleGroupSize,
+  type ToggleGroupVariant,
+  toggleGroupItemSizeStyles,
+  toggleGroupItemStylesheet,
+  toggleGroupItemVariantStyles,
+  toggleGroupStylesheet,
+} from './toggle-group.styles';
+
+// ============================================================================
+// Public types
+// ============================================================================
+
+export type ToggleGroupType = 'single' | 'multiple';
+
+// ============================================================================
+// Sanitization helpers
+// ============================================================================
+
+const GROUP_OBSERVED_ATTRIBUTES: ReadonlyArray<string> = [
+  'type',
+  'value',
+  'disabled',
+  'required',
+  'name',
+  'variant',
+  'size',
+  'orientation',
+] as const;
+
+const ITEM_OBSERVED_ATTRIBUTES: ReadonlyArray<string> = ['value', 'pressed', 'disabled'] as const;
+
+function parseType(value: string | null): ToggleGroupType {
+  return value === 'multiple' ? 'multiple' : 'single';
+}
+
+function parseVariant(value: string | null): ToggleGroupVariant {
+  if (value && value in toggleGroupItemVariantStyles) {
+    return value as ToggleGroupVariant;
+  }
+  return 'default';
+}
+
+function parseSize(value: string | null): ToggleGroupSize {
+  if (value && value in toggleGroupItemSizeStyles) {
+    return value as ToggleGroupSize;
+  }
+  return 'default';
+}
+
+function parseOrientation(value: string | null): ToggleGroupOrientation {
+  return value === 'vertical' ? 'vertical' : 'horizontal';
+}
+
+function splitCsv(value: string): string[] {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+interface ElementInternalsHost {
+  attachInternals?: () => ElementInternals;
+}
+
+// ============================================================================
+// Group component
+// ============================================================================
+
+/**
+ * Form-associated Web Component backing `<rafters-toggle-group>`.
+ */
+export class RaftersToggleGroup extends RaftersElement {
+  static formAssociated = true;
+  static observedAttributes: ReadonlyArray<string> = GROUP_OBSERVED_ATTRIBUTES;
+
+  private _internals: ElementInternals;
+  private _instanceSheet: CSSStyleSheet | null = null;
+  private _initialValue: string;
+  private _onItemClick: (event: Event) => void;
+  private _onKeyDown: (event: KeyboardEvent) => void;
+
+  constructor() {
+    super();
+    const host = this as unknown as ElementInternalsHost;
+    if (typeof host.attachInternals !== 'function') {
+      throw new TypeError('rafters-toggle-group requires ElementInternals support');
+    }
+    this._internals = host.attachInternals();
+    this._initialValue = this.getAttribute('value') ?? '';
+    this._onItemClick = (event: Event) => this.handleItemClick(event);
+    this._onKeyDown = (event: KeyboardEvent) => this.handleKeyDown(event);
+  }
+
+  // ==========================================================================
+  // Lifecycle
+  // ==========================================================================
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    if (!this.shadowRoot) return;
+
+    this._initialValue = this.getAttribute('value') ?? '';
+
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+
+    const existing = this.shadowRoot.adoptedStyleSheets;
+    this.shadowRoot.adoptedStyleSheets = [...existing, this._instanceSheet];
+
+    this.applyHostAttributes();
+    this.attachListeners();
+    this.syncItems();
+    this.syncFormValue();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+
+    if ((name === 'variant' || name === 'orientation') && this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+
+    if (name === 'orientation') {
+      this.applyHostAttributes();
+    }
+
+    if (name === 'type' || name === 'value') {
+      this.syncItems();
+      this.syncFormValue();
+    }
+
+    if (name === 'required' || name === 'name') {
+      this.syncFormValue();
+    }
+
+    if (name === 'disabled') {
+      this.propagateDisabled(this.hasAttribute('disabled'));
+    }
+
+    if (name === 'variant' || name === 'size') {
+      // Propagate inherited attributes to child items so their per-instance
+      // stylesheets refresh.
+      this.syncItemsStyle();
+    }
+  }
+
+  override disconnectedCallback(): void {
+    this.detachListeners();
+    this._instanceSheet = null;
+  }
+
+  // ==========================================================================
+  // Render
+  // ==========================================================================
+
+  override render(): Node {
+    this.detachListeners();
+    const group = document.createElement('div');
+    group.className = 'group';
+    const slot = document.createElement('slot');
+    group.appendChild(slot);
+    this.applyHostAttributes();
+    return group;
+  }
+
+  private applyHostAttributes(): void {
+    const orientation = parseOrientation(this.getAttribute('orientation'));
+    this.setAttribute('role', 'group');
+    this.setAttribute('data-orientation', orientation);
+  }
+
+  private composeCss(): string {
+    return toggleGroupStylesheet({
+      variant: parseVariant(this.getAttribute('variant')),
+      orientation: parseOrientation(this.getAttribute('orientation')),
+    });
+  }
+
+  // ==========================================================================
+  // Listeners
+  // ==========================================================================
+
+  private attachListeners(): void {
+    this.addEventListener('click', this._onItemClick);
+    this.addEventListener('keydown', this._onKeyDown);
+  }
+
+  private detachListeners(): void {
+    this.removeEventListener('click', this._onItemClick);
+    this.removeEventListener('keydown', this._onKeyDown);
+  }
+
+  // ==========================================================================
+  // Interaction
+  // ==========================================================================
+
+  private handleItemClick(event: Event): void {
+    const target = this.resolveItemFromEvent(event);
+    if (!target) return;
+    if (target.hasAttribute('disabled') || this.hasAttribute('disabled')) return;
+    const value = target.getAttribute('value') ?? '';
+    this.toggleItemValue(value);
+  }
+
+  private handleKeyDown(event: KeyboardEvent): void {
+    const orientation = parseOrientation(this.getAttribute('orientation'));
+    const key = event.key;
+
+    const horizontalKeys = new Set(['ArrowRight', 'ArrowLeft']);
+    const verticalKeys = new Set(['ArrowDown', 'ArrowUp']);
+    const allNavKeys = new Set([...horizontalKeys, ...verticalKeys, 'Home', 'End']);
+
+    if (key === ' ' || key === 'Enter') {
+      const focused = this.resolveFocusedItem();
+      if (!focused) return;
+      if (focused.hasAttribute('disabled') || this.hasAttribute('disabled')) return;
+      event.preventDefault();
+      const value = focused.getAttribute('value') ?? '';
+      this.toggleItemValue(value);
+      return;
+    }
+
+    if (!allNavKeys.has(key)) return;
+
+    if (orientation === 'horizontal' && verticalKeys.has(key)) return;
+    if (orientation === 'vertical' && horizontalKeys.has(key)) return;
+
+    const items = this.getEnabledItems();
+    if (items.length === 0) return;
+
+    event.preventDefault();
+
+    const current = this.resolveFocusedItem();
+    const currentIndex = current ? items.indexOf(current) : -1;
+
+    let nextIndex = currentIndex;
+    if (key === 'Home') {
+      nextIndex = 0;
+    } else if (key === 'End') {
+      nextIndex = items.length - 1;
+    } else if (key === 'ArrowRight' || key === 'ArrowDown') {
+      nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % items.length;
+    } else if (key === 'ArrowLeft' || key === 'ArrowUp') {
+      nextIndex =
+        currentIndex < 0 ? items.length - 1 : (currentIndex - 1 + items.length) % items.length;
+    }
+
+    const next = items[nextIndex];
+    if (!next) return;
+    next.focus();
+  }
+
+  // ==========================================================================
+  // State
+  // ==========================================================================
+
+  private toggleItemValue(itemValue: string): void {
+    if (!itemValue) return;
+    const type = parseType(this.getAttribute('type'));
+    const current = this.getAttribute('value') ?? '';
+    let nextValue: string;
+
+    if (type === 'single') {
+      nextValue = current === itemValue ? '' : itemValue;
+    } else {
+      const list = splitCsv(current);
+      const index = list.indexOf(itemValue);
+      if (index === -1) {
+        list.push(itemValue);
+      } else {
+        list.splice(index, 1);
+      }
+      nextValue = list.join(',');
+    }
+
+    if (nextValue === current) return;
+
+    this.setAttribute('value', nextValue);
+    // attributeChangedCallback handles sync + events below, but we still want
+    // a single change+input dispatch per user interaction.
+    this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+    this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+    this.dispatchEvent(
+      new CustomEvent('rafters-toggle-group-change', {
+        bubbles: true,
+        composed: true,
+        detail: { value: nextValue, type },
+      }),
+    );
+  }
+
+  private syncItems(): void {
+    const type = parseType(this.getAttribute('type'));
+    const current = this.getAttribute('value') ?? '';
+    const selected =
+      type === 'single' ? new Set([current].filter(Boolean)) : new Set(splitCsv(current));
+
+    for (const item of this.getAllItems()) {
+      const itemValue = item.getAttribute('value') ?? '';
+      const pressed = selected.has(itemValue);
+      if (pressed) {
+        item.setAttribute('pressed', '');
+      } else {
+        item.removeAttribute('pressed');
+      }
+    }
+  }
+
+  private syncItemsStyle(): void {
+    // Child items observe group variant/size at connect time; when the
+    // group's variant/size changes after connect, notify each item so it
+    // can rebuild its stylesheet.
+    for (const item of this.getAllItems()) {
+      if (item instanceof RaftersToggleGroupItem) {
+        item.refreshFromGroup();
+      }
+    }
+  }
+
+  private propagateDisabled(disabled: boolean): void {
+    for (const item of this.getAllItems()) {
+      if (disabled) {
+        item.setAttribute('data-group-disabled', '');
+      } else {
+        item.removeAttribute('data-group-disabled');
+      }
+      if (item instanceof RaftersToggleGroupItem) {
+        item.refreshFromGroup();
+      }
+    }
+  }
+
+  private syncFormValue(): void {
+    const name = this.getAttribute('name') ?? '';
+    const type = parseType(this.getAttribute('type'));
+    const current = this.getAttribute('value') ?? '';
+
+    if (type === 'multiple') {
+      if (name) {
+        const formData = new FormData();
+        for (const entry of splitCsv(current)) {
+          formData.append(name, entry);
+        }
+        this._internals.setFormValue(formData);
+      } else {
+        this._internals.setFormValue(current);
+      }
+    } else {
+      this._internals.setFormValue(current);
+    }
+
+    const required = this.hasAttribute('required');
+    const empty = current.length === 0 || (type === 'multiple' && splitCsv(current).length === 0);
+    if (required && empty) {
+      this._internals.setValidity({ valueMissing: true }, 'Please select at least one option.');
+    } else {
+      this._internals.setValidity({});
+    }
+  }
+
+  // ==========================================================================
+  // DOM lookup helpers
+  // ==========================================================================
+
+  private getAllItems(): HTMLElement[] {
+    const nodes = this.querySelectorAll('rafters-toggle-group-item');
+    const result: HTMLElement[] = [];
+    for (const node of Array.from(nodes)) {
+      if (node instanceof HTMLElement) result.push(node);
+    }
+    return result;
+  }
+
+  private getEnabledItems(): HTMLElement[] {
+    return this.getAllItems().filter((item) => !item.hasAttribute('disabled'));
+  }
+
+  private resolveFocusedItem(): HTMLElement | null {
+    const active = document.activeElement;
+    if (!(active instanceof HTMLElement)) return null;
+    if (active.tagName.toLowerCase() !== 'rafters-toggle-group-item') return null;
+    if (!this.contains(active)) return null;
+    return active;
+  }
+
+  private resolveItemFromEvent(event: Event): HTMLElement | null {
+    const path = event.composedPath();
+    for (const node of path) {
+      if (
+        node instanceof HTMLElement &&
+        node.tagName.toLowerCase() === 'rafters-toggle-group-item'
+      ) {
+        if (this.contains(node)) return node;
+        return null;
+      }
+    }
+    return null;
+  }
+
+  // ==========================================================================
+  // Form-associated lifecycle callbacks
+  // ==========================================================================
+
+  formAssociatedCallback(_form: HTMLFormElement | null): void {
+    // Hook for subclasses; default is a no-op. The internals already track
+    // the associated form for us.
+  }
+
+  formResetCallback(): void {
+    this.setAttribute('value', this._initialValue);
+    this.syncItems();
+    this.syncFormValue();
+  }
+
+  formDisabledCallback(disabled: boolean): void {
+    this.propagateDisabled(disabled);
+  }
+
+  formStateRestoreCallback(
+    state: string | File | FormData | null,
+    _mode: 'restore' | 'autocomplete',
+  ): void {
+    if (typeof state === 'string') {
+      this.setAttribute('value', state);
+    } else if (state === null) {
+      this.setAttribute('value', '');
+    }
+  }
+
+  // ==========================================================================
+  // Public form-control surface
+  // ==========================================================================
+
+  get internals(): ElementInternals {
+    return this._internals;
+  }
+
+  get type(): ToggleGroupType {
+    return parseType(this.getAttribute('type'));
+  }
+
+  set type(next: ToggleGroupType) {
+    this.setAttribute('type', next);
+  }
+
+  get value(): string {
+    return this.getAttribute('value') ?? '';
+  }
+
+  set value(next: string) {
+    this.setAttribute('value', next);
+  }
+
+  get name(): string {
+    return this.getAttribute('name') ?? '';
+  }
+
+  set name(value: string) {
+    this.setAttribute('name', value);
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+
+  set disabled(value: boolean) {
+    this.toggleAttribute('disabled', value);
+  }
+
+  get required(): boolean {
+    return this.hasAttribute('required');
+  }
+
+  set required(value: boolean) {
+    this.toggleAttribute('required', value);
+  }
+
+  get variant(): ToggleGroupVariant {
+    return parseVariant(this.getAttribute('variant'));
+  }
+
+  set variant(value: ToggleGroupVariant) {
+    this.setAttribute('variant', value);
+  }
+
+  get size(): ToggleGroupSize {
+    return parseSize(this.getAttribute('size'));
+  }
+
+  set size(value: ToggleGroupSize) {
+    this.setAttribute('size', value);
+  }
+
+  get orientation(): ToggleGroupOrientation {
+    return parseOrientation(this.getAttribute('orientation'));
+  }
+
+  set orientation(value: ToggleGroupOrientation) {
+    this.setAttribute('orientation', value);
+  }
+
+  get form(): HTMLFormElement | null {
+    return this._internals.form;
+  }
+
+  get validity(): ValidityState {
+    return this._internals.validity;
+  }
+
+  get validationMessage(): string {
+    return this._internals.validationMessage;
+  }
+
+  get willValidate(): boolean {
+    return this._internals.willValidate;
+  }
+
+  checkValidity(): boolean {
+    return this._internals.checkValidity();
+  }
+
+  reportValidity(): boolean {
+    return this._internals.reportValidity();
+  }
+
+  setCustomValidity(message: string): void {
+    this._internals.setValidity({ customError: message.length > 0 }, message);
+  }
+}
+
+// ============================================================================
+// Item component
+// ============================================================================
+
+/**
+ * Web Component backing `<rafters-toggle-group-item>`. Not form-associated
+ * on its own -- the parent group owns submission. Items render an inner
+ * <button type="button"> carrying role + aria-pressed + data-state.
+ */
+export class RaftersToggleGroupItem extends RaftersElement {
+  static observedAttributes: ReadonlyArray<string> = ITEM_OBSERVED_ATTRIBUTES;
+
+  private _instanceSheet: CSSStyleSheet | null = null;
+  private _button: HTMLButtonElement | null = null;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    if (!this.shadowRoot) return;
+
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+
+    const existing = this.shadowRoot.adoptedStyleSheets;
+    this.shadowRoot.adoptedStyleSheets = [...existing, this._instanceSheet];
+
+    this.applyHostAttributes();
+    this.mirrorStateToInner();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+
+    if ((name === 'pressed' || name === 'disabled') && this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+
+    this.mirrorStateToInner();
+  }
+
+  override disconnectedCallback(): void {
+    this._instanceSheet = null;
+    this._button = null;
+  }
+
+  override render(): Node {
+    const inner = document.createElement('button');
+    inner.className = 'item';
+    inner.setAttribute('type', 'button');
+    inner.setAttribute('data-roving-item', '');
+    const slot = document.createElement('slot');
+    inner.appendChild(slot);
+    this._button = inner;
+    this.mirrorStateToInner();
+    return inner;
+  }
+
+  private applyHostAttributes(): void {
+    if (!this.hasAttribute('tabindex')) {
+      this.setAttribute('tabindex', '0');
+    }
+  }
+
+  private composeCss(): string {
+    const group = this.closestGroup();
+    const variant = group
+      ? parseVariant(group.getAttribute('variant'))
+      : parseVariant(this.getAttribute('variant'));
+    const size = group
+      ? parseSize(group.getAttribute('size'))
+      : parseSize(this.getAttribute('size'));
+    return toggleGroupItemStylesheet({
+      variant,
+      size,
+      pressed: this.hasAttribute('pressed'),
+      disabled: this.isEffectivelyDisabled(),
+    });
+  }
+
+  private mirrorStateToInner(): void {
+    const inner = this.getInnerButton();
+    if (!inner) return;
+    const pressed = this.hasAttribute('pressed');
+    const disabled = this.isEffectivelyDisabled();
+    inner.setAttribute('aria-pressed', pressed ? 'true' : 'false');
+    inner.setAttribute('data-state', pressed ? 'on' : 'off');
+    inner.disabled = disabled;
+  }
+
+  private getInnerButton(): HTMLButtonElement | null {
+    if (this._button) return this._button;
+    const found = this.shadowRoot?.querySelector('button') ?? null;
+    if (found instanceof HTMLButtonElement) {
+      this._button = found;
+      return found;
+    }
+    return null;
+  }
+
+  private closestGroup(): RaftersToggleGroup | null {
+    let node: Node | null = this.parentNode;
+    while (node) {
+      if (node instanceof RaftersToggleGroup) return node;
+      node = node.parentNode;
+    }
+    return null;
+  }
+
+  private isEffectivelyDisabled(): boolean {
+    if (this.hasAttribute('disabled')) return true;
+    if (this.hasAttribute('data-group-disabled')) return true;
+    const group = this.closestGroup();
+    if (group?.hasAttribute('disabled')) return true;
+    return false;
+  }
+
+  /**
+   * Called by the parent group when its own variant/size/disabled changes.
+   * Rebuilds the per-instance stylesheet using the latest inherited values.
+   */
+  refreshFromGroup(): void {
+    if (this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+    this.mirrorStateToInner();
+  }
+
+  // ==========================================================================
+  // Public surface
+  // ==========================================================================
+
+  get value(): string {
+    return this.getAttribute('value') ?? '';
+  }
+
+  set value(next: string) {
+    this.setAttribute('value', next);
+  }
+
+  get pressed(): boolean {
+    return this.hasAttribute('pressed');
+  }
+
+  set pressed(next: boolean) {
+    this.toggleAttribute('pressed', next);
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+
+  set disabled(next: boolean) {
+    this.toggleAttribute('disabled', next);
+  }
+}
+
+// ============================================================================
+// Registration (module side-effect, guarded for re-import safety)
+// ============================================================================
+
+if (typeof customElements !== 'undefined') {
+  if (!customElements.get('rafters-toggle-group')) {
+    customElements.define('rafters-toggle-group', RaftersToggleGroup);
+  }
+  if (!customElements.get('rafters-toggle-group-item')) {
+    customElements.define('rafters-toggle-group-item', RaftersToggleGroupItem);
+  }
+}

--- a/packages/ui/src/components/ui/toggle-group.styles.test.ts
+++ b/packages/ui/src/components/ui/toggle-group.styles.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Unit tests for toggle-group.styles.ts.
+ *
+ * Verifies that the assembled stylesheets emit token-driven declarations,
+ * never leak `--duration-*`/`--ease-*` variables, and accept unknown
+ * inputs without throwing (silent fallback).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  type ToggleGroupOrientation,
+  type ToggleGroupSize,
+  type ToggleGroupVariant,
+  toggleGroupBase,
+  toggleGroupDefaultVariantStyles,
+  toggleGroupItemBase,
+  toggleGroupItemDefaultPressed,
+  toggleGroupItemDisabled,
+  toggleGroupItemFocusVisible,
+  toggleGroupItemOutlinePressed,
+  toggleGroupItemSizeStyles,
+  toggleGroupItemStylesheet,
+  toggleGroupStylesheet,
+} from './toggle-group.styles';
+
+describe('toggleGroupStylesheet', () => {
+  it('emits :host with display inline-flex', () => {
+    const css = toggleGroupStylesheet();
+    expect(css).toMatch(/:host\s*\{[^}]*display:\s*inline-flex/);
+  });
+
+  it('emits .group with token-driven radius', () => {
+    const css = toggleGroupStylesheet();
+    expect(css).toContain('border-radius: var(--radius-lg)');
+  });
+
+  it('applies default variant padding and muted background only for default variant', () => {
+    const defaultCss = toggleGroupStylesheet({ variant: 'default' });
+    expect(defaultCss).toContain('var(--color-muted)');
+    expect(defaultCss).toContain('var(--spacing-1)');
+
+    const outlineCss = toggleGroupStylesheet({ variant: 'outline' });
+    expect(outlineCss).not.toContain('var(--color-muted)');
+  });
+
+  it('sets flex-direction column for vertical orientation', () => {
+    const css = toggleGroupStylesheet({ orientation: 'vertical' });
+    expect(css).toMatch(/flex-direction:\s*column/);
+  });
+
+  it('defaults to horizontal flex-direction for unknown orientation', () => {
+    const css = toggleGroupStylesheet({
+      orientation: 'diagonal' as unknown as ToggleGroupOrientation,
+    });
+    expect(css).toMatch(/flex-direction:\s*row/);
+    expect(() =>
+      toggleGroupStylesheet({ orientation: 'diagonal' as unknown as ToggleGroupOrientation }),
+    ).not.toThrow();
+  });
+
+  it('silently falls back to default variant for unknown variant', () => {
+    expect(() =>
+      toggleGroupStylesheet({ variant: 'neon' as unknown as ToggleGroupVariant }),
+    ).not.toThrow();
+    const css = toggleGroupStylesheet({ variant: 'neon' as unknown as ToggleGroupVariant });
+    expect(css).toContain('var(--color-muted)');
+  });
+
+  it('exposes toggleGroupBase and toggleGroupDefaultVariantStyles maps with token refs', () => {
+    expect(toggleGroupBase['border-radius']).toBe('var(--radius-lg)');
+    expect(toggleGroupDefaultVariantStyles['background-color']).toBe('var(--color-muted)');
+    expect(toggleGroupDefaultVariantStyles.padding).toBe('var(--spacing-1)');
+  });
+});
+
+describe('toggleGroupItemStylesheet', () => {
+  it('emits :host with display inline-flex', () => {
+    const css = toggleGroupItemStylesheet();
+    expect(css).toMatch(/:host\s*\{[^}]*display:\s*inline-flex/);
+  });
+
+  it('uses --motion-duration-* and --motion-ease-*, never --duration-* or --ease-*', () => {
+    const css = toggleGroupItemStylesheet();
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+    expect(css).toContain('var(--motion-duration-base)');
+    expect(css).toContain('var(--motion-ease-standard)');
+  });
+
+  it('emits pressed rule with token-driven background for default variant', () => {
+    const css = toggleGroupItemStylesheet({ variant: 'default', pressed: true });
+    expect(css).toContain('var(--color-background)');
+    expect(css).toContain('var(--color-foreground)');
+  });
+
+  it('emits pressed rule with accent colours for outline variant', () => {
+    const css = toggleGroupItemStylesheet({ variant: 'outline', pressed: true });
+    expect(css).toContain('var(--color-accent)');
+    expect(css).toContain('var(--color-accent-foreground)');
+  });
+
+  it('emits data-state="on" pressed selector for the default variant', () => {
+    const css = toggleGroupItemStylesheet({ variant: 'default' });
+    expect(css).toMatch(/\.item\[data-state="on"\]\s*\{[^}]*var\(--color-background\)/);
+  });
+
+  it('emits data-state="on" pressed selector for the outline variant', () => {
+    const css = toggleGroupItemStylesheet({ variant: 'outline' });
+    expect(css).toMatch(/\.item\[data-state="on"\]\s*\{[^}]*var\(--color-accent\)/);
+  });
+
+  it('emits focus-visible rule with token-driven box-shadow', () => {
+    const css = toggleGroupItemStylesheet();
+    expect(css).toMatch(/\.item:focus-visible\s*\{[^}]*box-shadow:[^}]*var\(--color-/);
+    expect(css).toContain('var(--color-ring)');
+    expect(css).toContain('var(--color-background)');
+  });
+
+  it('wraps transitions in prefers-reduced-motion guard', () => {
+    const css = toggleGroupItemStylesheet();
+    expect(css).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)/);
+  });
+
+  it('emits disabled rule with reduced opacity', () => {
+    const css = toggleGroupItemStylesheet();
+    expect(css).toMatch(/\.item:disabled\s*\{[^}]*opacity:\s*0\.5/);
+  });
+
+  it('layers disabled declarations when disabled flag is true', () => {
+    const css = toggleGroupItemStylesheet({ disabled: true });
+    expect(css).toMatch(/\.item\s*\{[^}]*pointer-events:\s*none/);
+  });
+
+  it('silently falls back to default for unknown variant', () => {
+    expect(() =>
+      toggleGroupItemStylesheet({ variant: 'rainbow' as unknown as ToggleGroupVariant }),
+    ).not.toThrow();
+    const css = toggleGroupItemStylesheet({
+      variant: 'rainbow' as unknown as ToggleGroupVariant,
+      pressed: true,
+    });
+    expect(css).toContain('var(--color-background)');
+  });
+
+  it('silently falls back to default for unknown size', () => {
+    expect(() =>
+      toggleGroupItemStylesheet({ size: 'huge' as unknown as ToggleGroupSize }),
+    ).not.toThrow();
+    const css = toggleGroupItemStylesheet({ size: 'huge' as unknown as ToggleGroupSize });
+    expect(css).toContain('height: 2.25rem');
+  });
+
+  it('emits per-size heights', () => {
+    expect(toggleGroupItemStylesheet({ size: 'sm' })).toContain('height: 2rem');
+    expect(toggleGroupItemStylesheet({ size: 'default' })).toContain('height: 2.25rem');
+    expect(toggleGroupItemStylesheet({ size: 'lg' })).toContain('height: 2.5rem');
+  });
+
+  it('exposes item style maps', () => {
+    expect(toggleGroupItemBase['border-radius']).toBe('var(--radius-md)');
+    expect(toggleGroupItemFocusVisible.outline).toBe('none');
+    expect(toggleGroupItemDisabled.opacity).toBe('0.5');
+    expect(toggleGroupItemDefaultPressed['background-color']).toBe('var(--color-background)');
+    expect(toggleGroupItemOutlinePressed['background-color']).toBe('var(--color-accent)');
+    expect(toggleGroupItemSizeStyles.sm.height).toBe('2rem');
+  });
+});

--- a/packages/ui/src/components/ui/toggle-group.styles.ts
+++ b/packages/ui/src/components/ui/toggle-group.styles.ts
@@ -1,0 +1,294 @@
+/**
+ * Shadow DOM style definitions for Toggle Group web component
+ *
+ * Parallel to toggle-group.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ *
+ * The group host arranges its items in an inline-flex row (or column for
+ * vertical orientation). Each item is a separate custom element with its
+ * own per-instance stylesheet so variant/size/pressed state composes
+ * independently per item.
+ *
+ * All token references go through tokenVar() -- no raw CSS custom-property
+ * function literals appear in this module.
+ * Motion uses --motion-duration-* / --motion-ease-* only.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import {
+  atRule,
+  pick,
+  styleRule,
+  stylesheet,
+  tokenVar,
+  transition,
+  when,
+} from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export type ToggleGroupVariant = 'default' | 'outline';
+
+export type ToggleGroupSize = 'sm' | 'default' | 'lg';
+
+export type ToggleGroupOrientation = 'horizontal' | 'vertical';
+
+export interface ToggleGroupStylesheetOptions {
+  variant?: ToggleGroupVariant | undefined;
+  orientation?: ToggleGroupOrientation | undefined;
+}
+
+export interface ToggleGroupItemStylesheetOptions {
+  variant?: ToggleGroupVariant | undefined;
+  size?: ToggleGroupSize | undefined;
+  pressed?: boolean | undefined;
+  disabled?: boolean | undefined;
+}
+
+// ============================================================================
+// Group Styles
+// ============================================================================
+
+/**
+ * Base group declarations shared across every variant.
+ * Mirrors toggleGroupClasses from toggle-group.classes.ts.
+ */
+export const toggleGroupBase: CSSProperties = {
+  display: 'inline-flex',
+  'align-items': 'center',
+  'justify-content': 'center',
+  gap: '0.25rem',
+  'border-radius': tokenVar('radius-lg'),
+};
+
+/**
+ * Additional declarations layered onto the group when the default variant
+ * is active. The outline variant keeps the frame transparent.
+ */
+export const toggleGroupDefaultVariantStyles: CSSProperties = {
+  'background-color': tokenVar('color-muted'),
+  padding: tokenVar('spacing-1'),
+};
+
+// ============================================================================
+// Item Styles
+// ============================================================================
+
+/**
+ * Base item declarations shared across every variant and size. Mirrors
+ * toggleGroupItemBaseClasses from toggle-group.classes.ts. Background stays
+ * transparent by default; pressed/hover layer color on top.
+ */
+export const toggleGroupItemBase: CSSProperties = {
+  display: 'inline-flex',
+  'align-items': 'center',
+  'justify-content': 'center',
+  'border-radius': tokenVar('radius-md'),
+  'font-size': tokenVar('font-size-label-large'),
+  'background-color': 'transparent',
+  color: 'inherit',
+  cursor: 'pointer',
+  'user-select': 'none',
+  'white-space': 'nowrap',
+  'border-width': '0',
+  'border-style': 'solid',
+  'border-color': 'transparent',
+  transition: transition(
+    ['background-color', 'color', 'transform'],
+    tokenVar('motion-duration-base'),
+    tokenVar('motion-ease-standard'),
+  ),
+};
+
+/**
+ * Focus-visible ring on items -- neutral double-ring matching the rest of
+ * the Rafters form-control surface.
+ */
+export const toggleGroupItemFocusVisible: CSSProperties = {
+  outline: 'none',
+  'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar('color-ring')}`,
+};
+
+/**
+ * Disabled-state declarations for items.
+ */
+export const toggleGroupItemDisabled: CSSProperties = {
+  cursor: 'not-allowed',
+  opacity: '0.5',
+  'pointer-events': 'none',
+};
+
+/**
+ * Pressed background + foreground pair for the default variant.
+ * Elevates the pressed item above the muted group surface via a
+ * white background and a tiny shadow.
+ */
+export const toggleGroupItemDefaultPressed: CSSProperties = {
+  'background-color': tokenVar('color-background'),
+  color: tokenVar('color-foreground'),
+  'box-shadow': '0 1px 2px 0 rgba(0,0,0,0.05)',
+};
+
+/**
+ * Pressed background + foreground pair for the outline variant.
+ * Uses the accent pair so the pressed state reads as the primary
+ * selection without a full-frame chip.
+ */
+export const toggleGroupItemOutlinePressed: CSSProperties = {
+  'background-color': tokenVar('color-accent'),
+  color: tokenVar('color-accent-foreground'),
+};
+
+/**
+ * Unpressed base per variant. Outline paints a 1px input-coloured border
+ * so items read as interactive chips even before selection.
+ */
+export const toggleGroupItemVariantStyles: Record<ToggleGroupVariant, CSSProperties> = {
+  default: {
+    'background-color': 'transparent',
+  },
+  outline: {
+    'background-color': 'transparent',
+    'border-width': '1px',
+    'border-style': 'solid',
+    'border-color': tokenVar('color-input'),
+  },
+};
+
+/**
+ * Pressed declarations per variant. Looked up by key; unknown variant
+ * silently falls back to default via pick().
+ */
+export const toggleGroupItemVariantPressed: Record<ToggleGroupVariant, CSSProperties> = {
+  default: toggleGroupItemDefaultPressed,
+  outline: toggleGroupItemOutlinePressed,
+};
+
+/**
+ * Hover background per variant when not pressed.
+ */
+export const toggleGroupItemVariantHover: Record<ToggleGroupVariant, CSSProperties> = {
+  default: {
+    'background-color': tokenVar('color-muted'),
+    color: tokenVar('color-muted-foreground'),
+  },
+  outline: {
+    'background-color': tokenVar('color-muted'),
+    color: tokenVar('color-muted-foreground'),
+  },
+};
+
+/**
+ * Size declarations map explicit heights and padding pairs.
+ * Matches toggleGroupItemSizeClasses from toggle-group.classes.ts.
+ */
+export const toggleGroupItemSizeStyles: Record<ToggleGroupSize, CSSProperties> = {
+  sm: {
+    height: '2rem',
+    'padding-left': '0.5rem',
+    'padding-right': '0.5rem',
+  },
+  default: {
+    height: '2.25rem',
+    'padding-left': '0.75rem',
+    'padding-right': '0.75rem',
+  },
+  lg: {
+    height: '2.5rem',
+    'padding-left': '1rem',
+    'padding-right': '1rem',
+  },
+};
+
+// ============================================================================
+// Assembled Group Stylesheet
+// ============================================================================
+
+/**
+ * Resolve orientation, silently falling back to horizontal for unknown values.
+ */
+function resolveOrientation(value: ToggleGroupOrientation | undefined): ToggleGroupOrientation {
+  if (value === 'vertical') return 'vertical';
+  return 'horizontal';
+}
+
+/**
+ * Build the complete group stylesheet for a given configuration.
+ *
+ * Composition:
+ *   :host                  -> display: inline-flex, flex-direction (row|column)
+ *   .group                 -> base + optional default variant chrome
+ */
+export function toggleGroupStylesheet(options: ToggleGroupStylesheetOptions = {}): string {
+  const { variant, orientation } = options;
+  const resolvedOrientation = resolveOrientation(orientation);
+  const resolvedVariant: ToggleGroupVariant = variant === 'outline' ? 'outline' : 'default';
+
+  return stylesheet(
+    styleRule(':host', {
+      display: 'inline-flex',
+      'flex-direction': resolvedOrientation === 'vertical' ? 'column' : 'row',
+    }),
+
+    styleRule(
+      '.group',
+      toggleGroupBase,
+      when(resolvedVariant === 'default', toggleGroupDefaultVariantStyles),
+      resolvedOrientation === 'vertical' ? { 'flex-direction': 'column' } : {},
+    ),
+  );
+}
+
+// ============================================================================
+// Assembled Item Stylesheet
+// ============================================================================
+
+/**
+ * Build the complete item stylesheet for a given configuration.
+ *
+ * Composition:
+ *   :host                            -> display: inline-flex
+ *   .item                            -> base + variant + size (+ disabled when set)
+ *   .item:hover:not(:disabled)       -> variant hover surface (unpressed)
+ *   .item:active:not(:disabled)      -> scale(0.98) tactile feedback
+ *   .item:focus-visible              -> neutral focus ring
+ *   .item[data-state="on"]           -> pressed fill + foreground per variant
+ *   .item:disabled                   -> disabled declarations
+ *   @media reduced-motion            -> transition: none, transform: none
+ *
+ * Unknown variant/size falls back to 'default' via pick(). Never throws.
+ */
+export function toggleGroupItemStylesheet(options: ToggleGroupItemStylesheetOptions = {}): string {
+  const { variant, size, pressed, disabled } = options;
+
+  return stylesheet(
+    styleRule(':host', { display: 'inline-flex' }),
+
+    styleRule(
+      '.item',
+      toggleGroupItemBase,
+      pick(toggleGroupItemVariantStyles, variant, 'default'),
+      pick(toggleGroupItemSizeStyles, size, 'default'),
+      when(pressed, pick(toggleGroupItemVariantPressed, variant, 'default')),
+      when(disabled, toggleGroupItemDisabled),
+    ),
+
+    styleRule('.item:hover:not(:disabled)', pick(toggleGroupItemVariantHover, variant, 'default')),
+
+    styleRule('.item:active:not(:disabled)', { transform: 'scale(0.98)' }),
+
+    styleRule('.item:focus-visible', toggleGroupItemFocusVisible),
+
+    styleRule('.item[data-state="on"]', pick(toggleGroupItemVariantPressed, variant, 'default')),
+
+    styleRule('.item:disabled', toggleGroupItemDisabled),
+
+    atRule(
+      '@media (prefers-reduced-motion: reduce)',
+      styleRule('.item', { transition: 'none' }),
+      styleRule('.item:active:not(:disabled)', { transform: 'none' }),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

Adds the `<rafters-toggle-group>` + `<rafters-toggle-group-item>` custom
element pair. The group is form-associated via `ElementInternals` and
participates in native `<form>` submission, validation, reset, disabled
propagation, and state restoration. Items are not form-associated on
their own -- the group owns submission and updates state through
bubbled clicks.

- **Single mode**: `value` holds the selected item's value string;
  clicking the selected item deselects. Submits as `name=value`.
- **Multiple mode**: `value` holds a CSV of selected values. Submits
  via a `FormData` passed to `setFormValue` so `FormData.getAll(name)`
  returns the full list.
- **Required + empty selection**: `setValidity({ valueMissing: true })`
  with the message "Please select at least one option."
- **Keyboard**: arrow keys per orientation with looping; Space/Enter
  toggle the focused item; disabled items are skipped.
- **Per-instance `CSSStyleSheet`** adopted on the shadow root, rebuilt
  on variant/size/orientation changes.
- Unknown `type`/`variant`/`size`/`orientation` silently fall back to
  defaults. Constructor only throws `TypeError` when `attachInternals`
  is unavailable.

All token references route through `tokenVar()`; motion uses
`--motion-duration-*` / `--motion-ease-*` only. Auto-registers both
elements idempotently. Dispatches `change`, `input`, and a
`rafters-toggle-group-change` custom event on each state change.

## Files

- `packages/ui/src/components/ui/toggle-group.styles.ts` --
  token-driven stylesheet builders for the group wrapper and each
  item (variant/size/pressed/disabled matrix with reduced-motion
  guard).
- `packages/ui/src/components/ui/toggle-group.element.ts` --
  `RaftersToggleGroup` (form-associated) + `RaftersToggleGroupItem`,
  auto-registered on import.
- `packages/ui/src/components/ui/toggle-group.styles.test.ts` --
  Unit coverage for the stylesheet builders (token audit, motion
  namespace, orientation fallback, reduced-motion guard).
- `packages/ui/src/components/ui/toggle-group.element.test.ts` --
  Element coverage: registration, DOM shape, single/multiple
  selection, events, form submission via polyfilled `FormData`,
  validity, form lifecycle callbacks, roving keyboard, property
  surface.
- `packages/ui/src/components/ui/toggle-group.element.a11y.tsx` --
  vitest-axe coverage: role="group", aria-pressed, aria-label and
  aria-labelledby labelling, required group, disabled items.

## Test plan

- [x] `pnpm --filter=@rafters/ui typecheck` -- green
- [x] `pnpm --filter=@rafters/ui test toggle-group` -- 112/112 green
- [x] `pnpm preflight` -- green (4189 ui unit + 669 ui a11y + 24 other-package suites)
- [x] Zero `var(--` outside `tokenVar()` calls; zero `--duration-*` / `--ease-*` token refs
- [x] No `any` types, no emoji
- [x] Silent fallback for unknown attributes; `TypeError` only when `attachInternals` is unavailable

Closes #1344