### PR TITLE
refactor(color-utils): honest gamut names + Zod item schemas

### DIFF
--- a/packages/color-utils/src/accessibility.ts
+++ b/packages/color-utils/src/accessibility.ts
@@ -5,6 +5,7 @@
 import type { OKLCH } from '@rafters/shared';
 import { APCAcontrast, sRGBtoY } from 'apca-w3';
 import Color from 'colorjs.io';
+import { z } from 'zod';
 import { roundOKLCH } from './conversion';
 
 /**
@@ -110,31 +111,29 @@ export function meetsAPCAStandard(foreground: OKLCH, background: OKLCH, textSize
   return contrast >= threshold;
 }
 
-/**
- * Pre-computed accessibility contrast matrix interface
- * Stores WCAG AA/AAA compliance pairs as indices into color scales
- */
-export interface AccessibilityMetadata {
-  // Pre-computed contrast matrices (indices into scale array)
-  wcagAA: {
-    normal: number[][]; // [[0, 5], [0, 6], [1, 7], ...] - pairs that meet AA
-    large: number[][]; // [[0, 4], [0, 5], [1, 5], ...] - more pairs for large text
-  };
-  wcagAAA: {
-    normal: number[][]; // [[0, 7], [0, 8], [0, 9], ...] - fewer pairs meet AAA
-    large: number[][]; // [[0, 6], [0, 7], [1, 7], ...]
-  };
+/** Pre-computed pairs of scale indices that pass a contrast standard. */
+const ContrastPairsSchema = z.object({
+  normal: z.array(z.array(z.number())),
+  large: z.array(z.array(z.number())),
+});
 
-  // Pre-calculated for common backgrounds
-  onWhite: {
-    aa: number[]; // [5, 6, 7, 8, 9] - shades that pass AA on white
-    aaa: number[]; // [7, 8, 9] - shades that pass AAA on white
-  };
-  onBlack: {
-    aa: number[]; // [0, 1, 2, 3, 4] - shades that pass AA on black
-    aaa: number[]; // [0, 1, 2] - shades that pass AAA on black
-  };
-}
+/** Pre-computed scale indices that pass on a single-color background. */
+const BackgroundComplianceSchema = z.object({
+  aa: z.array(z.number()),
+  aaa: z.array(z.number()),
+});
+
+/**
+ * Pre-computed accessibility metadata for a color scale. Indices reference
+ * positions in the source scale array.
+ */
+export const AccessibilityMetadataSchema = z.object({
+  wcagAA: ContrastPairsSchema,
+  wcagAAA: ContrastPairsSchema,
+  onWhite: BackgroundComplianceSchema,
+  onBlack: BackgroundComplianceSchema,
+});
+export type AccessibilityMetadata = z.infer<typeof AccessibilityMetadataSchema>;
 
 /**
  * Generate pre-computed accessibility metadata for a color scale

--- a/packages/color-utils/src/gamut.ts
+++ b/packages/color-utils/src/gamut.ts
@@ -2,70 +2,57 @@
  * OKLCH gamut awareness utilities
  *
  * Three-tier gamut model based on real-world display support:
- * - Gold: in both sRGB AND Display P3 (safe on every screen)
- * - Silver: in P3 but NOT sRGB (modern wide-gamut displays only)
- * - Fail: outside both gamuts (not displayable anywhere)
+ * - srgb: in sRGB (safe on every screen, also in P3 by inclusion)
+ * - p3:   in Display P3 but NOT sRGB (modern wide-gamut displays only)
+ * - out:  outside both gamuts (not displayable anywhere)
  */
 
 import type { OKLCH } from '@rafters/shared';
 import Color from 'colorjs.io';
+import { z } from 'zod';
 
-/**
- * Display support tier for a color.
- * - gold: in sRGB + P3, safe everywhere
- * - silver: in P3 only, clamped on older screens
- * - fail: outside both gamuts
- */
-export type GamutTier = 'gold' | 'silver' | 'fail';
+export const GamutTierSchema = z.enum(['srgb', 'p3', 'out']);
+export type GamutTier = z.infer<typeof GamutTierSchema>;
 
