### PR TITLE
feat(ui): Grid columns 1-12 plus responsive object form

### DIFF
--- a/packages/ui/src/components/ui/grid-item.astro
+++ b/packages/ui/src/components/ui/grid-item.astro
@@ -9,7 +9,7 @@ import { gridColSpanClasses, gridRowSpanClasses } from './grid.classes';
 
 interface Props extends HTMLAttributes<'div'> {
   priority?: 'primary' | 'secondary' | 'tertiary';
-  colSpan?: 1 | 2 | 3 | 4;
+  colSpan?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
   rowSpan?: 1 | 2 | 3;
 }
 

--- a/packages/ui/src/components/ui/grid.astro
+++ b/packages/ui/src/components/ui/grid.astro
@@ -12,19 +12,21 @@ import type { HTMLAttributes } from 'astro/types';
 import classy from '../../primitives/classy';
 import {
   type BentoPattern,
+  columnsResolvesToAuto,
   type GridPreset,
   gridAutoSpacingClasses,
   gridBentoPatterns,
-  gridColumnClasses,
   gridGapClasses,
   gridGoldenClasses,
   gridPaddingClasses,
+  type ResponsiveColumns,
+  resolveColumnsClasses,
 } from './grid.classes';
 
 interface Props extends HTMLAttributes<'div'> {
   preset?: GridPreset;
   pattern?: BentoPattern;
-  columns?: 1 | 2 | 3 | 4 | 5 | 6 | 'auto';
+  columns?: ResponsiveColumns;
   gap?: '0' | '1' | '2' | '3' | '4' | '5' | '6' | '8' | '10' | '12';
   padding?: '0' | '1' | '2' | '3' | '4' | '5' | '6' | '8' | '10' | '12';
   role?: 'presentation' | 'grid';
@@ -48,10 +50,10 @@ const classes = classy(
   useAutoSpacing && gridAutoSpacingClasses,
   !useAutoSpacing && gap !== undefined && gridGapClasses[gap],
   !useAutoSpacing && padding !== undefined && gridPaddingClasses[padding],
-  preset === 'linear' && gridColumnClasses[columns],
+  preset === 'linear' && resolveColumnsClasses(columns),
   preset === 'golden' && gridGoldenClasses,
   preset === 'bento' && pattern && gridBentoPatterns[pattern],
-  preset === 'linear' && columns === 'auto' && 'sm:grid-cols-2 lg:grid-cols-3',
+  preset === 'linear' && columnsResolvesToAuto(columns) && 'sm:grid-cols-2 lg:grid-cols-3',
   className,
 );
 ---

--- a/packages/ui/src/components/ui/grid.classes.test.ts
+++ b/packages/ui/src/components/ui/grid.classes.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  columnsResolvesToAuto,
+  gridColSpanClasses,
+  gridColumnClasses,
+  resolveColumnsClasses,
+} from './grid.classes';
+
+describe('gridColumnClasses', () => {
+  it('covers 1-12 plus auto', () => {
+    for (let i = 1; i <= 12; i++) {
+      expect(gridColumnClasses[i]).toBe(`grid-cols-${i}`);
+    }
+    expect(gridColumnClasses.auto).toContain('grid-cols-1');
+  });
+});
+
+describe('gridColSpanClasses', () => {
+  it('covers 1-12', () => {
+    for (let i = 1; i <= 12; i++) {
+      expect(gridColSpanClasses[i]).toBe(`col-span-${i}`);
+    }
+  });
+});
+
+describe('resolveColumnsClasses', () => {
+  it('returns empty string when columns is undefined', () => {
+    expect(resolveColumnsClasses(undefined)).toBe('');
+  });
+
+  it('returns the matching class for a single numeric value', () => {
+    expect(resolveColumnsClasses(4)).toBe('grid-cols-4');
+    expect(resolveColumnsClasses(12)).toBe('grid-cols-12');
+  });
+
+  it('returns the auto fallback for the literal "auto"', () => {
+    expect(resolveColumnsClasses('auto')).toContain('grid-cols-1');
+  });
+
+  it('combines base with breakpoint variants in order', () => {
+    expect(resolveColumnsClasses({ base: 2, md: 4 })).toBe('grid-cols-2 md:grid-cols-4');
+    expect(resolveColumnsClasses({ base: 1, sm: 2, lg: 3, xl: 4 })).toBe(
+      'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
+    );
+  });
+
+  it('omits base when not provided and still emits breakpoints', () => {
+    expect(resolveColumnsClasses({ md: 4 })).toBe('md:grid-cols-4');
+  });
+
+  it('handles the 2xl breakpoint', () => {
+    expect(resolveColumnsClasses({ base: 2, '2xl': 6 })).toBe('grid-cols-2 2xl:grid-cols-6');
+  });
+});
+
+describe('columnsResolvesToAuto', () => {
+  it('returns true for undefined and the literal "auto"', () => {
+    expect(columnsResolvesToAuto(undefined)).toBe(true);
+    expect(columnsResolvesToAuto('auto')).toBe(true);
+  });
+
+  it('returns false for explicit numeric or responsive object values', () => {
+    expect(columnsResolvesToAuto(4)).toBe(false);
+    expect(columnsResolvesToAuto({ base: 2, md: 4 })).toBe(false);
+  });
+});

