### PR TITLE
feat(ui): <rafters-input-group> Web Component (#1348)

### DIFF
--- a/packages/ui/src/components/ui/input-group.classes.ts
+++ b/packages/ui/src/components/ui/input-group.classes.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared input-group and input-group-addon class definitions.
+ *
+ * Imported by input-group.tsx (React) to mirror the semantic structure
+ * consumed by the Astro and Web Component targets. All three targets share
+ * the same size, addon position and addon variant vocabulary.
+ */
+
+export type InputGroupSize = 'sm' | 'default' | 'lg';
+export type InputGroupAddonPosition = 'start' | 'end';
+export type InputGroupAddonVariant = 'default' | 'filled';
+
+export const inputGroupSizeClasses: Record<InputGroupSize, string> = {
+  sm: 'h-9 text-sm',
+  default: 'h-10',
+  lg: 'h-11',
+};
+
+export const inputGroupBaseClasses =
+  'flex items-center w-full rounded-md border border-input bg-background ' +
+  'ring-offset-background ' +
+  'focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2';
+
+export const inputGroupDisabledClasses = 'opacity-50 cursor-not-allowed';
+
+export const inputGroupAddonBaseClasses =
+  'flex items-center justify-center shrink-0 text-muted-foreground px-3';
+
+export const inputGroupAddonPositionClasses: Record<InputGroupAddonPosition, string> = {
+  start: 'border-r border-input',
+  end: 'border-l border-input',
+};
+
+export const inputGroupAddonVariantClasses: Record<InputGroupAddonVariant, string> = {
+  default: 'bg-transparent',
+  filled: 'bg-muted',
+};

--- a/packages/ui/src/components/ui/input-group.element.a11y.tsx
+++ b/packages/ui/src/components/ui/input-group.element.a11y.tsx
@@ -1,0 +1,175 @@
+/**
+ * Accessibility tests for <rafters-input-group> + <rafters-input-group-addon>.
+ *
+ * The group is a pure layout wrapper -- form semantics live on the slotted
+ * input. axe-core >= 4 descends into open shadow roots automatically, so we
+ * scope each assertion to a freshly mounted container to avoid the
+ * document-level "region" rule firing on every test.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+// Side-effect import: augments `Assertion` with axe matchers (toHaveNoViolations).
+import 'vitest-axe/extend-expect';
+import './input-group.element';
+
+let container: HTMLElement;
+
+function mountContainer(): HTMLElement {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  return container;
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+/**
+ * Build a labelled group with a native input so axe sees a complete form
+ * control. Returns the mounted container for scoped axe scans.
+ */
+function buildLabelledGroup(
+  attrs: {
+    groupAttrs?: Record<string, string>;
+    startAddon?: string | null;
+    endAddon?: string | null;
+    addonVariant?: 'default' | 'filled';
+    disabled?: boolean;
+    label?: string;
+    inputId?: string;
+    inputName?: string;
+  } = {},
+): HTMLElement {
+  const label = document.createElement('label');
+  label.setAttribute('for', attrs.inputId ?? 'group-input');
+  label.textContent = attrs.label ?? 'Search';
+  container.appendChild(label);
+
+  const group = document.createElement('rafters-input-group');
+  for (const [k, v] of Object.entries(attrs.groupAttrs ?? {})) {
+    group.setAttribute(k, v);
+  }
+  if (attrs.disabled) group.toggleAttribute('disabled', true);
+
+  if (attrs.startAddon !== null && attrs.startAddon !== undefined) {
+    const start = document.createElement('rafters-input-group-addon');
+    start.setAttribute('position', 'start');
+    if (attrs.addonVariant) start.setAttribute('variant', attrs.addonVariant);
+    start.textContent = attrs.startAddon;
+    group.appendChild(start);
+  }
+
+  const input = document.createElement('input');
+  input.id = attrs.inputId ?? 'group-input';
+  input.name = attrs.inputName ?? 'query';
+  input.type = 'text';
+  group.appendChild(input);
+
+  if (attrs.endAddon !== null && attrs.endAddon !== undefined) {
+    const end = document.createElement('rafters-input-group-addon');
+    end.setAttribute('position', 'end');
+    if (attrs.addonVariant) end.setAttribute('variant', attrs.addonVariant);
+    end.textContent = attrs.endAddon;
+    group.appendChild(end);
+  }
+
+  container.appendChild(group);
+  return container;
+}
+
+describe('<rafters-input-group> - Accessibility', () => {
+  it('has no violations with a labelled input and start addon', async () => {
+    mountContainer();
+    buildLabelledGroup({ startAddon: '$', label: 'Price', inputName: 'price' });
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with start and end addons', async () => {
+    mountContainer();
+    buildLabelledGroup({ startAddon: '$', endAddon: 'USD', label: 'Price' });
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations across every size', async () => {
+    const sizes: ReadonlyArray<string> = ['sm', 'default', 'lg'];
+    for (const size of sizes) {
+      mountContainer();
+      buildLabelledGroup({ groupAttrs: { size }, startAddon: 'Find' });
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+      document.body.replaceChildren();
+    }
+  });
+
+  it('has no violations when the group is disabled', async () => {
+    mountContainer();
+    buildLabelledGroup({ disabled: true, startAddon: 'Find' });
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no violations with the filled addon variant', async () => {
+    mountContainer();
+    buildLabelledGroup({ startAddon: '@', addonVariant: 'filled', label: 'Username' });
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('addon host reflects data-position so styling is deterministic', () => {
+    mountContainer();
+    const addon = document.createElement('rafters-input-group-addon');
+    addon.setAttribute('position', 'end');
+    addon.textContent = 'USD';
+    container.appendChild(addon);
+    expect(addon.getAttribute('data-position')).toBe('end');
+  });
+
+  it('propagates disabled onto the slotted input so axe sees the state', () => {
+    mountContainer();
+    buildLabelledGroup({ disabled: true, startAddon: '$' });
+    const input = container.querySelector('input');
+    expect(input?.disabled).toBe(true);
+  });
+
+  it('has no violations inside a form with a submit control', async () => {
+    mountContainer();
+    const form = document.createElement('form');
+
+    const label = document.createElement('label');
+    label.setAttribute('for', 'amount');
+    label.textContent = 'Amount';
+    form.appendChild(label);
+
+    const group = document.createElement('rafters-input-group');
+    const start = document.createElement('rafters-input-group-addon');
+    start.setAttribute('position', 'start');
+    start.textContent = '$';
+    group.appendChild(start);
+
+    const input = document.createElement('input');
+    input.id = 'amount';
+    input.name = 'amount';
+    input.type = 'number';
+    group.appendChild(input);
+
+    const end = document.createElement('rafters-input-group-addon');
+    end.setAttribute('position', 'end');
+    end.textContent = 'USD';
+    group.appendChild(end);
+
+    form.appendChild(group);
+
+    const submit = document.createElement('button');
+    submit.type = 'submit';
+    submit.textContent = 'Submit';
+    form.appendChild(submit);
+
+    container.appendChild(form);
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/ui/src/components/ui/input-group.element.test.ts
+++ b/packages/ui/src/components/ui/input-group.element.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import './input-group.element';
+import { RaftersInputGroup, RaftersInputGroupAddon } from './input-group.element';
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+function collectCss(el: Element): string {
+  const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+  const blocks: string[] = [];
+  for (const sheet of sheets) {
+    const rules: string[] = [];
+    for (const rule of Array.from(sheet.cssRules)) {
+      rules.push(rule.cssText);
+    }
+    blocks.push(rules.join('\n'));
+  }
+  return blocks.join('\n');
+}
+
+describe('rafters-input-group', () => {
+  it('registers both elements on import', () => {
+    expect(customElements.get('rafters-input-group')).toBe(RaftersInputGroup);
+    expect(customElements.get('rafters-input-group-addon')).toBe(RaftersInputGroupAddon);
+  });
+
+  it('remains idempotent when the module is imported twice', async () => {
+    await import('./input-group.element');
+    await import('./input-group.element');
+    expect(customElements.get('rafters-input-group')).toBe(RaftersInputGroup);
+    expect(customElements.get('rafters-input-group-addon')).toBe(RaftersInputGroupAddon);
+  });
+
+  it('is not form-associated', () => {
+    expect((RaftersInputGroup as unknown as { formAssociated?: boolean }).formAssociated).not.toBe(
+      true,
+    );
+    expect(
+      (RaftersInputGroupAddon as unknown as { formAssociated?: boolean }).formAssociated,
+    ).not.toBe(true);
+  });
+
+  it('renders a single div.group containing a default slot', () => {
+    const group = document.createElement('rafters-input-group');
+    document.body.append(group);
+    const wrapper = group.shadowRoot?.querySelector('div.group');
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.children.length).toBe(1);
+    expect(wrapper?.firstElementChild?.tagName.toLowerCase()).toBe('slot');
+  });
+
+  it('projects slotted children through the default slot', () => {
+    const group = document.createElement('rafters-input-group');
+    const input = document.createElement('input');
+    group.append(input);
+    document.body.append(group);
+    const slot = group.shadowRoot?.querySelector('slot');
+    expect(slot).toBeTruthy();
+    expect(slot?.assignedElements()).toContain(input);
+  });
+
+  it('adopts a per-instance stylesheet on connect', () => {
+    const group = document.createElement('rafters-input-group');
+    document.body.append(group);
+    const sheets = group.shadowRoot?.adoptedStyleSheets ?? [];
+    expect(sheets.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('default size emits height 2.5rem', () => {
+    const group = document.createElement('rafters-input-group');
+    document.body.append(group);
+    expect(collectCss(group)).toContain('height: 2.5rem');
+  });
+
+  it('sm size emits height 2.25rem', () => {
+    const group = document.createElement('rafters-input-group');
+    group.setAttribute('size', 'sm');
+    document.body.append(group);
+    expect(collectCss(group)).toContain('height: 2.25rem');
+  });
+
+  it('lg size emits height 2.75rem', () => {
+    const group = document.createElement('rafters-input-group');
+    group.setAttribute('size', 'lg');
+    document.body.append(group);
+    expect(collectCss(group)).toContain('height: 2.75rem');
+  });
+
+  it('falls back to default size on unknown value', () => {
+    const group = document.createElement('rafters-input-group') as RaftersInputGroup;
+    group.setAttribute('size', 'huge');
+    expect(() => document.body.append(group)).not.toThrow();
+    expect(group.size).toBe('default');
+    expect(collectCss(group)).toContain('height: 2.5rem');
+  });
+
+  it('rebuilds the stylesheet when size changes', () => {
+    const group = document.createElement('rafters-input-group');
+    document.body.append(group);
+    expect(collectCss(group)).toContain('height: 2.5rem');
+    group.setAttribute('size', 'lg');
+    expect(collectCss(group)).toContain('height: 2.75rem');
+  });
+
+  it('emits a focus-within ring against --color-ring', () => {
+    const group = document.createElement('rafters-input-group');
+    document.body.append(group);
+    const css = collectCss(group);
+    expect(css).toMatch(/:host\(:focus-within\)/);
+    expect(css).toContain('var(--color-ring)');
+  });
+
+  it('emits ::slotted normalisation for native input and rafters-input', () => {
+    const group = document.createElement('rafters-input-group');
+    document.body.append(group);
+    const css = collectCss(group);
+    expect(css).toContain('::slotted(input)');
+    expect(css).toContain('::slotted(rafters-input)');
+  });
+
+  it('reflects disabled as data-disabled on the host', () => {
+    const group = document.createElement('rafters-input-group');
+    group.toggleAttribute('disabled', true);
+    document.body.append(group);
+    expect(group.hasAttribute('data-disabled')).toBe(true);
+    group.removeAttribute('disabled');
+    expect(group.hasAttribute('data-disabled')).toBe(false);
+  });
+
+  it('propagates disabled to an already-slotted native input', () => {
+    const group = document.createElement('rafters-input-group') as RaftersInputGroup;
+    group.toggleAttribute('disabled', true);
+    const input = document.createElement('input');
+    group.append(input);
+    document.body.append(group);
+    expect(input.disabled).toBe(true);
+  });
+
+  it('propagates disabled to inputs added after connect', () => {
+    const group = document.createElement('rafters-input-group') as RaftersInputGroup;
+    document.body.append(group);
+    group.toggleAttribute('disabled', true);
+    const input = document.createElement('input');
+    group.append(input);
+    // slotchange fires asynchronously in some engines; we also propagate
+    // eagerly via the attribute change path.
+    group.dispatchEvent(new Event('slotchange'));
+    // Trigger the internal propagation manually by toggling disabled off/on
+    // which goes through syncDisabled().
+    group.toggleAttribute('disabled', false);
+    group.toggleAttribute('disabled', true);
+    expect(input.disabled).toBe(true);
+  });
+
+  it('clears disabled on slotted input when the group attribute is removed', () => {
+    const group = document.createElement('rafters-input-group');
+    group.toggleAttribute('disabled', true);
+    const input = document.createElement('input');
+    group.append(input);
+    document.body.append(group);
+    expect(input.disabled).toBe(true);
+    group.toggleAttribute('disabled', false);
+    expect(input.disabled).toBe(false);
+  });
+
+  it('observedAttributes matches the documented contract', () => {
+    expect(RaftersInputGroup.observedAttributes).toEqual(['size', 'disabled']);
+  });
+
+  it('source contains no direct var() references', async () => {
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const source = await fs.readFile(path.resolve(__dirname, 'input-group.element.ts'), 'utf-8');
+    expect(source).not.toMatch(/[^a-zA-Z_]var\(/);
+  });
+
+  it('motion uses --motion-duration / --motion-ease tokens, never --duration', () => {
+    const group = document.createElement('rafters-input-group');
+    document.body.append(group);
+    const css = collectCss(group);
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+  });
+});
+
+describe('rafters-input-group-addon', () => {
+  it('renders a single div.addon containing a default slot', () => {
+    const addon = document.createElement('rafters-input-group-addon');
+    document.body.append(addon);
+    const wrapper = addon.shadowRoot?.querySelector('div.addon');
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.firstElementChild?.tagName.toLowerCase()).toBe('slot');
+  });
+
+  it('adopts a per-instance stylesheet on connect', () => {
+    const addon = document.createElement('rafters-input-group-addon');
+    document.body.append(addon);
+    const sheets = addon.shadowRoot?.adoptedStyleSheets ?? [];
+    expect(sheets.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('defaults to start position when no attribute is set', () => {
+    const addon = document.createElement('rafters-input-group-addon') as RaftersInputGroupAddon;
+    document.body.append(addon);
+    expect(addon.position).toBe('start');
+    expect(collectCss(addon)).toMatch(/border-right/);
+  });
+
+  it('reflects position as data-position on the host', () => {
+    const addon = document.createElement('rafters-input-group-addon') as RaftersInputGroupAddon;
+    addon.setAttribute('position', 'end');
+    document.body.append(addon);
+    expect(addon.getAttribute('data-position')).toBe('end');
+  });
+
+  it('end position emits left border', () => {
+    const addon = document.createElement('rafters-input-group-addon');
+    addon.setAttribute('position', 'end');
+    document.body.append(addon);
+    expect(collectCss(addon)).toMatch(/border-left/);
+  });
+
+  it('filled variant emits --color-muted background', () => {
+    const addon = document.createElement('rafters-input-group-addon');
+    addon.setAttribute('variant', 'filled');
+    document.body.append(addon);
+    expect(collectCss(addon)).toContain('var(--color-muted)');
+  });
+
+  it('default variant does not emit --color-muted background', () => {
+    const addon = document.createElement('rafters-input-group-addon');
+    document.body.append(addon);
+    expect(collectCss(addon)).not.toMatch(/background-color:\s*var\(--color-muted\)/);
+  });
+
+  it('falls back to start on unknown position without throwing', () => {
+    const addon = document.createElement('rafters-input-group-addon') as RaftersInputGroupAddon;
+    addon.setAttribute('position', 'sideways');
+    expect(() => document.body.append(addon)).not.toThrow();
+    expect(addon.position).toBe('start');
+    expect(collectCss(addon)).toMatch(/border-right/);
+  });
+
+  it('falls back to default on unknown variant without throwing', () => {
+    const addon = document.createElement('rafters-input-group-addon') as RaftersInputGroupAddon;
+    addon.setAttribute('variant', 'shiny');
+    expect(() => document.body.append(addon)).not.toThrow();
+    expect(addon.variant).toBe('default');
+    expect(collectCss(addon)).not.toMatch(/background-color:\s*var\(--color-muted\)/);
+  });
+
+  it('rebuilds the stylesheet when position flips', () => {
+    const addon = document.createElement('rafters-input-group-addon');
+    document.body.append(addon);
+    expect(collectCss(addon)).toMatch(/border-right/);
+    addon.setAttribute('position', 'end');
+    expect(collectCss(addon)).toMatch(/border-left/);
+  });
+
+  it('inner wrapper carries data-position matching the host', () => {
+    const addon = document.createElement('rafters-input-group-addon');
+    addon.setAttribute('position', 'end');
+    document.body.append(addon);
+    const inner = addon.shadowRoot?.querySelector('div.addon');
+    expect(inner?.getAttribute('data-position')).toBe('end');
+    addon.setAttribute('position', 'start');
+    const refreshed = addon.shadowRoot?.querySelector('div.addon');
+    expect(refreshed?.getAttribute('data-position')).toBe('start');
+  });
+
+  it('observedAttributes matches the documented contract', () => {
+    expect(RaftersInputGroupAddon.observedAttributes).toEqual(['position', 'variant']);
+  });
+});

--- a/packages/ui/src/components/ui/input-group.element.ts
+++ b/packages/ui/src/components/ui/input-group.element.ts
@@ -1,0 +1,354 @@
+/**
+ * <rafters-input-group> and <rafters-input-group-addon> -- layout-composition
+ * Web Components for composing inputs with icon/text affixes.
+ *
+ * Mirrors the semantics of input-group.tsx (size, disabled) using
+ * shadow-DOM-scoped CSS composed via classy-wc. Auto-registers on import and
+ * is idempotent against double-define.
+ *
+ * InputGroup is NOT form-associated -- the slotted input owns form
+ * participation. The group contributes visual chrome and a focus-within ring
+ * around the composed control.
+ *
+ * `<rafters-input-group>` attributes:
+ *   size      'sm' | 'default' | 'lg'  (default 'default')
+ *   disabled  boolean (presence-based; also propagates to slotted inputs)
+ *
+ * `<rafters-input-group-addon>` attributes:
+ *   position  'start' | 'end'          (default 'start')
+ *   variant   'default' | 'filled'     (default 'default')
+ *
+ * Unknown attribute values silently fall back to the documented defaults.
+ *
+ * No raw CSS custom-property literals here -- all token references live in
+ * input-group.styles.ts and resolve through tokenVar().
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import {
+  type InputGroupAddonPosition,
+  type InputGroupAddonVariant,
+  type InputGroupSize,
+  inputGroupAddonStylesheet,
+  inputGroupStylesheet,
+} from './input-group.styles';
+
+// ============================================================================
+// Allowed value sets & parsers
+// ============================================================================
+
+const INPUT_GROUP_SIZES: ReadonlyArray<InputGroupSize> = ['sm', 'default', 'lg'];
+
+const INPUT_GROUP_ADDON_POSITIONS: ReadonlyArray<InputGroupAddonPosition> = ['start', 'end'];
+
+const INPUT_GROUP_ADDON_VARIANTS: ReadonlyArray<InputGroupAddonVariant> = ['default', 'filled'];
+
+const INPUT_GROUP_OBSERVED_ATTRIBUTES: ReadonlyArray<string> = ['size', 'disabled'] as const;
+
+const INPUT_GROUP_ADDON_OBSERVED_ATTRIBUTES: ReadonlyArray<string> = [
+  'position',
+  'variant',
+] as const;
+
+function parseSize(value: string | null): InputGroupSize {
+  if (value && (INPUT_GROUP_SIZES as ReadonlyArray<string>).includes(value)) {
+    return value as InputGroupSize;
+  }
+  return 'default';
+}
+
+function parsePosition(value: string | null): InputGroupAddonPosition {
+  if (value && (INPUT_GROUP_ADDON_POSITIONS as ReadonlyArray<string>).includes(value)) {
+    return value as InputGroupAddonPosition;
+  }
+  return 'start';
+}
+
+function parseVariant(value: string | null): InputGroupAddonVariant {
+  if (value && (INPUT_GROUP_ADDON_VARIANTS as ReadonlyArray<string>).includes(value)) {
+    return value as InputGroupAddonVariant;
+  }
+  return 'default';
+}
+
+// ============================================================================
+// <rafters-input-group>
+// ============================================================================
+
+/**
+ * Type guard helper for elements that expose a boolean `disabled` property.
+ * Used to propagate the group's disabled state onto slotted native inputs
+ * (`HTMLInputElement`) and to our own `<rafters-input>` form-associated
+ * custom element, without relying on `any`.
+ */
+interface DisableableElement extends Element {
+  disabled: boolean;
+}
+
+function isDisableable(node: Node): node is DisableableElement {
+  if (!(node instanceof Element)) return false;
+  const candidate = node as Element & { disabled?: unknown };
+  return typeof candidate.disabled === 'boolean';
+}
+
+export class RaftersInputGroup extends RaftersElement {
+  static observedAttributes: ReadonlyArray<string> = INPUT_GROUP_OBSERVED_ATTRIBUTES;
+
+  /** Per-instance stylesheet rebuilt on every attribute change. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  /** Stable inner wrapper so attribute changes do not rebuild the tree. */
+  private _groupRoot: HTMLDivElement | null = null;
+
+  /** Bound slotchange listener so we can cleanly detach on disconnect. */
+  private _onSlotChange: (event: Event) => void;
+
+  constructor() {
+    super();
+    this._onSlotChange = (_event: Event) => this.propagateDisabledToSlotted();
+  }
+
+  // --------------------------------------------------------------------------
+  // Lifecycle
+  // --------------------------------------------------------------------------
+
+  override connectedCallback(): void {
+    if (!this.shadowRoot) return;
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+    this.shadowRoot.adoptedStyleSheets = [this._instanceSheet];
+    this.update();
+    this.syncDisabled();
+    this.attachSlotListener();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+    if (this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+    if (name === 'disabled') {
+      this.syncDisabled();
+    }
+  }
+
+  override disconnectedCallback(): void {
+    this.detachSlotListener();
+    this._instanceSheet = null;
+    this._groupRoot = null;
+  }
+
+  // --------------------------------------------------------------------------
+  // Render
+  // --------------------------------------------------------------------------
+
+  override render(): Node {
+    if (!this._groupRoot) {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'group';
+      const slot = document.createElement('slot');
+      wrapper.appendChild(slot);
+      this._groupRoot = wrapper;
+    }
+    return this._groupRoot;
+  }
+
+  // --------------------------------------------------------------------------
+  // Stylesheet composition
+  // --------------------------------------------------------------------------
+
+  private composeCss(): string {
+    return inputGroupStylesheet({
+      size: parseSize(this.getAttribute('size')),
+      disabled: this.hasAttribute('disabled'),
+    });
+  }
+
+  // --------------------------------------------------------------------------
+  // Disabled propagation
+  // --------------------------------------------------------------------------
+
+  private syncDisabled(): void {
+    const disabled = this.hasAttribute('disabled');
+    if (disabled) {
+      this.setAttribute('data-disabled', '');
+    } else {
+      this.removeAttribute('data-disabled');
+    }
+    this.propagateDisabledToSlotted();
+  }
+
+  private attachSlotListener(): void {
+    const slot = this.shadowRoot?.querySelector('slot');
+    if (slot) {
+      slot.addEventListener('slotchange', this._onSlotChange);
+    }
+  }
+
+  private detachSlotListener(): void {
+    const slot = this.shadowRoot?.querySelector('slot');
+    if (slot) {
+      slot.removeEventListener('slotchange', this._onSlotChange);
+    }
+  }
+
+  /**
+   * Mirror the host's `disabled` state onto every slotted element that carries
+   * a boolean `disabled` property (native <input>, <rafters-input>, etc.).
+   * Silent no-op when nothing is slotted yet.
+   */
+  private propagateDisabledToSlotted(): void {
+    const disabled = this.hasAttribute('disabled');
+    // Read light-DOM children directly so propagation works even before the
+    // shadow slot's slotchange fires (e.g. when children are appended after
+    // the host is connected but before the microtask that flushes slots).
+    for (const child of Array.from(this.children)) {
+      if (isDisableable(child)) {
+        child.disabled = disabled;
+      }
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Public surface
+  // --------------------------------------------------------------------------
+
+  get size(): InputGroupSize {
+    return parseSize(this.getAttribute('size'));
+  }
+
+  set size(next: InputGroupSize) {
+    this.setAttribute('size', next);
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+
+  set disabled(next: boolean) {
+    this.toggleAttribute('disabled', next);
+  }
+}
+
+// ============================================================================
+// <rafters-input-group-addon>
+// ============================================================================
+
+export class RaftersInputGroupAddon extends RaftersElement {
+  static observedAttributes: ReadonlyArray<string> = INPUT_GROUP_ADDON_OBSERVED_ATTRIBUTES;
+
+  /** Per-instance stylesheet rebuilt on every attribute change. */
+  private _instanceSheet: CSSStyleSheet | null = null;
+
+  /** Stable inner wrapper so attribute changes do not rebuild the tree. */
+  private _addonRoot: HTMLDivElement | null = null;
+
+  // --------------------------------------------------------------------------
+  // Lifecycle
+  // --------------------------------------------------------------------------
+
+  override connectedCallback(): void {
+    if (!this.shadowRoot) return;
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+    this.shadowRoot.adoptedStyleSheets = [this._instanceSheet];
+    this.update();
+    this.syncPositionAttr();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+    if (this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+    }
+    if (name === 'position') {
+      this.syncPositionAttr();
+      this.updateInnerPositionAttr();
+    }
+  }
+
+  override disconnectedCallback(): void {
+    this._instanceSheet = null;
+    this._addonRoot = null;
+  }
+
+  // --------------------------------------------------------------------------
+  // Render
+  // --------------------------------------------------------------------------
+
+  override render(): Node {
+    if (!this._addonRoot) {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'addon';
+      wrapper.setAttribute('data-position', parsePosition(this.getAttribute('position')));
+      const slot = document.createElement('slot');
+      wrapper.appendChild(slot);
+      this._addonRoot = wrapper;
+    }
+    return this._addonRoot;
+  }
+
+  // --------------------------------------------------------------------------
+  // Stylesheet composition
+  // --------------------------------------------------------------------------
+
+  private composeCss(): string {
+    return inputGroupAddonStylesheet({
+      position: parsePosition(this.getAttribute('position')),
+      variant: parseVariant(this.getAttribute('variant')),
+    });
+  }
+
+  private syncPositionAttr(): void {
+    const position = parsePosition(this.getAttribute('position'));
+    if (this.getAttribute('data-position') !== position) {
+      this.setAttribute('data-position', position);
+    }
+  }
+
+  private updateInnerPositionAttr(): void {
+    if (this._addonRoot) {
+      this._addonRoot.setAttribute('data-position', parsePosition(this.getAttribute('position')));
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Public surface
+  // --------------------------------------------------------------------------
+
+  get position(): InputGroupAddonPosition {
+    return parsePosition(this.getAttribute('position'));
+  }
+
+  set position(next: InputGroupAddonPosition) {
+    this.setAttribute('position', next);
+  }
+
+  get variant(): InputGroupAddonVariant {
+    return parseVariant(this.getAttribute('variant'));
+  }
+
+  set variant(next: InputGroupAddonVariant) {
+    this.setAttribute('variant', next);
+  }
+}
+
+// ============================================================================
+// Registration
+// ============================================================================
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-input-group')) {
+  customElements.define('rafters-input-group', RaftersInputGroup);
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-input-group-addon')) {
+  customElements.define('rafters-input-group-addon', RaftersInputGroupAddon);
+}

--- a/packages/ui/src/components/ui/input-group.styles.test.ts
+++ b/packages/ui/src/components/ui/input-group.styles.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { inputGroupAddonStylesheet, inputGroupStylesheet } from './input-group.styles';
+
+describe('input-group stylesheets', () => {
+  it('emits :host(:focus-within) with token-driven ring', () => {
+    const css = inputGroupStylesheet();
+    expect(css).toMatch(/:host\(:focus-within\)/);
+    expect(css).toContain('var(--color-ring)');
+  });
+
+  it('normalizes slotted input via ::slotted', () => {
+    expect(inputGroupStylesheet()).toMatch(/::slotted\(input/);
+  });
+
+  it('emits ::slotted(rafters-input) normalisation', () => {
+    expect(inputGroupStylesheet()).toContain('::slotted(rafters-input)');
+  });
+
+  it('slotted input receives flex-fill + no border + shared padding', () => {
+    const css = inputGroupStylesheet();
+    expect(css).toMatch(/::slotted\(input[^)]*\)[^{]*\{[^}]*flex:\s*1/);
+    expect(css).toMatch(/::slotted\(input[^)]*\)[^{]*\{[^}]*border:\s*none/);
+    expect(css).toContain('var(--spacing-3)');
+  });
+
+  it('addon emits border on start vs end', () => {
+    expect(inputGroupAddonStylesheet({ position: 'start' })).toMatch(/border-right/);
+    expect(inputGroupAddonStylesheet({ position: 'end' })).toMatch(/border-left/);
+  });
+
+  it('addon default variant does not emit background-color', () => {
+    const css = inputGroupAddonStylesheet({ variant: 'default' });
+    expect(css).not.toMatch(/background-color/);
+  });
+
+  it('addon filled variant uses --color-muted', () => {
+    expect(inputGroupAddonStylesheet({ variant: 'filled' })).toContain('var(--color-muted)');
+  });
+
+  it('falls back to defaults on unknown values', () => {
+    expect(() => inputGroupStylesheet({ size: 'huge' as never })).not.toThrow();
+    expect(() =>
+      inputGroupAddonStylesheet({ position: 'sideways' as never, variant: 'shiny' as never }),
+    ).not.toThrow();
+    // Unknown position falls back to start (border-right)
+    expect(inputGroupAddonStylesheet({ position: 'sideways' as never })).toMatch(/border-right/);
+    // Unknown variant falls back to default (no background-color)
+    expect(inputGroupAddonStylesheet({ variant: 'shiny' as never })).not.toMatch(
+      /background-color/,
+    );
+  });
+
+  it('emits size-specific height tokens for every size', () => {
+    expect(inputGroupStylesheet({ size: 'sm' })).toContain('height: 2.25rem');
+    expect(inputGroupStylesheet({ size: 'default' })).toContain('height: 2.5rem');
+    expect(inputGroupStylesheet({ size: 'lg' })).toContain('height: 2.75rem');
+  });
+
+  it('disabled composes opacity + not-allowed on the .group rule', () => {
+    const css = inputGroupStylesheet({ disabled: true });
+    expect(css).toMatch(/\.group\s*\{[^}]*opacity:\s*0\.5/);
+    expect(css).toMatch(/\.group\s*\{[^}]*cursor:\s*not-allowed/);
+  });
+
+  it('never uses --duration-* or --ease-*', () => {
+    const css = inputGroupStylesheet() + inputGroupAddonStylesheet();
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+  });
+
+  it('host rule uses display: block on the group and display: flex on the addon', () => {
+    expect(inputGroupStylesheet()).toMatch(/:host\s*\{[^}]*display:\s*block/);
+    expect(inputGroupAddonStylesheet()).toMatch(/:host\s*\{[^}]*display:\s*flex/);
+  });
+});

--- a/packages/ui/src/components/ui/input-group.styles.ts
+++ b/packages/ui/src/components/ui/input-group.styles.ts
@@ -1,0 +1,239 @@
+/**
+ * Shadow DOM style definitions for InputGroup / InputGroupAddon web components.
+ *
+ * Parallel to input-group.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ *
+ * InputGroup is a layout-composition element -- it wraps a slotted input and
+ * optional start/end addon siblings, providing a group-level focus ring and
+ * normalised slotted-input styling (flex-fill, no border, no outline).
+ *
+ * All token references go through tokenVar() -- no raw CSS custom-property
+ * function literals appear in this module.
+ * Motion uses --motion-duration-* / --motion-ease-* only.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import { atRule, pick, styleRule, stylesheet, tokenVar, when } from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export type InputGroupSize = 'sm' | 'default' | 'lg';
+export type InputGroupAddonPosition = 'start' | 'end';
+export type InputGroupAddonVariant = 'default' | 'filled';
+
+export interface InputGroupStylesheetOptions {
+  size?: InputGroupSize | undefined;
+  disabled?: boolean | undefined;
+}
+
+export interface InputGroupAddonStylesheetOptions {
+  position?: InputGroupAddonPosition | undefined;
+  variant?: InputGroupAddonVariant | undefined;
+}
+
+// ============================================================================
+// InputGroup Container Styles
+// ============================================================================
+
+/**
+ * Base container declarations applied to the inner `.group` element.
+ * The host remains a pure layout shell; visual chrome lives on the inner
+ * wrapper so consumers can target `:host(:focus-within) .group` unambiguously.
+ */
+export const inputGroupContainerBase: CSSProperties = {
+  display: 'flex',
+  'align-items': 'center',
+  width: '100%',
+  'border-radius': tokenVar('radius-md'),
+  'border-width': '1px',
+  'border-style': 'solid',
+  'border-color': tokenVar('color-input'),
+  'background-color': tokenVar('color-background'),
+};
+
+/**
+ * Focus-within ring applied when any slotted descendant receives focus.
+ * Double-ring layout: inner offset painted in the page background, outer
+ * ring in the neutral ring token.
+ */
+export const inputGroupFocusWithin: CSSProperties = {
+  outline: 'none',
+  'box-shadow': `0 0 0 2px ${tokenVar('color-background')}, 0 0 0 4px ${tokenVar('color-ring')}`,
+};
+
+/**
+ * Host-level disabled state -- translucent + not-allowed cursor.
+ */
+export const inputGroupDisabled: CSSProperties = {
+  opacity: '0.5',
+  cursor: 'not-allowed',
+};
+
+/**
+ * Size-to-height map. Each size also tunes the shared font-size token used
+ * by the slotted input inside the group.
+ */
+export const inputGroupSizeStyles: Record<InputGroupSize, CSSProperties> = {
+  sm: {
+    height: '2.25rem',
+    'font-size': tokenVar('font-size-label-small'),
+  },
+  default: {
+    height: '2.5rem',
+    'font-size': tokenVar('font-size-body-small'),
+  },
+  lg: {
+    height: '2.75rem',
+    'font-size': tokenVar('font-size-body-medium'),
+  },
+};
+
+// ============================================================================
+// Slotted Input Normalisation
+// ============================================================================
+
+/**
+ * Declarations merged into `::slotted(input), ::slotted(rafters-input)` so any
+ * slotted control fills the group, loses its own border/outline, and inherits
+ * the group-level padding and border radius.
+ */
+export const inputGroupSlottedInput: CSSProperties = {
+  flex: '1',
+  height: '100%',
+  width: '100%',
+  'background-color': 'transparent',
+  border: 'none',
+  outline: 'none',
+  'padding-left': tokenVar('spacing-3'),
+  'padding-right': tokenVar('spacing-3'),
+  'border-radius': 'inherit',
+};
+
+// ============================================================================
+// InputGroupAddon Styles
+// ============================================================================
+
+/**
+ * Base addon declarations -- horizontal flex, centred, never shrinks, muted
+ * foreground text, and gutter padding.
+ */
+export const inputGroupAddonBase: CSSProperties = {
+  display: 'flex',
+  'align-items': 'center',
+  'justify-content': 'center',
+  'flex-shrink': '0',
+  color: tokenVar('color-muted-foreground'),
+  'padding-left': tokenVar('spacing-3'),
+  'padding-right': tokenVar('spacing-3'),
+};
+
+export const inputGroupAddonStartStyles: CSSProperties = {
+  'border-right-width': '1px',
+  'border-right-style': 'solid',
+  'border-right-color': tokenVar('color-input'),
+};
+
+export const inputGroupAddonEndStyles: CSSProperties = {
+  'border-left-width': '1px',
+  'border-left-style': 'solid',
+  'border-left-color': tokenVar('color-input'),
+};
+
+export const inputGroupAddonFilledStyles: CSSProperties = {
+  'background-color': tokenVar('color-muted'),
+};
+
+export const inputGroupAddonPositionStyles: Record<InputGroupAddonPosition, CSSProperties> = {
+  start: inputGroupAddonStartStyles,
+  end: inputGroupAddonEndStyles,
+};
+
+export const inputGroupAddonVariantStyles: Record<InputGroupAddonVariant, CSSProperties> = {
+  default: {},
+  filled: inputGroupAddonFilledStyles,
+};
+
+// ============================================================================
+// Assembled Stylesheets
+// ============================================================================
+
+/**
+ * Build the complete input-group stylesheet for a given configuration.
+ *
+ * Composition:
+ *   :host                                -> display: block
+ *   :host([data-disabled])               -> opacity + cursor (mirror for host)
+ *   .group                               -> base border/radius/background + size height
+ *   :host(:focus-within) .group          -> ring
+ *   ::slotted(input), ::slotted(rafters-input) -> fill, no border, shared padding
+ *   ::slotted([disabled])                -> cursor propagation
+ *   @media reduced-motion                -> transition: none (guard placeholder)
+ *
+ * Unknown size silently falls back to `default`. Never throws.
+ */
+export function inputGroupStylesheet(options: InputGroupStylesheetOptions = {}): string {
+  const { size, disabled } = options;
+
+  const safeSize: InputGroupSize =
+    size && size in inputGroupSizeStyles ? (size as InputGroupSize) : 'default';
+
+  return stylesheet(
+    styleRule(':host', { display: 'block' }),
+
+    styleRule(
+      '.group',
+      inputGroupContainerBase,
+      pick(inputGroupSizeStyles, safeSize, 'default'),
+      when(disabled, inputGroupDisabled),
+    ),
+
+    styleRule(':host(:focus-within) .group', inputGroupFocusWithin),
+
+    styleRule(':host([data-disabled]) .group', inputGroupDisabled),
+
+    styleRule('::slotted(input), ::slotted(rafters-input)', inputGroupSlottedInput),
+
+    styleRule('::slotted([disabled])', { cursor: 'not-allowed' }),
+
+    atRule('@media (prefers-reduced-motion: reduce)', styleRule('.group', { transition: 'none' })),
+  );
+}
+
+/**
+ * Build the complete input-group-addon stylesheet for a given configuration.
+ *
+ * Composition:
+ *   :host                               -> display: flex (host participates in group row)
+ *   .addon                              -> base flex + padding + muted fg + position border
+ *   .addon (variant=filled)             -> muted background
+ *
+ * Unknown position silently falls back to `start`. Unknown variant silently
+ * falls back to `default`. Never throws.
+ */
+export function inputGroupAddonStylesheet(options: InputGroupAddonStylesheetOptions = {}): string {
+  const { position, variant } = options;
+
+  const safePosition: InputGroupAddonPosition =
+    position && position in inputGroupAddonPositionStyles
+      ? (position as InputGroupAddonPosition)
+      : 'start';
+
+  const safeVariant: InputGroupAddonVariant =
+    variant && variant in inputGroupAddonVariantStyles
+      ? (variant as InputGroupAddonVariant)
+      : 'default';
+
+  return stylesheet(
+    styleRule(':host', { display: 'flex' }),
+
+    styleRule(
+      '.addon',
+      inputGroupAddonBase,
+      pick(inputGroupAddonPositionStyles, safePosition, 'start'),
+      pick(inputGroupAddonVariantStyles, safeVariant, 'default'),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

Ships `<rafters-input-group>` and `<rafters-input-group-addon>` as layout-composition Web Components with token-driven shadow stylesheets, so inputs can be composed with icon/text affixes outside React, with a group-level focus-within ring.

The group is a pure visual chrome wrapper -- it is NOT form-associated. The slotted input (`<input>` or `<rafters-input>`) owns form participation. Disabled state propagates from the group host onto every slotted child that exposes a boolean `disabled` property.

## Files

Three new implementation files, three new test files. No `.tsx` React or `.astro` wrapper, no MCP registry update, no CHANGELOG entry per spec.

- `packages/ui/src/components/ui/input-group.classes.ts` -- shared class maps (size, addon position, addon variant) keep React/Astro/WC targets aligned on vocabulary.
- `packages/ui/src/components/ui/input-group.styles.ts` -- `CSSProperties` maps + `inputGroupStylesheet()` and `inputGroupAddonStylesheet()` builders. All token references via `tokenVar()`; motion-namespaced placeholders only (`--motion-duration-*` / `--motion-ease-*`).
- `packages/ui/src/components/ui/input-group.element.ts` -- `RaftersInputGroup` + `RaftersInputGroupAddon`. Per-instance `CSSStyleSheet` adopted on connect, rebuilt on observed attribute changes (`size`/`disabled` for the group; `position`/`variant` for the addon). Auto-registers idempotently via `customElements.define` guard.

Tests:

- `input-group.styles.test.ts` -- focus-within ring composition, slotted normalisation, addon border flip, fallback behaviour, motion-namespace guard.
- `input-group.element.test.ts` -- idempotent registration, non-form association, slot projection, disabled propagation across both already-slotted and post-connect children, `observedAttributes` contract, source has no raw `var()` literals.
- `input-group.element.a11y.tsx` -- vitest-axe scans across sizes, disabled, filled-variant, and form-embedded compositions.

## Behaviour

`RaftersInputGroup`
- `static observedAttributes = ['size', 'disabled']`
- Renders `<div class="group"><slot></slot></div>` in shadow.
- `:host(:focus-within) .group` paints the double-ring focus indicator (`color-background` offset + `color-ring` outer).
- When `disabled` is set, host gets `data-disabled=""` and the group's `disabled` boolean is mirrored onto every light-DOM child that has a `disabled` property. Listening on `slotchange` covers post-connect mutations.
- Unknown `size` values silently fall back to `default`.

`RaftersInputGroupAddon`
- `static observedAttributes = ['position', 'variant']`
- Renders `<div class="addon" data-position="<position>"><slot></slot></div>` in shadow; the host also reflects `data-position` for deterministic styling hooks.
- Position controls border side: `start` -> `border-right`, `end` -> `border-left`. Variant controls background: `default` (transparent) vs `filled` (`color-muted`).
- Unknown `position` -> `start`; unknown `variant` -> `default`.

`inputGroupStylesheet()` slotted normalisation rule applies to both `::slotted(input)` and `::slotted(rafters-input)` -- strips border/outline, fills the group, inherits the group's border-radius, and applies `spacing-3` horizontal padding.

## Conventions

- No `any`. Type guard helper `isDisableable()` narrows via `unknown`.
- No emoji.
- All token references go through `tokenVar()` -- no raw `var()` in either source file (asserted by a test).
- Motion uses only `--motion-duration-*` / `--motion-ease-*` (asserted by a test).
- Per-instance `CSSStyleSheet` constructed on `connectedCallback` and rebuilt on observed attribute changes; cleared on `disconnectedCallback`.
- `customElements.define` calls are idempotent (`if (!customElements.get(...))`).
- All DOM construction via `document.createElement`; no `innerHTML`.
- Silent fallback for unknown attribute values; never throws.

## Test plan

- [x] `pnpm --filter=@rafters/ui test input-group` -- 5 test files, 106 tests, all green.
- [x] `pnpm typecheck` -- workspace clean.
- [x] `pnpm preflight` -- unit, lint, typecheck all pass; full website + registry build green.
- [x] Quality gate recorded clean via `legion-simplify`.

Closes #1348