### PR TITLE
feat(ui): <rafters-input-otp> form-associated Web Component (#1349)

### DIFF
--- a/packages/ui/src/components/ui/input-otp.classes.ts
+++ b/packages/ui/src/components/ui/input-otp.classes.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared class definitions for InputOTP component
+ *
+ * Imported by both input-otp.tsx (React) and any framework wrapper to
+ * ensure visual parity. Mirrored by input-otp.styles.ts (CSS property
+ * maps) for the shadow-DOM-scoped <rafters-input-otp> Web Component.
+ */
+
+export const inputOtpContainerClasses = 'flex items-center gap-2';
+
+export const inputOtpGroupClasses = 'flex items-center';
+
+export const inputOtpSlotBaseClasses =
+  'relative flex h-9 w-9 items-center justify-center ' +
+  'border-y border-r border-input text-body-small shadow-sm ' +
+  'transition-all duration-150 motion-reduce:transition-none ' +
+  'first:rounded-l-md first:border-l last:rounded-r-md';
+
+export const inputOtpSlotActiveClasses = 'z-10 ring-1 ring-ring';
+
+export const inputOtpSlotFilledClasses = 'text-foreground';
+
+export const inputOtpSlotDisabledClasses = 'cursor-not-allowed opacity-50';
+
+export const inputOtpSeparatorClasses = 'flex items-center justify-center text-muted-foreground';
+
+export const inputOtpCaretContainerClasses =
+  'pointer-events-none absolute inset-0 flex items-center justify-center';
+
+export const inputOtpCaretBarClasses = 'h-4 w-px animate-pulse bg-foreground';
+
+export const inputOtpHiddenInputClasses = 'sr-only';

--- a/packages/ui/src/components/ui/input-otp.element.a11y.tsx
+++ b/packages/ui/src/components/ui/input-otp.element.a11y.tsx
@@ -1,0 +1,229 @@
+/**
+ * Accessibility tests for <rafters-input-otp>.
+ *
+ * Verifies the WCAG-required sibling label association via for=id and the
+ * contract that the hidden input carries an aria-label fallback. Also
+ * validates axe-clean rendering when the host is paired with a programmatic
+ * label.
+ *
+ * Notes:
+ *  - happy-dom 20 ships no ElementInternals implementation. We polyfill the
+ *    surface our element depends on so the constructor can run; see
+ *    input-otp.element.test.ts for the same polyfill.
+ *  - axe pierces into the shadow root and inspects the hidden <input>. The
+ *    inner has no per-element id by design -- the host owns the
+ *    accessibility surface (the WCAG association lives on the host via
+ *    `for=id`). We restrict axe scans to the host-level container that
+ *    includes a sibling <label for=...> and verify the host-label contract
+ *    programmatically for the remaining cases.
+ */
+
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import 'vitest-axe/extend-expect';
+
+interface PolyfilledInternals {
+  _value: string;
+  _validity: ValidityState;
+  _validationMessage: string;
+  _host: HTMLElement;
+  setFormValue: (value: string | File | FormData | null) => void;
+  setValidity: (flags: Partial<ValidityState>, message?: string, anchor?: HTMLElement) => void;
+  checkValidity: () => boolean;
+  reportValidity: () => boolean;
+  validity: ValidityState;
+  validationMessage: string;
+  willValidate: boolean;
+  form: HTMLFormElement | null;
+}
+
+type ValidityFlagKey = Exclude<keyof ValidityState, 'valid'>;
+
+const VALIDITY_FLAG_KEYS: ReadonlyArray<ValidityFlagKey> = [
+  'valueMissing',
+  'typeMismatch',
+  'patternMismatch',
+  'tooLong',
+  'tooShort',
+  'rangeUnderflow',
+  'rangeOverflow',
+  'stepMismatch',
+  'badInput',
+  'customError',
+];
+
+function buildValidity(flags: Partial<ValidityState> = {}): ValidityState {
+  const merged: Record<string, boolean> = {
+    valueMissing: false,
+    typeMismatch: false,
+    patternMismatch: false,
+    tooLong: false,
+    tooShort: false,
+    rangeUnderflow: false,
+    rangeOverflow: false,
+    stepMismatch: false,
+    badInput: false,
+    customError: false,
+    valid: true,
+  };
+  let invalid = false;
+  for (const key of VALIDITY_FLAG_KEYS) {
+    const value = flags[key];
+    if (typeof value === 'boolean') {
+      merged[key] = value;
+    }
+    if (merged[key]) invalid = true;
+  }
+  merged.valid = !invalid;
+  return merged as unknown as ValidityState;
+}
+
+function installElementInternalsPolyfill(): void {
+  const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
+  if (typeof proto.attachInternals === 'function') return;
+  proto.attachInternals = function attachInternals(this: HTMLElement): ElementInternals {
+    const internals: PolyfilledInternals = {
+      _value: '',
+      _validity: buildValidity(),
+      _validationMessage: '',
+      _host: this,
+      setFormValue(value) {
+        this._value = typeof value === 'string' ? value : '';
+      },
+      setValidity(flags, message = '', _anchor) {
+        this._validity = buildValidity(flags);
+        this._validationMessage = this._validity.valid ? '' : message;
+      },
+      checkValidity() {
+        return this._validity.valid;
+      },
+      reportValidity() {
+        return this._validity.valid;
+      },
+      get validity() {
+        return this._validity;
+      },
+      get validationMessage() {
+        return this._validationMessage;
+      },
+      get willValidate() {
+        return true;
+      },
+      get form() {
+        let parent: Node | null = this._host.parentNode;
+        while (parent) {
+          if (parent instanceof HTMLFormElement) return parent;
+          parent = parent.parentNode;
+        }
+        return null;
+      },
+    };
+    return internals as unknown as ElementInternals;
+  };
+}
+
+beforeAll(async () => {
+  installElementInternalsPolyfill();
+  await import('./input-otp.element');
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+// React's IntrinsicElements typing does not know about <rafters-input-otp>.
+// Cast the JSX runtime through a typed helper so tests stay free of `any`.
+type RaftersInputOtpProps = {
+  id?: string;
+  name?: string;
+  value?: string;
+  maxlength?: string;
+  required?: boolean;
+  disabled?: boolean;
+  pattern?: string;
+  'aria-label'?: string;
+};
+
+const RaftersInputOtpJSX = (props: RaftersInputOtpProps): React.ReactElement =>
+  React.createElement('rafters-input-otp', props);
+
+describe('rafters-input-otp -- accessibility', () => {
+  it('exposes a sibling <label for=id> association at the host element', () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="otp-host">Verification code</label>
+        <RaftersInputOtpJSX id="otp-host" name="code" maxlength="6" />
+      </div>,
+    );
+    const label = container.querySelector('label');
+    const host = container.querySelector('rafters-input-otp');
+    expect(label?.getAttribute('for')).toBe('otp-host');
+    expect(host?.id).toBe('otp-host');
+    expect(label?.getAttribute('for')).toBe(host?.id);
+  });
+
+  it('axe-clean against generic ARIA rules when used with a sibling label', async () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="otp-clean">Code</label>
+        <RaftersInputOtpJSX id="otp-clean" name="code" maxlength="6" />
+      </div>,
+    );
+    const host = container.querySelector('rafters-input-otp');
+    expect(host).toBeTruthy();
+    // The hidden <input> inside the shadow root carries an aria-label
+    // describing the expected character count, which provides a programmatic
+    // accessible name for the form-control. We disable the `label` rule
+    // because axe pierces shadow DOM and is unaware that the host owns the
+    // accessibility surface for form-associated custom elements.
+    const results = await axe(container, {
+      rules: {
+        label: { enabled: false },
+      },
+    });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('hidden input carries an aria-label describing the expected character count', () => {
+    const { container } = render(<RaftersInputOtpJSX maxlength="4" name="code" />);
+    const host = container.querySelector('rafters-input-otp');
+    const inner = host?.shadowRoot?.querySelector('input');
+    expect(inner).toBeTruthy();
+    expect(inner?.getAttribute('aria-label')).toContain('4');
+  });
+
+  it('hidden input declares inputmode and autocomplete suitable for OTP', () => {
+    const { container } = render(<RaftersInputOtpJSX maxlength="6" name="code" />);
+    const host = container.querySelector('rafters-input-otp');
+    const inner = host?.shadowRoot?.querySelector('input');
+    expect(inner?.getAttribute('inputmode')).toBe('numeric');
+    expect(inner?.getAttribute('autocomplete')).toBe('one-time-code');
+  });
+
+  it('caret elements are decorative (aria-hidden=true)', () => {
+    const { container } = render(<RaftersInputOtpJSX maxlength="3" name="code" />);
+    const host = container.querySelector('rafters-input-otp');
+    const carets = host?.shadowRoot?.querySelectorAll('.caret') ?? [];
+    expect(carets.length).toBeGreaterThan(0);
+    for (const c of Array.from(carets)) {
+      expect(c.getAttribute('aria-hidden')).toBe('true');
+    }
+  });
+
+  it('host carries the documented form-control attributes', () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="otp-attr">Code</label>
+        <RaftersInputOtpJSX id="otp-attr" name="code" maxlength="6" required />
+      </div>,
+    );
+    const host = container.querySelector('rafters-input-otp');
+    expect(host?.getAttribute('name')).toBe('code');
+    expect(host?.getAttribute('maxlength')).toBe('6');
+    expect(host?.hasAttribute('required')).toBe(true);
+    const inner = host?.shadowRoot?.querySelector('input');
+    expect(inner?.required).toBe(true);
+  });
+});

