### PR TITLE
feat(design-tokens): install-time validation gate (#1442)

### DIFF
--- a/packages/design-tokens/src/bootstrap.ts
+++ b/packages/design-tokens/src/bootstrap.ts
@@ -1,0 +1,223 @@
+/**
+ * Install-time validation gate.
+ *
+ * Lifts the four invariants of a healthy design-token graph from "runtime
+ * surfaces them as confusing cascade failures" up to "build refuses to start
+ * with a clear, structured error":
+ *
+ *   1. No name collision between generators
+ *   2. Every dependsOn target resolves to a real token
+ *   3. Every token with a rule produces an input the plugin's schema accepts
+ *   4. The graph is a DAG (no cycles)
+ *
+ * Runs in collect-all mode: gathers every failure across all four checks
+ * before returning, so a single build surfaces the full picture instead of
+ * forcing iterative fix/run/fix loops. Runtime stays fail-fast (cascade);
+ * install is whole-or-nothing.
+ *
+ * No `class BuildError extends Error`. Per #1242 invariant: structured data
+ * on `Error.cause` only. Callers receive a discriminated-union value.
+ *
+ * See rafters #1442. Closes #1229 / #1231 once consumers route through this.
+ */
+
+import type { Token } from '@rafters/shared';
+import { TokenDependencyGraph } from './dependencies';
+import { GenerationRuleParser } from './generation-rules';
+import { getPlugin, resolveInput } from './plugins';
+import { TokenRegistry } from './registry';
+
+/**
+ * One generator's output. The generator name is carried so collision and
+ * unresolved-dependsOn errors can name their source.
+ */
+export interface GeneratorOutput {
+  name: string;
+  tokens: Token[];
+}
+
+export type BuildError =
+  | {
+      code: 'collision';
+      tokenName: string;
+      generators: [string, string];
+    }
+  | {
+      code: 'unresolved-dependsOn';
+      tokenName: string;
+      missingDependency: string;
+      sourceGenerator: string;
+    }
+  | {
+      code: 'shape-mismatch';
+      tokenName: string;
+      pluginId: string;
+      ruleString: string;
+      zodIssues: Array<{ path: Array<string | number>; message: string; expected?: string }>;
+    }
+  | {
+      code: 'cycle';
+      cyclePath: string[];
+    };
+
+export type BootstrapResult =
+  | { isValid: true; tokens: Token[] }
+  | { isValid: false; errors: BuildError[] };
+
+/**
+ * Validate generator outputs as a single graph. Returns the assembled token
+ * list on success, a list of BuildErrors on failure. Errors from independent
+ * checks are collected; one bad token does not hide problems in another.
+ */
+export function bootstrap(generatorOutputs: GeneratorOutput[]): BootstrapResult {
+  const errors: BuildError[] = [];
+
+  // 1. Name-collision check + assemble unique-token map keyed by name.
+  const tokenSource = new Map<string, string>();
+  const tokens = new Map<string, Token>();
+  for (const { name: generatorName, tokens: generatorTokens } of generatorOutputs) {
+    for (const token of generatorTokens) {
+      const prior = tokenSource.get(token.name);
+      if (prior !== undefined) {
+        errors.push({
+          code: 'collision',
+          tokenName: token.name,
+          generators: [prior, generatorName],
+        });
+        continue;
+      }
+      tokenSource.set(token.name, generatorName);
+      tokens.set(token.name, token);
+    }
+  }
+
+  // 2. DependsOn-resolvable check. Every dep target must be in the assembled set.
+  for (const [tokenName, token] of tokens.entries()) {
+    if (!token.dependsOn) continue;
+    for (const dep of token.dependsOn) {
+      if (!tokens.has(dep)) {
+        errors.push({
+          code: 'unresolved-dependsOn',
+          tokenName,
+          missingDependency: dep,
+          sourceGenerator: tokenSource.get(tokenName) ?? '<unknown>',
+        });
+      }
+    }
+  }
+
+  // 3. Cycle check. Build a temp graph and run topological sort.
+  const graph = new TokenDependencyGraph();
+  try {
+    for (const [tokenName, token] of tokens.entries()) {
+      if (token.dependsOn && token.dependsOn.length > 0) {
+        // Filter to known deps so unresolved-dependsOn does not double-report
+        // here. The unresolved check above already named the missing edges.
+        const resolvable = token.dependsOn.filter((d) => tokens.has(d));
+        graph.addDependency(tokenName, resolvable, token.generationRule ?? '');
+      }
+    }
+    graph.topologicalSort();
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    errors.push({
+      code: 'cycle',
+      cyclePath: extractCyclePath(message),
+    });
+  }
+
+  // 4. Shape-contract check. For each token with a rule, run resolveInput
+  // and parse the output against the plugin's input schema. A registry is
+  // built from the assembled tokens; resolveInput's reads come from there.
+  const allTokens = Array.from(tokens.values());
+  const ruleParser = new GenerationRuleParser();
+  if (allTokens.length > 0) {
+    const registry = new TokenRegistry(allTokens);
+    for (const token of allTokens) {
+      if (!token.generationRule) continue;
+
+      let parsed: ReturnType<GenerationRuleParser['parse']>;
+      try {
+        parsed = ruleParser.parse(token.generationRule);
+      } catch {
+        // Invalid rule syntax is caught elsewhere via validateRule; do not
+        // double-report here.
+        continue;
+      }
+
+      const plugin = getPlugin(parsed.type);
+      if (!plugin) continue;
+
+      let raw: unknown;
+      try {
+        raw = resolveInput(registry, parsed, token.name);
+      } catch (e) {
+        errors.push({
+          code: 'shape-mismatch',
+          tokenName: token.name,
+          pluginId: parsed.type,
+          ruleString: token.generationRule,
+          zodIssues: [
+            {
+              path: [],
+              message: e instanceof Error ? e.message : String(e),
+            },
+          ],
+        });
+        continue;
+      }
+
+      const result = plugin.input.safeParse(raw);
+      if (!result.success) {
+        errors.push({
+          code: 'shape-mismatch',
+          tokenName: token.name,
+          pluginId: parsed.type,
+          ruleString: token.generationRule,
+          zodIssues: result.error.issues.map((issue) => ({
+            path: issue.path.map((p): string | number => (typeof p === 'number' ? p : String(p))),
+            message: issue.message,
+            ...('expected' in issue ? { expected: String(issue.expected) } : {}),
+          })),
+        });
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    return { isValid: false, errors };
+  }
+  return { isValid: true, tokens: allTokens };
+}
+
+/**
+ * Pulls the cycle node names from a topological-sort error message. Best-effort
+ * -- the message format is owned by `topologicalSort`. Returns an empty array
+ * if the message does not carry path data.
+ */
+function extractCyclePath(message: string): string[] {
+  const match = message.match(/cycle.*detected.*?(\b[\w-]+(?:\s*->\s*[\w-]+)*)/i);
+  if (!match || !match[1]) return [];
+  return match[1].split(/\s*->\s*/).filter((s) => s.length > 0);
+}
+
+/**
+ * Throw a structured build error from a BuildError list. Use this when the
+ * caller cannot proceed with an invalid graph and needs propagation up the
+ * stack. The thrown Error carries the BuildError list on `cause`.
+ */
+export function throwOnInvalid(
+  result: BootstrapResult,
+): asserts result is { isValid: true; tokens: Token[] } {
+  if (!result.isValid) {
+    throw new Error(
+      `bootstrap: design-token graph failed validation (${result.errors.length} error${result.errors.length === 1 ? '' : 's'})`,
+      {
+        cause: {
+          code: 'bootstrap-invalid',
+          errors: result.errors,
+        },
+      },
+    );
+  }
+}

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -3,6 +3,7 @@
  * Revolutionary dependency-aware design token system with W3C DTCG compliance
  */
 
+export * from './bootstrap.js';
 export * from './dependencies.js';
 // Exporters - convert tokens to various output formats
 export * from './exporters/index.js';

--- a/packages/design-tokens/test/bootstrap-validation.test.ts
+++ b/packages/design-tokens/test/bootstrap-validation.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Bootstrap validation gate tests (#1442).
+ *
+ * Asserts the four install-time invariants:
+ *   1. No name collision between generators
+ *   2. Every dependsOn target resolves to a real token
+ *   3. Every token with a rule produces a plugin-shape-valid input
+ *   4. The graph is a DAG (no cycles)
+ *
+ * Plus the happy path on the real generateBaseSystem() output.
+ */
+
+import type { ColorReference, ColorValue, Token } from '@rafters/shared';
+import { afterEach, describe, expect, it } from 'vitest';
+import { bootstrap, throwOnInvalid } from '../src/bootstrap.js';
+import { generateBaseSystem } from '../src/index.js';
+import contrastPlugin from '../src/plugins/contrast.js';
+import scalePlugin from '../src/plugins/scale.js';
+import { clearPlugins, registerPlugin } from '../src/plugins.js';
+
+function ensureBuiltinPlugins(): void {
+  clearPlugins();
+  registerPlugin(contrastPlugin as never);
+  registerPlugin(scalePlugin as never);
+}
+
+function colorRef(family: string, position: string): ColorReference {
+  return { family, position };
+}
+
+function makeColorValue(name: string, hue: number): ColorValue {
+  return {
+    name,
+    scale: Array.from({ length: 11 }, (_, i) => ({
+      l: 0.05 + i * 0.09,
+      c: 0.1,
+      h: hue,
+      alpha: 1,
+    })),
+    tokenId: `${name}-id`,
+    accessibility: {
+      wcagAA: { normal: [[1, 8]], large: [] },
+      wcagAAA: { normal: [[0, 9]], large: [] },
+      onWhite: { wcagAA: false, wcagAAA: false, contrastRatio: 4.5, aa: [], aaa: [] },
+      onBlack: { wcagAA: false, wcagAAA: false, contrastRatio: 4.5, aa: [], aaa: [] },
+    },
+  };
+}
+
+describe('bootstrap: install-time validation gate', () => {
+  afterEach(() => {
+    clearPlugins();
+  });
+
+  describe('name collision', () => {
+    it('rejects two generators emitting the same token name', () => {
+      ensureBuiltinPlugins();
+      const a: Token = {
+        name: 'primary',
+        value: '#ff0000',
+        category: 'color',
+        namespace: 'color',
+        userOverride: null,
+      };
+      const b: Token = {
+        name: 'primary',
+        value: colorRef('neutral', '900'),
+        category: 'color',
+        namespace: 'semantic',
+        userOverride: null,
+      };
+
+      const result = bootstrap([
+        { name: 'gen-a', tokens: [a] },
+        { name: 'gen-b', tokens: [b] },
+      ]);
+
+      expect(result.isValid).toBe(false);
+      if (result.isValid) return;
+      const collisions = result.errors.filter((e) => e.code === 'collision');
+      expect(collisions).toHaveLength(1);
+      const [collision] = collisions;
+      if (!collision || collision.code !== 'collision') {
+        throw new Error('expected collision error');
+      }
+      expect(collision.tokenName).toBe('primary');
+      expect(collision.generators).toEqual(['gen-a', 'gen-b']);
+    });
+
+    it('does not flag distinct token names', () => {
+      ensureBuiltinPlugins();
+      const t1: Token = {
+        name: 'primary',
+        value: '#ff0000',
+        category: 'color',
+        namespace: 'color',
+        userOverride: null,
+      };
+      const t2: Token = {
+        name: 'secondary',
+        value: '#00ff00',
+        category: 'color',
+        namespace: 'color',
+        userOverride: null,
+      };
+      const result = bootstrap([{ name: 'gen', tokens: [t1, t2] }]);
+      expect(result.isValid).toBe(true);
+    });
+  });
+
+  describe('unresolved dependsOn', () => {
+    it('rejects a token referencing a non-existent dependency', () => {
+      ensureBuiltinPlugins();
+      const t: Token = {
+        name: 'derived',
+        value: '#aabbcc',
+        category: 'color',
+        namespace: 'color',
+        dependsOn: ['nonexistent'],
+        userOverride: null,
+      };
+      const result = bootstrap([{ name: 'gen', tokens: [t] }]);
+
+      expect(result.isValid).toBe(false);
+      if (result.isValid) return;
+      const unresolved = result.errors.filter((e) => e.code === 'unresolved-dependsOn');
+      expect(unresolved).toHaveLength(1);
+      const [err] = unresolved;
+      if (!err || err.code !== 'unresolved-dependsOn') throw new Error('expected unresolved');
+      expect(err.tokenName).toBe('derived');
+      expect(err.missingDependency).toBe('nonexistent');
+      expect(err.sourceGenerator).toBe('gen');
+    });
+  });
+
+  describe('cycle detection', () => {
+    it('rejects a two-node cycle', () => {
+      ensureBuiltinPlugins();
+      const a: Token = {
+        name: 'a',
+        value: '1',
+        category: 'spacing',
+        namespace: 'spacing',
+        dependsOn: ['b'],
+        userOverride: null,
+      };
+      const b: Token = {
+        name: 'b',
+        value: '2',
+        category: 'spacing',
+        namespace: 'spacing',
+        dependsOn: ['a'],
+        userOverride: null,
+      };
+      const result = bootstrap([{ name: 'gen', tokens: [a, b] }]);
+      expect(result.isValid).toBe(false);
+      if (result.isValid) return;
+      expect(result.errors.some((e) => e.code === 'cycle')).toBe(true);
+    });
+  });
+
+  describe('shape contract', () => {
+    it('rejects a contrast:auto rule whose dependsOn[0] is a ColorReference, not ColorValue', () => {
+      ensureBuiltinPlugins();
+      const family: Token = {
+        name: 'broken-family',
+        value: colorRef('neutral', '900'),
+        category: 'color',
+        namespace: 'semantic',
+        userOverride: null,
+      };
+      const fg: Token = {
+        name: 'broken-foreground',
+        value: colorRef('neutral', '50'),
+        category: 'color',
+        namespace: 'semantic',
+        dependsOn: ['broken-family'],
+        generationRule: 'contrast:auto',
+        userOverride: null,
+      };
+      const result = bootstrap([{ name: 'gen', tokens: [family, fg] }]);
+
+      expect(result.isValid).toBe(false);
+      if (result.isValid) return;
+      const shape = result.errors.find((e) => e.code === 'shape-mismatch');
+      expect(shape).toBeDefined();
+      if (!shape || shape.code !== 'shape-mismatch') throw new Error('expected shape-mismatch');
+      expect(shape.tokenName).toBe('broken-foreground');
+      expect(shape.pluginId).toBe('contrast');
+      expect(shape.ruleString).toBe('contrast:auto');
+      expect(shape.zodIssues.length).toBeGreaterThan(0);
+    });
+
+    it('passes a contrast:auto rule whose dependsOn[0] is a real ColorValue', () => {
+      ensureBuiltinPlugins();
+      const family: Token = {
+        name: 'good-family',
+        value: makeColorValue('good-family', 240),
+        category: 'color',
+        namespace: 'color',
+        userOverride: null,
+      };
+      const fg: Token = {
+        name: 'good-foreground',
+        value: colorRef('good-family', '50'),
+        category: 'color',
+        namespace: 'semantic',
+        dependsOn: ['good-family'],
+        generationRule: 'contrast:auto',
+        userOverride: null,
+      };
+      const result = bootstrap([{ name: 'gen', tokens: [family, fg] }]);
+
+      const shape = result.isValid ? null : result.errors.find((e) => e.code === 'shape-mismatch');
+      expect(shape, JSON.stringify(shape, null, 2)).toBeFalsy();
+    });
+  });
+
+  describe('happy path', () => {
+    it('the real generateBaseSystem() output reveals preexisting graph issues', () => {
+      ensureBuiltinPlugins();
+      const { allTokens } = generateBaseSystem();
+      const result = bootstrap([{ name: 'base-system', tokens: allTokens }]);
+
+      // Document the bugs the validation gate caught on its first run so they
+      // become a punch-list, not silent runtime confusion. Each is filed as a
+      // separate follow-up to fix; this test stops drift while they are open.
+      if (!result.isValid) {
+        const collisions = result.errors
+          .filter((e) => e.code === 'collision')
+          .map((e) => (e.code === 'collision' ? e.tokenName : ''));
+        const unresolved = result.errors
+          .filter((e) => e.code === 'unresolved-dependsOn')
+          .map((e) =>
+            e.code === 'unresolved-dependsOn' ? `${e.tokenName} -> ${e.missingDependency}` : '',
+          );
+        const shapes = result.errors.filter((e) => e.code === 'shape-mismatch');
+        const cycles = result.errors.filter((e) => e.code === 'cycle');
+
+        // eslint-disable-next-line no-console
+        console.log('[bootstrap-validation] preexisting issues caught at install:', {
+          collisions,
+          unresolved,
+          shapeCount: shapes.length,
+          cycleCount: cycles.length,
+        });
+
+        // The known set as of the introduction of this gate (#1442). Adjust as
+        // each follow-up lands. New regressions outside this set fail the test.
+        const KNOWN_COLLISIONS = new Set(['font-size-base']);
+        const KNOWN_UNRESOLVED = new Set(['shortcut -> letter-spacing-widest']);
+
+        const unknownCollisions = collisions.filter((c) => !KNOWN_COLLISIONS.has(c));
+        const unknownUnresolved = unresolved.filter((u) => !KNOWN_UNRESOLVED.has(u));
+
+        expect(
+          unknownCollisions,
+          `unexpected collisions beyond the known punch list: ${unknownCollisions.join(', ')}`,
+        ).toEqual([]);
+        expect(
+          unknownUnresolved,
+          `unexpected unresolved dependsOn beyond the known punch list: ${unknownUnresolved.join(', ')}`,
+        ).toEqual([]);
+        expect(shapes, 'shape-mismatch errors are unexpected and should be zero').toEqual([]);
+        expect(cycles, 'cycle errors are unexpected and should be zero').toEqual([]);
+        return;
+      }
+      expect(result.tokens.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('throwOnInvalid', () => {
+    it('throws structured Error when validation fails', () => {
+      ensureBuiltinPlugins();
+      const t: Token = {
+        name: 'derived',
+        value: '#aabbcc',
+        category: 'color',
+        namespace: 'color',
+        dependsOn: ['nonexistent'],
+        userOverride: null,
+      };
+      const result = bootstrap([{ name: 'gen', tokens: [t] }]);
+
+      expect(result.isValid).toBe(false);
+      expect(() => throwOnInvalid(result)).toThrow(/bootstrap: .*failed validation/);
+      try {
+        throwOnInvalid(result);
+      } catch (e) {
+        const cause = (e as Error & { cause: unknown }).cause as {
+          code: string;
+          errors: unknown[];
+        };
+        expect(cause.code).toBe('bootstrap-invalid');
+        expect(Array.isArray(cause.errors)).toBe(true);
+        expect(cause.errors.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('is a no-op when validation succeeds', () => {
+      ensureBuiltinPlugins();
+      const t: Token = {
+        name: 'simple',
+        value: '#aabbcc',
+        category: 'color',
+        namespace: 'color',
+        userOverride: null,
+      };
+      const result = bootstrap([{ name: 'gen', tokens: [t] }]);
+      expect(() => throwOnInvalid(result)).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Step C of the storage-layer surgery sub-epic (#1439, under #1242). The lock-in.

Adds `bootstrap(generators)` that validates four invariants of a healthy design-token graph before any cascade runs:

1. **No name collision** -- two generators emitting the same token name is a build error.
2. **DependsOn resolvable** -- every dependsOn target must be in the assembled set, with the source generator named in the error.
3. **Shape contract** -- for each token with a `generationRule`, `resolveInput` runs and the produced input is parsed against the plugin's input schema. A `ColorReference` where `ColorValue` is required surfaces as a structured `shape-mismatch` with the Zod issue path included.
4. **No cycles** -- topological sort over the assembled graph; cycle path reported when the underlying message format carries it.

Returns `BootstrapResult = { isValid: true; tokens } | { isValid: false; errors: BuildError[] }`. `BuildError` is a discriminated union; structured data only, no class hierarchy (#1242 invariant). `throwOnInvalid` lifts the result into a structured `Error` with `cause: { code: 'bootstrap-invalid', errors }` for callers that cannot proceed.

Collect-all on install: every check runs to completion before returning, so a single build surfaces the full picture instead of fix/run/fix loops. Runtime stays fail-fast (cascade); install is whole-or-nothing.

## What this does NOT do

- **Does not retrofit existing `generateBaseSystem` callers**. `bootstrap()` is a new entry point; existing internal calls are unaffected. A follow-up should switch `generateBaseSystem` to route through `bootstrap` so default consumers fail at install instead of at runtime.
- **Does not fix preexisting graph issues found by the gate** (see below).
- **Does not change the runtime cascade** -- still fail-fast, transitive, no aggregate.

## Preexisting graph issues caught at first run

The happy-path test on `generateBaseSystem()` documents what the gate caught immediately. Each is a real bug worth a follow-up:

- **`font-size-base` collision** -- typography generator and one other emit the same name.
- **`shortcut -> letter-spacing-widest` unresolved** -- `shortcut` token depends on a token that does not exist.

Tests fail loudly on regressions outside the punch list. Updating the `KNOWN_*` sets in the test is part of clearing each follow-up.

## Test plan

- [x] `pnpm --filter=@rafters/design-tokens test` -- 301/301 green
- [x] `pnpm preflight` -- exit 0
- [x] All four checks have dedicated tests (collision, unresolved, cycle, shape-mismatch)
- [x] Happy-path test pins the known issue set so future regressions surface

## Closes / Part of

Closes #1229 / #1231 once consumers route through `bootstrap` -- the collisions and shape contracts these issues describe become install-time errors instead of runtime cascade confusion. Part of #1442. Part of #1439.

## Quality gate

`legion quality-gate record` -- clean (0 findings). Gate row id `019e0570-47f3-7d72-9005-a1dddda31d5a`.

## Base

This PR is based on `step-b/tokendependency-reshape` (PR #1444). The diff shows only Step C's changes. Once #1443 and #1444 merge in order, rebase against main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)