### PR TITLE
fix(design-tokens): backfill generationRule for legacy semantic tokens

### DIFF
--- a/packages/design-tokens/src/plugins.ts
+++ b/packages/design-tokens/src/plugins.ts
@@ -22,7 +22,7 @@ import {
 import { z } from 'zod';
 import { GenerationRuleParser } from './generation-rules';
 import type { TokenRegistry } from './registry';
-import { POSITION_TO_INDEX, SCALE_POSITION_MAP } from './scale-positions';
+import { POSITION_TO_INDEX, parseTokenPosition, SCALE_POSITION_MAP } from './scale-positions';
 
 function hasPosition(v: unknown): v is { family?: string; position: string | number } {
   return typeof v === 'object' && v !== null && 'position' in v;
@@ -297,19 +297,10 @@ export function resolveInput(
 
       // Extract light index from dependency[1] (dark position token) or token name
       let basePosition = 5;
-      const darkDepName = dependencies[1];
-      if (darkDepName) {
-        const posMatch = darkDepName.match(/-(\d+)$/);
-        if (posMatch?.[1]) {
-          const idx = POSITION_TO_INDEX[posMatch[1]];
-          if (idx !== undefined) basePosition = idx;
-        }
-      } else {
-        const nameMatch = tokenName.match(/-(\d+)$/);
-        if (nameMatch?.[1]) {
-          const idx = POSITION_TO_INDEX[nameMatch[1]];
-          if (idx !== undefined) basePosition = idx;
-        }
+      const positionString = parseTokenPosition(dependencies[1] ?? tokenName);
+      if (positionString) {
+        const idx = POSITION_TO_INDEX[positionString];
+        if (idx !== undefined) basePosition = idx;
       }
 
       return {

--- a/packages/design-tokens/src/registry.ts
+++ b/packages/design-tokens/src/registry.ts
@@ -19,7 +19,12 @@ import { TokenDependencyGraph } from './dependencies';
 import { resolveColorReference } from './oklch-to-css';
 import type { PersistenceAdapter } from './persistence/types';
 import { cascade, regenerate } from './plugins';
-import { findDarkCounterpartIndex, INDEX_TO_POSITION, POSITION_TO_INDEX } from './scale-positions';
+import {
+  findDarkCounterpartIndex,
+  INDEX_TO_POSITION,
+  POSITION_TO_INDEX,
+  parseTokenPosition,
+} from './scale-positions';
 
 // Event types (inline to replace deleted types/events.js)
 export type TokenChangeEvent =
@@ -69,8 +74,8 @@ function inferSemanticGenerationRule(
   if (value && typeof value === 'object' && 'position' in value) {
     return `scale:${(value as ColorReference).position}`;
   }
-  const positionMatch = dependsOn[0]?.match(/-(\d+)$/);
-  return positionMatch ? `scale:${positionMatch[1]}` : null;
+  const position = dependsOn[0] ? parseTokenPosition(dependsOn[0]) : null;
+  return position ? `scale:${position}` : null;
 }
 
 export class TokenRegistry {

--- a/packages/design-tokens/src/registry.ts
+++ b/packages/design-tokens/src/registry.ts
@@ -49,6 +49,30 @@ export type TokenChangeEvent =
 
 export type RegistryChangeCallback = (event: TokenChangeEvent) => void | Promise<void>;
 
+/**
+ * Mirrors deriveGenerationRule in generators/semantic.ts. Kept local to avoid
+ * registry → generators import direction. If the rule patterns change, update both.
+ */
+function inferSemanticGenerationRule(
+  name: string,
+  value: Token['value'],
+  dependsOn: string[],
+): string | null {
+  if (name.endsWith('-foreground') || name.endsWith('-text') || name.endsWith('-contrast')) {
+    return 'contrast:auto';
+  }
+  if (name.endsWith('-hover')) return 'state:hover';
+  if (name.endsWith('-active')) return 'state:active';
+  if (name.endsWith('-focus')) return 'state:focus';
+  if (name.endsWith('-disabled')) return 'state:disabled';
+
+  if (value && typeof value === 'object' && 'position' in value) {
+    return `scale:${(value as ColorReference).position}`;
+  }
+  const positionMatch = dependsOn[0]?.match(/-(\d+)$/);
+  return positionMatch ? `scale:${positionMatch[1]}` : null;
+}
+
 export class TokenRegistry {
   private tokens: Map<string, Token> = new Map();
   public dependencyGraph: TokenDependencyGraph = new TokenDependencyGraph();
@@ -71,20 +95,32 @@ export class TokenRegistry {
   /**
    * Populate dependency graph from tokens that have dependsOn/generationRule.
    * Called after bulk loading to ensure all dependency targets exist.
+   *
+   * Self-healing backfill: semantic tokens persisted by older rafters versions
+   * may have dependsOn but no generationRule. Without it, populateDependencyGraph
+   * skips them and the cascade silently breaks. Infer the rule from name + dependsOn
+   * shape so existing projects cascade correctly without an on-disk migration.
    */
   private populateDependencyGraph(): void {
     for (const token of this.tokens.values()) {
-      if (token.dependsOn && token.dependsOn.length > 0 && token.generationRule) {
-        const missingDeps = token.dependsOn.filter((dep) => !this.tokens.has(dep));
-        if (missingDeps.length > 0) {
-          console.warn(
-            `[TokenRegistry] Token "${token.name}" skipped in dependency graph: ` +
-              `missing dependencies [${missingDeps.join(', ')}]`,
-          );
-          continue;
-        }
-        this.dependencyGraph.addDependency(token.name, token.dependsOn, token.generationRule);
+      if (!token.dependsOn || token.dependsOn.length === 0) continue;
+
+      if (!token.generationRule && token.namespace === 'semantic') {
+        const inferred = inferSemanticGenerationRule(token.name, token.value, token.dependsOn);
+        if (inferred) token.generationRule = inferred;
       }
+
+      if (!token.generationRule) continue;
+
+      const missingDeps = token.dependsOn.filter((dep) => !this.tokens.has(dep));
+      if (missingDeps.length > 0) {
+        console.warn(
+          `[TokenRegistry] Token "${token.name}" skipped in dependency graph: ` +
+            `missing dependencies [${missingDeps.join(', ')}]`,
+        );
+        continue;
+      }
+      this.dependencyGraph.addDependency(token.name, token.dependsOn, token.generationRule);
     }
   }
 

--- a/packages/design-tokens/src/scale-positions.ts
+++ b/packages/design-tokens/src/scale-positions.ts
@@ -66,6 +66,15 @@ for (const [pos, idx] of Object.entries(SCALE_POSITION_MAP)) {
 
 export const VALID_SCALE_POSITIONS = Object.keys(SCALE_POSITION_MAP).map(Number);
 
+/**
+ * Extract the numeric scale position suffix from a token name.
+ * "silver-true-sky-200" -> "200", "neutral" -> null.
+ */
+export function parseTokenPosition(tokenName: string): string | null {
+  const match = tokenName.match(/-(\d+)$/);
+  return match?.[1] ?? null;
+}
+
 /** Minimum index distance for a WCAG pair to be considered usable. */
 export const MIN_WCAG_PAIR_DISTANCE = 3;
 

--- a/packages/design-tokens/test/semantic-cascade.test.ts
+++ b/packages/design-tokens/test/semantic-cascade.test.ts
@@ -283,3 +283,39 @@ describe('applyComputed cascade behavior', () => {
     expect(afterVal.position).toBe(beforeVal.position);
   });
 });
+
+describe('legacy semantic token backfill', () => {
+  it('cascades semantic tokens loaded without generationRule', async () => {
+    const result = generateBaseSystem();
+    const legacyTokens: Token[] = result.allTokens.map((t) =>
+      t.namespace === 'semantic' ? { ...t, generationRule: undefined } : t,
+    );
+
+    const registry = new TokenRegistry(legacyTokens);
+
+    const { buildColorValue } = await import('@rafters/color-utils');
+    const teal = buildColorValue({ l: 0.5, c: 0.1, h: 180 }, { token: 'neutral' });
+    await registry.set('neutral', teal);
+
+    const primary = registry.get('primary') as Token;
+    expect(primary.dependsOn?.[0]).toBe('neutral');
+    expect((primary.value as ColorReference).family).toBe('neutral');
+
+    const primaryHover = registry.get('primary-hover') as Token;
+    expect((primaryHover.value as ColorReference).family).toBe('neutral');
+
+    const primaryForeground = registry.get('primary-foreground') as Token;
+    expect((primaryForeground.value as ColorReference).family).toBe('neutral');
+  });
+
+  it('preserves explicit generationRule when present (no double-write)', () => {
+    const result = generateBaseSystem();
+    const registry = new TokenRegistry(result.allTokens);
+
+    const primary = registry.get('primary') as Token;
+    expect(primary.generationRule).toBeDefined();
+
+    const primaryFg = registry.get('primary-foreground') as Token;
+    expect(primaryFg.generationRule).toBe('contrast:auto');
+  });
+});


### PR DESCRIPTION
## Summary

Existing rafters projects' on-disk `semantic.rafters.json` was authored before `semantic.ts` started writing `generationRule`. `populateDependencyGraph` requires both `dependsOn` AND `generationRule` to enter the dependency graph, so legacy semantic tokens are silently skipped at registry init -- the cascade is dormant on every project initialized before the fix shipped.

Verified in this repo: 198/198 semantic tokens in `.rafters/tokens/semantic.rafters.json` have `generationRule = null`. Setting `accent` to a new family via the studio API would update only the seed; every variant (`-foreground`, `-hover`, `-active`, `-border`, `-ring`) would stay pointing at the previous family. Designer sees a half-themed UI.

Self-heal at registry init by inferring the rule from the token name suffix and `dependsOn[0]` shape:
- `-foreground` / `-text` / `-contrast` -> `contrast:auto`
- `-hover` / `-active` / `-focus` / `-disabled` -> `state:*`
- everything else -> `scale:N` from value position or `dependsOn[0]` suffix

In-memory only -- no on-disk migration. The next normal write through the persist path picks up the backfilled rule.

Includes a small refactor: extracted `parseTokenPosition()` to `scale-positions.ts` to consolidate three inlined copies of the same regex.

## Test plan

- [x] New `legacy semantic token backfill` describe block in `packages/design-tokens/test/semantic-cascade.test.ts`
- [x] `cascades semantic tokens loaded without generationRule` -- strips `generationRule` from generated tokens, constructs registry, cascades neutral, asserts primary + primary-hover + primary-foreground all follow
- [x] `preserves explicit generationRule when present` -- regression guard so live-generated tokens still carry their explicit rule
- [x] All 294 design-tokens tests green
- [ ] Manual studio-server verification with accent -> silver-true-honey + highlight -> silver-true-sky (pending; the broken-cascade evidence motivated this fix, in-DOM verification of the fix still owed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)