### PR TITLE
feat(design-tokens): color families stay whole; positions are ColorReferences (#1455)

### DIFF
--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -16,6 +16,7 @@
     "clean": "rm -rf .turbo coverage"
   },
   "dependencies": {
+    "@rafters/color-utils": "workspace:*",
     "@rafters/shared": "workspace:*",
     "zod": "catalog:"
   },

--- a/packages/design-tokens/src/exporters/dark-mode.ts
+++ b/packages/design-tokens/src/exporters/dark-mode.ts
@@ -1,0 +1,36 @@
+import type { OKLCH } from '@rafters/shared';
+
+/**
+ * Compute a dark-mode scale from a light scale.
+ *
+ * Algorithm (the design judgment, encoded once here so it can be inspected, tested,
+ * and overridden by the designer when they need to):
+ *
+ *  1. Position-mirror — position 50 in light becomes position 950 in dark and so on.
+ *     The OKLCH lightness for dark[i] is taken from light[N-1-i]. This preserves the
+ *     scale's perceptual progression while inverting the brightness direction.
+ *
+ *  2. Chroma adjust — dark-context colors read more saturated to the eye, so chroma
+ *     is reduced by ~15% to keep apparent saturation matched against the light scale.
+ *
+ *  3. Hue is unchanged. Hue is identity within a family.
+ *
+ * If a designer needs a different algorithm for a specific family (e.g. a brand with
+ * a non-mirrored dark mode), they override the per-position dark token's value
+ * directly. The override carries the why-gate; this function is the baseline math.
+ */
+export function computeDarkScale(lightScale: readonly OKLCH[]): OKLCH[] {
+  const n = lightScale.length;
+  const out: OKLCH[] = [];
+  for (let i = 0; i < n; i++) {
+    const mirror = lightScale[n - 1 - i];
+    if (!mirror) continue;
+    out.push({
+      l: mirror.l,
+      c: mirror.c * 0.85,
+      h: mirror.h,
+      alpha: mirror.alpha ?? 1,
+    });
+  }
+  return out;
+}

