### PR TITLE
feat(design-tokens, shared): state plugin walks WCAG-AAA ladder; color generator emits accessibility

### DIFF
--- a/packages/design-tokens/src/generators/color.ts
+++ b/packages/design-tokens/src/generators/color.ts
@@ -8,8 +8,12 @@
  * Default scales are provided by the orchestrator from defaults.ts.
  */
 
-import { generateOKLCHScale } from '@rafters/color-utils';
-import type { ColorValue, OKLCH, Token } from '@rafters/shared';
+import {
+  calculateWCAGContrast,
+  generateAccessibilityMetadata,
+  generateOKLCHScale,
+} from '@rafters/color-utils';
+import type { ColorAccessibility, ColorValue, OKLCH, Token } from '@rafters/shared';
 import type { ColorScaleInput, SemanticColorBase } from './defaults.js';
 import type { GeneratorResult, ResolvedSystemConfig } from './types.js';
 import { COLOR_SCALE_POSITIONS } from './types.js';
@@ -74,12 +78,15 @@ export function generateColorTokens(
       (v): v is OKLCH => v !== undefined,
     );
 
-    // Create the color family token with full intelligence
+    // Pre-compute accessibility metadata so plugins (state, contrast) can
+    // walk the family's WCAG-AAA pair ladder without recomputing contrast
+    // ratios at cascade time.
     const colorFamily: ColorValue = {
       name,
       scale: scaleArray,
       token: name,
       use: description ?? `${name} color palette for UI elements.`,
+      accessibility: buildColorAccessibility(scaleArray),
     };
 
     // Create individual scale position tokens
@@ -143,6 +150,40 @@ export function generateColorTokens(
   return {
     namespace: 'color',
     tokens,
+  };
+}
+
+const WHITE: OKLCH = { l: 1, c: 0, h: 0, alpha: 1 };
+const BLACK: OKLCH = { l: 0, c: 0, h: 0, alpha: 1 };
+const WCAG_AA_NORMAL = 4.5;
+const WCAG_AAA_NORMAL = 7;
+const FAMILY_REFERENCE_INDEX = 5; // The 500 position is the family anchor for onWhite/onBlack ratios.
+
+function buildColorAccessibility(scale: OKLCH[]): ColorAccessibility {
+  const meta = generateAccessibilityMetadata(scale);
+  const reference = scale[FAMILY_REFERENCE_INDEX] ?? scale[0];
+  if (!reference) {
+    throw new Error('buildColorAccessibility: empty scale');
+  }
+  const onWhiteRatio = calculateWCAGContrast(reference, WHITE);
+  const onBlackRatio = calculateWCAGContrast(reference, BLACK);
+  return {
+    wcagAA: meta.wcagAA,
+    wcagAAA: meta.wcagAAA,
+    onWhite: {
+      wcagAA: onWhiteRatio >= WCAG_AA_NORMAL,
+      wcagAAA: onWhiteRatio >= WCAG_AAA_NORMAL,
+      contrastRatio: onWhiteRatio,
+      aa: meta.onWhite.aa,
+      aaa: meta.onWhite.aaa,
+    },
+    onBlack: {
+      wcagAA: onBlackRatio >= WCAG_AA_NORMAL,
+      wcagAAA: onBlackRatio >= WCAG_AAA_NORMAL,
+      contrastRatio: onBlackRatio,
+      aa: meta.onBlack.aa,
+      aaa: meta.onBlack.aaa,
+    },
   };
 }
 

--- a/packages/design-tokens/src/plugins/state.ts
+++ b/packages/design-tokens/src/plugins/state.ts
@@ -1,15 +1,10 @@
 import { SCALE_POSITIONS } from '@rafters/color-utils';
-import {
-  type ColorReference,
-  ColorReferenceSchema,
-  type ColorValue,
-  DEFAULT_STATE_OFFSETS,
-  type StateType,
-} from '@rafters/shared';
+import { type ColorReference, ColorReferenceSchema, type ColorValue } from '@rafters/shared';
 import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
 
 const StateTypeSchema = z.enum(['hover', 'active', 'focus', 'disabled']);
