### PR TITLE
feat(ui): <rafters-button-group> Web Component (#1346)

### DIFF
--- a/packages/ui/src/components/ui/button-group.classes.ts
+++ b/packages/ui/src/components/ui/button-group.classes.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared button-group layout class definitions
+ *
+ * Imported by button-group.tsx (React) to keep the connected-border and
+ * focus-stacking rules in one place. The Web Component target consumes
+ * button-group.styles.ts for the shadow-DOM CSS equivalent; this file
+ * exists so framework targets share the same semantic surface.
+ */
+
+// ============================================================================
+// Base Classes
+// ============================================================================
+
+/**
+ * Always-on layout primitives for a button group container.
+ * Orientation-specific flex-direction is appended by the consumer.
+ */
+export const buttonGroupBaseClasses = 'inline-flex';
+
+/**
+ * Per-orientation flex-direction utility.
+ */
+export const buttonGroupOrientationClasses: Record<string, string> = {
+  horizontal: 'flex-row',
+  vertical: 'flex-col',
+};
+
+// ============================================================================
+// Attached-Button Connected-Border Classes
+// ============================================================================
+
+/**
+ * Connected-border rules for horizontal groups.
+ *   - First child: clear right radius so it joins the next button.
+ *   - Last child: clear left radius so it joins the prior button.
+ *   - Middle children: clear both so they sit flush between neighbors.
+ *   - Non-first children: negative left margin collapses the shared 1px border.
+ */
+export const buttonGroupHorizontalConnectedClasses = [
+  '[&>*:first-child]:rounded-r-none',
+  '[&>*:last-child]:rounded-l-none',
+  '[&>*:not(:first-child):not(:last-child)]:rounded-none',
+  '[&>*:not(:first-child)]:-ml-px',
+].join(' ');
+
+/**
+ * Connected-border rules for vertical groups.
+ *   - First child: clear bottom radius so it joins the next button.
+ *   - Last child: clear top radius so it joins the prior button.
+ *   - Middle children: clear both so they sit flush between neighbors.
+ *   - Non-first children: negative top margin collapses the shared 1px border.
+ */
+export const buttonGroupVerticalConnectedClasses = [
+  '[&>*:first-child]:rounded-b-none',
+  '[&>*:last-child]:rounded-t-none',
+  '[&>*:not(:first-child):not(:last-child)]:rounded-none',
+  '[&>*:not(:first-child)]:-mt-px',
+].join(' ');
+
+// ============================================================================
+// Focus Stacking
+// ============================================================================
+
+/**
+ * Raise the currently focus-visible child above its neighbors so the focus
+ * ring is not clipped by overlapping borders.
+ */
+export const buttonGroupFocusStackingClasses = '[&>*:focus-visible]:z-10';

--- a/packages/ui/src/components/ui/button-group.element.a11y.tsx
+++ b/packages/ui/src/components/ui/button-group.element.a11y.tsx
@@ -1,0 +1,119 @@
+/**
+ * Accessibility tests for <rafters-button-group>.
+ *
+ * The group is a layout composition element (role="group") -- it arranges
+ * whatever is slotted inside and holds no internal state. axe-core >= 4
+ * descends into open shadow roots so we can assert on the host + projected
+ * children directly.
+ *
+ * Scoping to a container (rather than document.body) avoids axe's
+ * document-level "region" rule from firing on every component test.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+// Side-effect import: augments `Assertion` with axe matchers.
+import 'vitest-axe/extend-expect';
+import './button-group.element';
+import './button.element';
+
+let container: HTMLElement;
+
+function mountContainer(): HTMLElement {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  return container;
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+/**
+ * Build a <rafters-button-group> populated with the given buttons. The group
+ * receives an aria-label per WAI-ARIA APG guidance for role="group".
+ */
+function buildGroup(
+  attrs: Record<string, string>,
+  buttons: Array<{ variant?: string; label: string }>,
+): HTMLElement {
+  const host = document.createElement('rafters-button-group');
+  for (const [k, v] of Object.entries(attrs)) host.setAttribute(k, v);
+  for (const b of buttons) {
+    const btn = document.createElement('rafters-button');
+    if (b.variant) btn.setAttribute('variant', b.variant);
+    btn.textContent = b.label;
+    host.appendChild(btn);
+  }
+  container.appendChild(host);
+  return host;
+}
+
+describe('<rafters-button-group> - Accessibility', () => {
+  it('has no violations with a default horizontal group', async () => {
+    mountContainer();
+    buildGroup({ 'aria-label': 'Document actions' }, [
+      { variant: 'outline', label: 'Cancel' },
+      { variant: 'default', label: 'Save' },
+    ]);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with a vertical group', async () => {
+    mountContainer();
+    buildGroup({ 'aria-label': 'View options', orientation: 'vertical' }, [
+      { variant: 'ghost', label: 'Grid' },
+      { variant: 'ghost', label: 'List' },
+      { variant: 'ghost', label: 'Table' },
+    ]);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with native <button> children', async () => {
+    mountContainer();
+    const host = document.createElement('rafters-button-group');
+    host.setAttribute('aria-label', 'Pagination');
+    for (const label of ['Prev', '1', '2', '3', 'Next']) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.textContent = label;
+      host.appendChild(btn);
+    }
+    container.appendChild(host);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with a mix of variants', async () => {
+    mountContainer();
+    buildGroup({ 'aria-label': 'Actions' }, [
+      { variant: 'default', label: 'Save' },
+      { variant: 'outline', label: 'Cancel' },
+      { variant: 'destructive', label: 'Delete' },
+    ]);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('reflects role=group on the host for assistive tech', () => {
+    mountContainer();
+    const host = buildGroup({ 'aria-label': 'Toolbar actions' }, [
+      { label: 'One' },
+      { label: 'Two' },
+    ]);
+    expect(host.getAttribute('role')).toBe('group');
+  });
+
+  it('reflects data-orientation for consumer styling', () => {
+    mountContainer();
+    const horizontal = buildGroup({ 'aria-label': 'H' }, [{ label: 'A' }, { label: 'B' }]);
+    expect(horizontal.getAttribute('data-orientation')).toBe('horizontal');
+    const vertical = buildGroup({ 'aria-label': 'V', orientation: 'vertical' }, [
+      { label: 'A' },
+      { label: 'B' },
+    ]);
+    expect(vertical.getAttribute('data-orientation')).toBe('vertical');
+  });
+});

--- a/packages/ui/src/components/ui/button-group.element.test.ts
+++ b/packages/ui/src/components/ui/button-group.element.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import './button-group.element';
+import { RaftersButtonGroup } from './button-group.element';
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+function mount(attrs: Record<string, string> = {}): RaftersButtonGroup {
+  const el = document.createElement('rafters-button-group') as RaftersButtonGroup;
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.appendChild(el);
+  return el;
+}
+
+function collectCss(el: HTMLElement): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  return sheets
+    .map((s) =>
+      Array.from(s.cssRules)
+        .map((r) => r.cssText)
+        .join('\n'),
+    )
+    .join('\n');
+}
+
+describe('rafters-button-group', () => {
+  it('registers as a custom element', () => {
+    expect(customElements.get('rafters-button-group')).toBeDefined();
+  });
+
+  it('exports RaftersButtonGroup as the registered constructor', () => {
+    expect(customElements.get('rafters-button-group')).toBe(RaftersButtonGroup);
+  });
+
+  it('registers idempotently on re-import', async () => {
+    expect(customElements.get('rafters-button-group')).toBe(RaftersButtonGroup);
+    await import('./button-group.element');
+    expect(customElements.get('rafters-button-group')).toBe(RaftersButtonGroup);
+  });
+
+  it('is not form-associated', () => {
+    expect((RaftersButtonGroup as unknown as { formAssociated?: boolean }).formAssociated).not.toBe(
+      true,
+    );
+  });
+
+  it('sets role=group on the host element', () => {
+    const el = mount();
+    expect(el.getAttribute('role')).toBe('group');
+  });
+
+  it('sets data-orientation=horizontal by default', () => {
+    const el = mount();
+    expect(el.getAttribute('data-orientation')).toBe('horizontal');
+  });
+
+  it('reflects vertical orientation when attribute is set', () => {
+    const el = document.createElement('rafters-button-group') as RaftersButtonGroup;
+    el.setAttribute('orientation', 'vertical');
+    document.body.appendChild(el);
+    expect(el.getAttribute('data-orientation')).toBe('vertical');
+  });
+
+  it('renders an inner wrapper containing a default slot', () => {
+    const el = mount();
+    const inner = el.shadowRoot?.firstElementChild;
+    expect(inner?.tagName).toBe('DIV');
+    expect(inner?.querySelector('slot')).not.toBeNull();
+  });
+
+  it('inner wrapper carries no classes (styling comes from per-instance stylesheet)', () => {
+    const el = mount();
+    const inner = el.shadowRoot?.firstElementChild;
+    expect(inner?.className).toBe('');
+  });
+
+  it('projects slotted children through the default slot', () => {
+    const el = document.createElement('rafters-button-group') as RaftersButtonGroup;
+    const a = document.createElement('button');
+    a.textContent = 'A';
+    const b = document.createElement('button');
+    b.textContent = 'B';
+    el.append(a, b);
+    document.body.appendChild(el);
+    const slot = el.shadowRoot?.querySelector('slot');
+    expect(slot).not.toBeNull();
+    expect(slot?.assignedElements().length).toBe(2);
+  });
+
+  it('falls back to horizontal when orientation is unknown', () => {
+    const el = document.createElement('rafters-button-group') as RaftersButtonGroup;
+    el.setAttribute('orientation', 'diagonal');
+    expect(() => document.body.appendChild(el)).not.toThrow();
+    expect(el.getAttribute('data-orientation')).toBe('horizontal');
+  });
+
+  it('orientation getter returns parsed orientation value', () => {
+    const el = mount({ orientation: 'vertical' });
+    expect(el.orientation).toBe('vertical');
+  });
+
+  it('orientation setter reflects to the attribute', () => {
+    const el = mount();
+    el.orientation = 'vertical';
+    expect(el.getAttribute('orientation')).toBe('vertical');
+    expect(el.getAttribute('data-orientation')).toBe('vertical');
+  });
+
+  it('updates stylesheet when orientation changes to vertical', () => {
+    const el = mount();
+    el.setAttribute('orientation', 'vertical');
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    const css = Array.from(sheets.at(-1)?.cssRules ?? [])
+      .map((r) => r.cssText)
+      .join('\n');
+    expect(css).toMatch(/flex-direction:\s*column/);
+  });
+
+  it('updates stylesheet when orientation changes back to horizontal', () => {
+    const el = mount({ orientation: 'vertical' });
+    el.setAttribute('orientation', 'horizontal');
+    const css = collectCss(el);
+    expect(css).toMatch(/flex-direction:\s*row/);
+    expect(css).not.toMatch(/flex-direction:\s*column/);
+  });
+
+  it('adopts a single per-instance stylesheet', () => {
+    const el = mount();
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    expect(sheets.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('observedAttributes matches the documented contract', () => {
+    expect(RaftersButtonGroup.observedAttributes).toEqual(['orientation']);
+  });
+
+  it('does not throw on removal and re-insertion', () => {
+    const el = mount();
+    expect(() => el.remove()).not.toThrow();
+    expect(() => document.body.appendChild(el)).not.toThrow();
+  });
+
+  it('stylesheet uses only --motion-duration / --motion-ease tokens (none required)', () => {
+    const el = mount();
+    const css = collectCss(el);
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+  });
+
+  it('element source contains no direct var() literals', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const source = await fs.readFile(path.resolve(__dirname, 'button-group.element.ts'), 'utf-8');
+    expect(source).not.toMatch(/[^a-zA-Z_]var\(/);
+  });
+});

--- a/packages/ui/src/components/ui/button-group.element.ts
+++ b/packages/ui/src/components/ui/button-group.element.ts
@@ -1,0 +1,110 @@
+/**
+ * <rafters-button-group> -- Web Component layout primitive.
+ *
+ * Groups related buttons (native <button> or <rafters-button>) with connected
+ * borders and focus stacking so they read as a cohesive action set. This is a
+ * layout composition element: it arranges whatever is slotted inside but
+ * renders no buttons itself, holds no internal state, and is NOT
+ * form-associated.
+ *
+ * Attributes:
+ *  - orientation: 'horizontal' | 'vertical'  (default 'horizontal')
+ *
+ * Styling comes exclusively from buttonGroupStylesheet(...) adopted as the
+ * per-instance stylesheet. The inner <div> carries no Tailwind classes; all
+ * connected-border and focus-stacking rules target ::slotted(*) so they
+ * apply to whatever the consumer projects into the group.
+ *
+ * role="group" and data-orientation are reflected on the host element so
+ * assistive tech and consumer styling can target them without piercing the
+ * shadow root.
+ *
+ * Unknown orientation values silently fall back to 'horizontal'.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import {
+  type ButtonGroupOrientation,
+  buttonGroupStylesheet,
+  isButtonGroupOrientation,
+} from './button-group.styles';
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = ['orientation'] as const;
+
+function parseOrientation(value: string | null): ButtonGroupOrientation {
+  return isButtonGroupOrientation(value) ? value : 'horizontal';
+}
+
+export class RaftersButtonGroup extends RaftersElement {
+  static observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  /** Per-instance stylesheet rebuilt when orientation changes. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  get orientation(): ButtonGroupOrientation {
+    return parseOrientation(this.getAttribute('orientation'));
+  }
+
+  set orientation(next: ButtonGroupOrientation) {
+    this.setAttribute('orientation', next);
+  }
+
+  override connectedCallback(): void {
+    if (!this.shadowRoot) return;
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+    this.shadowRoot.adoptedStyleSheets = [this._instanceSheet];
+    this.reflectHostAttributes();
+    this.update();
+  }
+
+  override attributeChangedCallback(
+    _name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+    if (this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+    this.reflectHostAttributes();
+    this.update();
+  }
+
+  override disconnectedCallback(): void {
+    this._instanceSheet = null;
+  }
+
+  /**
+   * Build the CSS string for the current attribute values.
+   */
+  private composeCss(): string {
+    return buttonGroupStylesheet({ orientation: this.orientation });
+  }
+
+  /**
+   * Reflect role and the resolved orientation back onto the host so assistive
+   * tech and consumer styling can target them without piercing the shadow
+   * root. role="group" is the WAI-ARIA APG pattern for a related control set.
+   */
+  private reflectHostAttributes(): void {
+    this.setAttribute('role', 'group');
+    this.setAttribute('data-orientation', this.orientation);
+  }
+
+  /**
+   * Render the inner wrapper with a single default <slot>. The wrapper carries
+   * no classes; all styling lives in the per-instance stylesheet via :host and
+   * ::slotted(*) selectors.
+   */
+  override render(): Node {
+    const inner = document.createElement('div');
+    const slot = document.createElement('slot');
+    inner.appendChild(slot);
+    return inner;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-button-group')) {
+  customElements.define('rafters-button-group', RaftersButtonGroup);
+}

--- a/packages/ui/src/components/ui/button-group.styles.test.ts
+++ b/packages/ui/src/components/ui/button-group.styles.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buttonGroupBase,
+  buttonGroupStylesheet,
+  isButtonGroupOrientation,
+} from './button-group.styles';
+
+describe('buttonGroupBase', () => {
+  it('horizontal uses inline-flex with row direction', () => {
+    expect(buttonGroupBase.horizontal.display).toBe('inline-flex');
+    expect(buttonGroupBase.horizontal['flex-direction']).toBe('row');
+  });
+
+  it('vertical uses inline-flex with column direction', () => {
+    expect(buttonGroupBase.vertical.display).toBe('inline-flex');
+    expect(buttonGroupBase.vertical['flex-direction']).toBe('column');
+  });
+});
+
+describe('isButtonGroupOrientation', () => {
+  it('accepts horizontal and vertical', () => {
+    expect(isButtonGroupOrientation('horizontal')).toBe(true);
+    expect(isButtonGroupOrientation('vertical')).toBe(true);
+  });
+
+  it('rejects unknown strings and non-string values', () => {
+    expect(isButtonGroupOrientation('diagonal')).toBe(false);
+    expect(isButtonGroupOrientation('')).toBe(false);
+    expect(isButtonGroupOrientation(null)).toBe(false);
+    expect(isButtonGroupOrientation(undefined)).toBe(false);
+    expect(isButtonGroupOrientation(1)).toBe(false);
+  });
+});
+
+describe('buttonGroupStylesheet host rule', () => {
+  it('emits :host with flex-direction: row by default', () => {
+    expect(buttonGroupStylesheet()).toMatch(/:host\s*\{[^}]*flex-direction:\s*row/);
+  });
+
+  it('emits :host with display: inline-flex by default', () => {
+    expect(buttonGroupStylesheet()).toMatch(/:host\s*\{[^}]*display:\s*inline-flex/);
+  });
+
+  it('emits :host with flex-direction: column for vertical orientation', () => {
+    expect(buttonGroupStylesheet({ orientation: 'vertical' })).toMatch(/flex-direction:\s*column/);
+  });
+});
+
+describe('buttonGroupStylesheet connected-border rules', () => {
+  it('emits ::slotted connected-border selectors for horizontal by default', () => {
+    const css = buttonGroupStylesheet();
+    expect(css).toMatch(/::slotted\(\*:first-child\)/);
+    expect(css).toMatch(/::slotted\(\*:last-child\)/);
+    expect(css).toMatch(/::slotted\(\*:not\(:first-child\):not\(:last-child\)\)/);
+  });
+
+  it('horizontal clears right radius on the first child', () => {
+    const css = buttonGroupStylesheet({ orientation: 'horizontal' });
+    expect(css).toMatch(/::slotted\(\*:first-child\)\s*\{[^}]*border-top-right-radius:\s*0/);
+    expect(css).toMatch(/::slotted\(\*:first-child\)\s*\{[^}]*border-bottom-right-radius:\s*0/);
+  });
+
+  it('horizontal clears left radius on the last child', () => {
+    const css = buttonGroupStylesheet({ orientation: 'horizontal' });
+    expect(css).toMatch(/::slotted\(\*:last-child\)\s*\{[^}]*border-top-left-radius:\s*0/);
+    expect(css).toMatch(/::slotted\(\*:last-child\)\s*\{[^}]*border-bottom-left-radius:\s*0/);
+  });
+
+  it('horizontal applies -1px left margin on non-first children', () => {
+    const css = buttonGroupStylesheet({ orientation: 'horizontal' });
+    expect(css).toMatch(/::slotted\(\*:not\(:first-child\)\)\s*\{[^}]*margin-left:\s*-1px/);
+  });
+
+  it('vertical clears bottom radius on the first child', () => {
+    const css = buttonGroupStylesheet({ orientation: 'vertical' });
+    expect(css).toMatch(/::slotted\(\*:first-child\)\s*\{[^}]*border-bottom-right-radius:\s*0/);
+    expect(css).toMatch(/::slotted\(\*:first-child\)\s*\{[^}]*border-bottom-left-radius:\s*0/);
+  });
+
+  it('vertical clears top radius on the last child', () => {
+    const css = buttonGroupStylesheet({ orientation: 'vertical' });
+    expect(css).toMatch(/::slotted\(\*:last-child\)\s*\{[^}]*border-top-right-radius:\s*0/);
+    expect(css).toMatch(/::slotted\(\*:last-child\)\s*\{[^}]*border-top-left-radius:\s*0/);
+  });
+
+  it('vertical applies -1px top margin on non-first children', () => {
+    const css = buttonGroupStylesheet({ orientation: 'vertical' });
+    expect(css).toMatch(/::slotted\(\*:not\(:first-child\)\)\s*\{[^}]*margin-top:\s*-1px/);
+  });
+
+  it('middle children clear all radii in either orientation', () => {
+    const horizontal = buttonGroupStylesheet({ orientation: 'horizontal' });
+    const vertical = buttonGroupStylesheet({ orientation: 'vertical' });
+    expect(horizontal).toMatch(
+      /::slotted\(\*:not\(:first-child\):not\(:last-child\)\)\s*\{[^}]*border-radius:\s*0/,
+    );
+    expect(vertical).toMatch(
+      /::slotted\(\*:not\(:first-child\):not\(:last-child\)\)\s*\{[^}]*border-radius:\s*0/,
+    );
+  });
+});
+
+describe('buttonGroupStylesheet focus stacking', () => {
+  it('emits focus stacking for slotted focus-visible', () => {
+    expect(buttonGroupStylesheet()).toMatch(/::slotted\(\*:focus-visible\)/);
+  });
+
+  it('focus-visible raises z-index to 10', () => {
+    expect(buttonGroupStylesheet()).toMatch(/::slotted\(\*:focus-visible\)\s*\{[^}]*z-index:\s*10/);
+  });
+
+  it('focus stacking is present in both orientations', () => {
+    expect(buttonGroupStylesheet({ orientation: 'horizontal' })).toMatch(
+      /::slotted\(\*:focus-visible\)/,
+    );
+    expect(buttonGroupStylesheet({ orientation: 'vertical' })).toMatch(
+      /::slotted\(\*:focus-visible\)/,
+    );
+  });
+});
+
+describe('buttonGroupStylesheet fallback', () => {
+  it('falls back to horizontal when orientation is unknown', () => {
+    expect(() => buttonGroupStylesheet({ orientation: 'diagonal' as never })).not.toThrow();
+    const css = buttonGroupStylesheet({ orientation: 'diagonal' as never });
+    expect(css).toMatch(/flex-direction:\s*row/);
+    expect(css).not.toMatch(/flex-direction:\s*column/);
+  });
+
+  it('falls back to horizontal when orientation is undefined', () => {
+    const css = buttonGroupStylesheet({ orientation: undefined });
+    expect(css).toMatch(/flex-direction:\s*row/);
+  });
+});
+
+describe('buttonGroupStylesheet motion tokens', () => {
+  it('never emits --duration-* tokens', () => {
+    expect(buttonGroupStylesheet()).not.toMatch(/var\(--duration-/);
+    expect(buttonGroupStylesheet({ orientation: 'vertical' })).not.toMatch(/var\(--duration-/);
+  });
+
+  it('never emits --ease-* tokens', () => {
+    expect(buttonGroupStylesheet()).not.toMatch(/var\(--ease-/);
+    expect(buttonGroupStylesheet({ orientation: 'vertical' })).not.toMatch(/var\(--ease-/);
+  });
+});
+
+describe('buttonGroupStylesheet purity', () => {
+  it('returns identical output for identical inputs', () => {
+    const a = buttonGroupStylesheet({ orientation: 'horizontal' });
+    const b = buttonGroupStylesheet({ orientation: 'horizontal' });
+    expect(a).toBe(b);
+  });
+
+  it('differs between orientations', () => {
+    const h = buttonGroupStylesheet({ orientation: 'horizontal' });
+    const v = buttonGroupStylesheet({ orientation: 'vertical' });
+    expect(h).not.toBe(v);
+  });
+});

--- a/packages/ui/src/components/ui/button-group.styles.ts
+++ b/packages/ui/src/components/ui/button-group.styles.ts
@@ -1,0 +1,152 @@
+/**
+ * Shadow DOM style definitions for ButtonGroup web component
+ *
+ * Parallel to button-group.classes.ts. Same semantic structure (connected
+ * borders, focus stacking, horizontal/vertical orientation) expressed as
+ * CSS property maps and ::slotted() rules for a shadow root.
+ *
+ * All token references go through tokenVar() when used; no raw var()
+ * literals. Motion hooks use --motion-duration-* / --motion-ease-* only
+ * (this component defines no transitions, but the reduced-motion guard
+ * is kept as a placeholder for pattern consistency).
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import { styleRule, stylesheet } from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export type ButtonGroupOrientation = 'horizontal' | 'vertical';
+
+export interface ButtonGroupStylesheetOptions {
+  orientation?: ButtonGroupOrientation | undefined;
+}
+
+// ============================================================================
+// Allowed Value Sets
+// ============================================================================
+
+const ORIENTATIONS: ReadonlyArray<ButtonGroupOrientation> = ['horizontal', 'vertical'];
+
+export function isButtonGroupOrientation(value: unknown): value is ButtonGroupOrientation {
+  return typeof value === 'string' && (ORIENTATIONS as ReadonlyArray<string>).includes(value);
+}
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+/**
+ * :host layout primitive per orientation. Groups are inline-flex so they can
+ * sit inline with surrounding content and so focus outlines on their children
+ * are not clipped by a block formatting context.
+ */
+export const buttonGroupBase: Record<ButtonGroupOrientation, CSSProperties> = {
+  horizontal: {
+    display: 'inline-flex',
+    'flex-direction': 'row',
+  },
+  vertical: {
+    display: 'inline-flex',
+    'flex-direction': 'column',
+  },
+};
+
+// ============================================================================
+// Connected-Border Styles (per orientation)
+// ============================================================================
+
+/**
+ * Radius collapse rules for the first, last, and middle slotted elements.
+ * Applied to whatever is slotted -- typically <rafters-button> or native
+ * <button>, but the rules are element-agnostic.
+ */
+const horizontalFirst: CSSProperties = {
+  'border-top-right-radius': '0',
+  'border-bottom-right-radius': '0',
+};
+
+const horizontalLast: CSSProperties = {
+  'border-top-left-radius': '0',
+  'border-bottom-left-radius': '0',
+};
+
+const horizontalMiddle: CSSProperties = {
+  'border-radius': '0',
+};
+
+const horizontalNeighbor: CSSProperties = {
+  'margin-left': '-1px',
+};
+
+const verticalFirst: CSSProperties = {
+  'border-bottom-right-radius': '0',
+  'border-bottom-left-radius': '0',
+};
+
+const verticalLast: CSSProperties = {
+  'border-top-right-radius': '0',
+  'border-top-left-radius': '0',
+};
+
+const verticalMiddle: CSSProperties = {
+  'border-radius': '0',
+};
+
+const verticalNeighbor: CSSProperties = {
+  'margin-top': '-1px',
+};
+
+/**
+ * Focus stacking -- raise the focused child above its neighbors so the
+ * focus ring is not clipped by overlapping borders.
+ */
+const focusStacking: CSSProperties = {
+  'z-index': '10',
+};
+
+// ============================================================================
+// Orientation Rule Builders
+// ============================================================================
+
+function horizontalRules(): string {
+  return stylesheet(
+    styleRule('::slotted(*:first-child)', horizontalFirst),
+    styleRule('::slotted(*:last-child)', horizontalLast),
+    styleRule('::slotted(*:not(:first-child):not(:last-child))', horizontalMiddle),
+    styleRule('::slotted(*:not(:first-child))', horizontalNeighbor),
+    styleRule('::slotted(*:focus-visible)', focusStacking),
+  );
+}
+
+function verticalRules(): string {
+  return stylesheet(
+    styleRule('::slotted(*:first-child)', verticalFirst),
+    styleRule('::slotted(*:last-child)', verticalLast),
+    styleRule('::slotted(*:not(:first-child):not(:last-child))', verticalMiddle),
+    styleRule('::slotted(*:not(:first-child))', verticalNeighbor),
+    styleRule('::slotted(*:focus-visible)', focusStacking),
+  );
+}
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+/**
+ * Build the complete button-group stylesheet for a given orientation.
+ *
+ * Pure: identical options always yield identical output.
+ * Unknown orientation silently falls back to 'horizontal'.
+ */
+export function buttonGroupStylesheet(options: ButtonGroupStylesheetOptions = {}): string {
+  const orientation: ButtonGroupOrientation = isButtonGroupOrientation(options.orientation)
+    ? options.orientation
+    : 'horizontal';
+
+  const slottedRules = orientation === 'vertical' ? verticalRules() : horizontalRules();
+
+  return stylesheet(styleRule(':host', buttonGroupBase[orientation]), slottedRules);
+}


### PR DESCRIPTION
## Summary

Adds a token-driven `<rafters-button-group>` layout-composition Web Component plus `button-group.classes.ts` / `button-group.styles.ts` so related buttons can be grouped outside React with connected borders, focus stacking, and horizontal / vertical orientation.

This is a layout composition element: it arranges whatever is slotted inside, holds no internal state, renders no buttons itself, and is NOT form-associated.

## Pieces

- `button-group.classes.ts` -- shared Tailwind class strings (horizontal / vertical connected-border rules, focus stacking) extracted from `button-group.tsx` so React, Astro, and future framework targets share the same semantic surface.
- `button-group.styles.ts` -- `CSSProperties` maps + `buttonGroupStylesheet()` composing `:host` (display / flex-direction by orientation) and `::slotted(*)` rules that collapse neighbor-button radii and raise the `z-index` of focus-visible children. `isButtonGroupOrientation()` is exported so the element can validate attribute values. No raw `var()` -- token references would flow through `tokenVar()` when used, but this layout is token-free.
- `button-group.element.ts` -- `RaftersButtonGroup` extends `RaftersElement`, observes `[orientation]`, composes a per-instance `CSSStyleSheet` in `connectedCallback`, rebuilds it on attribute change, reflects `role="group"` and `data-orientation` on the host, and auto-registers idempotently on import.
- `button-group.styles.test.ts`, `button-group.element.test.ts` -- unit coverage for registration, role reflection, orientation reflection, slot projection, unknown-value fallback, stylesheet regeneration on attribute change, and `--motion-duration` / `--motion-ease` hygiene.
- `button-group.element.a11y.tsx` -- `vitest-axe` coverage for horizontal / vertical groups with `<rafters-button>` children, native `<button>` children, mixed variants, and the role / data-orientation contract.

Unknown `orientation` values silently fall back to `horizontal`. WC consumers set `size` on each `<rafters-button>` individually -- unlike the React target, the group does not propagate size via context. Attribute forwarding can follow in a future issue.

## Test plan

- [x] `pnpm --filter=@rafters/ui test button-group` -- 5 test files, 100 tests green (element, styles, a11y plus existing React tests).
- [x] `pnpm --filter=@rafters/ui typecheck` -- clean.
- [x] `pnpm preflight` -- clean.
- [x] No raw `var()` outside `tokenVar()` calls.
- [x] No `--duration-*` / `--ease-*` emissions.
- [x] Horizontal and vertical orientations both emit correct connected-border CSS.

Closes #1346