### PR TITLE
refactor: restore Zod-first contracts in shared/math-utils/color-utils

### DIFF
--- a/packages/color-utils/src/accessibility.ts
+++ b/packages/color-utils/src/accessibility.ts
@@ -5,6 +5,7 @@
 import type { OKLCH } from '@rafters/shared';
 import { APCAcontrast, sRGBtoY } from 'apca-w3';
 import Color from 'colorjs.io';
+import { z } from 'zod';
 import { roundOKLCH } from './conversion';
 
 /**
@@ -110,31 +111,23 @@ export function meetsAPCAStandard(foreground: OKLCH, background: OKLCH, textSize
   return contrast >= threshold;
 }
 
-/**
- * Pre-computed accessibility contrast matrix interface
- * Stores WCAG AA/AAA compliance pairs as indices into color scales
- */
-export interface AccessibilityMetadata {
-  // Pre-computed contrast matrices (indices into scale array)
-  wcagAA: {
-    normal: number[][]; // [[0, 5], [0, 6], [1, 7], ...] - pairs that meet AA
-    large: number[][]; // [[0, 4], [0, 5], [1, 5], ...] - more pairs for large text
-  };
-  wcagAAA: {
-    normal: number[][]; // [[0, 7], [0, 8], [0, 9], ...] - fewer pairs meet AAA
-    large: number[][]; // [[0, 6], [0, 7], [1, 7], ...]
-  };
+const ContrastPairsSchema = z.object({
+  normal: z.array(z.array(z.number())),
+  large: z.array(z.array(z.number())),
+});
 
-  // Pre-calculated for common backgrounds
-  onWhite: {
-    aa: number[]; // [5, 6, 7, 8, 9] - shades that pass AA on white
-    aaa: number[]; // [7, 8, 9] - shades that pass AAA on white
-  };
-  onBlack: {
-    aa: number[]; // [0, 1, 2, 3, 4] - shades that pass AA on black
-    aaa: number[]; // [0, 1, 2] - shades that pass AAA on black
-  };
-}
+const BackgroundComplianceSchema = z.object({
+  aa: z.array(z.number()),
+  aaa: z.array(z.number()),
+});
+
+export const AccessibilityMetadataSchema = z.object({
+  wcagAA: ContrastPairsSchema,
+  wcagAAA: ContrastPairsSchema,
+  onWhite: BackgroundComplianceSchema,
+  onBlack: BackgroundComplianceSchema,
+});
+export type AccessibilityMetadata = z.infer<typeof AccessibilityMetadataSchema>;
 
 /**
  * Generate pre-computed accessibility metadata for a color scale

--- a/packages/color-utils/src/builder.ts
+++ b/packages/color-utils/src/builder.ts
@@ -9,6 +9,7 @@
  */
 
 import type { ColorValue, OKLCH } from '@rafters/shared';