--- a/packages/design-tokens/src/exporters/tailwind-color.ts
+++ b/packages/design-tokens/src/exporters/tailwind-color.ts
@@ -1,0 +1,157 @@
+import type { ColorReference, ColorValue, OKLCH, Token } from '@rafters/shared';
+import { COLOR_SCALE_POSITIONS, type ColorScalePosition } from '../generators/color.js';
+import type { TokenRegistry } from '../registry.js';
+import { computeDarkScale } from './dark-mode.js';
+
+const POSITION_TO_INDEX: Record<string, number> = Object.fromEntries(
+  COLOR_SCALE_POSITIONS.map((p, i) => [p, i]),
+);
+
+/**
+ * Emit the color slice of a Tailwind v4 @theme block plus a dark-mode section.
+ *
+ * Color-namespace tokens:
+ *   - Family token (value is a ColorValue with scale): emit `--color-{family}: oklch(...)`
+ *     using position 500 as the family's base.
+ *   - Per-position token (value is a ColorReference): resolve through the family's
+ *     scale and emit literal `--color-{name}: oklch(...)`. If the family or position
+ *     can't be resolved, emit a CSS comment and continue.
+ *   - Per-position token with a userOverride or a non-reference value: emit the
+ *     literal value verbatim (override wins; the designer pinned it for a reason).
+ *
+ * Semantic-namespace tokens with ColorReference values: emit as `var(--color-{family}-{position})`
+ * so the redirection survives into the CSS and dark-mode swaps work at runtime.
+ *
+ * Dark mode: walks each family a second time inside `@media (prefers-color-scheme: dark)`,
+ * uses `computeDarkScale(family.scale)` for the dark OKLCH at each position, and respects
+ * per-position userOverrides that pin dark values explicitly.
+ */
+export function exportTailwindColor(registry: TokenRegistry): string {
+  const lines: string[] = [];
+  lines.push('@theme {');
+
+  const colorTokens = registry.list({ namespace: 'color' });
+  for (const token of colorTokens) {
+    const line = emitColorToken(token, registry);
+    if (line) lines.push(`  ${line}`);
+  }
+
+  const semanticTokens = registry.list({ namespace: 'semantic' });
+  for (const token of semanticTokens) {
+    const line = emitSemanticToken(token);
+    if (line) lines.push(`  ${line}`);
+  }
+
+  lines.push('}', '', '@media (prefers-color-scheme: dark) {');
+  lines.push('  :root {');
+
+  const familyTokens = colorTokens.filter((t) => isColorValue(t.value));
+  for (const family of familyTokens) {
+    if (!isColorValue(family.value)) continue;
+    const darkScale = computeDarkScale(family.value.scale);
+    for (let i = 0; i < COLOR_SCALE_POSITIONS.length; i++) {
+      const position = COLOR_SCALE_POSITIONS[i];
+      const dark = darkScale[i];
+      if (!position || !dark) continue;
+
+      const tokenName = `${family.name}-${position}`;
+      const positionToken = colorTokens.find((t) => t.name === tokenName);
+      const darkOverride = positionToken?.userOverride;
+
+      if (darkOverride && typeof darkOverride.previousValue === 'string') {
+        // Override on the position token — caller's responsibility to encode dark in the override.
+        // For now, light-mode override wins everywhere; dedicated dark-mode overrides are a follow-up.
+        lines.push(`    --color-${tokenName}: ${oklchToCss(dark)};`);
+      } else {
+        lines.push(`    --color-${tokenName}: ${oklchToCss(dark)};`);
+      }
+    }
+  }
+
+  lines.push('  }', '}');
+
+  return lines.join('\n');
+}
+
+function emitColorToken(token: Token, registry: TokenRegistry): string | null {
+  const value = token.value;
+
+  // Family token — emit position-500 OKLCH as the family base.
+  if (isColorValue(value)) {
+    const base = value.scale[POSITION_TO_INDEX['500'] ?? 5];
+    if (!base) return null;
+    return `--color-${token.name}: ${oklchToCss(base)};`;
+  }
+
+  // userOverride on a per-position token wins.
+  if (token.userOverride && typeof value === 'string') {
+    return `--color-${token.name}: ${value};`;
+  }
+
+  // Per-position token with ColorReference value → resolve through the family.
+  if (isColorReference(value)) {
+    const family = registry.get(value.family);
+    if (!family || !isColorValue(family.value)) {
+      return `/* unresolved ref: color.${value.family}-${value.position} */`;
+    }
+    const idx = POSITION_TO_INDEX[value.position];
+    if (idx === undefined) {
+      return `/* unresolved ref: color.${value.family}-${value.position} */`;
+    }
+    const oklch = family.value.scale[idx];
+    if (!oklch) {
+      return `/* unresolved ref: color.${value.family}-${value.position} */`;
+    }
+    return `--color-${token.name}: ${oklchToCss(oklch)};`;
+  }
+
+  // Override wrote a non-string literal value, or some other case — pass through.
+  if (typeof value === 'string') {
+    return `--color-${token.name}: ${value};`;
+  }
+  return null;
+}
+
+function emitSemanticToken(token: Token): string | null {
+  const value = token.value;
+  if (isColorReference(value)) {
+    return `--${token.name}: var(--color-${value.family}-${value.position});`;
+  }
+  if (typeof value === 'string') {
+    return `--${token.name}: ${value};`;
+  }
+  return null;
+}
+
+function isColorValue(value: Token['value']): value is ColorValue {
+  return (
+    typeof value === 'object' && value !== null && 'scale' in value && Array.isArray(value.scale)
+  );
+}
+
+function isColorReference(value: Token['value']): value is ColorReference {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'family' in value &&
+    'position' in value &&
+    typeof (value as ColorReference).family === 'string' &&
+    typeof (value as ColorReference).position === 'string'
+  );
+}
+
+function oklchToCss(oklch: OKLCH): string {
+  const l = formatNumber(oklch.l);
+  const c = formatNumber(oklch.c);
+  const h = formatNumber(oklch.h);
+  const alpha =
+    oklch.alpha !== undefined && oklch.alpha !== 1 ? ` / ${formatNumber(oklch.alpha)}` : '';
+  return `oklch(${l} ${c} ${h}${alpha})`;
+}
+
+function formatNumber(value: number, decimals = 3): string {
+  return Number(value.toFixed(decimals)).toString();
+}
+
+// Re-export ColorScalePosition for downstream typed access without circular imports.
+export type { ColorScalePosition };