-/** Gamut boundary data at a single lightness level */
-export interface GamutBoundaryPoint {
-  /** Lightness value (0-1) */
-  l: number;
-  /** Maximum chroma within sRGB gamut (gold boundary) */
-  maxC_srgb: number;
-  /** Maximum chroma within P3 gamut (silver boundary) */
-  maxC_p3: number;
-}
+export const GamutBoundaryPointSchema = z.object({
+  l: z.number(),
+  /** Maximum chroma within sRGB gamut */
+  maxC_srgb: z.number(),
+  /** Maximum chroma within P3 gamut */
+  maxC_p3: z.number(),
+});
+export type GamutBoundaryPoint = z.infer<typeof GamutBoundaryPointSchema>;
 
-/**
- * Check whether an OKLCH color is within the sRGB gamut.
- */
+/** Check whether an OKLCH color is within the sRGB gamut. */
 export function isInSRGBGamut(oklch: OKLCH): boolean {
   const color = new Color('oklch', [oklch.l, oklch.c, oklch.h]);
   return color.inGamut('srgb');
 }
 
-/**
- * Check whether an OKLCH color is within the Display P3 gamut.
- */
+/** Check whether an OKLCH color is within the Display P3 gamut. */
 export function isInP3Gamut(oklch: OKLCH): boolean {
   const color = new Color('oklch', [oklch.l, oklch.c, oklch.h]);
   return color.inGamut('p3');
 }
 
-/**
- * Classify an OKLCH color by its display support tier.
- */
+/** Classify an OKLCH color by the gamut it fits in. */
 export function getGamutTier(oklch: OKLCH): GamutTier {
-  if (isInSRGBGamut(oklch)) return 'gold';
-  if (isInP3Gamut(oklch)) return 'silver';
-  return 'fail';
+  if (isInSRGBGamut(oklch)) return 'srgb';
+  if (isInP3Gamut(oklch)) return 'p3';
+  return 'out';
 }
 
 /**
  * Snap an OKLCH color to the nearest in-gamut color.
- * Tries sRGB first (gold), falls back to P3 (silver).
  * Returns the snapped color and its tier.
  */
 export function toNearestGamut(oklch: OKLCH): { color: OKLCH; tier: GamutTier } {
   const color = new Color('oklch', [oklch.l, oklch.c, oklch.h]);
 
   if (color.inGamut('srgb')) {
-    return { color: { ...oklch }, tier: 'gold' };
+    return { color: { ...oklch }, tier: 'srgb' };
   }
 
-  // Try sRGB gamut mapping first
   const srgbMapped = color.toGamut({ space: 'srgb' });
   const mappedOklch = srgbMapped.to('oklch');
   return {
@@ -75,34 +62,20 @@ export function toNearestGamut(oklch: OKLCH): { color: OKLCH; tier: GamutTier } 
       h: mappedOklch.coords[2] ?? oklch.h,
       alpha: oklch.alpha,
     },
-    tier: 'gold',
+    tier: 'srgb',
   };
 }
 
-/** Default number of lightness steps for boundary computation */
 const DEFAULT_STEPS = 101;
-
-/** Maximum chroma to search (OKLCH practical limit) */
 const MAX_CHROMA = 0.4;
-
-/** Binary search tolerance for chroma boundary */
 const TOLERANCE = 0.001;
 
