### PR TITLE
chore(release): rafters v0.0.54

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # rafters
 
+## 0.0.54
+
+### Minor Changes
+
+- feat(ui): Tier 1 Web Component framework target. Fourteen presentational components now ship a `.element.ts` custom-element variant alongside their existing `.tsx` and `.astro` targets. Each auto-registers on import (idempotent), composes its shadow stylesheet from a sibling `.styles.ts` via `tokenVar()` (no raw `var()`, no Tailwind utilities), uses the per-instance `CSSStyleSheet` + `replaceSync` + `adoptedStyleSheets` pattern so attribute changes reflect to the live shadow root, and falls back silently on unknown attribute values. Components shipped: `<rafters-alert>` (#1320 / #1371), `<rafters-avatar>` (#1321 / #1374), `<rafters-breadcrumb>` (#1322 / #1372), `<rafters-empty>` (#1323 / #1373), `<rafters-item>` (#1324 / #1377), `<rafters-kbd>` (#1325 / #1375), `<rafters-label>` (#1326 / #1376), `<rafters-progress>` (#1327 / #1378), `<rafters-skeleton>` (#1328 / #1379), `<rafters-spinner>` (#1329 / #1380), `<rafters-aspect-ratio>` (#1330 / #1382), `<rafters-embed>` (#1331 / #1381), `<rafters-image>` (#1332 / #1384), `<rafters-separator>` (#1333 / #1383). Four of those (aspect-ratio, embed, image, separator) also ship new `.classes.ts` files since the React surface had not previously externalised one.
+- feat(ui): Tier 2 form-associated and layout-composition Web Components. Ten components: seven form-associated CEs (`static formAssociated = true`, `attachInternals()`, `setFormValue`, `setValidity`, all four form lifecycle callbacks) and three layout-composition wrappers. Components shipped: `<rafters-checkbox>` (#1340 / #1385), `<rafters-radio-group>` (#1341 / #1386), `<rafters-switch>` (#1342 / #1388), `<rafters-toggle>` (#1343 / #1387), `<rafters-toggle-group>` (#1344 / #1389), `<rafters-slider>` (#1345 / #1391), `<rafters-input-otp>` (#1349 / #1397) -- all form-associated; `<rafters-button-group>` (#1346 / #1390), `<rafters-field>` (#1347 / #1392), `<rafters-input-group>` (#1348 / #1396) -- layout composition. Form-associated members submit with `name=value`, propagate `validity` through `ElementInternals`, reset with the enclosing `<form>`, and re-fire input/change events from the host with `bubbles: true, composed: true`. Four of these (button-group, field, input-group, input-otp) ship new `.classes.ts` files since the React surface had not previously externalised one.
+
 ## 0.0.53
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "description": "CLI for Rafters design system - scaffold tokens and add components",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
Rolls up 24 Web Component ports from the Tier 1 + Tier 2 fan-out into one version bump + CHANGELOG entry.

## What shipped since v0.0.53
- **Tier 1 presentational (14)**: alert, avatar, breadcrumb, empty, item, kbd, label, progress, skeleton, spinner, aspect-ratio, embed, image, separator. PRs #1371-#1384 (assorted).
- **Tier 2 form-associated + layout (10)**: checkbox, radio-group, switch, toggle, toggle-group, slider, input-otp (form-associated CEs); button-group, field, input-group (layout composition). PRs #1385-#1392, #1396, #1397.

Every form-associated component implements `static formAssociated = true`, `attachInternals()`, `setFormValue`, `setValidity`, and the four form lifecycle callbacks. Every component uses the per-instance `CSSStyleSheet` + `replaceSync` + `adoptedStyleSheets` pattern (the bug caught in PR #1308 review and codified here as the standard).

## Why the bump is separate
Each feature PR intentionally skipped the version bump and CHANGELOG update. Bumping on every parallel PR would have forced constant rebases across the 24-PR fan-out. This PR is the single roll-up.

## Test plan
- [x] `pnpm preflight` passes
- [x] Each feature PR was reviewed before merge