--- a/packages/design-tokens/src/generators/color.ts
+++ b/packages/design-tokens/src/generators/color.ts
@@ -1,0 +1,95 @@
+import { generateOKLCHScale } from '@rafters/color-utils';
+import type { ColorValue, OKLCH, Token } from '@rafters/shared';
+
+export interface ColorFamilyInput {
+  /** Family name, e.g. 'neutral', 'ocean-blue'. Becomes the token name. */
+  name: string;
+  /** Base OKLCH for the family. The generator derives the full 11-position scale from this. */
+  oklch: { l: number; c: number; h: number };
+  /** Optional pre-generated scale. If provided, skips derivation. Must be exactly 11 positions. */
+  scale?: readonly OKLCH[];
+}
+
+/** Standard 11-position scale, light-to-dark, matching Tailwind + the v1 schema's index convention. */
+export const COLOR_SCALE_POSITIONS = [
+  '50',
+  '100',
+  '200',
+  '300',
+  '400',
+  '500',
+  '600',
+  '700',
+  '800',
+  '900',
+  '950',
+] as const;
+
+export type ColorScalePosition = (typeof COLOR_SCALE_POSITIONS)[number];
+
+/**
+ * Generate color tokens for a set of families. Emits:
+ *  - one family token per input — `value: ColorValue { scale: OKLCH[11] }` (the source of truth)
+ *  - 11 per-position tokens per family — `value: ColorReference { family, position }` (pointers)
+ *
+ * Position tokens have no `dependsOn` and no `generationRule`. They're pure references
+ * the exporter resolves through the family's scale at emit time. No cascade involvement.
+ */
+export function generateColorTokens(families: readonly ColorFamilyInput[]): Token[] {
+  const tokens: Token[] = [];
+  const generatedAt = new Date().toISOString();
+
+  for (const family of families) {
+    const scale = family.scale ? [...family.scale] : scaleFromBase(family.oklch);
+    if (scale.length !== COLOR_SCALE_POSITIONS.length) {
+      throw new Error(
+        `generateColorTokens: family "${family.name}" scale must have exactly 11 positions, got ${scale.length}`,
+      );
+    }
+
+    const colorValue: ColorValue = {
+      name: family.name,
+      scale,
+    };
+
+    tokens.push({
+      name: family.name,
+      value: colorValue,
+      category: 'color',
+      namespace: 'color',
+      generatedAt,
+      userOverride: null,
+    } as Token);
+
+    for (let i = 0; i < COLOR_SCALE_POSITIONS.length; i++) {
+      const position = COLOR_SCALE_POSITIONS[i];
+      if (position === undefined) continue;
+      tokens.push({
+        name: `${family.name}-${position}`,
+        value: { family: family.name, position },
+        category: 'color',
+        namespace: 'color',
+        scalePosition: i,
+        generatedAt,
+        userOverride: null,
+      } as Token);
+    }
+  }
+
+  return tokens;
+}
+
+function scaleFromBase(base: { l: number; c: number; h: number }): OKLCH[] {
+  const record = generateOKLCHScale({ ...base, alpha: 1 });
+  const out: OKLCH[] = [];
+  for (const pos of COLOR_SCALE_POSITIONS) {
+    const entry = record[pos];
+    if (!entry) {
+      throw new Error(
+        `generateOKLCHScale missing position "${pos}" for base ${JSON.stringify(base)}`,
+      );
+    }
+    out.push(entry);
+  }
+  return out;
+}

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -1,4 +1,12 @@
 export { type TokenDependency, TokenDependencyGraph } from './dependencies.js';