--- a/packages/ui/src/components/ui/grid.classes.ts
+++ b/packages/ui/src/components/ui/grid.classes.ts
@@ -47,6 +47,12 @@ export const gridColumnClasses: Record<string | number, string> = {
   4: 'grid-cols-4',
   5: 'grid-cols-5',
   6: 'grid-cols-6',
+  7: 'grid-cols-7',
+  8: 'grid-cols-8',
+  9: 'grid-cols-9',
+  10: 'grid-cols-10',
+  11: 'grid-cols-11',
+  12: 'grid-cols-12',
   auto: 'grid-cols-1 @sm:grid-cols-2 @lg:grid-cols-3 @xl:grid-cols-4',
 };
 
@@ -64,6 +70,14 @@ export const gridColSpanClasses: Record<number, string> = {
   2: 'col-span-2',
   3: 'col-span-3',
   4: 'col-span-4',
+  5: 'col-span-5',
+  6: 'col-span-6',
+  7: 'col-span-7',
+  8: 'col-span-8',
+  9: 'col-span-9',
+  10: 'col-span-10',
+  11: 'col-span-11',
+  12: 'col-span-12',
 };
 
 export const gridRowSpanClasses: Record<number, string> = {
@@ -71,3 +85,156 @@ export const gridRowSpanClasses: Record<number, string> = {
   2: 'row-span-2',
   3: 'row-span-3',
 };
+
+// ============================================================================
+// Responsive columns
+// ============================================================================
+
+/**
+ * A single columns value: 1-12 or 'auto' (the existing auto-fit behavior).
+ */
+export type ColumnsValue = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 'auto';
+
+/**
+ * Tailwind viewport breakpoint prefix used for responsive columns.
+ * Page-level marketing layouts respond to viewport, not container.
+ */
+export type ColumnsBreakpoint = 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+
+/**
+ * Responsive columns config: a base value plus optional per-breakpoint overrides.
+ * Example: `{ base: 2, md: 4 }` becomes `grid-cols-2 md:grid-cols-4`.
+ */
+export interface ResponsiveColumnsObject {
+  base?: ColumnsValue;
+  sm?: ColumnsValue;
+  md?: ColumnsValue;
+  lg?: ColumnsValue;
+  xl?: ColumnsValue;
+  '2xl'?: ColumnsValue;
+}
+
+/**
+ * Either a single columns value or a responsive object.
+ */
+export type ResponsiveColumns = ColumnsValue | ResponsiveColumnsObject;
+
+/**
+ * Per-breakpoint columns class maps. Tailwind needs these as literal strings
+ * for the JIT scanner.
+ */
+const gridResponsiveColumnClasses: Record<ColumnsBreakpoint, Record<string | number, string>> = {
+  sm: {
+    1: 'sm:grid-cols-1',
+    2: 'sm:grid-cols-2',
+    3: 'sm:grid-cols-3',
+    4: 'sm:grid-cols-4',
+    5: 'sm:grid-cols-5',
+    6: 'sm:grid-cols-6',
+    7: 'sm:grid-cols-7',
+    8: 'sm:grid-cols-8',
+    9: 'sm:grid-cols-9',
+    10: 'sm:grid-cols-10',
+    11: 'sm:grid-cols-11',
+    12: 'sm:grid-cols-12',
+  },
+  md: {
+    1: 'md:grid-cols-1',
+    2: 'md:grid-cols-2',
+    3: 'md:grid-cols-3',
+    4: 'md:grid-cols-4',
+    5: 'md:grid-cols-5',
+    6: 'md:grid-cols-6',
+    7: 'md:grid-cols-7',
+    8: 'md:grid-cols-8',
+    9: 'md:grid-cols-9',
+    10: 'md:grid-cols-10',
+    11: 'md:grid-cols-11',
+    12: 'md:grid-cols-12',
+  },
+  lg: {
+    1: 'lg:grid-cols-1',
+    2: 'lg:grid-cols-2',
+    3: 'lg:grid-cols-3',
+    4: 'lg:grid-cols-4',
+    5: 'lg:grid-cols-5',
+    6: 'lg:grid-cols-6',
+    7: 'lg:grid-cols-7',
+    8: 'lg:grid-cols-8',
+    9: 'lg:grid-cols-9',
+    10: 'lg:grid-cols-10',
+    11: 'lg:grid-cols-11',
+    12: 'lg:grid-cols-12',
+  },
+  xl: {
+    1: 'xl:grid-cols-1',
+    2: 'xl:grid-cols-2',
+    3: 'xl:grid-cols-3',
+    4: 'xl:grid-cols-4',
+    5: 'xl:grid-cols-5',
+    6: 'xl:grid-cols-6',
+    7: 'xl:grid-cols-7',
+    8: 'xl:grid-cols-8',
+    9: 'xl:grid-cols-9',
+    10: 'xl:grid-cols-10',
+    11: 'xl:grid-cols-11',
+    12: 'xl:grid-cols-12',
+  },
+  '2xl': {
+    1: '2xl:grid-cols-1',
+    2: '2xl:grid-cols-2',
+    3: '2xl:grid-cols-3',
+    4: '2xl:grid-cols-4',
+    5: '2xl:grid-cols-5',
+    6: '2xl:grid-cols-6',
+    7: '2xl:grid-cols-7',
+    8: '2xl:grid-cols-8',
+    9: '2xl:grid-cols-9',
+    10: '2xl:grid-cols-10',
+    11: '2xl:grid-cols-11',
+    12: '2xl:grid-cols-12',
+  },
+};
+
+const breakpointOrder: ColumnsBreakpoint[] = ['sm', 'md', 'lg', 'xl', '2xl'];
+
+/**
+ * Resolve a `columns` prop (single value or responsive object) to a class string.
+ *
+ * - Single value: returns the matching grid-cols class.
+ * - Object: returns base + per-breakpoint classes joined by spaces.
+ *
+ * Returns empty string when no resolvable classes are produced.
+ */
+export function resolveColumnsClasses(columns: ResponsiveColumns | undefined): string {
+  if (columns === undefined) return '';
+
+  if (typeof columns === 'number' || columns === 'auto') {
+    return gridColumnClasses[columns] ?? '';
+  }
+
+  const parts: string[] = [];
+  if (columns.base !== undefined) {
+    const base = gridColumnClasses[columns.base];
+    if (base) parts.push(base);
+  }
+  for (const bp of breakpointOrder) {
+    const value = columns[bp];
+    if (value !== undefined) {
+      const cls = gridResponsiveColumnClasses[bp][value];
+      if (cls) parts.push(cls);
+    }
+  }
+  return parts.join(' ');
+}
+
+/**
+ * True when the columns prop carries no useful 'auto' fallback. Used by Grid to
+ * decide whether to apply its default responsive columns when the consumer
+ * passes 'auto' or omits the prop entirely.
+ */
+export function columnsResolvesToAuto(columns: ResponsiveColumns | undefined): boolean {
+  if (columns === undefined) return true;
+  if (columns === 'auto') return true;
+  return false;
+}

--- a/packages/ui/src/components/ui/grid.tsx
+++ b/packages/ui/src/components/ui/grid.tsx
@@ -35,15 +35,17 @@ import * as React from 'react';
 import classy from '../../primitives/classy';
 import {
   type BentoPattern,
+  columnsResolvesToAuto,
   type GridPreset,
   gridAutoSpacingClasses,
   gridBentoPatterns,
   gridColSpanClasses,
-  gridColumnClasses,
   gridGapClasses,
   gridGoldenClasses,
   gridPaddingClasses,
   gridRowSpanClasses,
+  type ResponsiveColumns,
+  resolveColumnsClasses,
 } from './grid.classes';
 
 // ==================== Types ====================
@@ -69,7 +71,7 @@ function useGridContext() {
 
 /** Grid configuration for onConfigChange callback */
 export interface GridConfig {
-  columns?: 1 | 2 | 3 | 4 | 5 | 6 | 'auto';
+  columns?: ResponsiveColumns;
   gap?: '0' | '1' | '2' | '3' | '4' | '5' | '6' | '8' | '10' | '12';
   padding?: '0' | '1' | '2' | '3' | '4' | '5' | '6' | '8' | '10' | '12';
   preset?: GridPreset;
@@ -95,11 +97,15 @@ export interface GridProps extends React.HTMLAttributes<HTMLDivElement> {
   pattern?: BentoPattern;
 
   /**
-   * Column count for linear preset
-   * Responsive object or single value
-   * @default auto-fit based on content
+   * Column count for linear preset.
+   *
+   * Single value: a number 1-12 or 'auto' for the responsive auto-fit default.
+   * Responsive object: `{ base, sm, md, lg, xl, '2xl' }` resolves to per-
+   * breakpoint `grid-cols-N` classes. Example: `{ base: 2, md: 4 }`.
+   *
+   * @default 'auto'
    */
-  columns?: 1 | 2 | 3 | 4 | 5 | 6 | 'auto';
+  columns?: ResponsiveColumns;
 
   /**
    * Gap between items. Omit for auto-scaling via container queries.
@@ -147,7 +153,6 @@ export interface GridProps extends React.HTMLAttributes<HTMLDivElement> {
   onConfigChange?: ((config: GridConfig) => void) | undefined;
 }
 
-const columnClasses = gridColumnClasses;
 const bentoPatterns = gridBentoPatterns;
 const goldenClasses = gridGoldenClasses;
 
@@ -181,12 +186,12 @@ function GridRoot({
     !useAutoSpacing && padding !== undefined && gridPaddingClasses[padding],
 
     // Preset-specific layouts
-    preset === 'linear' && columnClasses[columns],
+    preset === 'linear' && resolveColumnsClasses(columns),
     preset === 'golden' && goldenClasses,
     preset === 'bento' && pattern && bentoPatterns[pattern],
 
     // Responsive defaults for linear
-    preset === 'linear' && columns === 'auto' && 'sm:grid-cols-2 lg:grid-cols-3',
+    preset === 'linear' && columnsResolvesToAuto(columns) && 'sm:grid-cols-2 lg:grid-cols-3',
 
     // Editable mode styling (R-202)
     editable && 'outline-2 outline-dashed outline-muted-foreground/30 outline-offset-2 rounded p-2',
@@ -204,6 +209,7 @@ function GridRoot({
         data-editable={editable || undefined}
         data-preset={preset}
         data-columns={typeof columns === 'number' ? columns : undefined}
+        data-responsive={typeof columns === 'object' ? '' : undefined}
         {...props}
       >
         {children}
@@ -222,9 +228,9 @@ export interface GridItemProps extends React.HTMLAttributes<HTMLDivElement> {
   priority?: ContentPriority;
 
   /**
-   * Explicit column span override
+   * Explicit column span override (1-12).
    */
-  colSpan?: 1 | 2 | 3 | 4;
+  colSpan?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
   /**
    * Explicit row span override


### PR DESCRIPTION
## Summary

Brings Grid's React/Astro variants up to parity with the Web Component (which already supports `cols=12`) and adds a responsive `columns` API. Surfaced by dogfooding @rafters/mail's marketing landing in [shingle#59](https://github.com/rafters-studio/shingle/pull/59), where the 8-cell modules grid needed 12 columns and the footer/hero needed responsive breakpoint variants.

## API additions

- `gridColumnClasses` extended to 7-12
- `gridColSpanClasses` extended to 5-12
- New `ResponsiveColumns` type: `number | 'auto' | { base?, sm?, md?, lg?, xl?, '2xl'? }`
- `resolveColumnsClasses(cols)` helper produces the class string
- `columnsResolvesToAuto(cols)` keeps the existing auto-fit fallback intact
- `Grid.tsx` and `grid.astro` both accept the new `ResponsiveColumns` for `columns`
- `Grid.Item` (React) and `grid-item.astro` accept `colSpan` 1-12

## Example

```tsx
<Grid columns={{ base: 2, md: 4 }}>
  ...
</Grid>
```

emits `grid-cols-2 md:grid-cols-4`.

## Tests

10 new cases in `grid.classes.test.ts` covering:
- Column 1-12 + auto
- Span 1-12
- Single-value resolution (numeric, 'auto')
- Base + breakpoint composition
- Auto-fallback detection

All 65 grid tests pass; full preflight clean.

## Notes

`gridResponsiveColumnClasses` contains 5 per-breakpoint maps (60 literal class strings). Tailwind v4's JIT scanner needs literal strings — generating them via template literals would make them invisible to the toolchain.

## Test plan

- [ ] `pnpm --filter=@rafters/ui test grid` — 65/65 pass
- [ ] `pnpm preflight` — clean
- [ ] In a consuming site, `<Grid columns={12}>` emits `grid-cols-12`
- [ ] In a consuming site, `<Grid columns={{ base: 2, md: 4 }}>` emits `grid-cols-2 md:grid-cols-4`
- [ ] `<Grid.Item colSpan={8}>` works
- [ ] Existing `<Grid columns={3}>` callers unchanged
- [ ] `<Grid columns="auto">` still triggers `sm:grid-cols-2 lg:grid-cols-3` fallback