### PR TITLE
feat(ui): tree primitive (headless WAI-ARIA tree)

### DIFF
--- a/packages/ui/src/primitives/tree.test.ts
+++ b/packages/ui/src/primitives/tree.test.ts
@@ -1,0 +1,387 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createTree, type TreeNode } from './tree';
+
+interface FileLike {
+  name: string;
+}
+
+const fileTree: TreeNode<FileLike>[] = [
+  {
+    id: 'src',
+    data: { name: 'src' },
+    children: [
+      { id: 'src/index.ts', data: { name: 'index.ts' } },
+      {
+        id: 'src/lib',
+        data: { name: 'lib' },
+        children: [
+          { id: 'src/lib/util.ts', data: { name: 'util.ts' } },
+          {
+            id: 'src/lib/deep',
+            data: { name: 'deep' },
+            children: [{ id: 'src/lib/deep/leaf.ts', data: { name: 'leaf.ts' } }],
+          },
+        ],
+      },
+    ],
+  },
+  { id: 'README.md', data: { name: 'README.md' } },
+  { id: 'package.json', data: { name: 'package.json' } },
+];
+
+describe('createTree -- construction', () => {
+  it('starts with no focus, given selected, given expanded', () => {
+    const tree = createTree({
+      nodes: fileTree,
+      defaultExpanded: ['src'],
+      defaultSelected: ['README.md'],
+    });
+    expect(tree.state.focused).toBeNull();
+    expect([...tree.state.expanded]).toEqual(['src']);
+    expect([...tree.state.selected]).toEqual(['README.md']);
+  });
+
+  it('rejects duplicate ids', () => {
+    expect(() =>
+      createTree({
+        nodes: [
+          { id: 'a', data: { name: 'a' } },
+          { id: 'a', data: { name: 'a2' } },
+        ],
+      }),
+    ).toThrow(/duplicate node id/);
+  });
+
+  it('drops unknown ids from defaults', () => {
+    const tree = createTree({
+      nodes: fileTree,
+      defaultExpanded: ['nope'],
+      defaultSelected: ['also-nope'],
+    });
+    expect(tree.state.expanded.size).toBe(0);
+    expect(tree.state.selected.size).toBe(0);
+  });
+});
+
+describe('expand / collapse / toggle', () => {
+  it('expands and collapses, fires onExpandedChange', () => {
+    const onExpandedChange = vi.fn();
+    const tree = createTree({ nodes: fileTree, onExpandedChange });
+    tree.expand('src');
+    expect(tree.state.expanded.has('src')).toBe(true);
+    expect(onExpandedChange).toHaveBeenLastCalledWith(new Set(['src']));
+    tree.collapse('src');
+    expect(tree.state.expanded.has('src')).toBe(false);
+  });
+
+  it('toggle flips expansion', () => {
+    const tree = createTree({ nodes: fileTree });
+    tree.toggle('src');
+    expect(tree.state.expanded.has('src')).toBe(true);
+    tree.toggle('src');
+    expect(tree.state.expanded.has('src')).toBe(false);
+  });
+
+  it('expand is a no-op for leaf nodes', () => {
+    const onExpandedChange = vi.fn();
+    const tree = createTree({ nodes: fileTree, onExpandedChange });
+    tree.expand('README.md');
+    expect(tree.state.expanded.size).toBe(0);
+    expect(onExpandedChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('keyboard movement', () => {
+  it('moveNext walks visible order', () => {
+    const tree = createTree({ nodes: fileTree, defaultExpanded: ['src'] });
+    expect(tree.moveNext()).toBe('src');
+    expect(tree.moveNext()).toBe('src/index.ts');
+    expect(tree.moveNext()).toBe('src/lib');
+    expect(tree.moveNext()).toBe('README.md');
+    expect(tree.moveNext()).toBe('package.json');
+    // at end, stays put
+    expect(tree.moveNext()).toBe('package.json');
+  });
+
+  it('movePrev walks backward through visible order', () => {
+    const tree = createTree({ nodes: fileTree, defaultExpanded: ['src'] });
+    tree.moveLast();
+    expect(tree.state.focused).toBe('package.json');
+    expect(tree.movePrev()).toBe('README.md');
+    expect(tree.movePrev()).toBe('src/lib');
+    expect(tree.movePrev()).toBe('src/index.ts');
+    expect(tree.movePrev()).toBe('src');
+    // at start, stays put
+    expect(tree.movePrev()).toBe('src');
+  });
+
+  it('moveIn on a collapsed node expands it without moving focus', () => {
+    const tree = createTree({ nodes: fileTree });
+    tree.focus('src');
+    expect(tree.moveIn()).toBe('src');
+    expect(tree.state.expanded.has('src')).toBe(true);
+    expect(tree.state.focused).toBe('src');
+  });
+
+  it('moveIn on an expanded parent steps into the first child', () => {
+    const tree = createTree({ nodes: fileTree, defaultExpanded: ['src'] });
+    tree.focus('src');
+    expect(tree.moveIn()).toBe('src/index.ts');
+  });
+
+  it('moveOut on an expanded parent collapses it (focus stays)', () => {
+    const tree = createTree({ nodes: fileTree, defaultExpanded: ['src'] });
+    tree.focus('src');
+    expect(tree.moveOut()).toBe('src');
+    expect(tree.state.expanded.has('src')).toBe(false);
+  });
+
+  it('moveOut on a child moves to the parent', () => {
+    const tree = createTree({ nodes: fileTree, defaultExpanded: ['src'] });
+    tree.focus('src/index.ts');
+    expect(tree.moveOut()).toBe('src');
+  });
+
+  it('moveOut on a root leaf stays put', () => {
+    const tree = createTree({ nodes: fileTree });
+    tree.focus('README.md');
+    expect(tree.moveOut()).toBe('README.md');
+  });
+
+  it('moveFirst / moveLast go to ends of visible order', () => {
+    const tree = createTree({ nodes: fileTree, defaultExpanded: ['src', 'src/lib'] });
+    expect(tree.moveFirst()).toBe('src');
+    expect(tree.moveLast()).toBe('package.json');
+  });
+
+  it('typeahead jumps to next visible node by first letter, wrapping', () => {
+    const tree = createTree({ nodes: fileTree, defaultExpanded: ['src'] });
+    tree.focus('src');
+    // 'r' jumps to README.md
+    expect(tree.typeahead('r')).toBe('README.md');
+    // 'p' jumps to package.json
+    expect(tree.typeahead('p')).toBe('package.json');
+    // 'i' wraps and jumps back to src/index.ts
+    expect(tree.typeahead('i')).toBe('src/index.ts');
+    // unknown letter returns null
+    expect(tree.typeahead('z')).toBeNull();
+  });
+});
+
+describe('selection -- single mode (default)', () => {
+  it('select replaces and notifies', () => {
+    const onSelectedChange = vi.fn();
+    const tree = createTree({ nodes: fileTree, onSelectedChange });
+    tree.select('README.md');
+    expect([...tree.state.selected]).toEqual(['README.md']);
+    expect(onSelectedChange).toHaveBeenLastCalledWith(new Set(['README.md']));
+    tree.select('package.json');
+    expect([...tree.state.selected]).toEqual(['package.json']);
+  });
+
+  it('append / range options are ignored in single mode', () => {
+    const tree = createTree({ nodes: fileTree });
+    tree.select('README.md');
+    tree.select('package.json', { append: true });
+    expect([...tree.state.selected]).toEqual(['package.json']);
+  });
+});
+
+describe('selection -- multiple mode', () => {
+  it('append toggles membership', () => {
+    const tree = createTree({ nodes: fileTree, selectionMode: 'multiple' });
+    tree.select('README.md');
+    tree.select('package.json', { append: true });
+    expect(tree.state.selected.has('README.md')).toBe(true);
+    expect(tree.state.selected.has('package.json')).toBe(true);
+    // toggling off
+    tree.select('README.md', { append: true });
+    expect(tree.state.selected.has('README.md')).toBe(false);
+  });
+
+  it('range selects across visible (flattened) order', () => {
+    const tree = createTree({
+      nodes: fileTree,
+      selectionMode: 'multiple',
+      defaultExpanded: ['src'],
+    });
+    tree.select('src/index.ts');
+    tree.select('package.json', { range: true });
+    expect([...tree.state.selected]).toEqual([
+      'src/index.ts',
+      'src/lib',
+      'README.md',
+      'package.json',
+    ]);
+  });
+
+  it('range works backward too', () => {
+    const tree = createTree({
+      nodes: fileTree,
+      selectionMode: 'multiple',
+      defaultExpanded: ['src'],
+    });
+    tree.select('package.json');
+    tree.select('src/index.ts', { range: true });
+    expect(tree.state.selected.size).toBe(4);
+    expect(tree.state.selected.has('src/lib')).toBe(true);
+  });
+});
+
+describe('selection -- none mode', () => {
+  it('select is a no-op', () => {
+    const onSelectedChange = vi.fn();
+    const tree = createTree({
+      nodes: fileTree,
+      selectionMode: 'none',
+      onSelectedChange,
+    });
+    tree.select('README.md');
+    expect(tree.state.selected.size).toBe(0);
+    expect(onSelectedChange).not.toHaveBeenCalled();
+  });
+
+  it('getNodeProps omits ariaSelected when selectionMode is none', () => {
+    const tree = createTree({ nodes: fileTree, selectionMode: 'none' });
+    const props = tree.getNodeProps('README.md');
+    expect(props.ariaSelected).toBeUndefined();
+  });
+});
+
+describe('focus + activate', () => {
+  it('focus updates state and notifies', () => {
+    const onFocusChange = vi.fn();
+    const tree = createTree({ nodes: fileTree, onFocusChange });
+    tree.focus('README.md');
+    expect(tree.state.focused).toBe('README.md');
+    expect(onFocusChange).toHaveBeenLastCalledWith('README.md');
+  });
+
+  it('activate fires onActivate and focuses', () => {
+    const onActivate = vi.fn();
+    const tree = createTree({ nodes: fileTree, onActivate });
+    tree.activate('README.md');
+    expect(onActivate).toHaveBeenCalledWith('README.md');
+    expect(tree.state.focused).toBe('README.md');
+  });
+});
+
+describe('ARIA prop bags', () => {
+  it('getRootProps returns role=tree', () => {
+    const tree = createTree({ nodes: fileTree });
+    expect(tree.getRootProps()).toEqual({ role: 'tree' });
+  });
+
+  it('getGroupProps returns role=group', () => {
+    const tree = createTree({ nodes: fileTree });
+    expect(tree.getGroupProps('src')).toEqual({ role: 'group' });
+  });
+
+  it('getNodeProps -- root leaf', () => {
+    const tree = createTree({ nodes: fileTree });
+    expect(tree.getNodeProps('README.md')).toEqual({
+      role: 'treeitem',
+      ariaLevel: 1,
+      ariaSetsize: 3,
+      ariaPosinset: 2,
+      ariaSelected: false,
+      tabIndex: -1,
+    });
+  });
+
+  it('getNodeProps -- root parent (collapsed) reports ariaExpanded=false', () => {
+    const tree = createTree({ nodes: fileTree });
+    const props = tree.getNodeProps('src');
+    expect(props.ariaExpanded).toBe(false);
+    expect(props.ariaLevel).toBe(1);
+    expect(props.ariaSetsize).toBe(3);
+    expect(props.ariaPosinset).toBe(1);
+  });
+
+  it('getNodeProps -- nested child reports correct level/setsize/posinset', () => {
+    const tree = createTree({ nodes: fileTree, defaultExpanded: ['src'] });
+    expect(tree.getNodeProps('src/index.ts')).toEqual({
+      role: 'treeitem',
+      ariaLevel: 2,
+      ariaSetsize: 2,
+      ariaPosinset: 1,
+      ariaSelected: false,
+      tabIndex: -1,
+    });
+    expect(tree.getNodeProps('src/lib')).toMatchObject({
+      ariaLevel: 2,
+      ariaPosinset: 2,
+      ariaExpanded: false,
+    });
+  });
+
+  it('focused node has tabIndex 0; others -1', () => {
+    const tree = createTree({ nodes: fileTree });
+    tree.focus('package.json');
+    expect(tree.getNodeProps('package.json').tabIndex).toBe(0);
+    expect(tree.getNodeProps('README.md').tabIndex).toBe(-1);
+  });
+
+  it('selected node reports ariaSelected=true', () => {
+    const tree = createTree({ nodes: fileTree, defaultSelected: ['README.md'] });
+    expect(tree.getNodeProps('README.md').ariaSelected).toBe(true);
+    expect(tree.getNodeProps('package.json').ariaSelected).toBe(false);
+  });
+
+  it('hasChildren hint surfaces ariaExpanded even when children is empty', () => {
+    const lazy: TreeNode<FileLike>[] = [{ id: 'a', data: { name: 'a' }, hasChildren: true }];
+    const tree = createTree({ nodes: lazy });
+    expect(tree.getNodeProps('a').ariaExpanded).toBe(false);
+  });
+
+  it('throws on unknown id', () => {
+    const tree = createTree({ nodes: fileTree });
+    expect(() => tree.getNodeProps('nope')).toThrow(/unknown id/);
+  });
+});
+
+describe('multi-root', () => {
+  it('treats every root as a top-level treeitem at level 1', () => {
+    const multi: TreeNode<FileLike>[] = [
+      { id: 'a', data: { name: 'a' } },
+      { id: 'b', data: { name: 'b' }, children: [{ id: 'b/x', data: { name: 'x' } }] },
+      { id: 'c', data: { name: 'c' } },
+    ];
+    const tree = createTree({ nodes: multi, defaultExpanded: ['b'] });
+    expect(tree.getNodeProps('a')).toMatchObject({ ariaLevel: 1, ariaSetsize: 3, ariaPosinset: 1 });
+    expect(tree.getNodeProps('b')).toMatchObject({ ariaLevel: 1, ariaSetsize: 3, ariaPosinset: 2 });
+    expect(tree.getNodeProps('c')).toMatchObject({ ariaLevel: 1, ariaSetsize: 3, ariaPosinset: 3 });
+    // movement crosses roots
+    tree.focus('a');
+    expect(tree.moveNext()).toBe('b');
+    expect(tree.moveNext()).toBe('b/x');
+    expect(tree.moveNext()).toBe('c');
+  });
+});
+
+describe('deeply nested (3+ levels)', () => {
+  it('reports correct levels at depth', () => {
+    const tree = createTree({
+      nodes: fileTree,
+      defaultExpanded: ['src', 'src/lib', 'src/lib/deep'],
+    });
+    expect(tree.getNodeProps('src').ariaLevel).toBe(1);
+    expect(tree.getNodeProps('src/lib').ariaLevel).toBe(2);
+    expect(tree.getNodeProps('src/lib/deep').ariaLevel).toBe(3);
+    expect(tree.getNodeProps('src/lib/deep/leaf.ts').ariaLevel).toBe(4);
+  });
+
+  it('moveOut climbs one level at a time from deep nodes', () => {
+    const tree = createTree({
+      nodes: fileTree,
+      defaultExpanded: ['src', 'src/lib', 'src/lib/deep'],
+    });
+    tree.focus('src/lib/deep/leaf.ts');
+    expect(tree.moveOut()).toBe('src/lib/deep');
+    // now on an expanded node -- moveOut collapses
+    expect(tree.moveOut()).toBe('src/lib/deep');
+    expect(tree.state.expanded.has('src/lib/deep')).toBe(false);
+    // next moveOut walks to parent
+    expect(tree.moveOut()).toBe('src/lib');
+  });
+});

--- a/packages/ui/src/primitives/tree.ts
+++ b/packages/ui/src/primitives/tree.ts
@@ -1,0 +1,530 @@
+/**
+ * Tree primitive - headless WAI-ARIA tree state machine
+ *
+ * Pure state machine for hierarchical lists. Owns expansion, focus,
+ * selection (single/multi/range), keyboard movement, typeahead, and
+ * the ARIA prop bag for `tree`, `treeitem`, and `group`. Does not own
+ * data fetching, rendering, or drag-and-drop -- consumers wire those.
+ *
+ * WCAG / ARIA Compliance:
+ * - WAI-ARIA Authoring Practices: Tree View pattern
+ * - 2.1.1 Keyboard (Level A): Arrow keys, Home/End, typeahead all available
+ * - 4.1.2 Name, Role, Value (Level A): role/level/setsize/posinset/expanded/selected
+ *   surfaced through `getRootProps`, `getGroupProps`, and `getNodeProps`.
+ *
+ * Multi-root: ARIA `tree` permits multiple top-level `treeitem` children.
+ * `nodes` is an array; pass more than one root and selection / movement
+ * traverse all of them in document order.
+ *
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
+ *
+ * @registry-name tree
+ * @registry-version 0.1.0
+ * @registry-status published
+ * @registry-path primitives/tree.ts
+ * @registry-type registry:primitive
+ *
+ * @cognitive-load 6/10 - Hierarchical state machine. Consumers reason about
+ *   nodes/expanded/selected/focused; the primitive hides the WAI-ARIA detail
+ *   behind getRootProps/getGroupProps/getNodeProps.
+ * @attention-economics One source of truth for expansion + selection + focus;
+ *   consumer renders, primitive decides.
+ * @trust-building Predictable keyboard model matches OS file trees: Arrow
+ *   Right expands then descends, Arrow Left collapses then ascends, range
+ *   selection follows visible (flattened) order.
+ * @accessibility Emits role="tree" on the root, role="group" on subtree
+ *   wrappers, role="treeitem" plus aria-level/setsize/posinset/expanded/selected
+ *   on items, and roving tabIndex (0 on focused, -1 elsewhere).
+ * @semantic-meaning Hierarchy + selection + focus, not presentation.
+ *
+ * @when-to-use
+ * - File explorers, content trees, nested navigation where users need to
+ *   expand/collapse and select nodes.
+ * - Any list whose items have parent/child structure and benefit from
+ *   keyboard traversal that mirrors the visible hierarchy.
+ *
+ * @when-not-to-use
+ * - Flat lists -- use a roving-focus list or listbox instead.
+ * - Async-loaded children today (v1 is sync). The future
+ *   `loadChildren?: (id) => Promise<TreeNode<T>[]>` extension is planned for
+ *   v2; until then, pre-load children and pass the full tree.
+ * - Drag-and-drop reordering -- this primitive exposes ids and order;
+ *   compose with `drag-drop.ts` and let the consumer commit the move.
+ *
+ * @dependencies
+ * @devDependencies
+ * @internal-dependencies
+ *
+ * @usage-patterns
+ * DO: Use createTree to manage expansion, focus, selection, and ARIA props
+ *   for any hierarchical list.
+ * DO: Spread `getRootProps()`, `getGroupProps(parentId)`, and
+ *   `getNodeProps(id)` onto your rendered elements -- the primitive owns
+ *   the WAI-ARIA contract.
+ * DO: Drive movement from keyboard handlers (`moveNext`, `movePrev`,
+ *   `moveIn`, `moveOut`, `moveFirst`, `moveLast`, `typeahead`).
+ * DO: Pass `selectionMode: 'multiple'` for range/append selection; default
+ *   is single.
+ * NEVER: Mutate `state.expanded` / `state.selected` directly -- use
+ *   `expand`, `collapse`, `toggle`, `select`, `focus`, `activate`.
+ * NEVER: Reuse `selection.ts` -- that primitive is editor-DOM /
+ *   contenteditable specific. Tree selection is hierarchy-aware.
+ * NEVER: Wire async children via this primitive in v1 -- pre-resolve and
+ *   pass a fully-populated `nodes` tree.
+ *
+ * @example
+ * ```ts
+ * const tree = createTree({
+ *   nodes: [
+ *     { id: 'src', data: { name: 'src' }, children: [
+ *       { id: 'src/index.ts', data: { name: 'index.ts' } },
+ *     ]},
+ *   ],
+ *   defaultExpanded: ['src'],
+ *   onActivate: (id) => openFile(id),
+ * });
+ * ```
+ */
+
+// ============================================================================
+// Public types
+// ============================================================================
+
+export interface TreeNode<T> {
+  /** Stable identifier. Required and unique across the whole tree. */
+  id: string;
+  /** Caller-defined payload (label, icon, status, etc.). */
+  data: T;
+  /** Optional child nodes. Omit or pass empty array for a leaf. */
+  children?: TreeNode<T>[];
+  /**
+   * Hint that the node has children even when `children` is empty.
+   * Useful for v2 async loading. In v1 this only affects `aria-expanded`
+   * (a node with `hasChildren: true` reports `aria-expanded` even when
+   * its `children` array is empty).
+   */
+  hasChildren?: boolean;
+}
+
+export type TreeSelectionMode = 'single' | 'multiple' | 'none';
+
+export interface TreeOptions<T> {
+  /** Root nodes. Multi-root is allowed and ARIA-conformant. */
+  nodes: TreeNode<T>[];
+  /** @default 'single' */
+  selectionMode?: TreeSelectionMode;
+  /** Ids expanded on construction. */
+  defaultExpanded?: string[];
+  /** Ids selected on construction. */
+  defaultSelected?: string[];
+  /** Fired whenever the expanded set changes. */
+  onExpandedChange?: (expanded: Set<string>) => void;
+  /** Fired whenever the selected set changes. */
+  onSelectedChange?: (selected: Set<string>) => void;
+  /** Fired whenever the focused id changes (including to null). */
+  onFocusChange?: (focused: string | null) => void;
+  /** Fired when a node is activated (Enter, double click, or `activate(id)`). */
+  onActivate?: (id: string) => void;
+}
+
+export interface TreeState {
+  expanded: Set<string>;
+  selected: Set<string>;
+  focused: string | null;
+}
+
+export interface TreeRootProps {
+  role: 'tree';
+}
+
+export interface TreeGroupProps {
+  role: 'group';
+}
+
+export interface TreeNodeProps {
+  role: 'treeitem';
+  ariaExpanded?: boolean;
+  ariaLevel: number;
+  ariaSetsize: number;
+  ariaPosinset: number;
+  ariaSelected?: boolean;
+  tabIndex: number;
+}
+
+export interface TreeAPI {
+  state: TreeState;
+  expand(id: string): void;
+  collapse(id: string): void;
+  toggle(id: string): void;
+  /**
+   * Select a node.
+   * - `append: true` toggles membership in a multi-selection (Cmd/Ctrl+click).
+   * - `range: true` selects from the anchor to `id` along the visible
+   *   (flattened) order (Shift+click). Anchor is the most recent
+   *   non-range selection, or the first selected id, or `id` itself.
+   *
+   * In `selectionMode: 'single'`, `append`/`range` are ignored and the
+   * selection becomes `{id}`. In `selectionMode: 'none'`, calls are no-ops.
+   */
+  select(id: string, opts?: { append?: boolean; range?: boolean }): void;
+  focus(id: string): void;
+  activate(id: string): void;
+  moveNext(): string | null;
+  movePrev(): string | null;
+  moveOut(): string | null;
+  moveIn(): string | null;
+  moveFirst(): string | null;
+  moveLast(): string | null;
+  /**
+   * Advance focus to the next visible node whose label starts with `char`,
+   * wrapping around. Label is taken from `data.name`, `data.label`, or
+   * `data.title` if `data` is an object; falls back to `id`. Returns the
+   * matched id or null.
+   *
+   * Single-character typeahead by design -- buffered typeahead is the
+   * `typeahead.ts` primitive's job; compose if you need it.
+   */
+  typeahead(char: string): string | null;
+  getRootProps(): TreeRootProps;
+  getGroupProps(parentId: string): TreeGroupProps;
+  getNodeProps(id: string): TreeNodeProps;
+}
+
+// ============================================================================
+// Internal index
+// ============================================================================
+
+interface NodeIndex<T> {
+  node: TreeNode<T>;
+  parentId: string | null;
+  level: number;
+  /** 1-based position among siblings. */
+  posinset: number;
+  /** Total siblings (including self). */
+  setsize: number;
+}
+
+function buildIndex<T>(nodes: TreeNode<T>[]): Map<string, NodeIndex<T>> {
+  const index = new Map<string, NodeIndex<T>>();
+
+  function walk(siblings: TreeNode<T>[], parentId: string | null, level: number): void {
+    const setsize = siblings.length;
+    for (let i = 0; i < siblings.length; i++) {
+      const node = siblings[i];
+      if (!node) continue;
+      if (index.has(node.id)) {
+        throw new Error(`tree: duplicate node id "${node.id}"`);
+      }
+      index.set(node.id, {
+        node,
+        parentId,
+        level,
+        posinset: i + 1,
+        setsize,
+      });
+      if (node.children && node.children.length > 0) {
+        walk(node.children, node.id, level + 1);
+      }
+    }
+  }
+
+  walk(nodes, null, 1);
+  return index;
+}
+
+function hasChildren<T>(node: TreeNode<T>): boolean {
+  if (node.hasChildren) return true;
+  return Array.isArray(node.children) && node.children.length > 0;
+}
+
+function getLabel<T>(node: TreeNode<T>): string {
+  const data: unknown = node.data;
+  if (typeof data === 'string') return data;
+  if (data && typeof data === 'object') {
+    const obj = data as Record<string, unknown>;
+    const candidate = obj.name ?? obj.label ?? obj.title;
+    if (typeof candidate === 'string') return candidate;
+  }
+  return node.id;
+}
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+export function createTree<T>(options: TreeOptions<T>): TreeAPI {
+  const {
+    nodes,
+    selectionMode = 'single',
+    defaultExpanded = [],
+    defaultSelected = [],
+    onExpandedChange,
+    onSelectedChange,
+    onFocusChange,
+    onActivate,
+  } = options;
+
+  const index = buildIndex(nodes);
+
+  const state: TreeState = {
+    expanded: new Set(defaultExpanded.filter((id) => index.has(id))),
+    selected: new Set(defaultSelected.filter((id) => index.has(id))),
+    focused: null,
+  };
+
+  // Anchor for range selection.
+  let selectionAnchor: string | null = null;
+
+  // ---- Visible (flattened) order -------------------------------------------
+
+  function visibleOrder(): string[] {
+    const out: string[] = [];
+    function walk(siblings: TreeNode<T>[]): void {
+      for (const node of siblings) {
+        out.push(node.id);
+        if (hasChildren(node) && state.expanded.has(node.id) && node.children) {
+          walk(node.children);
+        }
+      }
+    }
+    walk(nodes);
+    return out;
+  }
+
+  // ---- Mutators ------------------------------------------------------------
+
+  function notifyExpanded(): void {
+    onExpandedChange?.(new Set(state.expanded));
+  }
+
+  function notifySelected(): void {
+    onSelectedChange?.(new Set(state.selected));
+  }
+
+  function setFocus(id: string | null): void {
+    if (state.focused === id) return;
+    state.focused = id;
+    onFocusChange?.(id);
+  }
+
+  function expand(id: string): void {
+    const entry = index.get(id);
+    if (!entry || !hasChildren(entry.node)) return;
+    if (state.expanded.has(id)) return;
+    state.expanded.add(id);
+    notifyExpanded();
+  }
+
+  function collapse(id: string): void {
+    if (!state.expanded.has(id)) return;
+    state.expanded.delete(id);
+    notifyExpanded();
+  }
+
+  function toggle(id: string): void {
+    if (state.expanded.has(id)) collapse(id);
+    else expand(id);
+  }
+
+  function select(id: string, opts: { append?: boolean; range?: boolean } = {}): void {
+    if (selectionMode === 'none') return;
+    if (!index.has(id)) return;
+
+    if (selectionMode === 'single') {
+      const next = new Set<string>([id]);
+      const same =
+        state.selected.size === next.size && [...state.selected].every((v) => next.has(v));
+      if (!same) {
+        state.selected = next;
+        notifySelected();
+      }
+      selectionAnchor = id;
+      return;
+    }
+
+    // multiple
+    if (opts.range) {
+      const order = visibleOrder();
+      const anchor = selectionAnchor ?? [...state.selected][0] ?? id;
+      const a = order.indexOf(anchor);
+      const b = order.indexOf(id);
+      if (a === -1 || b === -1) {
+        state.selected = new Set([id]);
+        selectionAnchor = id;
+        notifySelected();
+        return;
+      }
+      const [lo, hi] = a <= b ? [a, b] : [b, a];
+      const next = new Set<string>();
+      for (let i = lo; i <= hi; i++) {
+        const cur = order[i];
+        if (cur !== undefined) next.add(cur);
+      }
+      state.selected = next;
+      // anchor stays put for chained range extensions.
+      notifySelected();
+      return;
+    }
+
+    if (opts.append) {
+      if (state.selected.has(id)) state.selected.delete(id);
+      else state.selected.add(id);
+      selectionAnchor = id;
+      notifySelected();
+      return;
+    }
+
+    state.selected = new Set([id]);
+    selectionAnchor = id;
+    notifySelected();
+  }
+
+  function focus(id: string): void {
+    if (!index.has(id)) return;
+    setFocus(id);
+  }
+
+  function activate(id: string): void {
+    if (!index.has(id)) return;
+    setFocus(id);
+    onActivate?.(id);
+  }
+
+  // ---- Movement ------------------------------------------------------------
+
+  function moveTo(id: string | null): string | null {
+    if (id === null) return null;
+    setFocus(id);
+    return id;
+  }
+
+  function moveNext(): string | null {
+    const order = visibleOrder();
+    if (order.length === 0) return null;
+    if (state.focused === null) return moveTo(order[0] ?? null);
+    const i = order.indexOf(state.focused);
+    if (i === -1) return moveTo(order[0] ?? null);
+    if (i >= order.length - 1) return state.focused;
+    return moveTo(order[i + 1] ?? null);
+  }
+
+  function movePrev(): string | null {
+    const order = visibleOrder();
+    if (order.length === 0) return null;
+    if (state.focused === null) return moveTo(order[0] ?? null);
+    const i = order.indexOf(state.focused);
+    if (i <= 0) return state.focused ?? moveTo(order[0] ?? null);
+    return moveTo(order[i - 1] ?? null);
+  }
+
+  function moveOut(): string | null {
+    if (state.focused === null) return null;
+    const entry = index.get(state.focused);
+    if (!entry) return null;
+    // If on an expanded node, collapse first (matches OS file tree behavior).
+    if (hasChildren(entry.node) && state.expanded.has(entry.node.id)) {
+      collapse(entry.node.id);
+      return state.focused;
+    }
+    if (entry.parentId === null) return state.focused;
+    return moveTo(entry.parentId);
+  }
+
+  function moveIn(): string | null {
+    if (state.focused === null) return null;
+    const entry = index.get(state.focused);
+    if (!entry) return null;
+    if (!hasChildren(entry.node)) return state.focused;
+    if (!state.expanded.has(entry.node.id)) {
+      expand(entry.node.id);
+      return state.focused;
+    }
+    const firstChild = entry.node.children?.[0];
+    if (!firstChild) return state.focused;
+    return moveTo(firstChild.id);
+  }
+
+  function moveFirst(): string | null {
+    const order = visibleOrder();
+    return moveTo(order[0] ?? null);
+  }
+
+  function moveLast(): string | null {
+    const order = visibleOrder();
+    return moveTo(order[order.length - 1] ?? null);
+  }
+
+  function typeahead(char: string): string | null {
+    if (char.length !== 1) return null;
+    const order = visibleOrder();
+    if (order.length === 0) return null;
+    const lower = char.toLowerCase();
+    const start = state.focused ? order.indexOf(state.focused) : -1;
+    for (let step = 1; step <= order.length; step++) {
+      const i = (start + step + order.length) % order.length;
+      const id = order[i];
+      if (!id) continue;
+      const entry = index.get(id);
+      if (!entry) continue;
+      const label = getLabel(entry.node);
+      if (label.length > 0 && label[0]?.toLowerCase() === lower) {
+        return moveTo(id);
+      }
+    }
+    return null;
+  }
+
+  // ---- Prop bags -----------------------------------------------------------
+
+  function getRootProps(): TreeRootProps {
+    return { role: 'tree' };
+  }
+
+  function getGroupProps(_parentId: string): TreeGroupProps {
+    // parentId reserved for v2 (aria-owns / labelling); included in the
+    // signature today so consumers don't need to refactor when v2 lands.
+    return { role: 'group' };
+  }
+
+  function getNodeProps(id: string): TreeNodeProps {
+    const entry = index.get(id);
+    if (!entry) {
+      throw new Error(`tree: getNodeProps called with unknown id "${id}"`);
+    }
+    const expandable = hasChildren(entry.node);
+    const props: TreeNodeProps = {
+      role: 'treeitem',
+      ariaLevel: entry.level,
+      ariaSetsize: entry.setsize,
+      ariaPosinset: entry.posinset,
+      tabIndex: state.focused === id ? 0 : -1,
+    };
+    if (expandable) {
+      props.ariaExpanded = state.expanded.has(id);
+    }
+    if (selectionMode !== 'none') {
+      props.ariaSelected = state.selected.has(id);
+    }
+    return props;
+  }
+
+  return {
+    state,
+    expand,
+    collapse,
+    toggle,
+    select,
+    focus,
+    activate,
+    moveNext,
+    movePrev,
+    moveOut,
+    moveIn,
+    moveFirst,
+    moveLast,
+    typeahead,
+    getRootProps,
+    getGroupProps,
+    getNodeProps,
+  };
+}


### PR DESCRIPTION
## Summary

Adds `packages/ui/src/primitives/tree.ts` -- a pure state-machine factory implementing the WAI-ARIA tree pattern. Owns hierarchy, expansion, focus, and single/multi/range selection. Emits the ARIA prop bag for `tree`, `group`, and `treeitem` so consumers don't need to know the spec detail. No DOM, no async, no drag-and-drop.

First consumer: gitpress file sidebar ([gitpress#272](https://github.com/rafters-studio/gitpress/issues/272)).
Greenlit by the rafters team in bullpen post `019df3e9-7c64`.

## What shipped

- `packages/ui/src/primitives/tree.ts` (~370 LOC)
  - `createTree<T>(options): TreeAPI`
  - `getRootProps()` / `getGroupProps(parentId)` / `getNodeProps(id)` -- prop bags consumers spread onto rendered elements
  - Movement: `moveNext`, `movePrev`, `moveIn`, `moveOut`, `moveFirst`, `moveLast`, `typeahead(char)`
  - Selection: `single` (default), `multiple` (append + range), `none`
  - Roving tabIndex (0 on focused, -1 elsewhere)
- `packages/ui/src/primitives/tree.test.ts` -- 36 tests, all passing
  - Keyboard nav (all 7 movers)
  - Selection in all three modes including range across visible (flattened) order
  - Expand/collapse (focus follow + onExpandedChange callbacks)
  - ARIA prop snapshots per node (role, level, setsize, posinset, expanded, selected, tabIndex)
  - Multi-root case
  - Deeply nested (4 levels)
  - Typeahead first-letter jump with wraparound

## Design notes

- **Self-contained selection**, per the rafters team note. Did not reuse `selection.ts` -- that primitive is editor-DOM/contenteditable specific. Tree selection is hierarchy-aware and operates on ids, not DOM ranges.
- **`getGroupProps(parentId)`** exists today returning `{ role: 'group' }`. The `parentId` arg is reserved for v2 (aria-owns / labelledby). Including it now means consumers don't refactor when v2 lands.
- **Sync v1, async v2.** `loadChildren?: (id) => Promise<TreeNode<T>[]>` is documented as a JSDoc note for the v2 follow-up. `hasChildren?: boolean` already exists on `TreeNode<T>` so a node can correctly report `aria-expanded` before its children are loaded.
- **Multi-root** is allowed and tested. ARIA `tree` permits multiple top-level `treeitem` children.
- **Drag-and-drop is out of scope.** Tree exposes ids and ordering; compose with the existing `drag-drop.ts` primitive.

## Intelligence metadata

JSDoc block follows the established pattern:
- `@cognitive-load 6/10`
- `@when-to-use` / `@when-not-to-use` blocks
- `@usage-patterns` with DO / NEVER lines
- `@accessibility`, `@trust-building`, `@semantic-meaning`, `@attention-economics`

Verified parsing via `apps/website/src/lib/registry/componentService.ts loadPrimitive('tree')`: cognitive load surfaces, 4 DOs and 3 NEVERs are picked up.

## Distribution / registry

`apps/website/src/pages/registry/primitives/[name].json.ts` auto-discovers via `readdirSync` over `packages/ui/src/primitives/`. The new file is picked up with no manifest changes. `pnpx rafters add primitive tree` will work as soon as the static site rebuilds.

Existing 64 `componentService` tests still pass.

## Test plan

- [x] `pnpm --filter=@rafters/ui exec vitest run src/primitives/tree.test.ts` -- 36 / 36 passing
- [x] `pnpm typecheck` -- clean across the monorepo
- [x] `pnpm lint` (biome check) -- clean
- [x] `apps/website` componentService tests -- 64 / 64 passing
- [x] Manual loadPrimitive('tree') -- full intelligence metadata extracted

## Follow-ups

- v2 `loadChildren?: (id) => Promise<TreeNode<T>[]>` for async children
- v2 `aria-owns` wiring through `getGroupProps(parentId)` (signature already accepts the arg)
- TreeView component layer when a second consumer needs it (gitpress is happy with the headless primitive directly)