### PR TITLE
feat(design-tokens): migrate every consumer from v1 to @rafters/design-tokens (#1459)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@hono/zod-openapi": "1.1.5",
     "@rafters/color-utils": "workspace:^",
-    "@rafters/design-tokens-v1": "workspace:^",
+    "@rafters/design-tokens": "workspace:^",
     "@scalar/hono-api-reference": "^0.9.28",
     "hono": "catalog:",
     "stoker": "catalog:",

--- a/apps/api/src/routes/index.route.ts
+++ b/apps/api/src/routes/index.route.ts
@@ -1,5 +1,5 @@
 import { createRoute, z } from '@hono/zod-openapi';
-import { getAvailableNamespaces } from '@rafters/design-tokens-v1';
+import { getAvailableNamespaces } from '@rafters/design-tokens';
 import { RAFTERS_VERSION } from '@rafters/shared';
 import * as HttpStatusCodes from 'stoker/http-status-codes';
 import { jsonContent } from 'stoker/openapi/helpers';

--- a/apps/api/src/routes/tokens/tokens.handlers.ts
+++ b/apps/api/src/routes/tokens/tokens.handlers.ts
@@ -5,8 +5,8 @@ import {
   generateNamespaces,
   getAvailableNamespaces,
   TokenRegistry,
-} from '@rafters/design-tokens-v1';
-import { COMPUTED, type Token } from '@rafters/shared';
+} from '@rafters/design-tokens';
+import type { Token } from '@rafters/shared';
 import * as HttpStatusCodes from 'stoker/http-status-codes';
 import type { AppRouteHandler } from '@/lib/types';
 import type * as routes from './tokens.routes';
@@ -144,7 +144,7 @@ export const clearOverride: AppRouteHandler<typeof routes.clearOverride> = async
     return c.json({ message: `Token "${name}" has no override` }, HttpStatusCodes.NOT_FOUND);
   }
 
-  await reg.set(name, COMPUTED);
+  await reg.clearOverride(name);
   return c.json({ ok: true as const }, HttpStatusCodes.OK);
 };
 

--- a/apps/api/test/routes/tokens/tokens.test.ts
+++ b/apps/api/test/routes/tokens/tokens.test.ts
@@ -1,5 +1,5 @@
 import { SELF } from 'cloudflare:test';
-import { buildColorSystem } from '@rafters/design-tokens-v1';
+import { buildColorSystem } from '@rafters/design-tokens';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { initializeRegistry } from '../../../src/routes/tokens/tokens.handlers';
 

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -17,7 +17,7 @@
     "@astrojs/react": "^4.4.2",
     "@rafters/color-utils": "workspace:*",
     "@rafters/composites": "workspace:*",
-    "@rafters/design-tokens-v1": "workspace:*",
+    "@rafters/design-tokens": "workspace:*",
     "@rafters/ui": "workspace:*",
     "@tailwindcss/vite": "^4.1.18",
     "@types/react": "catalog:",

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -16,7 +16,7 @@
     "@astrojs/cloudflare": "^12.6.12",
     "@astrojs/mdx": "^4.3.13",
     "@astrojs/react": "^4.4.2",
-    "@rafters/design-tokens-v1": "workspace:*",
+    "@rafters/design-tokens": "workspace:*",
     "@tailwindcss/vite": "^4.1.18",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",

--- a/apps/website/src/lib/registry/initService.ts
+++ b/apps/website/src/lib/registry/initService.ts
@@ -3,7 +3,7 @@
  * Generates the init payload for `rafters init`
  */
 