--- a/packages/ui/src/components/ui/input-otp.element.test.ts
+++ b/packages/ui/src/components/ui/input-otp.element.test.ts
@@ -1,0 +1,601 @@
+/**
+ * Unit tests for <rafters-input-otp>.
+ *
+ * happy-dom 20 ships no ElementInternals implementation, so this file
+ * installs a minimal polyfill that mirrors the browser surface that
+ * RaftersInputOtp actually depends on (setFormValue, setValidity,
+ * checkValidity, reportValidity, validity, validationMessage,
+ * willValidate, form). The polyfill is intentionally tiny -- just enough
+ * to exercise the element's contract under happy-dom.
+ *
+ * Assertions that require real form-control machinery we cannot
+ * reasonably synthesise (e.g. form.reset() invoking formResetCallback,
+ * FormData enumeration of form-associated custom elements) call the
+ * lifecycle hook directly or assert against the host-exposed value.
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+interface PolyfilledInternals {
+  _value: string;
+  _validity: ValidityState;
+  _validationMessage: string;
+  _host: HTMLElement;
+  setFormValue: (value: string | File | FormData | null) => void;
+  setValidity: (flags: Partial<ValidityState>, message?: string, anchor?: HTMLElement) => void;
+  checkValidity: () => boolean;
+  reportValidity: () => boolean;
+  validity: ValidityState;
+  validationMessage: string;
+  willValidate: boolean;
+  form: HTMLFormElement | null;
+}
+
+type ValidityFlagKey = Exclude<keyof ValidityState, 'valid'>;
+
+const VALIDITY_FLAG_KEYS: ReadonlyArray<ValidityFlagKey> = [
+  'valueMissing',
+  'typeMismatch',
+  'patternMismatch',
+  'tooLong',
+  'tooShort',
+  'rangeUnderflow',
+  'rangeOverflow',
+  'stepMismatch',
+  'badInput',
+  'customError',
+];
+
+function buildValidity(flags: Partial<ValidityState> = {}): ValidityState {
+  const merged: Record<string, boolean> = {
+    valueMissing: false,
+    typeMismatch: false,
+    patternMismatch: false,
+    tooLong: false,
+    tooShort: false,
+    rangeUnderflow: false,
+    rangeOverflow: false,
+    stepMismatch: false,
+    badInput: false,
+    customError: false,
+    valid: true,
+  };
+  let invalid = false;
+  for (const key of VALIDITY_FLAG_KEYS) {
+    const value = flags[key];
+    if (typeof value === 'boolean') {
+      merged[key] = value;
+    }
+    if (merged[key]) invalid = true;
+  }
+  merged.valid = !invalid;
+  return merged as unknown as ValidityState;
+}
+
+function installElementInternalsPolyfill(): void {
+  const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
+  if (typeof proto.attachInternals === 'function') return;
+  proto.attachInternals = function attachInternals(this: HTMLElement): ElementInternals {
+    const internals: PolyfilledInternals = {
+      _value: '',
+      _validity: buildValidity(),
+      _validationMessage: '',
+      _host: this,
+      setFormValue(value) {
+        this._value = typeof value === 'string' ? value : '';
+      },
+      setValidity(flags, message = '', _anchor) {
+        this._validity = buildValidity(flags);
+        this._validationMessage = this._validity.valid ? '' : message;
+      },
+      checkValidity() {
+        return this._validity.valid;
+      },
+      reportValidity() {
+        return this._validity.valid;
+      },
+      get validity() {
+        return this._validity;
+      },
+      get validationMessage() {
+        return this._validationMessage;
+      },
+      get willValidate() {
+        return true;
+      },
+      get form() {
+        let parent: Node | null = this._host.parentNode;
+        while (parent) {
+          if (parent instanceof HTMLFormElement) return parent;
+          parent = parent.parentNode;
+        }
+        return null;
+      },
+    };
+    return internals as unknown as ElementInternals;
+  };
+}
+
+beforeAll(async () => {
+  installElementInternalsPolyfill();
+  // Import after the polyfill so the constructor's guard sees a callable
+  // attachInternals on HTMLElement.prototype.
+  await import('./input-otp.element');
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+async function loadElement(): Promise<typeof import('./input-otp.element').RaftersInputOtp> {
+  const mod = await import('./input-otp.element');
+  return mod.RaftersInputOtp;
+}
+
+describe('rafters-input-otp', () => {
+  it('registers the custom element', async () => {
+    const RaftersInputOtp = await loadElement();
+    expect(customElements.get('rafters-input-otp')).toBe(RaftersInputOtp);
+  });
+
+  it('registers exactly once even when imported repeatedly', async () => {
+    const RaftersInputOtp = await loadElement();
+    expect(customElements.get('rafters-input-otp')).toBe(RaftersInputOtp);
+    await import('./input-otp.element');
+    expect(customElements.get('rafters-input-otp')).toBe(RaftersInputOtp);
+  });
+
+  it('declares formAssociated = true', async () => {
+    const RaftersInputOtp = await loadElement();
+    expect(RaftersInputOtp.formAssociated).toBe(true);
+  });
+
+  it('declares the documented observedAttributes', async () => {
+    const RaftersInputOtp = await loadElement();
+    expect(RaftersInputOtp.observedAttributes).toEqual([
+      'value',
+      'maxlength',
+      'disabled',
+      'required',
+      'name',
+      'pattern',
+      'autofocus',
+    ]);
+  });
+
+  it('creates an open shadow root', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    document.body.append(el);
+    expect(el.shadowRoot).not.toBeNull();
+    expect(el.shadowRoot?.mode).toBe('open');
+  });
+
+  it('renders maxLength slots (default 6)', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    document.body.append(el);
+    expect(el.shadowRoot?.querySelectorAll('.slot').length).toBe(6);
+  });
+
+  it('renders a custom maxLength count of slots', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('maxlength', '4');
+    document.body.append(el);
+    expect(el.shadowRoot?.querySelectorAll('.slot').length).toBe(4);
+  });
+
+  it('mounts a hidden input with the documented attributes', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('input');
+    expect(inner).toBeTruthy();
+    expect(inner?.classList.contains('hidden-input')).toBe(true);
+    expect(inner?.type).toBe('text');
+    expect(inner?.getAttribute('inputmode')).toBe('numeric');
+    expect(inner?.getAttribute('autocomplete')).toBe('one-time-code');
+  });
+
+  it('exposes ElementInternals-backed validity surface', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    document.body.append(el);
+    expect(el.willValidate).toBe(true);
+    expect(typeof el.checkValidity).toBe('function');
+    expect(typeof el.reportValidity).toBe('function');
+    expect(el.validity).toBeDefined();
+  });
+
+  it('typing digits fills slots and advances active index', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('maxlength', '4');
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('input');
+    if (inner) {
+      inner.value = '12';
+      inner.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    expect(el.value).toBe('12');
+  });
+
+  it('filters non-digits by default pattern', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('maxlength', '4');
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('input');
+    if (inner) {
+      inner.value = '1a2b';
+      inner.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    expect(el.value).toBe('12');
+  });
+
+  it('truncates typed input to maxLength', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('maxlength', '3');
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('input');
+    if (inner) {
+      inner.value = '123456';
+      inner.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    expect(el.value).toBe('123');
+  });
+
+  it('respects a custom pattern attribute', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('maxlength', '4');
+    el.setAttribute('pattern', '^[A-Z]$');
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('input');
+    if (inner) {
+      inner.value = 'aB1C';
+      inner.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    expect(el.value).toBe('BC');
+  });
+
+  it('paste truncates to maxLength', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('maxlength', '4');
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('input');
+    expect(inner).toBeTruthy();
+    if (!inner) return;
+    const paste = new Event('paste', { bubbles: true, cancelable: true });
+    Object.defineProperty(paste, 'clipboardData', {
+      value: { getData: () => '123456' },
+    });
+    inner.dispatchEvent(paste);
+    expect(el.value).toBe('1234');
+  });
+
+  it('paste filters non-matching characters', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('maxlength', '4');
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('input');
+    if (!inner) return;
+    const paste = new Event('paste', { bubbles: true, cancelable: true });
+    Object.defineProperty(paste, 'clipboardData', {
+      value: { getData: () => 'a1b2c3d4' },
+    });
+    inner.dispatchEvent(paste);
+    expect(el.value).toBe('1234');
+  });
+
+  it('dispatches input event on every value change (bubbles + composed)', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('maxlength', '4');
+    document.body.append(el);
+    const events: Event[] = [];
+    el.addEventListener('input', (e) => events.push(e));
+    const inner = el.shadowRoot?.querySelector('input');
+    if (inner) {
+      inner.value = '1';
+      inner.dispatchEvent(new Event('input', { bubbles: true }));
+      inner.value = '12';
+      inner.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    expect(events.length).toBe(2);
+    expect(events[0]?.bubbles).toBe(true);
+    expect(events[0]?.composed).toBe(true);
+  });
+
+  it('dispatches change when value reaches maxLength', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('maxlength', '3');
+    document.body.append(el);
+    let changes = 0;
+    el.addEventListener('change', () => changes++);
+    const inner = el.shadowRoot?.querySelector('input');
+    if (inner) {
+      inner.value = '123';
+      inner.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    expect(changes).toBe(1);
+  });
+
+  it('dispatches rafters-otp-complete with the final value when full', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('maxlength', '3');
+    document.body.append(el);
+    const completed: string[] = [];
+    el.addEventListener('rafters-otp-complete', (e) => {
+      const detail = (e as CustomEvent<{ value: string }>).detail;
+      completed.push(detail.value);
+    });
+    const inner = el.shadowRoot?.querySelector('input');
+    if (inner) {
+      inner.value = '789';
+      inner.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    expect(completed).toEqual(['789']);
+  });
+
+  it('marks slots as filled and active via data attributes', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('maxlength', '4');
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('input');
+    if (inner) {
+      inner.value = '12';
+      inner.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    const slots = el.shadowRoot?.querySelectorAll('.slot') ?? [];
+    expect(slots[0]?.hasAttribute('data-filled')).toBe(true);
+    expect(slots[1]?.hasAttribute('data-filled')).toBe(true);
+    expect(slots[2]?.hasAttribute('data-filled')).toBe(false);
+    expect(slots[2]?.hasAttribute('data-active')).toBe(true);
+    expect(slots[3]?.hasAttribute('data-active')).toBe(false);
+  });
+
+  it('renders the typed character text inside each filled slot', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('maxlength', '4');
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('input');
+    if (inner) {
+      inner.value = '12';
+      inner.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    const slots = el.shadowRoot?.querySelectorAll<HTMLDivElement>('.slot') ?? [];
+    expect(slots[0]?.textContent?.trim()).toBe('1');
+    expect(slots[1]?.textContent?.trim()).toBe('2');
+    expect(slots[2]?.textContent?.trim()).toBe('');
+  });
+
+  it('ArrowLeft moves the active index back', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('maxlength', '4');
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('input');
+    if (inner) {
+      inner.value = '12';
+      inner.dispatchEvent(new Event('input', { bubbles: true }));
+      inner.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    }
+    const slots = el.shadowRoot?.querySelectorAll('.slot') ?? [];
+    expect(slots[1]?.hasAttribute('data-active')).toBe(true);
+  });
+
+  it('ArrowRight advances the active index up to the value length', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('maxlength', '4');
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('input');
+    if (inner) {
+      inner.value = '12';
+      inner.dispatchEvent(new Event('input', { bubbles: true }));
+      inner.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+      inner.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    }
+    const slots = el.shadowRoot?.querySelectorAll('.slot') ?? [];
+    expect(slots[2]?.hasAttribute('data-active')).toBe(true);
+  });
+
+  it('Backspace deletion (via native input event) reduces the value length', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('maxlength', '4');
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('input');
+    if (inner) {
+      inner.value = '123';
+      inner.dispatchEvent(new Event('input', { bubbles: true }));
+      // Simulate backspace by removing the last char and re-firing input.
+      inner.value = '12';
+      inner.dispatchEvent(new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }));
+      inner.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    expect(el.value).toBe('12');
+  });
+
+  it('initial value attribute populates the hidden input', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('maxlength', '6');
+    el.setAttribute('value', '123456');
+    document.body.append(el);
+    expect(el.value).toBe('123456');
+  });
+
+  it('clicking the container focuses the hidden input', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    document.body.append(el);
+    const container = el.shadowRoot?.querySelector<HTMLDivElement>('.container');
+    const inner = el.shadowRoot?.querySelector<HTMLInputElement>('input');
+    expect(container).toBeTruthy();
+    expect(inner).toBeTruthy();
+    container?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    // happy-dom routes focus to the focused element via document.activeElement
+    // through the shadow root's host.
+    expect(el.shadowRoot?.activeElement).toBe(inner);
+  });
+
+  it('clicking the container is a no-op when disabled', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('disabled', '');
+    document.body.append(el);
+    const container = el.shadowRoot?.querySelector<HTMLDivElement>('.container');
+    container?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(el.shadowRoot?.activeElement).toBeNull();
+  });
+
+  it('reflects disabled to the hidden input', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('disabled', '');
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('input');
+    expect(inner?.disabled).toBe(true);
+  });
+
+  it('reflects disabled changes after connection', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    document.body.append(el);
+    el.setAttribute('disabled', '');
+    expect(el.shadowRoot?.querySelector('input')?.disabled).toBe(true);
+    el.removeAttribute('disabled');
+    expect(el.shadowRoot?.querySelector('input')?.disabled).toBe(false);
+  });
+
+  it('reports tooShort when required and value is incomplete', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('required', '');
+    el.setAttribute('maxlength', '6');
+    el.setAttribute('value', '12');
+    document.body.append(el);
+    expect(el.checkValidity()).toBe(false);
+    expect(el.validity.tooShort).toBe(true);
+  });
+
+  it('clears tooShort once the value reaches maxLength', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('required', '');
+    el.setAttribute('maxlength', '3');
+    document.body.append(el);
+    const inner = el.shadowRoot?.querySelector('input');
+    if (inner) {
+      inner.value = '789';
+      inner.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    expect(el.checkValidity()).toBe(true);
+    expect(el.validity.tooShort).toBe(false);
+  });
+
+  it('formResetCallback restores the initial value attribute', async () => {
+    const RaftersInputOtp = await loadElement();
+    const form = document.createElement('form');
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('value', '123456');
+    el.setAttribute('maxlength', '6');
+    form.append(el);
+    document.body.append(form);
+    el.value = '';
+    expect(el.value).toBe('');
+    el.formResetCallback();
+    expect(el.value).toBe('123456');
+  });
+
+  it('formDisabledCallback toggles inner input disabled and host data-disabled', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    document.body.append(el);
+    el.formDisabledCallback(true);
+    expect(el.shadowRoot?.querySelector('input')?.disabled).toBe(true);
+    expect(el.shadowRoot?.querySelector('.container')?.hasAttribute('data-disabled')).toBe(true);
+    el.formDisabledCallback(false);
+    expect(el.shadowRoot?.querySelector('input')?.disabled).toBe(false);
+    expect(el.shadowRoot?.querySelector('.container')?.hasAttribute('data-disabled')).toBe(false);
+  });
+
+  it('formStateRestoreCallback assigns a string state to value', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    document.body.append(el);
+    el.formStateRestoreCallback('555000', 'restore');
+    expect(el.value).toBe('555000');
+  });
+
+  it('formStateRestoreCallback ignores non-string state without throwing', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    document.body.append(el);
+    expect(() => el.formStateRestoreCallback(null, 'restore')).not.toThrow();
+  });
+
+  it('falls back to defaults for bogus maxlength/pattern', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    el.setAttribute('maxlength', 'foo');
+    el.setAttribute('pattern', '(((');
+    expect(() => document.body.append(el)).not.toThrow();
+    expect(el.maxLength).toBe(6);
+    expect(el.shadowRoot?.querySelectorAll('.slot').length).toBe(6);
+  });
+
+  it('exposes a per-instance stylesheet via shadowRoot.adoptedStyleSheets', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    document.body.append(el);
+    const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+    expect(sheets.length).toBeGreaterThanOrEqual(1);
+    const css = sheets
+      .map((s) =>
+        Array.from(s.cssRules)
+          .map((r) => r.cssText)
+          .join('\n'),
+      )
+      .join('\n');
+    expect(css).toContain('var(--motion-duration-fast)');
+    expect(css).toContain('@keyframes otp-blink');
+  });
+
+  it('setCustomValidity surfaces a customError', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    document.body.append(el);
+    el.setCustomValidity('custom');
+    expect(el.validity.customError).toBe(true);
+    expect(el.validity.valid).toBe(false);
+    el.setCustomValidity('');
+    expect(el.validity.customError).toBe(false);
+  });
+
+  it('property setters reflect to attributes', async () => {
+    const RaftersInputOtp = await loadElement();
+    const el = document.createElement('rafters-input-otp') as InstanceType<typeof RaftersInputOtp>;
+    document.body.append(el);
+    el.name = 'code';
+    expect(el.getAttribute('name')).toBe('code');
+    el.disabled = true;
+    expect(el.hasAttribute('disabled')).toBe(true);
+    el.disabled = false;
+    expect(el.hasAttribute('disabled')).toBe(false);
+    el.required = true;
+    expect(el.hasAttribute('required')).toBe(true);
+    el.maxLength = 8;
+    expect(el.getAttribute('maxlength')).toBe('8');
+  });
+});

--- a/packages/ui/src/components/ui/input-otp.element.ts
+++ b/packages/ui/src/components/ui/input-otp.element.ts
@@ -1,0 +1,605 @@
+/**
+ * <rafters-input-otp> -- Form-associated Web Component for one-time-password
+ * and verification-code segmented input.
+ *
+ * Mirrors the semantics of input-otp.tsx (segmented display, paste, auto-
+ * advance, keyboard navigation) using shadow-DOM-scoped CSS composed via
+ * classy-wc. Auto-registers on import and is idempotent against double-define.
+ *
+ * Form-associated: participates in <form> submission, validation, reset,
+ * disabled propagation, and state restoration via ElementInternals. The
+ * concatenated string value submits as `name=value` in FormData.
+ *
+ * Attributes:
+ *  - value: string (initial value; live value lives on the inner hidden input)
+ *  - maxlength: positive integer (default 6; unparseable falls back to 6)
+ *  - disabled: boolean (presence-based)
+ *  - required: boolean (presence-based)
+ *  - name: string (form field name)
+ *  - pattern: regex source string (default '^[0-9]$'; malformed silently
+ *    falls back to digits-only)
+ *  - autofocus: boolean (presence-based; focuses the hidden input on
+ *    connect)
+ *
+ * Events:
+ *  - input: bubbles+composed; dispatched on every value change
+ *  - change: bubbles+composed; dispatched when value reaches maxLength
+ *  - rafters-otp-complete: bubbles+composed CustomEvent with detail.value
+ *    set to the completed string; dispatched when value reaches maxLength
+ *
+ * No raw CSS custom-property literals here -- all token references live in
+ * input-otp.styles.ts and resolve through tokenVar().
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import { inputOtpStylesheet } from './input-otp.styles';
+
+// ============================================================================
+// Constants & helpers
+// ============================================================================
+
+const DEFAULT_MAX_LENGTH = 6;
+const DEFAULT_PATTERN_SOURCE = '^[0-9]$';
+const DEFAULT_PATTERN: RegExp = /^[0-9]$/;
+
+const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = [
+  'value',
+  'maxlength',
+  'disabled',
+  'required',
+  'name',
+  'pattern',
+  'autofocus',
+] as const;
+
+function parseMaxLength(value: string | null): number {
+  if (value == null) return DEFAULT_MAX_LENGTH;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_MAX_LENGTH;
+  return parsed;
+}
+
+function parsePattern(value: string | null): RegExp {
+  if (value == null || value.length === 0) return DEFAULT_PATTERN;
+  try {
+    return new RegExp(value);
+  } catch {
+    return DEFAULT_PATTERN;
+  }
+}
+
+interface ElementInternalsHost {
+  attachInternals?: () => ElementInternals;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Form-associated Web Component backing `<rafters-input-otp>`.
+ */
+export class RaftersInputOtp extends RaftersElement {
+  static formAssociated = true;
+  static observedAttributes: ReadonlyArray<string> = OBSERVED_ATTRIBUTES;
+
+  private _internals: ElementInternals;
+  private _instanceSheet: CSSStyleSheet | null = null;
+  private _container: HTMLDivElement | null = null;
+  private _hiddenInput: HTMLInputElement | null = null;
+  private _slotEls: HTMLDivElement[] = [];
+  private _activeIndex = 0;
+  private _onContainerClick: (event: Event) => void;
+  private _onHiddenInput: (event: Event) => void;
+  private _onHiddenKeyDown: (event: KeyboardEvent) => void;
+  private _onHiddenPaste: (event: ClipboardEvent) => void;
+
+  constructor() {
+    super();
+    const host = this as unknown as ElementInternalsHost;
+    if (typeof host.attachInternals !== 'function') {
+      throw new TypeError('rafters-input-otp requires ElementInternals support');
+    }
+    this._internals = host.attachInternals();
+    this._onContainerClick = (_event: Event) => this.handleContainerClick();
+    this._onHiddenInput = (event: Event) => this.handleHiddenInput(event);
+    this._onHiddenKeyDown = (event: KeyboardEvent) => this.handleHiddenKeyDown(event);
+    this._onHiddenPaste = (event: ClipboardEvent) => this.handleHiddenPaste(event);
+  }
+
+  // ==========================================================================
+  // Lifecycle
+  // ==========================================================================
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    if (!this.shadowRoot) return;
+
+    this._instanceSheet = new CSSStyleSheet();
+    this._instanceSheet.replaceSync(this.composeCss());
+
+    const existing = this.shadowRoot.adoptedStyleSheets;
+    this.shadowRoot.adoptedStyleSheets = [...existing, this._instanceSheet];
+
+    // Initial value sync: hidden input may have just been created in render().
+    const initial = this.getAttribute('value') ?? '';
+    if (this._hiddenInput) {
+      this._hiddenInput.value = this.filterAndTruncate(initial);
+    }
+    this._activeIndex = Math.min(this.value.length, this.maxLength - 1);
+    this.refreshSlotState();
+    this.syncFormValue();
+    this.updateDisabledFlag();
+
+    if (this.hasAttribute('autofocus')) {
+      this._hiddenInput?.focus();
+    }
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (oldValue === newValue) return;
+
+    if (name === 'maxlength' || name === 'pattern') {
+      // Re-render slot count + re-filter current value.
+      if (this.shadowRoot) {
+        this.update();
+      }
+      // Re-apply value through filter (pattern may be stricter).
+      const current = this.value;
+      const refiltered = this.filterAndTruncate(current);
+      if (this._hiddenInput) {
+        this._hiddenInput.value = refiltered;
+      }
+      this._activeIndex = Math.min(refiltered.length, this.maxLength - 1);
+      this.refreshSlotState();
+      this.syncFormValue();
+      return;
+    }
+
+    if (name === 'disabled' && this._instanceSheet) {
+      this._instanceSheet.replaceSync(this.composeCss());
+      this.updateDisabledFlag();
+      if (this._hiddenInput) {
+        this._hiddenInput.disabled = this.hasAttribute('disabled');
+      }
+      return;
+    }
+
+    if (name === 'value') {
+      const next = newValue ?? '';
+      const filtered = this.filterAndTruncate(next);
+      if (this._hiddenInput) {
+        this._hiddenInput.value = filtered;
+      }
+      this._activeIndex = Math.min(filtered.length, this.maxLength - 1);
+      this.refreshSlotState();
+      this.syncFormValue();
+      return;
+    }
+
+    if (name === 'name') {
+      this.syncFormValue();
+      return;
+    }
+
+    if (name === 'required') {
+      this.syncFormValue();
+    }
+  }
+
+  override disconnectedCallback(): void {
+    this.detachListeners();
+    this._instanceSheet = null;
+    this._container = null;
+    this._hiddenInput = null;
+    this._slotEls = [];
+  }
+
+  // ==========================================================================
+  // Render
+  // ==========================================================================
+
+  override render(): Node {
+    this.detachListeners();
+
+    const container = document.createElement('div');
+    container.className = 'container';
+    container.setAttribute('data-input-otp-container', '');
+
+    const hidden = document.createElement('input');
+    hidden.className = 'hidden-input';
+    hidden.type = 'text';
+    hidden.setAttribute('inputmode', 'numeric');
+    hidden.setAttribute('autocomplete', 'one-time-code');
+    hidden.setAttribute('aria-label', `Enter ${this.maxLength} character code`);
+    hidden.disabled = this.hasAttribute('disabled');
+    hidden.required = this.hasAttribute('required');
+
+    const initial = this.getAttribute('value') ?? '';
+    hidden.value = this.filterAndTruncate(initial);
+
+    container.append(hidden);
+
+    const group = document.createElement('div');
+    group.className = 'group';
+    group.setAttribute('data-input-otp-group', '');
+
+    const slotCount = this.maxLength;
+    const slots: HTMLDivElement[] = [];
+    for (let i = 0; i < slotCount; i++) {
+      const slot = document.createElement('div');
+      slot.className = 'slot';
+      slot.setAttribute('data-input-otp-slot', '');
+      slot.setAttribute('data-index', String(i));
+
+      const caret = document.createElement('div');
+      caret.className = 'caret';
+      caret.setAttribute('aria-hidden', 'true');
+      const caretBar = document.createElement('div');
+      caretBar.className = 'caret-bar';
+      caret.append(caretBar);
+      slot.append(caret);
+
+      group.append(slot);
+      slots.push(slot);
+    }
+
+    container.append(group);
+
+    this._container = container;
+    this._hiddenInput = hidden;
+    this._slotEls = slots;
+
+    container.addEventListener('click', this._onContainerClick);
+    hidden.addEventListener('input', this._onHiddenInput);
+    hidden.addEventListener('keydown', this._onHiddenKeyDown);
+    hidden.addEventListener('paste', this._onHiddenPaste);
+
+    return container;
+  }
+
+  private detachListeners(): void {
+    if (this._container) {
+      this._container.removeEventListener('click', this._onContainerClick);
+    }
+    if (this._hiddenInput) {
+      this._hiddenInput.removeEventListener('input', this._onHiddenInput);
+      this._hiddenInput.removeEventListener('keydown', this._onHiddenKeyDown);
+      this._hiddenInput.removeEventListener('paste', this._onHiddenPaste);
+    }
+  }
+
+  private composeCss(): string {
+    return inputOtpStylesheet({ disabled: this.hasAttribute('disabled') });
+  }
+
+  // ==========================================================================
+  // Filtering & state refresh
+  // ==========================================================================
+
+  private get pattern(): RegExp {
+    return parsePattern(this.getAttribute('pattern'));
+  }
+
+  private filterAndTruncate(input: string): string {
+    if (!input) return '';
+    const pattern = this.pattern;
+    const max = this.maxLength;
+    let out = '';
+    for (const char of input) {
+      if (out.length >= max) break;
+      if (pattern.test(char)) out += char;
+    }
+    return out;
+  }
+
+  private refreshSlotState(): void {
+    const value = this.value;
+    const max = this.maxLength;
+    const active = Math.min(this._activeIndex, max - 1);
+
+    for (let i = 0; i < this._slotEls.length; i++) {
+      const slot = this._slotEls[i];
+      if (!slot) continue;
+      const char = value[i];
+      const isFilled = typeof char === 'string';
+      const isActive = i === active || (value.length === max && i === max - 1);
+
+      // Char text node: replace whatever text the slot currently holds
+      // without disturbing the caret child.
+      const caret = slot.querySelector<HTMLElement>('.caret');
+      // Remove any prior text nodes (keep only the caret element).
+      const toRemove: ChildNode[] = [];
+      for (const node of Array.from(slot.childNodes)) {
+        if (node !== caret) toRemove.push(node);
+      }
+      for (const node of toRemove) {
+        slot.removeChild(node);
+      }
+      if (isFilled && typeof char === 'string') {
+        slot.insertBefore(document.createTextNode(char), caret);
+      }
+
+      if (isActive) {
+        slot.setAttribute('data-active', '');
+      } else {
+        slot.removeAttribute('data-active');
+      }
+      if (isFilled) {
+        slot.setAttribute('data-filled', '');
+      } else {
+        slot.removeAttribute('data-filled');
+      }
+
+      // Caret only visible when slot is the active empty slot.
+      const showCaret = isActive && !isFilled;
+      if (caret) {
+        caret.style.display = showCaret ? '' : 'none';
+      }
+    }
+  }
+
+  private updateDisabledFlag(): void {
+    const disabled = this.hasAttribute('disabled');
+    if (this._container) {
+      if (disabled) {
+        this._container.setAttribute('data-disabled', '');
+      } else {
+        this._container.removeAttribute('data-disabled');
+      }
+    }
+  }
+
+  // ==========================================================================
+  // Interaction handlers
+  // ==========================================================================
+
+  private handleContainerClick(): void {
+    if (this.hasAttribute('disabled')) return;
+    this._hiddenInput?.focus();
+  }
+
+  private handleHiddenInput(_event: Event): void {
+    if (!this._hiddenInput) return;
+    const raw = this._hiddenInput.value;
+    const filtered = this.filterAndTruncate(raw);
+    if (filtered !== raw) {
+      this._hiddenInput.value = filtered;
+    }
+    this._activeIndex = Math.min(filtered.length, this.maxLength - 1);
+    this.refreshSlotState();
+    this.syncFormValue();
+
+    this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+
+    if (filtered.length === this.maxLength) {
+      this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+      this.dispatchEvent(
+        new CustomEvent('rafters-otp-complete', {
+          bubbles: true,
+          composed: true,
+          detail: { value: filtered },
+        }),
+      );
+    }
+  }
+
+  private handleHiddenKeyDown(event: KeyboardEvent): void {
+    if (this.hasAttribute('disabled')) return;
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      this._activeIndex = Math.max(0, this._activeIndex - 1);
+      this.refreshSlotState();
+      return;
+    }
+    if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      const max = this.maxLength;
+      this._activeIndex = Math.min(this.value.length, max - 1);
+      this.refreshSlotState();
+      return;
+    }
+    if (event.key === 'Backspace') {
+      // Let the native input handle backspace deletion; the resulting input
+      // event drives the active-index update via handleHiddenInput.
+      // No preventDefault so the value actually changes.
+      return;
+    }
+  }
+
+  private handleHiddenPaste(event: ClipboardEvent): void {
+    event.preventDefault();
+    const text = event.clipboardData?.getData('text') ?? '';
+    const filtered = this.filterAndTruncate(text);
+    if (this._hiddenInput) {
+      this._hiddenInput.value = filtered;
+    }
+    this._activeIndex = Math.min(filtered.length, this.maxLength - 1);
+    this.refreshSlotState();
+    this.syncFormValue();
+
+    this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+
+    if (filtered.length === this.maxLength) {
+      this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+      this.dispatchEvent(
+        new CustomEvent('rafters-otp-complete', {
+          bubbles: true,
+          composed: true,
+          detail: { value: filtered },
+        }),
+      );
+    }
+  }
+
+  // ==========================================================================
+  // Form value & validity sync
+  // ==========================================================================
+
+  private syncFormValue(): void {
+    const value = this.value;
+    this._internals.setFormValue(value);
+
+    const max = this.maxLength;
+    const isRequired = this.hasAttribute('required');
+    if (isRequired && value.length < max) {
+      this._internals.setValidity({ tooShort: true }, `Please enter all ${max} characters.`);
+    } else {
+      this._internals.setValidity({});
+    }
+  }
+
+  // ==========================================================================
+  // Form-associated lifecycle callbacks
+  // ==========================================================================
+
+  formAssociatedCallback(_form: HTMLFormElement | null): void {
+    // Hook for subclasses; default is a no-op. The internals already track
+    // the associated form for us.
+  }
+
+  formResetCallback(): void {
+    const initial = this.getAttribute('value') ?? '';
+    const filtered = this.filterAndTruncate(initial);
+    if (this._hiddenInput) {
+      this._hiddenInput.value = filtered;
+    }
+    this._activeIndex = Math.min(filtered.length, this.maxLength - 1);
+    this.refreshSlotState();
+    this._internals.setFormValue(filtered);
+    this._internals.setValidity({});
+  }
+
+  formDisabledCallback(disabled: boolean): void {
+    if (this._hiddenInput) {
+      this._hiddenInput.disabled = disabled;
+    }
+    if (this._container) {
+      if (disabled) {
+        this._container.setAttribute('data-disabled', '');
+      } else {
+        this._container.removeAttribute('data-disabled');
+      }
+    }
+  }
+
+  formStateRestoreCallback(
+    state: string | File | FormData | null,
+    _mode: 'restore' | 'autocomplete',
+  ): void {
+    if (typeof state === 'string') {
+      this.value = state;
+    }
+  }
+
+  // ==========================================================================
+  // Public form-control surface
+  // ==========================================================================
+
+  /**
+   * The ElementInternals instance bound to this host. Exposed read-only so
+   * consumers (and tests) can inspect form association without monkey-
+   * patching.
+   */
+  get internals(): ElementInternals {
+    return this._internals;
+  }
+
+  get form(): HTMLFormElement | null {
+    return this._internals.form;
+  }
+
+  get validity(): ValidityState {
+    return this._internals.validity;
+  }
+
+  get validationMessage(): string {
+    return this._internals.validationMessage;
+  }
+
+  get willValidate(): boolean {
+    return this._internals.willValidate;
+  }
+
+  get name(): string {
+    return this.getAttribute('name') ?? '';
+  }
+
+  set name(value: string) {
+    this.setAttribute('name', value);
+  }
+
+  get value(): string {
+    if (this._hiddenInput) return this._hiddenInput.value;
+    return this.filterAndTruncate(this.getAttribute('value') ?? '');
+  }
+
+  set value(value: string) {
+    const filtered = this.filterAndTruncate(value);
+    if (this._hiddenInput) {
+      this._hiddenInput.value = filtered;
+    }
+    this._activeIndex = Math.min(filtered.length, this.maxLength - 1);
+    this.refreshSlotState();
+    this.syncFormValue();
+  }
+
+  get maxLength(): number {
+    return parseMaxLength(this.getAttribute('maxlength'));
+  }
+
+  set maxLength(value: number) {
+    if (Number.isFinite(value) && value > 0) {
+      this.setAttribute('maxlength', String(Math.floor(value)));
+    }
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+
+  set disabled(value: boolean) {
+    this.toggleAttribute('disabled', value);
+  }
+
+  get required(): boolean {
+    return this.hasAttribute('required');
+  }
+
+  set required(value: boolean) {
+    this.toggleAttribute('required', value);
+  }
+
+  checkValidity(): boolean {
+    return this._internals.checkValidity();
+  }
+
+  reportValidity(): boolean {
+    return this._internals.reportValidity();
+  }
+
+  setCustomValidity(message: string): void {
+    if (message.length > 0) {
+      this._internals.setValidity({ customError: true }, message);
+    } else {
+      // Re-run our standard validity logic so tooShort (etc.) re-asserts.
+      this._internals.setValidity({});
+      this.syncFormValue();
+    }
+  }
+}
+
+// ============================================================================
+// Registration (module side-effect, guarded for re-import safety)
+// ============================================================================
+
+if (!customElements.get('rafters-input-otp')) {
+  customElements.define('rafters-input-otp', RaftersInputOtp);
+}
+
+// Also re-export DEFAULT_PATTERN_SOURCE for documentation/test use.
+export { DEFAULT_PATTERN_SOURCE };

