### PR TITLE
feat(primitives): tree — headless tree-widget behavior

### DIFF
--- a/packages/ui/src/components/ui/sidebar-tree.classes.ts
+++ b/packages/ui/src/components/ui/sidebar-tree.classes.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared sidebar-tree class definitions
+ *
+ * Imported by sidebar-tree.tsx (React) to keep inline strings in a single
+ * source of truth.
+ */
+
+export const sidebarTreeRootClasses = 'flex w-full flex-col gap-px text-sm outline-none';
+
+export const sidebarTreeGroupClasses = 'flex flex-col gap-px';
+
+export const sidebarTreeItemClasses =
+  'group/sidebar-tree-item flex w-full cursor-default items-center gap-2 rounded-md px-2 py-1 ' +
+  'text-foreground transition-colors duration-150 motion-reduce:transition-none ' +
+  'hover:bg-accent hover:text-accent-foreground ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 ' +
+  'aria-[selected=true]:bg-accent aria-[selected=true]:text-accent-foreground ' +
+  'aria-[disabled=true]:pointer-events-none aria-[disabled=true]:opacity-50';
+
+export const sidebarTreeItemContentClasses = 'flex min-w-0 flex-1 items-center gap-2';
+
+export const sidebarTreeChevronClasses =
+  'h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform duration-150 ' +
+  'motion-reduce:transition-none aria-[expanded=true]:rotate-90';
+
+export const sidebarTreeChevronSpacerClasses = 'h-3.5 w-3.5 shrink-0';

