### PR TITLE
refactor(color-utils): SemanticColorSystem keys palette-namespaced (#1440)

### DIFF
--- a/packages/color-utils/src/color-wheel.ts
+++ b/packages/color-utils/src/color-wheel.ts
@@ -22,18 +22,25 @@ export interface ColorWheelOptions {
   chromaDistribution?: 'gaussian' | 'flat';
 }
 
+/**
+ * Keys are palette identifiers (`${role}-family`), distinct from the bare
+ * semantic role names (`primary`, `accent`, etc.) owned by
+ * `DEFAULT_SEMANTIC_COLOR_MAPPINGS`. The suffix prevents a name collision when
+ * the system is pushed into a `TokenRegistry` that also has semantic role
+ * tokens. See rafters issue #1440.
+ */
 export interface SemanticColorSystem {
-  primary: ColorValue;
-  secondary: ColorValue;
-  tertiary: ColorValue;
-  accent: ColorValue;
-  highlight: ColorValue;
-  neutral: ColorValue;
-  muted: ColorValue;
-  success: ColorValue;
-  warning: ColorValue;
-  destructive: ColorValue;
-  info: ColorValue;
+  'primary-family': ColorValue;
+  'secondary-family': ColorValue;
+  'tertiary-family': ColorValue;
+  'accent-family': ColorValue;
+  'highlight-family': ColorValue;
+  'neutral-family': ColorValue;
+  'muted-family': ColorValue;
+  'success-family': ColorValue;
+  'warning-family': ColorValue;
+  'destructive-family': ColorValue;
+  'info-family': ColorValue;
 }
 
 /**
@@ -99,37 +106,39 @@ function resolveSecondaryLightness(primaryColorValue: ColorValue, primaryOklch: 
 /**
  * Full complementary color wheel.
  *
- * Roles:
- *   primary     - the seed as-is
- *   secondary   - same hue, opposite lightness end (AAA against primary), chroma * 0.33
- *   accent      - complement (+180), full chroma
- *   tertiary    - CTA from complement hue, chroma * 1.2 (max 0.30), L clamped 0.45-0.65
- *   highlight   - secondary math applied to tertiary hue
- *   neutral     - seed hue, chroma * 0.02, L = 0.50
- *   muted       - seed hue, chroma * 0.05, L = 0.85
- *   success     - hue 145, L 0.55, C = min(0.18, seed.c * 0.9)
- *   warning     - hue 85,  L 0.75, C = min(0.18, seed.c * 0.9)
- *   destructive - hue 25,  L 0.55, C = min(0.20, seed.c)
- *   info        - hue 230, L 0.58, C = min(0.15, seed.c * 0.85)
+ * Palettes (returned under `${role}-family` keys):
+ *   primary-family     - the seed as-is
+ *   secondary-family   - same hue, opposite lightness end (AAA against primary), chroma * 0.33
+ *   accent-family      - complement (+180), full chroma
+ *   tertiary-family    - CTA from complement hue, chroma * 1.2 (max 0.30), L clamped 0.45-0.65
+ *   highlight-family   - secondary math applied to tertiary hue
+ *   neutral-family     - seed hue, chroma * 0.02, L = 0.50
+ *   muted-family       - seed hue, chroma * 0.05, L = 0.85
+ *   success-family     - hue 145, L 0.55, C = min(0.18, seed.c * 0.9)
+ *   warning-family     - hue 85,  L 0.75, C = min(0.18, seed.c * 0.9)
+ *   destructive-family - hue 25,  L 0.55, C = min(0.20, seed.c)
+ *   info-family        - hue 230, L 0.58, C = min(0.15, seed.c * 0.85)
  */
 function complementaryWheel(seed: OKLCH, options: ColorWheelOptions): SemanticColorSystem {
   const useGaussian = (options.chromaDistribution ?? 'gaussian') === 'gaussian';
   const alpha = seed.alpha ?? 1;
 
-  // primary: exact designer seed
-  const primaryColorValue = buildColorValue(seed, { token: 'primary' });
+  // primary-family: exact designer seed
+  const primaryColorValue = buildColorValue(seed, { token: 'primary-family' });
 
-  // secondary: same hue, AAA-verified lightness from primary matrix, chroma * 0.33
+  // secondary-family: same hue, AAA-verified lightness from primary matrix, chroma * 0.33
   const secondaryL = resolveSecondaryLightness(primaryColorValue, seed);
   const secondaryOklch: OKLCH = { l: secondaryL, c: seed.c * 0.33, h: seed.h, alpha };
   const secondaryFinal = useGaussian ? applyGaussianChroma(secondaryOklch) : secondaryOklch;
-  const secondaryColorValue = buildColorValue(roundOKLCH(secondaryFinal), { token: 'secondary' });
+  const secondaryColorValue = buildColorValue(roundOKLCH(secondaryFinal), {
+    token: 'secondary-family',
+  });
 
-  // accent: pure complement, full chroma -- no gaussian (needs full chroma)
+  // accent-family: pure complement, full chroma -- no gaussian (needs full chroma)
   const accentOklch = adjustHue(seed, 180);
-  const accentColorValue = buildColorValue(accentOklch, { token: 'accent' });
+  const accentColorValue = buildColorValue(accentOklch, { token: 'accent-family' });
 
-  // tertiary: CTA from complement hue, chroma boosted but capped, mid lightness
+  // tertiary-family: CTA from complement hue, chroma boosted but capped, mid lightness
   const tertiaryRaw: OKLCH = {
     l: Math.max(0.45, Math.min(0.65, seed.l)),
     c: Math.min(0.3, seed.c * 1.2),
@@ -137,9 +146,11 @@ function complementaryWheel(seed: OKLCH, options: ColorWheelOptions): SemanticCo
     alpha,
   };
   const tertiaryFinal = useGaussian ? applyGaussianChroma(tertiaryRaw) : tertiaryRaw;
-  const tertiaryColorValue = buildColorValue(roundOKLCH(tertiaryFinal), { token: 'tertiary' });
+  const tertiaryColorValue = buildColorValue(roundOKLCH(tertiaryFinal), {
+    token: 'tertiary-family',
+  });
 
-  // highlight: secondary math applied to tertiary hue
+  // highlight-family: secondary math applied to tertiary hue
   // AAA lightness from the tertiary's accessibility matrix, same desaturation as secondary.
   const highlightL = resolveSecondaryLightness(tertiaryColorValue, tertiaryFinal);
   const highlightOklch: OKLCH = {
@@ -149,48 +160,50 @@ function complementaryWheel(seed: OKLCH, options: ColorWheelOptions): SemanticCo
     alpha,
   };
   const highlightFinal = useGaussian ? applyGaussianChroma(highlightOklch) : highlightOklch;
-  const highlightColorValue = buildColorValue(roundOKLCH(highlightFinal), { token: 'highlight' });
+  const highlightColorValue = buildColorValue(roundOKLCH(highlightFinal), {
+    token: 'highlight-family',
+  });
 
-  // neutral: seed hue, very low chroma, mid lightness
+  // neutral-family: seed hue, very low chroma, mid lightness
   const neutralOklch: OKLCH = { l: 0.5, c: seed.c * 0.02, h: seed.h, alpha };
   const neutralFinal = useGaussian ? applyGaussianChroma(neutralOklch) : neutralOklch;
-  const neutralColorValue = buildColorValue(roundOKLCH(neutralFinal), { token: 'neutral' });
+  const neutralColorValue = buildColorValue(roundOKLCH(neutralFinal), { token: 'neutral-family' });
 
-  // muted: seed hue, slightly more chroma than neutral, high lightness
+  // muted-family: seed hue, slightly more chroma than neutral, high lightness
   const mutedOklch: OKLCH = { l: 0.85, c: seed.c * 0.05, h: seed.h, alpha };
   const mutedFinal = useGaussian ? applyGaussianChroma(mutedOklch) : mutedOklch;
-  const mutedColorValue = buildColorValue(roundOKLCH(mutedFinal), { token: 'muted' });
+  const mutedColorValue = buildColorValue(roundOKLCH(mutedFinal), { token: 'muted-family' });
 
-  // status colors -- no gaussian, must stay recognizable
+  // status families -- no gaussian, must stay recognizable
   const successColorValue = buildColorValue(
     roundOKLCH({ l: 0.55, c: Math.min(0.18, seed.c * 0.9), h: 145, alpha }),
-    { token: 'success' },
+    { token: 'success-family' },
   );
   const warningColorValue = buildColorValue(
     roundOKLCH({ l: 0.75, c: Math.min(0.18, seed.c * 0.9), h: 85, alpha }),
-    { token: 'warning' },
+    { token: 'warning-family' },
   );
   const destructiveColorValue = buildColorValue(
     roundOKLCH({ l: 0.55, c: Math.min(0.2, seed.c), h: 25, alpha }),
-    { token: 'destructive' },
+    { token: 'destructive-family' },
   );
   const infoColorValue = buildColorValue(
     roundOKLCH({ l: 0.58, c: Math.min(0.15, seed.c * 0.85), h: 230, alpha }),
-    { token: 'info' },
+    { token: 'info-family' },
   );
 
   return {
-    primary: primaryColorValue,
-    secondary: secondaryColorValue,
-    tertiary: tertiaryColorValue,
-    accent: accentColorValue,
-    highlight: highlightColorValue,
-    neutral: neutralColorValue,
-    muted: mutedColorValue,
-    success: successColorValue,
-    warning: warningColorValue,
-    destructive: destructiveColorValue,
-    info: infoColorValue,
+    'primary-family': primaryColorValue,
+    'secondary-family': secondaryColorValue,
+    'tertiary-family': tertiaryColorValue,
+    'accent-family': accentColorValue,
+    'highlight-family': highlightColorValue,
+    'neutral-family': neutralColorValue,
+    'muted-family': mutedColorValue,
+    'success-family': successColorValue,
+    'warning-family': warningColorValue,
+    'destructive-family': destructiveColorValue,
+    'info-family': infoColorValue,
   };
 }
 
@@ -215,8 +228,8 @@ function complementaryWheel(seed: OKLCH, options: ColorWheelOptions): SemanticCo
  *   'complementary'
  * );
  *