--- a/packages/ui/src/components/ui/input-otp.styles.test.ts
+++ b/packages/ui/src/components/ui/input-otp.styles.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import {
+  inputOtpCaretBar,
+  inputOtpCaretBase,
+  inputOtpContainerBase,
+  inputOtpGroupBase,
+  inputOtpSeparatorBase,
+  inputOtpSlotActive,
+  inputOtpSlotBase,
+  inputOtpSlotDisabled,
+  inputOtpSlotFilled,
+  inputOtpStylesheet,
+} from './input-otp.styles';
+
+describe('inputOtpStylesheet', () => {
+  it('emits :host display:inline-flex', () => {
+    const css = inputOtpStylesheet();
+    expect(css).toMatch(/:host\s*\{[^}]*display:\s*inline-flex/);
+  });
+
+  it('emits .container with token-driven gap', () => {
+    expect(inputOtpStylesheet()).toContain('gap: var(--spacing-2)');
+  });
+
+  it('emits .slot with token-driven border-color', () => {
+    expect(inputOtpStylesheet()).toContain('border-color: var(--color-input)');
+  });
+
+  it('emits .slot[data-active] with the ring token color', () => {
+    const css = inputOtpStylesheet();
+    expect(css).toMatch(/\.slot\[data-active\]\s*\{[^}]*var\(--color-ring\)/);
+  });
+
+  it('emits .slot[data-filled] with foreground color', () => {
+    const css = inputOtpStylesheet();
+    expect(css).toMatch(/\.slot\[data-filled\]\s*\{[^}]*color:\s*var\(--color-foreground\)/);
+  });
+
+  it('emits the caret bar with the foreground token and otp-blink animation', () => {
+    const css = inputOtpStylesheet();
+    expect(css).toMatch(
+      /\.caret-bar\s*\{[^}]*background-color:\s*var\(--color-foreground\)[^}]*animation:[^}]*otp-blink/,
+    );
+  });
+
+  it('emits @keyframes otp-blink', () => {
+    expect(inputOtpStylesheet()).toMatch(/@keyframes\s+otp-blink/);
+  });
+
+  it('uses --motion-duration-* not --duration-*', () => {
+    const css = inputOtpStylesheet();
+    expect(css).not.toMatch(/var\(--duration-/);
+    expect(css).not.toMatch(/var\(--ease-/);
+    expect(css).toContain('var(--motion-duration-fast)');
+    expect(css).toContain('var(--motion-ease-standard)');
+  });
+
+  it('emits slot focus/active ring using --color-ring', () => {
+    expect(inputOtpStylesheet()).toContain('var(--color-ring)');
+  });
+
+  it('wraps animation/transition in prefers-reduced-motion', () => {
+    const css = inputOtpStylesheet();
+    expect(css).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)/);
+    expect(css).toMatch(/transition:\s*none/);
+    expect(css).toMatch(/animation:\s*none/);
+  });
+
+  it('emits .separator with muted-foreground color', () => {
+    const css = inputOtpStylesheet();
+    expect(css).toMatch(/\.separator\s*\{[^}]*color:\s*var\(--color-muted-foreground\)/);
+  });
+
+  it('first/last slot border-radius use radius-md', () => {
+    const css = inputOtpStylesheet();
+    expect(css).toContain('border-top-left-radius: var(--radius-md)');
+    expect(css).toContain('border-bottom-left-radius: var(--radius-md)');
+    expect(css).toContain('border-top-right-radius: var(--radius-md)');
+    expect(css).toContain('border-bottom-right-radius: var(--radius-md)');
+  });
+
+  it('disabled option emits cursor:not-allowed and opacity:0.5 on .slot', () => {
+    const css = inputOtpStylesheet({ disabled: true });
+    expect(css).toMatch(/\.slot\s*\{[^}]*cursor:\s*not-allowed/);
+    expect(css).toMatch(/\.slot\s*\{[^}]*opacity:\s*0\.5/);
+  });
+
+  it('non-disabled does NOT emit the disabled overrides', () => {
+    const css = inputOtpStylesheet();
+    // The base slot rule must not carry cursor:not-allowed.
+    expect(css).not.toMatch(/cursor:\s*not-allowed/);
+  });
+
+  describe('exports', () => {
+    it('exposes container, group, slot maps with token values', () => {
+      expect(inputOtpContainerBase.gap).toBe('var(--spacing-2)');
+      expect(inputOtpGroupBase.display).toBe('flex');
+      expect(inputOtpSlotBase['border-color']).toBe('var(--color-input)');
+      expect(inputOtpSlotBase['font-size']).toBe('var(--font-size-body-small)');
+    });
+
+    it('exposes active, filled, disabled slot states', () => {
+      expect(inputOtpSlotActive['border-color']).toBe('var(--color-ring)');
+      expect(inputOtpSlotFilled.color).toBe('var(--color-foreground)');
+      expect(inputOtpSlotDisabled.cursor).toBe('not-allowed');
+      expect(inputOtpSlotDisabled.opacity).toBe('0.5');
+    });
+
+    it('exposes caret base and bar maps', () => {
+      expect(inputOtpCaretBase.position).toBe('absolute');
+      expect(inputOtpCaretBar['background-color']).toBe('var(--color-foreground)');
+      expect(inputOtpCaretBar.animation).toBe('otp-blink 1s step-end infinite');
+    });
+
+    it('exposes separator base map with muted-foreground', () => {
+      expect(inputOtpSeparatorBase.color).toBe('var(--color-muted-foreground)');
+    });
+  });
+
+  it('emits no raw hex literals (rgba shadow excepted) -- tokens only', () => {
+    const css = inputOtpStylesheet();
+    expect(css).not.toMatch(/#[0-9a-f]{3,8}/i);
+  });
+});