+type StateType = z.infer<typeof StateTypeSchema>;
 
 const StateInputSchema = z.object({
   familyName: z.string(),
@@ -22,6 +17,53 @@ type StateInput = z.infer<typeof StateInputSchema>;
 type ColorValueWithStateRefs = ColorValue & {
   stateReferences?: Record<string, { family: string; position: string }>;
 };
+
+/**
+ * Walk the family's WCAG-AAA pair ladder to derive a state variant.
+ *
+ * "Like invert/contrast" -- the family's pre-computed pair list is the
+ * source of truth. No hardcoded offset matrix. State variants step along
+ * the RANK of accessible positions (positions that appear in at least one
+ * wcagAAA pair). A family with more AAA-compliant positions gives finer
+ * state steps; a family with fewer gives coarser ones. The math reads
+ * the family's actual data, not a global constant.
+ *
+ * Ladder = sorted unique positions in any wcagAAA.normal pair. Base
+ * position must be on the ladder. Step per state type:
+ *   hover    -> +1 rank (next accessible neighbour toward dark, clamped)
+ *   active   -> +2 rank
+ *   focus    -> +1 rank (same as hover; the visual cue is the ring)
+ *   disabled -> closest ladder rank to the family midpoint (position 5)
+ */
+const STEP_BY_STATE: Record<StateType, (rank: number, ladder: readonly number[]) => number> = {
+  hover: (rank) => rank + 1,
+  active: (rank) => rank + 2,
+  focus: (rank) => rank + 1,
+  disabled: (_rank, ladder) => closestRankToMidpoint(ladder),
+};
+
+function closestRankToMidpoint(ladder: readonly number[]): number {
+  let bestRank = 0;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (let r = 0; r < ladder.length; r++) {
+    const position = ladder[r];
+    if (position === undefined) continue;
+    const distance = Math.abs(position - 5);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestRank = r;
+    }
+  }
+  return bestRank;
+}
+
+function collectLadder(pairs: readonly (readonly number[])[]): number[] {
+  const positions = new Set<number>();
+  for (const pair of pairs) {
+    for (const position of pair) positions.add(position);
+  }
+  return Array.from(positions).sort((a, b) => a - b);
+}
 
 export const statePlugin = definePlugin<StateInput, ColorReference>({
   name: 'state',
@@ -39,12 +81,32 @@ export const statePlugin = definePlugin<StateInput, ColorReference>({
       return { family: precomputed.family, position: String(precomputed.position) };
     }
 
-    const offset = DEFAULT_STATE_OFFSETS[input.stateType as StateType];
-    const adjustedIndex = Math.max(0, Math.min(10, input.basePosition + offset));
-    const position = SCALE_POSITIONS[adjustedIndex];
+    const pairs = family.accessibility?.wcagAAA?.normal;
+    if (!pairs || pairs.length === 0) {
+      throw new Error(
+        `state plugin: family "${input.familyName}" has no accessibility.wcagAAA.normal ladder (color generator must emit accessibility metadata)`,
+      );
+    }
+    const ladder = collectLadder(pairs);
+    const baseRank = ladder.indexOf(input.basePosition);
+    if (baseRank === -1) {
+      throw new Error(
+        `state plugin: basePosition ${input.basePosition} for family "${input.familyName}" is not in the WCAG-AAA ladder`,
+      );
+    }
+
+    const targetRank = STEP_BY_STATE[input.stateType](baseRank, ladder);
+    const clampedRank = Math.max(0, Math.min(ladder.length - 1, targetRank));
+    const targetIndex = ladder[clampedRank];
+    if (targetIndex === undefined) {
+      throw new Error(
+        `state plugin: ladder lookup failed for rank ${clampedRank} on family "${input.familyName}"`,
+      );
+    }
+    const position = SCALE_POSITIONS[targetIndex];
     if (!position) {
       throw new Error(
-        `state plugin: invalid scale index ${adjustedIndex} for base ${input.basePosition} + ${input.stateType}`,
+        `state plugin: invalid scale index ${targetIndex} for family "${input.familyName}"`,
       );
     }
     return { family: input.familyName, position };

--- a/packages/design-tokens/test/generators-parity.test.ts
+++ b/packages/design-tokens/test/generators-parity.test.ts
@@ -8,9 +8,17 @@ function stripVolatile(t: AnyToken): AnyToken {
   const {
     generatedAt: _generatedAt,
     binding: _binding,
+    value,
     ...rest
-  } = t as AnyToken & { generatedAt?: string; binding?: unknown };
-  return rest;
+  } = t as AnyToken & { generatedAt?: string; binding?: unknown; value?: unknown };
+  // Color family values now carry `accessibility` (new package only, see #1496).
+  // Strip it from the parity comparison so the rest of the token contract
+  // stays comparable to v1's output.
+  if (value && typeof value === 'object' && 'accessibility' in value) {
+    const { accessibility: _accessibility, ...valueRest } = value as Record<string, unknown>;
+    return { ...rest, value: valueRest };
+  }
+  return { ...rest, value };
 }
 
 describe('generators parity vs v1', () => {

--- a/packages/design-tokens/test/plugins/state.test.ts
+++ b/packages/design-tokens/test/plugins/state.test.ts
@@ -3,6 +3,33 @@ import { describe, expect, it } from 'vitest';
 import { statePlugin, TokenGraph } from '../../src/index.js';
 import { MINIMAL_SCALE as minimalScale } from './_fixtures.js';
 
+// Realistic-ish accessibility metadata: every position pairs with every position
+// that has at least a 4-step lightness gap. The set of positions in the ladder
+// is {0, 1, 2, ..., 10} (all positions show up in some pair).
+const fullLadderAccessibility = {
+  wcagAAA: {
+    normal: [
+      [0, 8],
+      [0, 9],
+      [0, 10],
+      [1, 8],
+      [1, 9],
+      [1, 10],
+      [2, 9],
+      [2, 10],
+      [3, 10],
+      [7, 0],
+      [8, 0],
+      [9, 0],
+      [10, 0],
+    ],
+    large: [],
+  },
+  wcagAA: { normal: [], large: [] },
+  onWhite: { wcagAA: true, wcagAAA: true, contrastRatio: 7, aa: [], aaa: [] },
+  onBlack: { wcagAA: true, wcagAAA: true, contrastRatio: 7, aa: [], aaa: [] },
+};
+
 describe('statePlugin', () => {
   it('declares dependency on the family name', () => {
     expect(
@@ -27,37 +54,85 @@ describe('statePlugin', () => {
     expect(g.get('active')).toEqual({ family: 'accent', position: '800' });
   });
 
-  it('applies positional offsets when no stateReferences', () => {
-    const family: ColorValue = { name: 'accent', scale: minimalScale };
+  it('walks the WCAG-AAA ladder for hover/active/focus', () => {
+    // Ladder positions sorted: [0, 1, 2, 3, 7, 8, 9, 10].
+    // Base 8 has rank 5 in the ladder.
+    // hover  rank +1 -> rank 6 -> position 9.
+    // active rank +2 -> rank 7 -> position 10.
+    // focus  rank +1 -> rank 6 -> position 9 (same as hover).
+    const family = {
+      name: 'accent',
+      scale: minimalScale,
+      accessibility: fullLadderAccessibility,
+    } as ColorValue;
     const g = new TokenGraph([statePlugin]);
     g.seed('accent', family);
-    g.bind('hover', 'state', { familyName: 'accent', basePosition: 5, stateType: 'hover' });
-    g.bind('active', 'state', { familyName: 'accent', basePosition: 5, stateType: 'active' });
-    g.bind('focus', 'state', { familyName: 'accent', basePosition: 5, stateType: 'focus' });
-    g.bind('disabled', 'state', { familyName: 'accent', basePosition: 5, stateType: 'disabled' });
-    expect(g.get('hover')).toEqual({ family: 'accent', position: '600' });
-    expect(g.get('active')).toEqual({ family: 'accent', position: '700' });
-    expect(g.get('focus')).toEqual({ family: 'accent', position: '600' });
+    g.bind('hover', 'state', { familyName: 'accent', basePosition: 8, stateType: 'hover' });
+    g.bind('active', 'state', { familyName: 'accent', basePosition: 8, stateType: 'active' });
+    g.bind('focus', 'state', { familyName: 'accent', basePosition: 8, stateType: 'focus' });
+    expect(g.get('hover')).toEqual({ family: 'accent', position: '900' });
+    expect(g.get('active')).toEqual({ family: 'accent', position: '950' });
+    expect(g.get('focus')).toEqual({ family: 'accent', position: '900' });
+  });
+
+  it('disabled returns the ladder rank closest to the family midpoint (position 5)', () => {
+    // Ladder positions sorted: [0, 1, 2, 3, 7, 8, 9, 10]. Closest to 5 is 3 (distance 2)
+    // or 7 (distance 2) -- first hit wins, which is rank 3 -> position 3.
+    const family = {
+      name: 'accent',
+      scale: minimalScale,
+      accessibility: fullLadderAccessibility,
+    } as ColorValue;
+    const g = new TokenGraph([statePlugin]);
+    g.seed('accent', family);
+    g.bind('disabled', 'state', { familyName: 'accent', basePosition: 8, stateType: 'disabled' });
     expect(g.get('disabled')).toEqual({ family: 'accent', position: '300' });
   });
 
-  it('clamps offsets at scale boundaries', () => {
+  it('clamps ladder steps at the top boundary', () => {
+    const family = {
+      name: 'accent',
+      scale: minimalScale,
+      accessibility: fullLadderAccessibility,
+    } as ColorValue;
+    const g = new TokenGraph([statePlugin]);
+    g.seed('accent', family);
+    // Base at position 10 has the top rank. hover +1 clamps to top -> position 10.
+    g.bind('top-hover', 'state', { familyName: 'accent', basePosition: 10, stateType: 'hover' });
+    expect(g.get('top-hover')).toEqual({ family: 'accent', position: '950' });
+  });
+
+  it('throws when the family has no accessibility.wcagAAA ladder', () => {
     const family: ColorValue = { name: 'accent', scale: minimalScale };
     const g = new TokenGraph([statePlugin]);
     g.seed('accent', family);
-    g.bind('top-hover', 'state', { familyName: 'accent', basePosition: 10, stateType: 'hover' });
-    g.bind('bottom-disabled', 'state', {
-      familyName: 'accent',
-      basePosition: 0,
-      stateType: 'disabled',
-    });
-    expect(g.get('top-hover')).toEqual({ family: 'accent', position: '950' });
-    expect(g.get('bottom-disabled')).toEqual({ family: 'accent', position: '50' });
+    expect(() =>
+      g.bind('hover', 'state', { familyName: 'accent', basePosition: 5, stateType: 'hover' }),
+    ).toThrow(/no accessibility\.wcagAAA\.normal ladder/);
+  });
+
+  it('throws when basePosition is not on the ladder', () => {
+    // Ladder = [0, 1, 2, 3, 7, 8, 9, 10]; 5 is not on it.
+    const family = {
+      name: 'accent',
+      scale: minimalScale,
+      accessibility: fullLadderAccessibility,
+    } as ColorValue;
+    const g = new TokenGraph([statePlugin]);
+    g.seed('accent', family);
+    expect(() =>
+      g.bind('hover', 'state', { familyName: 'accent', basePosition: 5, stateType: 'hover' }),
+    ).toThrow(/not in the WCAG-AAA ladder/);
   });
 
   it('rejects invalid stateType via Zod', () => {
+    const family = {
+      name: 'accent',
+      scale: minimalScale,
+      accessibility: fullLadderAccessibility,
+    } as ColorValue;
     const g = new TokenGraph([statePlugin]);
-    g.seed('accent', { name: 'accent', scale: minimalScale });
+    g.seed('accent', family);
     expect(() =>
       g.bind('x', 'state', { familyName: 'accent', basePosition: 5, stateType: 'pressed' }),
     ).toThrow();

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -439,22 +439,6 @@ export const BindingSchema = z.object({
 });
 export type Binding = z.infer<typeof BindingSchema>;
 
-// State plugin offsets vs. the base color position.
-// Hover/focus shift one step toward the dark counterpart; active shifts two
-// steps; disabled shifts two steps the other way. Versioned constant so
-// downstream plugins reference one source of truth.
-//
-// Snooze 019e2981 OPEN ITEM: Sean wants this redesigned to a WCAG-AAA-pair
-// lookup (like invert/contrast). Until that design lands, the offset matrix
-// is the documented fallback. Track follow-up before changing the values.
-export const DEFAULT_STATE_OFFSETS = {
-  hover: 1,
-  active: 2,
-  focus: 1,
-  disabled: -2,
-} as const;
-export type StateType = keyof typeof DEFAULT_STATE_OFFSETS;
-
 // Comprehensive Design Token Schema - Single Source of Truth
 export const TokenSchema = z.object({
   // Core token data


### PR DESCRIPTION
## Summary

Closes #1496. Snooze 019e2981 OPEN ITEM Sean flagged repeatedly: state plugin reads the family's pre-computed WCAG-AAA pair ladder instead of a hardcoded `DEFAULT_STATE_OFFSETS` matrix. The math is the family's data.

## Two coupled pieces

**1. Color generator bakes accessibility metadata.**

`packages/design-tokens/src/generators/color.ts` now calls `generateAccessibilityMetadata(scale)` from `@rafters/color-utils` and computes onWhite/onBlack contrast ratios at the 500 position. The result is stamped onto each `ColorValue.accessibility`. Schema-compatible with `@rafters/shared/ColorAccessibilitySchema` -- onWhite/onBlack carry `{ wcagAA, wcagAAA, contrastRatio, aa, aaa }` while `wcagAA`/`wcagAAA` carry `{normal, large}` pair arrays.

**2. State plugin walks the wcagAAA ladder.**

Algorithm in `packages/design-tokens/src/plugins/state.ts`:

- Read `family.accessibility.wcagAAA.normal` -- the pair array.
- **Ladder** = sorted unique positions in any pair. A family with more AAA-compliant positions gives finer state steps; fewer gives coarser. The step size is the family's structure, not a global constant.
- `hover`    = base rank + 1 (next accessible neighbour toward dark)
- `active`   = base rank + 2
- `focus`    = same rank as hover (visual cue is the ring, not the fill)
- `disabled` = ladder rank closest to the family midpoint (position 5)
- Clamps at boundaries. Throws if base is off the ladder or family has no accessibility data.

`DEFAULT_STATE_OFFSETS` and the `StateType` alias both deleted from `@rafters/shared`. The plugin no longer imports anything from shared beyond `ColorReference` + `ColorValue` types.

## Test plan

- [x] `pnpm --filter @rafters/shared typecheck` -- clean
- [x] `pnpm --filter @rafters/design-tokens typecheck` -- clean
- [x] `pnpm --filter @rafters/design-tokens test` -- 102 passing (was 99; added 4 ladder-walk tests, kept 1 stateReferences short-circuit, dropped 2 positional-offset tests since the offsets are gone)
- [x] `pnpm --filter rafters test:unit` -- 349 passing + 12 skipped
- [x] `rafters init --reset` in apps/demo: 13 namespaces re-emitted; neutral family carries 36 wcagAAA.normal pairs in its accessibility object.
- [x] Pre-push preflight -- green.
- [x] `legion-simplify` quality gate -- clean.

## Out of scope (still open, #1495)

The semantic generator still emits `binding: scale@neutral@N` for state variants like `primary-hover`, so no semantic token actually exercises the state plugin yet at init time. That's `#1495`: the semantic generator emits real `dependsOn` + `generatedBy` for derived semantics (`primary-hover.generatedBy={plugin:'state', args:{from:'primary', type:'hover'}}`, etc.). Once `#1495` lands, the state plugin shipped here is the one running every derivation -- not the fixed position offsets, but the family-data-driven walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)