### PR TITLE
fix(design-tokens, cli): every set records userOverride; --no-cascade goes away

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- breaking(set): every `rafters set <name> <value>` records a `userOverride` diary entry (previousValue + reason) on the token, and the resulting node becomes a cascade anchor -- future upstream changes do not clobber it. Downstream dependents still re-derive against the anchor's new value. The `--no-cascade` flag is removed; the only meaningful flag is now `--reason "..."` (required in `--agent` mode; interactive prompt otherwise). This fixes a silent-clobber bug where cascade-mode sets saved a value, left the binding pointing at the old upstream, and got reverted the next time the upstream changed. Matches the registry's new `set(name, value, { reason })` signature -- the `cascade` option is gone from the public API.
+- chore(set): `loadRegistryFromDir` calls now register the four built-in plugins (`scalePlugin`, `contrastPlugin`, `invertPlugin`, `statePlugin`), so any semantic token carrying a `binding` resolves at load time rather than throwing `Unknown plugin: scale`.
+
 ### Patch Changes
 
 - fix(set): the `--no-cascade` flag was silently ignored. Commander populates the long-form derived from `--no-cascade` as `options.cascade = false`, but the action handler was reading `options.noCascade`, which is never set. The flag now wires through correctly. Added a Commander integration test so the wiring is locked.

--- a/packages/cli/src/commands/set.ts
+++ b/packages/cli/src/commands/set.ts
@@ -1,15 +1,26 @@
 /**
  * rafters set
  *
- * Sets a token value in the registry. By default, cascades to dependent tokens.
- * With --no-cascade, records the value as a userOverride anchor — the token is
- * marked as a designer deviation and is skipped by future cascades.
+ * Sets a token's value. Every change is a diary entry -- the previous value
+ * and the reason are recorded as `userOverride`, and downstream cascade fires
+ * via plugin bindings so dependents re-derive against the new value.
+ *
+ * userOverride is metadata describing the change. It is also the anchor that
+ * blocks future upstream cascades from clobbering this node's value -- the
+ * downstream subtree keeps re-deriving from the override as its new root.
  */
 
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { input } from '@inquirer/prompts';
-import { loadRegistryFromDir, saveRegistryToDir } from '@rafters/design-tokens';
+import {
+  contrastPlugin,
+  invertPlugin,
+  loadRegistryFromDir,
+  saveRegistryToDir,
+  scalePlugin,
+  statePlugin,
+} from '@rafters/design-tokens';
 import { ColorReferenceSchema, ColorValueSchema } from '@rafters/shared';
 import { z } from 'zod';
 import { isAgentMode, log, setAgentMode } from '../utils/ui.js';
@@ -17,13 +28,7 @@ import { isAgentMode, log, setAgentMode } from '../utils/ui.js';
 const TokenValueSchema = z.union([z.string(), ColorValueSchema, ColorReferenceSchema]);
 type TokenValue = z.infer<typeof TokenValueSchema>;
 
-/**
- * Commander populates the long-form key derived from --no-cascade as `cascade`
- * (defaulting to true; `--no-cascade` flips it to false). Don't read `noCascade` --
- * it's never set by Commander.
- */
 export interface SetOptions {
-  cascade?: boolean;
   reason?: string;
   raftersDir?: string;
   agent?: boolean;
@@ -37,39 +42,38 @@ export async function set(name: string, value: string, options: SetOptions): Pro
     throw new Error(`tokens directory not found: ${dir}`);
   }
 
-  const cascade = options.cascade !== false;
   let reason = options.reason;
-  if (!cascade && !reason) {
+  if (!reason) {
     if (isAgentMode()) {
-      throw new Error('--no-cascade requires --reason in agent mode');
+      throw new Error('rafters set requires --reason in agent mode');
     }
     reason = await input({
-      message: 'Reason for this override (recorded with the userOverride):',
+      message: 'Reason for this change (recorded with userOverride):',
       validate: (v) => (v.trim().length > 0 ? true : 'A reason is required'),
     });
   }
 
   const parsedValue = parseValue(value);
-  const registry = loadRegistryFromDir(dir);
+  const registry = loadRegistryFromDir(dir, [
+    scalePlugin,
+    contrastPlugin,
+    invertPlugin,
+    statePlugin,
+  ]);
   if (!registry.has(name)) {
     throw new Error(`token "${name}" not found in ${dir}`);
   }
 
   const previous = registry.get(name)?.value;
-  if (cascade) {
-    registry.set(name, parsedValue);
-  } else if (reason) {
-    registry.set(name, parsedValue, { cascade: false, reason });
-  }
+  registry.set(name, parsedValue, { reason });
   saveRegistryToDir(dir, registry);
 
   log({
-    event: cascade ? 'token.set' : 'token.override',
+    event: 'token.set',
     name,
     previous,
     next: parsedValue,
-    cascade,
-    ...(reason ? { reason } : {}),
+    reason,
   });
 }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -61,11 +61,13 @@ program
 
 program
   .command('set')
-  .description('Set a token value (cascades to dependents by default)')
+  .description('Set a token value. Records userOverride and cascades to dependents.')
   .argument('<name>', 'Token name')
   .argument('<value>', 'New value (string, or JSON for ColorValue/ColorReference)')
-  .option('--no-cascade', 'Record as userOverride anchor; skip cascade on this node')
-  .option('--reason <text>', 'Reason for the override (required with --no-cascade)')
+  .option(
+    '--reason <text>',
+    'Reason for the change (recorded with userOverride; prompted if missing in non-agent mode)',
+  )
   .option('--rafters-dir <path>', 'Directory of .rafters.json files', '.rafters/tokens')
   .option('--agent', 'Output JSON for machine consumption')
   .action(withErrorHandler(set));

