### PR TITLE
fix(ui): typography overrides replace defaults instead of appending

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ test-results
 *.astro/
 .rafters/
 !apps/demo/.rafters/
+.scratch/
 .playwright-mcp/
 *.tsbuildinfo
 # Rust

--- a/packages/ui/src/components/ui/typography-abbr.astro
+++ b/packages/ui/src/components/ui/typography-abbr.astro
@@ -7,7 +7,7 @@
  */
 import type { HTMLAttributes } from 'astro/types';
 import classy from '../../primitives/classy';
-import { tokenPropsToClasses, typographyClasses } from './typography.classes';
+import { resolveTypography } from './typography.classes';
 
 interface Props extends HTMLAttributes<'abbr'> {
   title: string;
@@ -34,17 +34,10 @@ const {
   class: className,
   ...attrs
 } = Astro.props;
-const overrides = tokenPropsToClasses({
-  size,
-  weight,
-  color,
-  line,
-  tracking,
-  family,
-  align,
-  transform,
-});
-const classes = classy(typographyClasses.abbr, overrides, className);
+const classes = classy(
+  resolveTypography('abbr', { size, weight, color, line, tracking, family, align, transform }),
+  className,
+);
 ---
 
 <abbr class={classes} title={title} {...attrs}><slot /></abbr>

--- a/packages/ui/src/components/ui/typography-blockquote.astro
+++ b/packages/ui/src/components/ui/typography-blockquote.astro
@@ -7,7 +7,7 @@
  */
 import type { HTMLAttributes } from 'astro/types';
 import classy from '../../primitives/classy';
-import { tokenPropsToClasses, typographyClasses } from './typography.classes';
+import { resolveTypography } from './typography.classes';
 
 interface Props extends HTMLAttributes<'blockquote'> {
   size?: string;
@@ -32,17 +32,19 @@ const {
   class: className,
   ...attrs
 } = Astro.props;
-const overrides = tokenPropsToClasses({
-  size,
-  weight,
-  color,
-  line,
-  tracking,
-  family,
-  align,
-  transform,
-});
-const classes = classy(typographyClasses.blockquote, overrides, className);
+const classes = classy(
+  resolveTypography('blockquote', {
+    size,
+    weight,
+    color,
+    line,
+    tracking,
+    family,
+    align,
+    transform,
+  }),
+  className,
+);
 ---
 
 <blockquote class={classes} {...attrs}><slot /></blockquote>

--- a/packages/ui/src/components/ui/typography-code.astro
+++ b/packages/ui/src/components/ui/typography-code.astro
@@ -7,7 +7,7 @@
  */
 import type { HTMLAttributes } from 'astro/types';
 import classy from '../../primitives/classy';
-import { tokenPropsToClasses, typographyClasses } from './typography.classes';
+import { resolveTypography } from './typography.classes';
 
 interface Props extends HTMLAttributes<'code'> {
   size?: string;
@@ -32,17 +32,10 @@ const {
   class: className,
   ...attrs
 } = Astro.props;
-const overrides = tokenPropsToClasses({
-  size,
-  weight,
-  color,
-  line,
-  tracking,
-  family,
-  align,
-  transform,
-});
-const classes = classy(typographyClasses.code, overrides, className);
+const classes = classy(
+  resolveTypography('code', { size, weight, color, line, tracking, family, align, transform }),
+  className,
+);
 ---
 
 <code class={classes} {...attrs}><slot /></code>

--- a/packages/ui/src/components/ui/typography-h1.astro
+++ b/packages/ui/src/components/ui/typography-h1.astro
@@ -10,7 +10,7 @@
  */
 import type { HTMLAttributes } from 'astro/types';
 import classy from '../../primitives/classy';
-import { tokenPropsToClasses, typographyClasses } from './typography.classes';
+import { resolveTypography } from './typography.classes';
 
 interface Props extends HTMLAttributes<'h1'> {
   size?: string;
@@ -35,17 +35,10 @@ const {
   class: className,
   ...attrs
 } = Astro.props;
-const overrides = tokenPropsToClasses({
-  size,
-  weight,
-  color,
-  line,
-  tracking,
-  family,
-  align,
-  transform,
-});
-const classes = classy(typographyClasses.h1, overrides, className);
+const classes = classy(
+  resolveTypography('h1', { size, weight, color, line, tracking, family, align, transform }),
+  className,
+);
 ---
 
 <h1 class={classes} {...attrs}><slot /></h1>

--- a/packages/ui/src/components/ui/typography-h2.astro
+++ b/packages/ui/src/components/ui/typography-h2.astro
@@ -7,7 +7,7 @@
  */
 import type { HTMLAttributes } from 'astro/types';
 import classy from '../../primitives/classy';
-import { tokenPropsToClasses, typographyClasses } from './typography.classes';
+import { resolveTypography } from './typography.classes';
 
 interface Props extends HTMLAttributes<'h2'> {
   size?: string;
@@ -32,17 +32,10 @@ const {
   class: className,
   ...attrs
 } = Astro.props;
-const overrides = tokenPropsToClasses({
-  size,
-  weight,
-  color,
-  line,
-  tracking,
-  family,
-  align,
-  transform,
-});
-const classes = classy(typographyClasses.h2, overrides, className);
+const classes = classy(
+  resolveTypography('h2', { size, weight, color, line, tracking, family, align, transform }),
+  className,
+);
 ---
 
 <h2 class={classes} {...attrs}><slot /></h2>

--- a/packages/ui/src/components/ui/typography-h3.astro
+++ b/packages/ui/src/components/ui/typography-h3.astro
@@ -6,7 +6,7 @@
  */
 import type { HTMLAttributes } from 'astro/types';
 import classy from '../../primitives/classy';
-import { tokenPropsToClasses, typographyClasses } from './typography.classes';
+import { resolveTypography } from './typography.classes';
 
 interface Props extends HTMLAttributes<'h3'> {
   size?: string;
@@ -31,17 +31,10 @@ const {
   class: className,
   ...attrs
 } = Astro.props;
-const overrides = tokenPropsToClasses({
-  size,
-  weight,
-  color,
-  line,
-  tracking,
-  family,
-  align,
-  transform,
-});
-const classes = classy(typographyClasses.h3, overrides, className);
+const classes = classy(
+  resolveTypography('h3', { size, weight, color, line, tracking, family, align, transform }),
+  className,
+);
 ---
 
 <h3 class={classes} {...attrs}><slot /></h3>

--- a/packages/ui/src/components/ui/typography-h4.astro
+++ b/packages/ui/src/components/ui/typography-h4.astro
@@ -6,7 +6,7 @@
  */
 import type { HTMLAttributes } from 'astro/types';
 import classy from '../../primitives/classy';
-import { tokenPropsToClasses, typographyClasses } from './typography.classes';
+import { resolveTypography } from './typography.classes';
 
 interface Props extends HTMLAttributes<'h4'> {
   size?: string;
@@ -31,17 +31,10 @@ const {
   class: className,
   ...attrs
 } = Astro.props;
-const overrides = tokenPropsToClasses({
-  size,
-  weight,
-  color,
-  line,
-  tracking,
-  family,
-  align,
-  transform,
-});
-const classes = classy(typographyClasses.h4, overrides, className);
+const classes = classy(
+  resolveTypography('h4', { size, weight, color, line, tracking, family, align, transform }),
+  className,
+);
 ---
 
 <h4 class={classes} {...attrs}><slot /></h4>

--- a/packages/ui/src/components/ui/typography-h5.astro
+++ b/packages/ui/src/components/ui/typography-h5.astro
@@ -7,7 +7,7 @@
  */
 import type { HTMLAttributes } from 'astro/types';
 import classy from '../../primitives/classy';
-import { tokenPropsToClasses, typographyClasses } from './typography.classes';
+import { resolveTypography } from './typography.classes';
 
 interface Props extends HTMLAttributes<'h5'> {
   size?: string;
@@ -32,17 +32,10 @@ const {
   class: className,
   ...attrs
 } = Astro.props;
-const overrides = tokenPropsToClasses({
-  size,
-  weight,
-  color,
-  line,
-  tracking,
-  family,
-  align,
-  transform,
-});
-const classes = classy(typographyClasses.h4, overrides, className);
+const classes = classy(
+  resolveTypography('h4', { size, weight, color, line, tracking, family, align, transform }),
+  className,
+);
 ---
 
 <h5 class={classes} {...attrs}><slot /></h5>

--- a/packages/ui/src/components/ui/typography-h6.astro
+++ b/packages/ui/src/components/ui/typography-h6.astro
@@ -7,7 +7,7 @@
  */
 import type { HTMLAttributes } from 'astro/types';
 import classy from '../../primitives/classy';
-import { tokenPropsToClasses, typographyClasses } from './typography.classes';
+import { resolveTypography } from './typography.classes';
 
 interface Props extends HTMLAttributes<'h6'> {
   size?: string;
@@ -32,17 +32,10 @@ const {
   class: className,
   ...attrs
 } = Astro.props;
-const overrides = tokenPropsToClasses({
-  size,
-  weight,
-  color,
-  line,
-  tracking,
-  family,
-  align,
-  transform,
-});
-const classes = classy(typographyClasses.h4, overrides, className);
+const classes = classy(
+  resolveTypography('h4', { size, weight, color, line, tracking, family, align, transform }),
+  className,
+);
 ---
 
 <h6 class={classes} {...attrs}><slot /></h6>

--- a/packages/ui/src/components/ui/typography-mark.astro
+++ b/packages/ui/src/components/ui/typography-mark.astro
@@ -7,7 +7,7 @@
  */
 import type { HTMLAttributes } from 'astro/types';
 import classy from '../../primitives/classy';
-import { tokenPropsToClasses, typographyClasses } from './typography.classes';
+import { resolveTypography } from './typography.classes';
 
 interface Props extends HTMLAttributes<'mark'> {
   size?: string;
@@ -32,17 +32,10 @@ const {
   class: className,
   ...attrs
 } = Astro.props;
-const overrides = tokenPropsToClasses({
-  size,
-  weight,
-  color,
-  line,
-  tracking,
-  family,
-  align,
-  transform,
-});
-const classes = classy(typographyClasses.mark, overrides, className);
+const classes = classy(
+  resolveTypography('mark', { size, weight, color, line, tracking, family, align, transform }),
+  className,
+);
 ---
 
 <mark class={classes} {...attrs}><slot /></mark>

--- a/packages/ui/src/components/ui/typography-p.astro
+++ b/packages/ui/src/components/ui/typography-p.astro
@@ -11,7 +11,7 @@
  */
 import type { HTMLAttributes } from 'astro/types';
 import classy from '../../primitives/classy';
-import { tokenPropsToClasses, typographyClasses } from './typography.classes';
+import { resolveTypography } from './typography.classes';
 
 interface Props extends HTMLAttributes<'p'> {
   size?: string;
@@ -36,17 +36,10 @@ const {
   class: className,
   ...attrs
 } = Astro.props;
-const overrides = tokenPropsToClasses({
-  size,
-  weight,
-  color,
-  line,
-  tracking,
-  family,
-  align,
-  transform,
-});
-const classes = classy(typographyClasses.p, overrides, className);
+const classes = classy(
+  resolveTypography('p', { size, weight, color, line, tracking, family, align, transform }),
+  className,
+);
 ---
 
 <p class={classes} {...attrs}><slot /></p>

--- a/packages/ui/src/components/ui/typography-small.astro
+++ b/packages/ui/src/components/ui/typography-small.astro
@@ -7,7 +7,7 @@
  */
 import type { HTMLAttributes } from 'astro/types';
 import classy from '../../primitives/classy';
-import { tokenPropsToClasses, typographyClasses } from './typography.classes';
+import { resolveTypography } from './typography.classes';
 
 interface Props extends HTMLAttributes<'small'> {
   size?: string;
@@ -32,17 +32,10 @@ const {
   class: className,
   ...attrs
 } = Astro.props;
-const overrides = tokenPropsToClasses({
-  size,
-  weight,
-  color,
-  line,
-  tracking,
-  family,
-  align,
-  transform,
-});
-const classes = classy(typographyClasses.small, overrides, className);
+const classes = classy(
+  resolveTypography('small', { size, weight, color, line, tracking, family, align, transform }),
+  className,
+);
 ---
 
 <small class={classes} {...attrs}><slot /></small>

--- a/packages/ui/src/components/ui/typography.astro
+++ b/packages/ui/src/components/ui/typography.astro
@@ -19,7 +19,7 @@
  */
 import type { HTMLAttributes } from 'astro/types';
 import classy from '../../primitives/classy';
-import { tokenPropsToClasses, typographyClasses } from './typography.classes';
+import { resolveTypography } from './typography.classes';
 
 type TypographyElement =
   | 'h1'
@@ -83,18 +83,19 @@ const resolvedVariant =
     : Element === 'h5' || Element === 'h6'
       ? 'h4'
       : (Element as TypographyVariant));
-const variantClass = typographyClasses[resolvedVariant] ?? typographyClasses.p;
-const overrides = tokenPropsToClasses({
-  size,
-  weight,
-  color,
-  line,
-  tracking,
-  family,
-  align,
-  transform,
-});
-const classes = classy(variantClass, overrides, className);
+const classes = classy(
+  resolveTypography(resolvedVariant, {
+    size,
+    weight,
+    color,
+    line,
+    tracking,
+    family,
+    align,
+    transform,
+  }),
+  className,
+);
 ---
 
 {Element === 'h1' && <h1 class={classes} {...attrs}><slot /></h1>}

--- a/packages/ui/src/components/ui/typography.classes.ts
+++ b/packages/ui/src/components/ui/typography.classes.ts
@@ -122,6 +122,8 @@ const DIM_TO_UTIL: Record<keyof TypographyTokenProps, (v: string) => string> = {
   },
 };
 
+const DIM_KEYS = Object.keys(DIM_TO_UTIL) as (keyof TypographyTokenProps)[];
+
 function emitDim(dim: keyof TypographyTokenProps, value: string, prefix = ''): string {
   const util = DIM_TO_UTIL[dim](value);
   if (!prefix) return util;
@@ -131,12 +133,13 @@ function emitDim(dim: keyof TypographyTokenProps, value: string, prefix = ''): s
     .join(' ');
 }
 
-function pickDefined<T extends object>(obj: T): Partial<T> {
-  const out: Partial<T> = {};
-  for (const key of Object.keys(obj) as (keyof T)[]) {
-    if (obj[key] != null) out[key] = obj[key];
+function emitProps(props: TypographyTokenProps, prefix = ''): string {
+  const classes: string[] = [];
+  for (const key of DIM_KEYS) {
+    const value = props[key];
+    if (value != null) classes.push(emitDim(key, value, prefix));
   }
-  return out;
+  return classes.join(' ');
 }
 
 export function resolveTypography(
@@ -144,49 +147,39 @@ export function resolveTypography(
   overrides: TypographyTokenProps = {},
 ): string {
   const defaults = VARIANTS[variant];
-  const dims: TypographyTokenProps = { ...defaults, ...pickDefined(overrides) };
-  delete (dims as VariantDefaults).layout;
-  delete (dims as VariantDefaults).cq;
+  const merged: TypographyTokenProps = {};
+  for (const key of DIM_KEYS) merged[key] = overrides[key] ?? defaults[key];
 
-  const classes: string[] = [];
-  if (defaults.layout) classes.push(defaults.layout);
-
-  for (const key of Object.keys(DIM_TO_UTIL) as (keyof TypographyTokenProps)[]) {
-    const value = dims[key];
-    if (value != null) classes.push(emitDim(key, value));
-  }
+  const parts: string[] = [];
+  if (defaults.layout) parts.push(defaults.layout);
+  parts.push(emitProps(merged));
 
   // CQ defaults survive only where the prop didn't override the same dimension.
   if (defaults.cq) {
-    for (const [breakpoint, cqOverrides] of Object.entries(defaults.cq)) {
-      for (const key of Object.keys(cqOverrides) as (keyof CqOverrides)[]) {
-        if (overrides[key] != null) continue;
-        const value = cqOverrides[key];
-        if (value != null) classes.push(emitDim(key, value, `@${breakpoint}:`));
+    for (const [breakpoint, cqDefaults] of Object.entries(defaults.cq)) {
+      const surviving: TypographyTokenProps = {};
+      for (const key of Object.keys(cqDefaults) as (keyof CqOverrides)[]) {
+        if (overrides[key] == null) surviving[key] = cqDefaults[key];
       }
+      parts.push(emitProps(surviving, `@${breakpoint}:`));
     }
   }
 
-  return classes.join(' ');
+  return parts.filter(Boolean).join(' ');
 }
 
 /**
- * Back-compat flat string map. Computed from the dimensional defaults.
- * Prefer `resolveTypography(variant, props)` when overrides are in play.
+ * Emit token-prop classes without any variant defaults. Exposed for tests that
+ * exercise the prop-to-utility emit path in isolation (see typography-fill.test).
+ */
+export function tokenPropsToClasses(props: TypographyTokenProps): string {
+  return emitProps(props);
+}
+
+/**
+ * Flat-string map of variant defaults with no overrides. Kept for consumers
+ * that need the baseline class string (e.g. List's li, CodeBlock wrapper).
  */
 export const typographyClasses = Object.fromEntries(
   (Object.keys(VARIANTS) as TypographyVariant[]).map((v) => [v, resolveTypography(v)]),
 ) as Record<TypographyVariant, string>;
-
-/**
- * @deprecated Use `resolveTypography(variant, props)` so overrides replace
- * defaults instead of appending. Kept so existing consumers don't break.
- */
-export function tokenPropsToClasses(props: TypographyTokenProps): string {
-  const classes: string[] = [];
-  for (const key of Object.keys(DIM_TO_UTIL) as (keyof TypographyTokenProps)[]) {
-    const value = props[key];
-    if (value != null) classes.push(emitDim(key, value));
-  }
-  return classes.join(' ');
-}

--- a/packages/ui/src/components/ui/typography.classes.ts
+++ b/packages/ui/src/components/ui/typography.classes.ts
@@ -1,35 +1,35 @@
 /**
- * Shared class definitions for Typography components
- * Used by both typography.tsx (React) and typography .astro files (Astro)
+ * Shared class resolution for Typography components.
+ *
+ * Variant defaults are stored dimensionally (size, weight, color, line, tracking,
+ * family, align, transform) rather than as flat utility strings. Token prop
+ * overrides replace the matching dimension at emit time, so defaults never fight
+ * overrides in the Tailwind cascade (which orders utilities alphabetically and
+ * thus cannot be trusted for overrides: `text-accent` would lose to
+ * `text-foreground` on 'a' < 'f').
  */
 
 import { getFillMetadata, resolveFillClasses } from '../../primitives/fill-resolver';
 
-export const typographyClasses = {
-  h1: 'scroll-m-20 text-4xl font-bold tracking-tight @lg:text-5xl text-foreground',
-  h2: 'scroll-m-20 text-3xl font-semibold tracking-tight text-foreground',
-  h3: 'scroll-m-20 text-2xl font-semibold tracking-tight text-foreground',
-  h4: 'scroll-m-20 text-xl font-semibold tracking-tight text-foreground',
-  p: 'leading-7 text-foreground',
-  lead: 'text-xl text-muted-foreground',
-  large: 'text-lg font-semibold text-foreground',
-  small: 'text-sm font-medium leading-none text-foreground',
-  muted: 'text-sm text-muted-foreground',
-  code: 'rounded bg-muted px-1 py-0.5 font-mono text-sm text-foreground',
-  blockquote: 'mt-6 border-l-2 border-border pl-6 italic text-foreground',
-  ul: 'my-6 ml-6 list-disc [&>li]:mt-2 text-foreground',
-  ol: 'my-6 ml-6 list-decimal [&>li]:mt-2 text-foreground',
-  li: 'leading-7',
-  codeblock:
-    'relative rounded-lg bg-muted p-4 font-mono text-sm overflow-x-auto text-foreground [&_code]:bg-transparent [&_code]:p-0',
-  mark: 'bg-accent text-accent-foreground px-1 rounded',
-  abbr: 'cursor-help underline decoration-dotted underline-offset-4',
-} as const;
+export type TypographyVariant =
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'p'
+  | 'lead'
+  | 'large'
+  | 'small'
+  | 'muted'
+  | 'code'
+  | 'codeblock'
+  | 'blockquote'
+  | 'mark'
+  | 'abbr'
+  | 'ul'
+  | 'ol'
+  | 'li';
 
-/**
- * Token-level typography props for surgical override of any dimension.
- * Shared between React (.tsx) and Astro (.astro) tag components.
- */
 export interface TypographyTokenProps {
   size?: string | undefined;
   weight?: string | undefined;
@@ -41,35 +41,152 @@ export interface TypographyTokenProps {
   transform?: string | undefined;
 }
 
+interface CqOverrides {
+  size?: string;
+  weight?: string;
+  line?: string;
+  tracking?: string;
+}
+
+interface VariantDefaults extends TypographyTokenProps {
+  layout?: string;
+  cq?: Record<string, CqOverrides>;
+}
+
+const VARIANTS: Record<TypographyVariant, VariantDefaults> = {
+  h1: {
+    size: '4xl',
+    weight: 'bold',
+    tracking: 'tight',
+    color: 'foreground',
+    layout: 'scroll-m-20',
+    cq: { lg: { size: '5xl' } },
+  },
+  h2: {
+    size: '3xl',
+    weight: 'semibold',
+    tracking: 'tight',
+    color: 'foreground',
+    layout: 'scroll-m-20',
+  },
+  h3: {
+    size: '2xl',
+    weight: 'semibold',
+    tracking: 'tight',
+    color: 'foreground',
+    layout: 'scroll-m-20',
+  },
+  h4: {
+    size: 'xl',
+    weight: 'semibold',
+    tracking: 'tight',
+    color: 'foreground',
+    layout: 'scroll-m-20',
+  },
+  p: { line: '7', color: 'foreground' },
+  lead: { size: 'xl', color: 'muted-foreground' },
+  large: { size: 'lg', weight: 'semibold', color: 'foreground' },
+  small: { size: 'sm', weight: 'medium', line: 'none', color: 'foreground' },
+  muted: { size: 'sm', color: 'muted-foreground' },
+  code: {
+    size: 'sm',
+    family: 'mono',
+    color: 'foreground',
+    layout: 'rounded bg-muted px-1 py-0.5',
+  },
+  codeblock: {
+    size: 'sm',
+    family: 'mono',
+    color: 'foreground',
+    layout: 'relative rounded-lg bg-muted p-4 overflow-x-auto [&_code]:bg-transparent [&_code]:p-0',
+  },
+  blockquote: { color: 'foreground', layout: 'mt-6 border-l-2 border-border pl-6 italic' },
+  mark: { color: 'accent-foreground', layout: 'bg-accent px-1 rounded' },
+  abbr: { layout: 'cursor-help underline decoration-dotted underline-offset-4' },
+  ul: { color: 'foreground', layout: 'my-6 ml-6 list-disc [&>li]:mt-2' },
+  ol: { color: 'foreground', layout: 'my-6 ml-6 list-decimal [&>li]:mt-2' },
+  li: { line: '7' },
+};
+
+const DIM_TO_UTIL: Record<keyof TypographyTokenProps, (v: string) => string> = {
+  size: (v) => `text-${v}`,
+  weight: (v) => `font-${v}`,
+  line: (v) => `leading-${v}`,
+  tracking: (v) => `tracking-${v}`,
+  family: (v) => `font-${v}`,
+  align: (v) => `text-${v}`,
+  transform: (v) => v,
+  color: (v) => {
+    const fill = getFillMetadata(v);
+    return fill ? resolveFillClasses(fill, 'text') : `text-${v}`;
+  },
+};
+
+function emitDim(dim: keyof TypographyTokenProps, value: string, prefix = ''): string {
+  const util = DIM_TO_UTIL[dim](value);
+  if (!prefix) return util;
+  return util
+    .split(/\s+/)
+    .map((u) => `${prefix}${u}`)
+    .join(' ');
+}
+
+function pickDefined<T extends object>(obj: T): Partial<T> {
+  const out: Partial<T> = {};
+  for (const key of Object.keys(obj) as (keyof T)[]) {
+    if (obj[key] != null) out[key] = obj[key];
+  }
+  return out;
+}
+
+export function resolveTypography(
+  variant: TypographyVariant,
+  overrides: TypographyTokenProps = {},
+): string {
+  const defaults = VARIANTS[variant];
+  const dims: TypographyTokenProps = { ...defaults, ...pickDefined(overrides) };
+  delete (dims as VariantDefaults).layout;
+  delete (dims as VariantDefaults).cq;
+
+  const classes: string[] = [];
+  if (defaults.layout) classes.push(defaults.layout);
+
+  for (const key of Object.keys(DIM_TO_UTIL) as (keyof TypographyTokenProps)[]) {
+    const value = dims[key];
+    if (value != null) classes.push(emitDim(key, value));
+  }
+
+  // CQ defaults survive only where the prop didn't override the same dimension.
+  if (defaults.cq) {
+    for (const [breakpoint, cqOverrides] of Object.entries(defaults.cq)) {
+      for (const key of Object.keys(cqOverrides) as (keyof CqOverrides)[]) {
+        if (overrides[key] != null) continue;
+        const value = cqOverrides[key];
+        if (value != null) classes.push(emitDim(key, value, `@${breakpoint}:`));
+      }
+    }
+  }
+
+  return classes.join(' ');
+}
+
 /**
- * Build Tailwind utility classes from token props.
- * Returns a string of override classes or empty string if no overrides.
- *
- * Color resolution (in order):
- *   1. If the value names a registered fill token, resolve in text context.
- *      Solid fills -> text-{color} (+ opacity). Gradients -> bg-clip-text.
- *      e.g. color="hero" -> "bg-gradient-to-r from-primary to-primary/0 bg-clip-text text-transparent"
- *   2. Otherwise pass through as text-{value}:
- *      color="accent"            -> text-accent
- *      color="accent-foreground" -> text-accent-foreground
- *      color="muted-foreground"  -> text-muted-foreground
+ * Back-compat flat string map. Computed from the dimensional defaults.
+ * Prefer `resolveTypography(variant, props)` when overrides are in play.
+ */
+export const typographyClasses = Object.fromEntries(
+  (Object.keys(VARIANTS) as TypographyVariant[]).map((v) => [v, resolveTypography(v)]),
+) as Record<TypographyVariant, string>;
+
+/**
+ * @deprecated Use `resolveTypography(variant, props)` so overrides replace
+ * defaults instead of appending. Kept so existing consumers don't break.
  */
 export function tokenPropsToClasses(props: TypographyTokenProps): string {
   const classes: string[] = [];
-  if (props.size) classes.push(`text-${props.size}`);
-  if (props.weight) classes.push(`font-${props.weight}`);
-  if (props.color) {
-    const fillMeta = getFillMetadata(props.color);
-    if (fillMeta) {
-      classes.push(resolveFillClasses(fillMeta, 'text'));
-    } else {
-      classes.push(`text-${props.color}`);
-    }
+  for (const key of Object.keys(DIM_TO_UTIL) as (keyof TypographyTokenProps)[]) {
+    const value = props[key];
+    if (value != null) classes.push(emitDim(key, value));
   }
-  if (props.line) classes.push(`leading-${props.line}`);
-  if (props.tracking) classes.push(`tracking-${props.tracking}`);
-  if (props.family) classes.push(`font-${props.family}`);
-  if (props.align) classes.push(`text-${props.align}`);
-  if (props.transform) classes.push(props.transform);
   return classes.join(' ');
 }

--- a/packages/ui/src/components/ui/typography.tsx
+++ b/packages/ui/src/components/ui/typography.tsx
@@ -75,8 +75,8 @@ export interface EditableTypographyProps {
 // ============================================================================
 
 import {
+  resolveTypography,
   type TypographyTokenProps,
-  tokenPropsToClasses,
   typographyClasses,
 } from './typography.classes';
 
@@ -944,6 +944,8 @@ export const H1 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
       line,
       tracking,
       family,
+      align,
+      transform,
       editable,
       onChange,
       onFocus,
@@ -968,8 +970,6 @@ export const H1 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
       onBackspaceAtStart,
     });
 
-    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
-
     const combinedRef = (element: HTMLHeadingElement | null) => {
       (elementRef as React.MutableRefObject<HTMLElement | null>).current = element;
       if (typeof ref === 'function') {
@@ -983,8 +983,16 @@ export const H1 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
       <h1
         ref={combinedRef}
         className={classy(
-          typographyClasses.h1,
-          overrides,
+          resolveTypography('h1', {
+            size,
+            weight,
+            color,
+            line,
+            tracking,
+            family,
+            align,
+            transform,
+          }),
           editable && 'outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 rounded',
           className,
         )}
@@ -1015,6 +1023,8 @@ export const H2 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
       line,
       tracking,
       family,
+      align,
+      transform,
       editable,
       onChange,
       onFocus,
@@ -1039,8 +1049,6 @@ export const H2 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
       onBackspaceAtStart,
     });
 
-    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
-
     const combinedRef = (element: HTMLHeadingElement | null) => {
       (elementRef as React.MutableRefObject<HTMLElement | null>).current = element;
       if (typeof ref === 'function') {
@@ -1054,8 +1062,16 @@ export const H2 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
       <h2
         ref={combinedRef}
         className={classy(
-          typographyClasses.h2,
-          overrides,
+          resolveTypography('h2', {
+            size,
+            weight,
+            color,
+            line,
+            tracking,
+            family,
+            align,
+            transform,
+          }),
           editable && 'outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 rounded',
           className,
         )}
@@ -1086,6 +1102,8 @@ export const H3 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
       line,
       tracking,
       family,
+      align,
+      transform,
       editable,
       onChange,
       onFocus,
@@ -1110,8 +1128,6 @@ export const H3 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
       onBackspaceAtStart,
     });
 
-    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
-
     const combinedRef = (element: HTMLHeadingElement | null) => {
       (elementRef as React.MutableRefObject<HTMLElement | null>).current = element;
       if (typeof ref === 'function') {
@@ -1125,8 +1141,16 @@ export const H3 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
       <h3
         ref={combinedRef}
         className={classy(
-          typographyClasses.h3,
-          overrides,
+          resolveTypography('h3', {
+            size,
+            weight,
+            color,
+            line,
+            tracking,
+            family,
+            align,
+            transform,
+          }),
           editable && 'outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 rounded',
           className,
         )}
@@ -1157,6 +1181,8 @@ export const H4 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
       line,
       tracking,
       family,
+      align,
+      transform,
       editable,
       onChange,
       onFocus,
@@ -1181,8 +1207,6 @@ export const H4 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
       onBackspaceAtStart,
     });
 
-    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
-
     const combinedRef = (element: HTMLHeadingElement | null) => {
       (elementRef as React.MutableRefObject<HTMLElement | null>).current = element;
       if (typeof ref === 'function') {
@@ -1196,8 +1220,16 @@ export const H4 = React.forwardRef<HTMLHeadingElement, EditableHeadingProps>(
       <h4
         ref={combinedRef}
         className={classy(
-          typographyClasses.h4,
-          overrides,
+          resolveTypography('h4', {
+            size,
+            weight,
+            color,
+            line,
+            tracking,
+            family,
+            align,
+            transform,
+          }),
           editable && 'outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 rounded',
           className,
         )}
@@ -1217,12 +1249,23 @@ H4.displayName = 'H4';
  * Use for fine-grained subsections. Shares visual treatment with H4.
  */
 export const H5 = React.forwardRef<HTMLHeadingElement, TypographyProps>(
-  ({ className, size, weight, color, line, tracking, family, ...props }, ref) => {
-    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+  ({ className, size, weight, color, line, tracking, family, align, transform, ...props }, ref) => {
     return (
       <h5
         ref={ref as React.Ref<HTMLHeadingElement>}
-        className={classy(typographyClasses.h4, overrides, className)}
+        className={classy(
+          resolveTypography('h4', {
+            size,
+            weight,
+            color,
+            line,
+            tracking,
+            family,
+            align,
+            transform,
+          }),
+          className,
+        )}
         {...props}
       />
     );
@@ -1235,12 +1278,23 @@ H5.displayName = 'H5';
  * Use for the finest subsections. Shares visual treatment with H4.
  */
 export const H6 = React.forwardRef<HTMLHeadingElement, TypographyProps>(
-  ({ className, size, weight, color, line, tracking, family, ...props }, ref) => {
-    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+  ({ className, size, weight, color, line, tracking, family, align, transform, ...props }, ref) => {
     return (
       <h6
         ref={ref as React.Ref<HTMLHeadingElement>}
-        className={classy(typographyClasses.h4, overrides, className)}
+        className={classy(
+          resolveTypography('h4', {
+            size,
+            weight,
+            color,
+            line,
+            tracking,
+            family,
+            align,
+            transform,
+          }),
+          className,
+        )}
         {...props}
       />
     );
@@ -1287,6 +1341,8 @@ export const P = React.forwardRef<HTMLParagraphElement, EditableParagraphProps>(
       line,
       tracking,
       family,
+      align,
+      transform,
       editable,
       onChange,
       onFocus,
@@ -1315,9 +1371,6 @@ export const P = React.forwardRef<HTMLParagraphElement, EditableParagraphProps>(
       onSlashCommand,
     });
 
-    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
-
-    // Combine refs
     const combinedRef = (element: HTMLParagraphElement | null) => {
       (elementRef as React.MutableRefObject<HTMLElement | null>).current = element;
       if (typeof ref === 'function') {
@@ -1331,8 +1384,7 @@ export const P = React.forwardRef<HTMLParagraphElement, EditableParagraphProps>(
       <p
         ref={combinedRef}
         className={classy(
-          typographyClasses.p,
-          overrides,
+          resolveTypography('p', { size, weight, color, line, tracking, family, align, transform }),
           editable && 'outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 rounded',
           className,
         )}
@@ -1352,12 +1404,23 @@ P.displayName = 'P';
  * For fine print, captions, or supporting text
  */
 export const Small = React.forwardRef<HTMLElement, TypographyProps>(
-  ({ className, size, weight, color, line, tracking, family, ...props }, ref) => {
-    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+  ({ className, size, weight, color, line, tracking, family, align, transform, ...props }, ref) => {
     return (
       <small
         ref={ref as React.Ref<HTMLElement>}
-        className={classy(typographyClasses.small, overrides, className)}
+        className={classy(
+          resolveTypography('small', {
+            size,
+            weight,
+            color,
+            line,
+            tracking,
+            family,
+            align,
+            transform,
+          }),
+          className,
+        )}
         {...props}
       />
     );
@@ -1370,12 +1433,23 @@ Small.displayName = 'Small';
  * Monospace text for code snippets, commands, or technical terms
  */
 export const Code = React.forwardRef<HTMLElement, TypographyProps>(
-  ({ className, size, weight, color, line, tracking, family, ...props }, ref) => {
-    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+  ({ className, size, weight, color, line, tracking, family, align, transform, ...props }, ref) => {
     return (
       <code
         ref={ref as React.Ref<HTMLElement>}
-        className={classy(typographyClasses.code, overrides, className)}
+        className={classy(
+          resolveTypography('code', {
+            size,
+            weight,
+            color,
+            line,
+            tracking,
+            family,
+            align,
+            transform,
+          }),
+          className,
+        )}
         {...props}
       />
     );
@@ -1418,6 +1492,8 @@ export const Blockquote = React.forwardRef<HTMLQuoteElement, EditableQuoteProps>
       line,
       tracking,
       family,
+      align,
+      transform,
       editable,
       onChange,
       onFocus,
@@ -1446,8 +1522,6 @@ export const Blockquote = React.forwardRef<HTMLQuoteElement, EditableQuoteProps>
       onSelectionChange,
     });
 
-    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
-
     const citationRef = useRef<HTMLElement>(null);
 
     const handleCitationInput = useCallback(() => {
@@ -1470,8 +1544,16 @@ export const Blockquote = React.forwardRef<HTMLQuoteElement, EditableQuoteProps>
       <blockquote
         ref={combinedRef}
         className={classy(
-          typographyClasses.blockquote,
-          overrides,
+          resolveTypography('blockquote', {
+            size,
+            weight,
+            color,
+            line,
+            tracking,
+            family,
+            align,
+            transform,
+          }),
           editable && 'outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 rounded',
           className,
         )}
@@ -1974,12 +2056,23 @@ CodeBlock.displayName = 'CodeBlock';
  * ```
  */
 export const Mark = React.forwardRef<HTMLElement, TypographyProps>(
-  ({ className, size, weight, color, line, tracking, family, ...props }, ref) => {
-    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+  ({ className, size, weight, color, line, tracking, family, align, transform, ...props }, ref) => {
     return (
       <mark
         ref={ref as React.Ref<HTMLElement>}
-        className={classy(typographyClasses.mark, overrides, className)}
+        className={classy(
+          resolveTypography('mark', {
+            size,
+            weight,
+            color,
+            line,
+            tracking,
+            family,
+            align,
+            transform,
+          }),
+          className,
+        )}
         {...props}
       />
     );
@@ -1997,12 +2090,26 @@ Mark.displayName = 'Mark';
  * ```
  */
 export const Abbr = React.forwardRef<HTMLElement, TypographyProps & { title: string }>(
-  ({ className, size, weight, color, line, tracking, family, title, ...props }, ref) => {
-    const overrides = tokenPropsToClasses({ size, weight, color, line, tracking, family });
+  (
+    { className, size, weight, color, line, tracking, family, align, transform, title, ...props },
+    ref,
+  ) => {
     return (
       <abbr
         ref={ref as React.Ref<HTMLElement>}
-        className={classy(typographyClasses.abbr, overrides, className)}
+        className={classy(
+          resolveTypography('abbr', {
+            size,
+            weight,
+            color,
+            line,
+            tracking,
+            family,
+            align,
+            transform,
+          }),
+          className,
+        )}
         title={title}
         {...props}
       />

--- a/packages/ui/test/components/typography.test.tsx
+++ b/packages/ui/test/components/typography.test.tsx
@@ -439,21 +439,49 @@ describe('TypographyTokenProps', () => {
     expect(container.firstChild).toHaveClass('font-bold');
   });
 
-  it('Mark applies token overrides', () => {
+  it('Mark color override replaces the default color class', () => {
     const { container } = render(<Mark color="accent">highlighted</Mark>);
-    expect(container.firstChild).toHaveClass('text-accent-foreground');
+    const el = container.firstChild as HTMLElement;
+    expect(el).toHaveClass('text-accent');
+    expect(el).not.toHaveClass('text-accent-foreground');
+    expect(el).toHaveClass('bg-accent');
+    expect(el).toHaveClass('rounded');
   });
 
-  it('token overrides appear after base classes and before className', () => {
+  it('size override replaces the default size and drops matching CQ variants', () => {
     const { container } = render(
       <H1 size="xl" className="extra">
         Title
       </H1>,
     );
     const el = container.firstChild as HTMLElement;
-    expect(el).toHaveClass('text-4xl');
     expect(el).toHaveClass('text-xl');
+    expect(el).not.toHaveClass('text-4xl');
+    expect(el).not.toHaveClass('@lg:text-5xl');
+    expect(el).toHaveClass('scroll-m-20');
+    expect(el).toHaveClass('font-bold');
     expect(el).toHaveClass('extra');
+  });
+
+  it('color override replaces text-foreground default on headings', () => {
+    const { container } = render(<H1 color="accent">Title</H1>);
+    const el = container.firstChild as HTMLElement;
+    expect(el).toHaveClass('text-accent');
+    expect(el).not.toHaveClass('text-foreground');
+  });
+
+  it('weight override replaces font-bold default on H1', () => {
+    const { container } = render(<H1 weight="light">Title</H1>);
+    const el = container.firstChild as HTMLElement;
+    expect(el).toHaveClass('font-light');
+    expect(el).not.toHaveClass('font-bold');
+  });
+
+  it('CQ variant survives when the matching dimension is not overridden', () => {
+    const { container } = render(<H1 color="accent">Title</H1>);
+    const el = container.firstChild as HTMLElement;
+    expect(el).toHaveClass('@lg:text-5xl');
+    expect(el).toHaveClass('text-4xl');
   });
 });
 


### PR DESCRIPTION
## Summary

Token props on typography (`color`, `size`, `weight`, `line`, `tracking`, `family`, `align`, `transform`) now replace the matching default dimension at emit time instead of appending on top of a flat default string.

Tailwind v4 orders utilities alphabetically in generated CSS, so the cascade cannot be trusted for overrides:
- `text-accent` would lose to default `text-foreground` (a < f)
- `text-2xl` override would lose to default `text-4xl`
- `@lg:text-5xl` CQ defaults survived bare size overrides

Audited the other 50+ UI components -- they're fine because they use map-lookup replacement patterns (`variantClasses[v]`, `sizeClasses[s]`) rather than flat-string append. Typography was the outlier because its props are free-form dimensions (not enum variants) and went through `tokenPropsToClasses` which appended.

## Approach

- `typography.classes.ts`: variant defaults stored dimensionally (`size`, `weight`, `color`, `line`, `tracking`, `family`, `align`, `transform` + optional `layout` extras + `cq` responsive overrides), resolved via `resolveTypography(variant, props)`.
- Resolver reads `overrides[key] ?? defaults[key]` per dimension and emits utilities through a single `DIM_TO_UTIL` map -- one source of truth for the dimension-to-Tailwind mapping.
- `emitProps` shared primitive handles both the base emit and the CQ-prefixed emit; `tokenPropsToClasses` is a one-line wrapper kept as a test-only entry point.
- CQ variants survive only where the matching dimension isn't overridden (so `size="2xl"` correctly drops `@lg:text-5xl`).
- `typographyClasses` flat-string export preserved for consumers that don't take token props (List's `li`, CodeBlock wrapper), computed from the dimensional defaults.
- All React + Astro typography components switched to `resolveTypography`. Missing `align`/`transform` destructures added to React variants for parity with Astro.
- `classy` unchanged.
- One-line `.gitignore` chore adds `.scratch/` so scratchwork doesn't gate pushes via biome.

## Test plan

- [x] `pnpm --filter=@rafters/ui test typography` -- 288 tests pass
- [x] Full `@rafters/ui` suite -- 4907 pass, 6 pre-existing skips
- [x] Typecheck + lint + preflight green
- [x] Override-replaces-default asserted for color, size, weight
- [x] CQ variant survives when the matching dimension is not overridden