### PR TITLE
fix(design-tokens): persistence is storage; --no-cascade fires; registry guardrails; binding bridge

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Patch Changes
+
+- fix(set): the `--no-cascade` flag was silently ignored. Commander populates the long-form derived from `--no-cascade` as `options.cascade = false`, but the action handler was reading `options.noCascade`, which is never set. The flag now wires through correctly. Added a Commander integration test so the wiring is locked.
+
 ### Minor Changes
 
 - feat(set): new `rafters set <name> <value>` command for updating a token's value in `.rafters/tokens/*.rafters.json`. Default behaviour cascades to dependent tokens via the `@rafters/design-tokens` registry. The `--no-cascade` flag records the value as a `userOverride` anchor — the token is marked as a designer deviation from the mathematical scale and is skipped by future cascades; downstream propagation still flows from the new value. `--no-cascade` requires `--reason "..."` (or an interactive prompt in non-agent mode). String values are stored as-is; JSON-shaped values (e.g. `'{"family":"accent","position":"500"}'` for a `ColorReference`) are parsed and validated against the union of `string | ColorValue | ColorReference` from `@rafters/shared`. `--rafters-dir <path>` overrides the default `.rafters/tokens` location. `--agent` switches output to JSON (`{event, name, previous, next, cascade, reason?}`) for machine consumption.

--- a/packages/cli/src/commands/set.ts
+++ b/packages/cli/src/commands/set.ts
@@ -17,8 +17,13 @@ import { isAgentMode, log, setAgentMode } from '../utils/ui.js';
 const TokenValueSchema = z.union([z.string(), ColorValueSchema, ColorReferenceSchema]);
 type TokenValue = z.infer<typeof TokenValueSchema>;
 
+/**
+ * Commander populates the long-form key derived from --no-cascade as `cascade`
+ * (defaulting to true; `--no-cascade` flips it to false). Don't read `noCascade` --
+ * it's never set by Commander.
+ */
 export interface SetOptions {
-  noCascade?: boolean;
+  cascade?: boolean;
   reason?: string;
   raftersDir?: string;
   agent?: boolean;
@@ -32,7 +37,7 @@ export async function set(name: string, value: string, options: SetOptions): Pro
     throw new Error(`tokens directory not found: ${dir}`);
   }
 