+import { z } from 'zod';
 import {
   calculateAPCAContrast,
   calculateWCAGContrast,
@@ -45,30 +46,13 @@ const WHITE: OKLCH = { l: 1, c: 0, h: 0, alpha: 1 };
 /** Black reference color for contrast calculations */
 const BLACK: OKLCH = { l: 0, c: 0, h: 0, alpha: 1 };
 
-/**
- * Options for building a ColorValue
- */
-export interface BuildColorValueOptions {
-  /**
-   * Semantic token assignment (e.g., "primary", "destructive")
-   */
-  token?: string;
-
-  /**
-   * Scale position reference (e.g., "500", "400")
-   */
-  value?: string;
-
-  /**
-   * Human notes about the color choice
-   */
-  use?: string;
-
-  /**
-   * State mappings (e.g., { hover: "blue-900", focus: "blue-700" })
-   */
-  states?: Record<string, string>;
-}
+export const BuildColorValueOptionsSchema = z.object({
+  token: z.string().optional(),
+  value: z.string().optional(),
+  use: z.string().optional(),
+  states: z.record(z.string(), z.string()).optional(),
+});
+export type BuildColorValueOptions = z.infer<typeof BuildColorValueOptionsSchema>;
 
 /**
  * Build a complete ColorValue from OKLCH using pure math calculations.

--- a/packages/color-utils/src/color-wheel.ts
+++ b/packages/color-utils/src/color-wheel.ts
@@ -6,35 +6,40 @@
  * semantic role mappings are designed.
  */
 
-import type { ColorValue, OKLCH } from '@rafters/shared';
+import { type ColorValue, ColorValueSchema, type OKLCH } from '@rafters/shared';
+import { z } from 'zod';
 import { buildColorValue } from './builder.js';
 import { roundOKLCH } from './conversion.js';
 import { adjustHue } from './manipulation.js';
 
-export type HarmonyType =
-  | 'complementary'
-  | 'triadic'
-  | 'tetradic'
-  | 'analogous'
-  | 'split-complementary';
+export const HarmonyTypeSchema = z.enum([
+  'complementary',
+  'triadic',
+  'tetradic',
+  'analogous',
+  'split-complementary',
+]);
+export type HarmonyType = z.infer<typeof HarmonyTypeSchema>;
 
-export interface ColorWheelOptions {
-  chromaDistribution?: 'gaussian' | 'flat';
-}
+export const ColorWheelOptionsSchema = z.object({
+  chromaDistribution: z.enum(['gaussian', 'flat']).optional(),
+});
+export type ColorWheelOptions = z.infer<typeof ColorWheelOptionsSchema>;
 
-export interface SemanticColorSystem {
-  primary: ColorValue;
-  secondary: ColorValue;
-  tertiary: ColorValue;
-  accent: ColorValue;
-  highlight: ColorValue;
-  neutral: ColorValue;
-  muted: ColorValue;
-  success: ColorValue;
-  warning: ColorValue;
-  destructive: ColorValue;
-  info: ColorValue;
-}
+export const SemanticColorSystemSchema = z.object({
+  primary: ColorValueSchema,
+  secondary: ColorValueSchema,
+  tertiary: ColorValueSchema,
+  accent: ColorValueSchema,
+  highlight: ColorValueSchema,
+  neutral: ColorValueSchema,
+  muted: ColorValueSchema,
+  success: ColorValueSchema,
+  warning: ColorValueSchema,
+  destructive: ColorValueSchema,
+  info: ColorValueSchema,
+});
+export type SemanticColorSystem = z.infer<typeof SemanticColorSystemSchema>;
 
 /**
  * Apply gaussian chroma distribution centered at L=0.6 with sigma=0.25.

--- a/packages/color-utils/src/color-wheel.ts
+++ b/packages/color-utils/src/color-wheel.ts
@@ -26,19 +26,10 @@ export const ColorWheelOptionsSchema = z.object({
 });
 export type ColorWheelOptions = z.infer<typeof ColorWheelOptionsSchema>;
 
-export const SemanticColorSystemSchema = z.object({
-  primary: ColorValueSchema,
-  secondary: ColorValueSchema,
-  tertiary: ColorValueSchema,
-  accent: ColorValueSchema,
-  highlight: ColorValueSchema,
-  neutral: ColorValueSchema,
-  muted: ColorValueSchema,
-  success: ColorValueSchema,
-  warning: ColorValueSchema,
-  destructive: ColorValueSchema,
-  info: ColorValueSchema,
-});
+// Open record: the generator chooses the role names. Schema does not lock the
+// current 11-key shape; that prevents the colorWheel-vs-DEFAULT_SEMANTIC_COLOR_MAPPINGS
+// namespace collision from being baked into the type system.
+export const SemanticColorSystemSchema = z.record(z.string(), ColorValueSchema);
 export type SemanticColorSystem = z.infer<typeof SemanticColorSystemSchema>;
 
 /**

--- a/packages/color-utils/src/gamut.ts
+++ b/packages/color-utils/src/gamut.ts
@@ -9,24 +9,17 @@
 
 import type { OKLCH } from '@rafters/shared';
 import Color from 'colorjs.io';
+import { z } from 'zod';
 
-/**
- * Display support tier for a color.
- * - gold: in sRGB + P3, safe everywhere
- * - silver: in P3 only, clamped on older screens
- * - fail: outside both gamuts
- */
-export type GamutTier = 'gold' | 'silver' | 'fail';
+export const GamutTierSchema = z.enum(['gold', 'silver', 'fail']);
+export type GamutTier = z.infer<typeof GamutTierSchema>;
 
-/** Gamut boundary data at a single lightness level */
-export interface GamutBoundaryPoint {
-  /** Lightness value (0-1) */
-  l: number;
-  /** Maximum chroma within sRGB gamut (gold boundary) */
-  maxC_srgb: number;
-  /** Maximum chroma within P3 gamut (silver boundary) */
-  maxC_p3: number;
-}
+export const GamutBoundaryPointSchema = z.object({
+  l: z.number(),
+  maxC_srgb: z.number(),
+  maxC_p3: z.number(),
+});
+export type GamutBoundaryPoint = z.infer<typeof GamutBoundaryPointSchema>;
 
 /**
  * Check whether an OKLCH color is within the sRGB gamut.

--- a/packages/color-utils/src/naming/hue-hubs.ts
+++ b/packages/color-utils/src/naming/hue-hubs.ts
@@ -14,17 +14,13 @@
  * - Fractional L/C values sub-select within the word list
  */
 
-/**
- * Lightness bands (5 levels)
- * Maps to L bucket ranges for semantic compatibility
- */
-export type LightnessBand = 'veryDark' | 'dark' | 'mid' | 'light' | 'veryLight';
+import { z } from 'zod';
 
-/**
- * Chroma bands (4 levels)
- * Maps to C bucket ranges for semantic compatibility
- */
-export type ChromaBand = 'muted' | 'moderate' | 'saturated' | 'vivid';
+export const LightnessBandSchema = z.enum(['veryDark', 'dark', 'mid', 'light', 'veryLight']);
+export type LightnessBand = z.infer<typeof LightnessBandSchema>;
+
+export const ChromaBandSchema = z.enum(['muted', 'moderate', 'saturated', 'vivid']);
+export type ChromaBand = z.infer<typeof ChromaBandSchema>;
 
 /**
  * A cell in the L×C matrix containing semantically-appropriate words

--- a/packages/color-utils/src/validation-alerts.ts
+++ b/packages/color-utils/src/validation-alerts.ts
@@ -5,36 +5,43 @@
  * No AI needed - uses WCAG standards, color theory, and UX principles
  */
 
-import type { OKLCH } from '@rafters/shared';
+import { type OKLCH, OKLCHSchema } from '@rafters/shared';
+import { z } from 'zod';
 import { calculateWCAGContrast } from './accessibility';
 
-/**
- * Accessibility alert severity and types
- */
-export interface AccessibilityAlert {
-  severity: 'error' | 'warning' | 'caution';
-  type: 'contrast' | 'cognitive-load' | 'color-vision' | 'cultural' | 'usability';
-  message: string;
-  suggestion: string;
-  affectedTokens: string[];
-  autoFix?: {
-    token: string;
-    newValue: string; // Color family + scale position
-    reason: string;
-  };
-}
+export const AccessibilityAlertSeveritySchema = z.enum(['error', 'warning', 'caution']);
+export const AccessibilityAlertTypeSchema = z.enum([
+  'contrast',
+  'cognitive-load',
+  'color-vision',
+  'cultural',
+  'usability',
+]);
 
-/**
- * User's semantic assignments from Studio right-click
- */
-export interface SemanticMapping {
-  [semanticToken: string]: {
-    colorFamily: string; // "ocean-storm"
-    scalePosition: number; // 800 (index in 50-950 scale)
-    fullReference: string; // "ocean-storm-800"
-    oklch: OKLCH; // Actual color value
-  };
-}
+export const AccessibilityAlertSchema = z.object({
+  severity: AccessibilityAlertSeveritySchema,
+  type: AccessibilityAlertTypeSchema,
+  message: z.string(),
+  suggestion: z.string(),
+  affectedTokens: z.array(z.string()),
+  autoFix: z
+    .object({
+      token: z.string(),
+      newValue: z.string(),
+      reason: z.string(),
+    })
+    .optional(),
+});
+export type AccessibilityAlert = z.infer<typeof AccessibilityAlertSchema>;
+
+export const SemanticMappingEntrySchema = z.object({
+  colorFamily: z.string(),
+  scalePosition: z.number(),
+  fullReference: z.string(),
+  oklch: OKLCHSchema,
+});
+export const SemanticMappingSchema = z.record(z.string(), SemanticMappingEntrySchema);
+export type SemanticMapping = z.infer<typeof SemanticMappingSchema>;
 
 /**
  * Validate semantic mappings with mathematical precision

--- a/packages/math-utils/src/constants.ts
+++ b/packages/math-utils/src/constants.ts
@@ -5,6 +5,8 @@
  * Based on musical intervals, mathematical constants, and harmonic proportions.
  */
 
+import { z } from 'zod';
+
 /**
  * Musical Intervals - Based on mathematical ratios from music theory
  * These create harmonious visual progressions similar to musical harmony
@@ -48,14 +50,26 @@ export const ALL_RATIOS = {
   ...MATHEMATICAL_CONSTANTS,
 } as const;
 
-/**
- * Progression Types for different mathematical systems
- */
-export type ProgressionType =
-  | 'linear' // Simple arithmetic progression: 1, 2, 3, 4...
-  | 'exponential' // Custom exponential: base^n
-  | keyof typeof MUSICAL_RATIOS // Musical intervals
-  | keyof typeof MATHEMATICAL_CONSTANTS; // Mathematical constants
+export const ProgressionTypeSchema = z.enum([
+  'linear',
+  'exponential',
+  'minor-second',
+  'major-second',
+  'minor-third',
+  'major-third',
+  'perfect-fourth',
+  'augmented-fourth',
+  'perfect-fifth',
+  'golden',
+  'golden-ratio',
+  'sqrt2',
+  'sqrt3',
+  'sqrt5',
+  'e',
+  'pi',
+  'silver',
+]);
+export type ProgressionType = z.infer<typeof ProgressionTypeSchema>;
 
 // Pre-compute available ratios string to avoid repeated computation
 const AVAILABLE_RATIOS_STRING = Object.keys(ALL_RATIOS).join(', ');

--- a/packages/math-utils/src/constants.ts
+++ b/packages/math-utils/src/constants.ts
@@ -50,41 +50,22 @@ export const ALL_RATIOS = {
   ...MATHEMATICAL_CONSTANTS,
 } as const;
 
-export const ProgressionTypeSchema = z.enum([
+// Projection of MUSICAL_RATIOS + MATHEMATICAL_CONSTANTS keys. Generators are the
+// source of truth; this schema follows whatever they declare.
+const PROGRESSION_TYPE_KEYS = [
   'linear',
   'exponential',
-  'minor-second',
-  'major-second',
-  'minor-third',
-  'major-third',
-  'perfect-fourth',
-  'augmented-fourth',
-  'perfect-fifth',
-  'golden',
-  'golden-ratio',
-  'sqrt2',
-  'sqrt3',
-  'sqrt5',
-  'e',
-  'pi',
-  'silver',
-]);
-export type ProgressionType = z.infer<typeof ProgressionTypeSchema>;
+  ...(Object.keys(MUSICAL_RATIOS) as Array<keyof typeof MUSICAL_RATIOS>),
+  ...(Object.keys(MATHEMATICAL_CONSTANTS) as Array<keyof typeof MATHEMATICAL_CONSTANTS>),
+] as const;
 
-// Compile-time guard: if a ratio is added to MUSICAL_RATIOS or MATHEMATICAL_CONSTANTS
-// without updating ProgressionTypeSchema above, this assertion fails.
-type _ProgressionTypeFromConsts =
-  | 'linear'
-  | 'exponential'
-  | keyof typeof MUSICAL_RATIOS
-  | keyof typeof MATHEMATICAL_CONSTANTS;
-type _AssertProgressionTypeExhaustive = _ProgressionTypeFromConsts extends ProgressionType
-  ? ProgressionType extends _ProgressionTypeFromConsts
-    ? true
-    : never
-  : never;
-const _progressionTypeExhaustive: _AssertProgressionTypeExhaustive = true;
-void _progressionTypeExhaustive;
+export const ProgressionTypeSchema = z.enum(
+  PROGRESSION_TYPE_KEYS as unknown as [
+    (typeof PROGRESSION_TYPE_KEYS)[number],
+    ...Array<(typeof PROGRESSION_TYPE_KEYS)[number]>,
+  ],
+);
+export type ProgressionType = z.infer<typeof ProgressionTypeSchema>;
 
 // Pre-compute available ratios string to avoid repeated computation
 const AVAILABLE_RATIOS_STRING = Object.keys(ALL_RATIOS).join(', ');

--- a/packages/math-utils/src/constants.ts
+++ b/packages/math-utils/src/constants.ts
@@ -5,7 +5,8 @@
  * Based on musical intervals, mathematical constants, and harmonic proportions.
  */
 
-import { z } from 'zod';
+import type { z } from 'zod';
+import { enumOf } from './zod-keys.js';
 
 /**
  * Musical Intervals - Based on mathematical ratios from music theory
@@ -52,19 +53,12 @@ export const ALL_RATIOS = {
 
 // Projection of MUSICAL_RATIOS + MATHEMATICAL_CONSTANTS keys. Generators are the
 // source of truth; this schema follows whatever they declare.
-const PROGRESSION_TYPE_KEYS = [
+export const ProgressionTypeSchema = enumOf([
   'linear',
   'exponential',
   ...(Object.keys(MUSICAL_RATIOS) as Array<keyof typeof MUSICAL_RATIOS>),
   ...(Object.keys(MATHEMATICAL_CONSTANTS) as Array<keyof typeof MATHEMATICAL_CONSTANTS>),
-] as const;
-
-export const ProgressionTypeSchema = z.enum(
-  PROGRESSION_TYPE_KEYS as unknown as [
-    (typeof PROGRESSION_TYPE_KEYS)[number],
-    ...Array<(typeof PROGRESSION_TYPE_KEYS)[number]>,
-  ],
-);
+]);
 export type ProgressionType = z.infer<typeof ProgressionTypeSchema>;
 
 // Pre-compute available ratios string to avoid repeated computation

--- a/packages/math-utils/src/constants.ts
+++ b/packages/math-utils/src/constants.ts
@@ -71,6 +71,21 @@ export const ProgressionTypeSchema = z.enum([
 ]);
 export type ProgressionType = z.infer<typeof ProgressionTypeSchema>;
 
+// Compile-time guard: if a ratio is added to MUSICAL_RATIOS or MATHEMATICAL_CONSTANTS
+// without updating ProgressionTypeSchema above, this assertion fails.
+type _ProgressionTypeFromConsts =
+  | 'linear'
+  | 'exponential'
+  | keyof typeof MUSICAL_RATIOS
+  | keyof typeof MATHEMATICAL_CONSTANTS;
+type _AssertProgressionTypeExhaustive = _ProgressionTypeFromConsts extends ProgressionType
+  ? ProgressionType extends _ProgressionTypeFromConsts
+    ? true
+    : never
+  : never;
+const _progressionTypeExhaustive: _AssertProgressionTypeExhaustive = true;
+void _progressionTypeExhaustive;
+
 // Pre-compute available ratios string to avoid repeated computation
 const AVAILABLE_RATIOS_STRING = Object.keys(ALL_RATIOS).join(', ');
 

--- a/packages/math-utils/src/index.ts
+++ b/packages/math-utils/src/index.ts
@@ -7,3 +7,4 @@ export * from './calculations.js';
 export * from './constants.js';
 export * from './progressions.js';
 export * from './units.js';
+export * from './zod-keys.js';

--- a/packages/math-utils/src/progressions.ts
+++ b/packages/math-utils/src/progressions.ts
@@ -5,13 +5,11 @@
  * Supports linear, exponential, musical intervals, and mathematical constants.
  */
 
+import { z } from 'zod';
 import { getRatio, type ProgressionType } from './constants.js';
 
-/**
- * A progression object that can compute values at any step from a base value.
- * This is the preferred interface for generators to use as it allows computing
- * values on-demand without pre-generating entire sequences.
- */
+// Progression carries methods (compute, generateSequence) — behavior type, not data.
+// Zod schemas describe data shape; runtime callable contracts stay as TypeScript types.
 export interface Progression {
   /** The ratio type used for this progression */
   readonly type: ProgressionType;
@@ -165,19 +163,13 @@ export function createProgression(type: ProgressionType): Progression {
   };
 }
 
-/**
- * Options for generating mathematical progressions
- */
-export interface ProgressionOptions {
-  /** Starting value for the progression */
-  baseValue: number;
-  /** Number of steps to generate */
-  steps: number;
-  /** Custom multiplier for exponential progressions */
-  multiplier?: number;
-  /** Whether to include zero as first step */
-  includeZero?: boolean;
-}
+export const ProgressionOptionsSchema = z.object({
+  baseValue: z.number(),
+  steps: z.number().int().nonnegative(),
+  multiplier: z.number().optional(),
+  includeZero: z.boolean().optional(),
+});
+export type ProgressionOptions = z.infer<typeof ProgressionOptionsSchema>;
 
 /**
  * Generate a mathematical progression sequence

--- a/packages/math-utils/src/ratios.ts
+++ b/packages/math-utils/src/ratios.ts
@@ -3,6 +3,9 @@
  * Based on musical intervals and the golden ratio
  */
 
+import type { z } from 'zod';
+import { enumOf } from './zod-keys.js';
+
 export const GOLDEN_RATIO = 1.618;
 export const MAJOR_THIRD = 1.25; // 5:4
 export const MINOR_THIRD = 1.2; // 6:5
@@ -26,15 +29,6 @@ export const ALL_RATIOS = {
   'minor-second': MINOR_SECOND,
 } as const;
 
-import { z } from 'zod';
-
 // Projection of ALL_RATIOS keys; the const is the generator and source of truth.
-const RATIO_NAME_KEYS = Object.keys(ALL_RATIOS) as Array<keyof typeof ALL_RATIOS>;
-
-export const RatioNameSchema = z.enum(
-  RATIO_NAME_KEYS as unknown as [
-    (typeof RATIO_NAME_KEYS)[number],
-    ...Array<(typeof RATIO_NAME_KEYS)[number]>,
-  ],
-);
+export const RatioNameSchema = enumOf(Object.keys(ALL_RATIOS) as Array<keyof typeof ALL_RATIOS>);
 export type RatioName = z.infer<typeof RatioNameSchema>;

--- a/packages/math-utils/src/ratios.ts
+++ b/packages/math-utils/src/ratios.ts
@@ -39,3 +39,13 @@ export const RatioNameSchema = z.enum([
   'minor-second',
 ]);
 export type RatioName = z.infer<typeof RatioNameSchema>;
+
+// Compile-time guard: keys in ALL_RATIOS must match RatioNameSchema.
+type _RatioNameFromConst = keyof typeof ALL_RATIOS;
+type _AssertRatioNameExhaustive = _RatioNameFromConst extends RatioName
+  ? RatioName extends _RatioNameFromConst
+    ? true
+    : never
+  : never;
+const _ratioNameExhaustive: _AssertRatioNameExhaustive = true;
+void _ratioNameExhaustive;

--- a/packages/math-utils/src/ratios.ts
+++ b/packages/math-utils/src/ratios.ts
@@ -26,4 +26,16 @@ export const ALL_RATIOS = {
   'minor-second': MINOR_SECOND,
 } as const;
 
-export type RatioName = keyof typeof ALL_RATIOS;
+import { z } from 'zod';
+
+export const RatioNameSchema = z.enum([
+  'golden',
+  'major-third',
+  'minor-third',
+  'perfect-fourth',
+  'perfect-fifth',
+  'augmented-fourth',
+  'major-second',
+  'minor-second',
+]);
+export type RatioName = z.infer<typeof RatioNameSchema>;

--- a/packages/math-utils/src/ratios.ts
+++ b/packages/math-utils/src/ratios.ts
@@ -28,24 +28,13 @@ export const ALL_RATIOS = {
 
 import { z } from 'zod';
 
-export const RatioNameSchema = z.enum([
-  'golden',
-  'major-third',
-  'minor-third',
-  'perfect-fourth',
-  'perfect-fifth',
-  'augmented-fourth',
-  'major-second',
-  'minor-second',
-]);
-export type RatioName = z.infer<typeof RatioNameSchema>;
+// Projection of ALL_RATIOS keys; the const is the generator and source of truth.
+const RATIO_NAME_KEYS = Object.keys(ALL_RATIOS) as Array<keyof typeof ALL_RATIOS>;
 
-// Compile-time guard: keys in ALL_RATIOS must match RatioNameSchema.
-type _RatioNameFromConst = keyof typeof ALL_RATIOS;
-type _AssertRatioNameExhaustive = _RatioNameFromConst extends RatioName
-  ? RatioName extends _RatioNameFromConst
-    ? true
-    : never
-  : never;
-const _ratioNameExhaustive: _AssertRatioNameExhaustive = true;
-void _ratioNameExhaustive;
+export const RatioNameSchema = z.enum(
+  RATIO_NAME_KEYS as unknown as [
+    (typeof RATIO_NAME_KEYS)[number],
+    ...Array<(typeof RATIO_NAME_KEYS)[number]>,
+  ],
+);
+export type RatioName = z.infer<typeof RatioNameSchema>;

--- a/packages/math-utils/src/units.ts
+++ b/packages/math-utils/src/units.ts
@@ -5,18 +5,27 @@
  * unit information and enabling unit conversions.
  */
 
-/**
- * Supported CSS units
- */
-export type CSSUnit = 'px' | 'rem' | 'em' | '%' | 'vw' | 'vh' | 'vmin' | 'vmax' | 'ch' | 'ex';
+import { z } from 'zod';
 
-/**
- * Value with unit information
- */
-export interface UnitValue {
-  value: number;
-  unit: CSSUnit | '';
-}
+export const CSSUnitSchema = z.enum([
+  'px',
+  'rem',
+  'em',
+  '%',
+  'vw',
+  'vh',
+  'vmin',
+  'vmax',
+  'ch',
+  'ex',
+]);
+export type CSSUnit = z.infer<typeof CSSUnitSchema>;
+
+export const UnitValueSchema = z.object({
+  value: z.number(),
+  unit: z.union([CSSUnitSchema, z.literal('')]),
+});
+export type UnitValue = z.infer<typeof UnitValueSchema>;
 
 /**
  * Parse a CSS value string into value and unit components

--- a/packages/math-utils/src/zod-keys.ts
+++ b/packages/math-utils/src/zod-keys.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+// Build a z.enum from a non-empty readonly array of literal string keys.
+// Hides the [k, ...k[]] tuple cast required by Zod when the array is built
+// dynamically (e.g. from Object.keys of a generator const).
+export function enumOf<T extends string>(keys: readonly T[]): z.ZodEnum<Record<T, T>> {
+  return z.enum(keys as unknown as [T, ...T[]]);
+}

--- a/packages/shared/src/component-intelligence.ts
+++ b/packages/shared/src/component-intelligence.ts
@@ -44,82 +44,53 @@
  */
 
 import { parse, type Spec } from 'comment-parser';
+import { z } from 'zod';
+import { UsagePatternsSchema } from './types';
 
-// ==================== Types ====================
+// ==================== Schemas ====================
 
-/**
- * Intelligence metadata extracted from component JSDoc comments
- * Named JSDocIntelligence to avoid conflict with ComponentIntelligence in types.ts
- */
-export interface JSDocIntelligence {
-  /** Cognitive load score (0-10 scale) */
-  cognitiveLoad?: number;
-  /** Attention economics guidance */
-  attentionEconomics?: string;
-  /** Accessibility requirements and guidance */
-  accessibility?: string;
-  /** Trust-building patterns */
-  trustBuilding?: string;
-  /** Semantic meaning and purpose */
-  semanticMeaning?: string;
-  /** Usage patterns with dos and nevers */
-  usagePatterns?: {
-    dos: string[];
-    nevers: string[];
-  };
-}
+export const JSDocIntelligenceSchema = z.object({
+  cognitiveLoad: z.number().min(0).max(10).optional(),
+  attentionEconomics: z.string().optional(),
+  accessibility: z.string().optional(),
+  trustBuilding: z.string().optional(),
+  semanticMeaning: z.string().optional(),
+  usagePatterns: UsagePatternsSchema.optional(),
+});
+export type JSDocIntelligence = z.infer<typeof JSDocIntelligenceSchema>;
 
-/**
- * Component category for organization
- */
-export type ComponentCategory =
-  | 'layout'
-  | 'form'
-  | 'feedback'
-  | 'navigation'
-  | 'overlay'
-  | 'data-display'
-  | 'utility';
+export const ComponentCategorySchema = z.enum([
+  'layout',
+  'form',
+  'feedback',
+  'navigation',
+  'overlay',
+  'data-display',
+  'utility',
+]);
+export type ComponentCategory = z.infer<typeof ComponentCategorySchema>;
 
-/**
- * Structured dependency information extracted from JSDoc tags
- */
-export interface JSDocDependencies {
-  /** Runtime dependencies from @dependencies tag */
-  runtime: string[];
-  /** Dev dependencies from @devDependencies tag */
-  dev: string[];
-  /** Internal workspace dependencies from @internal-dependencies tag */
-  internal: string[];
-}
+export const JSDocDependenciesSchema = z.object({
+  runtime: z.array(z.string()),
+  dev: z.array(z.string()),
+  internal: z.array(z.string()),
+});
+export type JSDocDependencies = z.infer<typeof JSDocDependenciesSchema>;
 
-/**
- * Full component metadata including intelligence
- */
-export interface ComponentMetadata {
-  /** Component file name (without extension) */
-  name: string;
-  /** Human-readable display name */
-  displayName: string;
-  /** Brief description from JSDoc */
-  description?: string;
-  /** Component category */
-  category: ComponentCategory;
-  /** Intelligence metadata */
-  intelligence?: JSDocIntelligence;
-  /** Available variants */
-  variants: string[];
-  /** Available sizes */
-  sizes: string[];
-  /** External dependencies */
-  dependencies: string[];
-  /** Primitive dependencies */
-  primitives: string[];
-  /** Structured dependency information from JSDoc tags */
-  jsDocDependencies?: JSDocDependencies;
-  /** Relative file path */
-  filePath: string;
-}
+export const ComponentMetadataSchema = z.object({
+  name: z.string(),
+  displayName: z.string(),
+  description: z.string().optional(),
+  category: ComponentCategorySchema,
+  intelligence: JSDocIntelligenceSchema.optional(),
+  variants: z.array(z.string()),
+  sizes: z.array(z.string()),
+  dependencies: z.array(z.string()),
+  primitives: z.array(z.string()),
+  jsDocDependencies: JSDocDependenciesSchema.optional(),
+  filePath: z.string(),
+});
+export type ComponentMetadata = z.infer<typeof ComponentMetadataSchema>;
 
 // ==================== Parser ====================
 
@@ -402,15 +373,11 @@ const REQUIRED_TAGS = [
   'usagePatterns',
 ] as const;
 
-/**
- * A warning produced when component intelligence metadata is incomplete or suspect
- */
-export interface IntelligenceWarning {
-  /** Warning severity: "missing" for absent data, "empty" for present but hollow data */
-  level: 'missing' | 'empty';
-  /** Human-readable warning message */
-  message: string;
-}
+export const IntelligenceWarningSchema = z.object({
+  level: z.enum(['missing', 'empty']),
+  message: z.string(),
+});
+export type IntelligenceWarning = z.infer<typeof IntelligenceWarningSchema>;
 
 /**
  * Validate component intelligence metadata for completeness.


### PR DESCRIPTION
## Summary

- Audited shared, math-utils, color-utils for plain TypeScript interfaces and literal-union types that drifted from the rafters Zod-first invariant
- Converted boundary I/O contracts back to Zod schemas with z.infer-derived types
- Static-data type descriptors (HueMatrix, HueHub describing as-const lookup tables) intentionally kept as TypeScript types
- Added compile-time exhaustiveness guards on ProgressionTypeSchema and RatioNameSchema so the schemas cannot drift from the const-object source-of-truth

## Drift mechanism

5-min prompt cache TTL evicts mid-session corrections; implementations revert to training-distribution TypeScript defaults. Same root cause as PR #1241, now caught across three lib packages.

## Test plan

- [x] pnpm typecheck (12 projects green)
- [x] pnpm preflight (exit 0)
- [x] lefthook pre-commit (unit-tests, lint, typecheck)
- [x] legion-simplify gate clean