### PR TITLE
feat(ui): <rafters-field> Web Component (#1347)

### DIFF
--- a/packages/ui/src/components/ui/field.classes.ts
+++ b/packages/ui/src/components/ui/field.classes.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared class definitions for Field component
+ *
+ * Imported by field.tsx (React) to ensure visual parity with the Web Component
+ * target at field.styles.ts. Field is a layout-composition wrapper: container
+ * stacks label + control + helper/error with consistent spacing; the helper
+ * and error variants share the small label type ramp but flip color.
+ */
+
+export const fieldContainerClasses = 'flex flex-col gap-2';
+
+export const fieldLabelDisabledClasses = 'opacity-50';
+
+export const fieldRequiredMarkerClasses = 'text-destructive ml-1';
+
+export const fieldDescriptionClasses = 'text-sm text-muted-foreground';
+
+export const fieldErrorClasses = 'text-sm text-destructive';

--- a/packages/ui/src/components/ui/field.element.a11y.tsx
+++ b/packages/ui/src/components/ui/field.element.a11y.tsx
@@ -1,0 +1,122 @@
+/**
+ * Accessibility tests for <rafters-field>.
+ *
+ * Field wires ARIA attributes onto the slotted control (aria-describedby,
+ * aria-invalid, aria-required) and associates the label via for/id. axe-core
+ * >= 4 descends into open shadow roots, so mounting into a scoped container
+ * div exercises both the shadow label element and the light-DOM control.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import 'vitest-axe/extend-expect';
+import './field.element';
+
+let container: HTMLElement;
+
+function mountContainer(): HTMLElement {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  return container;
+}
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+function buildField(
+  attrs: Record<string, string> = {},
+  controlTag: 'input' | 'textarea' | 'select' = 'input',
+): { host: HTMLElement; control: HTMLElement } {
+  const host = document.createElement('rafters-field');
+  for (const [k, v] of Object.entries(attrs)) host.setAttribute(k, v);
+  const control = document.createElement(controlTag);
+  if (controlTag === 'input') {
+    (control as HTMLInputElement).type = 'text';
+  }
+  host.appendChild(control);
+  container.appendChild(host);
+  return { host, control };
+}
+
+describe('<rafters-field> - Accessibility', () => {
+  it('has no violations with a basic label + input', async () => {
+    mountContainer();
+    buildField({ label: 'Email' });
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with a description', async () => {
+    mountContainer();
+    buildField({ label: 'Email', description: 'We never share your email' });
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations in an error state', async () => {
+    mountContainer();
+    buildField({ label: 'Email', error: 'Email is required' });
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations when required', async () => {
+    mountContainer();
+    buildField({ label: 'Email', required: '' });
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations when disabled', async () => {
+    mountContainer();
+    buildField({ label: 'Email', disabled: '' });
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with a textarea control', async () => {
+    mountContainer();
+    buildField({ label: 'Bio', description: 'A short introduction' }, 'textarea');
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with a select control', async () => {
+    mountContainer();
+    const { control } = buildField({ label: 'Country' }, 'select');
+    const option = document.createElement('option');
+    option.textContent = 'United States';
+    control.appendChild(option);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with multiple fields stacked', async () => {
+    mountContainer();
+    buildField({ label: 'Name' });
+    buildField({ label: 'Email', description: 'Used for notifications' });
+    buildField({ label: 'Password', required: '', error: 'Too short' });
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations when field is nested inside a form', async () => {
+    mountContainer();
+    const form = document.createElement('form');
+    container.appendChild(form);
+
+    const host = document.createElement('rafters-field');
+    host.setAttribute('label', 'Email');
+    host.setAttribute('description', 'We never share your email');
+    const input = document.createElement('input');
+    input.type = 'email';
+    host.appendChild(input);
+    form.appendChild(host);
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/ui/src/components/ui/field.element.test.ts
+++ b/packages/ui/src/components/ui/field.element.test.ts
@@ -1,0 +1,289 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import './field.element';
+import { RaftersField } from './field.element';
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+function mount(attrs: Record<string, string> = {}): RaftersField {
+  const el = document.createElement('rafters-field') as RaftersField;
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.appendChild(el);
+  return el;
+}
+
+function collectCss(el: Element): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  return sheets
+    .map((s) =>
+      Array.from(s.cssRules)
+        .map((r) => r.cssText)
+        .join('\n'),
+    )
+    .join('\n');
+}
+
+describe('rafters-field', () => {
+  it('registers idempotently', async () => {
+    expect(customElements.get('rafters-field')).toBe(RaftersField);
+    await import('./field.element');
+    expect(customElements.get('rafters-field')).toBe(RaftersField);
+  });
+
+  it('is not form-associated', () => {
+    expect((RaftersField as unknown as { formAssociated?: boolean }).formAssociated).not.toBe(true);
+  });
+
+  it('observedAttributes matches the documented contract', () => {
+    expect(RaftersField.observedAttributes).toEqual([
+      'label',
+      'description',
+      'error',
+      'required',
+      'disabled',
+      'id',
+    ]);
+  });
+
+  it('renders label text from attribute', () => {
+    const el = mount({ label: 'Email' });
+    const label = el.shadowRoot?.querySelector('label');
+    expect(label?.textContent).toContain('Email');
+  });
+
+  it('renders required marker when required attribute present', () => {
+    const el = document.createElement('rafters-field') as RaftersField;
+    el.setAttribute('label', 'Email');
+    el.toggleAttribute('required', true);
+    document.body.append(el);
+    const marker = el.shadowRoot?.querySelector('.required');
+    expect(marker).not.toBeNull();
+    expect(marker?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('omits required marker when required attribute absent', () => {
+    const el = mount({ label: 'Email' });
+    expect(el.shadowRoot?.querySelector('.required')).toBeNull();
+  });
+
+  it('connects label[for] to slotted control id', () => {
+    const el = document.createElement('rafters-field') as RaftersField;
+    el.setAttribute('label', 'Email');
+    const input = document.createElement('input');
+    el.append(input);
+    document.body.append(el);
+    const label = el.shadowRoot?.querySelector('label');
+    expect(label?.getAttribute('for')).toBe(input.id);
+    expect(input.id.length).toBeGreaterThan(0);
+  });
+
+  it('sets aria-describedby on slotted control when description provided', () => {
+    const el = document.createElement('rafters-field') as RaftersField;
+    el.setAttribute('label', 'Email');
+    el.setAttribute('description', 'We never share your email');
+    const input = document.createElement('input');
+    el.append(input);
+    document.body.append(el);
+    const described = input.getAttribute('aria-describedby') ?? '';
+    const descriptionId = el.shadowRoot?.querySelector('.description')?.id;
+    expect(descriptionId).toBeDefined();
+    expect(described).toContain(descriptionId ?? '');
+  });
+
+  it('shows error with role=alert and sets aria-invalid on control', () => {
+    const el = document.createElement('rafters-field') as RaftersField;
+    el.setAttribute('label', 'Email');
+    el.setAttribute('error', 'Email is required');
+    const input = document.createElement('input');
+    el.append(input);
+    document.body.append(el);
+    const errorNode = el.shadowRoot?.querySelector('.error');
+    expect(errorNode?.getAttribute('role')).toBe('alert');
+    expect(errorNode?.textContent).toContain('Email is required');
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it('hides description when error is present', () => {
+    const el = mount({
+      label: 'Email',
+      description: 'We never share your email',
+      error: 'Email is required',
+    });
+    expect(el.shadowRoot?.querySelector('.description')).toBeNull();
+    expect(el.shadowRoot?.querySelector('.error')).not.toBeNull();
+  });
+
+  it('propagates disabled to slotted control', () => {
+    const el = document.createElement('rafters-field') as RaftersField;
+    el.setAttribute('label', 'Email');
+    el.toggleAttribute('disabled', true);
+    const input = document.createElement('input');
+    el.append(input);
+    document.body.append(el);
+    expect(input.disabled).toBe(true);
+  });
+
+  it('propagates aria-required to slotted control when required', () => {
+    const el = document.createElement('rafters-field') as RaftersField;
+    el.setAttribute('label', 'Email');
+    el.toggleAttribute('required', true);
+    const input = document.createElement('input');
+    el.append(input);
+    document.body.append(el);
+    expect(input.getAttribute('aria-required')).toBe('true');
+  });
+
+  it('clears aria-invalid when error attribute is removed', () => {
+    const el = document.createElement('rafters-field') as RaftersField;
+    el.setAttribute('label', 'Email');
+    el.setAttribute('error', 'Bad');
+    const input = document.createElement('input');
+    el.append(input);
+    document.body.append(el);
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+    el.removeAttribute('error');
+    expect(input.getAttribute('aria-invalid')).toBeNull();
+  });
+
+  it('clears disabled on control when host disabled is removed', () => {
+    const el = document.createElement('rafters-field') as RaftersField;
+    el.setAttribute('label', 'Email');
+    el.toggleAttribute('disabled', true);
+    const input = document.createElement('input');
+    el.append(input);
+    document.body.append(el);
+    expect(input.disabled).toBe(true);
+    el.removeAttribute('disabled');
+    expect(input.disabled).toBe(false);
+  });
+
+  it('does not overwrite control id when already set', () => {
+    const el = document.createElement('rafters-field') as RaftersField;
+    el.setAttribute('label', 'Email');
+    const input = document.createElement('input');
+    input.id = 'explicit-email';
+    el.append(input);
+    document.body.append(el);
+    expect(input.id).toBe('explicit-email');
+    expect(el.shadowRoot?.querySelector('label')?.getAttribute('for')).toBe('explicit-email');
+  });
+
+  it('does not overwrite author-provided aria-describedby on the control', () => {
+    const el = document.createElement('rafters-field') as RaftersField;
+    el.setAttribute('label', 'Email');
+    el.setAttribute('description', 'Helper');
+    const input = document.createElement('input');
+    input.setAttribute('aria-describedby', 'custom-helper');
+    el.append(input);
+    document.body.append(el);
+    expect(input.getAttribute('aria-describedby')).toBe('custom-helper');
+  });
+
+  it('does not throw on missing label attribute', () => {
+    const el = document.createElement('rafters-field') as RaftersField;
+    expect(() => document.body.append(el)).not.toThrow();
+  });
+
+  it('uses the provided id attribute as field id when present', () => {
+    const el = document.createElement('rafters-field') as RaftersField;
+    el.setAttribute('id', 'signup-email');
+    el.setAttribute('label', 'Email');
+    const input = document.createElement('input');
+    el.append(input);
+    document.body.append(el);
+    expect(input.id).toBe('signup-email');
+    expect(el.shadowRoot?.querySelector('label')?.getAttribute('for')).toBe('signup-email');
+  });
+
+  it('ignores id changes after connection (silent no-op)', () => {
+    const el = document.createElement('rafters-field') as RaftersField;
+    el.setAttribute('id', 'first-id');
+    el.setAttribute('label', 'Email');
+    const input = document.createElement('input');
+    el.append(input);
+    document.body.append(el);
+    const originalId = input.id;
+    el.setAttribute('id', 'second-id');
+    expect(input.id).toBe(originalId);
+  });
+
+  it('generates a field-prefixed id when no id attribute provided', () => {
+    const el = document.createElement('rafters-field') as RaftersField;
+    el.setAttribute('label', 'Email');
+    const input = document.createElement('input');
+    el.append(input);
+    document.body.append(el);
+    expect(input.id.startsWith('field-')).toBe(true);
+  });
+
+  it('adopts a per-instance stylesheet in the shadow root', () => {
+    const el = mount({ label: 'Email' });
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    expect(sheets.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('stylesheet uses only --motion-duration / --motion-ease tokens', () => {
+    const el = mount({ label: 'Email' });
+    const css = collectCss(el);
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+  });
+
+  it('updates stylesheet when disabled is toggled', () => {
+    const el = mount({ label: 'Email' });
+    expect(collectCss(el)).not.toMatch(/\.label\s*\{[^}]*opacity:\s*0\.5/);
+    el.setAttribute('disabled', '');
+    expect(collectCss(el)).toMatch(/opacity:\s*0\.5/);
+  });
+
+  it('re-wires accessibility attributes when the slotted control changes', () => {
+    const el = document.createElement('rafters-field') as RaftersField;
+    el.setAttribute('label', 'Email');
+    el.setAttribute('error', 'Required');
+    const first = document.createElement('input');
+    el.append(first);
+    document.body.append(el);
+    expect(first.getAttribute('aria-invalid')).toBe('true');
+
+    first.remove();
+    const second = document.createElement('input');
+    el.append(second);
+    // Force slotchange handling synchronously via the test hook.
+    el.setAttribute('error', 'Still required');
+    expect(second.getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it('property accessors mirror attributes', () => {
+    const el = mount();
+    el.label = 'Name';
+    el.description = 'Your full name';
+    el.error = 'Oops';
+    el.required = true;
+    el.disabled = true;
+    expect(el.getAttribute('label')).toBe('Name');
+    expect(el.getAttribute('description')).toBe('Your full name');
+    expect(el.getAttribute('error')).toBe('Oops');
+    expect(el.hasAttribute('required')).toBe(true);
+    expect(el.hasAttribute('disabled')).toBe(true);
+    el.required = false;
+    el.disabled = false;
+    expect(el.hasAttribute('required')).toBe(false);
+    expect(el.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('fieldId is stable across attribute changes', () => {
+    const el = mount({ label: 'Email' });
+    const first = el.fieldId;
+    el.setAttribute('description', 'Helper');
+    el.setAttribute('error', 'Bad');
+    expect(el.fieldId).toBe(first);
+  });
+
+  it('source contains no direct var() literals in either .ts file', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const elementSource = await fs.readFile(path.resolve(__dirname, 'field.element.ts'), 'utf-8');
+    expect(elementSource).not.toMatch(/[^a-zA-Z_]var\(/);
+  });
+});

--- a/packages/ui/src/components/ui/field.element.ts
+++ b/packages/ui/src/components/ui/field.element.ts
@@ -1,0 +1,327 @@
+/**
+ * <rafters-field> -- Web Component form field wrapper.
+ *
+ * Layout-composition primitive that pairs a label with a slotted control and
+ * optional helper/error text. NOT form-associated; the slotted control owns
+ * submission. The field wires accessibility attributes to the control:
+ *   - label[for] <-> control[id]
+ *   - aria-describedby merges description + error ids
+ *   - aria-invalid when error is present
+ *   - aria-required when required
+ *   - disabled propagated to the control
+ *
+ * Attributes (all observed):
+ *  - label: string -- label text (empty when missing)
+ *  - description: string -- helper text shown when no error
+ *  - error: string -- error text; replaces description
+ *  - required: boolean -- presence toggles the `*` marker and aria-required
+ *  - disabled: boolean -- presence dims label and propagates to control
+ *  - id: string -- stable field id; generated from crypto.randomUUID when absent
+ *
+ * Respects author-provided id / aria-describedby on the slotted control.
+ * All styling comes from fieldStylesheet(...) via an adopted per-instance
+ * CSSStyleSheet. No raw CSS custom-property literals; tokenVar() for every token.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import { fieldStylesheet } from './field.styles';
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = [
+  'label',
+  'description',
+  'error',
+  'required',
+  'disabled',
+  'id',
+] as const;
+
+function generateFieldId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `field-${crypto.randomUUID()}`;
+  }
+  return `field-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export class RaftersField extends RaftersElement {
+  static observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  /** Per-instance stylesheet rebuilt on every disabled/error change. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  /** Stable field id generated once per element lifetime. */
+  private _fieldId: string | null = null;
+
+  /** Bound listener reference for add/remove parity. */
+  private _onSlotChange: (() => void) | null = null;
+
+  // ==========================================================================
+  // Public accessors
+  // ==========================================================================
+
+  get fieldId(): string {
+    if (this._fieldId !== null) return this._fieldId;
+    const attrId = this.getAttribute('id');
+    this._fieldId = attrId && attrId.length > 0 ? attrId : generateFieldId();
+    return this._fieldId;
+  }
+
+  get label(): string {
+    return this.getAttribute('label') ?? '';
+  }
+
+  set label(next: string) {
+    this.setAttribute('label', next);
+  }
+
+  get description(): string {
+    return this.getAttribute('description') ?? '';
+  }
+
+  set description(next: string) {
+    this.setAttribute('description', next);
+  }
+
+  get error(): string {
+    return this.getAttribute('error') ?? '';
+  }
+
+  set error(next: string) {
+    this.setAttribute('error', next);
+  }
+
+  get required(): boolean {
+    return this.hasAttribute('required');
+  }
+
+  set required(next: boolean) {
+    this.toggleAttribute('required', next);
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+
+  set disabled(next: boolean) {
+    this.toggleAttribute('disabled', next);
+  }
+
+  // ==========================================================================
+  // Lifecycle
+  // ==========================================================================
+
+  override connectedCallback(): void {
+    if (!this.shadowRoot) return;
+
+    // Lock in the field id on first connection; subsequent `id` attribute
+    // changes are silent no-ops per spec.
+    void this.fieldId;
+
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+    this.shadowRoot.adoptedStyleSheets = [this._instanceSheet];
+
+    this.update();
+    this.attachSlotListener();
+    this.wireSlottedControl();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+
+    // `id` is intentionally immutable after first connect.
+    if (name === 'id') return;
+
+    if (this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+
+    this.update();
+    this.wireSlottedControl();
+  }
+
+  override disconnectedCallback(): void {
+    this.detachSlotListener();
+    this._instanceSheet = null;
+  }
+
+  // ==========================================================================
+  // Rendering
+  // ==========================================================================
+
+  private composeCss(): string {
+    return fieldStylesheet({
+      disabled: this.hasAttribute('disabled'),
+      error: this.hasAttribute('error'),
+    });
+  }
+
+  override render(): Node {
+    const container = document.createElement('div');
+    container.className = 'container';
+
+    const fieldId = this.fieldId;
+    const labelText = this.label;
+    const descriptionText = this.description;
+    const errorText = this.error;
+    const hasError = errorText.length > 0;
+    const hasDescription = descriptionText.length > 0;
+    const isRequired = this.required;
+
+    const labelEl = document.createElement('label');
+    labelEl.className = 'label';
+    labelEl.setAttribute('for', fieldId);
+    labelEl.textContent = labelText;
+
+    if (isRequired) {
+      const marker = document.createElement('span');
+      marker.className = 'required';
+      marker.setAttribute('aria-hidden', 'true');
+      marker.textContent = '*';
+      labelEl.appendChild(marker);
+    }
+
+    container.appendChild(labelEl);
+
+    const slot = document.createElement('slot');
+    container.appendChild(slot);
+
+    if (hasError) {
+      const errorEl = document.createElement('p');
+      errorEl.className = 'error';
+      errorEl.id = `${fieldId}-error`;
+      errorEl.setAttribute('role', 'alert');
+      errorEl.textContent = errorText;
+      container.appendChild(errorEl);
+    } else if (hasDescription) {
+      const descEl = document.createElement('p');
+      descEl.className = 'description';
+      descEl.id = `${fieldId}-description`;
+      descEl.textContent = descriptionText;
+      container.appendChild(descEl);
+    }
+
+    return container;
+  }
+
+  // ==========================================================================
+  // Slot wiring
+  // ==========================================================================
+
+  private attachSlotListener(): void {
+    if (!this.shadowRoot) return;
+    const slot = this.shadowRoot.querySelector('slot');
+    if (!slot) return;
+
+    const handler = (): void => {
+      this.wireSlottedControl();
+    };
+    slot.addEventListener('slotchange', handler);
+    this._onSlotChange = handler;
+  }
+
+  private detachSlotListener(): void {
+    if (!this._onSlotChange) return;
+    const slot = this.shadowRoot?.querySelector('slot');
+    if (slot) {
+      slot.removeEventListener('slotchange', this._onSlotChange);
+    }
+    this._onSlotChange = null;
+  }
+
+  /**
+   * Find the first slotted element control and wire accessibility attributes.
+   * Respects author-provided `id` and `aria-describedby`. Disabled propagation
+   * is unconditional so removing the host `disabled` attribute also clears it
+   * from the control.
+   */
+  private wireSlottedControl(): void {
+    const shadow = this.shadowRoot;
+    if (!shadow) return;
+
+    const slot = shadow.querySelector('slot');
+    if (!slot) return;
+
+    const assigned = slot.assignedElements({ flatten: true });
+    const firstControl = assigned.find((node): node is Element => node instanceof Element) ?? null;
+    if (!firstControl) return;
+
+    // Determine ownership: if the control arrived without these, the field
+    // generated them and is free to manage them. If the author supplied them,
+    // we never overwrite.
+    const authoredId = firstControl.hasAttribute('id') && firstControl.getAttribute('id') !== '';
+    const authoredDescribedBy = firstControl.hasAttribute('aria-describedby');
+    const authoredAriaLabel = firstControl.hasAttribute('aria-label');
+    const authoredAriaLabelledBy = firstControl.hasAttribute('aria-labelledby');
+
+    const fieldId = this.fieldId;
+    const labelText = this.label;
+    const hasError = this.error.length > 0;
+    const hasDescription = this.description.length > 0;
+    const errorId = `${fieldId}-error`;
+    const descriptionId = `${fieldId}-description`;
+
+    if (!authoredId) {
+      firstControl.setAttribute('id', fieldId);
+    }
+
+    // Labels rendered in shadow DOM cannot cross the tree-scope boundary to
+    // associate with slotted light-DOM controls via `for`/`id`. Mirror the
+    // label text onto the control as `aria-label` so screen readers still
+    // get a programmatic accessible name. Author-supplied aria-label or
+    // aria-labelledby wins.
+    if (!authoredAriaLabel && !authoredAriaLabelledBy && labelText.length > 0) {
+      firstControl.setAttribute('aria-label', labelText);
+    }
+
+    if (!authoredDescribedBy) {
+      const parts: string[] = [];
+      if (hasError) parts.push(errorId);
+      else if (hasDescription) parts.push(descriptionId);
+      if (parts.length > 0) {
+        firstControl.setAttribute('aria-describedby', parts.join(' '));
+      } else {
+        firstControl.removeAttribute('aria-describedby');
+      }
+    }
+
+    if (hasError) {
+      firstControl.setAttribute('aria-invalid', 'true');
+    } else {
+      firstControl.removeAttribute('aria-invalid');
+    }
+
+    if (this.required) {
+      firstControl.setAttribute('aria-required', 'true');
+    } else {
+      firstControl.removeAttribute('aria-required');
+    }
+
+    if (this.disabled) {
+      firstControl.setAttribute('disabled', '');
+      if ('disabled' in firstControl) {
+        (firstControl as HTMLInputElement).disabled = true;
+      }
+    } else {
+      firstControl.removeAttribute('disabled');
+      if ('disabled' in firstControl) {
+        (firstControl as HTMLInputElement).disabled = false;
+      }
+    }
+
+    // Keep the label[for] pointing at whatever id the control ended up with,
+    // which may be author-supplied when the control arrived with an explicit id.
+    const labelEl = shadow.querySelector('label');
+    const controlId = firstControl.getAttribute('id');
+    if (labelEl && controlId) {
+      labelEl.setAttribute('for', controlId);
+    }
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-field')) {
+  customElements.define('rafters-field', RaftersField);
+}

--- a/packages/ui/src/components/ui/field.styles.test.ts
+++ b/packages/ui/src/components/ui/field.styles.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { fieldStylesheet } from './field.styles';
+
+describe('fieldStylesheet', () => {
+  it('emits :host display:block', () => {
+    expect(fieldStylesheet()).toMatch(/:host\s*\{[^}]*display:\s*block/);
+  });
+
+  it('uses token-driven colors and font sizes', () => {
+    const css = fieldStylesheet();
+    expect(css).toContain('var(--color-foreground)');
+    expect(css).toContain('var(--color-muted-foreground)');
+    expect(css).toContain('var(--color-destructive)');
+    expect(css).toContain('var(--font-size-label-medium)');
+    expect(css).toContain('var(--font-size-label-small)');
+  });
+
+  it('never uses --duration-* or --ease-*', () => {
+    const css = fieldStylesheet();
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+  });
+
+  it('emits error + description rules when error option is set', () => {
+    const css = fieldStylesheet({ error: true });
+    expect(css).toMatch(/\.error\s*\{/);
+    expect(css).toMatch(/\.description\s*\{/);
+  });
+
+  it('emits .label .required rule for the required marker', () => {
+    const css = fieldStylesheet();
+    expect(css).toMatch(/\.label\s+\.required\s*\{/);
+  });
+
+  it('adds opacity override on label when disabled is set', () => {
+    const css = fieldStylesheet({ disabled: true });
+    expect(css).toMatch(/\.label\s*\{[^}]*opacity:\s*0\.5/);
+  });
+
+  it('does not add opacity override on label when disabled is absent', () => {
+    const css = fieldStylesheet();
+    expect(css).not.toMatch(/\.label\s*\{[^}]*opacity:\s*0\.5/);
+  });
+
+  it('includes container gap via spacing token', () => {
+    const css = fieldStylesheet();
+    expect(css).toContain('var(--spacing-2)');
+  });
+
+  it('includes reduced-motion guard', () => {
+    const css = fieldStylesheet();
+    expect(css).toMatch(/@media \(prefers-reduced-motion: reduce\)/);
+  });
+});

--- a/packages/ui/src/components/ui/field.styles.ts
+++ b/packages/ui/src/components/ui/field.styles.ts
@@ -1,0 +1,110 @@
+/**
+ * Shadow DOM style definitions for Field web component
+ *
+ * Parallel to field.classes.ts. Same semantic structure, CSS property maps
+ * instead of Tailwind class strings. Field is a layout-composition wrapper:
+ * flex column container stacks label + slotted control + helper/error.
+ *
+ * All token references go through tokenVar(); no raw var() literals.
+ * Motion uses --motion-duration-* / --motion-ease-* only.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import { atRule, styleRule, stylesheet, tokenVar } from '../../primitives/classy-wc';
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+/**
+ * Container shell: flex column with consistent gap between label, control,
+ * and helper/error. Mirrors `flex flex-col gap-2` from field.classes.ts.
+ */
+export const fieldContainerBase: CSSProperties = {
+  display: 'flex',
+  'flex-direction': 'column',
+  gap: tokenVar('spacing-2'),
+};
+
+/**
+ * Label typography: medium label ramp, medium weight, neutral foreground.
+ */
+export const fieldLabelBase: CSSProperties = {
+  'font-size': tokenVar('font-size-label-medium'),
+  'font-weight': '500',
+  color: tokenVar('color-foreground'),
+};
+
+/**
+ * Required indicator next to the label text. `aria-hidden` on the span keeps
+ * screen readers from reading the asterisk; `aria-required` on the control
+ * carries the semantic.
+ */
+export const fieldLabelRequiredMarker: CSSProperties = {
+  color: tokenVar('color-destructive'),
+  'margin-left': '0.25rem',
+};
+
+/**
+ * Helper text shown under the control when no error is present.
+ */
+export const fieldDescriptionBase: CSSProperties = {
+  'font-size': tokenVar('font-size-label-small'),
+  color: tokenVar('color-muted-foreground'),
+};
+
+/**
+ * Error text shown under the control; replaces description when set.
+ */
+export const fieldErrorBase: CSSProperties = {
+  'font-size': tokenVar('font-size-label-small'),
+  color: tokenVar('color-destructive'),
+};
+
+/**
+ * Disabled state: dim the label while the slotted control carries the
+ * native `disabled` attribute for interaction blocking.
+ */
+export const fieldDisabled: CSSProperties = {
+  opacity: '0.5',
+};
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+export interface FieldStylesheetOptions {
+  disabled?: boolean | undefined;
+  error?: boolean | undefined;
+}
+
+/**
+ * Build the complete field stylesheet for a given configuration.
+ *
+ * Unknown options fall back to the default layout. Never throws.
+ * Emits :host display:block plus .container / .label / .required /
+ * .description / .error rules and a prefers-reduced-motion block that
+ * neutralises transitions on descendants.
+ */
+export function fieldStylesheet(options: FieldStylesheetOptions = {}): string {
+  const { disabled, error } = options;
+
+  return stylesheet(
+    styleRule(':host', { display: 'block' }),
+
+    styleRule('.container', fieldContainerBase),
+
+    styleRule('.label', fieldLabelBase, disabled ? fieldDisabled : null),
+
+    styleRule('.label .required', fieldLabelRequiredMarker),
+
+    styleRule('.description', fieldDescriptionBase),
+
+    error ? styleRule('.error', fieldErrorBase) : '',
+
+    atRule(
+      '@media (prefers-reduced-motion: reduce)',
+      styleRule('.container', { transition: 'none' }),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

Implements `<rafters-field>` as a layout-composition Web Component plus the supporting `field.styles.ts` stylesheet and `field.classes.ts` class fragments. The element pairs a label with a slotted control and optional helper/error text. It is **not** form-associated -- the slotted control owns submission. The field wires accessibility attributes onto the slotted control while respecting any author-supplied values.

Spec: `.scratch/wc-tier2/field.md`. Closes #1347.

## What lands

Three new source files:
- `packages/ui/src/components/ui/field.classes.ts` -- Tailwind class fragments mirroring `field.tsx` for framework parity.
- `packages/ui/src/components/ui/field.styles.ts` -- shadow DOM stylesheet composed via `tokenVar()` only. Container uses `flex flex-col` with `spacing-2` gap; label uses `font-size-label-medium` + `color-foreground`; description uses `font-size-label-small` + `color-muted-foreground`; error uses `font-size-label-small` + `color-destructive`; required marker tints destructive.
- `packages/ui/src/components/ui/field.element.ts` -- `RaftersField` extending `RaftersElement`. Idempotent `customElements.define`. Per-instance `CSSStyleSheet` rebuilt on disabled/error change. Generates a stable `field-${randomUUID()}` id when no `id` attribute provided. Observes `label`, `description`, `error`, `required`, `disabled`, `id`. `id` is silently locked after `connectedCallback`. Slotchange listener re-applies wiring when slotted content changes.

## Accessibility wiring

For the first slotted element control:
- `id` -- assigned `fieldId` only when the control has none.
- `aria-label` -- mirrors the `label` attribute when the control has neither `aria-label` nor `aria-labelledby`. Cross-shadow `<label for>` cannot reach light-DOM controls in real browsers, so this guarantees a programmatic accessible name (the visible shadow `<label>` remains for click-focus and visual context).
- `aria-describedby` -- merges `${fieldId}-error` and/or `${fieldId}-description`; never overwrites an author-supplied value.
- `aria-invalid="true"` when `error` is present; removed otherwise.
- `aria-required="true"` when `required`; removed otherwise.
- `disabled` propagated to the control when the host is disabled; cleared otherwise.
- Shadow `<label for>` is kept in sync with whatever id the control ends up with (author-provided or generated).

## Tests

- `field.element.test.ts` -- 27 tests covering registration idempotency, observed attributes, label/required/error/description/disabled rendering, control wiring, author-id and author-aria-describedby preservation, id immutability after connect, stable `fieldId`, per-instance stylesheet adoption, and source-level guard against raw `var()` literals.
- `field.styles.test.ts` -- 9 tests covering `:host` block layout, token-driven colors and font sizes, motion-namespace guard, conditional `.error` emission, label opacity override under disabled, and reduced-motion guard.
- `field.element.a11y.tsx` -- 9 vitest-axe scenarios covering basic input, description, error, required, disabled, textarea, select, multiple stacked fields, and form-nested usage. All pass with zero violations.

## Test plan

- [x] `pnpm --filter=@rafters/ui typecheck`
- [x] `pnpm --filter=@rafters/ui test field` -- 5 files, 95 tests pass
- [x] `pnpm --filter=@rafters/ui test:a11y` -- 671/671 pass
- [x] `pnpm --filter=@rafters/ui test:unit` -- 4161/4161 pass
- [x] `pnpm preflight` -- typecheck + lint + unit + a11y + build all green
- [x] No raw `var()` calls in source; `tokenVar()` for every token
- [x] Only `--motion-duration-*` / `--motion-ease-*` motion tokens
- [x] Auto-register guarded against double-define