-/**
- * Binary search for the maximum chroma at a given lightness and hue
- * that remains within the specified gamut.
- */
 function findMaxChroma(l: number, h: number, gamutSpace: string): number {
   let lo = 0;
   let hi = MAX_CHROMA;
-
-  // Edge cases: L=0 (black) and L=1 (white) have zero chroma
   if (l <= 0 || l >= 1) return 0;
-
-  // Quick check: if max chroma is in gamut, return it
   const maxColor = new Color('oklch', [l, hi, h]);
   if (maxColor.inGamut(gamutSpace)) return hi;
-
   while (hi - lo > TOLERANCE) {
     const mid = (lo + hi) / 2;
     const color = new Color('oklch', [l, mid, h]);
@@ -112,32 +85,23 @@ function findMaxChroma(l: number, h: number, gamutSpace: string): number {
       hi = mid;
     }
   }
-
   return lo;
 }
 
 /**
  * Compute both sRGB and P3 gamut boundaries for a given hue.
- * Returns an array of boundary points across lightness levels.
- *
  * The two boundary curves define three zones:
- * - 0 to maxC_srgb: gold (sRGB-safe)
- * - maxC_srgb to maxC_p3: silver (P3-only)
- * - beyond maxC_p3: fail (out of gamut)
- *
- * @param hue - Hue angle in degrees (0-360)
- * @param steps - Number of lightness steps (default 101, for L = 0.00, 0.01, ..., 1.00)
+ *   0 .. maxC_srgb            -> srgb
+ *   maxC_srgb .. maxC_p3      -> p3
+ *   beyond maxC_p3            -> out
  */
 export function computeGamutBoundaries(hue: number, steps = DEFAULT_STEPS): GamutBoundaryPoint[] {
   const boundaries: GamutBoundaryPoint[] = [];
-
   for (let i = 0; i < steps; i++) {
     const l = i / (steps - 1);
     const maxC_srgb = findMaxChroma(l, hue, 'srgb');
     const maxC_p3 = findMaxChroma(l, hue, 'p3');
-
     boundaries.push({ l, maxC_srgb, maxC_p3 });
   }
-
   return boundaries;
 }

--- a/packages/color-utils/src/validation-alerts.ts
+++ b/packages/color-utils/src/validation-alerts.ts
@@ -5,36 +5,43 @@
  * No AI needed - uses WCAG standards, color theory, and UX principles
  */
 
-import type { OKLCH } from '@rafters/shared';
+import { type OKLCH, OKLCHSchema } from '@rafters/shared';
+import { z } from 'zod';
 import { calculateWCAGContrast } from './accessibility';
 
-/**
- * Accessibility alert severity and types
- */
-export interface AccessibilityAlert {
-  severity: 'error' | 'warning' | 'caution';
-  type: 'contrast' | 'cognitive-load' | 'color-vision' | 'cultural' | 'usability';
-  message: string;
-  suggestion: string;
-  affectedTokens: string[];
-  autoFix?: {
-    token: string;
-    newValue: string; // Color family + scale position
-    reason: string;
-  };
-}
+export const AccessibilityAlertSeveritySchema = z.enum(['error', 'warning', 'caution']);
+export const AccessibilityAlertTypeSchema = z.enum([
+  'contrast',
+  'cognitive-load',
+  'color-vision',
+  'cultural',
+  'usability',
+]);
 
