### PR TITLE
feat(composites): copy-button composite manifest (closes #1395)

### DIFF
--- a/packages/ui/src/composites/copy-button.composite.json
+++ b/packages/ui/src/composites/copy-button.composite.json
@@ -1,0 +1,53 @@
+{
+  "manifest": {
+    "id": "copy-button",
+    "name": "Copy Button",
+    "category": "action",
+    "description": "Button that copies a literal value to the clipboard on click using the existing clipboard primitive",
+    "keywords": ["copy", "clipboard", "share", "install", "command"],
+    "cognitiveLoad": 1,
+    "solves": "One-click copy of an install command, share URL, API key, SQID, or any literal value alongside its visible representation",
+    "appliesWhen": [
+      "install commands",
+      "share URLs",
+      "API keys",
+      "SQIDs",
+      "code snippets the reader will paste into a terminal",
+      "any literal value paired with a visible label"
+    ],
+    "usagePatterns": {
+      "do": [
+        "Use the existing clipboard primitive at packages/ui/src/primitives/clipboard.ts -- do not write a new copy implementation",
+        "Show success feedback via aria-live region announcing the copy succeeded",
+        "Swap the button label or icon to a checkmark for ~1.5s after a successful copy",
+        "Pair with a visible representation (Codeblock, code, or plain text) so the user knows what they copied",
+        "Use the existing Button component for the trigger -- variant=outline or ghost reads as secondary action"
+      ],
+      "never": [
+        "Wrap the clipboard primitive in a new component or new framework target",
+        "Disable the button after copy -- users may need to re-copy after switching tabs",
+        "Show toast notifications for copy success -- aria-live + icon swap is sufficient",
+        "Use document.execCommand('copy') -- the clipboard primitive uses the modern Navigator Clipboard API",
+        "Hand-roll the success-state timer in component-local state when site-level glue can hold the timing"
+      ]
+    }
+  },
+  "input": [],
+  "output": [],
+  "blocks": [
+    {
+      "id": "copy-button-trigger",
+      "type": "button",
+      "content": "Copy",
+      "meta": {
+        "variant": "outline",
+        "size": "default",
+        "action": "clipboard.write",
+        "actionSource": "literal",
+        "successLabel": "Copied",
+        "successHoldMs": 1500,
+        "ariaLive": "polite"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Resolves #1395 as a composite, not a primitive. The clipboard primitive (\`packages/ui/src/primitives/clipboard.ts\`) already does the work; a new \`<CopyButton>\` component would be wasted abstraction.

The composite captures the designer intent so agents and the editor assemble it correctly:
- existing Button + existing clipboard primitive pairing
- aria-live success feedback (no toast)
- icon swap for ~1.5s on success
- never wrap clipboard in a new component
- never disable the button after copy (re-copy after tab switch is fine)

## Why composite, not component
A primitive `<CopyButton>` would tightly couple a button (presentation) with clipboard (action). Rafters separates those by design: components are presentational; composites describe arrangements + intent. This is the right shape per the existing `feature-grid`, `hero-banner`, `login-form` precedent.

## Test plan
- [x] `pnpm preflight` passes
- [x] No code -- pure manifest addition