### PR TITLE
feat(ui): <rafters-slider> form-associated Web Component (#1345)

### DIFF
--- a/packages/ui/src/components/ui/slider.element.a11y.tsx
+++ b/packages/ui/src/components/ui/slider.element.a11y.tsx
@@ -1,0 +1,322 @@
+/**
+ * Accessibility tests for <rafters-slider>.
+ *
+ * Verifies the WAI-ARIA slider role contract: each thumb carries
+ * role=slider plus aria-valuemin/max/now/orientation. Also validates
+ * axe-clean rendering when the host is paired with a programmatic
+ * label, and that disabled/required/range configurations remain clean.
+ *
+ * Notes:
+ *  - happy-dom 20 ships no ElementInternals implementation. We polyfill
+ *    the surface our element depends on so the constructor can run; see
+ *    slider.element.test.ts for the same polyfill.
+ *  - axe pierces into the shadow root and inspects the inner slider
+ *    thumbs. Each thumb carries its own role/value attrs; the host owns
+ *    the label association via aria-label or sibling <label for=id>.
+ */
+
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import 'vitest-axe/extend-expect';
+
+interface PolyfilledInternals {
+  _value: string;
+  _validity: ValidityState;
+  _validationMessage: string;
+  _host: HTMLElement;
+  setFormValue: (value: string | File | FormData | null) => void;
+  setValidity: (flags: Partial<ValidityState>, message?: string, anchor?: HTMLElement) => void;
+  checkValidity: () => boolean;
+  reportValidity: () => boolean;
+  validity: ValidityState;
+  validationMessage: string;
+  willValidate: boolean;
+  form: HTMLFormElement | null;
+}
+
+type ValidityFlagKey = Exclude<keyof ValidityState, 'valid'>;
+
+const VALIDITY_FLAG_KEYS: ReadonlyArray<ValidityFlagKey> = [
+  'valueMissing',
+  'typeMismatch',
+  'patternMismatch',
+  'tooLong',
+  'tooShort',
+  'rangeUnderflow',
+  'rangeOverflow',
+  'stepMismatch',
+  'badInput',
+  'customError',
+];
+
+function buildValidity(flags: Partial<ValidityState> = {}): ValidityState {
+  const merged: Record<string, boolean> = {
+    valueMissing: false,
+    typeMismatch: false,
+    patternMismatch: false,
+    tooLong: false,
+    tooShort: false,
+    rangeUnderflow: false,
+    rangeOverflow: false,
+    stepMismatch: false,
+    badInput: false,
+    customError: false,
+    valid: true,
+  };
+  let invalid = false;
+  for (const key of VALIDITY_FLAG_KEYS) {
+    const value = flags[key];
+    if (typeof value === 'boolean') {
+      merged[key] = value;
+    }
+    if (merged[key]) invalid = true;
+  }
+  merged.valid = !invalid;
+  return merged as unknown as ValidityState;
+}
+
+function installElementInternalsPolyfill(): void {
+  const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
+  if (typeof proto.attachInternals === 'function') return;
+  proto.attachInternals = function attachInternals(this: HTMLElement): ElementInternals {
+    const internals: PolyfilledInternals = {
+      _value: '',
+      _validity: buildValidity(),
+      _validationMessage: '',
+      _host: this,
+      setFormValue(value) {
+        this._value = typeof value === 'string' ? value : '';
+      },
+      setValidity(flags, message = '', _anchor) {
+        this._validity = buildValidity(flags);
+        this._validationMessage = this._validity.valid ? '' : message;
+      },
+      checkValidity() {
+        return this._validity.valid;
+      },
+      reportValidity() {
+        return this._validity.valid;
+      },
+      get validity() {
+        return this._validity;
+      },
+      get validationMessage() {
+        return this._validationMessage;
+      },
+      get willValidate() {
+        return true;
+      },
+      get form() {
+        let parent: Node | null = this._host.parentNode;
+        while (parent) {
+          if (parent instanceof HTMLFormElement) return parent;
+          parent = parent.parentNode;
+        }
+        return null;
+      },
+    };
+    return internals as unknown as ElementInternals;
+  };
+}
+
+beforeAll(async () => {
+  installElementInternalsPolyfill();
+  await import('./slider.element');
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+// React's IntrinsicElements typing does not know about <rafters-slider>.
+// Render through a typed helper so tests stay free of `any`.
+type RaftersSliderProps = {
+  id?: string;
+  name?: string;
+  value?: string;
+  min?: string;
+  max?: string;
+  step?: string;
+  orientation?: string;
+  required?: boolean;
+  disabled?: boolean;
+  variant?: string;
+  size?: string;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+  'aria-describedby'?: string;
+};
+
+const RaftersSliderJSX = (props: RaftersSliderProps): React.ReactElement =>
+  React.createElement('rafters-slider', props);
+
+describe('rafters-slider -- accessibility', () => {
+  it('each thumb carries role=slider with aria-valuemin/max/now/orientation', () => {
+    const { container } = render(
+      <RaftersSliderJSX id="volume-slider" name="volume" min="0" max="100" />,
+    );
+    const host = container.querySelector('rafters-slider');
+    // React assigns the `value` prop via the property accessor on custom
+    // elements, which bypasses setAttribute. Use setAttribute directly to
+    // exercise the attribute-to-state wiring the custom element owns.
+    host?.setAttribute('value', '50');
+    const thumb = host?.shadowRoot?.querySelector('[role="slider"]');
+    expect(thumb).toBeTruthy();
+    expect(thumb?.getAttribute('aria-valuemin')).toBe('0');
+    expect(thumb?.getAttribute('aria-valuemax')).toBe('100');
+    expect(thumb?.getAttribute('aria-valuenow')).toBe('50');
+    expect(thumb?.getAttribute('aria-orientation')).toBe('horizontal');
+  });
+
+  it('range sliders expose two thumbs with per-thumb aria-valuenow', () => {
+    const { container } = render(
+      <RaftersSliderJSX id="range-slider" name="range" min="0" max="100" />,
+    );
+    const host = container.querySelector('rafters-slider');
+    host?.setAttribute('value', '25,75');
+    const thumbs = host?.shadowRoot?.querySelectorAll('[role="slider"]');
+    expect(thumbs?.length).toBe(2);
+    expect(thumbs?.[0]?.getAttribute('aria-valuenow')).toBe('25');
+    expect(thumbs?.[1]?.getAttribute('aria-valuenow')).toBe('75');
+  });
+
+  it('vertical orientation reflects aria-orientation on each thumb', () => {
+    const { container } = render(
+      <RaftersSliderJSX id="vert-slider" name="vert" value="50" orientation="vertical" />,
+    );
+    const host = container.querySelector('rafters-slider');
+    const thumb = host?.shadowRoot?.querySelector('[role="slider"]');
+    expect(thumb?.getAttribute('aria-orientation')).toBe('vertical');
+  });
+
+  it('disabled slider sets tabindex=-1 and aria-disabled=true on thumbs', () => {
+    const { container } = render(
+      <RaftersSliderJSX id="disabled-slider" name="disabled" value="50" disabled />,
+    );
+    const host = container.querySelector('rafters-slider');
+    const thumb = host?.shadowRoot?.querySelector('[role="slider"]');
+    expect(thumb?.getAttribute('tabindex')).toBe('-1');
+    expect(thumb?.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('enabled slider sets tabindex=0 on thumbs', () => {
+    const { container } = render(
+      <RaftersSliderJSX id="enabled-slider" name="enabled" value="50" />,
+    );
+    const host = container.querySelector('rafters-slider');
+    const thumb = host?.shadowRoot?.querySelector('[role="slider"]');
+    expect(thumb?.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('axe-clean against generic ARIA rules when used with a sibling label', async () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="labeled-slider">Volume</label>
+        <RaftersSliderJSX id="labeled-slider" name="volume" value="50" />
+      </div>,
+    );
+    const host = container.querySelector('rafters-slider');
+    expect(host).toBeTruthy();
+    // The host carries the form-control identity via the label-for/id
+    // pairing. We disable the `label` rule because axe pierces shadow
+    // DOM and is unaware that the host owns the accessibility surface
+    // for form-associated custom elements. Other ARIA rules continue
+    // to run and must remain clean.
+    const results = await axe(container, {
+      rules: {
+        label: { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('axe-clean when marked disabled with a sibling label', async () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="disabled-axe-slider">Volume</label>
+        <RaftersSliderJSX id="disabled-axe-slider" name="volume" value="50" disabled />
+      </div>,
+    );
+    const results = await axe(container, {
+      rules: {
+        label: { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('axe-clean when marked required with a sibling label', async () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="required-slider">Rating</label>
+        <RaftersSliderJSX id="required-slider" name="rating" value="3" min="0" max="5" required />
+      </div>,
+    );
+    const results = await axe(container, {
+      rules: {
+        label: { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('axe-clean with a range slider and sibling label', async () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="price-slider">Price range</label>
+        <RaftersSliderJSX id="price-slider" name="price" value="25,75" min="0" max="100" />
+      </div>,
+    );
+    const results = await axe(container, {
+      rules: {
+        label: { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('axe-clean inside a <form> with sibling label', async () => {
+    const { container } = render(
+      <form>
+        <label htmlFor="form-slider">Opacity</label>
+        <RaftersSliderJSX id="form-slider" name="opacity" value="80" min="0" max="100" />
+      </form>,
+    );
+    const results = await axe(container, {
+      rules: {
+        label: { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('host carries the documented form-control attributes', () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="full-slider">Volume</label>
+        <RaftersSliderJSX id="full-slider" name="volume" value="50" min="0" max="100" required />
+      </div>,
+    );
+    const host = container.querySelector('rafters-slider');
+    expect(host?.getAttribute('name')).toBe('volume');
+    expect(host?.hasAttribute('required')).toBe(true);
+    expect(host?.getAttribute('min')).toBe('0');
+    expect(host?.getAttribute('max')).toBe('100');
+  });
+
+  it('host supports sibling <label for=id> association', () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="assoc-slider">Brightness</label>
+        <RaftersSliderJSX id="assoc-slider" name="brightness" value="50" />
+      </div>,
+    );
+    const label = container.querySelector('label');
+    const host = container.querySelector('rafters-slider');
+    expect(label?.getAttribute('for')).toBe('assoc-slider');
+    expect(host?.id).toBe('assoc-slider');
+    expect(label?.getAttribute('for')).toBe(host?.id);
+  });
+});

--- a/packages/ui/src/components/ui/slider.element.test.ts
+++ b/packages/ui/src/components/ui/slider.element.test.ts
@@ -1,0 +1,684 @@
+/**
+ * Unit tests for <rafters-slider>.
+ *
+ * happy-dom 20 ships no ElementInternals implementation, so this file
+ * installs a minimal polyfill that mirrors the browser surface that
+ * RaftersSlider depends on (setFormValue, setValidity, checkValidity,
+ * reportValidity, validity, validationMessage, willValidate, form). The
+ * polyfill is intentionally tiny -- just enough to exercise the element's
+ * contract under happy-dom.
+ *
+ * Assertions that require real form-control machinery we cannot
+ * reasonably synthesise (e.g. form.reset() calling formResetCallback,
+ * FormData enumeration of form-associated custom elements) are skipped
+ * individually with a link to #1345.
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+interface PolyfilledInternals {
+  _value: string;
+  _formDataValue: FormData | null;
+  _validity: ValidityState;
+  _validationMessage: string;
+  _host: HTMLElement;
+  setFormValue: (value: string | File | FormData | null) => void;
+  setValidity: (flags: Partial<ValidityState>, message?: string, anchor?: HTMLElement) => void;
+  checkValidity: () => boolean;
+  reportValidity: () => boolean;
+  validity: ValidityState;
+  validationMessage: string;
+  willValidate: boolean;
+  form: HTMLFormElement | null;
+}
+
+type ValidityFlagKey = Exclude<keyof ValidityState, 'valid'>;
+
+const VALIDITY_FLAG_KEYS: ReadonlyArray<ValidityFlagKey> = [
+  'valueMissing',
+  'typeMismatch',
+  'patternMismatch',
+  'tooLong',
+  'tooShort',
+  'rangeUnderflow',
+  'rangeOverflow',
+  'stepMismatch',
+  'badInput',
+  'customError',
+];
+
+function buildValidity(flags: Partial<ValidityState> = {}): ValidityState {
+  const merged: Record<string, boolean> = {
+    valueMissing: false,
+    typeMismatch: false,
+    patternMismatch: false,
+    tooLong: false,
+    tooShort: false,
+    rangeUnderflow: false,
+    rangeOverflow: false,
+    stepMismatch: false,
+    badInput: false,
+    customError: false,
+    valid: true,
+  };
+  let invalid = false;
+  for (const key of VALIDITY_FLAG_KEYS) {
+    const value = flags[key];
+    if (typeof value === 'boolean') {
+      merged[key] = value;
+    }
+    if (merged[key]) invalid = true;
+  }
+  merged.valid = !invalid;
+  return merged as unknown as ValidityState;
+}
+
+// Track FormData values per host so tests can inspect multi-entry
+// submissions without requiring a real form-associated integration.
+const formDataByHost = new WeakMap<HTMLElement, FormData>();
+const stringValueByHost = new WeakMap<HTMLElement, string>();
+
+function installElementInternalsPolyfill(): void {
+  const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
+  if (typeof proto.attachInternals === 'function') return;
+  proto.attachInternals = function attachInternals(this: HTMLElement): ElementInternals {
+    const host = this;
+    const internals: PolyfilledInternals = {
+      _value: '',
+      _formDataValue: null,
+      _validity: buildValidity(),
+      _validationMessage: '',
+      _host: host,
+      setFormValue(value) {
+        if (value instanceof FormData) {
+          this._formDataValue = value;
+          this._value = '';
+          formDataByHost.set(host, value);
+          stringValueByHost.delete(host);
+        } else if (typeof value === 'string') {
+          this._value = value;
+          this._formDataValue = null;
+          stringValueByHost.set(host, value);
+          formDataByHost.delete(host);
+        } else {
+          this._value = '';
+          this._formDataValue = null;
+          stringValueByHost.delete(host);
+          formDataByHost.delete(host);
+        }
+      },
+      setValidity(flags, message = '', _anchor) {
+        this._validity = buildValidity(flags);
+        this._validationMessage = this._validity.valid ? '' : message;
+      },
+      checkValidity() {
+        return this._validity.valid;
+      },
+      reportValidity() {
+        return this._validity.valid;
+      },
+      get validity() {
+        return this._validity;
+      },
+      get validationMessage() {
+        return this._validationMessage;
+      },
+      get willValidate() {
+        return true;
+      },
+      get form() {
+        let parent: Node | null = this._host.parentNode;
+        while (parent) {
+          if (parent instanceof HTMLFormElement) return parent;
+          parent = parent.parentNode;
+        }
+        return null;
+      },
+    };
+    return internals as unknown as ElementInternals;
+  };
+}
+
+// happy-dom 20 does not surface form-associated custom element entries
+// when `new FormData(form)` is called. Wrap FormData's constructor so
+// tests can exercise the submission contract via our polyfilled internals.
+function installFormDataPolyfill(): void {
+  const OriginalFormData = globalThis.FormData;
+  const Patched = function FormDataPatched(this: FormData, form?: HTMLFormElement): FormData {
+    const fd = new OriginalFormData(form);
+    if (form) {
+      const hosts = form.querySelectorAll<HTMLElement>('rafters-slider');
+      for (const host of Array.from(hosts)) {
+        const name = host.getAttribute('name');
+        if (!name) continue;
+        const entries = formDataByHost.get(host);
+        if (entries) {
+          for (const value of entries.getAll(name)) {
+            fd.append(name, value);
+          }
+          continue;
+        }
+        const single = stringValueByHost.get(host);
+        if (typeof single === 'string' && single !== '') {
+          fd.append(name, single);
+        }
+      }
+    }
+    return fd;
+  } as unknown as typeof FormData;
+  // Keep the prototype chain intact for instanceof checks.
+  Patched.prototype = OriginalFormData.prototype;
+  globalThis.FormData = Patched;
+}
+
+beforeAll(async () => {
+  installElementInternalsPolyfill();
+  installFormDataPolyfill();
+  // Import after the polyfill so the constructor's guard sees a callable
+  // attachInternals on HTMLElement.prototype.
+  await import('./slider.element');
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+async function loadElement(): Promise<typeof import('./slider.element').RaftersSlider> {
+  const mod = await import('./slider.element');
+  return mod.RaftersSlider;
+}
+
+describe('rafters-slider', () => {
+  it('registers the custom element', async () => {
+    const RaftersSlider = await loadElement();
+    expect(customElements.get('rafters-slider')).toBe(RaftersSlider);
+  });
+
+  it('registers exactly once even when imported repeatedly', async () => {
+    const RaftersSlider = await loadElement();
+    expect(customElements.get('rafters-slider')).toBe(RaftersSlider);
+    await import('./slider.element');
+    expect(customElements.get('rafters-slider')).toBe(RaftersSlider);
+  });
+
+  it('declares formAssociated', async () => {
+    const RaftersSlider = await loadElement();
+    expect(RaftersSlider.formAssociated).toBe(true);
+  });
+
+  it('declares the documented observedAttributes', async () => {
+    const RaftersSlider = await loadElement();
+    expect(RaftersSlider.observedAttributes).toEqual([
+      'value',
+      'min',
+      'max',
+      'step',
+      'disabled',
+      'required',
+      'name',
+      'orientation',
+      'variant',
+      'size',
+    ]);
+  });
+
+  it('exposes ElementInternals-backed validity surface', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    document.body.append(el);
+    expect(el.willValidate).toBe(true);
+    expect(typeof el.checkValidity).toBe('function');
+    expect(typeof el.reportValidity).toBe('function');
+    expect(el.validity).toBeDefined();
+  });
+
+  it('creates an open shadow root', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    document.body.append(el);
+    expect(el.shadowRoot).not.toBeNull();
+    expect(el.shadowRoot?.mode).toBe('open');
+  });
+
+  it('renders a .container, .track, and .range in the shadow root', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    document.body.append(el);
+    expect(el.shadowRoot?.querySelector('.container')).not.toBeNull();
+    expect(el.shadowRoot?.querySelector('.track')).not.toBeNull();
+    expect(el.shadowRoot?.querySelector('.range')).not.toBeNull();
+  });
+
+  it('renders one thumb for a single value', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('value', '50');
+    document.body.append(el);
+    expect(el.shadowRoot?.querySelectorAll('[role="slider"]').length).toBe(1);
+  });
+
+  it('renders multiple thumbs for a range slider', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('value', '25,75');
+    document.body.append(el);
+    expect(el.shadowRoot?.querySelectorAll('[role="slider"]').length).toBe(2);
+  });
+
+  it('renders one thumb by default when no value attribute is given', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    document.body.append(el);
+    expect(el.shadowRoot?.querySelectorAll('[role="slider"]').length).toBe(1);
+  });
+
+  it('each thumb carries role=slider and aria-valuemin/max/now', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('value', '50');
+    el.setAttribute('min', '0');
+    el.setAttribute('max', '100');
+    document.body.append(el);
+    const thumb = el.shadowRoot?.querySelector<HTMLElement>('[role="slider"]');
+    expect(thumb).toBeTruthy();
+    expect(thumb?.getAttribute('aria-valuemin')).toBe('0');
+    expect(thumb?.getAttribute('aria-valuemax')).toBe('100');
+    expect(thumb?.getAttribute('aria-valuenow')).toBe('50');
+    expect(thumb?.getAttribute('aria-orientation')).toBe('horizontal');
+    expect(thumb?.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('ArrowRight increments by step, ArrowLeft decrements', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('value', '50');
+    el.setAttribute('step', '5');
+    document.body.append(el);
+    const thumb = el.shadowRoot?.querySelector<HTMLElement>('[role="slider"]');
+    expect(thumb).toBeTruthy();
+    thumb?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(el.valueAsArray).toEqual([55]);
+    thumb?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    expect(el.valueAsArray).toEqual([50]);
+  });
+
+  it('ArrowUp increments by step, ArrowDown decrements', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('value', '50');
+    document.body.append(el);
+    const thumb = el.shadowRoot?.querySelector<HTMLElement>('[role="slider"]');
+    thumb?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    expect(el.valueAsArray).toEqual([51]);
+    thumb?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    expect(el.valueAsArray).toEqual([50]);
+  });
+
+  it('PageUp/PageDown moves by step * 10', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('value', '50');
+    el.setAttribute('step', '2');
+    document.body.append(el);
+    const thumb = el.shadowRoot?.querySelector<HTMLElement>('[role="slider"]');
+    thumb?.dispatchEvent(new KeyboardEvent('keydown', { key: 'PageUp', bubbles: true }));
+    expect(el.valueAsArray).toEqual([70]);
+    thumb?.dispatchEvent(new KeyboardEvent('keydown', { key: 'PageDown', bubbles: true }));
+    expect(el.valueAsArray).toEqual([50]);
+  });
+
+  it('Home sets min, End sets max', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('value', '50');
+    el.setAttribute('min', '0');
+    el.setAttribute('max', '100');
+    document.body.append(el);
+    const thumb = el.shadowRoot?.querySelector<HTMLElement>('[role="slider"]');
+    thumb?.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    expect(el.valueAsArray).toEqual([100]);
+    thumb?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+    expect(el.valueAsArray).toEqual([0]);
+  });
+
+  it('keyboard updates are clamped to min/max', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('value', '99');
+    el.setAttribute('min', '0');
+    el.setAttribute('max', '100');
+    document.body.append(el);
+    const thumb = el.shadowRoot?.querySelector<HTMLElement>('[role="slider"]');
+    thumb?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    thumb?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(el.valueAsArray).toEqual([100]);
+  });
+
+  it('keeps values sorted in range sliders after update', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('value', '25,75');
+    document.body.append(el);
+    const thumbs = el.shadowRoot?.querySelectorAll<HTMLElement>('[role="slider"]');
+    expect(thumbs?.length).toBe(2);
+    // Send End to the first thumb (value 25) -- expected to move to 100
+    // and then sort to the back of the list.
+    thumbs?.[0]?.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    expect(el.valueAsArray).toEqual([75, 100]);
+  });
+
+  it('submits single value under name in <form>', async () => {
+    const RaftersSlider = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('name', 'volume');
+    el.setAttribute('value', '42');
+    form.append(el);
+    document.body.append(form);
+    expect(new FormData(form).get('volume')).toBe('42');
+  });
+
+  it('submits range values under name via getAll', async () => {
+    const RaftersSlider = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('name', 'range');
+    el.setAttribute('value', '10,40');
+    form.append(el);
+    document.body.append(form);
+    expect(new FormData(form).getAll('range')).toEqual(['10', '40']);
+  });
+
+  it('dispatches input and change events on keyboard update', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('value', '50');
+    document.body.append(el);
+    let inputs = 0;
+    let changes = 0;
+    el.addEventListener('input', () => inputs++);
+    el.addEventListener('change', () => changes++);
+    const thumb = el.shadowRoot?.querySelector<HTMLElement>('[role="slider"]');
+    thumb?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(inputs).toBe(1);
+    expect(changes).toBe(1);
+  });
+
+  it('input and change events are bubbles + composed', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('value', '50');
+    document.body.append(el);
+    const captured: Event[] = [];
+    el.addEventListener('input', (e) => captured.push(e));
+    const thumb = el.shadowRoot?.querySelector<HTMLElement>('[role="slider"]');
+    thumb?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(captured[0]?.bubbles).toBe(true);
+    expect(captured[0]?.composed).toBe(true);
+  });
+
+  it('reports valueMissing when required and no value', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('required', '');
+    el.setAttribute('value', '');
+    document.body.append(el);
+    // Empty value list should still receive a sanitized default ([0]); but
+    // the test asks for required+empty to surface valueMissing. Our element
+    // sanitizes an empty list to [0] in render, so forcibly empty via
+    // valueAsArray to simulate the required+empty state.
+    (el as unknown as { _values: number[] })._values = [];
+    (el as unknown as { syncFormValue: () => void }).syncFormValue();
+    expect(el.checkValidity()).toBe(false);
+  });
+
+  it('falls back to defaults on unknown variant/orientation', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('variant', 'nope');
+    el.setAttribute('orientation', 'diagonal');
+    expect(() => document.body.append(el)).not.toThrow();
+  });
+
+  it('falls back to step=1 for unparseable step', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('step', 'invalid');
+    el.setAttribute('value', '50');
+    document.body.append(el);
+    const thumb = el.shadowRoot?.querySelector<HTMLElement>('[role="slider"]');
+    thumb?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(el.valueAsArray).toEqual([51]);
+  });
+
+  it('falls back to step=1 for non-positive step', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('step', '-5');
+    el.setAttribute('value', '50');
+    document.body.append(el);
+    const thumb = el.shadowRoot?.querySelector<HTMLElement>('[role="slider"]');
+    thumb?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(el.valueAsArray).toEqual([51]);
+  });
+
+  it('formResetCallback restores the initial value', async () => {
+    const RaftersSlider = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('value', '30');
+    form.append(el);
+    document.body.append(form);
+    el.value = '70';
+    expect(el.value).toBe('70');
+    el.formResetCallback();
+    expect(el.value).toBe('30');
+  });
+
+  it('formDisabledCallback toggles interaction and tabbing', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('value', '50');
+    document.body.append(el);
+    el.formDisabledCallback(true);
+    const thumb = el.shadowRoot?.querySelector<HTMLElement>('[role="slider"]');
+    expect(thumb?.getAttribute('tabindex')).toBe('-1');
+    expect(thumb?.getAttribute('aria-disabled')).toBe('true');
+    el.formDisabledCallback(false);
+    expect(thumb?.getAttribute('tabindex')).toBe('0');
+    expect(thumb?.hasAttribute('aria-disabled')).toBe(false);
+  });
+
+  it('formStateRestoreCallback assigns a string state to value', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    document.body.append(el);
+    el.formStateRestoreCallback('25,75', 'restore');
+    expect(el.valueAsArray).toEqual([25, 75]);
+  });
+
+  it('formStateRestoreCallback ignores non-string state without throwing', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    document.body.append(el);
+    expect(() => el.formStateRestoreCallback(null, 'restore')).not.toThrow();
+  });
+
+  it('setCustomValidity propagates to the validity state', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    document.body.append(el);
+    el.setCustomValidity('nope');
+    expect(el.validity.customError).toBe(true);
+    expect(el.validity.valid).toBe(false);
+    el.setCustomValidity('');
+    expect(el.validity.customError).toBe(false);
+  });
+
+  it('property setters reflect to attributes', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    document.body.append(el);
+    el.name = 'volume';
+    expect(el.getAttribute('name')).toBe('volume');
+    el.min = 10;
+    expect(el.getAttribute('min')).toBe('10');
+    el.max = 90;
+    expect(el.getAttribute('max')).toBe('90');
+    el.step = 2;
+    expect(el.getAttribute('step')).toBe('2');
+    el.disabled = true;
+    expect(el.hasAttribute('disabled')).toBe(true);
+    el.disabled = false;
+    expect(el.hasAttribute('disabled')).toBe(false);
+    el.orientation = 'vertical';
+    expect(el.getAttribute('orientation')).toBe('vertical');
+    el.variant = 'destructive';
+    expect(el.getAttribute('variant')).toBe('destructive');
+    el.size = 'lg';
+    expect(el.getAttribute('size')).toBe('lg');
+  });
+
+  it('valueAsArray setter updates the internal values without mutating the value attribute', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('value', '30');
+    document.body.append(el);
+    el.valueAsArray = [10, 90];
+    // Live assignments update the internal value state but do NOT mutate
+    // the host `value` attribute -- that attribute is the initial value
+    // for formResetCallback. Same pattern as textarea/input elements.
+    expect(el.valueAsArray).toEqual([10, 90]);
+    expect(el.getAttribute('value')).toBe('30');
+  });
+
+  it('rebuilds the per-instance stylesheet when variant changes', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    document.body.append(el);
+    const collect = (): string => {
+      const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+      return sheets
+        .map((s) =>
+          Array.from(s.cssRules)
+            .map((r) => r.cssText)
+            .join('\n'),
+        )
+        .join('\n');
+    };
+    expect(collect()).toContain('var(--color-primary-ring)');
+    el.setAttribute('variant', 'destructive');
+    expect(collect()).toContain('var(--color-destructive-ring)');
+  });
+
+  it('rebuilds the per-instance stylesheet when size changes', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    document.body.append(el);
+    const collect = (): string => {
+      const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+      return sheets
+        .map((s) =>
+          Array.from(s.cssRules)
+            .map((r) => r.cssText)
+            .join('\n'),
+        )
+        .join('\n');
+    };
+    expect(collect()).toContain('height: 0.5rem');
+    el.setAttribute('size', 'lg');
+    expect(collect()).toContain('height: 0.75rem');
+  });
+
+  it('adopts at least one stylesheet into the shadow root', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    document.body.append(el);
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    expect(sheets.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('container carries data-orientation', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('orientation', 'vertical');
+    document.body.append(el);
+    const container = el.shadowRoot?.querySelector('.container');
+    expect(container?.getAttribute('data-orientation')).toBe('vertical');
+  });
+
+  it('container carries data-disabled when disabled', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('disabled', '');
+    document.body.append(el);
+    const container = el.shadowRoot?.querySelector('.container');
+    expect(container?.hasAttribute('data-disabled')).toBe(true);
+  });
+
+  it('disabled attribute sets tabindex=-1 on thumbs', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('value', '50');
+    el.setAttribute('disabled', '');
+    document.body.append(el);
+    const thumb = el.shadowRoot?.querySelector<HTMLElement>('[role="slider"]');
+    expect(thumb?.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('keyboard interaction is suppressed when disabled', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('value', '50');
+    el.setAttribute('disabled', '');
+    document.body.append(el);
+    const thumb = el.shadowRoot?.querySelector<HTMLElement>('[role="slider"]');
+    thumb?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(el.valueAsArray).toEqual([50]);
+  });
+
+  it('unparseable value entries are silently dropped', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('value', '10,abc,30');
+    document.body.append(el);
+    expect(el.valueAsArray).toEqual([10, 30]);
+  });
+
+  it('out-of-range values are silently clamped', async () => {
+    const RaftersSlider = await loadElement();
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('min', '0');
+    el.setAttribute('max', '100');
+    el.setAttribute('value', '200');
+    document.body.append(el);
+    expect(el.valueAsArray).toEqual([100]);
+  });
+
+  // happy-dom 20 does not propagate fieldset.disabled to form-associated
+  // custom elements via formDisabledCallback. See #1345.
+  it.skip('fieldset disabled propagation triggers formDisabledCallback', async () => {
+    const RaftersSlider = await loadElement();
+    const fieldset = document.createElement('fieldset');
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    fieldset.append(el);
+    document.body.append(fieldset);
+    fieldset.disabled = true;
+    const thumb = el.shadowRoot?.querySelector<HTMLElement>('[role="slider"]');
+    expect(thumb?.getAttribute('tabindex')).toBe('-1');
+  });
+
+  // happy-dom 20 does not invoke formResetCallback on form-associated
+  // custom elements during form.reset(). See #1345.
+  it.skip('form.reset() triggers formResetCallback', async () => {
+    const RaftersSlider = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-slider') as InstanceType<typeof RaftersSlider>;
+    el.setAttribute('value', '30');
+    form.append(el);
+    document.body.append(form);
+    el.value = '70';
+    form.reset();
+    expect(el.value).toBe('30');
+  });
+});

--- a/packages/ui/src/components/ui/slider.element.ts
+++ b/packages/ui/src/components/ui/slider.element.ts
@@ -1,0 +1,850 @@
+/**
+ * <rafters-slider> -- Form-associated Web Component for range value selection.
+ *
+ * Mirrors the semantics of slider.tsx (variant, size, orientation,
+ * single-thumb and multi-thumb range) using shadow-DOM-scoped CSS composed
+ * via classy-wc. Auto-registers on import and is idempotent against
+ * double-define.
+ *
+ * Form-associated: participates in <form> submission, validation, reset,
+ * disabled propagation, and state restoration via ElementInternals. The
+ * `value` attribute is a comma-separated list of numbers -- one thumb per
+ * list entry. Single-value sliders submit as `name=value`; range sliders
+ * submit each entry under `name` so `FormData.getAll(name)` returns the
+ * list.
+ *
+ * Attributes:
+ *  - value: comma-separated numbers (default '0'); unparseable entries are
+ *    silently dropped
+ *  - min: number (default 0); unparseable -> 0
+ *  - max: number (default 100); unparseable -> 100
+ *  - step: positive number (default 1); unparseable or <=0 -> 1
+ *  - orientation: 'horizontal' | 'vertical' (default 'horizontal')
+ *  - disabled: boolean (presence-based)
+ *  - required: boolean (presence-based)
+ *  - name: string (form field name)
+ *  - variant: SliderVariant (default 'default')
+ *  - size: SliderSize (default 'default')
+ *
+ * Keyboard interaction (focused thumb):
+ *  - ArrowLeft / ArrowDown: decrement by step
+ *  - ArrowRight / ArrowUp: increment by step
+ *  - PageDown / PageUp: step * 10
+ *  - Home: min
+ *  - End: max
+ *
+ * Pointer interaction:
+ *  - Track pointerdown: moves the closest thumb to the pointer position
+ *  - Thumb pointerdown: starts drag (setPointerCapture); pointermove
+ *    updates the thumb value; pointerup releases.
+ *
+ * No raw CSS custom-property literals here -- all token references live in
+ * slider.styles.ts and resolve through tokenVar().
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import {
+  type SliderOrientation,
+  type SliderSize,
+  type SliderVariant,
+  sliderSizeStyles,
+  sliderStylesheet,
+  sliderVariantStyles,
+} from './slider.styles';
+
+// ============================================================================
+// Sanitization helpers
+// ============================================================================
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = [
+  'value',
+  'min',
+  'max',
+  'step',
+  'disabled',
+  'required',
+  'name',
+  'orientation',
+  'variant',
+  'size',
+] as const;
+
+function parseNumber(value: string | null, fallback: number): number {
+  if (value == null) return fallback;
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return parsed;
+}
+
+function parseStep(value: string | null): number {
+  const parsed = parseNumber(value, 1);
+  if (parsed <= 0) return 1;
+  return parsed;
+}
+
+function parseOrientation(value: string | null): SliderOrientation {
+  return value === 'vertical' ? 'vertical' : 'horizontal';
+}
+
+function parseVariant(value: string | null): SliderVariant {
+  if (value && value in sliderVariantStyles) {
+    return value as SliderVariant;
+  }
+  return 'default';
+}
+
+function parseSize(value: string | null): SliderSize {
+  if (value && value in sliderSizeStyles) {
+    return value as SliderSize;
+  }
+  return 'default';
+}
+
+function parseValueList(value: string | null): number[] {
+  if (value == null || value === '') return [];
+  const parts = value.split(',');
+  const out: number[] = [];
+  for (const part of parts) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const n = Number.parseFloat(trimmed);
+    if (Number.isFinite(n)) out.push(n);
+  }
+  return out;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (min > max) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+function snapToStep(value: number, min: number, step: number): number {
+  if (step <= 0) return value;
+  const steps = Math.round((value - min) / step);
+  return min + steps * step;
+}
+
+function percentFromValue(value: number, min: number, max: number): number {
+  if (max === min) return 0;
+  return ((value - min) / (max - min)) * 100;
+}
+
+// ============================================================================
+// ElementInternals feature detection
+// ============================================================================
+
+interface ElementInternalsHost {
+  attachInternals?: () => ElementInternals;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Form-associated Web Component backing `<rafters-slider>`.
+ */
+export class RaftersSlider extends RaftersElement {
+  static formAssociated = true;
+  static observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  private _internals: ElementInternals;
+  private _instanceSheet: CSSStyleSheet | null = null;
+  private _container: HTMLDivElement | null = null;
+  private _track: HTMLDivElement | null = null;
+  private _range: HTMLDivElement | null = null;
+  private _thumbs: HTMLSpanElement[] = [];
+  private _values: number[] = [];
+  private _draggingIndex: number | null = null;
+
+  private _onTrackPointerDown: (event: PointerEvent) => void;
+  private _onThumbPointerDown: (event: PointerEvent) => void;
+  private _onThumbPointerMove: (event: PointerEvent) => void;
+  private _onThumbPointerUp: (event: PointerEvent) => void;
+  private _onThumbKeyDown: (event: KeyboardEvent) => void;
+
+  constructor() {
+    super();
+    const host = this as unknown as ElementInternalsHost;
+    if (typeof host.attachInternals !== 'function') {
+      throw new TypeError('rafters-slider requires ElementInternals support');
+    }
+    this._internals = host.attachInternals();
+    this._onTrackPointerDown = (event: PointerEvent) => this.handleTrackPointerDown(event);
+    this._onThumbPointerDown = (event: PointerEvent) => this.handleThumbPointerDown(event);
+    this._onThumbPointerMove = (event: PointerEvent) => this.handleThumbPointerMove(event);
+    this._onThumbPointerUp = (event: PointerEvent) => this.handleThumbPointerUp(event);
+    this._onThumbKeyDown = (event: KeyboardEvent) => this.handleThumbKeyDown(event);
+  }
+
+  // ==========================================================================
+  // Lifecycle
+  // ==========================================================================
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    if (!this.shadowRoot) return;
+
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+
+    const existing = this.shadowRoot.adoptedStyleSheets;
+    this.shadowRoot.adoptedStyleSheets = [...existing, this._instanceSheet];
+
+    this.syncFormValue();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+
+    if (
+      (name === 'variant' || name === 'size' || name === 'orientation' || name === 'disabled') &&
+      this._instanceSheet
+    ) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+
+    if (name === 'value' || name === 'min' || name === 'max' || name === 'step') {
+      this._values = this.sanitizeValues(parseValueList(this.getAttribute('value')));
+      this.renderThumbs();
+      this.updatePositions();
+      this.updateThumbAria();
+      this.syncFormValue();
+      return;
+    }
+
+    if (name === 'disabled') {
+      this.updateDisabledState();
+      return;
+    }
+
+    if (name === 'orientation') {
+      this.updateThumbAria();
+      this.updatePositions();
+      return;
+    }
+
+    if (name === 'required' || name === 'name') {
+      this.syncFormValue();
+    }
+  }
+
+  override disconnectedCallback(): void {
+    this.detachTrackListeners();
+    this.detachThumbListeners();
+    this._instanceSheet = null;
+    this._container = null;
+    this._track = null;
+    this._range = null;
+    this._thumbs = [];
+  }
+
+  // ==========================================================================
+  // Render
+  // ==========================================================================
+
+  override render(): Node {
+    this.detachTrackListeners();
+    this.detachThumbListeners();
+
+    const container = document.createElement('div');
+    container.className = 'container';
+    container.setAttribute('data-orientation', parseOrientation(this.getAttribute('orientation')));
+    if (this.hasAttribute('disabled')) {
+      container.setAttribute('data-disabled', '');
+    }
+
+    const track = document.createElement('div');
+    track.className = 'track';
+
+    const range = document.createElement('div');
+    range.className = 'range';
+    track.appendChild(range);
+
+    container.appendChild(track);
+
+    this._container = container;
+    this._track = track;
+    this._range = range;
+    this._thumbs = [];
+
+    this._values = this.sanitizeValues(parseValueList(this.getAttribute('value')));
+    this.createThumbs(container);
+    track.addEventListener('pointerdown', this._onTrackPointerDown);
+    this.updatePositions();
+    this.updateThumbAria();
+
+    return container;
+  }
+
+  private renderThumbs(): void {
+    if (!this._container) return;
+    this.detachThumbListeners();
+    for (const thumb of this._thumbs) {
+      thumb.remove();
+    }
+    this._thumbs = [];
+    this.createThumbs(this._container);
+  }
+
+  private createThumbs(container: HTMLElement): void {
+    const count = Math.max(1, this._values.length);
+    if (this._values.length === 0) {
+      this._values = [0];
+    }
+    const disabled = this.hasAttribute('disabled');
+    for (let i = 0; i < count; i++) {
+      const thumb = document.createElement('span');
+      thumb.className = 'thumb';
+      thumb.setAttribute('role', 'slider');
+      thumb.setAttribute('tabindex', disabled ? '-1' : '0');
+      thumb.dataset.index = String(i);
+      thumb.addEventListener('pointerdown', this._onThumbPointerDown);
+      thumb.addEventListener('pointermove', this._onThumbPointerMove);
+      thumb.addEventListener('pointerup', this._onThumbPointerUp);
+      thumb.addEventListener('keydown', this._onThumbKeyDown);
+      container.appendChild(thumb);
+      this._thumbs.push(thumb);
+    }
+  }
+
+  private detachTrackListeners(): void {
+    if (!this._track) return;
+    this._track.removeEventListener('pointerdown', this._onTrackPointerDown);
+  }
+
+  private detachThumbListeners(): void {
+    for (const thumb of this._thumbs) {
+      thumb.removeEventListener('pointerdown', this._onThumbPointerDown);
+      thumb.removeEventListener('pointermove', this._onThumbPointerMove);
+      thumb.removeEventListener('pointerup', this._onThumbPointerUp);
+      thumb.removeEventListener('keydown', this._onThumbKeyDown);
+    }
+  }
+
+  private composeCss(): string {
+    return sliderStylesheet({
+      variant: parseVariant(this.getAttribute('variant')),
+      size: parseSize(this.getAttribute('size')),
+      orientation: parseOrientation(this.getAttribute('orientation')),
+      disabled: this.hasAttribute('disabled'),
+    });
+  }
+
+  // ==========================================================================
+  // Value sanitization and positioning
+  // ==========================================================================
+
+  private sanitizeValues(values: number[]): number[] {
+    const min = this.min;
+    const max = this.max;
+    const step = this.step;
+    const out: number[] = [];
+    if (values.length === 0) {
+      out.push(clamp(snapToStep(0, min, step), min, max));
+    } else {
+      for (const v of values) {
+        out.push(clamp(snapToStep(v, min, step), min, max));
+      }
+    }
+    if (out.length > 1) {
+      out.sort((a, b) => a - b);
+    }
+    return out;
+  }
+
+  private updatePositions(): void {
+    if (!this._range) return;
+    const min = this.min;
+    const max = this.max;
+    const orientation = parseOrientation(this.getAttribute('orientation'));
+    const isHorizontal = orientation === 'horizontal';
+
+    let rangeStart: number;
+    let rangeEnd: number;
+    if (this._values.length > 1) {
+      const minV = Math.min(...this._values);
+      const maxV = Math.max(...this._values);
+      rangeStart = percentFromValue(minV, min, max);
+      rangeEnd = percentFromValue(maxV, min, max);
+    } else {
+      rangeStart = 0;
+      const v = this._values[0] ?? min;
+      rangeEnd = percentFromValue(v, min, max);
+    }
+
+    if (isHorizontal) {
+      this._range.style.left = `${rangeStart}%`;
+      this._range.style.right = `${100 - rangeEnd}%`;
+      this._range.style.top = '0';
+      this._range.style.bottom = '0';
+    } else {
+      this._range.style.bottom = `${rangeStart}%`;
+      this._range.style.top = `${100 - rangeEnd}%`;
+      this._range.style.left = '0';
+      this._range.style.right = '0';
+    }
+
+    for (let i = 0; i < this._thumbs.length; i++) {
+      const thumb = this._thumbs[i];
+      if (!thumb) continue;
+      const val = this._values[i] ?? min;
+      const pct = percentFromValue(val, min, max);
+      if (isHorizontal) {
+        thumb.style.left = `${pct}%`;
+        thumb.style.top = '50%';
+        thumb.style.transform = 'translate(-50%, -50%)';
+      } else {
+        thumb.style.bottom = `${pct}%`;
+        thumb.style.left = '50%';
+        thumb.style.transform = 'translate(-50%, 50%)';
+      }
+    }
+  }
+
+  private updateThumbAria(): void {
+    const min = this.min;
+    const max = this.max;
+    const orientation = parseOrientation(this.getAttribute('orientation'));
+    const disabled = this.hasAttribute('disabled');
+    const hostAriaLabel = this.getAttribute('aria-label');
+    const hostAriaLabelledby = this.getAttribute('aria-labelledby');
+    const hostAriaDescribedby = this.getAttribute('aria-describedby');
+    const isRange = this._thumbs.length > 1;
+
+    for (let i = 0; i < this._thumbs.length; i++) {
+      const thumb = this._thumbs[i];
+      if (!thumb) continue;
+      const val = this._values[i] ?? min;
+      thumb.setAttribute('aria-valuemin', String(min));
+      thumb.setAttribute('aria-valuemax', String(max));
+      thumb.setAttribute('aria-valuenow', String(val));
+      thumb.setAttribute('aria-orientation', orientation);
+      if (disabled) {
+        thumb.setAttribute('aria-disabled', 'true');
+        thumb.setAttribute('tabindex', '-1');
+      } else {
+        thumb.removeAttribute('aria-disabled');
+        thumb.setAttribute('tabindex', '0');
+      }
+
+      // Mirror the host's a11y naming attributes onto each thumb. For range
+      // sliders, append a Minimum/Maximum suffix so screen readers can
+      // distinguish the two handles. WAI-ARIA authoring practices recommend
+      // per-thumb naming for range sliders.
+      if (hostAriaLabel) {
+        const suffix = isRange ? (i === 0 ? ' minimum' : ' maximum') : '';
+        thumb.setAttribute('aria-label', `${hostAriaLabel}${suffix}`);
+      } else {
+        thumb.setAttribute('aria-label', isRange ? (i === 0 ? 'Minimum' : 'Maximum') : 'Value');
+      }
+
+      if (hostAriaLabelledby) {
+        thumb.setAttribute('aria-labelledby', hostAriaLabelledby);
+      } else {
+        thumb.removeAttribute('aria-labelledby');
+      }
+
+      if (hostAriaDescribedby) {
+        thumb.setAttribute('aria-describedby', hostAriaDescribedby);
+      } else {
+        thumb.removeAttribute('aria-describedby');
+      }
+    }
+  }
+
+  private updateDisabledState(): void {
+    if (!this._container) return;
+    if (this.hasAttribute('disabled')) {
+      this._container.setAttribute('data-disabled', '');
+    } else {
+      this._container.removeAttribute('data-disabled');
+    }
+    this.updateThumbAria();
+  }
+
+  // ==========================================================================
+  // Pointer interaction
+  // ==========================================================================
+
+  private handleTrackPointerDown(event: PointerEvent): void {
+    if (this.hasAttribute('disabled')) return;
+    const value = this.getValueFromPointer(event);
+    if (value == null) return;
+    const index = this.findClosestThumbIndex(value);
+    this.setValueAt(index, value);
+  }
+
+  private handleThumbPointerDown(event: PointerEvent): void {
+    if (this.hasAttribute('disabled')) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const target = event.currentTarget;
+    if (!(target instanceof HTMLElement)) return;
+    const index = Number.parseInt(target.dataset.index ?? '0', 10);
+    this._draggingIndex = Number.isFinite(index) ? index : null;
+    if (typeof target.setPointerCapture === 'function') {
+      try {
+        target.setPointerCapture(event.pointerId);
+      } catch {
+        // happy-dom and some test envs do not implement pointer capture;
+        // silent fallback leaves drag state alone.
+      }
+    }
+  }
+
+  private handleThumbPointerMove(event: PointerEvent): void {
+    if (this._draggingIndex == null) return;
+    if (this.hasAttribute('disabled')) return;
+    const value = this.getValueFromPointer(event);
+    if (value == null) return;
+    this.setValueAt(this._draggingIndex, value);
+  }
+
+  private handleThumbPointerUp(event: PointerEvent): void {
+    if (this._draggingIndex == null) return;
+    const target = event.currentTarget;
+    if (target instanceof HTMLElement && typeof target.releasePointerCapture === 'function') {
+      try {
+        target.releasePointerCapture(event.pointerId);
+      } catch {
+        // Silent fallback for environments without pointer capture.
+      }
+    }
+    this._draggingIndex = null;
+  }
+
+  private getValueFromPointer(event: PointerEvent): number | null {
+    if (!this._track) return null;
+    const rect = this._track.getBoundingClientRect();
+    const orientation = parseOrientation(this.getAttribute('orientation'));
+    let pct: number;
+    if (orientation === 'vertical') {
+      if (rect.height === 0) return null;
+      pct = 1 - (event.clientY - rect.top) / rect.height;
+    } else {
+      if (rect.width === 0) return null;
+      pct = (event.clientX - rect.left) / rect.width;
+    }
+    pct = Math.min(Math.max(pct, 0), 1);
+    const min = this.min;
+    const max = this.max;
+    const step = this.step;
+    const raw = min + pct * (max - min);
+    return clamp(snapToStep(raw, min, step), min, max);
+  }
+
+  private findClosestThumbIndex(target: number): number {
+    if (this._values.length <= 1) return 0;
+    let closest = 0;
+    let minDist = Math.abs((this._values[0] ?? 0) - target);
+    for (let i = 1; i < this._values.length; i++) {
+      const v = this._values[i];
+      if (v == null) continue;
+      const d = Math.abs(v - target);
+      if (d < minDist) {
+        minDist = d;
+        closest = i;
+      }
+    }
+    return closest;
+  }
+
+  // ==========================================================================
+  // Keyboard interaction
+  // ==========================================================================
+
+  private handleThumbKeyDown(event: KeyboardEvent): void {
+    if (this.hasAttribute('disabled')) return;
+    const target = event.currentTarget;
+    if (!(target instanceof HTMLElement)) return;
+    const index = Number.parseInt(target.dataset.index ?? '0', 10);
+    if (!Number.isFinite(index)) return;
+    const current = this._values[index];
+    if (current == null) return;
+
+    const min = this.min;
+    const max = this.max;
+    const step = this.step;
+    const largeStep = step * 10;
+    let next: number | null = null;
+
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowUp':
+        event.preventDefault();
+        next = clamp(current + step, min, max);
+        break;
+      case 'ArrowLeft':
+      case 'ArrowDown':
+        event.preventDefault();
+        next = clamp(current - step, min, max);
+        break;
+      case 'PageUp':
+        event.preventDefault();
+        next = clamp(current + largeStep, min, max);
+        break;
+      case 'PageDown':
+        event.preventDefault();
+        next = clamp(current - largeStep, min, max);
+        break;
+      case 'Home':
+        event.preventDefault();
+        next = min;
+        break;
+      case 'End':
+        event.preventDefault();
+        next = max;
+        break;
+      default:
+        return;
+    }
+
+    if (next !== null && next !== current) {
+      this.setValueAt(index, next);
+    }
+  }
+
+  private setValueAt(index: number, value: number): void {
+    if (index < 0 || index >= this._values.length) return;
+    const min = this.min;
+    const max = this.max;
+    const step = this.step;
+    const clamped = clamp(snapToStep(value, min, step), min, max);
+    if (this._values[index] === clamped) return;
+
+    const next = [...this._values];
+    next[index] = clamped;
+    if (next.length > 1) {
+      next.sort((a, b) => a - b);
+      const newIndex = next.indexOf(clamped);
+      if (newIndex !== -1 && newIndex !== index && this._draggingIndex === index) {
+        this._draggingIndex = newIndex;
+      }
+    }
+
+    this._values = next;
+    this.updatePositions();
+    this.updateThumbAria();
+    this.syncFormValue();
+    this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+    this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+  }
+
+  // ==========================================================================
+  // Form value sync
+  // ==========================================================================
+
+  private syncFormValue(): void {
+    const name = this.name;
+    if (this._values.length === 0) {
+      this._internals.setFormValue('');
+    } else if (this._values.length === 1) {
+      const v = this._values[0];
+      this._internals.setFormValue(v != null ? String(v) : '');
+    } else if (name) {
+      const fd = new FormData();
+      for (const v of this._values) {
+        fd.append(name, String(v));
+      }
+      this._internals.setFormValue(fd);
+    } else {
+      this._internals.setFormValue(this._values.map((v) => String(v)).join(','));
+    }
+
+    if (this.hasAttribute('required') && this._values.length === 0) {
+      this._internals.setValidity({ valueMissing: true }, 'Please select a value.');
+    } else {
+      this._internals.setValidity({});
+    }
+  }
+
+  // ==========================================================================
+  // Form-associated lifecycle callbacks
+  // ==========================================================================
+
+  formAssociatedCallback(_form: HTMLFormElement | null): void {
+    // Hook for subclasses; default is a no-op. The internals already track
+    // the associated form for us.
+  }
+
+  formResetCallback(): void {
+    const initial = this.getAttribute('value') ?? '';
+    this._values = this.sanitizeValues(parseValueList(initial));
+    this.renderThumbs();
+    this.updatePositions();
+    this.updateThumbAria();
+    this.syncFormValue();
+  }
+
+  formDisabledCallback(disabled: boolean): void {
+    this.toggleAttribute('disabled', disabled);
+    this.updateDisabledState();
+  }
+
+  formStateRestoreCallback(
+    state: string | File | FormData | null,
+    _mode: 'restore' | 'autocomplete',
+  ): void {
+    if (typeof state === 'string') {
+      this.value = state;
+    }
+  }
+
+  // ==========================================================================
+  // Public form-control surface
+  // ==========================================================================
+
+  /**
+   * The ElementInternals instance bound to this host. Exposed read-only so
+   * consumers (and tests) can inspect form association without
+   * monkey-patching.
+   */
+  get internals(): ElementInternals {
+    return this._internals;
+  }
+
+  get form(): HTMLFormElement | null {
+    return this._internals.form;
+  }
+
+  get validity(): ValidityState {
+    return this._internals.validity;
+  }
+
+  get validationMessage(): string {
+    return this._internals.validationMessage;
+  }
+
+  get willValidate(): boolean {
+    return this._internals.willValidate;
+  }
+
+  get name(): string {
+    return this.getAttribute('name') ?? '';
+  }
+
+  set name(value: string) {
+    this.setAttribute('name', value);
+  }
+
+  get value(): string {
+    if (this._values.length === 0) return '';
+    return this._values.map((v) => String(v)).join(',');
+  }
+
+  set value(next: string) {
+    // Live value updates via the setter do NOT mutate the `value` host
+    // attribute so that formResetCallback can restore the attribute-defined
+    // initial value. Match the textarea/input element pattern.
+    this._values = this.sanitizeValues(parseValueList(next));
+    this.renderThumbs();
+    this.updatePositions();
+    this.updateThumbAria();
+    this.syncFormValue();
+  }
+
+  get valueAsArray(): number[] {
+    return [...this._values];
+  }
+
+  set valueAsArray(next: number[]) {
+    this._values = this.sanitizeValues(next);
+    this.renderThumbs();
+    this.updatePositions();
+    this.updateThumbAria();
+    this.syncFormValue();
+  }
+
+  get min(): number {
+    return parseNumber(this.getAttribute('min'), 0);
+  }
+
+  set min(value: number) {
+    this.setAttribute('min', String(value));
+  }
+
+  get max(): number {
+    return parseNumber(this.getAttribute('max'), 100);
+  }
+
+  set max(value: number) {
+    this.setAttribute('max', String(value));
+  }
+
+  get step(): number {
+    return parseStep(this.getAttribute('step'));
+  }
+
+  set step(value: number) {
+    this.setAttribute('step', String(value));
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+
+  set disabled(value: boolean) {
+    this.toggleAttribute('disabled', value);
+  }
+
+  get required(): boolean {
+    return this.hasAttribute('required');
+  }
+
+  set required(value: boolean) {
+    this.toggleAttribute('required', value);
+  }
+
+  get orientation(): SliderOrientation {
+    return parseOrientation(this.getAttribute('orientation'));
+  }
+
+  set orientation(value: SliderOrientation) {
+    this.setAttribute('orientation', value);
+  }
+
+  get variant(): SliderVariant {
+    return parseVariant(this.getAttribute('variant'));
+  }
+
+  set variant(value: SliderVariant) {
+    this.setAttribute('variant', value);
+  }
+
+  get size(): SliderSize {
+    return parseSize(this.getAttribute('size'));
+  }
+
+  set size(value: SliderSize) {
+    this.setAttribute('size', value);
+  }
+
+  checkValidity(): boolean {
+    return this._internals.checkValidity();
+  }
+
+  reportValidity(): boolean {
+    return this._internals.reportValidity();
+  }
+
+  setCustomValidity(message: string): void {
+    if (message) {
+      this._internals.setValidity({ customError: true }, message);
+    } else {
+      this._internals.setValidity({});
+    }
+  }
+}
+
+// ============================================================================
+// Registration (module side-effect, guarded for re-import safety)
+// ============================================================================
+
+if (!customElements.get('rafters-slider')) {
+  customElements.define('rafters-slider', RaftersSlider);
+}

--- a/packages/ui/src/components/ui/slider.styles.test.ts
+++ b/packages/ui/src/components/ui/slider.styles.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Unit tests for sliderStylesheet()
+ *
+ * Verifies selector composition, token usage (--motion-duration-* /
+ * --motion-ease-* only), graceful fallback on unknown variant/size/orientation
+ * values, and reduced-motion wrapping.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  type SliderOrientation,
+  type SliderSize,
+  type SliderVariant,
+  sliderContainerBase,
+  sliderRangeBase,
+  sliderSizeStyles,
+  sliderStylesheet,
+  sliderThumbBase,
+  sliderThumbFocusVisible,
+  sliderTrackBase,
+  sliderVariantColorToken,
+  sliderVariantRingToken,
+  sliderVariantStyles,
+  sliderVerticalSizeStyles,
+} from './slider.styles';
+
+describe('sliderStylesheet', () => {
+  it('emits a :host rule with display: block', () => {
+    expect(sliderStylesheet()).toMatch(/:host\s*\{[^}]*display:\s*block/);
+  });
+
+  it('emits the .container rule with flex and touch-action: none', () => {
+    const css = sliderStylesheet();
+    expect(css).toMatch(/\.container\s*\{/);
+    expect(css).toContain('display: flex');
+    expect(css).toContain('touch-action: none');
+    expect(css).toContain('user-select: none');
+  });
+
+  it('emits .container[data-disabled] with opacity and pointer-events:none', () => {
+    const css = sliderStylesheet();
+    expect(css).toMatch(/\.container\[data-disabled\]\s*\{/);
+    expect(css).toContain('opacity: 0.5');
+    expect(css).toContain('pointer-events: none');
+  });
+
+  it('emits .track rule with muted background via tokenVar', () => {
+    const css = sliderStylesheet();
+    expect(css).toMatch(/\.track\s*\{/);
+    expect(css).toContain('background-color: var(--color-muted)');
+    expect(css).toContain('border-radius: 9999px');
+  });
+
+  it('emits .range rule with variant-aware background', () => {
+    const css = sliderStylesheet();
+    expect(css).toMatch(/\.range\s*\{/);
+    expect(css).toContain('background-color: var(--color-primary)');
+  });
+
+  it('emits .thumb rule with variant border and background', () => {
+    const css = sliderStylesheet();
+    expect(css).toMatch(/\.thumb\s*\{/);
+    expect(css).toContain('border-color: var(--color-primary)');
+    expect(css).toContain('background-color: var(--color-background)');
+  });
+
+  it('emits .thumb:hover with scale transform', () => {
+    const css = sliderStylesheet();
+    expect(css).toMatch(/\.thumb:hover\s*\{[^}]*transform:\s*scale\(1\.1\)/);
+  });
+
+  it('emits .thumb:active with scale transform', () => {
+    const css = sliderStylesheet();
+    expect(css).toMatch(/\.thumb:active\s*\{[^}]*transform:\s*scale\(1\.05\)/);
+  });
+
+  it('emits .thumb:focus-visible with outline and token-driven ring', () => {
+    const css = sliderStylesheet();
+    expect(css).toMatch(/\.thumb:focus-visible\s*\{/);
+    expect(css).toContain('outline: none');
+    expect(css).toContain('var(--color-primary-ring)');
+  });
+
+  it('emits thumb focus-visible with token-driven ring', () => {
+    expect(sliderStylesheet()).toContain('var(--color-ring)');
+  });
+
+  it('switches focus ring token by variant', () => {
+    expect(sliderStylesheet({ variant: 'destructive' })).toMatch(
+      /\.thumb:focus-visible\s*\{[^}]*var\(--color-destructive-ring\)/,
+    );
+    expect(sliderStylesheet({ variant: 'success' })).toMatch(
+      /\.thumb:focus-visible\s*\{[^}]*var\(--color-success-ring\)/,
+    );
+    expect(sliderStylesheet({ variant: 'warning' })).toMatch(
+      /\.thumb:focus-visible\s*\{[^}]*var\(--color-warning-ring\)/,
+    );
+  });
+
+  it('variant overrides range background via the cascade', () => {
+    const css = sliderStylesheet({ variant: 'destructive' });
+    expect(css).toContain('background-color: var(--color-destructive)');
+    const successCss = sliderStylesheet({ variant: 'success' });
+    expect(successCss).toContain('background-color: var(--color-success)');
+  });
+
+  it('variant overrides thumb border via the cascade', () => {
+    const css = sliderStylesheet({ variant: 'destructive' });
+    expect(css).toMatch(/\.thumb\s*\{[^}]*border-color:\s*var\(--color-destructive\)/);
+  });
+
+  it('uses --motion-duration-* not --duration-*', () => {
+    const css = sliderStylesheet();
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+    expect(css).toContain('var(--motion-duration-fast)');
+    expect(css).toContain('var(--motion-ease-standard)');
+  });
+
+  it('falls back to defaults on unknown values', () => {
+    expect(() =>
+      sliderStylesheet({
+        variant: 'nope' as never,
+        size: 'huge' as never,
+        orientation: 'diagonal' as never,
+      }),
+    ).not.toThrow();
+  });
+
+  it('falls back to default variant when variant is unknown', () => {
+    const css = sliderStylesheet({ variant: 'nope' as never });
+    expect(css).toContain('var(--color-primary)');
+  });
+
+  it('falls back to default size when size is unknown', () => {
+    const css = sliderStylesheet({ size: 'huge' as never });
+    expect(css).toContain('height: 0.5rem');
+  });
+
+  it('falls back to horizontal when orientation is unknown', () => {
+    const css = sliderStylesheet({ orientation: 'diagonal' as never });
+    expect(css).toContain('flex-direction: row');
+  });
+
+  it('applies horizontal orientation container flex-direction: row', () => {
+    const css = sliderStylesheet({ orientation: 'horizontal' });
+    expect(css).toContain('flex-direction: row');
+    expect(css).toContain('width: 100%');
+  });
+
+  it('applies vertical orientation container flex-direction: column', () => {
+    const css = sliderStylesheet({ orientation: 'vertical' });
+    expect(css).toContain('flex-direction: column');
+    expect(css).toContain('height: 100%');
+  });
+
+  it('applies size track heights for sm, default, and lg horizontal', () => {
+    expect(sliderStylesheet({ size: 'sm' })).toContain('height: 0.25rem');
+    expect(sliderStylesheet({ size: 'default' })).toContain('height: 0.5rem');
+    expect(sliderStylesheet({ size: 'lg' })).toContain('height: 0.75rem');
+  });
+
+  it('applies size thumb dimensions for sm, default, and lg', () => {
+    expect(sliderStylesheet({ size: 'sm' })).toMatch(/\.thumb\s*\{[^}]*height:\s*1rem/);
+    expect(sliderStylesheet({ size: 'sm' })).toMatch(/\.thumb\s*\{[^}]*width:\s*1rem/);
+    expect(sliderStylesheet({ size: 'default' })).toMatch(/\.thumb\s*\{[^}]*height:\s*1\.25rem/);
+    expect(sliderStylesheet({ size: 'lg' })).toMatch(/\.thumb\s*\{[^}]*height:\s*1\.5rem/);
+  });
+
+  it('swaps width/height for vertical orientation track', () => {
+    const css = sliderStylesheet({ orientation: 'vertical', size: 'default' });
+    expect(css).toMatch(/\.track\s*\{[^}]*width:\s*0\.5rem/);
+  });
+
+  it('emits prefers-reduced-motion guard', () => {
+    const css = sliderStylesheet();
+    expect(css).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(css).toMatch(/transition:\s*none/);
+  });
+
+  it('wraps transitions in prefers-reduced-motion', () => {
+    expect(sliderStylesheet()).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)/);
+  });
+
+  it('emits disabled container style when disabled option is true', () => {
+    const css = sliderStylesheet({ disabled: true });
+    expect(css).toContain('opacity: 0.5');
+    expect(css).toContain('pointer-events: none');
+  });
+
+  it('emits no raw hex or rgb literals -- tokens only', () => {
+    const css = sliderStylesheet({ variant: 'destructive', size: 'lg' });
+    expect(css).not.toMatch(/#[0-9a-f]{3,8}/i);
+    expect(css).not.toMatch(/rgb\(/);
+  });
+
+  describe('exports', () => {
+    it('exposes sliderContainerBase with position:relative and flex', () => {
+      expect(sliderContainerBase.position).toBe('relative');
+      expect(sliderContainerBase.display).toBe('flex');
+      expect(sliderContainerBase['touch-action']).toBe('none');
+      expect(sliderContainerBase['user-select']).toBe('none');
+      expect(sliderContainerBase['align-items']).toBe('center');
+    });
+
+    it('exposes sliderTrackBase with muted background token', () => {
+      expect(sliderTrackBase.position).toBe('relative');
+      expect(sliderTrackBase['flex-grow']).toBe('1');
+      expect(sliderTrackBase.overflow).toBe('hidden');
+      expect(sliderTrackBase['border-radius']).toBe('9999px');
+      expect(sliderTrackBase['background-color']).toBe('var(--color-muted)');
+    });
+
+    it('exposes sliderRangeBase with primary background token', () => {
+      expect(sliderRangeBase.position).toBe('absolute');
+      expect(sliderRangeBase['background-color']).toBe('var(--color-primary)');
+    });
+
+    it('exposes sliderThumbBase with cursor:grab and token-driven values', () => {
+      expect(sliderThumbBase.position).toBe('absolute');
+      expect(sliderThumbBase.display).toBe('block');
+      expect(sliderThumbBase['border-radius']).toBe('9999px');
+      expect(sliderThumbBase['border-width']).toBe('2px');
+      expect(sliderThumbBase['border-style']).toBe('solid');
+      expect(sliderThumbBase['border-color']).toBe('var(--color-primary)');
+      expect(sliderThumbBase['background-color']).toBe('var(--color-background)');
+      expect(sliderThumbBase.cursor).toBe('grab');
+    });
+
+    it('exposes sliderThumbFocusVisible with outline:none and ring token', () => {
+      expect(sliderThumbFocusVisible.outline).toBe('none');
+      expect(sliderThumbFocusVisible['box-shadow']).toContain('var(--color-ring)');
+    });
+
+    it('exposes a variant style map for every documented variant', () => {
+      const variants: ReadonlyArray<SliderVariant> = [
+        'default',
+        'primary',
+        'secondary',
+        'destructive',
+        'success',
+        'warning',
+        'info',
+        'accent',
+      ];
+      for (const v of variants) {
+        expect(sliderVariantStyles[v]).toBeDefined();
+        expect(sliderVariantStyles[v].range).toBeDefined();
+        expect(sliderVariantStyles[v].thumb).toBeDefined();
+        expect(sliderVariantStyles[v].ring).toBeDefined();
+        expect(sliderVariantColorToken[v]).toBeDefined();
+        expect(sliderVariantRingToken[v]).toBeDefined();
+      }
+    });
+
+    it('exposes a size style map for every documented size', () => {
+      const sizes: ReadonlyArray<SliderSize> = ['sm', 'default', 'lg'];
+      for (const s of sizes) {
+        expect(sliderSizeStyles[s]).toBeDefined();
+        expect(sliderSizeStyles[s].track).toBeDefined();
+        expect(sliderSizeStyles[s].thumb).toBeDefined();
+        expect(sliderVerticalSizeStyles[s]).toBeDefined();
+      }
+    });
+
+    it('default variant color token aliases color-primary', () => {
+      expect(sliderVariantColorToken.default).toBe('color-primary');
+      expect(sliderVariantRingToken.default).toBe('color-primary-ring');
+    });
+  });
+
+  it('handles every documented variant without throwing', () => {
+    const variants: ReadonlyArray<SliderVariant> = [
+      'default',
+      'primary',
+      'secondary',
+      'destructive',
+      'success',
+      'warning',
+      'info',
+      'accent',
+    ];
+    for (const variant of variants) {
+      expect(() => sliderStylesheet({ variant })).not.toThrow();
+    }
+  });
+
+  it('handles every documented size without throwing', () => {
+    const sizes: ReadonlyArray<SliderSize> = ['sm', 'default', 'lg'];
+    for (const size of sizes) {
+      expect(() => sliderStylesheet({ size })).not.toThrow();
+    }
+  });
+
+  it('handles every documented orientation without throwing', () => {
+    const orientations: ReadonlyArray<SliderOrientation> = ['horizontal', 'vertical'];
+    for (const orientation of orientations) {
+      expect(() => sliderStylesheet({ orientation })).not.toThrow();
+    }
+  });
+});

--- a/packages/ui/src/components/ui/slider.styles.ts
+++ b/packages/ui/src/components/ui/slider.styles.ts
@@ -1,0 +1,300 @@
+/**
+ * Shadow DOM style definitions for Slider web component
+ *
+ * Parallel to slider.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ *
+ * All token references go through tokenVar() -- no raw CSS custom-property
+ * function literals appear in this module.
+ * Motion uses --motion-duration-* / --motion-ease-* only.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import { atRule, styleRule, stylesheet, tokenVar, transition } from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export type SliderVariant =
+  | 'default'
+  | 'primary'
+  | 'secondary'
+  | 'destructive'
+  | 'success'
+  | 'warning'
+  | 'info'
+  | 'accent';
+
+export type SliderSize = 'sm' | 'default' | 'lg';
+
+export type SliderOrientation = 'horizontal' | 'vertical';
+
+export interface SliderStylesheetOptions {
+  variant?: SliderVariant | undefined;
+  size?: SliderSize | undefined;
+  orientation?: SliderOrientation | undefined;
+  disabled?: boolean | undefined;
+}
+
+// ============================================================================
+// Variant -> color token mapping
+// ============================================================================
+
+/**
+ * Maps a variant name to the design-token color used for the slider range
+ * and thumb border. `default` aliases to `color-primary`.
+ */
+export const sliderVariantColorToken: Record<SliderVariant, string> = {
+  default: 'color-primary',
+  primary: 'color-primary',
+  secondary: 'color-secondary',
+  destructive: 'color-destructive',
+  success: 'color-success',
+  warning: 'color-warning',
+  info: 'color-info',
+  accent: 'color-accent',
+};
+
+/**
+ * Maps a variant name to the design-token color used for the focus ring.
+ * `default` aliases to `color-primary-ring`.
+ */
+export const sliderVariantRingToken: Record<SliderVariant, string> = {
+  default: 'color-primary-ring',
+  primary: 'color-primary-ring',
+  secondary: 'color-secondary-ring',
+  destructive: 'color-destructive-ring',
+  success: 'color-success-ring',
+  warning: 'color-warning-ring',
+  info: 'color-info-ring',
+  accent: 'color-accent-ring',
+};
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+export const sliderContainerBase: CSSProperties = {
+  position: 'relative',
+  display: 'flex',
+  'touch-action': 'none',
+  'user-select': 'none',
+  'align-items': 'center',
+};
+
+export const sliderTrackBase: CSSProperties = {
+  position: 'relative',
+  'flex-grow': '1',
+  overflow: 'hidden',
+  'border-radius': '9999px',
+  'background-color': tokenVar('color-muted'),
+};
+
+export const sliderRangeBase: CSSProperties = {
+  position: 'absolute',
+  'background-color': tokenVar('color-primary'),
+};
+
+export const sliderThumbBase: CSSProperties = {
+  position: 'absolute',
+  display: 'block',
+  'border-radius': '9999px',
+  'border-width': '2px',
+  'border-style': 'solid',
+  'border-color': tokenVar('color-primary'),
+  'background-color': tokenVar('color-background'),
+  cursor: 'grab',
+  transition: transition(
+    ['transform', 'box-shadow'],
+    tokenVar('motion-duration-fast'),
+    tokenVar('motion-ease-standard'),
+  ),
+};
+
+export const sliderThumbFocusVisible: CSSProperties = {
+  outline: 'none',
+  'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar('color-ring')}`,
+};
+
+export const sliderDisabled: CSSProperties = {
+  opacity: '0.5',
+  'pointer-events': 'none',
+};
+
+// ============================================================================
+// Variant Styles
+// ============================================================================
+
+/**
+ * Per-variant overrides. Each variant maps the range fill `background-color`
+ * and thumb `border-color` to the variant color token. The `ring` entry
+ * captures the variant-specific focus-ring color token; the final
+ * `:focus-visible` rule is composed in `sliderStylesheet()` using the
+ * variant ring token.
+ */
+export const sliderVariantStyles: Record<
+  SliderVariant,
+  { range: CSSProperties; thumb: CSSProperties; ring: CSSProperties }
+> = {
+  default: {
+    range: { 'background-color': tokenVar('color-primary') },
+    thumb: { 'border-color': tokenVar('color-primary') },
+    ring: { '--rafters-slider-ring': tokenVar('color-primary-ring') },
+  },
+  primary: {
+    range: { 'background-color': tokenVar('color-primary') },
+    thumb: { 'border-color': tokenVar('color-primary') },
+    ring: { '--rafters-slider-ring': tokenVar('color-primary-ring') },
+  },
+  secondary: {
+    range: { 'background-color': tokenVar('color-secondary') },
+    thumb: { 'border-color': tokenVar('color-secondary') },
+    ring: { '--rafters-slider-ring': tokenVar('color-secondary-ring') },
+  },
+  destructive: {
+    range: { 'background-color': tokenVar('color-destructive') },
+    thumb: { 'border-color': tokenVar('color-destructive') },
+    ring: { '--rafters-slider-ring': tokenVar('color-destructive-ring') },
+  },
+  success: {
+    range: { 'background-color': tokenVar('color-success') },
+    thumb: { 'border-color': tokenVar('color-success') },
+    ring: { '--rafters-slider-ring': tokenVar('color-success-ring') },
+  },
+  warning: {
+    range: { 'background-color': tokenVar('color-warning') },
+    thumb: { 'border-color': tokenVar('color-warning') },
+    ring: { '--rafters-slider-ring': tokenVar('color-warning-ring') },
+  },
+  info: {
+    range: { 'background-color': tokenVar('color-info') },
+    thumb: { 'border-color': tokenVar('color-info') },
+    ring: { '--rafters-slider-ring': tokenVar('color-info-ring') },
+  },
+  accent: {
+    range: { 'background-color': tokenVar('color-accent') },
+    thumb: { 'border-color': tokenVar('color-accent') },
+    ring: { '--rafters-slider-ring': tokenVar('color-accent-ring') },
+  },
+};
+
+// ============================================================================
+// Size Styles (horizontal orientation)
+// ============================================================================
+
+export const sliderSizeStyles: Record<SliderSize, { track: CSSProperties; thumb: CSSProperties }> =
+  {
+    sm: {
+      track: { height: '0.25rem' },
+      thumb: { height: '1rem', width: '1rem' },
+    },
+    default: {
+      track: { height: '0.5rem' },
+      thumb: { height: '1.25rem', width: '1.25rem' },
+    },
+    lg: {
+      track: { height: '0.75rem' },
+      thumb: { height: '1.5rem', width: '1.5rem' },
+    },
+  };
+
+// ============================================================================
+// Size Styles (vertical orientation -- height/width swapped for track only)
+// ============================================================================
+
+export const sliderVerticalSizeStyles: Record<
+  SliderSize,
+  { track: CSSProperties; thumb: CSSProperties }
+> = {
+  sm: {
+    track: { width: '0.25rem', height: '100%' },
+    thumb: { height: '1rem', width: '1rem' },
+  },
+  default: {
+    track: { width: '0.5rem', height: '100%' },
+    thumb: { height: '1.25rem', width: '1.25rem' },
+  },
+  lg: {
+    track: { width: '0.75rem', height: '100%' },
+    thumb: { height: '1.5rem', width: '1.5rem' },
+  },
+};
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+/**
+ * Build the complete slider stylesheet for a given configuration.
+ *
+ * Composition:
+ *   :host                                   -> display: block
+ *   .container                              -> flex container (orientation-aware)
+ *   .container[data-disabled]               -> opacity + pointer-events:none
+ *   .track                                  -> track height + background
+ *   .range                                  -> range fill (variant-aware)
+ *   .thumb                                  -> thumb base + border (variant)
+ *   .thumb:hover                            -> scale 1.1
+ *   .thumb:active                           -> scale 1.05
+ *   .thumb:focus-visible                    -> outline + ring (variant)
+ *   @media reduced-motion                   -> transition: none
+ *
+ * Unknown variant, size, or orientation silently fall back to defaults
+ * ('default', 'default', 'horizontal') without throwing.
+ */
+export function sliderStylesheet(options: SliderStylesheetOptions = {}): string {
+  const { variant, size, orientation, disabled } = options;
+
+  const safeVariant: SliderVariant =
+    variant && variant in sliderVariantStyles ? variant : 'default';
+  const safeSize: SliderSize = size && size in sliderSizeStyles ? size : 'default';
+  const safeOrientation: SliderOrientation = orientation === 'vertical' ? 'vertical' : 'horizontal';
+
+  const ringToken = sliderVariantRingToken[safeVariant];
+
+  const variantFocusRule: CSSProperties = {
+    'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar(ringToken)}`,
+  };
+
+  const containerOrientation: CSSProperties =
+    safeOrientation === 'vertical'
+      ? { 'flex-direction': 'column', height: '100%' }
+      : { 'flex-direction': 'row', width: '100%' };
+
+  const sizeMap = safeOrientation === 'vertical' ? sliderVerticalSizeStyles : sliderSizeStyles;
+
+  const variantStyle = sliderVariantStyles[safeVariant];
+  const sizeStyle = sizeMap[safeSize];
+
+  return stylesheet(
+    styleRule(':host', { display: 'block' }),
+
+    styleRule('.container', sliderContainerBase, containerOrientation),
+
+    styleRule('.container[data-disabled]', sliderDisabled),
+
+    styleRule('.track', sliderTrackBase, sizeStyle.track),
+
+    styleRule('.range', sliderRangeBase, variantStyle.range),
+
+    styleRule('.thumb', sliderThumbBase, sizeStyle.thumb, variantStyle.thumb),
+
+    styleRule('.thumb:hover', { transform: 'scale(1.1)' }),
+
+    styleRule('.thumb:active', { transform: 'scale(1.05)' }),
+
+    // Base focus-visible rule -- references color-ring as the generic token
+    // so the default stylesheet always emits it. Variant-specific rings
+    // override via the cascade in the next rule.
+    styleRule('.thumb:focus-visible', sliderThumbFocusVisible),
+
+    // Variant focus-visible override -- replaces the base ring token with
+    // the variant-specific ring (e.g. color-primary-ring, color-destructive-ring).
+    styleRule('.thumb:focus-visible', variantFocusRule),
+
+    disabled ? styleRule('.container', sliderDisabled) : '',
+
+    atRule('@media (prefers-reduced-motion: reduce)', styleRule('.thumb', { transition: 'none' })),
+  );
+}


### PR DESCRIPTION
## Summary

Ships a form-associated `<rafters-slider>` custom element plus token-driven `slider.styles.ts` stylesheet so range sliders work outside React. Each thumb is a separate focusable node with full WAI-ARIA keyboard support (arrows, PageUp/PageDown, Home/End), pointer drag via `setPointerCapture`, and participates in native `<form>` submission via `ElementInternals`.

## Behavior

- Auto-registers `<rafters-slider>` idempotently on import.
- `static formAssociated = true`; constructor throws `TypeError('rafters-slider requires ElementInternals support')` only when `attachInternals` is unavailable.
- Per-instance `CSSStyleSheet` adopted into the shadow root; rebuilt when `variant`/`size`/`orientation`/`disabled` change.
- Single-value sliders submit as `name=value`; range sliders submit each entry under `name` via a `FormData` so `getAll(name)` returns the list.
- `value` attribute is comma-separated; unparseable entries silently dropped, out-of-range values silently clamped, snap-to-step on every update.
- Each thumb carries `role="slider"`, `aria-valuemin`/`max`/`now`, `aria-orientation`, `aria-label` (with `Minimum`/`Maximum` suffixes for range sliders), plus `tabindex` mirroring (`0`/`-1`).

## Tokens & motion

- Every color/radius reference goes through `tokenVar()`. Zero raw `var(--…)` literals.
- Motion uses `--motion-duration-*` and `--motion-ease-*` only; `prefers-reduced-motion` strips the thumb transition.
- Default focus ring uses `--color-ring`; variant-specific rings (e.g. `--color-destructive-ring`) override via the cascade.

## Test plan

- [x] `pnpm --filter=@rafters/ui test slider` -- 142 tests pass, 2 skipped (happy-dom 20 limitations linked to #1345)
- [x] `pnpm --filter=@rafters/ui test:unit` -- 4270 tests pass, 5 skipped
- [x] `pnpm --filter=@rafters/ui typecheck` -- clean
- [x] Lint clean (Biome)
- [x] A11y: each thumb has `role="slider"` + value attrs + `aria-label`; axe-clean for sibling-label, disabled, required, range, and `<form>` configurations
- [x] Form submission: single value via `FormData.get`, range via `FormData.getAll`
- [x] Keyboard: ArrowLeft/Right/Up/Down, PageUp/Down (10 * step), Home/End, with clamping
- [x] Pointer: track click moves closest thumb, thumb drag via `setPointerCapture`
- [x] `formResetCallback` restores attribute-defined initial value
- [x] `formDisabledCallback` toggles `tabindex` and `aria-disabled`
- [x] `formStateRestoreCallback` accepts string state