### PR TITLE
refactor(shared): ComponentCategory as schema + default registry

### DIFF
--- a/packages/shared/src/component-intelligence.ts
+++ b/packages/shared/src/component-intelligence.ts
@@ -44,6 +44,7 @@
  */
 
 import { parse, type Spec } from 'comment-parser';
+import { z } from 'zod';
 
 // ==================== Types ====================
 
@@ -70,16 +71,31 @@ export interface JSDocIntelligence {
 }
 
 /**
- * Component category for organization
+ * A component category is a label + description. The library ships a default
+ * registry covering the rafters component taxonomy; consumers may use, extend,
+ * or replace it. Built-in and user-defined categories are structurally identical.
  */
-export type ComponentCategory =
-  | 'layout'
-  | 'form'
-  | 'feedback'
-  | 'navigation'
-  | 'overlay'
-  | 'data-display'
-  | 'utility';
+export const ComponentCategorySchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+});
+export type ComponentCategory = z.infer<typeof ComponentCategorySchema>;
+
+export const DEFAULT_COMPONENT_CATEGORIES: ComponentCategory[] = [
+  { name: 'layout', description: 'Components for structuring and organizing content' },
+  { name: 'form', description: 'Input controls and form elements' },
+  { name: 'feedback', description: 'Status indicators and user feedback' },
+  { name: 'navigation', description: 'Wayfinding and navigation components' },
+  { name: 'overlay', description: 'Modals, dialogs, and overlay components' },
+  { name: 'data-display', description: 'Components for displaying data and content' },
+  { name: 'utility', description: 'Helper and utility components' },
+];
+
+/** Look up a category by name in a registry. Returns undefined if not found. */
+export const findComponentCategory = (
+  registry: readonly ComponentCategory[],
+  name: string,
+): ComponentCategory | undefined => registry.find((c) => c.name === name);
 
 /**
  * Structured dependency information extracted from JSDoc tags
@@ -103,8 +119,8 @@ export interface ComponentMetadata {
   displayName: string;
   /** Brief description from JSDoc */
   description?: string;
-  /** Component category */
-  category: ComponentCategory;
+  /** Category name -- reference into a ComponentCategory registry */
+  category: string;
   /** Intelligence metadata */
   intelligence?: JSDocIntelligence;
   /** Available variants */

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -412,7 +412,10 @@ export const ColorReferenceSchema = z.object({
 
 export type ColorReference = z.infer<typeof ColorReferenceSchema>;
 
-// Progression System Types - exported for consistency across the codebase
+// Progression system labels stamped on tokens to record which math system
+// produced them. Used only by TokenSchema below; the math-utils package
+// carries the actual ratio definitions in DEFAULT_RATIOS. This array will be
+// reshaped when the design-tokens package is refactored.
 export const PROGRESSION_SYSTEMS = [
   'linear',
   'golden',
@@ -425,8 +428,6 @@ export const PROGRESSION_SYSTEMS = [
   'minor-second',
   'custom',
 ] as const;
-
-export type ProgressionSystem = (typeof PROGRESSION_SYSTEMS)[number];
 
 // Comprehensive Design Token Schema - Single Source of Truth
 export const TokenSchema = z.object({


### PR DESCRIPTION
## Summary

Replaces the hardcoded `ComponentCategory` literal-union enum with the schema-and-default-registry pattern.

**New surface** in `@rafters/shared`:
- `ComponentCategorySchema = z.object({ name, description? })`
- `DEFAULT_COMPONENT_CATEGORIES: ComponentCategory[]` (7 starter items: layout, form, feedback, navigation, overlay, data-display, utility, each with description)
- `findComponentCategory(registry, name)` lookup helper

**Killed**:
- The `ComponentCategory` literal-union type (replaced by inferred schema type)
- The unused `ProgressionSystem` type alias in types.ts

**Kept** (deferred to design-tokens refactor): the `PROGRESSION_SYSTEMS` const array, because `TokenSchema.progressionSystem` actively validates against it. That whole enum surface gets reworked when design-tokens lands.

**ComponentMetadata.category** changes from the literal-union to `string` (a name reference into a registry). Consumers can look up the full ComponentCategory in whatever registry they choose.

## Demo migration

The `apps/demo` app maintains its own local `ComponentCategory` literal-union type for narrow Map/Record keying. It does not import from `@rafters/shared`, so the shared change does not break the demo. A follow-up migration to consume `DEFAULT_COMPONENT_CATEGORIES` for descriptions is possible but out of scope here.

## Test plan

- [x] `pnpm --filter=@rafters/shared test` (110 tests pass)
- [x] `pnpm typecheck` across all 12 typechecked projects
- [x] `pnpm preflight` exit 0
- [x] `legion-simplify` quality gate clean

## Sibling PR

This is the small half of the lib-package rewrite. See PR #1447 for `math-utils` (the larger half).