- * console.log(system.primary.name);   // e.g. "slate-bold-sapphire"
- * console.log(system.destructive.accessibility?.onWhite.wcagAAA); // true/false
+ * console.log(system['primary-family'].name);   // e.g. "slate-bold-sapphire"
+ * console.log(system['destructive-family'].accessibility?.onWhite.wcagAAA); // true/false
  * ```
  */
 export function colorWheel(

--- a/packages/color-utils/test/color-wheel.test.ts
+++ b/packages/color-utils/test/color-wheel.test.ts
@@ -1,5 +1,9 @@
 /**
  * Tests for colorWheel() -- complete 11-family semantic color system from a single OKLCH seed.
+ *
+ * The system is keyed by palette identifiers (`${role}-family`) so consumers can
+ * push the result into a TokenRegistry without colliding with the bare semantic
+ * role tokens owned by DEFAULT_SEMANTIC_COLOR_MAPPINGS. See rafters #1440.
  */
 
 import type { OKLCH } from '@rafters/shared';
@@ -21,35 +25,35 @@ const HARMONY_TYPES: HarmonyType[] = [
   'split-complementary',
 ];
 
-const SEMANTIC_ROLES = [
-  'primary',
-  'secondary',
-  'tertiary',
-  'accent',
-  'highlight',
-  'neutral',
-  'muted',
-  'success',
-  'warning',
-  'destructive',
-  'info',
-] as const;
+const SEMANTIC_FAMILIES = [
+  'primary-family',
+  'secondary-family',
+  'tertiary-family',
+  'accent-family',
+  'highlight-family',
+  'neutral-family',
+  'muted-family',
+  'success-family',
+  'warning-family',
+  'destructive-family',
+  'info-family',
+] as const satisfies ReadonlyArray<keyof SemanticColorSystem>;
 
 describe('colorWheel', () => {
   describe('output shape', () => {
-    it('returns all 11 semantic roles', () => {
+    it('returns all 11 palette families', () => {
       const system = colorWheel(blue, 'complementary');
 
-      for (const role of SEMANTIC_ROLES) {
-        expect(system).toHaveProperty(role);
+      for (const family of SEMANTIC_FAMILIES) {
+        expect(system).toHaveProperty(family);
       }
     });
 
-    it('each role is a ColorValue with required fields', () => {
+    it('each family is a ColorValue with required fields', () => {
       const system = colorWheel(blue, 'complementary');
 
-      for (const role of SEMANTIC_ROLES) {
-        const cv = system[role];
+      for (const family of SEMANTIC_FAMILIES) {
+        const cv = system[family];
         expect(cv).toHaveProperty('name');
         expect(cv).toHaveProperty('scale');
         expect(cv).toHaveProperty('tokenId');
@@ -60,8 +64,8 @@ describe('colorWheel', () => {
     it('each ColorValue has an 11-position scale', () => {
       const system = colorWheel(blue, 'complementary');
 
-      for (const role of SEMANTIC_ROLES) {
-        expect(system[role].scale).toHaveLength(11);
+      for (const family of SEMANTIC_FAMILIES) {
+        expect(system[family].scale).toHaveLength(11);
       }
     });
   });
@@ -71,114 +75,114 @@ describe('colorWheel', () => {
       const a = colorWheel(blue, 'complementary');
       const b = colorWheel(blue, 'complementary');
 
-      expect(a.primary.name).toBe(b.primary.name);
-      expect(a.accent.scale[5]?.h).toBe(b.accent.scale[5]?.h);
-      expect(a.destructive.scale[0]?.l).toBe(b.destructive.scale[0]?.l);
+      expect(a['primary-family'].name).toBe(b['primary-family'].name);
+      expect(a['accent-family'].scale[5]?.h).toBe(b['accent-family'].scale[5]?.h);
+      expect(a['destructive-family'].scale[0]?.l).toBe(b['destructive-family'].scale[0]?.l);
     });
 
     it('produces different primaries for different seeds', () => {
       const fromBlue = colorWheel(blue, 'complementary');
       const fromRed = colorWheel(red, 'complementary');
 
-      expect(fromBlue.primary.name).not.toBe(fromRed.primary.name);
+      expect(fromBlue['primary-family'].name).not.toBe(fromRed['primary-family'].name);
     });
   });
 
-  describe('complementary wheel -- primary', () => {
-    it('primary preserves the exact seed hue', () => {
+  describe('complementary wheel -- primary-family', () => {
+    it('primary-family preserves the exact seed hue', () => {
       const system = colorWheel(blue, 'complementary');
 
       // The 600 position in the scale is the anchor (index 6)
-      const scaleAnchor = system.primary.scale[6];
+      const scaleAnchor = system['primary-family'].scale[6];
       expect(scaleAnchor?.h).toBeCloseTo(blue.h, 1);
     });
   });
 
-  describe('complementary wheel -- accent', () => {
-    it('accent hue is approximately seed hue + 180', () => {
+  describe('complementary wheel -- accent-family', () => {
+    it('accent-family hue is approximately seed hue + 180', () => {
       const system = colorWheel(blue, 'complementary');
 
       // seed hue 240, complement 60
-      const accentAnchor = system.accent.scale[6];
+      const accentAnchor = system['accent-family'].scale[6];
       const expectedHue = (blue.h + 180) % 360;
       expect(accentAnchor?.h).toBeCloseTo(expectedHue, 0);
     });
 
-    it('accent hue for red seed is approximately 205', () => {
+    it('accent-family hue for red seed is approximately 205', () => {
       const system = colorWheel(red, 'complementary');
 
       const expectedHue = (red.h + 180) % 360;
-      const accentAnchor = system.accent.scale[6];
+      const accentAnchor = system['accent-family'].scale[6];
       expect(accentAnchor?.h).toBeCloseTo(expectedHue, 0);
     });
   });
 
-  describe('complementary wheel -- secondary', () => {
-    it('secondary has same hue as primary', () => {
+  describe('complementary wheel -- secondary-family', () => {
+    it('secondary-family has same hue as primary-family', () => {
       const system = colorWheel(blue, 'complementary');
 
       // Both scale anchors should share the same hue
-      const primaryH = system.primary.scale[6]?.h ?? 0;
-      const secondaryH = system.secondary.scale[6]?.h ?? 0;
+      const primaryH = system['primary-family'].scale[6]?.h ?? 0;
+      const secondaryH = system['secondary-family'].scale[6]?.h ?? 0;
       expect(Math.abs(primaryH - secondaryH)).toBeLessThan(2);
     });
 
-    it('secondary chroma is substantially reduced compared to primary', () => {
+    it('secondary-family chroma is substantially reduced compared to primary-family', () => {
       const system = colorWheel(blue, 'complementary');
 
-      const primaryC = system.primary.scale[6]?.c ?? 0;
-      const secondaryC = system.secondary.scale[6]?.c ?? 0;
+      const primaryC = system['primary-family'].scale[6]?.c ?? 0;
+      const secondaryC = system['secondary-family'].scale[6]?.c ?? 0;
       // secondary chroma is seeded at 0.33x before gaussian
       expect(secondaryC).toBeLessThan(primaryC);
     });
   });
 
-  describe('complementary wheel -- tertiary (CTA)', () => {
-    it('tertiary hue matches accent hue (complement)', () => {
+  describe('complementary wheel -- tertiary-family (CTA)', () => {
+    it('tertiary-family hue matches accent-family hue (complement)', () => {
       const system = colorWheel(blue, 'complementary');
 
-      const accentH = system.accent.scale[6]?.h ?? 0;
-      const tertiaryH = system.tertiary.scale[6]?.h ?? 0;
+      const accentH = system['accent-family'].scale[6]?.h ?? 0;
+      const tertiaryH = system['tertiary-family'].scale[6]?.h ?? 0;
       expect(Math.abs(accentH - tertiaryH)).toBeLessThan(2);
     });
 
-    it('tertiary lightness is clamped in the 0.45-0.65 CTA range', () => {
+    it('tertiary-family lightness is clamped in the 0.45-0.65 CTA range', () => {
       // We test that the 600 anchor (index 6) falls in the CTA range
       // (The actual stored value may vary slightly from gaussian application)
       const system = colorWheel(blue, 'complementary');
-      const tertiaryAnchor = system.tertiary.scale[6];
+      const tertiaryAnchor = system['tertiary-family'].scale[6];
       // Allow a small tolerance from the scale generation
       expect(tertiaryAnchor?.l).toBeGreaterThanOrEqual(0.3);
       expect(tertiaryAnchor?.l).toBeLessThanOrEqual(0.8);
     });
   });
 
-  describe('complementary wheel -- status colors', () => {
-    it('success hue is near 145', () => {
+  describe('complementary wheel -- status families', () => {
+    it('success-family hue is near 145', () => {
       const system = colorWheel(blue, 'complementary');
 
-      const successAnchor = system.success.scale[6];
+      const successAnchor = system['success-family'].scale[6];
       expect(successAnchor?.h).toBeCloseTo(145, 0);
     });
 
-    it('warning hue is near 85', () => {
+    it('warning-family hue is near 85', () => {
       const system = colorWheel(blue, 'complementary');
 
-      const warningAnchor = system.warning.scale[6];
+      const warningAnchor = system['warning-family'].scale[6];
       expect(warningAnchor?.h).toBeCloseTo(85, 0);
     });
 
-    it('destructive hue is near 25', () => {
+    it('destructive-family hue is near 25', () => {
       const system = colorWheel(blue, 'complementary');
 
-      const destructiveAnchor = system.destructive.scale[6];
+      const destructiveAnchor = system['destructive-family'].scale[6];
       expect(destructiveAnchor?.h).toBeCloseTo(25, 0);
     });
 
-    it('info hue is near 230', () => {
+    it('info-family hue is near 230', () => {
       const system = colorWheel(blue, 'complementary');
 
-      const infoAnchor = system.info.scale[6];
+      const infoAnchor = system['info-family'].scale[6];
       expect(infoAnchor?.h).toBeCloseTo(230, 0);
     });
 
@@ -186,27 +190,27 @@ describe('colorWheel', () => {
       const system = colorWheel(lowChroma, 'complementary');
 
       // lowChroma seed has c=0.04, so status should be well below caps
-      expect(system.success.scale[6]?.c).toBeLessThanOrEqual(0.18);
-      expect(system.warning.scale[6]?.c).toBeLessThanOrEqual(0.18);
-      expect(system.destructive.scale[6]?.c).toBeLessThanOrEqual(0.2);
-      expect(system.info.scale[6]?.c).toBeLessThanOrEqual(0.15);
+      expect(system['success-family'].scale[6]?.c).toBeLessThanOrEqual(0.18);
+      expect(system['warning-family'].scale[6]?.c).toBeLessThanOrEqual(0.18);
+      expect(system['destructive-family'].scale[6]?.c).toBeLessThanOrEqual(0.2);
+      expect(system['info-family'].scale[6]?.c).toBeLessThanOrEqual(0.15);
     });
   });
 
-  describe('complementary wheel -- neutral and muted', () => {
-    it('neutral chroma is very low', () => {
+  describe('complementary wheel -- neutral-family and muted-family', () => {
+    it('neutral-family chroma is very low', () => {
       const system = colorWheel(blue, 'complementary');
 
       // seed c=0.15, neutral = 0.02 * 0.15 = 0.003
-      const neutralAnchor = system.neutral.scale[6];
+      const neutralAnchor = system['neutral-family'].scale[6];
       expect(neutralAnchor?.c).toBeLessThan(0.05);
     });
 
-    it('muted chroma is low but higher than neutral', () => {
+    it('muted-family chroma is low but higher than neutral-family', () => {
       const system = colorWheel(blue, 'complementary');
 
-      const neutralC = system.neutral.scale[6]?.c ?? 0;
-      const mutedC = system.muted.scale[6]?.c ?? 0;
+      const neutralC = system['neutral-family'].scale[6]?.c ?? 0;
+      const mutedC = system['muted-family'].scale[6]?.c ?? 0;
       // muted is 0.05x vs neutral 0.02x before gaussian
       // muted at L=0.85 actually gets less gaussian boost than neutral at L=0.5
       // but muted starts higher so it may still be higher -- if not, just check it is low
@@ -214,47 +218,46 @@ describe('colorWheel', () => {
       expect(neutralC).toBeLessThan(0.05);
     });
 
-    it('neutral hue matches seed hue', () => {
+    it('neutral-family hue matches seed hue', () => {
       const system = colorWheel(blue, 'complementary');
 
-      const neutralAnchor = system.neutral.scale[6];
+      const neutralAnchor = system['neutral-family'].scale[6];
       expect(neutralAnchor?.h).toBeCloseTo(blue.h, 0);
     });
   });
 
   describe('gaussian vs flat chroma distribution', () => {
-    it('gaussian produces lower secondary chroma than flat', () => {
+    it('gaussian produces lower secondary-family chroma than flat', () => {
       const gaussian = colorWheel(blue, 'complementary', { chromaDistribution: 'gaussian' });
       const flat = colorWheel(blue, 'complementary', { chromaDistribution: 'flat' });
 
       // Secondary resolves to a light scale position (high L, far from seed L=0.5).
       // At L~0.95, gaussian ≈ 0.38 -- so gaussian chroma is ~38% of flat.
       // This is the main perceptual benefit of the gaussian distribution.
-      const gaussianSecondaryC = gaussian.secondary.scale[6]?.c ?? 0;
-      const flatSecondaryC = flat.secondary.scale[6]?.c ?? 0;
+      const gaussianSecondaryC = gaussian['secondary-family'].scale[6]?.c ?? 0;
+      const flatSecondaryC = flat['secondary-family'].scale[6]?.c ?? 0;
 
       expect(gaussianSecondaryC).toBeLessThan(flatSecondaryC);
     });
 
-    it('flat distribution skips gaussian on secondary', () => {
+    it('flat distribution skips gaussian on roles that bypass the curve', () => {
       const flat = colorWheel(blue, 'complementary', { chromaDistribution: 'flat' });
       const gaussian = colorWheel(blue, 'complementary', { chromaDistribution: 'gaussian' });
 
-      // At least one of primary/accent/success/destructive should be identical between modes
-      // since gaussian is NOT applied to those roles
-      expect(flat.primary.name).toBe(gaussian.primary.name);
-      expect(flat.accent.name).toBe(gaussian.accent.name);
-      expect(flat.success.name).toBe(gaussian.success.name);
+      // primary-family / accent-family / status families bypass gaussian; they should be identical.
+      expect(flat['primary-family'].name).toBe(gaussian['primary-family'].name);
+      expect(flat['accent-family'].name).toBe(gaussian['accent-family'].name);
+      expect(flat['success-family'].name).toBe(gaussian['success-family'].name);
     });
   });
 
   describe('all harmony types return valid systems', () => {
     for (const harmony of HARMONY_TYPES) {
-      it(`${harmony} returns a complete 11-role system`, () => {
+      it(`${harmony} returns a complete 11-family system`, () => {
         const system = colorWheel(blue, harmony);
 
-        for (const role of SEMANTIC_ROLES) {
-          const cv = system[role];
+        for (const family of SEMANTIC_FAMILIES) {
+          const cv = system[family];
           expect(cv).toHaveProperty('name');
           expect(cv.scale).toHaveLength(11);
         }
@@ -263,24 +266,24 @@ describe('colorWheel', () => {
   });
 
   describe('token assignment', () => {
-    it('each ColorValue has the correct token name assigned', () => {
+    it('each ColorValue has its palette name in the token field', () => {
       const system = colorWheel(blue, 'complementary');
 
-      // buildColorValue receives the token option for each role
-      for (const role of SEMANTIC_ROLES) {
-        const cv = system[role];
-        // token is optional in schema, but we set it for all roles
-        expect(cv.token).toBe(role);
+      // buildColorValue receives `{ token: '<role>-family' }` so the value carries its
+      // registry pointer. Matches the SemanticColorSystem key it is stored under.
+      for (const family of SEMANTIC_FAMILIES) {
+        const cv = system[family];
+        expect(cv.token).toBe(family);
       }
     });
   });
 
-  describe('all roles produce valid scales', () => {
+  describe('all families produce valid scales', () => {
     it('every scale position has valid OKLCH values', () => {
       const system = colorWheel(blue, 'complementary');
 
-      for (const role of SEMANTIC_ROLES) {
-        for (const scaleColor of system[role].scale) {
+      for (const family of SEMANTIC_FAMILIES) {
+        for (const scaleColor of system[family].scale) {
           expect(typeof scaleColor.l).toBe('number');
           expect(typeof scaleColor.c).toBe('number');
           expect(typeof scaleColor.h).toBe('number');
@@ -293,21 +296,21 @@ describe('colorWheel', () => {
   });
 
   describe('accessibility', () => {
-    it('primary has accessibility metadata', () => {
+    it('primary-family has accessibility metadata', () => {
       const system = colorWheel(blue, 'complementary');
 
-      expect(system.primary.accessibility).toBeDefined();
-      expect(system.primary.accessibility?.onWhite).toBeDefined();
-      expect(system.primary.accessibility?.onBlack).toBeDefined();
+      expect(system['primary-family'].accessibility).toBeDefined();
+      expect(system['primary-family'].accessibility?.onWhite).toBeDefined();
+      expect(system['primary-family'].accessibility?.onBlack).toBeDefined();
     });
 
-    it('destructive has accessibility metadata', () => {
+    it('destructive-family has accessibility metadata', () => {
       const system = colorWheel(blue, 'complementary');
 
-      expect(system.destructive.accessibility).toBeDefined();
+      expect(system['destructive-family'].accessibility).toBeDefined();
     });
 
-    it('primary and secondary together span high contrast range within each scale', () => {
+    it('primary-family and secondary-family together span high contrast range within each scale', () => {
       // resolveSecondaryLightness picks a lightness from primary's AAA accessibility
       // matrix that is far from the seed. The secondary scale then spans its own full
       // lightness range from that anchor. Together they provide complementary
@@ -316,8 +319,8 @@ describe('colorWheel', () => {
 
       // Primary scale dark end (scale[10]) vs secondary scale light end (scale[0])
       // should provide strong contrast -- these are the typical text/bg pairing regions.
-      const primaryDark = system.primary.scale[10];
-      const secondaryLight = system.secondary.scale[0];
+      const primaryDark = system['primary-family'].scale[10];
+      const secondaryLight = system['secondary-family'].scale[0];
 
       if (!primaryDark || !secondaryLight) {
         throw new Error('Scale positions missing');
@@ -358,7 +361,7 @@ describe('colorWheel', () => {
       const hue0: OKLCH = { l: 0.5, c: 0.15, h: 0, alpha: 1 };
       const system = colorWheel(hue0, 'complementary');
 
-      const accentAnchor = system.accent.scale[6];
+      const accentAnchor = system['accent-family'].scale[6];
       expect(accentAnchor?.h).toBeCloseTo(180, 0);
     });
 
@@ -370,27 +373,27 @@ describe('colorWheel', () => {
 
       const system = colorWheel(achromatic, 'complementary');
       // seed.l = 0.6 > 0.5, so fallback returns 0.25 (dark secondary)
-      const secondaryAnchor = system.secondary.scale[6];
+      const secondaryAnchor = system['secondary-family'].scale[6];
       expect(secondaryAnchor).toBeDefined();
       // secondary should be darker than seed (L < 0.6)
       expect(secondaryAnchor?.l).toBeLessThan(0.6);
     });
   });
 
-  describe('highlight', () => {
-    it('highlight hue matches tertiary hue', () => {
+  describe('highlight-family', () => {
+    it('highlight-family hue matches tertiary-family hue', () => {
       const system = colorWheel(blue, 'complementary');
 
-      const tertiaryH = system.tertiary.scale[6]?.h ?? 0;
-      const highlightH = system.highlight.scale[6]?.h ?? 0;
+      const tertiaryH = system['tertiary-family'].scale[6]?.h ?? 0;
+      const highlightH = system['highlight-family'].scale[6]?.h ?? 0;
       expect(Math.abs(tertiaryH - highlightH)).toBeLessThan(2);
     });
 
-    it('highlight chroma is lower than tertiary chroma', () => {
+    it('highlight-family chroma is lower than tertiary-family chroma', () => {
       const system = colorWheel(blue, 'complementary');
 
-      const tertiaryC = system.tertiary.scale[6]?.c ?? 0;
-      const highlightC = system.highlight.scale[6]?.c ?? 0;
+      const tertiaryC = system['tertiary-family'].scale[6]?.c ?? 0;
+      const highlightC = system['highlight-family'].scale[6]?.c ?? 0;
       expect(highlightC).toBeLessThan(tertiaryC);
     });
   });

--- a/packages/design-tokens/test/color-wheel-integration.test.ts
+++ b/packages/design-tokens/test/color-wheel-integration.test.ts
@@ -50,22 +50,30 @@ const SCALE_POSITIONS = [
   '950',
 ] as const;
 
+/**
+ * Palette identifiers returned by colorWheel(). Distinct from the bare semantic
+ * role names so the colorWheel ColorValues do not collide with semantic tokens
+ * owned by DEFAULT_SEMANTIC_COLOR_MAPPINGS. See rafters #1440.
+ */
 const FAMILY_NAMES = [
-  'primary',
-  'secondary',
-  'tertiary',
-  'accent',
-  'highlight',
-  'neutral',
-  'muted',
-  'success',
-  'warning',
-  'destructive',
-  'info',
+  'primary-family',
+  'secondary-family',
+  'tertiary-family',
+  'accent-family',
+  'highlight-family',
+  'neutral-family',
+  'muted-family',
+  'success-family',
+  'warning-family',
+  'destructive-family',
+  'info-family',
 ] as const;
 
 /**
- * Families that have semantic token mappings in DEFAULT_SEMANTIC_COLOR_MAPPINGS.
+ * Bare semantic role names. These are owned by DEFAULT_SEMANTIC_COLOR_MAPPINGS
+ * and emitted by the semantic generator as ColorReferences (rendered as
+ * `--primary:` etc. in the Tailwind exporter). Distinct from FAMILY_NAMES.
+ *
  * tertiary and neutral are excluded:
  * - tertiary: not defined as a semantic token
  * - neutral: used indirectly via background, foreground, card tokens, not as --neutral:
@@ -182,10 +190,10 @@ describe('colorWheel -> TokenRegistry integration', () => {
       }
     });
 
-    it('every ColorValue has the token field set to its semantic role name', () => {
+    it('every ColorValue has the token field set to its palette name', () => {
       const system = colorWheel(TAILWIND_BLUE_500, 'complementary');
-      for (const [roleName, cv] of Object.entries(system)) {
-        expect(cv.token, `${roleName} missing token field`).toBe(roleName);
+      for (const [paletteName, cv] of Object.entries(system)) {
+        expect(cv.token, `${paletteName} missing token field`).toBe(paletteName);
       }
     });
   });
@@ -212,18 +220,18 @@ describe('colorWheel -> TokenRegistry integration', () => {
     });
 
     it('ingested family token value is a ColorValue with a 11-step scale', async () => {
-      // Known fixture gap (#1229/#1230): the DEFAULT_TOKENS set includes a semantic
-      // "primary" token with generationRule: "scale:900" depending on "neutral".
-      // When buildRegistry sets neutral (a later iteration), the cascade regenerates
-      // "primary" from its rule, overwriting the ColorValue with a ColorReference.
-      // The fix is to use a separate namespace for colorWheel families vs. semantic tokens.
-      // For now, assert the value is defined and skip the ColorValue shape check.
+      // After #1440 (palette-namespaced colorWheel keys), the family ColorValue
+      // lives at `${role}-family`, distinct from the semantic role token at the
+      // bare role name. No cascade clobber path: primary-family has no semantic
+      // dependents, so its ColorValue persists across the buildRegistry pass.
       const registry = await buildRegistry(TAILWIND_BLUE_500);
-      const value = registry.get('primary')?.value;
+      const value = registry.get('primary-family')?.value;
       expect(value).toBeDefined();
       expect(value).not.toBeNull();
-      // After cascade, primary may hold a ColorReference (fixture gap #1229/#1230).
-      // Either shape (ColorValue or ColorReference) is acceptable until #1229 is resolved.
+      expect(value && typeof value === 'object' && 'scale' in value).toBe(true);
+      if (value && typeof value === 'object' && 'scale' in value) {
+        expect((value as ColorValue).scale).toHaveLength(11);
+      }
     });
   });
 
@@ -240,37 +248,23 @@ describe('colorWheel -> TokenRegistry integration', () => {
       expect(fg?.value, 'primary-foreground value is undefined').toBeDefined();
     });
 
-    it('accent-foreground cascades to a new value after accent colorWheel update', async () => {
-      // Known cascade gap (#1223): when the contrast plugin has no WCAG pair data
-      // for the accent family, it falls back to the neutral family. If both the
-      // original and updated accent families produce the same neutral fallback,
-      // the before/after values appear identical even though cascade fired.
-      // Full fix tracked in #1231. For now, verify cascade does not throw.
+    it('accent-foreground cascade after accent-family colorWheel update does not throw', async () => {
+      // After #1440 (palette rename), accent-family has no semantic dependents
+      // -- DEFAULT_SEMANTIC_COLOR_MAPPINGS still points accent-foreground at the
+      // pre-rename family names. The cascade rewiring (semantic dependsOn[0]
+      // points at the implied family) lands in #1441 / #1442. For now the
+      // assertion is just that set on a colorWheel-managed family does not
+      // throw a cascade-aggregate error. #1441 will tighten this to assert the
+      // value actually changes.
       const registry = await buildRegistry(TAILWIND_BLUE_500);
       const fgBefore = JSON.stringify(registry.get('accent-foreground')?.value);
 
       const newSystem = colorWheel(BRAND_MAGENTA, 'complementary');
-      // Cascade should fire without throwing a cascade-aggregate error
-      let caughtError: unknown;
-      try {
-        await registry.set('accent', newSystem.accent);
-      } catch (e) {
-        caughtError = e;
-      }
+      await registry.set('accent-family', newSystem['accent-family']);
 
-      if (caughtError) {
-        // If cascade threw, it must be a cascade-aggregate error (not a crash)
-        expect((caughtError as Error).message).toBe('cascade failed');
-        const cause = (caughtError as Error & { cause: unknown }).cause as { code: string };
-        expect(cause.code).toBe('cascade-aggregate');
-      } else {
-        // Cascade succeeded. Value may or may not have changed depending on
-        // WCAG data availability (fixture gap #1223/#1231).
-        const fgAfter = JSON.stringify(registry.get('accent-foreground')?.value);
-        // Just verify it's still a defined value
-        expect(fgAfter).toBeDefined();
-        void fgBefore; // referenced above
-      }
+      const fgAfter = JSON.stringify(registry.get('accent-foreground')?.value);
+      expect(fgAfter).toBeDefined();
+      void fgBefore;
     });
 
     it('destructive-foreground exists and has a value', async () => {
@@ -316,10 +310,11 @@ describe('colorWheel -> TokenRegistry integration', () => {
       const token = registry.get('primary');
       const value = token?.value;
       expect(value).toBeDefined();
-      // After replacing with ColorValue, value should be a ColorValue
-      if (value && typeof value === 'object' && 'scale' in value) {
-        expect((value as ColorValue).scale.length).toBeGreaterThan(0);
-      }
+      // primary is a semantic ColorReference (rule scale:N pointing at the lightRef family).
+      // colorWheel pushes its ColorValue under primary-family; the bare primary slot stays a ref.
+      expect(value && typeof value === 'object' && 'family' in value && 'position' in value).toBe(
+        true,
+      );
     });
   });
 
@@ -409,13 +404,13 @@ describe('colorWheel -> TokenRegistry integration', () => {
   });
 
   describe('real-world seeds', () => {
-    it('Tailwind blue-500 seed: primary scale mid-tone hue stays near 259', () => {
+    it('Tailwind blue-500 seed: primary-family scale mid-tone hue stays near 259', () => {
       const system = colorWheel(TAILWIND_BLUE_500, 'complementary');
-      const primaryMid = system.primary.scale[5];
+      const primaryMid = system['primary-family'].scale[5];
       if (primaryMid) {
         expect(
           Math.abs(primaryMid.h - 259),
-          `primary mid-tone hue drifted: got ${primaryMid.h}`,
+          `primary-family mid-tone hue drifted: got ${primaryMid.h}`,
         ).toBeLessThan(15);
       }
     });


### PR DESCRIPTION
## Summary

Step A of #1439 (storage-layer surgery sub-epic, under #1242). Pure rename + caller updates so install-time collision validation can land in step C without rejecting every `colorWheel` consumer.

`colorWheel()` now returns ColorValues keyed by `${role}-family` (e.g. `primary-family`, `accent-family`, ...) instead of the bare role names that `DEFAULT_SEMANTIC_COLOR_MAPPINGS` already owns. Two generators emitting under the same names was the install-time collision that weaponized the latent TokenDependency anti-pattern (Sept 2025 commit c58c1f84) when `colorWheel` landed (#1217, Apr 13 2026).

Each ColorValue's `token` field now matches its palette identifier (`system['primary-family'].token === 'primary-family'`).

## Scope

- `packages/color-utils/src/color-wheel.ts` -- `SemanticColorSystem` keys, `buildColorValue` token strings, return shape, JSDoc.
- `packages/color-utils/test/color-wheel.test.ts` -- bracket-access + `SEMANTIC_FAMILIES` const with `as const satisfies ReadonlyArray<keyof SemanticColorSystem>`.
- `packages/design-tokens/test/color-wheel-integration.test.ts` -- `FAMILY_NAMES`, ingestion test, cascade test now sets `accent-family` instead of `accent`.

## What this does NOT do

- No change to OKLCH math, scale generation, accessibility metadata, or CSS output.
- No change to `DEFAULT_SEMANTIC_COLOR_MAPPINGS` lightRef/darkRef. That belongs in #1441.
- No change to `packages/design-tokens/src/generators/color.ts`.
- No deprecated alias for the old role-name keys. Consumers update or fail to compile.

## Test plan

- [x] `pnpm --filter=@rafters/color-utils test` -- 194/194 green
- [x] `pnpm --filter=@rafters/design-tokens test` -- 292/292 green
- [x] `pnpm preflight` -- exit 0

## Closes / Part of / Blocks

Closes #1440. Part of #1439. Blocks #1442.

## Quality gate

`legion quality-gate record` -- clean (0 findings). Gate row id `019e055d-6dba-7030-aa39-0bb09cbca27e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)