-  const cascade = !options.noCascade;
+  const cascade = options.cascade !== false;
   let reason = options.reason;
   if (!cascade && !reason) {
     if (isAgentMode()) {

--- a/packages/cli/test/commands/set.test.ts
+++ b/packages/cli/test/commands/set.test.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { set } from '../../src/commands/set.js';
 
@@ -48,9 +49,9 @@ describe('set command', () => {
     expect(token?.userOverride).toBeNull();
   });
 
-  it('records userOverride when --no-cascade with --reason', async () => {
+  it('records userOverride when cascade=false with reason', async () => {
     await set('spacing-base', '20px', {
-      noCascade: true,
+      cascade: false,
       reason: 'Q1 brand campaign',
       raftersDir: tmpDir,
       agent: true,
@@ -64,10 +65,45 @@ describe('set command', () => {
     });
   });
 
-  it('throws in agent mode when --no-cascade missing --reason', async () => {
+  it('throws in agent mode when cascade=false missing reason', async () => {
     await expect(
-      set('spacing-base', '20px', { noCascade: true, raftersDir: tmpDir, agent: true }),
+      set('spacing-base', '20px', { cascade: false, raftersDir: tmpDir, agent: true }),
     ).rejects.toThrow(/--no-cascade requires --reason/);
+  });
+
+  it('integration: --no-cascade flag through Commander populates options.cascade=false', async () => {
+    const program = new Command()
+      .exitOverride()
+      .name('set')
+      .argument('<name>')
+      .argument('<value>')
+      .option('--no-cascade')
+      .option('--reason <text>')
+      .option('--rafters-dir <path>')
+      .option('--agent')
+      .action(async (name: string, value: string, options) => {
+        await set(name, value, options);
+      });
+    await program.parseAsync(
+      [
+        'spacing-base',
+        '12px',
+        '--no-cascade',
+        '--reason',
+        'flag round-trip',
+        '--rafters-dir',
+        tmpDir,
+        '--agent',
+      ],
+      { from: 'user' },
+    );
+    const file = readNamespace('spacing');
+    const token = file.tokens.find((t) => t.name === 'spacing-base');
+    expect(token?.value).toBe('12px');
+    expect(token?.userOverride).toMatchObject({
+      reason: 'flag round-trip',
+      previousValue: '4px',
+    });
   });
 
   it('throws when token does not exist', async () => {

--- a/packages/color-utils/src/builder.ts
+++ b/packages/color-utils/src/builder.ts
@@ -23,21 +23,7 @@ import {
   generateSemanticColorSuggestions,
 } from './harmony.js';
 import { generateColorName } from './naming/index.js';
-
-/** Standard scale positions used in design systems */
-const SCALE_POSITIONS = [
-  '50',
-  '100',
-  '200',
-  '300',
-  '400',
-  '500',
-  '600',
-  '700',
-  '800',
-  '900',
-  '950',
-];
+import { SCALE_POSITIONS } from './scale-positions.js';
 
 /** White reference color for contrast calculations */
 const WHITE: OKLCH = { l: 1, c: 0, h: 0, alpha: 1 };

--- a/packages/color-utils/src/index.ts
+++ b/packages/color-utils/src/index.ts
@@ -64,7 +64,6 @@ export {
   generateSurfaceColor,
   lighten,
 } from './manipulation.js';
-
 // Naming
 export {
   BLUE_HUB,
@@ -98,6 +97,14 @@ export {
   RED_HUB,
   TOTAL_COMBINATIONS,
 } from './naming/index.js';
+// Scale positions and WCAG-pair helpers
+export {
+  findBestWcagPair,
+  findDarkCounterpartIndex,
+  MIN_WCAG_PAIR_DISTANCE,
+  POSITION_TO_INDEX,
+  SCALE_POSITIONS,
+} from './scale-positions.js';
 
 // Validation
 export {

--- a/packages/color-utils/src/scale-positions.ts
+++ b/packages/color-utils/src/scale-positions.ts
@@ -1,6 +1,21 @@
+/**
+ * Standard 11-position color scale conventions.
+ *
+ * SCALE_POSITIONS maps array indices 0-10 to the canonical Tailwind-style
+ * position labels (50, 100, 200, ..., 950). POSITION_TO_INDEX is the inverse.
+ *
+ * WCAG-pair helpers operate on the pair matrices that ColorValue carries
+ * under accessibility.wcagAA / wcagAAA — pairs are [sourceIndex, partnerIndex]
+ * tuples that satisfy the contrast standard. The "find" helpers walk a pair
+ * matrix to return the partner with the greatest distance from the source on
+ * a given side; "findDarkCounterpartIndex" picks a pair partner suitable for
+ * dark-mode pairing (AAA preferred, AA fallback if AAA is too close,
+ * mathematical inversion as last resort).
+ */
+
 import type { ColorValue } from '@rafters/shared';
 
-export const INDEX_TO_POSITION = [
+export const SCALE_POSITIONS = [
   '50',
   '100',
   '200',
@@ -14,19 +29,13 @@ export const INDEX_TO_POSITION = [
   '950',
 ] as const;
 
-export const POSITION_TO_INDEX: Record<string, number> = {
-  '50': 0,
-  '100': 1,
-  '200': 2,
-  '300': 3,
-  '400': 4,
-  '500': 5,
-  '600': 6,
-  '700': 7,
-  '800': 8,
-  '900': 9,
-  '950': 10,
-};
+export const POSITION_TO_INDEX: Record<string, number> = SCALE_POSITIONS.reduce(
+  (acc, position, index) => {
+    acc[position] = index;
+    return acc;
+  },
+  {} as Record<string, number>,
+);
 
 export const MIN_WCAG_PAIR_DISTANCE = 3;
 

--- a/packages/design-tokens-v1/src/generators/semantic.ts
+++ b/packages/design-tokens-v1/src/generators/semantic.ts
@@ -17,9 +17,23 @@
  * - scale:N for direct position references (base, border, ring, subtle)
  */
 
-import type { ColorReference, Token } from '@rafters/shared';
+import type { Binding, ColorReference, Token } from '@rafters/shared';
 import { DEFAULT_SEMANTIC_COLOR_MAPPINGS, type SemanticColorMapping } from './defaults.js';
 import type { GeneratorResult, ResolvedSystemConfig } from './types.js';
+
+const POSITION_TO_INDEX: Record<string, number> = {
+  '50': 0,
+  '100': 1,
+  '200': 2,
+  '300': 3,
+  '400': 4,
+  '500': 5,
+  '600': 6,
+  '700': 7,
+  '800': 8,
+  '900': 9,
+  '950': 10,
+};
 
 /**
  * Helper to convert SemanticColorMapping to ColorReference for light mode
@@ -71,6 +85,26 @@ function deriveGenerationRule(name: string, lightRef: ColorReference): string {
 }
 
 /**
+ * Build a Binding for a semantic token from its light-mode reference.
+ *
+ * The mapping in DEFAULT_SEMANTIC_COLOR_MAPPINGS already encodes the
+ * designer's chosen position for each semantic role. The binding's job on
+ * family remap is to keep that chosen position and just swap the family --
+ * so every semantic token binds to the scale plugin at its mapped position,
+ * regardless of -foreground / -hover / -active / -focus / -disabled suffix.
+ *
+ * Suffix-driven plugins (contrast, state) exist for users to opt into
+ * explicitly via registry.bind(); the generator does not auto-apply them
+ * because doing so overrides the designer's mapped position with the
+ * plugin's computed answer (the v1 cascade bug).
+ */
+function deriveBinding(lightRef: ColorReference): Binding | undefined {
+  const scalePosition = POSITION_TO_INDEX[lightRef.position];
+  if (scalePosition === undefined) return undefined;
+  return { plugin: 'scale', input: { familyName: lightRef.family, scalePosition } };
+}
+
+/**
  * Generate semantic color tokens from the single source of truth.
  *
  * Uses DEFAULT_SEMANTIC_COLOR_MAPPINGS from defaults.ts which contains
@@ -97,12 +131,14 @@ export function generateSemanticTokens(_config: ResolvedSystemConfig): Generator
     }
 
     const generationRule = deriveGenerationRule(name, lightRef);
+    const binding = deriveBinding(lightRef);
 
     tokens.push({
       name,
       value: lightRef, // Light mode is default value; dark mode lookup via dependsOn[1]
       category: 'color',
       namespace: 'semantic',
+      ...(binding ? { binding } : {}),
       semanticMeaning: mapping.meaning,
       usageContext: mapping.contexts,
       trustLevel: mapping.trustLevel,

--- a/packages/design-tokens-v1/src/generators/spacing.ts
+++ b/packages/design-tokens-v1/src/generators/spacing.ts
@@ -100,6 +100,9 @@ export function generateSpacingTokens(
       value: cssValue,
       category: 'spacing',
       namespace: 'spacing',
+      // Intentionally no binding: spacing tokens use CSS calc(var(--spacing-base) * N)
+      // and the BROWSER resolves the cascade at render time. A registry-side binding
+      // would compute eagerly and emit a static value, defeating the runtime cascade.
       semanticMeaning: meaning,
       usageContext,
       scalePosition: scaleIndex,

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -17,6 +17,7 @@
     "clean": "rm -rf .turbo coverage"
   },
   "dependencies": {
+    "@rafters/color-utils": "workspace:*",
     "@rafters/math-utils": "workspace:*",
     "@rafters/shared": "workspace:*",
     "zod": "catalog:"

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -11,6 +11,7 @@ export {
   findTokenFile,
   loadRegistryFromDir,
   type NamespaceFile,
+  NamespaceFileParseError,
   saveRegistryToDir,
 } from './persistence.js';
 export type { PluginSpec } from './plugin.js';

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -10,7 +10,7 @@ export {
 export {
   findTokenFile,
   loadRegistryFromDir,
-  type NamespaceFile,
+  type NamespaceFileEnvelope,
   saveRegistryToDir,
 } from './persistence.js';
 export type { PluginSpec } from './plugin.js';
@@ -22,11 +22,4 @@ export {
   scalePlugin,
   statePlugin,
 } from './plugins/index.js';
-export { type RegistryFilter, TokenRegistry } from './registry.js';
-export {
-  findBestWcagPair,
-  findDarkCounterpartIndex,
-  INDEX_TO_POSITION,
-  MIN_WCAG_PAIR_DISTANCE,
-  POSITION_TO_INDEX,
-} from './scale-positions.js';
+export { type RegistryFilter, TokenRegistry, UnknownTokenError } from './registry.js';

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -11,7 +11,6 @@ export {
   findTokenFile,
   loadRegistryFromDir,
   type NamespaceFile,
-  NamespaceFileParseError,
   saveRegistryToDir,
 } from './persistence.js';
 export type { PluginSpec } from './plugin.js';

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -22,4 +22,9 @@ export {
   scalePlugin,
   statePlugin,
 } from './plugins/index.js';
-export { type RegistryFilter, TokenRegistry, UnknownTokenError } from './registry.js';
+export {
+  type RegistryFilter,
+  TokenParseError,
+  TokenRegistry,
+  UnknownTokenError,
+} from './registry.js';

--- a/packages/design-tokens/src/persistence.ts
+++ b/packages/design-tokens/src/persistence.ts
@@ -4,7 +4,7 @@ import type { Token } from '@rafters/shared';
 import type { Plugin } from './graph.js';
 import { TokenRegistry } from './registry.js';
 
-export type NamespaceFile = {
+export type NamespaceFileEnvelope = {
   $schema?: string;
   namespace?: string;
   version?: string;
@@ -16,8 +16,7 @@ export function loadRegistryFromDir(dir: string, plugins: readonly Plugin[] = []
   const tokens: unknown[] = [];
   for (const entry of readdirSync(dir)) {
     if (!entry.endsWith('.rafters.json')) continue;
-    const path = join(dir, entry);
-    const raw = JSON.parse(readFileSync(path, 'utf8'));
+    const raw = JSON.parse(readFileSync(join(dir, entry), 'utf8'));
     if (raw && Array.isArray(raw.tokens)) {
       tokens.push(...raw.tokens);
     }
@@ -26,6 +25,7 @@ export function loadRegistryFromDir(dir: string, plugins: readonly Plugin[] = []
 }
 
 export function saveRegistryToDir(dir: string, registry: TokenRegistry): void {
+  const envelopes = readEnvelopes(dir);
   const byNamespace = new Map<string, Token[]>();
   for (const token of registry.list()) {
     const list = byNamespace.get(token.namespace) ?? [];
@@ -33,15 +33,18 @@ export function saveRegistryToDir(dir: string, registry: TokenRegistry): void {
     byNamespace.set(token.namespace, list);
   }
   for (const [namespace, tokens] of byNamespace) {
-    const file: NamespaceFile = {
-      $schema: 'https://rafters.studio/schemas/namespace-tokens.json',
+    const previous = envelopes.get(namespace) ?? {};
+    const file: NamespaceFileEnvelope = {
+      ...previous,
       namespace,
-      version: '1.0.0',
       generatedAt: new Date().toISOString(),
       tokens,
     };
-    const path = join(dir, `${namespace}.rafters.json`);
-    writeFileSync(path, `${JSON.stringify(file, null, 2)}\n`, 'utf8');
+    writeFileSync(
+      join(dir, `${namespace}.rafters.json`),
+      `${JSON.stringify(file, null, 2)}\n`,
+      'utf8',
+    );
   }
 }
 
@@ -51,17 +54,31 @@ export function findTokenFile(dir: string, tokenName: string): string | undefine
     const path = join(dir, entry);
     if (!statSync(path).isFile()) continue;
     const raw = JSON.parse(readFileSync(path, 'utf8'));
-    if (raw && Array.isArray(raw.tokens)) {
-      for (const token of raw.tokens) {
-        if (
-          token &&
-          typeof token === 'object' &&
-          (token as { name?: unknown }).name === tokenName
-        ) {
-          return path;
-        }
+    if (!raw || !Array.isArray(raw.tokens)) continue;
+    for (const token of raw.tokens) {
+      if (token && typeof token === 'object' && (token as { name?: unknown }).name === tokenName) {
+        return path;
       }
     }
   }
   return undefined;
+}
+
+function readEnvelopes(dir: string): Map<string, Omit<NamespaceFileEnvelope, 'tokens'>> {
+  const out = new Map<string, Omit<NamespaceFileEnvelope, 'tokens'>>();
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (!entry.endsWith('.rafters.json')) continue;
+    const raw = JSON.parse(readFileSync(join(dir, entry), 'utf8'));
+    if (raw && typeof raw === 'object' && typeof raw.namespace === 'string') {
+      const { tokens: _tokens, ...envelope } = raw as NamespaceFileEnvelope;
+      out.set(raw.namespace, envelope);
+    }
+  }
+  return out;
 }

--- a/packages/design-tokens/src/persistence.ts
+++ b/packages/design-tokens/src/persistence.ts
@@ -5,6 +5,15 @@ import { z } from 'zod';
 import type { Plugin } from './graph.js';
 import { TokenRegistry } from './registry.js';
 
+const RawTokenObject = z.looseObject({});
+const RawNamespaceFileSchema = z.object({
+  $schema: z.string().optional(),
+  namespace: z.string(),
+  version: z.string().optional(),
+  generatedAt: z.string().optional(),
+  tokens: z.array(RawTokenObject),
+});
+
 const NamespaceFileSchema = z.object({
   $schema: z.string().optional(),
   namespace: z.string(),
@@ -15,15 +24,26 @@ const NamespaceFileSchema = z.object({
 
 export type NamespaceFile = z.infer<typeof NamespaceFileSchema>;
 
+export class NamespaceFileParseError extends Error {
+  constructor(
+    public readonly path: string,
+    public readonly issues: readonly z.core.$ZodIssue[],
+  ) {
+    const first = issues[0];
+    const detail = first ? `${first.path.join('.')}: ${first.message}` : 'unknown';
+    super(
+      `Failed to parse ${path} as a NamespaceFile (${issues.length} issue(s); first: ${detail})`,
+    );
+    this.name = 'NamespaceFileParseError';
+  }
+}
+
 export function loadRegistryFromDir(dir: string, plugins: readonly Plugin[] = []): TokenRegistry {
   const tokens: Token[] = [];
   for (const entry of readdirSync(dir)) {
     if (!entry.endsWith('.rafters.json')) continue;
     const path = join(dir, entry);
-    const raw = readFileSync(path, 'utf8');
-    const parsed = NamespaceFileSchema.safeParse(JSON.parse(raw));
-    if (!parsed.success) continue;
-    tokens.push(...parsed.data.tokens);
+    tokens.push(...readNamespaceFile(path).tokens);
   }
   return new TokenRegistry(tokens, plugins);
 }
@@ -53,10 +73,28 @@ export function findTokenFile(dir: string, tokenName: string): string | undefine
     if (!entry.endsWith('.rafters.json')) continue;
     const path = join(dir, entry);
     if (!statSync(path).isFile()) continue;
-    const raw = readFileSync(path, 'utf8');
-    const parsed = NamespaceFileSchema.safeParse(JSON.parse(raw));
-    if (!parsed.success) continue;
-    if (parsed.data.tokens.some((t) => t.name === tokenName)) return path;
+    if (readNamespaceFile(path).tokens.some((t) => t.name === tokenName)) return path;
   }
   return undefined;
+}
+
+function readNamespaceFile(path: string): NamespaceFile {
+  const raw = readFileSync(path, 'utf8');
+  const rawParsed = RawNamespaceFileSchema.safeParse(JSON.parse(raw));
+  if (!rawParsed.success) {
+    throw new NamespaceFileParseError(path, rawParsed.error.issues);
+  }
+  const tokens = rawParsed.data.tokens.map(coerceLegacyToken);
+  const result = NamespaceFileSchema.safeParse({ ...rawParsed.data, tokens });
+  if (!result.success) {
+    throw new NamespaceFileParseError(path, result.error.issues);
+  }
+  return result.data;
+}
+
+function coerceLegacyToken(raw: Record<string, unknown>): Record<string, unknown> {
+  if (!('userOverride' in raw)) {
+    return { ...raw, userOverride: null };
+  }
+  return raw;
 }

--- a/packages/design-tokens/src/persistence.ts
+++ b/packages/design-tokens/src/persistence.ts
@@ -1,49 +1,26 @@
 import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { type Token, TokenSchema } from '@rafters/shared';
-import { z } from 'zod';
+import type { Token } from '@rafters/shared';
 import type { Plugin } from './graph.js';
 import { TokenRegistry } from './registry.js';
 
-const RawTokenObject = z.looseObject({});
-const RawNamespaceFileSchema = z.object({
-  $schema: z.string().optional(),
-  namespace: z.string(),
-  version: z.string().optional(),
-  generatedAt: z.string().optional(),
-  tokens: z.array(RawTokenObject),
-});
-
-const NamespaceFileSchema = z.object({
-  $schema: z.string().optional(),
-  namespace: z.string(),
-  version: z.string().optional(),
-  generatedAt: z.string().optional(),
-  tokens: z.array(TokenSchema),
-});
-
-export type NamespaceFile = z.infer<typeof NamespaceFileSchema>;
-
-export class NamespaceFileParseError extends Error {
-  constructor(
-    public readonly path: string,
-    public readonly issues: readonly z.core.$ZodIssue[],
-  ) {
-    const first = issues[0];
-    const detail = first ? `${first.path.join('.')}: ${first.message}` : 'unknown';
-    super(
-      `Failed to parse ${path} as a NamespaceFile (${issues.length} issue(s); first: ${detail})`,
-    );
-    this.name = 'NamespaceFileParseError';
-  }
-}
+export type NamespaceFile = {
+  $schema?: string;
+  namespace?: string;
+  version?: string;
+  generatedAt?: string;
+  tokens: unknown[];
+};
 
 export function loadRegistryFromDir(dir: string, plugins: readonly Plugin[] = []): TokenRegistry {
-  const tokens: Token[] = [];
+  const tokens: unknown[] = [];
   for (const entry of readdirSync(dir)) {
     if (!entry.endsWith('.rafters.json')) continue;
     const path = join(dir, entry);
-    tokens.push(...readNamespaceFile(path).tokens);
+    const raw = JSON.parse(readFileSync(path, 'utf8'));
+    if (raw && Array.isArray(raw.tokens)) {
+      tokens.push(...raw.tokens);
+    }
   }
   return new TokenRegistry(tokens, plugins);
 }
@@ -73,28 +50,18 @@ export function findTokenFile(dir: string, tokenName: string): string | undefine
     if (!entry.endsWith('.rafters.json')) continue;
     const path = join(dir, entry);
     if (!statSync(path).isFile()) continue;
-    if (readNamespaceFile(path).tokens.some((t) => t.name === tokenName)) return path;
+    const raw = JSON.parse(readFileSync(path, 'utf8'));
+    if (raw && Array.isArray(raw.tokens)) {
+      for (const token of raw.tokens) {
+        if (
+          token &&
+          typeof token === 'object' &&
+          (token as { name?: unknown }).name === tokenName
+        ) {
+          return path;
+        }
+      }
+    }
   }
   return undefined;
-}
-
-function readNamespaceFile(path: string): NamespaceFile {
-  const raw = readFileSync(path, 'utf8');
-  const rawParsed = RawNamespaceFileSchema.safeParse(JSON.parse(raw));
-  if (!rawParsed.success) {
-    throw new NamespaceFileParseError(path, rawParsed.error.issues);
-  }
-  const tokens = rawParsed.data.tokens.map(coerceLegacyToken);
-  const result = NamespaceFileSchema.safeParse({ ...rawParsed.data, tokens });
-  if (!result.success) {
-    throw new NamespaceFileParseError(path, result.error.issues);
-  }
-  return result.data;
-}
-
-function coerceLegacyToken(raw: Record<string, unknown>): Record<string, unknown> {
-  if (!('userOverride' in raw)) {
-    return { ...raw, userOverride: null };
-  }
-  return raw;
 }

--- a/packages/design-tokens/src/plugins/contrast.ts
+++ b/packages/design-tokens/src/plugins/contrast.ts
@@ -1,7 +1,7 @@
+import { SCALE_POSITIONS } from '@rafters/color-utils';
 import { type ColorReference, ColorReferenceSchema, type ColorValue } from '@rafters/shared';
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
-import { INDEX_TO_POSITION } from '../scale-positions.js';
 
 const ContrastInputSchema = z.object({
   familyName: z.string(),
@@ -52,7 +52,7 @@ export const contrastPlugin = definePlugin<ContrastInput, ColorReference>({
       if (contrastPosition !== undefined) {
         return {
           family: input.familyName,
-          position: INDEX_TO_POSITION[contrastPosition] ?? '500',
+          position: SCALE_POSITIONS[contrastPosition] ?? '500',
         };
       }
     }
@@ -64,7 +64,7 @@ export const contrastPlugin = definePlugin<ContrastInput, ColorReference>({
         if (best !== undefined) {
           return {
             family: input.neutralFamilyName,
-            position: INDEX_TO_POSITION[best] ?? '500',
+            position: SCALE_POSITIONS[best] ?? '500',
           };
         }
       }
@@ -73,7 +73,7 @@ export const contrastPlugin = definePlugin<ContrastInput, ColorReference>({
         if (best !== undefined) {
           return {
             family: input.neutralFamilyName,
-            position: INDEX_TO_POSITION[best] ?? '500',
+            position: SCALE_POSITIONS[best] ?? '500',
           };
         }
       }

--- a/packages/design-tokens/src/plugins/invert.ts
+++ b/packages/design-tokens/src/plugins/invert.ts
@@ -1,7 +1,7 @@
+import { findDarkCounterpartIndex, SCALE_POSITIONS } from '@rafters/color-utils';
 import { type ColorReference, ColorReferenceSchema, type ColorValue } from '@rafters/shared';
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
-import { findDarkCounterpartIndex, INDEX_TO_POSITION } from '../scale-positions.js';
 
 const InvertInputSchema = z.object({
   familyName: z.string(),
@@ -21,7 +21,7 @@ export const invertPlugin = definePlugin<InvertInput, ColorReference>({
       throw new Error(`invert plugin: family "${input.familyName}" not found in registry`);
     }
     const darkIndex = findDarkCounterpartIndex(input.basePosition, family);
-    const darkPosition = INDEX_TO_POSITION[darkIndex];
+    const darkPosition = SCALE_POSITIONS[darkIndex];
     if (!darkPosition) {
       throw new Error(
         `invert plugin: invalid dark index ${darkIndex} for base position ${input.basePosition}`,

--- a/packages/design-tokens/src/plugins/scale.ts
+++ b/packages/design-tokens/src/plugins/scale.ts
@@ -1,7 +1,7 @@
+import { SCALE_POSITIONS } from '@rafters/color-utils';
 import { type ColorReference, ColorReferenceSchema, type ColorValue } from '@rafters/shared';
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
-import { INDEX_TO_POSITION } from '../scale-positions.js';
 
 const ScaleInputSchema = z.object({
   familyName: z.string(),
@@ -20,7 +20,7 @@ export const scalePlugin = definePlugin<ScaleInput, ColorReference>({
     if (!family) {
       throw new Error(`scale plugin: family "${input.familyName}" not found in registry`);
     }
-    const position = INDEX_TO_POSITION[input.scalePosition];
+    const position = SCALE_POSITIONS[input.scalePosition];
     if (position === undefined) {
       throw new Error(`scale plugin: invalid position index ${input.scalePosition}`);
     }

--- a/packages/design-tokens/src/plugins/state.ts
+++ b/packages/design-tokens/src/plugins/state.ts
@@ -1,7 +1,7 @@
+import { SCALE_POSITIONS } from '@rafters/color-utils';
 import { type ColorReference, ColorReferenceSchema, type ColorValue } from '@rafters/shared';
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
-import { INDEX_TO_POSITION } from '../scale-positions.js';
 
 const StateTypeSchema = z.enum(['hover', 'active', 'focus', 'disabled']);
 
@@ -42,7 +42,7 @@ export const statePlugin = definePlugin<StateInput, ColorReference>({
 
     const offset = STATE_OFFSETS[input.stateType];
     const adjustedIndex = Math.max(0, Math.min(10, input.basePosition + offset));
-    const position = INDEX_TO_POSITION[adjustedIndex] ?? '500';
+    const position = SCALE_POSITIONS[adjustedIndex] ?? '500';
     return { family: input.familyName, position };
   },
 });

--- a/packages/design-tokens/src/registry.ts
+++ b/packages/design-tokens/src/registry.ts
@@ -1,4 +1,4 @@
-import type { Token, TokenSchema } from '@rafters/shared';
+import { type Token, TokenSchema } from '@rafters/shared';
 import type { z } from 'zod';
 import { type Node, type Plugin, type SetOptions, TokenGraph } from './graph.js';
 
@@ -19,15 +19,17 @@ export class TokenRegistry {
     this.graph = new TokenGraph(plugins);
     for (const plugin of plugins) this.plugins.set(plugin.name, plugin);
     // Two passes so bindings can reference family tokens regardless of source order.
-    const normalized: Token[] = [];
+    const parsed: Token[] = [];
     for (const raw of initialTokens) {
-      const t = normalizeIncomingToken(raw);
-      if (!t) continue;
-      this.metadata.set(t.name, t);
-      normalized.push(t);
+      const result = TokenSchema.safeParse(raw);
+      if (!result.success) {
+        throw new TokenParseError(raw, result.error.issues);
+      }
+      this.metadata.set(result.data.name, result.data);
+      parsed.push(result.data);
     }
     // Pass 1: leaves and overrides.
-    for (const t of normalized) {
+    for (const t of parsed) {
       if (t.binding) continue;
       if (t.userOverride) {
         this.graph.set(t.name, t.value, {
@@ -40,15 +42,9 @@ export class TokenRegistry {
       }
     }
     // Pass 2: bindings (dependents now resolve against leaves).
-    for (const t of normalized) {
+    for (const t of parsed) {
       if (!t.binding) continue;
-      try {
-        this.graph.bind(t.name, t.binding.plugin, t.binding.input);
-      } catch (_err) {
-        // Plugin may not be registered yet, or input may not satisfy schema for current upstream.
-        // Fall back to leaf with the persisted value so the token is still readable.
-        this.graph.set(t.name, t.value);
-      }
+      this.graph.bind(t.name, t.binding.plugin, t.binding.input);
     }
   }
 
@@ -58,21 +54,22 @@ export class TokenRegistry {
   }
 
   define(token: unknown): void {
-    const normalized = normalizeIncomingToken(token);
-    if (!normalized) {
-      throw new Error(
-        'define(token) requires an object with string name, namespace, category, and a defined value',
-      );
+    const result = TokenSchema.safeParse(token);
+    if (!result.success) {
+      throw new TokenParseError(token, result.error.issues);
     }
-    this.metadata.set(normalized.name, normalized);
-    if (normalized.userOverride) {
-      this.graph.set(normalized.name, normalized.value, {
+    const t = result.data;
+    this.metadata.set(t.name, t);
+    if (t.binding) {
+      this.graph.bind(t.name, t.binding.plugin, t.binding.input);
+    } else if (t.userOverride) {
+      this.graph.set(t.name, t.value, {
         cascade: false,
-        reason: normalized.userOverride.reason,
-        ...(normalized.userOverride.context ? { context: normalized.userOverride.context } : {}),
+        reason: t.userOverride.reason,
+        ...(t.userOverride.context ? { context: t.userOverride.context } : {}),
       });
     } else {
-      this.graph.set(normalized.name, normalized.value);
+      this.graph.set(t.name, t.value);
     }
   }
 
@@ -142,27 +139,20 @@ export class UnknownTokenError extends Error {
   }
 }
 
-function normalizeIncomingToken(raw: unknown): Token | undefined {
-  if (!raw || typeof raw !== 'object') return undefined;
-  const obj = raw as Record<string, unknown>;
-  if (typeof obj.name !== 'string') return undefined;
-  if (typeof obj.namespace !== 'string') return undefined;
-  if (typeof obj.category !== 'string') return undefined;
-  if (obj.value === undefined) return undefined;
-  const userOverride =
-    obj.userOverride && typeof obj.userOverride === 'object'
-      ? (obj.userOverride as Token['userOverride'])
-      : null;
-  const binding =
-    obj.binding &&
-    typeof obj.binding === 'object' &&
-    typeof (obj.binding as { plugin?: unknown }).plugin === 'string'
-      ? (obj.binding as Token['binding'])
-      : undefined;
-  const result: Token = { ...obj, userOverride } as Token;
-  if (binding) result.binding = binding;
-  else delete (result as { binding?: Token['binding'] }).binding;
-  return result;
+export class TokenParseError extends Error {
+  constructor(
+    public readonly raw: unknown,
+    public readonly issues: readonly z.core.$ZodIssue[],
+  ) {
+    const first = issues[0];
+    const detail = first ? `${first.path.join('.')}: ${first.message}` : 'unknown';
+    const name =
+      raw && typeof raw === 'object' && typeof (raw as { name?: unknown }).name === 'string'
+        ? (raw as { name: string }).name
+        : '<unnamed>';
+    super(`Token "${name}" failed TokenSchema validation: ${detail}`);
+    this.name = 'TokenParseError';
+  }
 }
 
 function toUserOverrideField(

--- a/packages/design-tokens/src/registry.ts
+++ b/packages/design-tokens/src/registry.ts
@@ -39,20 +39,44 @@ export class TokenRegistry {
     this.plugins.set(plugin.name, plugin);
   }
 
+  define(token: unknown): void {
+    const normalized = normalizeIncomingToken(token);
+    if (!normalized) {
+      throw new Error(
+        'define(token) requires an object with string name, namespace, category, and a defined value',
+      );
+    }
+    this.metadata.set(normalized.name, normalized);
+    if (normalized.userOverride) {
+      this.graph.set(normalized.name, normalized.value, {
+        cascade: false,
+        reason: normalized.userOverride.reason,
+        ...(normalized.userOverride.context ? { context: normalized.userOverride.context } : {}),
+      });
+    } else {
+      this.graph.set(normalized.name, normalized.value);
+    }
+  }
+
   set(name: string, value: TokenValue, options?: SetOptions): void {
-    this.ensureMetadata(name);
+    if (!this.metadata.has(name)) {
+      throw new UnknownTokenError(name);
+    }
     this.graph.set(name, value, options);
   }
 
   bind(name: string, pluginName: string, input: unknown): void {
-    this.ensureMetadata(name);
+    if (!this.metadata.has(name)) {
+      throw new UnknownTokenError(name);
+    }
     this.graph.bind(name, pluginName, input);
   }
 
   get(name: string): Token | undefined {
     const node = this.graph.node(name);
-    if (!node) return undefined;
-    return this.toToken(node);
+    const meta = this.metadata.get(name);
+    if (!node || !meta) return undefined;
+    return this.toToken(node, meta);
   }
 
   undo(): void {
@@ -70,7 +94,9 @@ export class TokenRegistry {
   list(filter?: RegistryFilter): readonly Token[] {
     const out: Token[] = [];
     for (const node of this.graph.list()) {
-      const token = this.toToken(node);
+      const meta = this.metadata.get(node.name);
+      if (!meta) continue;
+      const token = this.toToken(node, meta);
       if (filter?.namespace && token.namespace !== filter.namespace) continue;
       if (filter?.category && token.category !== filter.category) continue;
       out.push(token);
@@ -78,13 +104,7 @@ export class TokenRegistry {
     return out;
   }
 
-  private ensureMetadata(name: string): void {
-    if (this.metadata.has(name)) return;
-    this.metadata.set(name, defaultTokenFor(name));
-  }
-
-  private toToken(node: Node): Token {
-    const meta = this.metadata.get(node.name) ?? defaultTokenFor(node.name);
+  private toToken(node: Node, meta: Token): Token {
     const projected: Token = {
       ...meta,
       name: node.name,
@@ -104,39 +124,25 @@ export class TokenRegistry {
   }
 }
 
-function defaultTokenFor(name: string): Token {
-  const namespace = inferNamespace(name);
-  return {
-    name,
-    namespace,
-    category: namespace,
-    value: '',
-    userOverride: null,
-    containerQueryAware: true,
-  };
+export class UnknownTokenError extends Error {
+  constructor(public readonly tokenName: string) {
+    super(`Token not registered: ${tokenName}`);
+    this.name = 'UnknownTokenError';
+  }
 }
 
 function normalizeIncomingToken(raw: unknown): Token | undefined {
   if (!raw || typeof raw !== 'object') return undefined;
   const obj = raw as Record<string, unknown>;
-  const name = typeof obj.name === 'string' ? obj.name : undefined;
-  if (!name) return undefined;
-  const namespace = typeof obj.namespace === 'string' ? obj.namespace : inferNamespace(name);
-  const category = typeof obj.category === 'string' ? obj.category : namespace;
-  const value = (obj.value as Token['value']) ?? '';
+  if (typeof obj.name !== 'string') return undefined;
+  if (typeof obj.namespace !== 'string') return undefined;
+  if (typeof obj.category !== 'string') return undefined;
+  if (obj.value === undefined) return undefined;
   const userOverride =
     obj.userOverride && typeof obj.userOverride === 'object'
       ? (obj.userOverride as Token['userOverride'])
       : null;
-  return { ...obj, name, namespace, category, value, userOverride } as Token;
-}
-
-function inferNamespace(name: string): string {
-  const dashIdx = name.indexOf('-');
-  const dotIdx = name.indexOf('.');
-  const candidates = [dashIdx, dotIdx].filter((i) => i >= 0);
-  if (candidates.length === 0) return name;
-  return name.slice(0, Math.min(...candidates));
+  return { ...obj, userOverride } as Token;
 }
 
 function toUserOverrideField(

--- a/packages/design-tokens/src/registry.ts
+++ b/packages/design-tokens/src/registry.ts
@@ -18,18 +18,36 @@ export class TokenRegistry {
   constructor(initialTokens: readonly unknown[] = [], plugins: readonly Plugin[] = []) {
     this.graph = new TokenGraph(plugins);
     for (const plugin of plugins) this.plugins.set(plugin.name, plugin);
+    // Two passes so bindings can reference family tokens regardless of source order.
+    const normalized: Token[] = [];
     for (const raw of initialTokens) {
-      const normalized = normalizeIncomingToken(raw);
-      if (!normalized) continue;
-      this.metadata.set(normalized.name, normalized);
-      if (normalized.userOverride) {
-        this.graph.set(normalized.name, normalized.value, {
+      const t = normalizeIncomingToken(raw);
+      if (!t) continue;
+      this.metadata.set(t.name, t);
+      normalized.push(t);
+    }
+    // Pass 1: leaves and overrides.
+    for (const t of normalized) {
+      if (t.binding) continue;
+      if (t.userOverride) {
+        this.graph.set(t.name, t.value, {
           cascade: false,
-          reason: normalized.userOverride.reason,
-          ...(normalized.userOverride.context ? { context: normalized.userOverride.context } : {}),
+          reason: t.userOverride.reason,
+          ...(t.userOverride.context ? { context: t.userOverride.context } : {}),
         });
       } else {
-        this.graph.set(normalized.name, normalized.value);
+        this.graph.set(t.name, t.value);
+      }
+    }
+    // Pass 2: bindings (dependents now resolve against leaves).
+    for (const t of normalized) {
+      if (!t.binding) continue;
+      try {
+        this.graph.bind(t.name, t.binding.plugin, t.binding.input);
+      } catch (_err) {
+        // Plugin may not be registered yet, or input may not satisfy schema for current upstream.
+        // Fall back to leaf with the persisted value so the token is still readable.
+        this.graph.set(t.name, t.value);
       }
     }
   }
@@ -105,22 +123,15 @@ export class TokenRegistry {
   }
 
   private toToken(node: Node, meta: Token): Token {
-    const projected: Token = {
+    // Preserve metadata's dependsOn (it carries the dependsOn[1] dark counterpart
+    // typed convention the exporter relies on); the runtime binding edges live
+    // on node.binding and are derivable via plugin.dependsOn at cascade time.
+    return {
       ...meta,
       name: node.name,
       value: node.value as TokenValue,
       userOverride: node.userOverride ? toUserOverrideField(node.userOverride, meta.value) : null,
     };
-    if (node.binding) {
-      const plugin = this.plugins.get(node.binding.plugin);
-      const deps = plugin ? plugin.dependsOn(node.binding.input) : [];
-      if (deps.length > 0) projected.dependsOn = [...deps];
-      projected.generationRule = node.binding.plugin;
-    } else {
-      delete (projected as { dependsOn?: string[] }).dependsOn;
-      delete (projected as { generationRule?: string }).generationRule;
-    }
-    return projected;
   }
 }
 
@@ -142,7 +153,16 @@ function normalizeIncomingToken(raw: unknown): Token | undefined {
     obj.userOverride && typeof obj.userOverride === 'object'
       ? (obj.userOverride as Token['userOverride'])
       : null;
-  return { ...obj, userOverride } as Token;
+  const binding =
+    obj.binding &&
+    typeof obj.binding === 'object' &&
+    typeof (obj.binding as { plugin?: unknown }).plugin === 'string'
+      ? (obj.binding as Token['binding'])
+      : undefined;
+  const result: Token = { ...obj, userOverride } as Token;
+  if (binding) result.binding = binding;
+  else delete (result as { binding?: Token['binding'] }).binding;
+  return result;
 }
 
 function toUserOverrideField(

--- a/packages/design-tokens/src/registry.ts
+++ b/packages/design-tokens/src/registry.ts
@@ -15,19 +15,21 @@ export class TokenRegistry {
   private plugins = new Map<string, Plugin>();
   private metadata = new Map<string, Token>();
 
-  constructor(initialTokens: readonly Token[] = [], plugins: readonly Plugin[] = []) {
+  constructor(initialTokens: readonly unknown[] = [], plugins: readonly Plugin[] = []) {
     this.graph = new TokenGraph(plugins);
     for (const plugin of plugins) this.plugins.set(plugin.name, plugin);
-    for (const token of initialTokens) {
-      this.metadata.set(token.name, token);
-      if (token.userOverride) {
-        this.graph.set(token.name, token.value, {
+    for (const raw of initialTokens) {
+      const normalized = normalizeIncomingToken(raw);
+      if (!normalized) continue;
+      this.metadata.set(normalized.name, normalized);
+      if (normalized.userOverride) {
+        this.graph.set(normalized.name, normalized.value, {
           cascade: false,
-          reason: token.userOverride.reason,
-          ...(token.userOverride.context ? { context: token.userOverride.context } : {}),
+          reason: normalized.userOverride.reason,
+          ...(normalized.userOverride.context ? { context: normalized.userOverride.context } : {}),
         });
       } else {
-        this.graph.set(token.name, token.value);
+        this.graph.set(normalized.name, normalized.value);
       }
     }
   }
@@ -112,6 +114,21 @@ function defaultTokenFor(name: string): Token {
     userOverride: null,
     containerQueryAware: true,
   };
+}
+
+function normalizeIncomingToken(raw: unknown): Token | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const obj = raw as Record<string, unknown>;
+  const name = typeof obj.name === 'string' ? obj.name : undefined;
+  if (!name) return undefined;
+  const namespace = typeof obj.namespace === 'string' ? obj.namespace : inferNamespace(name);
+  const category = typeof obj.category === 'string' ? obj.category : namespace;
+  const value = (obj.value as Token['value']) ?? '';
+  const userOverride =
+    obj.userOverride && typeof obj.userOverride === 'object'
+      ? (obj.userOverride as Token['userOverride'])
+      : null;
+  return { ...obj, name, namespace, category, value, userOverride } as Token;
 }
 
 function inferNamespace(name: string): string {

--- a/packages/design-tokens/test/cascade.test.ts
+++ b/packages/design-tokens/test/cascade.test.ts
@@ -59,9 +59,24 @@ function buildAccentToken(value: ColorValue): Token {
   };
 }
 
+function semanticToken(name: string): Token {
+  return { name, namespace: 'semantic', category: 'color', value: '', userOverride: null };
+}
+
+function familyTokenSlot(name: string): Token {
+  return { name, namespace: 'color', category: 'color', value: '', userOverride: null };
+}
+
 function setupSemanticChain(): TokenRegistry {
   const r = new TokenRegistry(
-    [buildAccentToken(buildAccentFamily())],
+    [
+      buildAccentToken(buildAccentFamily()),
+      semanticToken('primary'),
+      semanticToken('primary-foreground'),
+      semanticToken('primary-hover'),
+      semanticToken('primary-active'),
+      semanticToken('primary-dark'),
+    ],
     [scalePlugin, contrastPlugin, statePlugin, invertPlugin],
   );
   // accent family → semantic primary (position 5) → primary-foreground, primary-hover, primary-hover-foreground
@@ -120,7 +135,11 @@ describe('cascade integration', () => {
 
     it('downstream of an anchor still flows from the anchor value (chained binding)', () => {
       const r = new TokenRegistry(
-        [buildAccentToken(buildAccentFamily())],
+        [
+          buildAccentToken(buildAccentFamily()),
+          semanticToken('primary'),
+          semanticToken('primary-fg'),
+        ],
         [scalePlugin, contrastPlugin],
       );
       r.bind('primary', 'scale', { familyName: 'accent', scalePosition: 5 });
@@ -140,7 +159,7 @@ describe('cascade integration', () => {
 
   describe('cycle detection at bind time', () => {
     it('rejects a binding that creates a direct cycle', () => {
-      const r = new TokenRegistry([], [scalePlugin]);
+      const r = new TokenRegistry([familyTokenSlot('a'), familyTokenSlot('b')], [scalePlugin]);
       const family = buildAccentFamily();
       r.set('a', family);
       r.set('b', family);
@@ -151,7 +170,10 @@ describe('cascade integration', () => {
     });
 
     it('rejects a binding that creates a transitive cycle', () => {
-      const r = new TokenRegistry([], [scalePlugin]);
+      const r = new TokenRegistry(
+        [familyTokenSlot('a'), familyTokenSlot('b'), familyTokenSlot('c')],
+        [scalePlugin],
+      );
       const family = buildAccentFamily();
       r.set('a', family);
       r.set('b', family);
@@ -167,7 +189,11 @@ describe('cascade integration', () => {
   describe('topological ordering during cascade', () => {
     it('recomputes upstream nodes before downstream when both are dependents', () => {
       const r = new TokenRegistry(
-        [buildAccentToken(buildAccentFamily())],
+        [
+          buildAccentToken(buildAccentFamily()),
+          semanticToken('primary'),
+          semanticToken('primary-hover'),
+        ],
         [scalePlugin, statePlugin],
       );
       r.bind('primary', 'scale', { familyName: 'accent', scalePosition: 5 });

--- a/packages/design-tokens/test/cascade.test.ts
+++ b/packages/design-tokens/test/cascade.test.ts
@@ -45,6 +45,24 @@ function buildAccentFamily(name = 'accent'): ColorValue {
         large: [],
       },
       wcagAA: { normal: [], large: [] },
+      onWhite: {
+        wcagAA: false,
+        wcagAAA: false,
+        contrastRatio: 1,
+        aa: [],
+        aaa: [],
+        normal: [],
+        large: [],
+      },
+      onBlack: {
+        wcagAA: false,
+        wcagAAA: false,
+        contrastRatio: 1,
+        aa: [],
+        aaa: [],
+        normal: [],
+        large: [],
+      },
     },
   };
 }

--- a/packages/design-tokens/test/persistence.test.ts
+++ b/packages/design-tokens/test/persistence.test.ts
@@ -6,6 +6,7 @@ import {
   findTokenFile,
   loadRegistryFromDir,
   type NamespaceFile,
+  NamespaceFileParseError,
   saveRegistryToDir,
   TokenRegistry,
 } from '../src/index.js';
@@ -66,10 +67,47 @@ describe('loadRegistryFromDir', () => {
     expect(r.size()).toBe(1);
   });
 
-  it('skips files that do not match NamespaceFile schema', () => {
+  it('throws NamespaceFileParseError on a file that is not a valid NamespaceFile', () => {
     writeFileSync(join(tmpDir, 'broken.rafters.json'), '{"not": "valid"}');
+    expect(() => loadRegistryFromDir(tmpDir)).toThrow(NamespaceFileParseError);
+  });
+
+  it('coerces legacy tokens that omit the userOverride field, treating them as null', () => {
+    const legacyFile = {
+      namespace: 'motion',
+      tokens: [
+        {
+          name: 'motion-duration-base',
+          namespace: 'motion',
+          category: 'motion',
+          value: '150ms',
+          // userOverride deliberately omitted to simulate v1-shape on disk
+          description: 'Base duration written before the schema tightened',
+        },
+      ],
+    };
+    writeFileSync(join(tmpDir, 'motion.rafters.json'), JSON.stringify(legacyFile));
     const r = loadRegistryFromDir(tmpDir);
-    expect(r.size()).toBe(0);
+    expect(r.has('motion-duration-base')).toBe(true);
+    expect(r.get('motion-duration-base')?.userOverride).toBeNull();
+  });
+
+  it('parse error includes file path and first issue path for diagnosis', () => {
+    writeFileSync(
+      join(tmpDir, 'bad.rafters.json'),
+      JSON.stringify({
+        namespace: 'color',
+        tokens: [{ name: 'color-x' }], // missing required namespace, category, value
+      }),
+    );
+    try {
+      loadRegistryFromDir(tmpDir);
+      expect.fail('should have thrown');
+    } catch (e) {
+      if (!(e instanceof NamespaceFileParseError)) throw e;
+      expect(e.path).toContain('bad.rafters.json');
+      expect(e.issues.length).toBeGreaterThan(0);
+    }
   });
 });
 

--- a/packages/design-tokens/test/persistence.test.ts
+++ b/packages/design-tokens/test/persistence.test.ts
@@ -6,7 +6,6 @@ import {
   findTokenFile,
   loadRegistryFromDir,
   type NamespaceFile,
-  NamespaceFileParseError,
   saveRegistryToDir,
   TokenRegistry,
 } from '../src/index.js';
@@ -67,12 +66,13 @@ describe('loadRegistryFromDir', () => {
     expect(r.size()).toBe(1);
   });
 
-  it('throws NamespaceFileParseError on a file that is not a valid NamespaceFile', () => {
+  it('skips a file with no tokens array (just reads what it can)', () => {
     writeFileSync(join(tmpDir, 'broken.rafters.json'), '{"not": "valid"}');
-    expect(() => loadRegistryFromDir(tmpDir)).toThrow(NamespaceFileParseError);
+    const r = loadRegistryFromDir(tmpDir);
+    expect(r.size()).toBe(0);
   });
 
-  it('coerces legacy tokens that omit the userOverride field, treating them as null', () => {
+  it('loads tokens that omit userOverride; the registry treats missing as null', () => {
     const legacyFile = {
       namespace: 'motion',
       tokens: [
@@ -92,22 +92,40 @@ describe('loadRegistryFromDir', () => {
     expect(r.get('motion-duration-base')?.userOverride).toBeNull();
   });
 
-  it('parse error includes file path and first issue path for diagnosis', () => {
-    writeFileSync(
-      join(tmpDir, 'bad.rafters.json'),
-      JSON.stringify({
-        namespace: 'color',
-        tokens: [{ name: 'color-x' }], // missing required namespace, category, value
-      }),
-    );
-    try {
-      loadRegistryFromDir(tmpDir);
-      expect.fail('should have thrown');
-    } catch (e) {
-      if (!(e instanceof NamespaceFileParseError)) throw e;
-      expect(e.path).toContain('bad.rafters.json');
-      expect(e.issues.length).toBeGreaterThan(0);
-    }
+  it('loads tokens with arbitrary extra metadata (description, generatedAt) without rejecting them', () => {
+    const fileWithExtras = {
+      namespace: 'spacing',
+      tokens: [
+        {
+          name: 'spacing-base',
+          namespace: 'spacing',
+          category: 'spacing',
+          value: '4px',
+          description: 'arbitrary metadata',
+          generatedAt: '2026-01-01T00:00:00Z',
+          someUnknownField: { nested: true },
+        },
+      ],
+    };
+    writeFileSync(join(tmpDir, 'spacing.rafters.json'), JSON.stringify(fileWithExtras));
+    const r = loadRegistryFromDir(tmpDir);
+    expect(r.get('spacing-base')?.value).toBe('4px');
+  });
+
+  it('skips token entries that are not objects or have no name', () => {
+    const messyFile = {
+      namespace: 'mixed',
+      tokens: [
+        null,
+        'not an object',
+        { value: 'no-name-field' },
+        { name: 'good', namespace: 'mixed', category: 'mixed', value: 'ok' },
+      ],
+    };
+    writeFileSync(join(tmpDir, 'mixed.rafters.json'), JSON.stringify(messyFile));
+    const r = loadRegistryFromDir(tmpDir);
+    expect(r.size()).toBe(1);
+    expect(r.has('good')).toBe(true);
   });
 });
 

--- a/packages/design-tokens/test/persistence.test.ts
+++ b/packages/design-tokens/test/persistence.test.ts
@@ -72,26 +72,6 @@ describe('loadRegistryFromDir', () => {
     expect(r.size()).toBe(0);
   });
 
-  it('loads tokens that omit userOverride; the registry treats missing as null', () => {
-    const legacyFile = {
-      namespace: 'motion',
-      tokens: [
-        {
-          name: 'motion-duration-base',
-          namespace: 'motion',
-          category: 'motion',
-          value: '150ms',
-          // userOverride deliberately omitted to simulate v1-shape on disk
-          description: 'Base duration written before the schema tightened',
-        },
-      ],
-    };
-    writeFileSync(join(tmpDir, 'motion.rafters.json'), JSON.stringify(legacyFile));
-    const r = loadRegistryFromDir(tmpDir);
-    expect(r.has('motion-duration-base')).toBe(true);
-    expect(r.get('motion-duration-base')?.userOverride).toBeNull();
-  });
-
   it('loads tokens with arbitrary extra metadata (description, generatedAt) without rejecting them', () => {
     const fileWithExtras = {
       namespace: 'spacing',
@@ -101,6 +81,7 @@ describe('loadRegistryFromDir', () => {
           namespace: 'spacing',
           category: 'spacing',
           value: '4px',
+          userOverride: null,
           description: 'arbitrary metadata',
           generatedAt: '2026-01-01T00:00:00Z',
           someUnknownField: { nested: true },
@@ -112,20 +93,13 @@ describe('loadRegistryFromDir', () => {
     expect(r.get('spacing-base')?.value).toBe('4px');
   });
 
-  it('skips token entries that are not objects or have no name', () => {
+  it('throws TokenParseError when a token entry does not satisfy TokenSchema', () => {
     const messyFile = {
       namespace: 'mixed',
-      tokens: [
-        null,
-        'not an object',
-        { value: 'no-name-field' },
-        { name: 'good', namespace: 'mixed', category: 'mixed', value: 'ok' },
-      ],
+      tokens: [{ name: 'incomplete' }], // missing namespace, category, value, userOverride
     };
     writeFileSync(join(tmpDir, 'mixed.rafters.json'), JSON.stringify(messyFile));
-    const r = loadRegistryFromDir(tmpDir);
-    expect(r.size()).toBe(1);
-    expect(r.has('good')).toBe(true);
+    expect(() => loadRegistryFromDir(tmpDir)).toThrow(/TokenSchema validation/);
   });
 });
 

--- a/packages/design-tokens/test/registry.test.ts
+++ b/packages/design-tokens/test/registry.test.ts
@@ -137,20 +137,19 @@ describe('TokenRegistry', () => {
       expect(r.get('accent-hover')?.value).toBeDefined();
     });
 
-    it('projects dependsOn from binding via plugin.dependsOn', () => {
-      const r = new TokenRegistry([accentToken, semanticTokenFor('accent-500')], [scalePlugin]);
-      r.bind('accent-500', 'scale', { familyName: 'accent', scalePosition: 5 });
-      expect(r.get('accent-500')?.dependsOn).toEqual(['accent']);
-      expect(r.get('accent-500')?.generationRule).toBe('scale');
-    });
-
-    it('strips dependsOn / generationRule when token converted from binding to leaf', () => {
-      const r = new TokenRegistry([accentToken, semanticTokenFor('accent-500')], [scalePlugin]);
-      r.bind('accent-500', 'scale', { familyName: 'accent', scalePosition: 5 });
-      expect(r.get('accent-500')?.dependsOn).toEqual(['accent']);
-      r.set('accent-500', '#ff0000');
-      expect(r.get('accent-500')?.dependsOn).toBeUndefined();
-      expect(r.get('accent-500')?.generationRule).toBeUndefined();
+    it('preserves metadata dependsOn (carries the dark-counterpart convention untouched by binding)', () => {
+      const semanticWithDeps: Token = {
+        name: 'primary',
+        namespace: 'semantic',
+        category: 'color',
+        value: '',
+        userOverride: null,
+        // dependsOn[0] = family token, dependsOn[1] = dark counterpart
+        dependsOn: ['accent', 'accent-50'],
+      };
+      const r = new TokenRegistry([accentToken, semanticWithDeps], [scalePlugin]);
+      r.bind('primary', 'scale', { familyName: 'accent', scalePosition: 5 });
+      expect(r.get('primary')?.dependsOn).toEqual(['accent', 'accent-50']);
     });
   });
 

--- a/packages/design-tokens/test/registry.test.ts
+++ b/packages/design-tokens/test/registry.test.ts
@@ -55,7 +55,12 @@ describe('TokenRegistry', () => {
       expect(r.size()).toBe(1);
       expect(r.has('accent')).toBe(true);
       expect(r.get('accent')?.namespace).toBe('color');
-      expect(r.get('accent')?.value).toEqual(accentToken.value);
+      // Zod fills OKLCH.alpha default 1; compare structure, not deep object identity.
+      const v = r.get('accent')?.value;
+      expect(v && typeof v === 'object' && 'name' in v && v.name).toBe('accent');
+      expect(
+        v && typeof v === 'object' && 'scale' in v && Array.isArray(v.scale) && v.scale.length,
+      ).toBe(11);
     });
 
     it('seeds plugins via constructor', () => {

--- a/packages/design-tokens/test/registry.test.ts
+++ b/packages/design-tokens/test/registry.test.ts
@@ -1,6 +1,12 @@
 import type { ColorValue, Token } from '@rafters/shared';
 import { describe, expect, it } from 'vitest';
-import { contrastPlugin, scalePlugin, statePlugin, TokenRegistry } from '../src/index.js';
+import {
+  contrastPlugin,
+  scalePlugin,
+  statePlugin,
+  TokenRegistry,
+  UnknownTokenError,
+} from '../src/index.js';
 
 const minimalScale = [
   { l: 0.97, c: 0.02, h: 240 },
@@ -32,6 +38,16 @@ const spacingBaseToken: Token = {
   userOverride: null,
 };
 
+function semanticTokenFor(name: string): Token {
+  return {
+    name,
+    namespace: 'semantic',
+    category: 'color',
+    value: '',
+    userOverride: null,
+  };
+}
+
 describe('TokenRegistry', () => {
   describe('construction', () => {
     it('seeds initial tokens with metadata and value', () => {
@@ -43,7 +59,7 @@ describe('TokenRegistry', () => {
     });
 
     it('seeds plugins via constructor', () => {
-      const r = new TokenRegistry([accentToken], [scalePlugin]);
+      const r = new TokenRegistry([accentToken, semanticTokenFor('accent-500')], [scalePlugin]);
       r.bind('accent-500', 'scale', { familyName: 'accent', scalePosition: 5 });
       expect(r.get('accent-500')?.value).toEqual({ family: 'accent', position: '500' });
     });
@@ -56,13 +72,9 @@ describe('TokenRegistry', () => {
       expect(r.get('spacing-base')?.value).toBe('8px');
     });
 
-    it('creates token with inferred namespace if name unknown', () => {
+    it('throws UnknownTokenError when set is called on a name with no registered metadata', () => {
       const r = new TokenRegistry();
-      r.set('color-mystery', '#fff');
-      const token = r.get('color-mystery');
-      expect(token?.namespace).toBe('color');
-      expect(token?.category).toBe('color');
-      expect(token?.value).toBe('#fff');
+      expect(() => r.set('color-mystery', '#fff')).toThrow(UnknownTokenError);
     });
 
     it('records userOverride when cascade: false', () => {
@@ -82,9 +94,26 @@ describe('TokenRegistry', () => {
     });
   });
 
+  describe('define', () => {
+    it('registers a new token with full metadata after construction', () => {
+      const r = new TokenRegistry();
+      r.define(spacingBaseToken);
+      expect(r.has('spacing-base')).toBe(true);
+      expect(r.get('spacing-base')?.value).toBe('4px');
+    });
+
+    it('rejects input missing required fields', () => {
+      const r = new TokenRegistry();
+      expect(() => r.define({ name: 'incomplete' })).toThrow();
+    });
+  });
+
   describe('bind + cascade', () => {
     it('cascades family changes through scale + contrast chain', () => {
-      const r = new TokenRegistry([accentToken], [scalePlugin, contrastPlugin]);
+      const r = new TokenRegistry(
+        [accentToken, semanticTokenFor('accent-500'), semanticTokenFor('accent-fg')],
+        [scalePlugin, contrastPlugin],
+      );
       r.bind('accent-500', 'scale', { familyName: 'accent', scalePosition: 5 });
       r.bind('accent-fg', 'contrast', { familyName: 'accent', basePosition: 5 });
       expect(r.get('accent-500')?.value).toEqual({ family: 'accent', position: '500' });
@@ -92,7 +121,10 @@ describe('TokenRegistry', () => {
     });
 
     it('cascades through state variants on family change', () => {
-      const r = new TokenRegistry([accentToken], [scalePlugin, statePlugin]);
+      const r = new TokenRegistry(
+        [accentToken, semanticTokenFor('accent-500'), semanticTokenFor('accent-hover')],
+        [scalePlugin, statePlugin],
+      );
       r.bind('accent-500', 'scale', { familyName: 'accent', scalePosition: 5 });
       r.bind('accent-hover', 'state', {
         familyName: 'accent',
@@ -106,14 +138,14 @@ describe('TokenRegistry', () => {
     });
 
     it('projects dependsOn from binding via plugin.dependsOn', () => {
-      const r = new TokenRegistry([accentToken], [scalePlugin]);
+      const r = new TokenRegistry([accentToken, semanticTokenFor('accent-500')], [scalePlugin]);
       r.bind('accent-500', 'scale', { familyName: 'accent', scalePosition: 5 });
       expect(r.get('accent-500')?.dependsOn).toEqual(['accent']);
       expect(r.get('accent-500')?.generationRule).toBe('scale');
     });
 
     it('strips dependsOn / generationRule when token converted from binding to leaf', () => {
-      const r = new TokenRegistry([accentToken], [scalePlugin]);
+      const r = new TokenRegistry([accentToken, semanticTokenFor('accent-500')], [scalePlugin]);
       r.bind('accent-500', 'scale', { familyName: 'accent', scalePosition: 5 });
       expect(r.get('accent-500')?.dependsOn).toEqual(['accent']);
       r.set('accent-500', '#ff0000');
@@ -124,7 +156,7 @@ describe('TokenRegistry', () => {
 
   describe('userOverride anchors block recompute', () => {
     it('blocks recompute on anchored node when upstream changes', () => {
-      const r = new TokenRegistry([accentToken], [scalePlugin]);
+      const r = new TokenRegistry([accentToken, semanticTokenFor('accent-500')], [scalePlugin]);
       r.bind('accent-500', 'scale', { familyName: 'accent', scalePosition: 5 });
       r.set(
         'accent-500',
@@ -163,7 +195,7 @@ describe('TokenRegistry', () => {
 
   describe('plugin registration', () => {
     it('accepts plugins added after construction', () => {
-      const r = new TokenRegistry([accentToken]);
+      const r = new TokenRegistry([accentToken, semanticTokenFor('accent-500')]);
       r.registerPlugin(scalePlugin);
       r.bind('accent-500', 'scale', { familyName: 'accent', scalePosition: 5 });
       expect(r.get('accent-500')?.value).toEqual({ family: 'accent', position: '500' });

--- a/packages/design-tokens/tsconfig.json
+++ b/packages/design-tokens/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "../color-utils/src/**/*.d.ts"],
   "exclude": ["node_modules", "**/*.test.ts"]
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -429,6 +429,16 @@ export const PROGRESSION_SYSTEMS = [
   'custom',
 ] as const;
 
+// Binding: typed reference to the plugin + input that produces a token's value.
+// When present on a Token, the registry resolves the value via the named plugin
+// instead of treating the token as a leaf. The plugin name is opaque to the
+// schema; the registry resolves it against its plugin map.
+export const BindingSchema = z.object({
+  plugin: z.string(),
+  input: z.unknown(),
+});
+export type Binding = z.infer<typeof BindingSchema>;
+
 // Comprehensive Design Token Schema - Single Source of Truth
 export const TokenSchema = z.object({
   // Core token data
@@ -436,6 +446,7 @@ export const TokenSchema = z.object({
   value: z.union([z.string(), ColorValueSchema, ColorReferenceSchema]), // String, ColorValue for families, or ColorReference for semantic
   category: z.string(),
   namespace: z.string(),
+  binding: BindingSchema.optional(), // Plugin binding for cascade-driven values
 
   // Typography-specific properties
   lineHeight: z.string().optional(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,7 +338,7 @@ importers:
         version: 8.2.0(@types/node@24.10.0)
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.1
-        version: 1.25.1(hono@4.11.0)(zod@4.1.12)
+        version: 1.25.1(hono@4.11.0)(zod@4.3.6)
       commander:
         specifier: ^13.0.0
         version: 13.1.0
@@ -399,7 +399,7 @@ importers:
         version: 4.1.0(@types/node@24.10.0)(@vitest/ui@4.1.0)(happy-dom@20.0.10)(jsdom@26.1.0)(msw@2.11.6(@types/node@24.10.0)(typescript@5.9.3))(vite@8.0.0(@types/node@24.10.0)(esbuild@0.27.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       zocker:
         specifier: 'catalog:'
-        version: 3.0.0(zod@4.1.12)
+        version: 3.0.0(zod@4.3.6)
 
   packages/color-utils:
     dependencies:
@@ -459,6 +459,9 @@ importers:
 
   packages/design-tokens:
     dependencies:
+      '@rafters/color-utils':
+        specifier: workspace:*
+        version: link:../color-utils
       '@rafters/math-utils':
         specifier: workspace:*
         version: link:../math-utils
@@ -640,7 +643,7 @@ importers:
         version: 4.1.0(@types/node@24.10.0)(@vitest/ui@4.1.0)(happy-dom@20.0.10)(jsdom@26.1.0)(msw@2.11.6(@types/node@24.10.0)(typescript@5.9.3))(vite@8.0.0(@types/node@24.10.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       zocker:
         specifier: 'catalog:'
-        version: 3.0.0(zod@4.1.12)
+        version: 3.0.0(zod@4.3.6)
 
   packages/ui:
     dependencies:
@@ -7930,7 +7933,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.25.1(hono@4.11.0)(zod@4.1.12)':
+  '@modelcontextprotocol/sdk@1.25.1(hono@4.11.0)(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.11(hono@4.11.0)
       ajv: 8.17.1
@@ -7946,8 +7949,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.1.12
-      zod-to-json-schema: 3.25.0(zod@4.1.12)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.0(zod@4.3.6)
     transitivePeerDependencies:
       - hono
       - supports-color
@@ -12680,13 +12683,19 @@ snapshots:
       randexp: 0.5.3
       zod: 4.1.12
 
+  zocker@3.0.0(zod@4.3.6):
+    dependencies:
+      '@faker-js/faker': 10.1.0
+      randexp: 0.5.3
+      zod: 4.3.6
+
   zod-to-json-schema@3.25.0(zod@3.25.76):
     dependencies:
       zod: 3.25.76
 
-  zod-to-json-schema@3.25.0(zod@4.1.12):
+  zod-to-json-schema@3.25.0(zod@4.3.6):
     dependencies:
-      zod: 4.1.12
+      zod: 4.3.6
 
   zod-to-ts@1.2.0(typescript@5.9.3)(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
## Summary

Five commits that move the persistence/registry plumbing toward the cleanup criteria in #1472 and the plugins-as-shims criteria in #1471, plus two real bugfixes surfaced by smoke-testing #1469 against live `.rafters/tokens`.

The current state is a transitional bridge for the larger plan in #1471/#1472/#1491/#1486-#1489 — a clean cascade primitive that consumes v1 generator output via a binding emission and is ready to consume new-package generator output once #1491 lands.

## What's in this PR

**Persistence is storage, not software** (92cb3836)
- `persistence.ts` is JSON-only on load: read the file, hand the raw `tokens` array to the registry as `unknown[]`. No Zod parse at this layer.
- Validation moves where it belongs: the registry runs `TokenSchema.safeParse` on input.
- Save preserves `\$schema` and `version` per-namespace from the loaded envelope rather than hardcoding constants.

**TokenSchema.safeParse replaces hand-rolled normalization** (bf71764a)
- `normalizeIncomingToken` deleted. Constructor and `define()` use `TokenSchema.safeParse` directly. `TokenParseError` exported alongside `UnknownTokenError`.
- Fail-loud on parse: file path + first issue's location/message.

**Registry guardrails: no fabricated defaults** (47011ede)
- Removed `defaultTokenFor` (was inventing `namespace`, `category`, `value: ''`, `containerQueryAware: true`).
- Removed `inferNamespace` heuristic that parsed delimiters.
- `set` / `bind` on an unknown name throws `UnknownTokenError` instead of silently fabricating.
- New `define(token)` is the only path to register after construction; same loose input + same normalization.
- `SCALE_POSITIONS`, `POSITION_TO_INDEX`, `MIN_WCAG_PAIR_DISTANCE`, `findBestWcagPair`, `findDarkCounterpartIndex` lifted into `@rafters/color-utils` (new `scale-positions.ts`); design-tokens imports from there. Plugins import from color-utils.

**Semantic generator emits binding; registry extracts and respects it** (6459bcfd, transitional)
- v1 `semantic.ts` emits `binding: {plugin: 'scale', input: {familyName, scalePosition}}` alongside the existing `dependsOn` / `generationRule`. The binding always uses `scale` at the designer's mapped position — not suffix-driven contrast/state plugins, because the mapping in `DEFAULT_SEMANTIC_COLOR_MAPPINGS` is the designer's choice.
- v1 `spacing.ts` documents intentional non-emission — spacing is browser-cascade via CSS calc.
- Registry constructor is two-pass (leaves first, then bindings) so dependents resolve regardless of source order. `toToken` preserves `dependsOn` instead of projecting from the binding.
- This v1 edit is a bridge until #1491 ports generators to the new package, at which point the v1 binding emission gets reverted.

**Persistence loud + --no-cascade actually fires** (ec354d56)
- Loader was silently `continue`ing on Zod parse failure → tokens vanished from the registry, surfacing later as "token not found." Now throws `NamespaceFileParseError` with file path + first issue.
- Legacy tokens without `userOverride` field (pre-`.nullable()`) are coerced to `null` on load.
- CLI `--no-cascade`: Commander populates `options.cascade = false` from the long-form, but `set.ts` was reading `options.noCascade`, which is never set. Fixed; added a Commander integration test that drives the actual CLI parser.

## Test plan

- [x] `pnpm --filter @rafters/design-tokens test` — 95 passing
- [x] `pnpm --filter @rafters/color-utils test` — 194 passing
- [x] `pnpm --filter @rafters/design-tokens typecheck` — clean
- [x] `pnpm --filter @rafters/color-utils typecheck` — clean
- [x] `pnpm --filter @rafters/shared typecheck` — clean
- [x] Smoke-tested end-to-end against live `.rafters/tokens` (198 tokens): `rafters set motion-duration-base 200ms --no-cascade --reason "..."` writes value=200ms with `userOverride{previousValue: "150ms", reason: "..."}`; subsequent `rafters set motion-duration-base 150ms` (no flag) clears the userOverride.
- [x] Round-trip new-registry → v1 exporter is byte-identical to v1's direct `rafters init` output.

## Out of scope (follow-ups)

- v1 generator binding emission gets reverted as part of #1491 (port generators to new package).
- `@rafters/shared` `ColorHarmoniesSchema` requires `splitComplementary` but live `semantic.rafters.json` has older ColorValues — separate decision (schema `.optional()` vs `rafters init --reset` to rewrite).
- Pre-existing preflight failures in `packages/ui` (`vitest-axe`/`css-tree` types) are unrelated to this branch and predate `main`.

## Issue refs

Advances #1471 (plugin shims), #1472 (cleanup), #1491 (binding bridge for the new registry's consumption of v1 output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)