--- a/packages/cli/test/commands/set.test.ts
+++ b/packages/cli/test/commands/set.test.ts
@@ -41,43 +41,33 @@ function readNamespace(name: string): { tokens: Array<Record<string, unknown>> }
 }
 
 describe('set command', () => {
-  it('updates a leaf token value with cascade (default)', async () => {
-    await set('spacing-base', '8px', { raftersDir: tmpDir, agent: true });
-    const file = readNamespace('spacing');
-    const token = file.tokens.find((t) => t.name === 'spacing-base');
-    expect(token?.value).toBe('8px');
-    expect(token?.userOverride).toBeNull();
-  });
-
-  it('records userOverride when cascade=false with reason', async () => {
-    await set('spacing-base', '20px', {
-      cascade: false,
-      reason: 'Q1 brand campaign',
+  it('updates a leaf token value and records userOverride', async () => {
+    await set('spacing-base', '8px', {
+      reason: 'designer choice',
       raftersDir: tmpDir,
       agent: true,
     });
     const file = readNamespace('spacing');
     const token = file.tokens.find((t) => t.name === 'spacing-base');
-    expect(token?.value).toBe('20px');
+    expect(token?.value).toBe('8px');
     expect(token?.userOverride).toMatchObject({
-      reason: 'Q1 brand campaign',
+      reason: 'designer choice',
       previousValue: '4px',
     });
   });
 
-  it('throws in agent mode when cascade=false missing reason', async () => {
-    await expect(
-      set('spacing-base', '20px', { cascade: false, raftersDir: tmpDir, agent: true }),
-    ).rejects.toThrow(/--no-cascade requires --reason/);
+  it('throws in agent mode when reason is missing', async () => {
+    await expect(set('spacing-base', '20px', { raftersDir: tmpDir, agent: true })).rejects.toThrow(
+      /requires --reason in agent mode/,
+    );
   });
 
-  it('integration: --no-cascade flag through Commander populates options.cascade=false', async () => {
+  it('integration: --reason flag through Commander wires through to userOverride', async () => {
     const program = new Command()
       .exitOverride()
       .name('set')
       .argument('<name>')
       .argument('<value>')
-      .option('--no-cascade')
       .option('--reason <text>')
       .option('--rafters-dir <path>')
       .option('--agent')
@@ -85,16 +75,7 @@ describe('set command', () => {
         await set(name, value, options);
       });
     await program.parseAsync(
-      [
-        'spacing-base',
-        '12px',
-        '--no-cascade',
-        '--reason',
-        'flag round-trip',
-        '--rafters-dir',
-        tmpDir,
-        '--agent',
-      ],
+      ['spacing-base', '12px', '--reason', 'flag round-trip', '--rafters-dir', tmpDir, '--agent'],
       { from: 'user' },
     );
     const file = readNamespace('spacing');
@@ -107,14 +88,18 @@ describe('set command', () => {
   });
 
   it('throws when token does not exist', async () => {
-    await expect(set('does-not-exist', '4px', { raftersDir: tmpDir, agent: true })).rejects.toThrow(
-      /not found/,
-    );
+    await expect(
+      set('does-not-exist', '4px', { reason: 'test', raftersDir: tmpDir, agent: true }),
+    ).rejects.toThrow(/not found/);
   });
 
   it('throws when tokens directory does not exist', async () => {
     await expect(
-      set('spacing-base', '4px', { raftersDir: '/nonexistent/path', agent: true }),
+      set('spacing-base', '4px', {
+        reason: 'test',
+        raftersDir: '/nonexistent/path',
+        agent: true,
+      }),
     ).rejects.toThrow(/tokens directory not found/);
   });
 
@@ -135,6 +120,7 @@ describe('set command', () => {
       }),
     );
     await set('color-primary', '{"family":"warning","position":"700"}', {
+      reason: 'remap to warning',
       raftersDir: tmpDir,
       agent: true,
     });

--- a/packages/design-tokens/src/graph.ts
+++ b/packages/design-tokens/src/graph.ts
@@ -33,8 +33,7 @@ export const NodeSchema = z.object({
 export type Node = z.infer<typeof NodeSchema>;
 
 export type SetOptions = {
-  cascade?: boolean;
-  reason?: string;
+  reason: string;
   context?: string;
 };
 
@@ -65,22 +64,38 @@ export class TokenGraph {
     this.plugins.set(plugin.name, plugin);
   }
 
-  set(name: string, value: unknown, options?: SetOptions): void {
+  set(name: string, value: unknown, options: SetOptions): void {
     this.takeSnapshot();
     const existing = this.nodes.get(name);
-    const next: Node = { name, value };
-
-    if (options?.cascade === false) {
-      next.userOverride = {
+    const next: Node = {
+      name,
+      value,
+      userOverride: {
         previousValue: existing?.value,
-        reason: options.reason ?? '',
+        reason: options.reason,
         ...(options.context ? { context: options.context } : {}),
-      };
-      if (existing?.binding) next.binding = existing.binding;
-    }
-
+      },
+      ...(existing?.binding ? { binding: existing.binding } : {}),
+    };
     this.nodes.set(name, next);
     this.cascadeFrom(name);
+  }
+
+  // Hydrate a node from persisted state. No cascade fires; the caller
+  // (registry constructor) is responsible for ordering: leaves first, then
+  // bindings. userOverride / binding are preserved verbatim from the persisted
+  // token so that the anchor + re-derivation hook both survive reload.
+  seed(
+    name: string,
+    value: unknown,
+    extras?: { userOverride?: UserOverride; binding?: Binding },
+  ): void {
+    this.nodes.set(name, {
+      name,
+      value,
+      ...(extras?.userOverride ? { userOverride: extras.userOverride } : {}),
+      ...(extras?.binding ? { binding: extras.binding } : {}),
+    });
   }
 
   bind(name: string, pluginName: string, input: unknown): void {

--- a/packages/design-tokens/src/registry.ts
+++ b/packages/design-tokens/src/registry.ts
@@ -28,22 +28,30 @@ export class TokenRegistry {
       this.metadata.set(result.data.name, result.data);
       parsed.push(result.data);
     }
-    // Pass 1: leaves and overrides.
+    // Pass 1: leaves (no binding) plus any token carrying a userOverride.
+    // An overridden token is seeded with its on-disk value AND its binding
+    // metadata -- the binding stays as a re-derivation hook for future
+    // rebinds, but the override anchor blocks pass 2 from re-running the
+    // transform now.
     for (const t of parsed) {
-      if (t.binding) continue;
-      if (t.userOverride) {
-        this.graph.set(t.name, t.value, {
-          cascade: false,
-          reason: t.userOverride.reason,
-          ...(t.userOverride.context ? { context: t.userOverride.context } : {}),
-        });
-      } else {
-        this.graph.set(t.name, t.value);
-      }
+      const override = t.userOverride
+        ? {
+            previousValue: t.userOverride.previousValue,
+            reason: t.userOverride.reason,
+            ...(t.userOverride.context ? { context: t.userOverride.context } : {}),
+          }
+        : undefined;
+      if (t.binding && !override) continue;
+      this.graph.seed(t.name, t.value, {
+        ...(override ? { userOverride: override } : {}),
+        ...(t.binding ? { binding: t.binding } : {}),
+      });
     }
-    // Pass 2: bindings (dependents now resolve against leaves).
+    // Pass 2: bound tokens without a userOverride re-derive against the
+    // leaves seeded in pass 1.
     for (const t of parsed) {
       if (!t.binding) continue;
+      if (t.userOverride) continue;
       this.graph.bind(t.name, t.binding.plugin, t.binding.input);
     }
   }
@@ -60,20 +68,24 @@ export class TokenRegistry {
     }
     const t = result.data;
     this.metadata.set(t.name, t);
-    if (t.binding) {
+    const override = t.userOverride
+      ? {
+          previousValue: t.userOverride.previousValue,
+          reason: t.userOverride.reason,
+          ...(t.userOverride.context ? { context: t.userOverride.context } : {}),
+        }
+      : undefined;
+    if (t.binding && !override) {
       this.graph.bind(t.name, t.binding.plugin, t.binding.input);
-    } else if (t.userOverride) {
-      this.graph.set(t.name, t.value, {
-        cascade: false,
-        reason: t.userOverride.reason,
-        ...(t.userOverride.context ? { context: t.userOverride.context } : {}),
-      });
     } else {
-      this.graph.set(t.name, t.value);
+      this.graph.seed(t.name, t.value, {
+        ...(override ? { userOverride: override } : {}),
+        ...(t.binding ? { binding: t.binding } : {}),
+      });
     }
   }
 
-  set(name: string, value: TokenValue, options?: SetOptions): void {
+  set(name: string, value: TokenValue, options: SetOptions): void {
     if (!this.metadata.has(name)) {
       throw new UnknownTokenError(name);
     }

--- a/packages/design-tokens/test/cascade.test.ts
+++ b/packages/design-tokens/test/cascade.test.ts
@@ -124,7 +124,7 @@ describe('cascade integration', () => {
       expect(initial.primaryActive).toEqual({ family: 'accent', position: '700' });
 
       const remapped = buildAccentFamily('remapped');
-      r.set('accent', remapped);
+      r.set('accent', remapped, { reason: 'test' });
 
       expect(r.get('accent')?.value).toEqual(remapped);
       expect(r.get('primary')?.value).toEqual({ family: 'accent', position: '500' });
@@ -139,15 +139,12 @@ describe('cascade integration', () => {
     it('anchored hover keeps its value when family changes', () => {
       const r = setupSemanticChain();
       const manualHover = { family: 'override', position: 'manual' };
-      r.set('primary-hover', manualHover, {
-        cascade: false,
-        reason: 'designer chose specific tone',
-      });
+      r.set('primary-hover', manualHover, { reason: 'designer chose specific tone' });
 
       expect(r.get('primary-hover')?.value).toEqual(manualHover);
       expect(r.get('primary-hover')?.userOverride?.reason).toBe('designer chose specific tone');
 
-      r.set('accent', buildAccentFamily('changed'));
+      r.set('accent', buildAccentFamily('changed'), { reason: 'test' });
       expect(r.get('primary-hover')?.value).toEqual(manualHover);
     });
 
@@ -164,11 +161,7 @@ describe('cascade integration', () => {
       r.bind('primary-fg', 'contrast', { familyName: 'accent', basePosition: 5 });
 
       const downstreamBefore = r.get('primary-fg')?.value;
-      r.set(
-        'primary',
-        { family: 'override', position: 'manual' },
-        { cascade: false, reason: 'manual' },
-      );
+      r.set('primary', { family: 'override', position: 'manual' }, { reason: 'manual' });
       expect(r.get('primary')?.userOverride?.reason).toBe('manual');
       const downstreamAfter = r.get('primary-fg')?.value;
       expect(downstreamAfter).toEqual(downstreamBefore);
@@ -179,8 +172,8 @@ describe('cascade integration', () => {
     it('rejects a binding that creates a direct cycle', () => {
       const r = new TokenRegistry([familyTokenSlot('a'), familyTokenSlot('b')], [scalePlugin]);
       const family = buildAccentFamily();
-      r.set('a', family);
-      r.set('b', family);
+      r.set('a', family, { reason: 'test' });
+      r.set('b', family, { reason: 'test' });
       r.bind('a', 'scale', { familyName: 'b', scalePosition: 5 });
       expect(() => r.bind('b', 'scale', { familyName: 'a', scalePosition: 5 })).toThrow(
         CircularDependencyError,
@@ -193,9 +186,9 @@ describe('cascade integration', () => {
         [scalePlugin],
       );
       const family = buildAccentFamily();
-      r.set('a', family);
-      r.set('b', family);
-      r.set('c', family);
+      r.set('a', family, { reason: 'test' });
+      r.set('b', family, { reason: 'test' });
+      r.set('c', family, { reason: 'test' });
       r.bind('b', 'scale', { familyName: 'a', scalePosition: 5 });
       r.bind('c', 'scale', { familyName: 'b', scalePosition: 5 });
       expect(() => r.bind('a', 'scale', { familyName: 'c', scalePosition: 5 })).toThrow(
@@ -221,7 +214,7 @@ describe('cascade integration', () => {
         basePosition: 5,
         stateType: 'hover',
       });
-      r.set('accent', buildAccentFamily('mutated'));
+      r.set('accent', buildAccentFamily('mutated'), { reason: 'test' });
       expect(r.get('primary')?.value).toEqual({ family: 'accent', position: '500' });
       expect(r.get('primary-hover')?.value).toEqual({ family: 'accent', position: '600' });
     });
@@ -235,7 +228,7 @@ describe('cascade integration', () => {
         primary: r.get('primary')?.value,
         primaryHover: r.get('primary-hover')?.value,
       };
-      r.set('accent', buildAccentFamily('different'));
+      r.set('accent', buildAccentFamily('different'), { reason: 'test' });
       r.undo();
       expect(r.get('accent')?.value).toEqual(before.accent);
       expect(r.get('primary')?.value).toEqual(before.primary);

--- a/packages/design-tokens/test/graph.test.ts
+++ b/packages/design-tokens/test/graph.test.ts
@@ -7,14 +7,15 @@ import {
   UnknownPluginError,
 } from '../src/index.js';
 
+const R = { reason: 'test' } as const;
+
 const doublePlugin: Plugin = {
   name: 'double',
   inputSchema: z.object({ source: z.string() }),
   outputSchema: z.number(),
   dependsOn: (input) => [(input as { source: string }).source],
   transform: (input, get) => {
-    const v = get((input as { source: string }).source);
-    if (typeof v !== 'number') throw new Error('expected number');
+    const v = get((input as { source: string }).source) as number;
     return v * 2;
   },
 };
@@ -26,13 +27,7 @@ const sumPlugin: Plugin = {
   dependsOn: (input) => (input as { sources: string[] }).sources,
   transform: (input, get) => {
     const sources = (input as { sources: string[] }).sources;
-    let total = 0;
-    for (const s of sources) {
-      const v = get(s);
-      if (typeof v !== 'number') throw new Error(`expected number for ${s}`);
-      total += v;
-    }
-    return total;
+    return sources.reduce<number>((acc, name) => acc + (get(name) as number), 0);
   },
 };
 
@@ -45,17 +40,17 @@ const identityPlugin: Plugin = {
 };
 
 describe('TokenGraph', () => {
-  describe('set + get', () => {
+  describe('seed + get', () => {
     it('stores and retrieves leaf values', () => {
       const g = new TokenGraph();
-      g.set('a', 1);
+      g.seed('a', 1);
       expect(g.get('a')).toBe(1);
     });
 
     it('overwrites existing value', () => {
       const g = new TokenGraph();
-      g.set('a', 1);
-      g.set('a', 5);
+      g.seed('a', 1);
+      g.seed('a', 5);
       expect(g.get('a')).toBe(5);
     });
 
@@ -68,27 +63,27 @@ describe('TokenGraph', () => {
   describe('bind + cascade', () => {
     it('computes initial value via plugin on bind', () => {
       const g = new TokenGraph([doublePlugin]);
-      g.set('a', 3);
+      g.seed('a', 3);
       g.bind('b', 'double', { source: 'a' });
       expect(g.get('b')).toBe(6);
     });
 
     it('propagates upstream changes through dependents', () => {
       const g = new TokenGraph([doublePlugin]);
-      g.set('a', 1);
+      g.seed('a', 1);
       g.bind('b', 'double', { source: 'a' });
-      g.set('a', 5);
+      g.set('a', 5, R);
       expect(g.get('b')).toBe(10);
     });
 
     it('propagates transitively through multi-hop chains', () => {
       const g = new TokenGraph([doublePlugin]);
-      g.set('a', 2);
+      g.seed('a', 2);
       g.bind('b', 'double', { source: 'a' });
       g.bind('c', 'double', { source: 'b' });
       g.bind('d', 'double', { source: 'c' });
       expect(g.get('d')).toBe(16);
-      g.set('a', 3);
+      g.set('a', 3, R);
       expect(g.get('b')).toBe(6);
       expect(g.get('c')).toBe(12);
       expect(g.get('d')).toBe(24);
@@ -96,11 +91,11 @@ describe('TokenGraph', () => {
 
     it('handles fan-out: many dependents on one source', () => {
       const g = new TokenGraph([doublePlugin]);
-      g.set('a', 4);
+      g.seed('a', 4);
       g.bind('x', 'double', { source: 'a' });
       g.bind('y', 'double', { source: 'a' });
       g.bind('z', 'double', { source: 'a' });
-      g.set('a', 10);
+      g.set('a', 10, R);
       expect(g.get('x')).toBe(20);
       expect(g.get('y')).toBe(20);
       expect(g.get('z')).toBe(20);
@@ -108,68 +103,70 @@ describe('TokenGraph', () => {
 
     it('handles fan-in: dependent reads multiple sources', () => {
       const g = new TokenGraph([sumPlugin]);
-      g.set('a', 1);
-      g.set('b', 2);
-      g.set('c', 3);
+      g.seed('a', 1);
+      g.seed('b', 2);
+      g.seed('c', 3);
       g.bind('total', 'sum', { sources: ['a', 'b', 'c'] });
       expect(g.get('total')).toBe(6);
-      g.set('b', 10);
+      g.set('b', 10, R);
       expect(g.get('total')).toBe(14);
     });
   });
 
-  describe('userOverride anchors', () => {
-    it('records userOverride when cascade: false', () => {
+  describe('userOverride is the diary entry for every set', () => {
+    it('records reason on every set', () => {
       const g = new TokenGraph();
-      g.set('a', 1, { cascade: false, reason: 'designer choice' });
+      g.set('a', 1, { reason: 'designer choice' });
       expect(g.node('a')?.userOverride?.reason).toBe('designer choice');
     });
 
     it('records optional context on userOverride', () => {
       const g = new TokenGraph();
-      g.set('a', 1, { cascade: false, reason: 'designer choice', context: 'Q1 brand campaign' });
+      g.set('a', 1, { reason: 'designer choice', context: 'Q1 brand campaign' });
       expect(g.node('a')?.userOverride?.context).toBe('Q1 brand campaign');
     });
 
-    it('captures previous value in userOverride', () => {
+    it('captures previous value on every set', () => {
       const g = new TokenGraph();
-      g.set('a', 1);
-      g.set('a', 99, { cascade: false, reason: 'override' });
+      g.seed('a', 1);
+      g.set('a', 99, { reason: 'override' });
       expect(g.node('a')?.userOverride?.previousValue).toBe(1);
     });
 
-    it('blocks recompute on the anchored node when upstream changes', () => {
+    it('replaces userOverride on subsequent set (latest set wins)', () => {
+      const g = new TokenGraph();
+      g.set('a', 1, { reason: 'first' });
+      g.set('a', 5, { reason: 'second' });
+      expect(g.node('a')?.userOverride?.reason).toBe('second');
+      expect(g.node('a')?.userOverride?.previousValue).toBe(1);
+    });
+  });
+
+  describe('userOverride anchors the cascade boundary', () => {
+    it('blocks upstream re-derivation on the anchored node', () => {
       const g = new TokenGraph([doublePlugin]);
-      g.set('a', 2);
+      g.seed('a', 2);
       g.bind('b', 'double', { source: 'a' });
       expect(g.get('b')).toBe(4);
-      g.set('b', 100, { cascade: false, reason: 'manual' });
-      g.set('a', 7);
+      g.set('b', 100, { reason: 'manual' });
+      g.set('a', 7, R);
       expect(g.get('b')).toBe(100);
     });
 
-    it('downstream of an anchor still receives propagation from the anchor value', () => {
+    it('downstream of an anchor still re-derives from the anchor value', () => {
       const g = new TokenGraph([doublePlugin]);
-      g.set('a', 2);
+      g.seed('a', 2);
       g.bind('b', 'double', { source: 'a' });
       g.bind('c', 'double', { source: 'b' });
-      g.set('b', 50, { cascade: false, reason: 'manual' });
+      g.set('b', 50, { reason: 'manual' });
       expect(g.get('c')).toBe(100);
     });
 
-    it('clears userOverride when set called without cascade: false', () => {
-      const g = new TokenGraph();
-      g.set('a', 1, { cascade: false, reason: 'manual' });
-      expect(g.node('a')?.userOverride).toBeDefined();
-      g.set('a', 5);
-      expect(g.node('a')?.userOverride).toBeUndefined();
-    });
-
-    it('preserves binding when overriding so cascade can resume on later bind/clear', () => {
+    it('preserves binding when overriding so cascade can resume on later rebind', () => {
       const g = new TokenGraph([doublePlugin]);
-      g.set('a', 2);
+      g.seed('a', 2);
       g.bind('b', 'double', { source: 'a' });
-      g.set('b', 999, { cascade: false, reason: 'manual' });
+      g.set('b', 999, { reason: 'manual' });
       expect(g.node('b')?.binding?.plugin).toBe('double');
     });
   });
@@ -177,17 +174,17 @@ describe('TokenGraph', () => {
   describe('undo', () => {
     it('reverses the last set', () => {
       const g = new TokenGraph();
-      g.set('a', 1);
-      g.set('a', 5);
+      g.seed('a', 1);
+      g.set('a', 5, R);
       g.undo();
       expect(g.get('a')).toBe(1);
     });
 
     it('reverses the last bind including cascade effects', () => {
       const g = new TokenGraph([doublePlugin]);
-      g.set('a', 3);
+      g.seed('a', 3);
       g.bind('b', 'double', { source: 'a' });
-      g.set('a', 10);
+      g.set('a', 10, R);
       g.undo();
       expect(g.get('a')).toBe(3);
       expect(g.get('b')).toBe(6);
@@ -195,9 +192,9 @@ describe('TokenGraph', () => {
 
     it('is single-step (does not stack)', () => {
       const g = new TokenGraph();
-      g.set('a', 1);
-      g.set('a', 5);
-      g.set('a', 9);
+      g.seed('a', 1);
+      g.set('a', 5, R);
+      g.set('a', 9, R);
       g.undo();
       expect(g.get('a')).toBe(5);
       g.undo();
@@ -208,17 +205,17 @@ describe('TokenGraph', () => {
   describe('cycle detection', () => {
     it('throws CircularDependencyError on direct cycle', () => {
       const g = new TokenGraph([identityPlugin]);
-      g.set('a', 1);
-      g.set('b', 2);
+      g.seed('a', 1);
+      g.seed('b', 2);
       g.bind('a', 'identity', { source: 'b' });
       expect(() => g.bind('b', 'identity', { source: 'a' })).toThrow(CircularDependencyError);
     });
 
     it('throws CircularDependencyError on transitive cycle', () => {
       const g = new TokenGraph([identityPlugin]);
-      g.set('a', 1);
-      g.set('b', 2);
-      g.set('c', 3);
+      g.seed('a', 1);
+      g.seed('b', 2);
+      g.seed('c', 3);
       g.bind('b', 'identity', { source: 'a' });
       g.bind('c', 'identity', { source: 'b' });
       expect(() => g.bind('a', 'identity', { source: 'c' })).toThrow(CircularDependencyError);
@@ -226,8 +223,8 @@ describe('TokenGraph', () => {
 
     it('cycle error includes the cycle path', () => {
       const g = new TokenGraph([identityPlugin]);
-      g.set('a', 1);
-      g.set('b', 2);
+      g.seed('a', 1);
+      g.seed('b', 2);
       g.bind('a', 'identity', { source: 'b' });
       try {
         g.bind('b', 'identity', { source: 'a' });
@@ -249,7 +246,7 @@ describe('TokenGraph', () => {
     it('accepts plugins registered after construction', () => {
       const g = new TokenGraph();
       g.registerPlugin(doublePlugin);
-      g.set('a', 4);
+      g.seed('a', 4);
       g.bind('b', 'double', { source: 'a' });
       expect(g.get('b')).toBe(8);
     });
@@ -259,24 +256,24 @@ describe('TokenGraph', () => {
     it('reports size accurately', () => {
       const g = new TokenGraph();
       expect(g.size()).toBe(0);
-      g.set('a', 1);
-      g.set('b', 2);
+      g.seed('a', 1);
+      g.seed('b', 2);
       expect(g.size()).toBe(2);
     });
 
     it('has() reflects presence', () => {
       const g = new TokenGraph();
-      g.set('a', 1);
+      g.seed('a', 1);
       expect(g.has('a')).toBe(true);
       expect(g.has('b')).toBe(false);
     });
 
     it('list() filters by namespace prefix (dash and dot separators)', () => {
       const g = new TokenGraph();
-      g.set('color-primary', 1);
-      g.set('color-secondary', 2);
-      g.set('color.tertiary', 3);
-      g.set('spacing-base', 4);
+      g.seed('color-primary', 1);
+      g.seed('color-secondary', 2);
+      g.seed('color.tertiary', 3);
+      g.seed('spacing-base', 4);
       const colors = g.list({ namespace: 'color' });
       expect(colors.map((n) => n.name).sort()).toEqual([
         'color-primary',

--- a/packages/design-tokens/test/persistence.test.ts
+++ b/packages/design-tokens/test/persistence.test.ts
@@ -116,7 +116,7 @@ describe('saveRegistryToDir', () => {
 
   it('round-trips tokens through save+load preserving values', () => {
     const r = new TokenRegistry([colorFile.tokens[0] as Token]);
-    r.set('color-accent', '#ff0000');
+    r.set('color-accent', '#ff0000', { reason: 'test' });
     saveRegistryToDir(tmpDir, r);
     const reloaded = loadRegistryFromDir(tmpDir);
     expect(reloaded.get('color-accent')?.value).toBe('#ff0000');
@@ -124,7 +124,7 @@ describe('saveRegistryToDir', () => {
 
   it('round-trips userOverride records', () => {
     const r = new TokenRegistry([colorFile.tokens[0] as Token]);
-    r.set('color-accent', '#ff0000', { cascade: false, reason: 'Q1 brand campaign' });
+    r.set('color-accent', '#ff0000', { reason: 'Q1 brand campaign' });
     saveRegistryToDir(tmpDir, r);
     const reloaded = loadRegistryFromDir(tmpDir);
     expect(reloaded.get('color-accent')?.userOverride?.reason).toBe('Q1 brand campaign');

--- a/packages/design-tokens/test/plugins/calc.test.ts
+++ b/packages/design-tokens/test/plugins/calc.test.ts
@@ -11,37 +11,37 @@ describe('calcPlugin', () => {
 
   it('substitutes token values and evaluates', () => {
     const g = new TokenGraph([calcPlugin]);
-    g.set('base', '4');
+    g.seed('base', '4');
     g.bind('result', 'calc', { expression: '{base} * 2', tokens: ['base'] });
     expect(g.get('result')).toBe('8');
   });
 
   it('preserves the unit of the first token with a unit', () => {
     const g = new TokenGraph([calcPlugin]);
-    g.set('base', '16px');
+    g.seed('base', '16px');
     g.bind('result', 'calc', { expression: '{base} * 2', tokens: ['base'] });
     expect(g.get('result')).toBe('32px');
   });
 
   it('detects unit from literal in the expression when no token has one', () => {
     const g = new TokenGraph([calcPlugin]);
-    g.set('factor', '3');
+    g.seed('factor', '3');
     g.bind('result', 'calc', { expression: '{factor} * 4rem', tokens: ['factor'] });
     expect(g.get('result')).toBe('12rem');
   });
 
   it('cascades when a referenced token changes', () => {
     const g = new TokenGraph([calcPlugin]);
-    g.set('base', '8');
+    g.seed('base', '8');
     g.bind('doubled', 'calc', { expression: '{base} * 2', tokens: ['base'] });
     expect(g.get('doubled')).toBe('16');
-    g.set('base', '20');
+    g.set('base', '20', { reason: 'cascade test' });
     expect(g.get('doubled')).toBe('40');
   });
 
   it('throws when a referenced token is non-numeric', () => {
     const g = new TokenGraph([calcPlugin]);
-    g.set('base', 'not-a-number');
+    g.seed('base', 'not-a-number');
     expect(() => g.bind('result', 'calc', { expression: '{base} * 2', tokens: ['base'] })).toThrow(
       /not numeric/,
     );
@@ -49,7 +49,7 @@ describe('calcPlugin', () => {
 
   it('throws when a referenced token is not a string', () => {
     const g = new TokenGraph([calcPlugin]);
-    g.set('base', 42);
+    g.seed('base', 42);
     expect(() => g.bind('result', 'calc', { expression: '{base} * 2', tokens: ['base'] })).toThrow(
       /not a string/,
     );

--- a/packages/design-tokens/test/plugins/contrast.test.ts
+++ b/packages/design-tokens/test/plugins/contrast.test.ts
@@ -25,7 +25,7 @@ describe('contrastPlugin', () => {
       foregroundReferences: { auto: { family: 'gray', position: '50' } },
     } as ColorValue;
     const g = new TokenGraph([contrastPlugin]);
-    g.set('accent', family);
+    g.seed('accent', family);
     g.bind('accent-fg', 'contrast', { familyName: 'accent', basePosition: 5 });
     expect(g.get('accent-fg')).toEqual({ family: 'gray', position: '50' });
   });
@@ -40,7 +40,7 @@ describe('contrastPlugin', () => {
       },
     };
     const g = new TokenGraph([contrastPlugin]);
-    g.set('accent', family);
+    g.seed('accent', family);
     g.bind('accent-fg', 'contrast', { familyName: 'accent', basePosition: 5 });
     expect(g.get('accent-fg')).toEqual({ family: 'accent', position: '50' });
   });
@@ -55,7 +55,7 @@ describe('contrastPlugin', () => {
       },
     };
     const g = new TokenGraph([contrastPlugin]);
-    g.set('accent', family);
+    g.seed('accent', family);
     g.bind('accent-fg', 'contrast', { familyName: 'accent', basePosition: 5 });
     expect(g.get('accent-fg')).toEqual({ family: 'accent', position: '950' });
   });
@@ -72,8 +72,8 @@ describe('contrastPlugin', () => {
       },
     };
     const g = new TokenGraph([contrastPlugin]);
-    g.set('accent', family);
-    g.set('gray', neutral);
+    g.seed('accent', family);
+    g.seed('gray', neutral);
     g.bind('accent-fg', 'contrast', {
       familyName: 'accent',
       basePosition: 5,
@@ -86,8 +86,8 @@ describe('contrastPlugin', () => {
     const family: ColorValue = { name: 'accent', scale: minimalScale };
     const neutral: ColorValue = { name: 'gray', scale: minimalScale };
     const g = new TokenGraph([contrastPlugin]);
-    g.set('accent', family);
-    g.set('gray', neutral);
+    g.seed('accent', family);
+    g.seed('gray', neutral);
     expect(() =>
       g.bind('light-fg', 'contrast', {
         familyName: 'accent',
@@ -100,7 +100,7 @@ describe('contrastPlugin', () => {
   it('throws when family has no foregroundReferences and no WCAG pairs', () => {
     const family: ColorValue = { name: 'accent', scale: minimalScale };
     const g = new TokenGraph([contrastPlugin]);
-    g.set('accent', family);
+    g.seed('accent', family);
     expect(() => g.bind('fg-light', 'contrast', { familyName: 'accent', basePosition: 2 })).toThrow(
       /no foregroundReferences and no accessibility WCAG pairs/,
     );

--- a/packages/design-tokens/test/plugins/invert.test.ts
+++ b/packages/design-tokens/test/plugins/invert.test.ts
@@ -18,7 +18,7 @@ describe('invertPlugin', () => {
       },
     };
     const g = new TokenGraph([invertPlugin]);
-    g.set('accent', family);
+    g.seed('accent', family);
     g.bind('accent-dark', 'invert', { familyName: 'accent', basePosition: 2 });
     expect(g.get('accent-dark')).toEqual({ family: 'accent', position: '900' });
   });
@@ -33,7 +33,7 @@ describe('invertPlugin', () => {
       },
     };
     const g = new TokenGraph([invertPlugin]);
-    g.set('accent', family);
+    g.seed('accent', family);
     g.bind('accent-dark', 'invert', { familyName: 'accent', basePosition: 2 });
     expect(g.get('accent-dark')).toEqual({ family: 'accent', position: '800' });
   });
@@ -48,7 +48,7 @@ describe('invertPlugin', () => {
       },
     };
     const g = new TokenGraph([invertPlugin]);
-    g.set('accent', family);
+    g.seed('accent', family);
     g.bind('accent-dark', 'invert', { familyName: 'accent', basePosition: 2 });
     expect(g.get('accent-dark')).toEqual({ family: 'accent', position: '800' });
   });
@@ -56,7 +56,7 @@ describe('invertPlugin', () => {
   it('throws when family has no accessibility data at all', () => {
     const family: ColorValue = { name: 'accent', scale: minimalScale };
     const g = new TokenGraph([invertPlugin]);
-    g.set('accent', family);
+    g.seed('accent', family);
     expect(() =>
       g.bind('accent-dark', 'invert', { familyName: 'accent', basePosition: 5 }),
     ).toThrow(/No WCAG accessibility data/);

--- a/packages/design-tokens/test/plugins/scale.test.ts
+++ b/packages/design-tokens/test/plugins/scale.test.ts
@@ -12,14 +12,14 @@ describe('scalePlugin', () => {
 
   it('returns ColorReference with mapped position string', () => {
     const g = new TokenGraph([scalePlugin]);
-    g.set('accent', minimalAccent);
+    g.seed('accent', minimalAccent);
     g.bind('accent-500', 'scale', { familyName: 'accent', scalePosition: 5 });
     expect(g.get('accent-500')).toEqual({ family: 'accent', position: '500' });
   });
 
   it('maps all 11 positions correctly', () => {
     const g = new TokenGraph([scalePlugin]);
-    g.set('accent', minimalAccent);
+    g.seed('accent', minimalAccent);
     const expected = ['50', '100', '200', '300', '400', '500', '600', '700', '800', '900', '950'];
     for (let i = 0; i < 11; i++) {
       g.bind(`accent-${expected[i]}`, 'scale', { familyName: 'accent', scalePosition: i });
@@ -36,7 +36,7 @@ describe('scalePlugin', () => {
 
   it('rejects out-of-range scalePosition via Zod', () => {
     const g = new TokenGraph([scalePlugin]);
-    g.set('accent', minimalAccent);
+    g.seed('accent', minimalAccent);
     expect(() => g.bind('x', 'scale', { familyName: 'accent', scalePosition: 11 })).toThrow();
     expect(() => g.bind('x', 'scale', { familyName: 'accent', scalePosition: -1 })).toThrow();
   });

--- a/packages/design-tokens/test/plugins/state.test.ts
+++ b/packages/design-tokens/test/plugins/state.test.ts
@@ -20,7 +20,7 @@ describe('statePlugin', () => {
       },
     } as ColorValue;
     const g = new TokenGraph([statePlugin]);
-    g.set('accent', family);
+    g.seed('accent', family);
     g.bind('hover', 'state', { familyName: 'accent', basePosition: 5, stateType: 'hover' });
     g.bind('active', 'state', { familyName: 'accent', basePosition: 5, stateType: 'active' });
     expect(g.get('hover')).toEqual({ family: 'accent', position: '700' });
@@ -30,7 +30,7 @@ describe('statePlugin', () => {
   it('applies positional offsets when no stateReferences', () => {
     const family: ColorValue = { name: 'accent', scale: minimalScale };
     const g = new TokenGraph([statePlugin]);
-    g.set('accent', family);
+    g.seed('accent', family);
     g.bind('hover', 'state', { familyName: 'accent', basePosition: 5, stateType: 'hover' });
     g.bind('active', 'state', { familyName: 'accent', basePosition: 5, stateType: 'active' });
     g.bind('focus', 'state', { familyName: 'accent', basePosition: 5, stateType: 'focus' });
@@ -44,7 +44,7 @@ describe('statePlugin', () => {
   it('clamps offsets at scale boundaries', () => {
     const family: ColorValue = { name: 'accent', scale: minimalScale };
     const g = new TokenGraph([statePlugin]);
-    g.set('accent', family);
+    g.seed('accent', family);
     g.bind('top-hover', 'state', { familyName: 'accent', basePosition: 10, stateType: 'hover' });
     g.bind('bottom-disabled', 'state', {
       familyName: 'accent',
@@ -57,7 +57,7 @@ describe('statePlugin', () => {
 
   it('rejects invalid stateType via Zod', () => {
     const g = new TokenGraph([statePlugin]);
-    g.set('accent', { name: 'accent', scale: minimalScale });
+    g.seed('accent', { name: 'accent', scale: minimalScale });
     expect(() =>
       g.bind('x', 'state', { familyName: 'accent', basePosition: 5, stateType: 'pressed' }),
     ).toThrow();

--- a/packages/design-tokens/test/registry.test.ts
+++ b/packages/design-tokens/test/registry.test.ts
@@ -80,31 +80,27 @@ describe('TokenRegistry', () => {
   });
 
   describe('set', () => {
-    it('writes value on existing token', () => {
+    it('writes value on existing token and records userOverride', () => {
       const r = new TokenRegistry([spacingBaseToken]);
-      r.set('spacing-base', '8px');
+      r.set('spacing-base', '8px', { reason: 'designer choice' });
       expect(r.get('spacing-base')?.value).toBe('8px');
+      expect(r.get('spacing-base')?.userOverride?.reason).toBe('designer choice');
+      expect(r.get('spacing-base')?.userOverride?.previousValue).toBe('4px');
     });
 
     it('throws UnknownTokenError when set is called on a name with no registered metadata', () => {
       const r = new TokenRegistry();
-      expect(() => r.set('color-mystery', '#fff')).toThrow(UnknownTokenError);
+      expect(() => r.set('color-mystery', '#fff', { reason: 'test' })).toThrow(UnknownTokenError);
     });
 
-    it('records userOverride when cascade: false', () => {
+    it('replaces userOverride on subsequent set (latest reason wins)', () => {
       const r = new TokenRegistry([spacingBaseToken]);
-      r.set('spacing-base', '20px', { cascade: false, reason: 'designer override' });
+      r.set('spacing-base', '20px', { reason: 'first change' });
+      r.set('spacing-base', '24px', { reason: 'second change' });
       const token = r.get('spacing-base');
-      expect(token?.userOverride?.reason).toBe('designer override');
-      expect(token?.userOverride?.previousValue).toBe('4px');
-    });
-
-    it('clears userOverride on subsequent normal set', () => {
-      const r = new TokenRegistry([spacingBaseToken]);
-      r.set('spacing-base', '20px', { cascade: false, reason: 'override' });
-      expect(r.get('spacing-base')?.userOverride).not.toBeNull();
-      r.set('spacing-base', '24px');
-      expect(r.get('spacing-base')?.userOverride).toBeNull();
+      expect(token?.value).toBe('24px');
+      expect(token?.userOverride?.reason).toBe('second change');
+      expect(token?.userOverride?.previousValue).toBe('20px');
     });
   });
 
@@ -146,7 +142,7 @@ describe('TokenRegistry', () => {
         stateType: 'hover',
       });
       const newAccent = { ...accentToken.value, name: 'mutated' } as ColorValue;
-      r.set('accent', newAccent);
+      r.set('accent', newAccent, { reason: 'test mutation' });
       expect(r.get('accent')?.value).toEqual(newAccent);
       expect(r.get('accent-hover')?.value).toBeDefined();
     });
@@ -171,16 +167,9 @@ describe('TokenRegistry', () => {
     it('blocks recompute on anchored node when upstream changes', () => {
       const r = new TokenRegistry([accentToken, semanticTokenFor('accent-500')], [scalePlugin]);
       r.bind('accent-500', 'scale', { familyName: 'accent', scalePosition: 5 });
-      r.set(
-        'accent-500',
-        { family: 'override', position: 'manual' },
-        {
-          cascade: false,
-          reason: 'manual',
-        },
-      );
+      r.set('accent-500', { family: 'override', position: 'manual' }, { reason: 'manual' });
       const newAccent = { ...accentToken.value, name: 'mutated' } as ColorValue;
-      r.set('accent', newAccent);
+      r.set('accent', newAccent, { reason: 'family remap' });
       expect(r.get('accent-500')?.value).toEqual({ family: 'override', position: 'manual' });
     });
   });
@@ -218,7 +207,7 @@ describe('TokenRegistry', () => {
   describe('undo', () => {
     it('reverses the most recent operation', () => {
       const r = new TokenRegistry([spacingBaseToken]);
-      r.set('spacing-base', '16px');
+      r.set('spacing-base', '16px', { reason: 'test undo' });
       r.undo();
       expect(r.get('spacing-base')?.value).toBe('4px');
     });


### PR DESCRIPTION
## Summary

Closes #1494. Fixes a silent-clobber bug found while smoke-testing the cascade end-to-end with a simple `rafters set primary-hover` change.

userOverride is the diary entry for any change to a token (previousValue + reason). The old `cascade: false` flag was the only path that recorded it, which meant a default cascade-mode set silently saved the new value while leaving the binding untouched -- and the next upstream cascade snapped the value back. The diary was lost; the override boundary semantics were unreachable from the default flow.

## Before / After

```bash
# BEFORE
rafters set primary-hover '{family:silver-true-citrine,position:500}' --agent
# value=citrine-500 saved, binding still scale@neutral@8, userOverride=null
rafters set neutral <new-family> --agent
# cascade walks; primary-hover has no userOverride; re-derives via
# scale@neutral@8 -> snaps back to neutral-800. Citrine is gone.

# AFTER
rafters set primary-hover '{family:silver-true-citrine,position:500}' \
  --reason "designer wants yellow hover" --agent
# value=citrine-500, userOverride={previousValue:neutral-800, reason:...}
rafters set neutral <new-family> --reason "remap to green" --agent
# cascade walks; primary-hover has userOverride; SKIPS re-derivation.
# primary-hover stays citrine-500. Diary entry intact.
```

## Surface changes (breaking)

- `registry.set(name, value, options)` -- `options` is required and must include `reason: string`. The `cascade?: boolean` option is removed.
- `graph.set(name, value, options)` -- same signature. Always records userOverride.
- New `graph.seed(name, value, extras?: { userOverride?, binding? })` for hydration from disk. No cascade fires. The caller orders leaves before bindings.
- CLI `rafters set` -- `--no-cascade` flag removed. `--reason "..."` is required in `--agent` mode; non-agent mode prompts.
- Registry constructor + `define()` use `seed()` for tokens that carry userOverride; pass-2 bind() is skipped for them, so the on-disk anchor survives reload (this was the second half of the bug -- bind() would re-derive and clobber).

## CLI plugin wiring

`loadRegistryFromDir` now ships with the four built-in plugins (`scalePlugin`, `contrastPlugin`, `invertPlugin`, `statePlugin`) so any semantic token carrying a `binding` resolves at load time rather than throwing `Unknown plugin: scale`.

## Test plan

- [x] `pnpm --filter @rafters/design-tokens typecheck` -- clean
- [x] `pnpm --filter @rafters/design-tokens test` -- 99 passing (one test consolidated since the semantic shift -- "clears userOverride on subsequent normal set" is gone; replaced with "replaces userOverride on subsequent set (latest set wins)")
- [x] `pnpm --filter rafters test:unit` -- 349 passing + 12 skipped
- [x] Pre-push preflight -- green (82s).
- [x] `legion-simplify` quality gate -- clean.
- [x] End-to-end smoke: set with reason -> userOverride recorded; change upstream -> override holds; downstream of the override still cascades against its new value.

## Out of scope (filed as follow-ups)

- **#1495** -- semantic generator emits real `dependsOn` / `generatedBy` for derived tokens. Right now `primary-hover-foreground` declares `dependsOn=['neutral', 'neutral-?']` and binds to `scale@neutral@50` -- so nothing actually depends on `primary-hover` in the binding graph. Without that fix, the cascade has nothing to walk when primary-hover is overridden; the override holds but the downstream subtree doesn't recompute against the new family.
- **#1496** -- state plugin reads the family's `accessibility.wcagAAA` pair ladder instead of `DEFAULT_STATE_OFFSETS`. The hardcoded offset matrix Sean has called out repeatedly.

Both are needed to make the "set primary-hover to yellow, everything below regenerates with yellow math" story end-to-end. This PR is the diary-entry / anchor / CLI flag piece -- the layer that the other two issues compose against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)