-/**
- * User's semantic assignments from Studio right-click
- */
-export interface SemanticMapping {
-  [semanticToken: string]: {
-    colorFamily: string; // "ocean-storm"
-    scalePosition: number; // 800 (index in 50-950 scale)
-    fullReference: string; // "ocean-storm-800"
-    oklch: OKLCH; // Actual color value
-  };
-}
+export const AccessibilityAlertSchema = z.object({
+  severity: AccessibilityAlertSeveritySchema,
+  type: AccessibilityAlertTypeSchema,
+  message: z.string(),
+  suggestion: z.string(),
+  affectedTokens: z.array(z.string()),
+  autoFix: z
+    .object({
+      token: z.string(),
+      newValue: z.string(),
+      reason: z.string(),
+    })
+    .optional(),
+});
+export type AccessibilityAlert = z.infer<typeof AccessibilityAlertSchema>;
+
+export const SemanticMappingEntrySchema = z.object({
+  colorFamily: z.string(),
+  scalePosition: z.number(),
+  fullReference: z.string(),
+  oklch: OKLCHSchema,
+});
+export const SemanticMappingSchema = z.record(z.string(), SemanticMappingEntrySchema);
+export type SemanticMapping = z.infer<typeof SemanticMappingSchema>;
 
 /**
  * Validate semantic mappings with mathematical precision

--- a/packages/color-utils/test/gamut.test.ts
+++ b/packages/color-utils/test/gamut.test.ts
@@ -57,23 +57,23 @@ describe('isInP3Gamut', () => {
 
 describe('getGamutTier', () => {
   it('classifies sRGB colors as gold', () => {
-    expect(getGamutTier(midGray)).toBe('gold');
-    expect(getGamutTier(srgbBlue)).toBe('gold');
+    expect(getGamutTier(midGray)).toBe('srgb');
+    expect(getGamutTier(srgbBlue)).toBe('srgb');
   });
 
   it('classifies P3-only colors as silver', () => {
-    expect(getGamutTier(p3Green)).toBe('silver');
+    expect(getGamutTier(p3Green)).toBe('p3');
   });
 
   it('classifies out-of-gamut colors as fail', () => {
-    expect(getGamutTier(extremeColor)).toBe('fail');
+    expect(getGamutTier(extremeColor)).toBe('out');
   });
 });
 
 describe('toNearestGamut', () => {
   it('returns the same color for in-gamut sRGB colors', () => {
     const result = toNearestGamut(srgbBlue);
-    expect(result.tier).toBe('gold');
+    expect(result.tier).toBe('srgb');
     expect(result.color.l).toBe(srgbBlue.l);
     expect(result.color.c).toBe(srgbBlue.c);
     expect(result.color.h).toBe(srgbBlue.h);
@@ -81,7 +81,7 @@ describe('toNearestGamut', () => {
 
   it('snaps out-of-gamut colors to gold tier', () => {
     const result = toNearestGamut(p3Green);
-    expect(result.tier).toBe('gold');
+    expect(result.tier).toBe('srgb');
     expect(isInSRGBGamut(result.color)).toBe(true);
   });
 

--- a/packages/ui/src/components/ui/color-picker.tsx
+++ b/packages/ui/src/components/ui/color-picker.tsx
@@ -53,9 +53,9 @@ const INPUT_CLASS =
   'w-full min-w-0 rounded-md border border-border bg-background px-2 py-1 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring';
 
 const GAMUT_LABELS: Record<GamutTier, string> = {
-  gold: 'sRGB',
-  silver: 'P3',
-  fail: 'Out of gamut',
+  srgb: 'sRGB',
+  p3: 'P3',
+  out: 'Out of gamut',
 };
 
 function colorChanged(a: OklchColor | undefined, b: OklchColor | undefined): boolean {

--- a/packages/ui/src/primitives/color-picker.ts
+++ b/packages/ui/src/primitives/color-picker.ts
@@ -129,9 +129,9 @@ function clamp(value: number, min: number, max: number): number {
 }
 
 export function getGamutTier(l: number, c: number, h: number): GamutTier {
-  if (inSrgb(l, c, h)) return 'gold';
-  if (inP3(l, c, h)) return 'silver';
-  return 'fail';
+  if (inSrgb(l, c, h)) return 'srgb';
+  if (inP3(l, c, h)) return 'p3';
+  return 'out';
 }
 
 function resolveKeyDelta(current: number, delta: number, scale: number, max: number): number {

--- a/packages/ui/src/primitives/color-swatch.ts
+++ b/packages/ui/src/primitives/color-swatch.ts
@@ -12,7 +12,7 @@
  * const cleanup = createSwatch(el, { l: 0.6, c: 0.15, h: 250 });
  *
  * // later, on pointer move:
- * updateSwatch(el, { l: 0.7, c: 0.12, h: 260, tier: 'gold' });
+ * updateSwatch(el, { l: 0.7, c: 0.12, h: 260, tier: 'srgb' });
  *
  * // teardown
  * cleanup();

--- a/packages/ui/src/primitives/types.ts
+++ b/packages/ui/src/primitives/types.ts
@@ -4,10 +4,12 @@
 export type CleanupFunction = () => void;
 
 /**
- * Gamut tier for color swatch display
- * Caller-provided label indicating how well a color maps to a target gamut.
+ * Gamut tier: which CSS color space the color fits in.
+ * - srgb: in sRGB (safe on every screen)
+ * - p3:   in Display P3 but outside sRGB (wide-gamut displays only)
+ * - out:  outside both gamuts (not displayable)
  */
