### PR TITLE
feat(design-tokens): port v1 to clean @rafters/design-tokens (#1453)

### DIFF
--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@rafters/design-tokens",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "src"
+  ],
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf .turbo coverage"
+  },
+  "dependencies": {
+    "@rafters/shared": "workspace:*",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/design-tokens/src/dependencies.ts
+++ b/packages/design-tokens/src/dependencies.ts
@@ -1,0 +1,230 @@
+import type { Token } from '@rafters/shared';
+import {
+  type CascadeFailure,
+  type CascadeResult,
+  type Plugin,
+  parseGenerationRule,
+  runPlugin,
+} from './plugins.js';
+
+export interface TokenDependency {
+  /** Direct upstream sources this token derives from. Frozen at add time. */
+  dependsOn: string[];
+  /** Direct downstream consumers. Maintained alongside dependsOn on every add. */
+  dependents: string[];
+  /** Opaque rule tag (e.g. 'scale:500', 'state:hover', 'calc({base}*2)'). The graph never parses it. */
+  generationRule: string;
+}
+
+/**
+ * Forward-edge DAG over token names with bidirectional indexes maintained on every
+ * mutation. Stores `generationRule` per edge as an opaque tag string — never parses
+ * it. Rule syntax lives in plugins.
+ */
+export class TokenDependencyGraph {
+  private readonly dependencies = new Map<string, TokenDependency>();
+
+  /** Record forward edges for `tokenName`. Replaces any prior entry. Rejects cycles. */
+  addDependency(tokenName: string, dependsOn: readonly string[], rule: string): void {
+    const uniqueDependsOn = [...new Set(dependsOn)];
+    if (this.wouldCreateCircularDependency(tokenName, uniqueDependsOn)) {
+      const error = new Error(`TokenDependencyGraph: cycle detected adding "${tokenName}"`);
+      (error as Error & { cause?: unknown }).cause = { code: 'cycle', at: tokenName };
+      throw error;
+    }
+
+    const existing = this.dependencies.get(tokenName) ?? {
+      dependsOn: [],
+      dependents: [],
+      generationRule: rule,
+    };
+    const oldDependsOn = [...existing.dependsOn];
+    existing.dependsOn = [...uniqueDependsOn];
+    existing.generationRule = rule;
+    this.dependencies.set(tokenName, existing);
+
+    for (const dep of uniqueDependsOn) {
+      const depEntry = this.dependencies.get(dep) ?? {
+        dependsOn: [],
+        dependents: [],
+        generationRule: '',
+      };
+      if (!depEntry.dependents.includes(tokenName)) depEntry.dependents.push(tokenName);
+      this.dependencies.set(dep, depEntry);
+    }
+
+    for (const oldDep of oldDependsOn) {
+      if (uniqueDependsOn.includes(oldDep)) continue;
+      const depEntry = this.dependencies.get(oldDep);
+      if (depEntry) depEntry.dependents = depEntry.dependents.filter((d) => d !== tokenName);
+    }
+  }
+
+  removeToken(tokenName: string): void {
+    const entry = this.dependencies.get(tokenName);
+    if (!entry) return;
+    for (const dep of entry.dependsOn) {
+      const depEntry = this.dependencies.get(dep);
+      if (depEntry) depEntry.dependents = depEntry.dependents.filter((d) => d !== tokenName);
+    }
+    for (const dependent of entry.dependents) {
+      const dependentEntry = this.dependencies.get(dependent);
+      if (dependentEntry) {
+        dependentEntry.dependsOn = dependentEntry.dependsOn.filter((d) => d !== tokenName);
+      }
+    }
+    this.dependencies.delete(tokenName);
+  }
+
+  getDependencies(tokenName: string): string[] {
+    return [...(this.dependencies.get(tokenName)?.dependsOn ?? [])];
+  }
+
+  getDependents(tokenName: string): string[] {
+    return [...(this.dependencies.get(tokenName)?.dependents ?? [])];
+  }
+
+  getGenerationRule(tokenName: string): string | undefined {
+    const rule = this.dependencies.get(tokenName)?.generationRule;
+    return rule && rule.length > 0 ? rule : undefined;
+  }
+
+  getAllTokens(): string[] {
+    const all = new Set<string>();
+    for (const [name, dep] of this.dependencies) {
+      all.add(name);
+      for (const d of dep.dependsOn) all.add(d);
+      for (const d of dep.dependents) all.add(d);
+    }
+    return [...all];
+  }
+
+  /** Topological order: dependencies before dependents. Throws on cycle. */
+  topologicalSort(): string[] {
+    const order: string[] = [];
+    const visited = new Set<string>();
+    const onStack = new Set<string>();
+    const all = this.getAllTokens();
+
+    const visit = (name: string): void => {
+      if (visited.has(name)) return;
+      if (onStack.has(name)) {
+        const error = new Error(`TokenDependencyGraph: cycle at "${name}"`);
+        (error as Error & { cause?: unknown }).cause = { code: 'cycle', at: name };
+        throw error;
+      }
+      onStack.add(name);
+      for (const dep of this.getDependencies(name)) visit(dep);
+      onStack.delete(name);
+      visited.add(name);
+      order.push(name);
+    };
+
+    for (const name of all) visit(name);
+    return order;
+  }
+
+  clear(): void {
+    this.dependencies.clear();
+  }
+
+  /**
+   * Walk the graph in topological order, dispatching each derived token's
+   * `generationRule` tag to the matching plugin. Pure with respect to the registry:
+   * takes value getter/setter callbacks; never holds a registry reference.
+   *
+   * If `startName` is provided, only walks the transitive dependents of that node.
+   * Unknown rule tags (no plugin registered) record a failure and continue.
+   */
+  async cascade(
+    plugins: ReadonlyMap<string, Plugin>,
+    getValue: (name: string) => Token['value'] | undefined,
+    setValue: (name: string, value: Token['value']) => void,
+    startName?: string,
+  ): Promise<CascadeResult> {
+    const recomputed: string[] = [];
+    const changed: string[] = [];
+    const failures: CascadeFailure[] = [];
+
+    const order = this.topologicalSort();
+    const scope = startName ? this.collectDependentsTransitive(startName) : undefined;
+
+    for (const name of order) {
+      if (scope && !scope.has(name)) continue;
+      const entry = this.dependencies.get(name);
+      const rule = entry?.generationRule;
+      if (!rule || entry.dependsOn.length === 0) continue;
+
+      const { rule: ruleTag, rawArgs } = parseGenerationRule(rule);
+      const plugin = plugins.get(ruleTag);
+      if (!plugin) {
+        failures.push({
+          name,
+          code: 'unknown-plugin',
+          message: `Token "${name}" requires plugin for rule "${ruleTag}" which is not registered`,
+        });
+        continue;
+      }
+
+      const sourceName = entry.dependsOn[0];
+      if (sourceName === undefined) continue;
+      const sourceValue = getValue(sourceName);
+      if (sourceValue === undefined) {
+        failures.push({
+          name,
+          code: 'missing-source',
+          message: `Token "${name}" depends on "${sourceName}" which has no value`,
+        });
+        continue;
+      }
+
+      recomputed.push(name);
+      const result = runPlugin(plugin, sourceValue, rawArgs, name);
+      if (result.ok) {
+        const before = getValue(name);
+        if (!valuesEqual(before, result.value)) {
+          setValue(name, result.value);
+          changed.push(name);
+        }
+      } else {
+        failures.push(result.failure);
+      }
+    }
+
+    return { recomputed, changed, failures };
+  }
+
+  private wouldCreateCircularDependency(tokenName: string, dependsOn: readonly string[]): boolean {
+    if (dependsOn.includes(tokenName)) return true;
+    const visited = new Set<string>();
+    const walk = (name: string): boolean => {
+      if (name === tokenName) return true;
+      if (visited.has(name)) return false;
+      visited.add(name);
+      for (const next of this.getDependencies(name)) {
+        if (walk(next)) return true;
+      }
+      return false;
+    };
+    return dependsOn.some(walk);
+  }
+
+  private collectDependentsTransitive(startName: string): Set<string> {
+    const out = new Set<string>([startName]);
+    const queue: string[] = [startName];
+    while (queue.length > 0) {
+      const next = queue.shift();
+      if (next === undefined) break;
+      for (const dependent of this.getDependents(next)) {
+        if (out.has(dependent)) continue;
+        out.add(dependent);
+        queue.push(dependent);
+      }
+    }
+    return out;
+  }
+}
+
+function valuesEqual(a: Token['value'] | undefined, b: Token['value'] | undefined): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -1,0 +1,19 @@
+export { type TokenDependency, TokenDependencyGraph } from './dependencies.js';
+export {
+  NodePersistenceAdapter,
+  type PersistenceAdapter,
+} from './persistence.js';
+export {
+  type CascadeFailure,
+  type CascadeFailureCode,
+  type CascadeResult,
+  type Plugin,
+  type PluginContext,
+  parseGenerationRule,
+  runPlugin,
+} from './plugins.js';
+export {
+  type MutationEvent,
+  type MutationHook,
+  TokenRegistry,
+} from './registry.js';

--- a/packages/design-tokens/src/persistence.ts
+++ b/packages/design-tokens/src/persistence.ts
@@ -1,0 +1,67 @@
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { NamespaceFileSchema, type Token } from '@rafters/shared';
+
+/**
+ * Persistence seam. The OSS default is NodePersistenceAdapter (one file per
+ * namespace under `.rafters/tokens/`). The commercial Rafters+ host swaps in its
+ * own adapter to record changes to its cloud for deep history. Adapters never
+ * implement granular event tracking — that comes through TokenRegistry.onMutation.
+ */
+export interface PersistenceAdapter {
+  load(): Promise<Token[]>;
+  save(tokens: Token[]): Promise<void>;
+}
+
+/** Writes one file per namespace under `${projectRoot}/.rafters/tokens/`. */
+export class NodePersistenceAdapter implements PersistenceAdapter {
+  private readonly tokensDir: string;
+
+  constructor(projectRoot: string) {
+    this.tokensDir = join(projectRoot, '.rafters', 'tokens');
+  }
+
+  async load(): Promise<Token[]> {
+    let entries: string[];
+    try {
+      entries = await readdir(this.tokensDir);
+    } catch {
+      return [];
+    }
+    const files = entries.filter((f) => f.endsWith('.rafters.json'));
+    const out: Token[] = [];
+    for (const file of files) {
+      const raw = await readFile(join(this.tokensDir, file), 'utf8');
+      const json: unknown = JSON.parse(raw);
+      const parsed = NamespaceFileSchema.parse(json);
+      out.push(...parsed.tokens);
+    }
+    return out;
+  }
+
+  async save(tokens: readonly Token[]): Promise<void> {
+    await mkdir(this.tokensDir, { recursive: true });
+    const byNamespace = new Map<string, Token[]>();
+    for (const token of tokens) {
+      const bucket = byNamespace.get(token.namespace) ?? [];
+      bucket.push(token);
+      byNamespace.set(token.namespace, bucket);
+    }
+    const timestamp = new Date().toISOString();
+    for (const [namespace, nsTokens] of byNamespace) {
+      const file = {
+        $schema: 'https://rafters.studio/schemas/namespace-tokens.json',
+        namespace,
+        version: '1.0.0',
+        generatedAt: timestamp,
+        tokens: nsTokens,
+      };
+      const validated = NamespaceFileSchema.parse(file);
+      await writeFile(
+        join(this.tokensDir, `${namespace}.rafters.json`),
+        `${JSON.stringify(validated, null, 2)}\n`,
+        'utf8',
+      );
+    }
+  }
+}

--- a/packages/design-tokens/src/plugins.ts
+++ b/packages/design-tokens/src/plugins.ts
@@ -1,0 +1,132 @@
+import type { Token } from '@rafters/shared';
+import type { z } from 'zod';
+
+/**
+ * Context handed to a plugin's derive(). Deterministic only — no registry handle.
+ * Plugins must never reach back into the registry; the cascade walker passes them
+ * pre-resolved source values via the value-getter callback.
+ */
+export interface PluginContext {
+  readonly dependentName: string;
+}
+
+/**
+ * A derivation plugin. Pure: same (source, args, ctx) → same output.
+ *
+ * `rule` is the opaque tag the graph stores on edges (e.g. 'scale', 'state:hover',
+ * 'calc'). The cascade dispatches each edge to the plugin whose `rule` matches the
+ * edge's `generationRule`.
+ *
+ * argsSchema validates the dependency's `generationRule` parameters at derive time.
+ * outputSchema validates the plugin honored its contract before the cascade writes
+ * the result back.
+ */
+export interface Plugin<Args = unknown, Output extends Token['value'] = Token['value']> {
+  readonly id: string;
+  readonly rule: string;
+  readonly argsSchema: z.ZodType<Args>;
+  readonly outputSchema: z.ZodType<Output>;
+  derive(source: Token['value'], args: Args, ctx: PluginContext): Output;
+}
+
+export type CascadeFailureCode =
+  | 'unknown-plugin'
+  | 'invalid-args'
+  | 'derive-threw'
+  | 'invalid-output'
+  | 'missing-source';
+
+export interface CascadeFailure {
+  name: string;
+  code: CascadeFailureCode;
+  message: string;
+  cause?: unknown;
+}
+
+export interface CascadeResult {
+  recomputed: string[];
+  changed: string[];
+  failures: CascadeFailure[];
+}
+
+/**
+ * Run one derivation through a plugin with boundary validation. Used by the graph's
+ * cascade walker. Returns either a value to write or a structured failure; never
+ * throws (failures are caught and reported so the cascade can continue past one
+ * broken edge).
+ */
+export type RunPluginResult =
+  | { ok: true; value: Token['value'] }
+  | { ok: false; failure: CascadeFailure };
+
+export function runPlugin(
+  plugin: Plugin,
+  source: Token['value'],
+  rawArgs: unknown,
+  dependentName: string,
+): RunPluginResult {
+  const parsedArgs = plugin.argsSchema.safeParse(rawArgs);
+  if (!parsedArgs.success) {
+    return {
+      ok: false,
+      failure: {
+        name: dependentName,
+        code: 'invalid-args',
+        message: `Plugin "${plugin.id}" rejected args for ${dependentName}`,
+        cause: parsedArgs.error.issues,
+      },
+    };
+  }
+
+  let raw: unknown;
+  try {
+    raw = plugin.derive(source, parsedArgs.data, { dependentName });
+  } catch (cause) {
+    return {
+      ok: false,
+      failure: {
+        name: dependentName,
+        code: 'derive-threw',
+        message: `Plugin "${plugin.id}" threw while deriving ${dependentName}`,
+        cause,
+      },
+    };
+  }
+
+  const parsedOutput = plugin.outputSchema.safeParse(raw);
+  if (!parsedOutput.success) {
+    return {
+      ok: false,
+      failure: {
+        name: dependentName,
+        code: 'invalid-output',
+        message: `Plugin "${plugin.id}" returned a value that violates its outputSchema while deriving ${dependentName}`,
+        cause: parsedOutput.error.issues,
+      },
+    };
+  }
+
+  return { ok: true, value: parsedOutput.data };
+}
+
+/**
+ * Parse a generationRule tag into { rule, rawArgs }. Rules can be:
+ *  - bare tag: `scale` → { rule: 'scale', rawArgs: undefined }
+ *  - tag with simple arg: `scale:500` → { rule: 'scale', rawArgs: '500' }
+ *  - tag with parens: `calc({base}*2)` → { rule: 'calc', rawArgs: '{base}*2' }
+ *
+ * The graph stores the full tag string opaquely; only the cascade walker peels off
+ * the leading rule prefix so it can dispatch to the right plugin. Plugins receive
+ * the raw arg string and parse it through their argsSchema.
+ */
+export function parseGenerationRule(tag: string): { rule: string; rawArgs: string | undefined } {
+  const colonIdx = tag.indexOf(':');
+  const parenIdx = tag.indexOf('(');
+  if (colonIdx !== -1 && (parenIdx === -1 || colonIdx < parenIdx)) {
+    return { rule: tag.slice(0, colonIdx), rawArgs: tag.slice(colonIdx + 1) };
+  }
+  if (parenIdx !== -1 && tag.endsWith(')')) {
+    return { rule: tag.slice(0, parenIdx), rawArgs: tag.slice(parenIdx + 1, -1) };
+  }
+  return { rule: tag, rawArgs: undefined };
+}

--- a/packages/design-tokens/src/registry.ts
+++ b/packages/design-tokens/src/registry.ts
@@ -1,0 +1,253 @@
+import type { Token } from '@rafters/shared';
+import { TokenDependencyGraph } from './dependencies.js';
+import type { PersistenceAdapter } from './persistence.js';
+import type { CascadeResult, Plugin } from './plugins.js';
+
+export interface MutationEvent {
+  kind: 'add' | 'set' | 'remove' | 'clear-override' | 'cascade';
+  tokenName?: string | undefined;
+  before?: Token['value'] | undefined;
+  after?: Token['value'] | undefined;
+  timestamp: string;
+}
+
+export type MutationHook = (event: MutationEvent) => void;
+
+/**
+ * TokenRegistry — flat map of tokens plus a forward-edge dependency graph.
+ *
+ * `set` is a Map write only: it updates the value, preserves metadata, never
+ * cascades, never persists, never fires events beyond `onMutation`. Cascade
+ * lives on the graph; `registry.cascade()` is sugar that wires the graph's
+ * cascade walker to this registry's value getter/setter.
+ *
+ * Plugins register here (`use(plugin)`) and are dispatched by their `rule` tag
+ * during cascade. Plugins never reach back into the registry — they receive
+ * pre-resolved source values via the cascade's callbacks.
+ *
+ * Persistence is a swappable adapter seam. OSS uses `NodePersistenceAdapter`;
+ * the commercial Rafters+ host swaps in its own to record deep history.
+ * Granular event history comes through `onMutation`, not through the adapter.
+ */
+export class TokenRegistry {
+  private readonly tokens = new Map<string, Token>();
+  readonly graph = new TokenDependencyGraph();
+  private readonly plugins = new Map<string, Plugin>();
+  private adapter: PersistenceAdapter | undefined;
+  onMutation: MutationHook | undefined;
+
+  constructor(initialTokens?: readonly Token[]) {
+    if (!initialTokens) return;
+    for (const token of initialTokens) this.tokens.set(token.name, token);
+    this.populateDependencyGraph();
+  }
+
+  // -- Read --
+
+  get(name: string): Token | undefined {
+    return this.tokens.get(name);
+  }
+
+  has(name: string): boolean {
+    return this.tokens.has(name);
+  }
+
+  size(): number {
+    return this.tokens.size;
+  }
+
+  list(filter?: { category?: string; namespace?: string }): Token[] {
+    const all = [...this.tokens.values()];
+    if (!filter) return all;
+    return all.filter((token) => {
+      if (filter.category && token.category !== filter.category) return false;
+      if (filter.namespace && token.namespace !== filter.namespace) return false;
+      return true;
+    });
+  }
+
+  // -- Write --
+
+  add(token: Token): void {
+    this.tokens.set(token.name, token);
+    if (token.dependsOn && token.dependsOn.length > 0 && token.generationRule) {
+      this.graph.addDependency(token.name, token.dependsOn, token.generationRule);
+    }
+    this.fire({
+      kind: 'add',
+      tokenName: token.name,
+      after: token.value,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  /** Map write. Updates value, preserves metadata. No cascade, no persist. */
+  set(name: string, value: Token['value']): void {
+    const existing = this.tokens.get(name);
+    if (!existing) {
+      throw new Error(`Token "${name}" does not exist`);
+    }
+    const before = existing.value;
+    this.tokens.set(name, { ...existing, value });
+    this.fire({
+      kind: 'set',
+      tokenName: name,
+      before,
+      after: value,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  /**
+   * Clear a token's userOverride.
+   *  - Derived token (has generationRule): remove userOverride, cascade to recompute baseline.
+   *  - Root token: remove userOverride, restore previousValue (throws if absent).
+   */
+  async clearOverride(name: string): Promise<void> {
+    const existing = this.tokens.get(name);
+    if (!existing) {
+      throw new Error(`Token "${name}" does not exist`);
+    }
+    if (!existing.userOverride) {
+      return;
+    }
+
+    const before = existing.value;
+    const rule = this.graph.getGenerationRule(name);
+
+    if (rule) {
+      const { userOverride: _, ...rest } = existing;
+      this.tokens.set(name, rest as Token);
+      await this.cascade(name);
+    } else {
+      const { previousValue } = existing.userOverride;
+      if (previousValue === undefined) {
+        throw new Error(
+          `Cannot clear override for root token "${name}": no previousValue to restore`,
+        );
+      }
+      const { userOverride: _, ...rest } = existing;
+      this.tokens.set(name, { ...rest, value: previousValue } as Token);
+    }
+
+    const after = this.tokens.get(name)?.value;
+    this.fire({
+      kind: 'clear-override',
+      tokenName: name,
+      before,
+      after,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  remove(name: string): boolean {
+    if (!this.tokens.has(name)) return false;
+    const before = this.tokens.get(name)?.value;
+    this.graph.removeToken(name);
+    this.tokens.delete(name);
+    this.fire({
+      kind: 'remove',
+      tokenName: name,
+      before,
+      timestamp: new Date().toISOString(),
+    });
+    return true;
+  }
+
+  clear(): void {
+    this.tokens.clear();
+    this.graph.clear();
+  }
+
+  // -- Graph aliases --
+
+  dependencies(name: string): string[] {
+    return this.graph.getDependencies(name);
+  }
+
+  dependents(name: string): string[] {
+    return this.graph.getDependents(name);
+  }
+
+  addDependency(name: string, dependsOn: readonly string[], rule: string): void {
+    if (!this.tokens.has(name)) {
+      throw new Error(`Token "${name}" does not exist`);
+    }
+    for (const dep of dependsOn) {
+      if (!this.tokens.has(dep)) {
+        throw new Error(`Token "${dep}" does not exist`);
+      }
+    }
+    this.graph.addDependency(name, dependsOn, rule);
+  }
+
+  // -- Plugin layer --
+
+  use(plugin: Plugin): void {
+    this.plugins.set(plugin.rule, plugin);
+  }
+
+  /** Aliases graph.cascade with the registry's value getter/setter. */
+  async cascade(startName?: string): Promise<CascadeResult> {
+    const result = await this.graph.cascade(
+      this.plugins,
+      (n) => this.tokens.get(n)?.value,
+      (n, value) => {
+        const token = this.tokens.get(n);
+        if (token) this.tokens.set(n, { ...token, value });
+      },
+      startName,
+    );
+    this.fire({
+      kind: 'cascade',
+      tokenName: startName,
+      timestamp: new Date().toISOString(),
+    });
+    return result;
+  }
+
+  // -- Persistence --
+
+  setAdapter(adapter: PersistenceAdapter): void {
+    this.adapter = adapter;
+  }
+
+  async persist(): Promise<void> {
+    if (!this.adapter) {
+      throw new Error('TokenRegistry: no persistence adapter set (call setAdapter first)');
+    }
+    await this.adapter.save(this.list());
+  }
+
+  async load(): Promise<void> {
+    if (!this.adapter) {
+      throw new Error('TokenRegistry: no persistence adapter set (call setAdapter first)');
+    }
+    const tokens = await this.adapter.load();
+    this.tokens.clear();
+    this.graph.clear();
+    for (const token of tokens) this.tokens.set(token.name, token);
+    this.populateDependencyGraph();
+  }
+
+  // -- Internal --
+
+  private populateDependencyGraph(): void {
+    for (const token of this.tokens.values()) {
+      if (token.dependsOn && token.dependsOn.length > 0 && token.generationRule) {
+        const missing = token.dependsOn.filter((dep) => !this.tokens.has(dep));
+        if (missing.length > 0) {
+          console.warn(
+            `[TokenRegistry] "${token.name}" skipped in graph: missing [${missing.join(', ')}]`,
+          );
+          continue;
+        }
+        this.graph.addDependency(token.name, token.dependsOn, token.generationRule);
+      }
+    }
+  }
+
+  private fire(event: MutationEvent): void {
+    this.onMutation?.(event);
+  }
+}

--- a/packages/design-tokens/test/_helpers.ts
+++ b/packages/design-tokens/test/_helpers.ts
@@ -1,0 +1,36 @@
+import type { Token } from '@rafters/shared';
+import { z } from 'zod';
+import type { Plugin } from '../src/index.js';
+
+export function baseToken(partial: Partial<Token> & { name: string }): Token {
+  return {
+    name: partial.name,
+    value: partial.value ?? '0',
+    category: partial.category ?? 'spacing',
+    namespace: partial.namespace ?? 'spacing',
+    userOverride: partial.userOverride ?? null,
+    ...partial,
+  } as Token;
+}
+
+export const doublePlugin: Plugin<undefined, string> = {
+  id: 'double',
+  rule: 'double',
+  argsSchema: z.undefined(),
+  outputSchema: z.string(),
+  derive(source) {
+    if (typeof source !== 'string') throw new Error('source must be string');
+    return String(Number.parseFloat(source) * 2);
+  },
+};
+
+export const factorPlugin: Plugin<string, string> = {
+  id: 'factor',
+  rule: 'factor',
+  argsSchema: z.string(),
+  outputSchema: z.string(),
+  derive(source, args) {
+    if (typeof source !== 'string') throw new Error('source must be string');
+    return String(Number.parseFloat(source) * Number.parseFloat(args));
+  },
+};

--- a/packages/design-tokens/test/dependencies.test.ts
+++ b/packages/design-tokens/test/dependencies.test.ts
@@ -1,0 +1,178 @@
+import type { Token } from '@rafters/shared';
+import { describe, expect, it } from 'vitest';
+import { type Plugin, TokenDependencyGraph } from '../src/index.js';
+import { doublePlugin, factorPlugin } from './_helpers.js';
+
+describe('TokenDependencyGraph', () => {
+  it('records forward edges and derives dependents', () => {
+    const g = new TokenDependencyGraph();
+    g.addDependency('b', ['a'], 'scale:500');
+    expect(g.getDependencies('b')).toEqual(['a']);
+    expect(g.getDependents('a')).toEqual(['b']);
+  });
+
+  it('rejects self-cycles', () => {
+    const g = new TokenDependencyGraph();
+    expect(() => g.addDependency('a', ['a'], 'r')).toThrow(/cycle/);
+  });
+
+  it('rejects two-node cycles', () => {
+    const g = new TokenDependencyGraph();
+    g.addDependency('b', ['a'], 'r');
+    expect(() => g.addDependency('a', ['b'], 'r')).toThrow(/cycle/);
+  });
+
+  it('rejects longer cycles', () => {
+    const g = new TokenDependencyGraph();
+    g.addDependency('b', ['a'], 'r');
+    g.addDependency('c', ['b'], 'r');
+    expect(() => g.addDependency('a', ['c'], 'r')).toThrow(/cycle/);
+  });
+
+  it('cycle errors carry structured cause', () => {
+    const g = new TokenDependencyGraph();
+    try {
+      g.addDependency('a', ['a'], 'r');
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as Error & { cause?: unknown }).cause).toMatchObject({ code: 'cycle' });
+    }
+  });
+
+  it('topologically sorts dependencies before dependents', () => {
+    const g = new TokenDependencyGraph();
+    g.addDependency('b', ['a'], 'r');
+    g.addDependency('c', ['b'], 'r');
+    const order = g.topologicalSort();
+    expect(order.indexOf('a')).toBeLessThan(order.indexOf('b'));
+    expect(order.indexOf('b')).toBeLessThan(order.indexOf('c'));
+  });
+
+  it('removeToken cleans up bidirectional edges', () => {
+    const g = new TokenDependencyGraph();
+    g.addDependency('b', ['a'], 'r');
+    g.removeToken('b');
+    expect(g.getDependents('a')).toEqual([]);
+    expect(g.getDependencies('b')).toEqual([]);
+  });
+
+  it('replacing a dependency updates the reverse index', () => {
+    const g = new TokenDependencyGraph();
+    g.addDependency('b', ['a'], 'r');
+    g.addDependency('b', ['c'], 'r');
+    expect(g.getDependents('a')).toEqual([]);
+    expect(g.getDependents('c')).toEqual(['b']);
+  });
+
+  it('getGenerationRule returns undefined for tokens without rules', () => {
+    const g = new TokenDependencyGraph();
+    g.addDependency('b', ['a'], 'r');
+    expect(g.getGenerationRule('b')).toBe('r');
+    expect(g.getGenerationRule('a')).toBeUndefined();
+  });
+
+  describe('cascade', () => {
+    it('dispatches plugins by rule tag', async () => {
+      const g = new TokenDependencyGraph();
+      g.addDependency('b', ['a'], 'double');
+      const values = new Map<string, Token['value']>([
+        ['a', '4'],
+        ['b', '0'],
+      ]);
+      const plugins = new Map([['double', doublePlugin as Plugin]]);
+      const result = await g.cascade(
+        plugins,
+        (n) => values.get(n),
+        (n, v) => values.set(n, v),
+      );
+      expect(values.get('b')).toBe('8');
+      expect(result.recomputed).toEqual(['b']);
+      expect(result.changed).toEqual(['b']);
+    });
+
+    it('skips tokens with unknown plugin rules and records the failure', async () => {
+      const g = new TokenDependencyGraph();
+      g.addDependency('b', ['a'], 'mystery');
+      const values = new Map<string, Token['value']>([
+        ['a', '4'],
+        ['b', '0'],
+      ]);
+      const result = await g.cascade(
+        new Map(),
+        (n) => values.get(n),
+        () => {},
+      );
+      expect(result.failures[0]?.code).toBe('unknown-plugin');
+      expect(values.get('b')).toBe('0');
+    });
+
+    it('parses generationRule tag with simple arg', async () => {
+      const g = new TokenDependencyGraph();
+      g.addDependency('b', ['a'], 'factor:3');
+      const values = new Map<string, Token['value']>([
+        ['a', '5'],
+        ['b', '0'],
+      ]);
+      const plugins = new Map([['factor', factorPlugin as Plugin]]);
+      const result = await g.cascade(
+        plugins,
+        (n) => values.get(n),
+        (n, v) => values.set(n, v),
+      );
+      expect(values.get('b')).toBe('15');
+      expect(result.changed).toEqual(['b']);
+    });
+
+    it('reports missing-source when dependency has no value', async () => {
+      const g = new TokenDependencyGraph();
+      g.addDependency('b', ['a'], 'double');
+      const result = await g.cascade(
+        new Map([['double', doublePlugin as Plugin]]),
+        () => undefined,
+        () => {},
+      );
+      expect(result.failures[0]?.code).toBe('missing-source');
+    });
+
+    it('scopes to transitive dependents when startName is given', async () => {
+      const g = new TokenDependencyGraph();
+      g.addDependency('b', ['a'], 'double');
+      g.addDependency('d', ['c'], 'double');
+      const values = new Map<string, Token['value']>([
+        ['a', '4'],
+        ['b', '0'],
+        ['c', '7'],
+        ['d', '0'],
+      ]);
+      const plugins = new Map([['double', doublePlugin as Plugin]]);
+      const result = await g.cascade(
+        plugins,
+        (n) => values.get(n),
+        (n, v) => values.set(n, v),
+        'a',
+      );
+      expect(result.recomputed).toEqual(['b']);
+      expect(values.get('d')).toBe('0');
+    });
+
+    it('continues past one failed token to recompute others', async () => {
+      const g = new TokenDependencyGraph();
+      g.addDependency('b', ['a'], 'mystery');
+      g.addDependency('d', ['c'], 'double');
+      const values = new Map<string, Token['value']>([
+        ['a', '4'],
+        ['b', '0'],
+        ['c', '5'],
+        ['d', '0'],
+      ]);
+      const plugins = new Map([['double', doublePlugin as Plugin]]);
+      const result = await g.cascade(
+        plugins,
+        (n) => values.get(n),
+        (n, v) => values.set(n, v),
+      );
+      expect(result.failures.length).toBe(1);
+      expect(values.get('d')).toBe('10');
+    });
+  });
+});

--- a/packages/design-tokens/test/persistence.test.ts
+++ b/packages/design-tokens/test/persistence.test.ts
@@ -1,0 +1,60 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { NodePersistenceAdapter } from '../src/index.js';
+import { baseToken } from './_helpers.js';
+
+describe('NodePersistenceAdapter', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'rafters-design-tokens-persist-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('writes one file per namespace with NamespaceFileSchema envelope', async () => {
+    const adapter = new NodePersistenceAdapter(dir);
+    await adapter.save([
+      baseToken({ name: 'a', namespace: 'spacing', value: '1rem' }),
+      baseToken({ name: 'b', namespace: 'color', value: 'oklch(0.5 0.1 240)', category: 'color' }),
+    ]);
+    const spacing = JSON.parse(
+      await readFile(join(dir, '.rafters/tokens/spacing.rafters.json'), 'utf8'),
+    );
+    expect(spacing.namespace).toBe('spacing');
+    expect(spacing.$schema).toMatch(/namespace-tokens/);
+    expect(spacing.tokens).toHaveLength(1);
+  });
+
+  it('round-trips a multi-namespace set', async () => {
+    const adapter = new NodePersistenceAdapter(dir);
+    const input = [
+      baseToken({ name: 'a', namespace: 'spacing', value: '1rem' }),
+      baseToken({ name: 'b', namespace: 'spacing', value: '2rem' }),
+      baseToken({ name: 'c', namespace: 'radius', value: '0.25rem' }),
+    ];
+    await adapter.save(input);
+    const loaded = await adapter.load();
+    expect(loaded).toHaveLength(3);
+    expect(loaded.map((t) => t.name).sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('load returns empty array when tokens dir does not exist', async () => {
+    const adapter = new NodePersistenceAdapter(dir);
+    expect(await adapter.load()).toEqual([]);
+  });
+
+  it('load rejects malformed namespace files', async () => {
+    await mkdir(join(dir, '.rafters/tokens'), { recursive: true });
+    await writeFile(
+      join(dir, '.rafters/tokens/broken.rafters.json'),
+      JSON.stringify({ not: 'a valid namespace file' }),
+      'utf8',
+    );
+    await expect(new NodePersistenceAdapter(dir).load()).rejects.toThrow();
+  });
+});

--- a/packages/design-tokens/test/plugins.test.ts
+++ b/packages/design-tokens/test/plugins.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { type Plugin, parseGenerationRule, runPlugin } from '../src/index.js';
+
+describe('parseGenerationRule', () => {
+  it('parses bare tag', () => {
+    expect(parseGenerationRule('scale')).toEqual({ rule: 'scale', rawArgs: undefined });
+  });
+
+  it('parses colon-arg form', () => {
+    expect(parseGenerationRule('scale:500')).toEqual({ rule: 'scale', rawArgs: '500' });
+  });
+
+  it('parses parens form', () => {
+    expect(parseGenerationRule('calc({base}*2)')).toEqual({ rule: 'calc', rawArgs: '{base}*2' });
+  });
+
+  it('parses state tag', () => {
+    expect(parseGenerationRule('state:hover')).toEqual({ rule: 'state', rawArgs: 'hover' });
+  });
+});
+
+describe('runPlugin', () => {
+  const plugin: Plugin<{ factor: number }, string> = {
+    id: 'scale',
+    rule: 'scale',
+    argsSchema: z.object({ factor: z.number() }),
+    outputSchema: z.string(),
+    derive(source, args) {
+      if (typeof source !== 'string') throw new Error('source must be string');
+      return String(Number.parseFloat(source) * args.factor);
+    },
+  };
+
+  it('returns ok and the validated value on success', () => {
+    const result = runPlugin(plugin, '4', { factor: 1.5 }, 'spacing.lg');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toBe('6');
+  });
+
+  it('returns invalid-args when args fail schema', () => {
+    const result = runPlugin(plugin, '4', { factor: 'nope' }, 'spacing.lg');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.failure.code).toBe('invalid-args');
+  });
+
+  it('returns derive-threw when plugin throws', () => {
+    const result = runPlugin(plugin, { name: 'x', scale: [] }, { factor: 2 }, 'spacing.lg');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.failure.code).toBe('derive-threw');
+  });
+
+  it('returns invalid-output when plugin violates its output contract', () => {
+    const broken: Plugin<Record<string, never>, string> = {
+      id: 'broken',
+      rule: 'broken',
+      argsSchema: z.object({}),
+      outputSchema: z.string(),
+      derive: () => 42 as unknown as string,
+    };
+    const result = runPlugin(broken, '0', {}, 'x');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.failure.code).toBe('invalid-output');
+  });
+});

--- a/packages/design-tokens/test/registry.test.ts
+++ b/packages/design-tokens/test/registry.test.ts
@@ -1,0 +1,238 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type MutationEvent, NodePersistenceAdapter, TokenRegistry } from '../src/index.js';
+import { baseToken, doublePlugin } from './_helpers.js';
+
+describe('TokenRegistry', () => {
+  describe('add / set / preserve metadata', () => {
+    it('set updates value only and preserves metadata', () => {
+      const r = new TokenRegistry([baseToken({ name: 'x', value: '1rem', semanticMeaning: 'hi' })]);
+      r.set('x', '2rem');
+      expect(r.get('x')?.value).toBe('2rem');
+      expect(r.get('x')?.semanticMeaning).toBe('hi');
+    });
+
+    it('set throws for non-existent tokens', () => {
+      const r = new TokenRegistry();
+      expect(() => r.set('nope', '1rem')).toThrow(/does not exist/);
+    });
+
+    it('set does NOT trigger cascade', () => {
+      const r = new TokenRegistry([
+        baseToken({ name: 'a', value: '1' }),
+        baseToken({ name: 'b', value: '2', dependsOn: ['a'], generationRule: 'double' }),
+      ]);
+      r.use(doublePlugin);
+      r.set('a', '3');
+      expect(r.get('b')?.value).toBe('2');
+    });
+
+    it('add inserts and populates the graph', () => {
+      const r = new TokenRegistry();
+      r.add(baseToken({ name: 'a', value: '1' }));
+      r.add(baseToken({ name: 'b', value: '0', dependsOn: ['a'], generationRule: 'double' }));
+      expect(r.dependents('a')).toEqual(['b']);
+    });
+
+    it('list filters by category and namespace', () => {
+      const r = new TokenRegistry([
+        baseToken({ name: 'x', namespace: 'color', category: 'color' }),
+        baseToken({ name: 'y', namespace: 'spacing', category: 'spacing' }),
+        baseToken({ name: 'font-sans', namespace: 'font', category: 'typography' }),
+        baseToken({ name: 'text-base', namespace: 'text', category: 'typography' }),
+      ]);
+      expect(r.list({ category: 'typography' })).toHaveLength(2);
+      expect(r.list({ namespace: 'color' })).toHaveLength(1);
+    });
+  });
+
+  describe('cascade', () => {
+    it('explicit cascade recomputes dependents', async () => {
+      const r = new TokenRegistry([
+        baseToken({ name: 'a', value: '1' }),
+        baseToken({ name: 'b', value: '0', dependsOn: ['a'], generationRule: 'double' }),
+      ]);
+      r.use(doublePlugin);
+      r.set('a', '5');
+      const result = await r.cascade('a');
+      expect(r.get('b')?.value).toBe('10');
+      expect(result.changed).toEqual(['b']);
+    });
+
+    it('records unknown-plugin failures without throwing', async () => {
+      const r = new TokenRegistry([
+        baseToken({ name: 'a', value: '1' }),
+        baseToken({ name: 'b', value: '0', dependsOn: ['a'], generationRule: 'mystery' }),
+      ]);
+      const result = await r.cascade();
+      expect(result.failures[0]?.code).toBe('unknown-plugin');
+    });
+  });
+
+  describe('clearOverride', () => {
+    it('on derived token restores math via cascade', async () => {
+      const r = new TokenRegistry([
+        baseToken({ name: 'a', value: '1' }),
+        baseToken({
+          name: 'b',
+          value: '99',
+          dependsOn: ['a'],
+          generationRule: 'double',
+          userOverride: {
+            previousValue: '2',
+            reason: 'campaign',
+          },
+        }),
+      ]);
+      r.use(doublePlugin);
+      await r.clearOverride('b');
+      expect(r.get('b')?.value).toBe('2');
+      expect(r.get('b')?.userOverride).toBeUndefined();
+    });
+
+    it('on root token restores previousValue', async () => {
+      const r = new TokenRegistry([
+        baseToken({
+          name: 'a',
+          value: '5',
+          userOverride: { previousValue: '1', reason: 'campaign' },
+        }),
+      ]);
+      await r.clearOverride('a');
+      expect(r.get('a')?.value).toBe('1');
+      expect(r.get('a')?.userOverride).toBeUndefined();
+    });
+
+    it('throws when root token has no previousValue and no rule', async () => {
+      const r = new TokenRegistry([
+        baseToken({
+          name: 'a',
+          value: '5',
+          userOverride: {
+            previousValue: undefined as unknown as string,
+            reason: 'broken',
+          },
+        }),
+      ]);
+      await expect(r.clearOverride('a')).rejects.toThrow(/no previousValue/);
+    });
+
+    it('is a no-op when token has no userOverride', async () => {
+      const r = new TokenRegistry([baseToken({ name: 'a', value: '5' })]);
+      await r.clearOverride('a');
+      expect(r.get('a')?.value).toBe('5');
+    });
+  });
+
+  describe('remove / clear', () => {
+    it('remove cleans up graph edges', () => {
+      const r = new TokenRegistry([
+        baseToken({ name: 'a', value: '1' }),
+        baseToken({ name: 'b', value: '0', dependsOn: ['a'], generationRule: 'double' }),
+      ]);
+      r.remove('b');
+      expect(r.has('b')).toBe(false);
+      expect(r.dependents('a')).toEqual([]);
+    });
+
+    it('clear empties tokens and graph', () => {
+      const r = new TokenRegistry([baseToken({ name: 'a', value: '1' })]);
+      r.clear();
+      expect(r.size()).toBe(0);
+    });
+  });
+
+  describe('addDependency validation', () => {
+    it('throws when token does not exist', () => {
+      const r = new TokenRegistry();
+      expect(() => r.addDependency('a', ['b'], 'r')).toThrow(/does not exist/);
+    });
+
+    it('throws when dependency does not exist', () => {
+      const r = new TokenRegistry([baseToken({ name: 'a', value: '1' })]);
+      expect(() => r.addDependency('a', ['b'], 'r')).toThrow(/does not exist/);
+    });
+  });
+
+  describe('onMutation hook', () => {
+    it('fires on every mutation', () => {
+      const r = new TokenRegistry();
+      const events: MutationEvent[] = [];
+      r.onMutation = (e) => events.push(e);
+      r.add(baseToken({ name: 'a', value: '1' }));
+      r.set('a', '2');
+      r.remove('a');
+      expect(events.map((e) => e.kind)).toEqual(['add', 'set', 'remove']);
+    });
+
+    it('event carries before/after for set', () => {
+      const r = new TokenRegistry([baseToken({ name: 'a', value: '1' })]);
+      const events: MutationEvent[] = [];
+      r.onMutation = (e) => events.push(e);
+      r.set('a', '2');
+      expect(events[0]?.before).toBe('1');
+      expect(events[0]?.after).toBe('2');
+    });
+  });
+
+  describe('two-pass constructor', () => {
+    it('handles forward references during bulk load', () => {
+      const r = new TokenRegistry([
+        baseToken({ name: 'b', value: '0', dependsOn: ['a'], generationRule: 'double' }),
+        baseToken({ name: 'a', value: '1' }),
+      ]);
+      expect(r.dependencies('b')).toEqual(['a']);
+      expect(r.dependents('a')).toEqual(['b']);
+    });
+  });
+
+  describe('persistence', () => {
+    let dir: string;
+
+    beforeEach(async () => {
+      dir = await mkdtemp(join(tmpdir(), 'rafters-design-tokens-'));
+    });
+
+    afterEach(async () => {
+      await rm(dir, { recursive: true, force: true });
+    });
+
+    it('persist + load round-trip through NodePersistenceAdapter', async () => {
+      const r1 = new TokenRegistry([baseToken({ name: 'x', namespace: 'spacing', value: '1rem' })]);
+      r1.setAdapter(new NodePersistenceAdapter(dir));
+      await r1.persist();
+
+      const r2 = new TokenRegistry();
+      r2.setAdapter(new NodePersistenceAdapter(dir));
+      await r2.load();
+      expect(r2.get('x')?.value).toBe('1rem');
+    });
+
+    it('persist throws when no adapter is set', async () => {
+      const r = new TokenRegistry();
+      await expect(r.persist()).rejects.toThrow(/no persistence adapter/);
+    });
+
+    it('load throws when no adapter is set', async () => {
+      const r = new TokenRegistry();
+      await expect(r.load()).rejects.toThrow(/no persistence adapter/);
+    });
+
+    it('swappable adapter — in-memory test double', async () => {
+      const stored: Array<{ tokens: unknown[] }> = [];
+      const memoryAdapter = {
+        load: async () => [],
+        save: vi.fn(async (tokens: Parameters<NodePersistenceAdapter['save']>[0]) => {
+          stored.push({ tokens: [...tokens] });
+        }),
+      };
+      const r = new TokenRegistry([baseToken({ name: 'a', value: '1' })]);
+      r.setAdapter(memoryAdapter);
+      await r.persist();
+      expect(memoryAdapter.save).toHaveBeenCalledOnce();
+      expect(stored[0]?.tokens).toHaveLength(1);
+    });
+  });
+});

--- a/packages/design-tokens/tsconfig.json
+++ b/packages/design-tokens/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/packages/design-tokens/vitest.config.ts
+++ b/packages/design-tokens/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    passWithNoTests: true,
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,16 +456,13 @@ importers:
 
   packages/design-tokens:
     dependencies:
+      '@rafters/shared':
+        specifier: workspace:*
+        version: link:../shared
       zod:
         specifier: 'catalog:'
         version: 4.1.12
     devDependencies:
-      '@rafters/design-tokens-v1':
-        specifier: workspace:*
-        version: link:../design-tokens-v1
-      '@rafters/shared':
-        specifier: workspace:*
-        version: link:../shared
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.0

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -45,6 +45,8 @@
       "@rafters/color-utils/*": ["./packages/color-utils/src/*"],
       "@rafters/math-utils": ["./packages/math-utils/src/index.ts"],
       "@rafters/math-utils/*": ["./packages/math-utils/src/*"],
+      "@rafters/design-tokens": ["./packages/design-tokens/src/index.ts"],
+      "@rafters/design-tokens/*": ["./packages/design-tokens/src/*"],
       "@rafters/design-tokens-v1": ["./packages/design-tokens-v1/src/index.ts"],
       "@rafters/design-tokens-v1/*": ["./packages/design-tokens-v1/src/*"],
       "@rafters/chrome": ["./packages/chrome/src/index.ts"],


### PR DESCRIPTION
## Summary

Implements #1453. Ports v1's good parts — schemas (via `@rafters/shared`), the dependency-graph DAG primitive, and the plugin protocol — into a clean `@rafters/design-tokens` package without the bolt-on couplings.

## Files

5 source files, 4 test files. ~600 total LoC including tests.

```
packages/design-tokens/
  src/
    dependencies.ts  — TokenDependencyGraph (forward-edge DAG, opaque rule tags, cascade as pure graph operation)
    plugins.ts       — Plugin protocol, runPlugin boundary validation, parseGenerationRule
    persistence.ts   — PersistenceAdapter interface + NodePersistenceAdapter (Rafters+ seam)
    registry.ts      — TokenRegistry (Map write only on set, explicit clearOverride, onMutation hook)
    index.ts         — barrel
  test/
    _helpers.ts
    dependencies.test.ts  (15 tests)
    registry.test.ts      (22 tests)
    plugins.test.ts        (8 tests)
    persistence.test.ts    (4 tests)
```

## Imports tracked (per #1453's success criteria)

- `registry.ts` imports only: `Token` (from `@rafters/shared`), `TokenDependencyGraph` (local), `PersistenceAdapter` (local), `CascadeResult`/`Plugin` types (local)
- `dependencies.ts` imports only: `Token` type (from `@rafters/shared`), `CascadeFailure`/`CascadeResult`/`Plugin`/`runPlugin`/`parseGenerationRule` (local)
- `plugins.ts` imports only: `Token` (from `@rafters/shared`), `zod`
- `persistence.ts` imports only: `Token`/`NamespaceFileSchema` (from `@rafters/shared`), `node:fs/promises`, `node:path`

**Zero imports from `@rafters/color-utils`, `@rafters/math-utils`, or `@rafters/design-tokens-v1`.**

## Key design choices

- **Cascade is a graph operation, not a registry operation.** `graph.cascade(plugins, getValue, setValue, startName?)` is the primitive; `registry.cascade(startName?)` is sugar that wires the registry's value getter/setter. The graph never imports the registry.
- **`set` is a pure Map write.** No automatic cascade. Preserves metadata. Test asserts `set` does NOT recompute dependents — cascade is explicit.
- **`clearOverride` replaces the `COMPUTED` sentinel** with a named method. For derived tokens: remove `userOverride`, run cascade. For root tokens: restore `previousValue` or throw.
- **`PersistenceAdapter` is the Rafters+ seam.** OSS uses `NodePersistenceAdapter` (one file per namespace under `.rafters/tokens/`). Whole-state load/save — no granular methods. Granular event history comes through `onMutation`, not the adapter.
- **`onMutation` hook for deep-history overload** — OSS leaves it unset; commercial Tauri host overloads to record full history.
- **Rule tags stay opaque in the graph.** `generationRule` is a string. The graph never imports `GenerationRuleParser`. `parseGenerationRule` (cascade-side helper) peels off the rule prefix to dispatch the right plugin; plugins parse their own rawArgs through their `argsSchema`.

## Out of scope (per #1453)

- **Phase 7:** families-stay-whole restoration + Tailwind-namespace alignment (color generator emitting one token per family; typography splitting into `font`/`text`/`leading`/`tracking`/`font-weight` matching Tailwind v4; `category` grouping). Generators and exporters not touched.
- **Phase 8:** filling the why-gate content slots with research-grounded vault content. Architecture not content.
- **Consumer migration:** `apps/api`, `apps/website`, `apps/demo`, `packages/cli`, `packages/studio` still import from `@rafters/design-tokens-v1`. v1 unchanged.

## Test plan

- [x] `pnpm preflight` green
- [x] 49 new tests across 4 files passing in `@rafters/design-tokens`
- [x] All v1 tests still passing
- [x] All apps still building (`apps/api`, `apps/website`, `apps/demo`)
- [x] No imports of color-utils / math-utils / design-tokens-v1 in `packages/design-tokens/src/`

Closes #1453.