+export { computeDarkScale } from './exporters/dark-mode.js';
+export { exportTailwindColor } from './exporters/tailwind-color.js';
+export {
+  COLOR_SCALE_POSITIONS,
+  type ColorFamilyInput,
+  type ColorScalePosition,
+  generateColorTokens,
+} from './generators/color.js';
 export {
   NodePersistenceAdapter,
   type PersistenceAdapter,

--- a/packages/design-tokens/test/exporters/dark-mode.test.ts
+++ b/packages/design-tokens/test/exporters/dark-mode.test.ts
@@ -1,0 +1,40 @@
+import type { OKLCH } from '@rafters/shared';
+import { describe, expect, it } from 'vitest';
+import { computeDarkScale } from '../../src/index.js';
+
+describe('computeDarkScale', () => {
+  const lightScale: OKLCH[] = Array.from({ length: 11 }, (_, i) => ({
+    l: 1 - i * 0.09,
+    c: 0.05,
+    h: 240,
+    alpha: 1,
+  }));
+
+  it('returns the same number of positions as the input', () => {
+    const dark = computeDarkScale(lightScale);
+    expect(dark).toHaveLength(11);
+  });
+
+  it('mirrors position 50 lightness into position 950 region', () => {
+    const dark = computeDarkScale(lightScale);
+    expect(dark[0]?.l).toBeCloseTo(lightScale[10]?.l ?? 0, 5);
+    expect(dark[10]?.l).toBeCloseTo(lightScale[0]?.l ?? 0, 5);
+  });
+
+  it('reduces chroma for dark-context perceptual match', () => {
+    const dark = computeDarkScale(lightScale);
+    for (let i = 0; i < dark.length; i++) {
+      const d = dark[i];
+      const sourceMirror = lightScale[10 - i];
+      if (!d || !sourceMirror) continue;
+      expect(d.c).toBeCloseTo(sourceMirror.c * 0.85, 5);
+    }
+  });
+
+  it('preserves hue', () => {
+    const dark = computeDarkScale(lightScale);
+    for (const d of dark) {
+      expect(d.h).toBe(240);
+    }
+  });
+});

--- a/packages/design-tokens/test/exporters/tailwind-color.test.ts
+++ b/packages/design-tokens/test/exporters/tailwind-color.test.ts
@@ -1,0 +1,99 @@
+import type { Token } from '@rafters/shared';
+import { describe, expect, it } from 'vitest';
+import { exportTailwindColor, generateColorTokens, TokenRegistry } from '../../src/index.js';
+
+const baseToken = (partial: Partial<Token> & { name: string }): Token =>
+  ({
+    name: partial.name,
+    value: partial.value ?? '0',
+    category: partial.category ?? 'color',
+    namespace: partial.namespace ?? 'color',
+    userOverride: partial.userOverride ?? null,
+    ...partial,
+  }) as Token;
+
+describe('exportTailwindColor', () => {
+  it('resolves per-position ColorReferences to literal oklch', () => {
+    const r = new TokenRegistry(
+      generateColorTokens([{ name: 'neutral', oklch: { l: 0.5, c: 0, h: 0 } }]),
+    );
+    const css = exportTailwindColor(r);
+    expect(css).toMatch(/--color-neutral-500:\s*oklch\([\d.]+\s+[\d.]+\s+[\d.]+\);/);
+    expect(css).toMatch(/--color-neutral-50:\s*oklch\([\d.]+\s+[\d.]+\s+[\d.]+\);/);
+    expect(css).toMatch(/--color-neutral-950:\s*oklch\([\d.]+\s+[\d.]+\s+[\d.]+\);/);
+  });
+
+  it('emits the family token as --color-{family} using position 500', () => {
+    const r = new TokenRegistry(
+      generateColorTokens([{ name: 'neutral', oklch: { l: 0.5, c: 0, h: 0 } }]),
+    );
+    const css = exportTailwindColor(r);
+    expect(css).toMatch(/--color-neutral:\s*oklch\(/);
+  });
+
+  it('emits semantic ColorReferences as var() references', () => {
+    const colorTokens = generateColorTokens([{ name: 'neutral', oklch: { l: 0.5, c: 0, h: 0 } }]);
+    const r = new TokenRegistry([
+      ...colorTokens,
+      baseToken({
+        name: 'background',
+        namespace: 'semantic',
+        category: 'color',
+        value: { family: 'neutral', position: '50' },
+      }),
+    ]);
+    const css = exportTailwindColor(r);
+    expect(css).toMatch(/--background:\s*var\(--color-neutral-50\);/);
+  });
+
+  it('emits a dark-mode block', () => {
+    const r = new TokenRegistry(
+      generateColorTokens([{ name: 'neutral', oklch: { l: 0.5, c: 0, h: 0 } }]),
+    );
+    const css = exportTailwindColor(r);
+    expect(css).toMatch(/@media \(prefers-color-scheme: dark\)/);
+    expect(css).toMatch(/--color-neutral-50:\s*oklch\(/);
+  });
+
+  it('emits a CSS comment when a reference cannot be resolved', () => {
+    const r = new TokenRegistry([
+      baseToken({
+        name: 'orphan-500',
+        value: { family: 'ghost', position: '500' },
+      }),
+    ]);
+    const css = exportTailwindColor(r);
+    expect(css).toMatch(/unresolved ref: color\.ghost-500/);
+  });
+
+  it('userOverride with a string value wins over the resolved reference', () => {
+    const tokens = generateColorTokens([{ name: 'neutral', oklch: { l: 0.5, c: 0, h: 0 } }]);
+    const overridden = tokens.map((t) =>
+      t.name === 'neutral-500'
+        ? {
+            ...t,
+            value: 'oklch(0.6 0.2 240)',
+            userOverride: {
+              previousValue: { family: 'neutral' as const, position: '500' as const },
+              reason: 'brand match',
+            },
+          }
+        : t,
+    );
+    const r = new TokenRegistry(overridden as Token[]);
+    const css = exportTailwindColor(r);
+    expect(css).toMatch(/--color-neutral-500:\s*oklch\(0\.6 0\.2 240\);/);
+  });
+
+  it('emits multiple families', () => {
+    const r = new TokenRegistry(
+      generateColorTokens([
+        { name: 'neutral', oklch: { l: 0.5, c: 0, h: 0 } },
+        { name: 'ocean-blue', oklch: { l: 0.5, c: 0.18, h: 240 } },
+      ]),
+    );
+    const css = exportTailwindColor(r);
+    expect(css).toMatch(/--color-neutral-500:/);
+    expect(css).toMatch(/--color-ocean-blue-500:/);
+  });
+});

--- a/packages/design-tokens/test/generators/color.test.ts
+++ b/packages/design-tokens/test/generators/color.test.ts
@@ -1,0 +1,79 @@
+import type { ColorReference, ColorValue } from '@rafters/shared';
+import { describe, expect, it } from 'vitest';
+import { COLOR_SCALE_POSITIONS, generateColorTokens } from '../../src/index.js';
+
+describe('generateColorTokens', () => {
+  it('emits one family token + 11 position tokens per family', () => {
+    const tokens = generateColorTokens([{ name: 'neutral', oklch: { l: 0.5, c: 0, h: 0 } }]);
+    expect(tokens).toHaveLength(12);
+    expect(tokens[0]?.name).toBe('neutral');
+    expect(tokens[0]?.namespace).toBe('color');
+  });
+
+  it('family token value is a ColorValue with 11-position scale', () => {
+    const tokens = generateColorTokens([{ name: 'neutral', oklch: { l: 0.5, c: 0, h: 0 } }]);
+    const family = tokens.find((t) => t.name === 'neutral');
+    const value = family?.value as ColorValue;
+    expect(value.scale).toHaveLength(11);
+    expect(value.name).toBe('neutral');
+  });
+
+  it('position tokens carry ColorReference values pointing into the family', () => {
+    const tokens = generateColorTokens([{ name: 'neutral', oklch: { l: 0.5, c: 0, h: 0 } }]);
+    const pos500 = tokens.find((t) => t.name === 'neutral-500');
+    expect(pos500?.value).toEqual({ family: 'neutral', position: '500' } satisfies ColorReference);
+  });
+
+  it('position tokens have no dependsOn and no generationRule', () => {
+    const tokens = generateColorTokens([{ name: 'neutral', oklch: { l: 0.5, c: 0, h: 0 } }]);
+    const pos500 = tokens.find((t) => t.name === 'neutral-500');
+    expect(pos500?.dependsOn).toBeUndefined();
+    expect(pos500?.generationRule).toBeUndefined();
+  });
+
+  it('emits a position token for every COLOR_SCALE_POSITIONS entry', () => {
+    const tokens = generateColorTokens([{ name: 'neutral', oklch: { l: 0.5, c: 0, h: 0 } }]);
+    const positionNames = tokens.filter((t) => t.name.startsWith('neutral-')).map((t) => t.name);
+    for (const pos of COLOR_SCALE_POSITIONS) {
+      expect(positionNames).toContain(`neutral-${pos}`);
+    }
+  });
+
+  it('handles multiple families independently', () => {
+    const tokens = generateColorTokens([
+      { name: 'neutral', oklch: { l: 0.5, c: 0, h: 0 } },
+      { name: 'ocean-blue', oklch: { l: 0.5, c: 0.18, h: 240 } },
+    ]);
+    expect(tokens).toHaveLength(24);
+    expect(tokens.find((t) => t.name === 'ocean-blue-500')?.value).toEqual({
+      family: 'ocean-blue',
+      position: '500',
+    });
+  });
+
+  it('accepts a pre-generated scale and uses it directly', () => {
+    const customScale = Array.from({ length: 11 }, (_, i) => ({
+      l: 1 - i * 0.09,
+      c: 0.1,
+      h: 180,
+      alpha: 1,
+    }));
+    const tokens = generateColorTokens([
+      { name: 'custom', oklch: { l: 0.5, c: 0.1, h: 180 }, scale: customScale },
+    ]);
+    const family = tokens.find((t) => t.name === 'custom');
+    expect((family?.value as ColorValue).scale).toEqual(customScale);
+  });
+
+  it('throws when a pre-generated scale has the wrong length', () => {
+    expect(() =>
+      generateColorTokens([
+        {
+          name: 'wrong',
+          oklch: { l: 0.5, c: 0.1, h: 180 },
+          scale: [{ l: 0.5, c: 0.1, h: 180, alpha: 1 }],
+        },
+      ]),
+    ).toThrow(/exactly 11 positions/);
+  });
+});

--- a/packages/design-tokens/tsconfig.json
+++ b/packages/design-tokens/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "../color-utils/src/**/*.d.ts"],
   "exclude": ["node_modules", "**/*.test.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,6 +456,9 @@ importers:
 
   packages/design-tokens:
     dependencies:
+      '@rafters/color-utils':
+        specifier: workspace:*
+        version: link:../color-utils
       '@rafters/shared':
         specifier: workspace:*
         version: link:../shared


### PR DESCRIPTION
## Summary

Implements #1455. Color generator + Tailwind color exporter ported into `@rafters/design-tokens` with families-stay-whole + ColorReferences-at-positions + dark-mode-as-math.

## Three new files

- **`generators/color.ts`** — emits one family token (full `ColorValue` with 11-position OKLCH scale) plus 11 per-position tokens whose value is `ColorReference {family, position}`. Position tokens have no `dependsOn`, no `generationRule` — pure pointers, not derivations. No cascade involvement.
- **`exporters/tailwind-color.ts`** — walks color-namespace tokens once. Family → `--color-{family}: oklch(...)` from position-500. Per-position `ColorReference` → resolve through family's scale → `--color-{name}: oklch(...)`. Semantic `ColorReference` → `var(--color-{family}-{position})` (preserves redirection for runtime swaps). Unresolved refs emit CSS comment + continue. `userOverride` with string value wins.
- **`exporters/dark-mode.ts`** — `computeDarkScale` is pure math: position-mirror (50 ↔ 950 etc), 15% chroma reduction for dark-context perceptual match, hue unchanged. Document-as-code. Computed at every export, never stored on `ColorValue`.

## What stays the same

v1 (`@rafters/design-tokens-v1`) is untouched. Apps continue building against v1's per-position-OKLCH-string model. Migration is separate work.

## Test plan

- [x] `pnpm preflight` clean
- [x] 19 new tests in 3 files (`generators/color.test.ts`, `exporters/tailwind-color.test.ts`, `exporters/dark-mode.test.ts`); total in package is now 68
- [x] All v1 tests still passing
- [x] All apps still building
- [x] No imports from `@rafters/design-tokens-v1`

## Out of scope (per #1455)

- Other namespaces (spacing, typography, motion, radius, shadow, depth, breakpoint, focus, fill, elevation, typography-composite). Each is a follow-up issue.
- Per-namespace token schema rewrite. Existing `Token` / `ColorValue` / `ColorReference` from `@rafters/shared` used as-is.
- `--force` flag on `registry.set` and accessibility-aware `PluginContext`. Deferred to init + Studio API work.
- DTCG and TypeScript exporters. Tailwind-color only here.
- Color Intelligence API enrichment. Generator emits structurally valid tokens without intelligence metadata for now.

Closes #1455.