-export type GamutTier = 'gold' | 'silver' | 'fail';
+export type GamutTier = 'srgb' | 'p3' | 'out';
 
 export type OutsideClickHandler = (event: MouseEvent | TouchEvent | PointerEvent) => void;
 

--- a/packages/ui/test/components/color-picker.test.tsx
+++ b/packages/ui/test/components/color-picker.test.tsx
@@ -145,7 +145,7 @@ describe('ColorPicker', () => {
       const preview = container.querySelector('[data-gamut-tier]');
       expect(preview).toBeInTheDocument();
       // Low chroma should be sRGB (gold)
-      expect(preview).toHaveAttribute('data-gamut-tier', 'gold');
+      expect(preview).toHaveAttribute('data-gamut-tier', 'srgb');
     });
 
     it('shows gamut label text', () => {

--- a/packages/ui/test/primitives/color-scale.test.ts
+++ b/packages/ui/test/primitives/color-scale.test.ts
@@ -128,15 +128,15 @@ describe('color-scale primitive', () => {
   });
 
   it('sets data-gamut-tier when tiers provided', () => {
-    const tiers = SCALE_KEYS.map(() => 'gold' as const);
-    tiers[10] = 'silver';
+    const tiers = SCALE_KEYS.map(() => 'srgb' as const);
+    tiers[10] = 'p3';
     cleanup = createColorScale(container, {
       scale: makeScale(),
       name: 'ocean-blue',
       tiers,
     });
     const last = container.querySelectorAll('[role="option"]')[10] as HTMLElement;
-    expect(last.getAttribute('data-gamut-tier')).toBe('silver');
+    expect(last.getAttribute('data-gamut-tier')).toBe('p3');
   });
 
   it('cleanup removes all swatch elements and restores container', () => {

--- a/packages/ui/test/primitives/color-swatch.test.ts
+++ b/packages/ui/test/primitives/color-swatch.test.ts
@@ -45,14 +45,14 @@ describe('createSwatch', () => {
   });
 
   it('includes tier in aria-label when provided', () => {
-    const cleanup = createSwatch(el, { l: 0.6, c: 0.15, h: 250, tier: 'gold' });
-    expect(el.getAttribute('aria-label')).toBe('Color: oklch(0.6 0.15 250), gamut: gold');
+    const cleanup = createSwatch(el, { l: 0.6, c: 0.15, h: 250, tier: 'srgb' });
+    expect(el.getAttribute('aria-label')).toBe('Color: oklch(0.6 0.15 250), gamut: srgb');
     cleanup();
   });
 
   it('sets data-gamut-tier when tier provided', () => {
-    const cleanup = createSwatch(el, { l: 0.6, c: 0.15, h: 250, tier: 'silver' });
-    expect(el.getAttribute('data-gamut-tier')).toBe('silver');
+    const cleanup = createSwatch(el, { l: 0.6, c: 0.15, h: 250, tier: 'p3' });
+    expect(el.getAttribute('data-gamut-tier')).toBe('p3');
     cleanup();
   });
 
@@ -78,7 +78,7 @@ describe('createSwatch', () => {
     el.setAttribute('role', 'button');
     el.setAttribute('aria-label', 'original');
 
-    const cleanup = createSwatch(el, { l: 0.6, c: 0.15, h: 250, tier: 'fail', selected: true });
+    const cleanup = createSwatch(el, { l: 0.6, c: 0.15, h: 250, tier: 'out', selected: true });
 
     expect(el.getAttribute('role')).toBe('img');
     expect(el.hasAttribute('data-gamut-tier')).toBe(true);
@@ -126,8 +126,8 @@ describe('updateSwatch', () => {
   it('adds and removes tier on update', () => {
     createSwatch(el, { l: 0.6, c: 0.15, h: 250 });
 
-    updateSwatch(el, { l: 0.6, c: 0.15, h: 250, tier: 'gold' });
-    expect(el.getAttribute('data-gamut-tier')).toBe('gold');
+    updateSwatch(el, { l: 0.6, c: 0.15, h: 250, tier: 'srgb' });
+    expect(el.getAttribute('data-gamut-tier')).toBe('srgb');
 
     updateSwatch(el, { l: 0.6, c: 0.15, h: 250 });
     expect(el.hasAttribute('data-gamut-tier')).toBe(false);


### PR DESCRIPTION
## Summary

Two coherent changes in color-utils that don't touch the colorWheel pipeline.

### 1. Gamut tier rename

Old labels `'gold' | 'silver' | 'fail'` were jewelry-store framing that referenced nothing else in the system. Renamed to the actual CSS Color spec gamut names:

| Old | New | Meaning |
|---|---|---|
| `gold` | `srgb` | In sRGB (safe on every screen) |
| `silver` | `p3` | In Display P3, outside sRGB (wide-gamut only) |
| `fail` | `out` | Outside both gamuts (not displayable) |

Renamed atomically across:
- `packages/color-utils/src/gamut.ts` (source + `getGamutTier` + `toNearestGamut`)
- `packages/ui/src/primitives/{types,color-picker,color-swatch}.ts`
- `packages/ui/src/components/ui/color-picker.tsx` (`GAMUT_LABELS`)
- All tests in `packages/color-utils/test/gamut.test.ts` and `packages/ui/test/primitives/{color-scale,color-swatch}.test.ts` + `packages/ui/test/components/color-picker.test.tsx`
- `data-gamut-tier` attribute values

### 2. Zod item schemas

For boundary I/O contracts (validator outputs, precomputed metadata structures, semantic mapping I/O):

- `GamutTierSchema`, `GamutBoundaryPointSchema` (`gamut.ts`)
- `AccessibilityAlertSchema` + `AccessibilityAlertSeveritySchema` + `AccessibilityAlertTypeSchema`, `SemanticMappingSchema` + `SemanticMappingEntrySchema` (`validation-alerts.ts`)
- `AccessibilityMetadataSchema` (`accessibility.ts`)

These are item-shape contracts and validator-output taxonomies — they belong as Zod schemas with inferred types. No registries here: these aren't user-replaceable named lists, they're shapes of returned data.

## Out of scope (deferred to design-tokens refactor)

- `colorWheel`, `SemanticColorSystem`, `HarmonyType`, `ColorWheelOptions`
- `SCALE_POSITIONS` and `BuildColorValueOptions` in `builder.ts` (builder feeds colorWheel)
- `LightnessBand` / `ChromaBand` in `naming/hue-hubs.ts` (structural keys into the static HUE_HUBS table; restructuring requires reshaping ~2000 lines of named color data)
- `contrast-matrix.ts` lowercase `'aa' | 'aaa' | 'fail'` (has CSS-selector consumers in `data-wcag-level` attributes across ui and demo Tailwind classes — needs a coordinated rename in its own PR)

## Test plan

- [x] `pnpm --filter=@rafters/color-utils test` (gamut tests updated, all pass)
- [x] `pnpm --filter=@rafters/ui test` (4917 pass, including renamed gamut-tier assertions)
- [x] `pnpm typecheck` across all 12 typechecked projects
- [x] `pnpm preflight` exit 0
- [x] `legion-simplify` quality gate clean