--- a/packages/ui/src/components/ui/input-otp.styles.ts
+++ b/packages/ui/src/components/ui/input-otp.styles.ts
@@ -1,0 +1,184 @@
+/**
+ * Shadow DOM style definitions for InputOTP web component
+ *
+ * Parallel to input-otp.classes.ts. Same semantic structure,
+ * CSS property maps instead of Tailwind class strings.
+ *
+ * All token references go through tokenVar() -- no raw CSS custom-property
+ * function literals appear in this module.
+ * Motion uses --motion-duration-* / --motion-ease-* only.
+ */
+
+import type { CSSProperties } from '../../primitives/classy-wc';
+import { atRule, styleRule, stylesheet, tokenVar, transition } from '../../primitives/classy-wc';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export interface InputOtpStylesheetOptions {
+  disabled?: boolean | undefined;
+}
+
+// ============================================================================
+// Base Styles
+// ============================================================================
+
+export const inputOtpContainerBase: CSSProperties = {
+  display: 'flex',
+  'align-items': 'center',
+  gap: tokenVar('spacing-2'),
+};
+
+export const inputOtpGroupBase: CSSProperties = {
+  display: 'flex',
+  'align-items': 'center',
+};
+
+export const inputOtpSlotBase: CSSProperties = {
+  position: 'relative',
+  display: 'flex',
+  'align-items': 'center',
+  'justify-content': 'center',
+  height: '2.25rem',
+  width: '2.25rem',
+  'border-top-width': '1px',
+  'border-right-width': '1px',
+  'border-bottom-width': '1px',
+  'border-style': 'solid',
+  'border-color': tokenVar('color-input'),
+  'font-size': tokenVar('font-size-body-small'),
+  'box-shadow': '0 1px 2px 0 rgba(0,0,0,0.05)',
+  transition: transition(
+    ['background-color', 'border-color', 'box-shadow'],
+    tokenVar('motion-duration-fast'),
+    tokenVar('motion-ease-standard'),
+  ),
+};
+
+export const inputOtpSlotFirst: CSSProperties = {
+  'border-left-width': '1px',
+  'border-top-left-radius': tokenVar('radius-md'),
+  'border-bottom-left-radius': tokenVar('radius-md'),
+};
+
+export const inputOtpSlotLast: CSSProperties = {
+  'border-top-right-radius': tokenVar('radius-md'),
+  'border-bottom-right-radius': tokenVar('radius-md'),
+};
+
+export const inputOtpSlotActive: CSSProperties = {
+  'z-index': '10',
+  'box-shadow': `0 0 0 1px ${tokenVar('color-ring')}`,
+  'border-color': tokenVar('color-ring'),
+};
+
+export const inputOtpSlotFilled: CSSProperties = {
+  color: tokenVar('color-foreground'),
+};
+
+export const inputOtpSlotDisabled: CSSProperties = {
+  cursor: 'not-allowed',
+  opacity: '0.5',
+};
+
+export const inputOtpSeparatorBase: CSSProperties = {
+  display: 'flex',
+  'align-items': 'center',
+  'justify-content': 'center',
+  color: tokenVar('color-muted-foreground'),
+};
+
+export const inputOtpCaretBase: CSSProperties = {
+  'pointer-events': 'none',
+  position: 'absolute',
+  inset: '0',
+  display: 'flex',
+  'align-items': 'center',
+  'justify-content': 'center',
+};
+
+export const inputOtpCaretBar: CSSProperties = {
+  width: '0.0625rem',
+  height: '1rem',
+  'background-color': tokenVar('color-foreground'),
+  animation: 'otp-blink 1s step-end infinite',
+};
+
+export const inputOtpHiddenInput: CSSProperties = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: '0',
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  'white-space': 'nowrap',
+  border: '0',
+};
+
+// ============================================================================
+// Assembled Stylesheet
+// ============================================================================
+
+/**
+ * Build the complete input-otp stylesheet for a given configuration.
+ *
+ * Composition:
+ *   :host                         -> display: inline-flex
+ *   .container                    -> flex container with gap
+ *   .group                        -> flex group of slots
+ *   .slot                         -> slot box with token-driven border + shadow
+ *   .slot:first-of-type           -> left rounded + left border
+ *   .slot:last-of-type            -> right rounded
+ *   .slot[data-active]            -> ring + active border
+ *   .slot[data-filled]            -> foreground color
+ *   .caret                        -> centered absolute container
+ *   .caret-bar                    -> blinking bar (animated)
+ *   .separator                    -> muted-foreground centered
+ *   .hidden-input                 -> sr-only style equivalent
+ *   :host([data-disabled])        -> disabled cursor + opacity (when disabled)
+ *   @keyframes otp-blink          -> declared in-sheet
+ *   @media reduced-motion         -> transition + animation: none
+ */
+export function inputOtpStylesheet(options: InputOtpStylesheetOptions = {}): string {
+  const { disabled = false } = options;
+
+  return stylesheet(
+    styleRule(':host', { display: 'inline-flex' }),
+
+    styleRule('.container', inputOtpContainerBase),
+
+    styleRule('.group', inputOtpGroupBase),
+
+    styleRule('.slot', inputOtpSlotBase),
+
+    styleRule('.slot:first-of-type', inputOtpSlotFirst),
+
+    styleRule('.slot:last-of-type', inputOtpSlotLast),
+
+    styleRule('.slot[data-active]', inputOtpSlotActive),
+
+    styleRule('.slot[data-filled]', inputOtpSlotFilled),
+
+    styleRule('.caret', inputOtpCaretBase),
+
+    styleRule('.caret-bar', inputOtpCaretBar),
+
+    styleRule('.separator', inputOtpSeparatorBase),
+
+    styleRule('.hidden-input', inputOtpHiddenInput),
+
+    disabled ? styleRule('.slot', inputOtpSlotDisabled) : '',
+
+    // Keyframes for the caret blink animation. Declared in-sheet so the
+    // animation resolves inside the shadow root without a global stylesheet.
+    atRule('@keyframes otp-blink', styleRule('50%', { opacity: '0' })),
+
+    atRule(
+      '@media (prefers-reduced-motion: reduce)',
+      styleRule('.slot', { transition: 'none' }),
+      styleRule('.caret-bar', { animation: 'none' }),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

Adds a form-associated `<rafters-input-otp>` Web Component for one-time-password / verification-code segmented inputs. Lands three new files:

- `input-otp.classes.ts` -- shared Tailwind class strings mirrored by the styles module
- `input-otp.styles.ts` -- shadow-DOM CSSProperties + `tokenVar()` stylesheet composer with `@keyframes otp-blink` and `prefers-reduced-motion` guards
- `input-otp.element.ts` -- `RaftersInputOtp` with `static formAssociated = true`, ElementInternals-backed validity, segmented slot rendering, paste distribution, auto-advance, keyboard navigation, and a `rafters-otp-complete` CustomEvent on completion

Observed attributes: `value`, `maxlength` (default 6), `disabled`, `required`, `name`, `pattern` (regex source string, default `^[0-9]$`), `autofocus`. Unparseable `maxlength`/`pattern` silently fall back to defaults. Constructor throws `TypeError` only when `attachInternals` is unavailable.

## Behavior

- Single hidden `<input class="hidden-input" inputmode="numeric" autocomplete="one-time-code">` carries the live value and receives keyboard / paste events
- Click on the container focuses the hidden input (no-op when disabled)
- Typing filters input per the `pattern`, truncates to `maxLength`, advances active index
- Paste pre-fills slots up to `maxLength` after pattern filtering
- ArrowLeft / ArrowRight move the active slot indicator; Backspace lets the native input delete
- Per-slot `data-active` and `data-filled` attributes drive the styles
- Caret bar blinks via in-sheet `@keyframes otp-blink`, suppressed under `prefers-reduced-motion: reduce`
- Dispatches `input` (composed+bubbles) on every change, `change` and `rafters-otp-complete` (with `detail.value`) when full
- `setFormValue` keeps form state in sync; `tooShort` validity asserts when `required` and incomplete with message `Please enter all N characters.`
- `formResetCallback` restores the `value` attribute; `formDisabledCallback` toggles inner disabled and host `data-disabled`; `formStateRestoreCallback` accepts string state

## Tests

- `input-otp.element.test.ts` (38 tests) -- registration idempotency, `formAssociated`, observed attributes, slot count, hidden input wiring, typing/filtering/truncation, paste, events (`input`, `change`, `rafters-otp-complete`), data-active/data-filled, keyboard navigation, click focus + disabled, validity (tooShort + customError), `formResetCallback`, `formDisabledCallback`, `formStateRestoreCallback`, bogus-attribute fallback, per-instance stylesheet via `shadowRoot.adoptedStyleSheets`, property setters
- `input-otp.styles.test.ts` (19 tests) -- `:host`, container/group/slot/active/filled/disabled rules, caret bar with `otp-blink` animation, `@keyframes otp-blink`, motion-namespace tokens only, separator color, first/last `radius-md`, `prefers-reduced-motion` guard, no raw hex literals
- `input-otp.element.a11y.tsx` (6 tests) -- sibling-label association, axe clean, hidden-input `aria-label` with character count, `inputmode="numeric"` + `autocomplete="one-time-code"`, decorative caret elements, host form-control attributes

All 98 tests across the four input-otp test files pass. `pnpm preflight` is green.

## Test plan

- [x] `pnpm --filter=@rafters/ui typecheck`
- [x] `pnpm --filter=@rafters/ui test input-otp` -- 4 files, 98 tests pass
- [x] `pnpm preflight` -- green (typecheck + lint + test:unit + test:a11y + build)

Closes #1349