-import { buildColorSystem } from '@rafters/design-tokens-v1';
+import { buildColorSystem } from '@rafters/design-tokens';
 
 export interface InitPayload {
   version: string;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,7 @@
     "@playwright/test": "catalog:",
     "@rafters/color-utils": "workspace:*",
     "@rafters/composites": "workspace:*",
-    "@rafters/design-tokens-v1": "workspace:*",
+    "@rafters/design-tokens": "workspace:*",
     "@rafters/shared": "workspace:*",
     "@rafters/studio": "workspace:*",
     "@types/css-tree": "^2.3.11",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -19,7 +19,7 @@ import {
   registryToTypeScript,
   TokenRegistry,
   toDTCG,
-} from '@rafters/design-tokens-v1';
+} from '@rafters/design-tokens';
 import { onboard, previewOnboard } from '../onboard/orchestrator.js';
 import { toImportPending, writeImportPending } from '../onboard/writer.js';
 import {

--- a/packages/cli/test/commands/studio.test.ts
+++ b/packages/cli/test/commands/studio.test.ts
@@ -13,7 +13,7 @@ import {
   NodePersistenceAdapter,
   registryToVars,
   TokenRegistry,
-} from '@rafters/design-tokens-v1';
+} from '@rafters/design-tokens';
 import { describe, expect, it } from 'vitest';
 import { cleanupFixture, createFixture } from '../fixtures/projects';
 

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -9,7 +9,7 @@ export default defineConfig([
     noExternal: [
       '@rafters/color-utils',
       '@rafters/composites',
-      '@rafters/design-tokens-v1',
+      '@rafters/design-tokens',
       '@rafters/shared',
       '@rafters/studio',
     ],

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -19,6 +19,7 @@
     "@rafters/color-utils": "workspace:*",
     "@rafters/math-utils": "workspace:*",
     "@rafters/shared": "workspace:*",
+    "@tailwindcss/cli": "^4.1.18",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/design-tokens/src/build-color-system.ts
+++ b/packages/design-tokens/src/build-color-system.ts
@@ -1,0 +1,46 @@
+import { toDTCG } from './exporters/dtcg.js';
+import { exportTailwind } from './exporters/tailwind.js';
+import { registryToTypeScript } from './exporters/typescript.js';
+import { type BuildSystemResult, buildSystem } from './generators/index.js';
+import type { BaseSystemConfig } from './generators/types.js';
+import { TokenRegistry } from './registry.js';
+
+export interface BuildColorSystemOptions {
+  /** Base system configuration overrides. */
+  config?: Partial<BaseSystemConfig>;
+  /** Which exporters to run alongside the registry build. */
+  exports?: {
+    tailwind?: boolean | { includeImport?: boolean };
+    typescript?: boolean | { includeJSDoc?: boolean };
+    dtcg?: boolean;
+  };
+}
+
+export interface BuildColorSystemResult {
+  /** The generated token system (matches v1's GenerateAllResult shape). */
+  system: BuildSystemResult;
+  /** TokenRegistry populated with all tokens. */
+  registry: TokenRegistry;
+  /** Exported formats if requested. */
+  exports: {
+    tailwind?: string;
+    typescript?: string;
+    dtcg?: object;
+  };
+}
+
+/**
+ * Compatibility wrapper preserving v1's `buildColorSystem` surface for the cli init
+ * + apps/api + apps/website consumers. Internally: run `buildSystem`, wrap tokens
+ * in a `TokenRegistry`, optionally run the requested exporters, return the
+ * `{ registry, exports }` shape v1 callers expect.
+ */
+export function buildColorSystem(options: BuildColorSystemOptions = {}): BuildColorSystemResult {
+  const system = buildSystem(options.config);
+  const registry = new TokenRegistry(system.allTokens);
+  const exportsOut: BuildColorSystemResult['exports'] = {};
+  if (options.exports?.tailwind) exportsOut.tailwind = exportTailwind(registry);
+  if (options.exports?.typescript) exportsOut.typescript = registryToTypeScript(registry);
+  if (options.exports?.dtcg) exportsOut.dtcg = toDTCG(system.allTokens);
+  return { system, registry, exports: exportsOut };
+}

--- a/packages/design-tokens/src/build-color-system.ts
+++ b/packages/design-tokens/src/build-color-system.ts
@@ -39,7 +39,11 @@ export function buildColorSystem(options: BuildColorSystemOptions = {}): BuildCo
   const system = buildSystem(options.config);
   const registry = new TokenRegistry(system.allTokens);
   const exportsOut: BuildColorSystemResult['exports'] = {};
-  if (options.exports?.tailwind) exportsOut.tailwind = exportTailwind(registry);
+  if (options.exports?.tailwind) {
+    const tw = options.exports.tailwind;
+    const includeImport = typeof tw === 'object' ? (tw.includeImport ?? true) : true;
+    exportsOut.tailwind = exportTailwind(registry, { includeImport });
+  }
   if (options.exports?.typescript) exportsOut.typescript = registryToTypeScript(registry);
   if (options.exports?.dtcg) exportsOut.dtcg = toDTCG(system.allTokens);
   return { system, registry, exports: exportsOut };

--- a/packages/design-tokens/src/exporters/tailwind.ts
+++ b/packages/design-tokens/src/exporters/tailwind.ts
@@ -30,8 +30,20 @@ const POSITION_TO_INDEX: Record<string, number> = Object.fromEntries(
  * Dark mode: walks each family inside `@media (prefers-color-scheme: dark)`, emits
  * per-position dark vars from `computeDarkScale(family.scale)`.
  */
-export function exportTailwind(registry: TokenRegistry): string {
+export interface ExportTailwindOptions {
+  /** Emit `@import "tailwindcss";` at the top so the output is a complete entry CSS file. Default: true. */
+  includeImport?: boolean | undefined;
+}
+
+export function exportTailwind(
+  registry: TokenRegistry,
+  options: ExportTailwindOptions = {},
+): string {
+  const { includeImport = true } = options;
   const lines: string[] = [];
+  if (includeImport) {
+    lines.push('@import "tailwindcss";', '');
+  }
   lines.push('@theme {');
 
   const colorTokens = registry.list({ namespace: 'color' });
@@ -173,17 +185,16 @@ export interface TailwindExportOptions {
 }
 
 /**
- * Compatibility shim for v1 consumers. Delegates to `exportTailwind`; the options
- * are accepted for backward compat but currently ignored (the new exporter emits a
- * `@theme` block + `@media (prefers-color-scheme: dark)`, no `@import`, no `.dark`
- * class machinery). When init/studio surface gaps that need v1 behavior restored,
- * they land as separate PRs.
+ * Compatibility shim for v1 consumers. Delegates to `exportTailwind`, passing
+ * `includeImport` through. v1's `darkMode` option is currently a no-op — the new
+ * exporter emits `@media (prefers-color-scheme: dark)` regardless. When init/studio
+ * surface gaps that need `.dark` class machinery, that lands as a separate PR.
  */
 export function registryToTailwind(
   registry: TokenRegistry,
-  _options?: TailwindExportOptions,
+  options?: TailwindExportOptions,
 ): string {
-  return exportTailwind(registry);
+  return exportTailwind(registry, { includeImport: options?.includeImport });
 }
 
 /**

--- a/packages/design-tokens/src/exporters/tailwind.ts
+++ b/packages/design-tokens/src/exporters/tailwind.ts
@@ -165,3 +165,108 @@ function oklchToCss(oklch: OKLCH): string {
 function formatNumber(value: number, decimals = 3): string {
   return Number(value.toFixed(decimals)).toString();
 }
+
+/** Options accepted by v1's `registryToTailwind`. Honored for surface compatibility; the new exporter currently ignores `includeImport` (does not emit a Tailwind import line). */
+export interface TailwindExportOptions {
+  includeImport?: boolean;
+  darkMode?: 'class' | 'media';
+}
+
+/**
+ * Compatibility shim for v1 consumers. Delegates to `exportTailwind`; the options
+ * are accepted for backward compat but currently ignored (the new exporter emits a
+ * `@theme` block + `@media (prefers-color-scheme: dark)`, no `@import`, no `.dark`
+ * class machinery). When init/studio surface gaps that need v1 behavior restored,
+ * they land as separate PRs.
+ */
+export function registryToTailwind(
+  registry: TokenRegistry,
+  _options?: TailwindExportOptions,
+): string {
+  return exportTailwind(registry);
+}
+
+/**
+ * Emit only the `:root` block with token values (no `@theme`).
+ * Used by Studio's vite-plugin to inject token values into a dev server.
+ * Walks every namespace and emits `--{name}: {value}` for each token, mirroring
+ * `exportTailwind`'s rules: color refs resolve through the family scale, semantic
+ * refs emit as var() pointers, composite JSON values are skipped.
+ */
+export function registryToVars(registry: TokenRegistry): string {
+  if (registry.list().length === 0) {
+    throw new Error('Registry is empty');
+  }
+  const lines: string[] = [':root {'];
+
+  for (const token of registry.list({ namespace: 'color' })) {
+    const line = emitColorToken(token, registry);
+    if (line) lines.push(`  ${line}`);
+  }
+  for (const token of registry.list({ namespace: 'semantic' })) {
+    const line = emitSemanticToken(token);
+    if (line) lines.push(`  ${line}`);
+  }
+  for (const ns of uniqueNamespaces(registry).filter((n) => n !== 'color' && n !== 'semantic')) {
+    for (const token of registry.list({ namespace: ns })) {
+      const line = emitOtherToken(token);
+      if (line) lines.push(`  ${line}`);
+    }
+  }
+
+  lines.push('}');
+  return lines.join('\n');
+}
+
+/** Options for `registryToCompiled`. */
+export interface CompiledCssOptions {
+  /** Minify the output (default: true) */
+  minify?: boolean;
+  /** Include `@import "tailwindcss"` in the source (default: true). Currently advisory — the new exporter does not emit the import line. */
+  includeImport?: boolean;
+}
+
+/**
+ * Generate Tailwind theme CSS and compile it through the Tailwind CLI into
+ * fully-resolved standalone CSS. No Tailwind installation required by the
+ * consumer. Ported from v1; uses `@tailwindcss/cli` as a workspace dep.
+ */
+export async function registryToCompiled(
+  registry: TokenRegistry,
+  options: CompiledCssOptions = {},
+): Promise<string> {
+  const { minify = true } = options;
+  const themeCss = exportTailwind(registry);
+
+  const { execFileSync } = await import('node:child_process');
+  const { mkdtempSync, writeFileSync, readFileSync, rmSync } = await import('node:fs');
+  const { join, dirname } = await import('node:path');
+  const { createRequire } = await import('node:module');
+
+  const require = createRequire(import.meta.url);
+  let pkgDir: string;
+  try {
+    const pkgJsonPath = require.resolve('@tailwindcss/cli/package.json');
+    pkgDir = dirname(pkgJsonPath);
+  } catch {
+    throw new Error('Failed to resolve @tailwindcss/cli');
+  }
+
+  const binPath = join(pkgDir, 'dist', 'index.mjs');
+  const tempDir = mkdtempSync(join(pkgDir, '.tmp-compile-'));
+  const tempInput = join(tempDir, 'input.css');
+  const tempOutput = join(tempDir, 'output.css');
+
+  try {
+    writeFileSync(tempInput, themeCss);
+    const args = [binPath, '-i', tempInput, '-o', tempOutput];
+    if (minify) args.push('--minify');
+    execFileSync('node', args, { stdio: 'pipe', timeout: 30_000 });
+    return readFileSync(tempOutput, 'utf-8');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to compile CSS: ${message}`);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}

--- a/packages/design-tokens/src/generators/index.ts
+++ b/packages/design-tokens/src/generators/index.ts
@@ -231,6 +231,25 @@ export function buildSystem(config: Partial<BaseSystemConfig> = {}): BuildSystem
  * Generate tokens for specific namespaces only. Useful for re-running a slice
  * after a config change without paying for the whole graph.
  */
+/** Names of every namespace the generators support. */
+export function getAvailableNamespaces(): readonly string[] {
+  return [
+    'color',
+    'spacing',
+    'typography',
+    'breakpoint',
+    'semantic',
+    'typography-composite',
+    'radius',
+    'shadow',
+    'depth',
+    'motion',
+    'fill',
+    'elevation',
+    'focus',
+  ];
+}
+
 export function generateNamespaces(
   namespaces: readonly string[],
   config: Partial<BaseSystemConfig> = {},

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -8,6 +8,7 @@ export { computeDarkScale } from './exporters/dark-mode.js';
 export { toDTCG, toDTCGByNamespace } from './exporters/dtcg.js';
 export {
   type CompiledCssOptions,
+  type ExportTailwindOptions,
   exportTailwind,
   registryToCompiled,
   registryToTailwind,

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -1,7 +1,19 @@
+export {
+  type BuildColorSystemOptions,
+  type BuildColorSystemResult,
+  buildColorSystem,
+} from './build-color-system.js';
 export { type TokenDependency, TokenDependencyGraph } from './dependencies.js';
 export { computeDarkScale } from './exporters/dark-mode.js';
 export { toDTCG, toDTCGByNamespace } from './exporters/dtcg.js';
-export { exportTailwind } from './exporters/tailwind.js';
+export {
+  type CompiledCssOptions,
+  exportTailwind,
+  registryToCompiled,
+  registryToTailwind,
+  registryToVars,
+  type TailwindExportOptions,
+} from './exporters/tailwind.js';
 export { registryToTypeScript, tokensToTypeScript } from './exporters/typescript.js';
 export * from './generators/index.js';
 export {

--- a/packages/design-tokens/src/registry.ts
+++ b/packages/design-tokens/src/registry.ts
@@ -81,6 +81,43 @@ export class TokenRegistry {
     });
   }
 
+  /**
+   * Compatibility shim for v1's `setToken`. Replaces the full token (add semantics)
+   * and auto-persists if an adapter is set. Prefer `add` + explicit `persist` for new code.
+   */
+  async setToken(token: Token): Promise<void> {
+    this.add(token);
+    if (this.adapter) await this.persist();
+  }
+
+  /**
+   * Compatibility shim for v1's `setTokens`. Batch full-token replacement, single persist.
+   * Prefer iterating `add` + explicit `persist` for new code.
+   */
+  async setTokens(tokens: readonly Token[]): Promise<void> {
+    for (const token of tokens) this.add(token);
+    if (this.adapter) await this.persist();
+  }
+
+  /**
+   * Compatibility shim for v1's `updateToken`. Sync value update — no auto-persist,
+   * matching v1's `updateToken` behavior. Prefer `set` for new code.
+   */
+  updateToken(name: string, value: Token['value']): void {
+    this.set(name, value);
+  }
+
+  /**
+   * Compatibility shim for v1's `setChangeCallback`. Wires the callback through
+   * `onMutation`. Note: event shapes differ — v1 emitted `TokenChangeEvent` with a
+   * `type` field; this calls the callback with a `MutationEvent` carrying `kind`.
+   * Studio's callback consumer is being rearchitected; this shim unblocks the
+   * migration until that lands.
+   */
+  setChangeCallback(callback: MutationHook): void {
+    this.onMutation = callback;
+  }
+
   /** Map write. Updates value, preserves metadata. No cascade, no persist. */
   set(name: string, value: Token['value']): void {
     const existing = this.tokens.get(name);
@@ -167,6 +204,21 @@ export class TokenRegistry {
 
   dependents(name: string): string[] {
     return this.graph.getDependents(name);
+  }
+
+  /** Compatibility shim for v1 consumers. Alias for `dependents`. */
+  getDependents(name: string): string[] {
+    return this.dependents(name);
+  }
+
+  /** Compatibility shim for v1 consumers. Alias for `dependencies`. */
+  getDependencies(name: string): string[] {
+    return this.dependencies(name);
+  }
+
+  /** Compatibility shim for v1 consumers. Reads the generationRule edge from the graph. */
+  getGenerationRule(name: string): string | undefined {
+    return this.graph.getGenerationRule(name);
   }
 
   addDependency(name: string, dependsOn: readonly string[], rule: string): void {

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -181,7 +181,7 @@ packages/studio/
 
 **THIN UI Pattern**: Studio is just a UI layer. All intelligence lives in:
 - `@rafters/color-utils` - Color calculations
-- `@rafters/design-tokens-v1` - TokenRegistry, persistence
+- `@rafters/design-tokens` - TokenRegistry, persistence
 - `@rafters/shared` - Zod schemas, types
 
 ## Development

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@rafters/color-utils": "workspace:*",
-    "@rafters/design-tokens-v1": "workspace:*",
+    "@rafters/design-tokens": "workspace:*",
     "@rafters/shared": "workspace:*",
     "@rafters/ui": "workspace:*",
     "@tanstack/react-query": "^5.90.20",

--- a/packages/studio/scripts/setup-standalone.ts
+++ b/packages/studio/scripts/setup-standalone.ts
@@ -13,7 +13,7 @@ import {
   buildColorSystem,
   NodePersistenceAdapter,
   registryToTailwind,
-} from '@rafters/design-tokens-v1';
+} from '@rafters/design-tokens';
 
 const STUDIO_ROOT = join(import.meta.dirname, '..');
 const RAFTERS_ROOT = join(STUDIO_ROOT, '.rafters');

--- a/packages/studio/src/api/vite-plugin.ts
+++ b/packages/studio/src/api/vite-plugin.ts
@@ -12,7 +12,7 @@
 import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { buildColorValue } from '@rafters/color-utils';
-import { NodePersistenceAdapter, registryToVars, TokenRegistry } from '@rafters/design-tokens-v1';
+import { NodePersistenceAdapter, registryToVars, TokenRegistry } from '@rafters/design-tokens';
 import { ColorReferenceSchema, ColorValueSchema, OKLCHSchema, TokenSchema } from '@rafters/shared';
 import type { Plugin, ViteDevServer } from 'vite';
 import { z } from 'zod';

--- a/packages/studio/test/api/vite-plugin.test.ts
+++ b/packages/studio/test/api/vite-plugin.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { EventEmitter } from 'node:events';
-import { TokenRegistry } from '@rafters/design-tokens-v1';
+import { TokenRegistry } from '@rafters/design-tokens';
 import type { Token } from '@rafters/shared';
 import { ColorReferenceSchema, ColorValueSchema, TokenSchema } from '@rafters/shared';
 import { describe, expect, it } from 'vitest';

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -18,12 +18,12 @@ export default defineConfig({
     extensions: ['.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx', '.json'],
   },
   optimizeDeps: {
-    include: ['@rafters/color-utils', '@rafters/design-tokens-v1', '@rafters/shared'],
+    include: ['@rafters/color-utils', '@rafters/design-tokens', '@rafters/shared'],
   },
   ssr: {
     noExternal: [
       '@rafters/color-utils',
-      '@rafters/design-tokens-v1',
+      '@rafters/design-tokens',
       '@rafters/shared',
       '@rafters/math-utils',
     ],

--- a/packages/ui/src/primitives/fill-resolver.ts
+++ b/packages/ui/src/primitives/fill-resolver.ts
@@ -136,7 +136,7 @@ function resolveGradientFill(fill: FillMetadata, context: FillContext): string {
 /**
  * Built-in fill registry.
  *
- * Mirrors the default fill definitions shipped by @rafters/design-tokens-v1 so
+ * Mirrors the default fill definitions shipped by @rafters/design-tokens so
  * components resolve common names without needing the token package at
  * runtime (ui is copied into consumer projects via the registry and must stay
  * zero-dep). Apps can override or extend via `registerFill`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,9 +170,9 @@ importers:
       '@rafters/color-utils':
         specifier: workspace:^
         version: link:../../packages/color-utils
-      '@rafters/design-tokens-v1':
+      '@rafters/design-tokens':
         specifier: workspace:^
-        version: link:../../packages/design-tokens-v1
+        version: link:../../packages/design-tokens
       '@scalar/hono-api-reference':
         specifier: ^0.9.28
         version: 0.9.28(hono@4.11.0)
@@ -225,9 +225,9 @@ importers:
       '@rafters/composites':
         specifier: workspace:*
         version: link:../../packages/composites
-      '@rafters/design-tokens-v1':
+      '@rafters/design-tokens':
         specifier: workspace:*
-        version: link:../../packages/design-tokens-v1
+        version: link:../../packages/design-tokens
       '@rafters/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -290,9 +290,9 @@ importers:
       '@astrojs/react':
         specifier: ^4.4.2
         version: 4.4.2(@types/node@24.10.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
-      '@rafters/design-tokens-v1':
+      '@rafters/design-tokens':
         specifier: workspace:*
-        version: link:../../packages/design-tokens-v1
+        version: link:../../packages/design-tokens
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@8.0.0(@types/node@24.10.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -364,9 +364,9 @@ importers:
       '@rafters/composites':
         specifier: workspace:*
         version: link:../composites
-      '@rafters/design-tokens-v1':
+      '@rafters/design-tokens':
         specifier: workspace:*
-        version: link:../design-tokens-v1
+        version: link:../design-tokens
       '@rafters/shared':
         specifier: workspace:*
         version: link:../shared
@@ -465,6 +465,9 @@ importers:
       '@rafters/shared':
         specifier: workspace:*
         version: link:../shared
+      '@tailwindcss/cli':
+        specifier: ^4.1.18
+        version: 4.1.18
       zod:
         specifier: 'catalog:'
         version: 4.1.12
@@ -559,9 +562,9 @@ importers:
       '@rafters/color-utils':
         specifier: workspace:*
         version: link:../color-utils
-      '@rafters/design-tokens-v1':
+      '@rafters/design-tokens':
         specifier: workspace:*
-        version: link:../design-tokens-v1
+        version: link:../design-tokens
       '@rafters/shared':
         specifier: workspace:*
         version: link:../shared


### PR DESCRIPTION
## Summary

Closes #1459. Every consumer of `@rafters/design-tokens-v1` now imports from `@rafters/design-tokens`. v1 stays mounted but has zero consumers — deletable in a follow-up after one release cycle.

## Surface added to the new package

- `buildColorSystem(options)` — v1's surface exactly: `{ system, registry, exports }`. Wraps `buildSystem` + `new TokenRegistry` + optional exporter runs.
- `getAvailableNamespaces()` — string[] of namespace literals.
- `registryToTailwind` — alias for `exportTailwind`, accepts v1's options shape (currently ignored).
- `registryToVars(registry)` — emits `:root` block of CSS vars, used by studio's vite-plugin.
- `registryToCompiled(registry, options)` — shells out to `@tailwindcss/cli` (added as workspace dep).

## Compatibility shims on `TokenRegistry`

To avoid rewriting every consumer:

- `setToken(token): Promise<void>` — async + auto-persist (matches v1).
- `setTokens(tokens): Promise<void>` — batch async + auto-persist.
- `updateToken(name, value): void` — sync alias for `set`.
- `setChangeCallback(callback)` — wires through `onMutation`. Event shape differs (`MutationEvent` vs v1's `TokenChangeEvent`); studio's callback consumer is being rearchitected separately.
- `getDependents` / `getDependencies` / `getGenerationRule` — name aliases for the cleaner methods.

## Consumer changes

- **apps/api**: `COMPUTED` sentinel → `registry.clearOverride(name)` (the explicit method). Other call sites resolve through shims.
- **apps/website**, **packages/cli**, **packages/studio**: import path swap only. Call sites unchanged.
- **package.json files**: dep renamed.
- **tsup.config.ts / vite.config.ts / README / CHANGELOG**: text renames.

## Test plan

- [x] `pnpm preflight` clean
- [x] apps/api: 48 tests passing
- [x] packages/cli: 342 tests passing
- [x] packages/design-tokens: 70 tests passing
- [x] All apps still build
- [x] No source file imports `@rafters/design-tokens-v1` outside the v1 package itself

## Out of scope

- Deleting `@rafters/design-tokens-v1`. Follow-up after a release cycle.
- Restoring v1's `--rafters-*` indirection layer, `.dark` class machinery, `@custom-variant`, article base layer, keyframes-as-CSS, typography-overrides-on-registry. Separate issues if init's output regressed visibly when consumers test it in practice.
- Studio vite-plugin's `MutationEvent` consumer rewrite — its typecheck is already skipped, and the rewrite belongs to studio's larger rearchitecture.

Closes #1459.