--- a/packages/ui/src/components/ui/sidebar-tree.tsx
+++ b/packages/ui/src/components/ui/sidebar-tree.tsx
@@ -1,0 +1,419 @@
+/**
+ * SidebarTree component for hierarchical navigation in a sidebar context
+ *
+ * Visual wrapper around the tree primitive (createTree). Renders nodes as
+ * indented rows with chevron expanders, hooks the tree's keyboard nav
+ * to the root container, and exposes the focus / selection / expansion
+ * state to the consumer via a render prop. The consumer owns icons,
+ * status indicators, and any per-node decoration — SidebarTree owns
+ * layout, keyboard, and ARIA.
+ *
+ * @cognitive-load 4/10 — Hierarchical lists carry parent/child relationships
+ *   plus selection state; the component centralizes the keyboard + ARIA cost
+ *   so every consumer doesn't re-pay it.
+ * @attention-economics Indentation + chevrons signal hierarchy at a glance;
+ *   roving tabindex keeps Tab order linear.
+ * @trust-building Predictable arrow-key semantics (right expands then
+ *   descends, left collapses then ascends), persistent expansion state
+ *   when the consumer drives it.
+ * @accessibility WAI-ARIA tree pattern: role=tree on root, role=treeitem
+ *   on rows, role=group on child containers, aria-expanded on parents,
+ *   aria-level / aria-setsize / aria-posinset, aria-selected, roving
+ *   tabindex.
+ * @semantic-meaning Hierarchical navigation: file trees, outlines,
+ *   taxonomies. NOT for flat menus (use Sidebar.Menu).
+ *
+ * @usage-patterns
+ * DO: Use for file / folder browsers, outlines, taxonomy editors
+ * DO: Render the consumer's per-node content via the renderNode prop
+ * DO: Drive expansion state from outside if it needs to persist across
+ *   reloads (controlled mode via expanded + onExpandedChange)
+ * DO: Pair with Sidebar.Group / Sidebar.GroupLabel for section framing
+ * NEVER: Use for flat lists (use Sidebar.Menu instead)
+ * NEVER: Fetch data inside renderNode — the tree is fed materialized
+ *   nodes; loading is the consumer's job above this component
+ * NEVER: Render hand-rolled chevrons that disagree with the aria-expanded
+ *   state — use the provided expander or set it via render prop carefully
+ *
+ * @example
+ * ```tsx
+ * <Sidebar.Group>
+ *   <Sidebar.GroupLabel>Files</Sidebar.GroupLabel>
+ *   <SidebarTree
+ *     nodes={fileNodes}
+ *     selectionMode="single"
+ *     onActivate={(id) => openFile(id)}
+ *     renderNode={({ node, isExpanded }) => (
+ *       <>
+ *         {node.children?.length ? (
+ *           <FolderIcon open={isExpanded} />
+ *         ) : (
+ *           <FileIcon ext={node.data.ext} />
+ *         )}
+ *         <span className="truncate">{node.data.label}</span>
+ *         {node.data.status ? <StatusDot status={node.data.status} /> : null}
+ *       </>
+ *     )}
+ *   />
+ * </Sidebar.Group>
+ * ```
+ */
+
+import * as React from 'react';
+import classy from '../../primitives/classy';
+import {
+  createTree,
+  getVisibleEntries,
+  type TreeFlatEntry,
+  type TreeNode,
+  type TreeSelectionMode,
+} from '../../primitives/tree';
+import {
+  sidebarTreeChevronClasses,
+  sidebarTreeChevronSpacerClasses,
+  sidebarTreeGroupClasses,
+  sidebarTreeItemClasses,
+  sidebarTreeItemContentClasses,
+  sidebarTreeRootClasses,
+} from './sidebar-tree.classes';
+
+// ==================== Types ====================
+
+/** State exposed to the renderNode prop for each visible entry */
+export interface SidebarTreeNodeRenderState<T> {
+  /** The tree node */
+  node: TreeNode<T>;
+  /** 1-based depth (matches aria-level) */
+  level: number;
+  /** Whether this node is currently expanded */
+  isExpanded: boolean;
+  /** Whether this node has children */
+  hasChildren: boolean;
+  /** Whether this node is the focused (roving-tabindex=0) one */
+  isFocused: boolean;
+  /** Whether this node is selected */
+  isSelected: boolean;
+  /** Whether this node is disabled */
+  isDisabled: boolean;
+}
+
+export interface SidebarTreeProps<T> extends React.HTMLAttributes<HTMLUListElement> {
+  /** Root nodes (multi-root supported) */
+  nodes: TreeNode<T>[];
+  /** Selection mode (default 'single') */
+  selectionMode?: TreeSelectionMode;
+  /** Initial expanded ids (uncontrolled). Ignored when `expanded` is supplied. */
+  defaultExpanded?: string[];
+  /** Initial selected ids (uncontrolled). Ignored when `selected` is supplied. */
+  defaultSelected?: string[];
+  /** Initial focused id (uncontrolled). Ignored when `focused` is supplied. */
+  defaultFocused?: string | null;
+  /** Controlled expansion */
+  expanded?: ReadonlySet<string> | string[];
+  /** Controlled selection */
+  selected?: ReadonlySet<string> | string[];
+  /** Controlled focused id */
+  focused?: string | null;
+  /** Notified on expansion change */
+  onExpandedChange?: (expanded: ReadonlySet<string>) => void;
+  /** Notified on selection change */
+  onSelectedChange?: (selected: ReadonlySet<string>) => void;
+  /** Notified on focus change */
+  onFocusChange?: (focused: string | null) => void;
+  /** Notified when a node is activated (Enter or click on the row) */
+  onActivate?: (id: string) => void;
+  /** Render the per-node content (icon, label, decorations). Required. */
+  renderNode: (state: SidebarTreeNodeRenderState<T>) => React.ReactNode;
+  /** Optional aria-label for the root tree element */
+  'aria-label'?: string;
+  /** Optional aria-labelledby for the root tree element */
+  'aria-labelledby'?: string;
+}
+
+// ==================== Helpers ====================
+
+function toSet(input: ReadonlySet<string> | string[] | undefined): Set<string> | null {
+  if (input === undefined) return null;
+  return new Set(input);
+}
+
+function setsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const v of a) if (!b.has(v)) return false;
+  return true;
+}
+
+// ==================== Component ====================
+
+export function SidebarTree<T = unknown>(props: SidebarTreeProps<T>): React.ReactElement {
+  const {
+    nodes,
+    selectionMode = 'single',
+    defaultExpanded,
+    defaultSelected,
+    defaultFocused,
+    expanded: expandedProp,
+    selected: selectedProp,
+    focused: focusedProp,
+    onExpandedChange,
+    onSelectedChange,
+    onFocusChange,
+    onActivate,
+    renderNode,
+    className,
+    onKeyDown,
+    onClick,
+    ...rest
+  } = props;
+
+  // Force re-render on internal state changes (the tree primitive holds the
+  // canonical state; React just needs a tick to reflect it).
+  const [, setVersion] = React.useState(0);
+  const rerender = React.useCallback(() => setVersion((v) => v + 1), []);
+
+  // Build the tree controller once. setNodes is called when the nodes prop
+  // identity changes.
+  const treeRef = React.useRef<ReturnType<typeof createTree<T>> | null>(null);
+  if (treeRef.current === null) {
+    const treeOptions: Parameters<typeof createTree<T>>[0] = {
+      nodes,
+      selectionMode,
+      onExpandedChange: (next) => {
+        onExpandedChange?.(next);
+        rerender();
+      },
+      onSelectedChange: (next) => {
+        onSelectedChange?.(next);
+        rerender();
+      },
+      onFocusChange: (next) => {
+        onFocusChange?.(next);
+        rerender();
+      },
+      onActivate: (id) => onActivate?.(id),
+    };
+    if (defaultExpanded !== undefined) treeOptions.defaultExpanded = defaultExpanded;
+    if (defaultSelected !== undefined) treeOptions.defaultSelected = defaultSelected;
+    if (defaultFocused !== undefined) treeOptions.defaultFocused = defaultFocused;
+    treeRef.current = createTree<T>(treeOptions);
+  }
+  const tree = treeRef.current;
+
+  // Sync controlled props in. Avoid feedback loops by comparing against the
+  // current internal state before applying.
+  React.useEffect(() => {
+    tree.setNodes(nodes);
+    rerender();
+  }, [nodes, tree, rerender]);
+
+  React.useEffect(() => {
+    const incoming = toSet(expandedProp);
+    if (incoming === null) return;
+    if (setsEqual(tree.state.expanded, incoming)) return;
+    // Apply by toggling the diff.
+    for (const id of incoming) if (!tree.state.expanded.has(id)) tree.expand(id);
+    for (const id of Array.from(tree.state.expanded)) if (!incoming.has(id)) tree.collapse(id);
+  }, [expandedProp, tree]);
+
+  React.useEffect(() => {
+    const incoming = toSet(selectedProp);
+    if (incoming === null) return;
+    if (setsEqual(tree.state.selected, incoming)) return;
+    if (selectionMode === 'single') {
+      const first = incoming.values().next().value;
+      if (typeof first === 'string') tree.select(first);
+    } else if (selectionMode === 'multiple') {
+      // Replace the entire set: clear by toggling appendingly, then add.
+      for (const id of Array.from(tree.state.selected))
+        if (!incoming.has(id)) tree.select(id, { append: true });
+      for (const id of incoming)
+        if (!tree.state.selected.has(id)) tree.select(id, { append: true });
+    }
+  }, [selectedProp, tree, selectionMode]);
+
+  React.useEffect(() => {
+    if (focusedProp === undefined) return;
+    if (focusedProp === null) return;
+    if (tree.state.focused === focusedProp) return;
+    tree.focus(focusedProp);
+  }, [focusedProp, tree]);
+
+  // Compute fresh on every render. The tree primitive mutates its expanded
+  // Set in place, so the reference is stable across changes — useMemo would
+  // skip even when the set's contents change. Walking is O(visible) anyway.
+  const visible = getVisibleEntries(nodes, tree.state.expanded);
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLUListElement>) => {
+      onKeyDown?.(event);
+      if (event.defaultPrevented) return;
+      tree.handleKeyDown(event.nativeEvent);
+    },
+    [onKeyDown, tree],
+  );
+
+  const handleRowClick = React.useCallback(
+    (id: string, event: React.MouseEvent<HTMLLIElement>) => {
+      if (event.defaultPrevented) return;
+      tree.focus(id);
+      if (selectionMode !== 'none') {
+        tree.select(id, {
+          append: event.metaKey || event.ctrlKey,
+          range: event.shiftKey,
+        });
+      }
+      tree.activate(id);
+    },
+    [selectionMode, tree],
+  );
+
+  const handleChevronClick = React.useCallback(
+    (id: string, event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      tree.toggle(id);
+    },
+    [tree],
+  );
+
+  return (
+    <ul
+      // biome-ignore lint/a11y/noNoninteractiveElementToInteractiveRole: WAI-ARIA tree pattern uses role=tree on a list container; the role overrides the implicit list role intentionally
+      role="tree"
+      aria-multiselectable={selectionMode === 'multiple' ? true : undefined}
+      tabIndex={visible.length > 0 ? 0 : -1}
+      className={classy(sidebarTreeRootClasses, className)}
+      onKeyDown={handleKeyDown}
+      onClick={onClick}
+      {...rest}
+    >
+      <SidebarTreeBody
+        visible={visible}
+        tree={tree}
+        renderNode={renderNode}
+        onRowClick={handleRowClick}
+        onChevronClick={handleChevronClick}
+      />
+    </ul>
+  );
+}
+
+// ==================== Body (rendered list) ====================
+
+interface SidebarTreeBodyProps<T> {
+  visible: TreeFlatEntry<T>[];
+  tree: ReturnType<typeof createTree<T>>;
+  renderNode: (state: SidebarTreeNodeRenderState<T>) => React.ReactNode;
+  onRowClick: (id: string, event: React.MouseEvent<HTMLLIElement>) => void;
+  onChevronClick: (id: string, event: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+function SidebarTreeBody<T>(props: SidebarTreeBodyProps<T>): React.ReactElement {
+  const { visible, tree, renderNode, onRowClick, onChevronClick } = props;
+
+  // Group consecutive same-parent entries so we can wrap each parent's
+  // children in a single role=group container per WAI-ARIA tree spec.
+  const elements: React.ReactNode[] = [];
+  let currentGroup: TreeFlatEntry<T>[] = [];
+  let currentParent: string | null | undefined;
+
+  const flushGroup = () => {
+    if (currentGroup.length === 0) return;
+    const parentId = currentParent;
+    const groupItems = currentGroup.map((entry) =>
+      renderRow(entry, tree, renderNode, onRowClick, onChevronClick),
+    );
+    if (parentId === null || parentId === undefined) {
+      // Top-level: emit directly, no wrapper (the role=tree root is the container)
+      elements.push(...groupItems);
+    } else {
+      elements.push(
+        // biome-ignore lint/a11y/useSemanticElements: WAI-ARIA tree pattern uses role=group on the children container; the role overrides the implicit list role intentionally
+        <ul key={`group-${parentId}`} role="group" className={sidebarTreeGroupClasses}>
+          {groupItems}
+        </ul>,
+      );
+    }
+    currentGroup = [];
+  };
+
+  for (const entry of visible) {
+    if (entry.parentId !== currentParent) {
+      flushGroup();
+      currentParent = entry.parentId;
+    }
+    currentGroup.push(entry);
+  }
+  flushGroup();
+
+  return <>{elements}</>;
+}
+
+function renderRow<T>(
+  entry: TreeFlatEntry<T>,
+  tree: ReturnType<typeof createTree<T>>,
+  renderNode: (state: SidebarTreeNodeRenderState<T>) => React.ReactNode,
+  onRowClick: (id: string, event: React.MouseEvent<HTMLLIElement>) => void,
+  onChevronClick: (id: string, event: React.MouseEvent<HTMLButtonElement>) => void,
+): React.ReactNode {
+  const ariaProps = tree.getNodeProps(entry.node.id);
+  const hasChildren = !!(entry.node.children && entry.node.children.length > 0);
+  const isExpanded = tree.state.expanded.has(entry.node.id);
+  const isFocused = tree.state.focused === entry.node.id;
+  const isSelected = tree.state.selected.has(entry.node.id);
+  const isDisabled = !!entry.node.disabled;
+
+  const renderState: SidebarTreeNodeRenderState<T> = {
+    node: entry.node,
+    level: entry.level,
+    isExpanded,
+    hasChildren,
+    isFocused,
+    isSelected,
+    isDisabled,
+  };
+
+  return (
+    // biome-ignore lint/a11y/useAriaPropsSupportedByRole: aria-level/setsize/posinset are supported on role=treeitem regardless of the underlying li element
+    // biome-ignore lint/a11y/useKeyWithClickEvents: keyboard nav is handled at the role=tree root via onKeyDown; per-row keydown would fight the roving-tabindex pattern
+    <li
+      key={entry.node.id}
+      role={ariaProps.role}
+      aria-level={ariaProps['aria-level']}
+      aria-setsize={ariaProps['aria-setsize']}
+      aria-posinset={ariaProps['aria-posinset']}
+      aria-expanded={ariaProps['aria-expanded']}
+      aria-selected={ariaProps['aria-selected']}
+      aria-disabled={isDisabled || undefined}
+      tabIndex={ariaProps.tabIndex}
+      data-tree-item={entry.node.id}
+      style={{ paddingInlineStart: `${(entry.level - 1) * 0.75}rem` }}
+      className={sidebarTreeItemClasses}
+      onClick={(event) => onRowClick(entry.node.id, event)}
+    >
+      {hasChildren ? (
+        <button
+          type="button"
+          tabIndex={-1}
+          aria-label={isExpanded ? 'Collapse' : 'Expand'}
+          aria-expanded={isExpanded}
+          className={sidebarTreeChevronClasses}
+          onClick={(event) => onChevronClick(entry.node.id, event)}
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path d="M9 5l7 7-7 7" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+      ) : (
+        <span className={sidebarTreeChevronSpacerClasses} aria-hidden="true" />
+      )}
+      <span className={sidebarTreeItemContentClasses}>{renderNode(renderState)}</span>
+    </li>
+  );
+}

--- a/packages/ui/src/primitives/tree.ts
+++ b/packages/ui/src/primitives/tree.ts
@@ -1,0 +1,664 @@
+/**
+ * Tree primitive
+ * Headless tree-widget behavior: hierarchy walk, selection, expand/collapse,
+ * keyboard navigation, and ARIA prop generation per the WAI-ARIA tree pattern.
+ *
+ * Composes existing primitives:
+ * - roving-focus (tabindex management) — applied via getNodeProps tabIndex
+ * - keyboard-handler (key dispatch) — implemented inline; tree's keymap is
+ *   tighter than the generic primitive (in/out semantics depend on expansion)
+ * - typeahead (first-letter jump) — composed via createControlledTypeahead
+ *
+ * Cognitive load: 4/15 (medium). Tree widgets carry hierarchy + state; the
+ * primitive moves that complexity off the consumer's plate.
+ *
+ * When to use:
+ * - File / folder browsers
+ * - Outline / table-of-contents widgets
+ * - Settings hierarchies
+ * - Taxonomy editors
+ *
+ * When NOT to use:
+ * - Flat lists (use roving-focus directly)
+ * - Trees that need server-driven async children (wait for v2 loadChildren)
+ * - Drag-drop reordering — compose with drag-drop primitive separately
+ * - Data fetching of any kind — that's the consumer's job
+ *
+ * The primitive does NOT:
+ * - Fetch data (no fs, fetch, octokit)
+ * - Render or style anything
+ * - Implement domain logic (file icons, status badges, etc.)
+ * - Virtualize (compose with a virtual-list primitive)
+ *
+ * WCAG Compliance:
+ * - 2.1.1 Keyboard (Level A): Full keyboard nav (arrows, Home/End, Enter, type-ahead)
+ * - 2.4.3 Focus Order (Level A): Roving tabindex; logical visible-order traversal
+ * - 4.1.2 Name, Role, Value (Level A): role=tree, role=treeitem, role=group, aria-expanded, aria-level, aria-setsize, aria-posinset, aria-selected
+ *
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
+ */
+
+import { createControlledTypeahead } from './typeahead';
+import type { CleanupFunction } from './types';
+
+/**
+ * A node in the tree. Consumers shape `data` however they like.
+ *
+ * `children` is the materialized child list. Pass an empty array (or omit) for
+ * leaves. v1 is synchronous: consumers must materialize children before passing
+ * the tree in. v2 will introduce `loadChildren?: () => Promise<TreeNode<T>[]>`
+ * + per-node loading state; the sync API stays source-compatible.
+ */
+export interface TreeNode<T = unknown> {
+  /** Stable id, unique across the entire tree */
+  id: string;
+  /** Consumer-defined payload (file entry, outline heading, etc.) */
+  data: T;
+  /** Materialized children. Omit or pass empty for leaves. */
+  children?: TreeNode<T>[];
+  /** Whether this node accepts selection / activation. Defaults to true. */
+  disabled?: boolean;
+}
+
+/** Selection mode. Default 'single'. */
+export type TreeSelectionMode = 'single' | 'multiple' | 'none';
+
+export interface TreeOptions<T = unknown> {
+  /** Root nodes. Multi-root is allowed (WAI-ARIA permits multiple roots in one tree). */
+  nodes: TreeNode<T>[];
+  /** @default 'single' */
+  selectionMode?: TreeSelectionMode;
+  /** Initial expanded ids */
+  defaultExpanded?: string[];
+  /** Initial selected ids */
+  defaultSelected?: string[];
+  /** Initial focused id (default: first node) */
+  defaultFocused?: string | null;
+  /** Notify when expansion changes */
+  onExpandedChange?: (expanded: ReadonlySet<string>) => void;
+  /** Notify when selection changes */
+  onSelectedChange?: (selected: ReadonlySet<string>) => void;
+  /** Notify when focused node changes */
+  onFocusChange?: (focused: string | null) => void;
+  /**
+   * Notify when a node is "activated" (Enter key, or consumer-driven double click).
+   * The consumer decides what activate means: open file, navigate, etc.
+   */
+  onActivate?: (id: string) => void;
+}
+
+/** Plain object returned by getRootProps */
+export interface TreeRootProps {
+  role: 'tree';
+}
+
+/** Plain object returned by getNodeProps */
+export interface TreeNodeProps {
+  role: 'treeitem';
+  /** Present only on parent nodes (children > 0) */
+  'aria-expanded'?: boolean;
+  'aria-level': number;
+  'aria-setsize': number;
+  'aria-posinset': number;
+  /** Present only when selectionMode !== 'none' */
+  'aria-selected'?: boolean;
+  /** Roving tabindex: 0 for focused node, -1 for the rest */
+  tabIndex: number;
+}
+
+/** Plain object returned by getGroupProps */
+export interface TreeGroupProps {
+  role: 'group';
+}
+
+export interface TreeAPI<T = unknown> {
+  /** Read-only state snapshot */
+  readonly state: {
+    readonly expanded: ReadonlySet<string>;
+    readonly selected: ReadonlySet<string>;
+    readonly focused: string | null;
+  };
+  /** Replace the node list (e.g. after the consumer refetches data) */
+  setNodes: (nodes: TreeNode<T>[]) => void;
+  /** Programmatic state changes */
+  expand: (id: string) => void;
+  collapse: (id: string) => void;
+  toggle: (id: string) => void;
+  select: (id: string, opts?: { append?: boolean; range?: boolean }) => void;
+  focus: (id: string) => void;
+  activate: (id: string) => void;
+  /** Keyboard movers — return the new focused id, or null if no movement */
+  moveNext: () => string | null;
+  movePrev: () => string | null;
+  moveOut: () => string | null;
+  moveIn: () => string | null;
+  moveFirst: () => string | null;
+  moveLast: () => string | null;
+  /** Type-ahead first-letter jump. Returns matched id or null. */
+  typeahead: (char: string) => string | null;
+  /** Generic key handler — dispatches to the movers + activate. */
+  handleKeyDown: (event: KeyboardEvent) => void;
+  /** ARIA prop getters */
+  getRootProps: () => TreeRootProps;
+  getNodeProps: (id: string) => TreeNodeProps;
+  getGroupProps: (parentId: string) => TreeGroupProps;
+}
+
+interface FlatEntry<T> {
+  node: TreeNode<T>;
+  level: number;
+  parentId: string | null;
+  /** 1-based index within parent's child list (for aria-posinset) */
+  posInSet: number;
+  /** Total siblings (for aria-setsize) */
+  setSize: number;
+}
+
+/**
+ * Walk the visible (expanded) nodes in DFS order. Excludes children of
+ * collapsed nodes. Used for next/prev movement.
+ */
+function flattenVisible<T>(nodes: TreeNode<T>[], expanded: ReadonlySet<string>): FlatEntry<T>[] {
+  const out: FlatEntry<T>[] = [];
+  const walk = (siblings: TreeNode<T>[], level: number, parentId: string | null) => {
+    const setSize = siblings.length;
+    for (let i = 0; i < siblings.length; i++) {
+      const node = siblings[i];
+      if (!node) continue;
+      out.push({ node, level, parentId, posInSet: i + 1, setSize });
+      if (node.children && node.children.length > 0 && expanded.has(node.id)) {
+        walk(node.children, level + 1, node.id);
+      }
+    }
+  };
+  walk(nodes, 1, null);
+  return out;
+}
+
+/** Build a quick lookup of every node by id, regardless of expansion. */
+function indexNodes<T>(nodes: TreeNode<T>[]): Map<string, FlatEntry<T>> {
+  const map = new Map<string, FlatEntry<T>>();
+  const walk = (siblings: TreeNode<T>[], level: number, parentId: string | null) => {
+    const setSize = siblings.length;
+    for (let i = 0; i < siblings.length; i++) {
+      const node = siblings[i];
+      if (!node) continue;
+      map.set(node.id, { node, level, parentId, posInSet: i + 1, setSize });
+      if (node.children && node.children.length > 0) {
+        walk(node.children, level + 1, node.id);
+      }
+    }
+  };
+  walk(nodes, 1, null);
+  return map;
+}
+
+function firstSelectableId<T>(entries: FlatEntry<T>[]): string | null {
+  for (const e of entries) {
+    if (!e.node.disabled) return e.node.id;
+  }
+  return null;
+}
+
+/**
+ * Create a headless tree controller. No DOM, no JSX — the consumer wires
+ * the returned `getNodeProps` / `getGroupProps` / `getRootProps` and
+ * `handleKeyDown` to whatever rendering layer they're using.
+ *
+ * @example Basic React consumer
+ * ```tsx
+ * const tree = createTree({ nodes, onActivate: (id) => openFile(id) });
+ * const visible = flattenVisible(nodes, tree.state.expanded); // or use a render walker
+ *
+ * function Node({ entry }) {
+ *   const props = tree.getNodeProps(entry.node.id);
+ *   return (
+ *     <li {...props} onClick={() => tree.focus(entry.node.id)}>
+ *       {entry.node.data.label}
+ *       {entry.node.children?.length ? (
+ *         <ul {...tree.getGroupProps(entry.node.id)}>...</ul>
+ *       ) : null}
+ *     </li>
+ *   );
+ * }
+ *
+ * return <ul {...tree.getRootProps()} onKeyDown={tree.handleKeyDown}>...</ul>;
+ * ```
+ */
+export function createTree<T = unknown>(options: TreeOptions<T>): TreeAPI<T> {
+  const {
+    selectionMode = 'single',
+    defaultExpanded = [],
+    defaultSelected = [],
+    defaultFocused = null,
+    onExpandedChange,
+    onSelectedChange,
+    onFocusChange,
+    onActivate,
+  } = options;
+
+  let nodes = options.nodes;
+  let index = indexNodes(nodes);
+  const expanded = new Set<string>(defaultExpanded);
+  const selected = new Set<string>(selectionMode === 'none' ? [] : defaultSelected);
+  let focused: string | null = defaultFocused ?? firstSelectableId(flattenVisible(nodes, expanded));
+  /** Anchor id for shift-range selection */
+  let rangeAnchor: string | null = focused;
+
+  const emitExpanded = () => onExpandedChange?.(new Set(expanded));
+  const emitSelected = () => onSelectedChange?.(new Set(selected));
+  const emitFocus = () => onFocusChange?.(focused);
+
+  const visible = (): FlatEntry<T>[] => flattenVisible(nodes, expanded);
+
+  const visibleIndexOf = (id: string | null): number => {
+    if (id === null) return -1;
+    const v = visible();
+    for (let i = 0; i < v.length; i++) {
+      const entry = v[i];
+      if (entry && entry.node.id === id) return i;
+    }
+    return -1;
+  };
+
+  const setFocus = (id: string | null): string | null => {
+    if (id === focused) return id;
+    focused = id;
+    emitFocus();
+    return id;
+  };
+
+  const setNodes = (next: TreeNode<T>[]): void => {
+    nodes = next;
+    index = indexNodes(nodes);
+    // Drop expanded / selected / focused entries that no longer exist.
+    for (const id of Array.from(expanded)) if (!index.has(id)) expanded.delete(id);
+    let selectedChanged = false;
+    for (const id of Array.from(selected))
+      if (!index.has(id)) {
+        selected.delete(id);
+        selectedChanged = true;
+      }
+    if (focused !== null && !index.has(focused)) {
+      focused = firstSelectableId(visible());
+      emitFocus();
+    }
+    if (selectedChanged) emitSelected();
+    emitExpanded();
+  };
+
+  const expand = (id: string): void => {
+    const entry = index.get(id);
+    if (!entry || !entry.node.children || entry.node.children.length === 0) return;
+    if (expanded.has(id)) return;
+    expanded.add(id);
+    emitExpanded();
+  };
+
+  const collapse = (id: string): void => {
+    if (!expanded.has(id)) return;
+    expanded.delete(id);
+    emitExpanded();
+  };
+
+  const toggle = (id: string): void => {
+    if (expanded.has(id)) collapse(id);
+    else expand(id);
+  };
+
+  /**
+   * Compute the visible-flat range between two ids (inclusive). Returns ids in
+   * visible order. If either id is not visible, returns [].
+   */
+  const rangeBetween = (a: string, b: string): string[] => {
+    const v = visible();
+    let aIdx = -1;
+    let bIdx = -1;
+    for (let i = 0; i < v.length; i++) {
+      const entry = v[i];
+      if (!entry) continue;
+      if (entry.node.id === a) aIdx = i;
+      if (entry.node.id === b) bIdx = i;
+    }
+    if (aIdx === -1 || bIdx === -1) return [];
+    const [from, to] = aIdx <= bIdx ? [aIdx, bIdx] : [bIdx, aIdx];
+    const out: string[] = [];
+    for (let i = from; i <= to; i++) {
+      const entry = v[i];
+      if (entry && !entry.node.disabled) out.push(entry.node.id);
+    }
+    return out;
+  };
+
+  const select = (id: string, opts: { append?: boolean; range?: boolean } = {}): void => {
+    if (selectionMode === 'none') return;
+    const entry = index.get(id);
+    if (!entry || entry.node.disabled) return;
+
+    if (selectionMode === 'single') {
+      if (selected.size === 1 && selected.has(id)) return;
+      selected.clear();
+      selected.add(id);
+      rangeAnchor = id;
+      emitSelected();
+      return;
+    }
+
+    // multiple
+    if (opts.range && rangeAnchor !== null) {
+      const ids = rangeBetween(rangeAnchor, id);
+      if (ids.length === 0) return;
+      selected.clear();
+      for (const i of ids) selected.add(i);
+      emitSelected();
+      return;
+    }
+
+    if (opts.append) {
+      if (selected.has(id)) selected.delete(id);
+      else selected.add(id);
+      rangeAnchor = id;
+      emitSelected();
+      return;
+    }
+
+    // plain click in multi-select replaces the selection
+    selected.clear();
+    selected.add(id);
+    rangeAnchor = id;
+    emitSelected();
+  };
+
+  const focus = (id: string): void => {
+    const entry = index.get(id);
+    if (!entry || entry.node.disabled) return;
+    setFocus(id);
+  };
+
+  const activate = (id: string): void => {
+    const entry = index.get(id);
+    if (!entry || entry.node.disabled) return;
+    onActivate?.(id);
+  };
+
+  const moveNext = (): string | null => {
+    const v = visible();
+    if (v.length === 0) return null;
+    const start = visibleIndexOf(focused);
+    for (let i = start + 1; i < v.length; i++) {
+      const entry = v[i];
+      if (entry && !entry.node.disabled) return setFocus(entry.node.id);
+    }
+    return focused;
+  };
+
+  const movePrev = (): string | null => {
+    const v = visible();
+    if (v.length === 0) return null;
+    const start = visibleIndexOf(focused);
+    const from = start === -1 ? v.length : start;
+    for (let i = from - 1; i >= 0; i--) {
+      const entry = v[i];
+      if (entry && !entry.node.disabled) return setFocus(entry.node.id);
+    }
+    return focused;
+  };
+
+  const moveOut = (): string | null => {
+    if (focused === null) return null;
+    const entry = index.get(focused);
+    if (!entry) return focused;
+    // If currently expanded with children: collapse instead of moving.
+    if (entry.node.children && entry.node.children.length > 0 && expanded.has(focused)) {
+      collapse(focused);
+      return focused;
+    }
+    // Otherwise move to parent (if any).
+    if (entry.parentId !== null) {
+      return setFocus(entry.parentId);
+    }
+    return focused;
+  };
+
+  const moveIn = (): string | null => {
+    if (focused === null) return null;
+    const entry = index.get(focused);
+    if (!entry || !entry.node.children || entry.node.children.length === 0) return focused;
+    if (!expanded.has(focused)) {
+      expand(focused);
+      return focused;
+    }
+    // Already expanded: move to first child.
+    for (const child of entry.node.children) {
+      if (!child.disabled) return setFocus(child.id);
+    }
+    return focused;
+  };
+
+  const moveFirst = (): string | null => {
+    const v = visible();
+    for (const entry of v) {
+      if (!entry.node.disabled) return setFocus(entry.node.id);
+    }
+    return focused;
+  };
+
+  const moveLast = (): string | null => {
+    const v = visible();
+    for (let i = v.length - 1; i >= 0; i--) {
+      const entry = v[i];
+      if (entry && !entry.node.disabled) return setFocus(entry.node.id);
+    }
+    return focused;
+  };
+
+  /**
+   * Type-ahead matching uses the typeahead primitive's prefix mode against
+   * the visible nodes' aria-label or text representation. Consumers control
+   * the text via a getNodeText option in a future extension; v1 reads
+   * `data` as a string when possible, otherwise falls back to id.
+   */
+  const typeaheadController = createControlledTypeahead({
+    getItems: () => {
+      // Synthesize iterable HTMLElements. We don't have real DOM here; instead
+      // we expose tiny shims carrying the text and id. The typeahead primitive
+      // only reads textContent / aria-label on these, so a minimal stand-in works.
+      const v = visible();
+      return v.map((entry) => {
+        const text = nodeText(entry.node);
+        const shim = { textContent: text, getAttribute: () => null, hasAttribute: () => false };
+        // Cast through unknown — typeahead's contract is "read-only text source".
+        return shim as unknown as HTMLElement;
+      });
+    },
+    onMatch: (_item, idx) => {
+      const v = visible();
+      const entry = v[idx];
+      if (entry && !entry.node.disabled) setFocus(entry.node.id);
+    },
+  });
+
+  const typeahead = (char: string): string | null => {
+    if (char.length !== 1) return focused;
+    const before = focused;
+    typeaheadController.handleKeyDown(new KeyboardEvent('keydown', { key: char }));
+    return focused !== before ? focused : null;
+  };
+
+  const handleKeyDown = (event: KeyboardEvent): void => {
+    if (event.ctrlKey || event.altKey || event.metaKey) {
+      // Modifier-key combos are consumer-owned (cmd-click select, etc.).
+      return;
+    }
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        moveNext();
+        return;
+      case 'ArrowUp':
+        event.preventDefault();
+        movePrev();
+        return;
+      case 'ArrowRight':
+        event.preventDefault();
+        moveIn();
+        return;
+      case 'ArrowLeft':
+        event.preventDefault();
+        moveOut();
+        return;
+      case 'Home':
+        event.preventDefault();
+        moveFirst();
+        return;
+      case 'End':
+        event.preventDefault();
+        moveLast();
+        return;
+      case 'Enter':
+        event.preventDefault();
+        if (focused !== null) {
+          if (selectionMode !== 'none') select(focused);
+          activate(focused);
+        }
+        return;
+      case ' ':
+        event.preventDefault();
+        if (focused !== null && selectionMode !== 'none') {
+          select(focused, { append: selectionMode === 'multiple' && event.shiftKey === false });
+        }
+        return;
+      default:
+        // Single-char keys feed typeahead. Skip whitespace and modifier-chars.
+        if (event.key.length === 1 && event.key !== ' ') {
+          typeaheadController.handleKeyDown(event);
+        }
+        return;
+    }
+  };
+
+  const getRootProps = (): TreeRootProps => ({ role: 'tree' });
+
+  const getNodeProps = (id: string): TreeNodeProps => {
+    const entry = index.get(id);
+    if (!entry) {
+      return {
+        role: 'treeitem',
+        'aria-level': 1,
+        'aria-setsize': 0,
+        'aria-posinset': 0,
+        tabIndex: -1,
+      };
+    }
+    const hasChildren = !!(entry.node.children && entry.node.children.length > 0);
+    const props: TreeNodeProps = {
+      role: 'treeitem',
+      'aria-level': entry.level,
+      'aria-setsize': entry.setSize,
+      'aria-posinset': entry.posInSet,
+      tabIndex: focused === id ? 0 : -1,
+    };
+    if (hasChildren) {
+      props['aria-expanded'] = expanded.has(id);
+    }
+    if (selectionMode !== 'none') {
+      props['aria-selected'] = selected.has(id);
+    }
+    return props;
+  };
+
+  const getGroupProps = (_parentId: string): TreeGroupProps => ({ role: 'group' });
+
+  const stateView = {
+    get expanded() {
+      return expanded as ReadonlySet<string>;
+    },
+    get selected() {
+      return selected as ReadonlySet<string>;
+    },
+    get focused() {
+      return focused;
+    },
+  };
+
+  return {
+    state: stateView,
+    setNodes,
+    expand,
+    collapse,
+    toggle,
+    select,
+    focus,
+    activate,
+    moveNext,
+    movePrev,
+    moveOut,
+    moveIn,
+    moveFirst,
+    moveLast,
+    typeahead,
+    handleKeyDown,
+    getRootProps,
+    getNodeProps,
+    getGroupProps,
+  };
+}
+
+/**
+ * Best-effort text extraction for typeahead. If the consumer's data is a
+ * string, use it; if it's `{ label }` or `{ name }`, use that. Otherwise
+ * fall back to the node id so typeahead at least does something useful.
+ *
+ * Consumers wanting custom text should bypass `typeahead()` and feed their
+ * own labels via the typeahead primitive directly.
+ */
+function nodeText<T>(node: TreeNode<T>): string {
+  const data = node.data as unknown;
+  if (typeof data === 'string') return data;
+  if (data && typeof data === 'object') {
+    const obj = data as Record<string, unknown>;
+    if (typeof obj.label === 'string') return obj.label;
+    if (typeof obj.name === 'string') return obj.name;
+    if (typeof obj.title === 'string') return obj.title;
+  }
+  return node.id;
+}
+
+/**
+ * Walk the visible (expanded) entries — exported for consumers that want to
+ * render in DFS order without re-implementing the walker.
+ */
+export function getVisibleEntries<T>(
+  nodes: TreeNode<T>[],
+  expanded: ReadonlySet<string>,
+): FlatEntry<T>[] {
+  return flattenVisible(nodes, expanded);
+}
+
+export type { FlatEntry as TreeFlatEntry };
+
+/**
+ * DOM-attached convenience wrapper. Wires `handleKeyDown` to the container
+ * element. Consumers typically don't need this — they wire keys via their
+ * framework's onKeyDown binding. Provided for parity with sibling primitives
+ * (createRovingFocus, createTypeahead) that ship both forms.
+ *
+ * Returns a cleanup function plus the underlying TreeAPI.
+ */
+export function attachTree<T = unknown>(
+  container: HTMLElement,
+  options: TreeOptions<T>,
+): { api: TreeAPI<T>; cleanup: CleanupFunction } {
+  const api = createTree(options);
+  if (typeof window === 'undefined') {
+    return { api, cleanup: () => {} };
+  }
+  const onKeyDown = (event: KeyboardEvent) => api.handleKeyDown(event);
+  container.addEventListener('keydown', onKeyDown);
+  return {
+    api,
+    cleanup: () => {
+      container.removeEventListener('keydown', onKeyDown);
+    },
+  };
+}

--- a/packages/ui/test/components/sidebar-tree.test.tsx
+++ b/packages/ui/test/components/sidebar-tree.test.tsx
@@ -1,0 +1,127 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SidebarTree, type SidebarTreeNodeRenderState } from '../../src/components/ui/sidebar-tree';
+import type { TreeNode } from '../../src/primitives/tree';
+
+interface FileLike {
+  label: string;
+  status?: 'draft' | 'in-review';
+}
+
+function n(id: string, label: string, children?: TreeNode<FileLike>[]): TreeNode<FileLike> {
+  const node: TreeNode<FileLike> = { id, data: { label } };
+  if (children) node.children = children;
+  return node;
+}
+
+const FILES: TreeNode<FileLike>[] = [
+  n('a', 'Apple'),
+  n('b', 'Banana', [n('b1', 'Blackberry'), n('b2', 'Blueberry')]),
+  n('c', 'Cherry'),
+];
+
+const renderLabel = ({ node }: SidebarTreeNodeRenderState<FileLike>) => (
+  <span data-testid={`label-${node.id}`}>{node.data.label}</span>
+);
+
+describe('SidebarTree', () => {
+  it('renders top-level nodes as treeitems with role=tree root', () => {
+    render(<SidebarTree nodes={FILES} renderNode={renderLabel} aria-label="Files" />);
+    const tree = screen.getByRole('tree', { name: 'Files' });
+    expect(tree).toBeInTheDocument();
+    expect(
+      within(tree)
+        .getAllByRole('treeitem')
+        .map((el) => el.textContent),
+    ).toEqual(['Apple', 'Banana', 'Cherry']);
+  });
+
+  it('children of collapsed parents are not in the DOM', () => {
+    render(<SidebarTree nodes={FILES} renderNode={renderLabel} />);
+    expect(screen.queryByTestId('label-b1')).not.toBeInTheDocument();
+  });
+
+  it('clicking the chevron expands the parent', () => {
+    render(<SidebarTree nodes={FILES} renderNode={renderLabel} />);
+    const expand = screen.getByRole('button', { name: 'Expand' });
+    fireEvent.click(expand);
+    expect(screen.getByTestId('label-b1')).toBeInTheDocument();
+    expect(screen.getByTestId('label-b2')).toBeInTheDocument();
+  });
+
+  it('renders a role=group wrapper around expanded children', () => {
+    render(<SidebarTree nodes={FILES} renderNode={renderLabel} defaultExpanded={['b']} />);
+    const groups = screen.getAllByRole('group');
+    expect(groups.length).toBe(1);
+    expect(
+      within(groups[0] as HTMLElement)
+        .getAllByRole('treeitem')
+        .map((el) => el.textContent),
+    ).toEqual(['Blackberry', 'Blueberry']);
+  });
+
+  it('clicking a row activates it and reports via onActivate', () => {
+    const onActivate = vi.fn();
+    render(<SidebarTree nodes={FILES} renderNode={renderLabel} onActivate={onActivate} />);
+    fireEvent.click(screen.getByText('Cherry'));
+    expect(onActivate).toHaveBeenCalledWith('c');
+  });
+
+  it('clicking a row updates aria-selected', () => {
+    render(<SidebarTree nodes={FILES} renderNode={renderLabel} />);
+    fireEvent.click(screen.getByText('Apple'));
+    const apple = screen.getByText('Apple').closest('[role="treeitem"]') as HTMLElement;
+    expect(apple).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('keyboard ArrowRight expands parent then descends on second press', () => {
+    render(<SidebarTree nodes={FILES} renderNode={renderLabel} defaultFocused="b" />);
+    const tree = screen.getByRole('tree');
+    fireEvent.keyDown(tree, { key: 'ArrowRight' });
+    expect(screen.getByTestId('label-b1')).toBeInTheDocument();
+    fireEvent.keyDown(tree, { key: 'ArrowRight' });
+    const b1 = screen.getByText('Blackberry').closest('[role="treeitem"]') as HTMLElement;
+    expect(b1).toHaveAttribute('tabindex', '0');
+  });
+
+  it('aria-level reflects depth', () => {
+    render(<SidebarTree nodes={FILES} renderNode={renderLabel} defaultExpanded={['b']} />);
+    const apple = screen.getByText('Apple').closest('[role="treeitem"]') as HTMLElement;
+    const b1 = screen.getByText('Blackberry').closest('[role="treeitem"]') as HTMLElement;
+    expect(apple).toHaveAttribute('aria-level', '1');
+    expect(b1).toHaveAttribute('aria-level', '2');
+  });
+
+  it('renderNode receives expansion + selection state', () => {
+    const renderState: SidebarTreeNodeRenderState<FileLike>[] = [];
+    render(
+      <SidebarTree
+        nodes={FILES}
+        renderNode={(state) => {
+          renderState.push(state);
+          return <span>{state.node.data.label}</span>;
+        }}
+        defaultExpanded={['b']}
+        defaultSelected={['b1']}
+        defaultFocused="b1"
+      />,
+    );
+    const b1State = renderState.find((s) => s.node.id === 'b1');
+    expect(b1State?.isSelected).toBe(true);
+    expect(b1State?.isFocused).toBe(true);
+    expect(b1State?.level).toBe(2);
+    const bState = renderState.find((s) => s.node.id === 'b');
+    expect(bState?.isExpanded).toBe(true);
+    expect(bState?.hasChildren).toBe(true);
+  });
+
+  it('multiple selection mode supports cmd-click append', () => {
+    render(<SidebarTree nodes={FILES} renderNode={renderLabel} selectionMode="multiple" />);
+    fireEvent.click(screen.getByText('Apple'));
+    fireEvent.click(screen.getByText('Cherry'), { metaKey: true });
+    const apple = screen.getByText('Apple').closest('[role="treeitem"]') as HTMLElement;
+    const cherry = screen.getByText('Cherry').closest('[role="treeitem"]') as HTMLElement;
+    expect(apple).toHaveAttribute('aria-selected', 'true');
+    expect(cherry).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/packages/ui/test/primitives/tree.test.ts
+++ b/packages/ui/test/primitives/tree.test.ts
@@ -1,0 +1,357 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  attachTree,
+  createTree,
+  getVisibleEntries,
+  type TreeNode,
+} from '../../src/primitives/tree';
+
+interface NamedData {
+  label: string;
+}
+
+function n(id: string, label?: string, children?: TreeNode<NamedData>[]): TreeNode<NamedData> {
+  const node: TreeNode<NamedData> = { id, data: { label: label ?? id } };
+  if (children) node.children = children;
+  return node;
+}
+
+const SIMPLE_TREE: TreeNode<NamedData>[] = [
+  n('a', 'Apple'),
+  n('b', 'Banana', [n('b1', 'Blackberry'), n('b2', 'Blueberry')]),
+  n('c', 'Cherry'),
+];
+
+const DEEP_TREE: TreeNode<NamedData>[] = [
+  n('root', 'Root', [
+    n('l1', 'Level 1', [n('l2', 'Level 2', [n('l3', 'Level 3'), n('l3b', 'Level 3b')])]),
+  ]),
+];
+
+describe('createTree — initial state', () => {
+  it('focuses the first selectable node by default', () => {
+    const tree = createTree({ nodes: SIMPLE_TREE });
+    expect(tree.state.focused).toBe('a');
+  });
+
+  it('honors defaultFocused', () => {
+    const tree = createTree({ nodes: SIMPLE_TREE, defaultFocused: 'c' });
+    expect(tree.state.focused).toBe('c');
+  });
+
+  it('honors defaultExpanded + defaultSelected', () => {
+    const tree = createTree({
+      nodes: SIMPLE_TREE,
+      defaultExpanded: ['b'],
+      defaultSelected: ['b1'],
+    });
+    expect([...tree.state.expanded]).toEqual(['b']);
+    expect([...tree.state.selected]).toEqual(['b1']);
+  });
+
+  it('handles empty nodes', () => {
+    const tree = createTree<NamedData>({ nodes: [] });
+    expect(tree.state.focused).toBe(null);
+    expect(tree.moveNext()).toBe(null);
+  });
+});
+
+describe('createTree — expand / collapse', () => {
+  it('toggles expansion only on parents', () => {
+    const tree = createTree({ nodes: SIMPLE_TREE });
+    tree.toggle('a'); // leaf — no-op
+    expect(tree.state.expanded.has('a')).toBe(false);
+    tree.toggle('b');
+    expect(tree.state.expanded.has('b')).toBe(true);
+    tree.toggle('b');
+    expect(tree.state.expanded.has('b')).toBe(false);
+  });
+
+  it('emits onExpandedChange when expansion changes', () => {
+    const onExpandedChange = vi.fn();
+    const tree = createTree({ nodes: SIMPLE_TREE, onExpandedChange });
+    tree.expand('b');
+    expect(onExpandedChange).toHaveBeenCalledTimes(1);
+    expect([...(onExpandedChange.mock.calls[0]?.[0] ?? [])]).toEqual(['b']);
+    tree.expand('b'); // already expanded
+    expect(onExpandedChange).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createTree — keyboard movement', () => {
+  it('ArrowDown / ArrowUp walk visible nodes', () => {
+    const tree = createTree({ nodes: SIMPLE_TREE });
+    expect(tree.moveNext()).toBe('b');
+    expect(tree.moveNext()).toBe('c');
+    expect(tree.moveNext()).toBe('c'); // bottom — stays
+    expect(tree.movePrev()).toBe('b');
+    expect(tree.movePrev()).toBe('a');
+    expect(tree.movePrev()).toBe('a'); // top — stays
+  });
+
+  it('ArrowRight expands a collapsed parent', () => {
+    const tree = createTree({ nodes: SIMPLE_TREE, defaultFocused: 'b' });
+    expect(tree.state.expanded.has('b')).toBe(false);
+    expect(tree.moveIn()).toBe('b');
+    expect(tree.state.expanded.has('b')).toBe(true);
+  });
+
+  it('ArrowRight on already-expanded parent moves to first child', () => {
+    const tree = createTree({
+      nodes: SIMPLE_TREE,
+      defaultFocused: 'b',
+      defaultExpanded: ['b'],
+    });
+    expect(tree.moveIn()).toBe('b1');
+  });
+
+  it('ArrowLeft on expanded parent collapses it', () => {
+    const tree = createTree({
+      nodes: SIMPLE_TREE,
+      defaultFocused: 'b',
+      defaultExpanded: ['b'],
+    });
+    expect(tree.moveOut()).toBe('b');
+    expect(tree.state.expanded.has('b')).toBe(false);
+  });
+
+  it('ArrowLeft on a child moves to parent', () => {
+    const tree = createTree({
+      nodes: SIMPLE_TREE,
+      defaultFocused: 'b1',
+      defaultExpanded: ['b'],
+    });
+    expect(tree.moveOut()).toBe('b');
+  });
+
+  it('Home / End jump to first / last visible', () => {
+    const tree = createTree({
+      nodes: SIMPLE_TREE,
+      defaultFocused: 'b',
+      defaultExpanded: ['b'],
+    });
+    expect(tree.moveLast()).toBe('c');
+    expect(tree.moveFirst()).toBe('a');
+  });
+
+  it('walks deeply nested trees in DFS order', () => {
+    const tree = createTree({
+      nodes: DEEP_TREE,
+      defaultExpanded: ['root', 'l1', 'l2'],
+    });
+    const order: (string | null)[] = [tree.state.focused];
+    let cursor: string | null = tree.state.focused;
+    while (true) {
+      const next = tree.moveNext();
+      if (next === cursor) break;
+      cursor = next;
+      order.push(cursor);
+    }
+    expect(order).toEqual(['root', 'l1', 'l2', 'l3', 'l3b']);
+  });
+});
+
+describe('createTree — selection', () => {
+  it('single mode replaces selection', () => {
+    const tree = createTree({ nodes: SIMPLE_TREE });
+    tree.select('a');
+    tree.select('c');
+    expect([...tree.state.selected]).toEqual(['c']);
+  });
+
+  it('multiple + append toggles individual ids', () => {
+    const tree = createTree({ nodes: SIMPLE_TREE, selectionMode: 'multiple' });
+    tree.select('a', { append: true });
+    tree.select('c', { append: true });
+    expect([...tree.state.selected].sort()).toEqual(['a', 'c']);
+    tree.select('a', { append: true });
+    expect([...tree.state.selected]).toEqual(['c']);
+  });
+
+  it('multiple + range selects across visible nodes', () => {
+    const tree = createTree({
+      nodes: SIMPLE_TREE,
+      selectionMode: 'multiple',
+      defaultExpanded: ['b'],
+    });
+    tree.select('a');
+    tree.select('b2', { range: true });
+    expect([...tree.state.selected].sort()).toEqual(['a', 'b', 'b1', 'b2']);
+  });
+
+  it('selectionMode "none" suppresses aria-selected and selection state', () => {
+    const tree = createTree({ nodes: SIMPLE_TREE, selectionMode: 'none' });
+    tree.select('a');
+    expect(tree.state.selected.size).toBe(0);
+    expect(tree.getNodeProps('a')['aria-selected']).toBeUndefined();
+  });
+
+  it('disabled nodes cannot be selected or focused', () => {
+    const disabledTree: TreeNode<NamedData>[] = [
+      { id: 'a', data: { label: 'A' }, disabled: true },
+      n('b', 'B'),
+    ];
+    const tree = createTree({ nodes: disabledTree });
+    tree.select('a');
+    expect(tree.state.selected.size).toBe(0);
+    tree.focus('a');
+    expect(tree.state.focused).toBe('b'); // initial focus skipped 'a'
+  });
+});
+
+describe('createTree — ARIA props', () => {
+  it('getRootProps returns role=tree', () => {
+    const tree = createTree({ nodes: SIMPLE_TREE });
+    expect(tree.getRootProps()).toEqual({ role: 'tree' });
+  });
+
+  it('getGroupProps returns role=group', () => {
+    const tree = createTree({ nodes: SIMPLE_TREE });
+    expect(tree.getGroupProps('b')).toEqual({ role: 'group' });
+  });
+
+  it('getNodeProps reflects level, posinset, setsize', () => {
+    const tree = createTree({ nodes: SIMPLE_TREE, defaultExpanded: ['b'] });
+    expect(tree.getNodeProps('a')).toMatchObject({
+      role: 'treeitem',
+      'aria-level': 1,
+      'aria-posinset': 1,
+      'aria-setsize': 3,
+    });
+    expect(tree.getNodeProps('b1')).toMatchObject({
+      'aria-level': 2,
+      'aria-posinset': 1,
+      'aria-setsize': 2,
+    });
+  });
+
+  it('aria-expanded only set on parents', () => {
+    const tree = createTree({ nodes: SIMPLE_TREE });
+    expect(tree.getNodeProps('a')['aria-expanded']).toBeUndefined();
+    expect(tree.getNodeProps('b')['aria-expanded']).toBe(false);
+    tree.expand('b');
+    expect(tree.getNodeProps('b')['aria-expanded']).toBe(true);
+  });
+
+  it('roving tabindex: only focused node gets 0', () => {
+    const tree = createTree({ nodes: SIMPLE_TREE });
+    expect(tree.getNodeProps('a').tabIndex).toBe(0);
+    expect(tree.getNodeProps('b').tabIndex).toBe(-1);
+    tree.focus('b');
+    expect(tree.getNodeProps('a').tabIndex).toBe(-1);
+    expect(tree.getNodeProps('b').tabIndex).toBe(0);
+  });
+});
+
+describe('createTree — multi-root', () => {
+  it('treats sibling roots as a single tree', () => {
+    const multiRoot: TreeNode<NamedData>[] = [n('r1', 'Root 1'), n('r2', 'Root 2')];
+    const tree = createTree({ nodes: multiRoot });
+    expect(tree.state.focused).toBe('r1');
+    expect(tree.moveNext()).toBe('r2');
+    expect(tree.getNodeProps('r1')['aria-setsize']).toBe(2);
+    expect(tree.getNodeProps('r2')['aria-posinset']).toBe(2);
+  });
+});
+
+describe('createTree — typeahead', () => {
+  it('jumps to the first match by label prefix', () => {
+    const tree = createTree({ nodes: SIMPLE_TREE });
+    expect(tree.typeahead('c')).toBe('c');
+  });
+
+  it('falls back to id when data has no label', () => {
+    const idOnly: TreeNode<{ extra: number }>[] = [
+      { id: 'apple', data: { extra: 1 } },
+      { id: 'banana', data: { extra: 2 } },
+    ];
+    const tree = createTree({ nodes: idOnly });
+    expect(tree.typeahead('b')).toBe('banana');
+  });
+});
+
+describe('createTree — handleKeyDown', () => {
+  function key(name: string, init: KeyboardEventInit = {}): KeyboardEvent {
+    return new KeyboardEvent('keydown', { key: name, bubbles: true, cancelable: true, ...init });
+  }
+
+  it('dispatches arrows + Home + End', () => {
+    const tree = createTree({ nodes: SIMPLE_TREE });
+    tree.handleKeyDown(key('ArrowDown'));
+    expect(tree.state.focused).toBe('b');
+    tree.handleKeyDown(key('End'));
+    expect(tree.state.focused).toBe('c');
+    tree.handleKeyDown(key('Home'));
+    expect(tree.state.focused).toBe('a');
+  });
+
+  it('Enter activates and selects', () => {
+    const onActivate = vi.fn();
+    const tree = createTree({ nodes: SIMPLE_TREE, onActivate });
+    tree.handleKeyDown(key('Enter'));
+    expect(onActivate).toHaveBeenCalledWith('a');
+    expect([...tree.state.selected]).toEqual(['a']);
+  });
+
+  it('skips when modifier keys are held', () => {
+    const tree = createTree({ nodes: SIMPLE_TREE });
+    tree.handleKeyDown(key('ArrowDown', { metaKey: true }));
+    expect(tree.state.focused).toBe('a');
+  });
+});
+
+describe('createTree — setNodes', () => {
+  it('drops stale focused / selected / expanded ids', () => {
+    const tree = createTree({
+      nodes: SIMPLE_TREE,
+      defaultExpanded: ['b'],
+      defaultSelected: ['b1'],
+      defaultFocused: 'b1',
+    });
+    tree.setNodes([n('x', 'X'), n('y', 'Y')]);
+    expect(tree.state.focused).toBe('x');
+    expect(tree.state.selected.size).toBe(0);
+    expect(tree.state.expanded.size).toBe(0);
+  });
+});
+
+describe('getVisibleEntries — exported walker', () => {
+  it('skips children of collapsed parents', () => {
+    const visible = getVisibleEntries(SIMPLE_TREE, new Set());
+    expect(visible.map((e) => e.node.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('includes children of expanded parents', () => {
+    const visible = getVisibleEntries(SIMPLE_TREE, new Set(['b']));
+    expect(visible.map((e) => e.node.id)).toEqual(['a', 'b', 'b1', 'b2', 'c']);
+  });
+});
+
+describe('attachTree — DOM-attached form', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  it('wires keydown to the API and cleans up on dispose', () => {
+    const onActivate = vi.fn();
+    const { api, cleanup } = attachTree(container, { nodes: SIMPLE_TREE, onActivate });
+    expect(api.state.focused).toBe('a');
+
+    container.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }),
+    );
+    expect(api.state.focused).toBe('b');
+
+    cleanup();
+
+    container.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }),
+    );
+    expect(api.state.focused).toBe('b'); // listener removed
+
+    document.body.removeChild(container);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a headless tree primitive at `packages/ui/src/primitives/tree.ts`. Sibling layer to `roving-focus`, `keyboard-handler`, `typeahead`, `block-handler`. Greenlit by rafters team in legion bullpen `019df3e9-7c64`.

## What this is

Behavioral primitive owning hierarchy walk, expand/collapse, single/multiple/range selection, keyboard nav (arrows, Home/End, Enter, type-ahead via existing `typeahead` primitive), ARIA prop generation per WAI-ARIA tree pattern (role=tree/treeitem/group, aria-expanded, aria-level, aria-setsize, aria-posinset, aria-selected), and roving tabindex.

## What this explicitly is not

Per the design discussion and the consumer invariant, the primitive does NOT:

- Fetch data (no fs, fetch, octokit) -- consumer materializes nodes
- Render or style -- consumer wires the returned prop objects to JSX
- Implement domain logic (file icons, status badges)
- Drag-and-drop (compose with existing `drag-drop` primitive)
- Virtualize (compose with a future virtual-list primitive)
- Async children loading -- deferred to v2 via `loadChildren?` extension

## Public surface

- `createTree<T>(options): TreeAPI<T>` -- framework-agnostic, no DOM
- `attachTree<T>(container, options): { api, cleanup }` -- DOM-attached convenience form (parity with `createRovingFocus` / `createTypeahead`)
- `getVisibleEntries<T>(nodes, expanded): TreeFlatEntry<T>[]` -- exported walker for render layers

## Test coverage (33 tests, all passing locally)

- 7 movers (ArrowDown/Up/Right/Left, Home, End, Enter)
- Selection modes (single / multi-append / range-shift / none)
- Disabled nodes skipped by initial focus + selection
- Expand/collapse with focus follow
- ARIA prop snapshots
- Multi-root trees
- 3+-level deep nesting (DFS order)
- Typeahead jump (with id fallback when data lacks label/name/title)
- `setNodes` drops stale focused/selected/expanded ids
- `attachTree` keydown wiring + cleanup

## Verification done locally

- `pnpm vitest run packages/ui/test/primitives/tree.test.ts` -- 33/33 pass
- `pnpm typecheck` -- clean
- `pnpm lint` (biome) -- clean

## Test plan

- [ ] CI full unit + a11y suite green
- [ ] First consumer (gitpress file sidebar gitpress#272) verifies the API in practice
- [ ] `pnpx rafters add primitive tree` registers post-merge

## References

- Design proposal: rafters bullpen 019df3e7-bb05-7fb1-b42a-b57293122bdd
- Greenlight: 019df3e9-7c64 + signal 019df3e9-8fde
- First consumer: gitpress#272