### PR TITLE
feat(design-tokens, cli): semantic generator emits real derivation tree

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -12,16 +12,22 @@ import { createRequire } from 'node:module';
 import { join, relative } from 'node:path';
 import { checkbox, confirm, select } from '@inquirer/prompts';
 import {
+  contrastPlugin,
   generateBaseSystem,
+  invertPlugin,
   loadRegistryFromDir,
   registryToCompiled,
   registryToTailwind,
   registryToTypeScript,
   saveRegistryToDir,
   scalePlugin,
+  statePlugin,
   TokenRegistry,
   toDTCG,
 } from '@rafters/design-tokens';
+
+const REGISTRY_PLUGINS = [scalePlugin, contrastPlugin, statePlugin, invertPlugin];
+
 import { onboard, previewOnboard } from '../onboard/orchestrator.js';
 import { toImportPending, writeImportPending } from '../onboard/writer.js';
 import {
@@ -433,7 +439,7 @@ async function regenerateFromExisting(
   }
 
   // Load all tokens from .rafters/tokens/
-  const registry = loadRegistryFromDir(paths.tokens, [scalePlugin]);
+  const registry = loadRegistryFromDir(paths.tokens, REGISTRY_PLUGINS);
 
   if (registry.size() === 0) {
     throw new Error('No tokens found. Cannot regenerate without existing tokens.');
@@ -526,7 +532,7 @@ async function resetToDefaults(
   // Load existing tokens to check for userOverride backups
   let existingTokens: ReturnType<TokenRegistry['list']> = [];
   try {
-    existingTokens = loadRegistryFromDir(paths.tokens, [scalePlugin]).list();
+    existingTokens = loadRegistryFromDir(paths.tokens, REGISTRY_PLUGINS).list();
   } catch {
     // No existing tokens directory; nothing to back up.
   }
@@ -570,7 +576,7 @@ async function resetToDefaults(
 
   // Re-run generators fresh
   const system = generateBaseSystem();
-  const registry = new TokenRegistry(system.allTokens, [scalePlugin]);
+  const registry = new TokenRegistry(system.allTokens, REGISTRY_PLUGINS);
 
   log({
     event: 'init:reset_generated',
@@ -799,7 +805,7 @@ export async function init(options: InitOptions): Promise<void> {
 
   // Generate default token system - registry is the source of truth
   const system = generateBaseSystem();
-  const registry = new TokenRegistry(system.allTokens, [scalePlugin]);
+  const registry = new TokenRegistry(system.allTokens, REGISTRY_PLUGINS);
 
   log({
     event: 'init:generated',

--- a/packages/cli/src/commands/set.ts
+++ b/packages/cli/src/commands/set.ts
@@ -13,6 +13,7 @@
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { input } from '@inquirer/prompts';
+import { calculateWCAGContrast, generateAccessibilityMetadata } from '@rafters/color-utils';
 import {
   contrastPlugin,
   invertPlugin,
@@ -21,7 +22,13 @@ import {
   scalePlugin,
   statePlugin,
 } from '@rafters/design-tokens';
-import { ColorReferenceSchema, ColorValueSchema } from '@rafters/shared';
+import {
+  type ColorAccessibility,
+  ColorReferenceSchema,
+  type ColorValue,
+  ColorValueSchema,
+  type OKLCH,
+} from '@rafters/shared';
 import { z } from 'zod';
 import { isAgentMode, log, setAgentMode } from '../utils/ui.js';
 
@@ -53,7 +60,7 @@ export async function set(name: string, value: string, options: SetOptions): Pro
     });
   }
 
-  const parsedValue = parseValue(value);
+  const parsedValue = bakeAccessibility(parseValue(value));
   const registry = loadRegistryFromDir(dir, [
     scalePlugin,
     contrastPlugin,
@@ -75,6 +82,52 @@ export async function set(name: string, value: string, options: SetOptions): Pro
     next: parsedValue,
     reason,
   });
+}
+
+const WHITE: OKLCH = { l: 1, c: 0, h: 0, alpha: 1 };
+const BLACK: OKLCH = { l: 0, c: 0, h: 0, alpha: 1 };
+const WCAG_AA_NORMAL = 4.5;
+const WCAG_AAA_NORMAL = 7;
+
+/**
+ * Rebake accessibility metadata when the user sets a ColorValue family. The
+ * incoming JSON typically supplies only `{name, scale}`, so without this the
+ * cascade's contrast/state plugins would lose the WCAG pair list that the
+ * color generator populated at init time. Same algorithm as the color
+ * generator -- generateAccessibilityMetadata over the scale, ratios from
+ * position 5 vs white/black.
+ *
+ * No-op for string values and ColorReference values (those don't carry a
+ * scale to derive accessibility from).
+ */
+function bakeAccessibility(value: TokenValue): TokenValue {
+  if (typeof value !== 'object' || value === null) return value;
+  if (!('scale' in value) || !Array.isArray(value.scale)) return value;
+  const colorValue = value as ColorValue;
+  const meta = generateAccessibilityMetadata(colorValue.scale);
+  const reference = colorValue.scale[5] ?? colorValue.scale[0];
+  if (!reference) return value;
+  const onWhiteRatio = calculateWCAGContrast(reference, WHITE);
+  const onBlackRatio = calculateWCAGContrast(reference, BLACK);
+  const accessibility: ColorAccessibility = {
+    wcagAA: meta.wcagAA,
+    wcagAAA: meta.wcagAAA,
+    onWhite: {
+      wcagAA: onWhiteRatio >= WCAG_AA_NORMAL,
+      wcagAAA: onWhiteRatio >= WCAG_AAA_NORMAL,
+      contrastRatio: onWhiteRatio,
+      aa: meta.onWhite.aa,
+      aaa: meta.onWhite.aaa,
+    },
+    onBlack: {
+      wcagAA: onBlackRatio >= WCAG_AA_NORMAL,
+      wcagAAA: onBlackRatio >= WCAG_AAA_NORMAL,
+      contrastRatio: onBlackRatio,
+      aa: meta.onBlack.aa,
+      aaa: meta.onBlack.aaa,
+    },
+  };
+  return { ...colorValue, accessibility };
 }
 
 function parseValue(raw: string): TokenValue {

--- a/packages/design-tokens/src/generators/semantic.ts
+++ b/packages/design-tokens/src/generators/semantic.ts
@@ -1,20 +1,26 @@
 /**
  * Semantic Color Generator
  *
- * Generates semantic color tokens using the single source of truth from defaults.ts.
- * All semantic mappings (primary, secondary, destructive, success, warning, info,
- * highlight, sidebar tokens, chart colors, etc.) are defined in DEFAULT_SEMANTIC_COLOR_MAPPINGS.
+ * Emits semantic color tokens with a real derivation tree: dependsOn[0] points
+ * at the parent semantic (or family for top-of-tree tokens), and the binding
+ * encodes the same derivation as a runtime hook for the cascade.
  *
- * Uses ColorReference to point to color families + positions, allowing
- * the underlying colors to change while semantic meaning stays consistent.
+ *   primary             dependsOn=[family]                binding: scale@family@N
+ *   primary-foreground  dependsOn=[primary]               binding: contrast@primary,AAA
+ *   primary-ring        dependsOn=[family]                binding: scale@family@N   (sibling of primary)
+ *   primary-hover       dependsOn=[primary]               binding: state@primary,hover
+ *   primary-active      dependsOn=[primary]               binding: state@primary,active
+ *   primary-focus       dependsOn=[primary]               binding: state@primary,focus
+ *   primary-disabled    dependsOn=[primary]               binding: state@primary,disabled
+ *   primary-hover-fg    dependsOn=[primary-hover]         binding: contrast@primary-hover,AAA
  *
- * Supports both light and dark mode references.
+ * When the user runs `rafters set primary-hover {family:yellow,position:500}`,
+ * cascadeFrom(primary-hover) walks dependents -- primary-hover-foreground
+ * recomputes via contrast against yellow's accessibility ladder; primary-hover
+ * itself anchors because the override is recorded as userOverride.
  *
- * Each token gets a generationRule so the dependency graph can auto-cascade
- * when the underlying color family changes:
- * - contrast:auto for foreground tokens (WCAG-safe pairing)
- * - state:hover/active/focus/disabled for state variants
- * - scale:N for direct position references (base, border, ring, subtle)
+ * dependsOn[1] keeps the dark-counterpart token name for the Tailwind exporter
+ * convention (typed: dependsOn[1] is the dark-mode position token).
  */
 
 import type { Binding, ColorReference, Token } from '@rafters/shared';
@@ -35,116 +41,137 @@ const POSITION_TO_INDEX: Record<string, number> = {
   '950': 10,
 };
 
-/**
- * Helper to convert SemanticColorMapping to ColorReference for light mode
- */
+const FOREGROUND_SUFFIXES = ['-foreground', '-text', '-contrast'] as const;
+const STATE_SUFFIXES = ['-hover', '-active', '-focus', '-disabled'] as const;
+type StateSuffix = (typeof STATE_SUFFIXES)[number];
+
+type Derivation =
+  | { kind: 'scale'; family: string; scalePosition: number }
+  | { kind: 'state'; from: string; stateType: 'hover' | 'active' | 'focus' | 'disabled' }
+  | { kind: 'contrast'; against: string; level: 'AAA' };
+
 function toColorRef(mapping: SemanticColorMapping): ColorReference {
   return { family: mapping.light.family, position: mapping.light.position };
 }
 
-/**
- * Get dark mode color reference from mapping
- */
 function toDarkColorRef(mapping: SemanticColorMapping): ColorReference {
   return { family: mapping.dark.family, position: mapping.dark.position };
 }
 
 /**
- * Determine the generation rule for a semantic token based on its name and role.
+ * Pick the derivation for a semantic token from its name. The suffix wins
+ * over the literal scale position in the mapping -- the mapping is the
+ * designer's chosen position for top-of-tree tokens; suffixed variants
+ * derive from their parent semantic instead.
  *
- * Pattern matching:
- * - *-foreground, *-text, *-contrast -> contrast:auto (WCAG pair lookup)
- * - *-hover -> state:hover
- * - *-active -> state:active
- * - *-focus -> state:focus
- * - *-disabled -> state:disabled
- * - everything else -> scale:position (direct reference)
+ * Pattern matching order matters: -hover-foreground must hit the foreground
+ * branch and use 'primary-hover' as the parent, not the state branch.
  */
-function deriveGenerationRule(name: string, lightRef: ColorReference): string {
-  // Foreground/text tokens need WCAG contrast pairing
-  if (name.endsWith('-foreground') || name.endsWith('-text') || name.endsWith('-contrast')) {
-    return 'contrast:auto';
+function deriveDerivation(
+  name: string,
+  lightRef: ColorReference,
+  knownTokens: ReadonlySet<string>,
+): Derivation {
+  // Foreground branch first so `-hover-foreground` resolves to contrast
+  // against `primary-hover` rather than as a state variant.
+  for (const suffix of FOREGROUND_SUFFIXES) {
+    if (name.endsWith(suffix)) {
+      const parent = name.slice(0, -suffix.length);
+      if (knownTokens.has(parent)) {
+        return { kind: 'contrast', against: parent, level: 'AAA' };
+      }
+    }
   }
 
-  // State variant tokens
-  if (name.endsWith('-hover') && !name.endsWith('-hover-foreground')) {
-    return 'state:hover';
-  }
-  if (name.endsWith('-active') && !name.endsWith('-active-foreground')) {
-    return 'state:active';
-  }
-  if (name.endsWith('-focus') && !name.endsWith('-focus-foreground')) {
-    return 'state:focus';
-  }
-  if (name.endsWith('-disabled') && !name.endsWith('-disabled-foreground')) {
-    return 'state:disabled';
+  for (const suffix of STATE_SUFFIXES) {
+    if (name.endsWith(suffix)) {
+      const parent = name.slice(0, -suffix.length);
+      if (knownTokens.has(parent)) {
+        return {
+          kind: 'state',
+          from: parent,
+          stateType: suffix.slice(1) as StateSuffix extends `-${infer S}` ? S : never,
+        };
+      }
+    }
   }
 
-  // Everything else: direct scale position reference
-  return `scale:${lightRef.position}`;
-}
-
-/**
- * Build a Binding for a semantic token from its light-mode reference.
- *
- * The mapping in DEFAULT_SEMANTIC_COLOR_MAPPINGS already encodes the
- * designer's chosen position for each semantic role. The binding's job on
- * family remap is to keep that chosen position and just swap the family --
- * so every semantic token binds to the scale plugin at its mapped position,
- * regardless of -foreground / -hover / -active / -focus / -disabled suffix.
- *
- * Suffix-driven plugins (contrast, state) exist for users to opt into
- * explicitly via registry.bind(); the generator does not auto-apply them
- * because doing so overrides the designer's mapped position with the
- * plugin's computed answer (the v1 cascade bug).
- */
-function deriveBinding(lightRef: ColorReference): Binding | undefined {
+  // No matching parent -- this is a top-of-tree token. Bind to the family
+  // scale at the designer-chosen position.
   const scalePosition = POSITION_TO_INDEX[lightRef.position];
-  if (scalePosition === undefined) return undefined;
-  return { plugin: 'scale', input: { familyName: lightRef.family, scalePosition } };
+  if (scalePosition === undefined) {
+    throw new Error(
+      `semantic generator: token "${name}" has unknown scale position "${lightRef.position}"`,
+    );
+  }
+  return { kind: 'scale', family: lightRef.family, scalePosition };
 }
 
-/**
- * Generate semantic color tokens from the single source of truth.
- *
- * Uses DEFAULT_SEMANTIC_COLOR_MAPPINGS from defaults.ts which contains
- * all semantic color definitions with proper color family references.
- *
- * Each token includes a generationRule so the registry's dependency graph
- * can automatically cascade changes when color families are updated.
- */
+function derivationToBinding(derivation: Derivation): Binding {
+  switch (derivation.kind) {
+    case 'scale':
+      return {
+        plugin: 'scale',
+        input: { familyName: derivation.family, scalePosition: derivation.scalePosition },
+      };
+    case 'state':
+      return {
+        plugin: 'state',
+        input: { from: derivation.from, stateType: derivation.stateType },
+      };
+    case 'contrast':
+      return {
+        plugin: 'contrast',
+        input: { against: derivation.against, level: derivation.level },
+      };
+  }
+}
+
+function derivationParent(derivation: Derivation): string {
+  switch (derivation.kind) {
+    case 'scale':
+      return derivation.family;
+    case 'state':
+      return derivation.from;
+    case 'contrast':
+      return derivation.against;
+  }
+}
+
 export function generateSemanticTokens(_config: ResolvedSystemConfig): GeneratorResult {
   const tokens: Token[] = [];
   const timestamp = new Date().toISOString();
+  const knownTokens = new Set(Object.keys(DEFAULT_SEMANTIC_COLOR_MAPPINGS));
 
   for (const [name, mapping] of Object.entries(DEFAULT_SEMANTIC_COLOR_MAPPINGS)) {
     const lightRef = toColorRef(mapping);
     const darkRef = toDarkColorRef(mapping);
 
-    // dependsOn[0] = the color family token (for ColorValue/WCAG data access)
-    // dependsOn[1] = dark mode position token (for Tailwind exporter)
-    const familyDep = lightRef.family;
+    const derivation = deriveDerivation(name, lightRef, knownTokens);
+    const binding = derivationToBinding(derivation);
+    const parent = derivationParent(derivation);
+
+    // dependsOn[0] = the actual upstream node in the cascade graph (parent
+    // semantic or family).
+    // dependsOn[1] = dark-mode position token for the Tailwind exporter's
+    // typed convention. Preserved verbatim from the v1 generator.
     const darkTokenName = `${darkRef.family}-${darkRef.position}`;
-    const dependsOn: string[] = [familyDep];
-    if (darkTokenName !== familyDep) {
+    const dependsOn: string[] = [parent];
+    if (darkTokenName !== parent) {
       dependsOn.push(darkTokenName);
     }
 
-    const generationRule = deriveGenerationRule(name, lightRef);
-    const binding = deriveBinding(lightRef);
-
     tokens.push({
       name,
-      value: lightRef, // Light mode is default value; dark mode lookup via dependsOn[1]
+      value: lightRef,
       category: 'color',
       namespace: 'semantic',
-      ...(binding ? { binding } : {}),
+      binding,
       semanticMeaning: mapping.meaning,
       usageContext: mapping.contexts,
       trustLevel: mapping.trustLevel,
       consequence: mapping.consequence,
       dependsOn,
-      generationRule,
       description: `${mapping.meaning}. Light: ${lightRef.family}-${lightRef.position}, Dark: ${darkRef.family}-${darkRef.position}.`,
       generatedAt: timestamp,
       containerQueryAware: true,

--- a/packages/design-tokens/src/plugins/contrast.ts
+++ b/packages/design-tokens/src/plugins/contrast.ts
@@ -4,9 +4,8 @@ import { z } from 'zod';
 import { definePlugin } from '../plugin.js';
 
 const ContrastInputSchema = z.object({
-  familyName: z.string(),
-  basePosition: z.number().int().min(0).max(10),
-  neutralFamilyName: z.string().optional(),
+  against: z.string(),
+  level: z.enum(['AA', 'AAA']).default('AAA'),
 });
 
 type ContrastInput = z.infer<typeof ContrastInputSchema>;
@@ -27,6 +26,35 @@ function partnerForBase(
   return undefined;
 }
 
+/**
+ * If no pair contains the exact base position, walk outward to find the
+ * nearest position that does. Returns the partner of that nearest position.
+ * This lets contrast pick a valid foreground even when the designer's
+ * chosen position isn't itself a WCAG pair anchor.
+ */
+function nearestPartner(
+  pairs: readonly (readonly number[])[] | undefined,
+  basePosition: number,
+): number | undefined {
+  if (!pairs || pairs.length === 0) return undefined;
+  const anchors = new Set<number>();
+  for (const pair of pairs) {
+    for (const position of pair) anchors.add(position);
+  }
+  if (anchors.size === 0) return undefined;
+  let nearest = -1;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (const anchor of anchors) {
+    const distance = Math.abs(anchor - basePosition);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      nearest = anchor;
+    }
+  }
+  if (nearest === -1) return undefined;
+  return partnerForBase(pairs, nearest);
+}
+
 function requireScalePosition(index: number, label: string): string {
   const position = SCALE_POSITIONS[index];
   if (!position) {
@@ -35,16 +63,66 @@ function requireScalePosition(index: number, label: string): string {
   return position;
 }
 
+function isPositionString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+function resolveBasePosition(position: string): number {
+  const map: Record<string, number> = {
+    '50': 0,
+    '100': 1,
+    '200': 2,
+    '300': 3,
+    '400': 4,
+    '500': 5,
+    '600': 6,
+    '700': 7,
+    '800': 8,
+    '900': 9,
+    '950': 10,
+  };
+  const index = map[position];
+  if (index === undefined) {
+    throw new Error(`contrast plugin: unknown scale position "${position}"`);
+  }
+  return index;
+}
+
+/**
+ * Find a WCAG-compliant foreground for a parent token's current value.
+ *
+ * Reads parent's ColorReference via `get`, resolves the family's accessibility
+ * metadata, and walks the WCAG-AAA pair list (falling back to AA if AAA has
+ * no partner) to find an accessible partner position. The `against` input is
+ * a TOKEN NAME -- the cascade re-runs this transform whenever that token's
+ * value changes, so the foreground always reflects the parent's current
+ * family and position.
+ */
 export const contrastPlugin = definePlugin<ContrastInput, ColorReference>({
   name: 'contrast',
   inputSchema: ContrastInputSchema,
   outputSchema: ColorReferenceSchema,
-  dependsOn: (input) =>
-    input.neutralFamilyName ? [input.familyName, input.neutralFamilyName] : [input.familyName],
+  dependsOn: (input) => [input.against],
   transform: (input, get) => {
-    const family = get(input.familyName) as ColorValueWithForegroundRefs | undefined;
+    const parent = get(input.against);
+    if (!parent || typeof parent !== 'object' || !('family' in parent) || !('position' in parent)) {
+      throw new Error(
+        `contrast plugin: parent token "${input.against}" did not resolve to a ColorReference`,
+      );
+    }
+    const parentRef = parent as { family: string; position: unknown };
+    if (!isPositionString(parentRef.position)) {
+      throw new Error(
+        `contrast plugin: parent token "${input.against}" position is not a scale string`,
+      );
+    }
+    const basePosition = resolveBasePosition(parentRef.position);
+
+    const family = get(parentRef.family) as ColorValueWithForegroundRefs | undefined;
     if (!family) {
-      throw new Error(`contrast plugin: family "${input.familyName}" not found in registry`);
+      throw new Error(
+        `contrast plugin: family "${parentRef.family}" (from "${input.against}") not in registry`,
+      );
     }
 
     if (family.foregroundReferences?.auto) {
@@ -53,40 +131,24 @@ export const contrastPlugin = definePlugin<ContrastInput, ColorReference>({
     }
 
     if (family.accessibility) {
-      const partner =
-        partnerForBase(family.accessibility.wcagAAA?.normal, input.basePosition) ??
-        partnerForBase(family.accessibility.wcagAA?.normal, input.basePosition);
+      const aaaPartner =
+        partnerForBase(family.accessibility.wcagAAA?.normal, basePosition) ??
+        nearestPartner(family.accessibility.wcagAAA?.normal, basePosition);
+      const aaPartner =
+        partnerForBase(family.accessibility.wcagAA?.normal, basePosition) ??
+        nearestPartner(family.accessibility.wcagAA?.normal, basePosition);
+      const partner = input.level === 'AAA' ? (aaaPartner ?? aaPartner) : aaPartner;
       if (partner !== undefined) {
         return {
-          family: input.familyName,
-          position: requireScalePosition(partner, `${input.familyName} pair`),
+          family: parentRef.family,
+          position: requireScalePosition(partner, `${parentRef.family} pair`),
         };
       }
-    }
-
-    if (input.neutralFamilyName) {
-      const neutral = get(input.neutralFamilyName) as ColorValue | undefined;
-      const aaaBest = neutral?.accessibility?.onWhite?.aaa?.[0];
-      if (aaaBest !== undefined) {
-        return {
-          family: input.neutralFamilyName,
-          position: requireScalePosition(aaaBest, `${input.neutralFamilyName} onWhite.aaa`),
-        };
-      }
-      const aaBest = neutral?.accessibility?.onWhite?.aa?.[0];
-      if (aaBest !== undefined) {
-        return {
-          family: input.neutralFamilyName,
-          position: requireScalePosition(aaBest, `${input.neutralFamilyName} onWhite.aa`),
-        };
-      }
-      throw new Error(
-        `contrast plugin: neutral family "${input.neutralFamilyName}" has no accessibility.onWhite data; cannot derive contrast partner`,
-      );
     }
 
     throw new Error(
-      `contrast plugin: family "${input.familyName}" has no foregroundReferences and no accessibility WCAG pairs; supply one or pass neutralFamilyName`,
+      `contrast plugin: family "${parentRef.family}" has no foregroundReferences and no accessibility ` +
+        `WCAG pair partner for position ${parentRef.position} (against ${input.against})`,
     );
   },
 });

--- a/packages/design-tokens/src/plugins/state.ts
+++ b/packages/design-tokens/src/plugins/state.ts
@@ -7,8 +7,7 @@ const StateTypeSchema = z.enum(['hover', 'active', 'focus', 'disabled']);
 type StateType = z.infer<typeof StateTypeSchema>;
 
 const StateInputSchema = z.object({
-  familyName: z.string(),
-  basePosition: z.number().int().min(0).max(10),
+  from: z.string(),
   stateType: StateTypeSchema,
 });
 
@@ -18,22 +17,35 @@ type ColorValueWithStateRefs = ColorValue & {
   stateReferences?: Record<string, { family: string; position: string }>;
 };
 
+const POSITION_TO_INDEX: Record<string, number> = {
+  '50': 0,
+  '100': 1,
+  '200': 2,
+  '300': 3,
+  '400': 4,
+  '500': 5,
+  '600': 6,
+  '700': 7,
+  '800': 8,
+  '900': 9,
+  '950': 10,
+};
+
 /**
- * Walk the family's WCAG-AAA pair ladder to derive a state variant.
+ * Walk the family's WCAG-AAA pair ladder to derive a state variant from a
+ * parent token's current value.
  *
- * "Like invert/contrast" -- the family's pre-computed pair list is the
- * source of truth. No hardcoded offset matrix. State variants step along
- * the RANK of accessible positions (positions that appear in at least one
- * wcagAAA pair). A family with more AAA-compliant positions gives finer
- * state steps; a family with fewer gives coarser ones. The math reads
- * the family's actual data, not a global constant.
+ * "Like invert/contrast" -- the family's pre-computed pair list is the source
+ * of truth. No hardcoded offset matrix. The `from` input is a TOKEN NAME --
+ * the cascade re-runs this transform whenever the parent's value changes, so
+ * the state variant always reflects the parent's current family and position.
  *
- * Ladder = sorted unique positions in any wcagAAA.normal pair. Base
+ * Ladder = sorted unique positions in any wcagAAA.normal pair. Parent
  * position must be on the ladder. Step per state type:
- *   hover    -> +1 rank (next accessible neighbour toward dark, clamped)
+ *   hover    -> +1 rank
  *   active   -> +2 rank
  *   focus    -> +1 rank (same as hover; the visual cue is the ring)
- *   disabled -> closest ladder rank to the family midpoint (position 5)
+ *   disabled -> ladder rank closest to family midpoint (position 5)
  */
 const STEP_BY_STATE: Record<StateType, (rank: number, ladder: readonly number[]) => number> = {
   hover: (rank) => rank + 1,
@@ -57,6 +69,21 @@ function closestRankToMidpoint(ladder: readonly number[]): number {
   return bestRank;
 }
 
+function nearestRankOnLadder(ladder: readonly number[], position: number): number {
+  let bestRank = 0;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (let r = 0; r < ladder.length; r++) {
+    const candidate = ladder[r];
+    if (candidate === undefined) continue;
+    const distance = Math.abs(candidate - position);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestRank = r;
+    }
+  }
+  return bestRank;
+}
+
 function collectLadder(pairs: readonly (readonly number[])[]): number[] {
   const positions = new Set<number>();
   for (const pair of pairs) {
@@ -69,11 +96,30 @@ export const statePlugin = definePlugin<StateInput, ColorReference>({
   name: 'state',
   inputSchema: StateInputSchema,
   outputSchema: ColorReferenceSchema,
-  dependsOn: (input) => [input.familyName],
+  dependsOn: (input) => [input.from],
   transform: (input, get) => {
-    const family = get(input.familyName) as ColorValueWithStateRefs | undefined;
+    const parent = get(input.from);
+    if (!parent || typeof parent !== 'object' || !('family' in parent) || !('position' in parent)) {
+      throw new Error(
+        `state plugin: parent token "${input.from}" did not resolve to a ColorReference`,
+      );
+    }
+    const parentRef = parent as { family: string; position: unknown };
+    if (typeof parentRef.position !== 'string') {
+      throw new Error(`state plugin: parent token "${input.from}" position is not a scale string`);
+    }
+    const basePosition = POSITION_TO_INDEX[parentRef.position];
+    if (basePosition === undefined) {
+      throw new Error(
+        `state plugin: parent token "${input.from}" position "${parentRef.position}" is not a known scale step`,
+      );
+    }
+
+    const family = get(parentRef.family) as ColorValueWithStateRefs | undefined;
     if (!family) {
-      throw new Error(`state plugin: family "${input.familyName}" not found in registry`);
+      throw new Error(
+        `state plugin: family "${parentRef.family}" (from "${input.from}") not in registry`,
+      );
     }
 
     const precomputed = family.stateReferences?.[input.stateType];
@@ -84,31 +130,29 @@ export const statePlugin = definePlugin<StateInput, ColorReference>({
     const pairs = family.accessibility?.wcagAAA?.normal;
     if (!pairs || pairs.length === 0) {
       throw new Error(
-        `state plugin: family "${input.familyName}" has no accessibility.wcagAAA.normal ladder (color generator must emit accessibility metadata)`,
+        `state plugin: family "${parentRef.family}" has no accessibility.wcagAAA.normal ladder (color generator must emit accessibility metadata)`,
       );
     }
     const ladder = collectLadder(pairs);
-    const baseRank = ladder.indexOf(input.basePosition);
-    if (baseRank === -1) {
-      throw new Error(
-        `state plugin: basePosition ${input.basePosition} for family "${input.familyName}" is not in the WCAG-AAA ladder`,
-      );
-    }
+    // If the parent position isn't itself on the AAA ladder, snap to the
+    // nearest ladder rank. Avoids throwing for positions like '600' that may
+    // not have any AAA partner in a given family but are valid scale steps.
+    const baseRank = nearestRankOnLadder(ladder, basePosition);
 
     const targetRank = STEP_BY_STATE[input.stateType](baseRank, ladder);
     const clampedRank = Math.max(0, Math.min(ladder.length - 1, targetRank));
     const targetIndex = ladder[clampedRank];
     if (targetIndex === undefined) {
       throw new Error(
-        `state plugin: ladder lookup failed for rank ${clampedRank} on family "${input.familyName}"`,
+        `state plugin: ladder lookup failed for rank ${clampedRank} on family "${parentRef.family}"`,
       );
     }
     const position = SCALE_POSITIONS[targetIndex];
     if (!position) {
       throw new Error(
-        `state plugin: invalid scale index ${targetIndex} for family "${input.familyName}"`,
+        `state plugin: invalid scale index ${targetIndex} for family "${parentRef.family}"`,
       );
     }
-    return { family: input.familyName, position };
+    return { family: parentRef.family, position };
   },
 });

--- a/packages/design-tokens/test/cascade.test.ts
+++ b/packages/design-tokens/test/cascade.test.ts
@@ -100,9 +100,9 @@ function setupSemanticChain(): TokenRegistry {
   // accent family → semantic primary (position 5) → primary-foreground, primary-hover, primary-hover-foreground
   // and dark counterparts via invert
   r.bind('primary', 'scale', { familyName: 'accent', scalePosition: 5 });
-  r.bind('primary-foreground', 'contrast', { familyName: 'accent', basePosition: 5 });
-  r.bind('primary-hover', 'state', { familyName: 'accent', basePosition: 5, stateType: 'hover' });
-  r.bind('primary-active', 'state', { familyName: 'accent', basePosition: 5, stateType: 'active' });
+  r.bind('primary-foreground', 'contrast', { against: 'primary', level: 'AAA' });
+  r.bind('primary-hover', 'state', { from: 'primary', stateType: 'hover' });
+  r.bind('primary-active', 'state', { from: 'primary', stateType: 'active' });
   r.bind('primary-dark', 'invert', { familyName: 'accent', basePosition: 5 });
   return r;
 }
@@ -148,7 +148,11 @@ describe('cascade integration', () => {
       expect(r.get('primary-hover')?.value).toEqual(manualHover);
     });
 
-    it('downstream of an anchor still flows from the anchor value (chained binding)', () => {
+    it('downstream of an anchor recomputes from the anchor value (chained binding)', () => {
+      // The override on primary remaps to a different position; primary-fg
+      // re-derives via contrast against the new position. The anchor on
+      // primary blocks scale@accent@5 from clobbering it; primary-fg's
+      // contrast binding still re-runs because primary changed.
       const r = new TokenRegistry(
         [
           buildAccentToken(buildAccentFamily()),
@@ -158,12 +162,16 @@ describe('cascade integration', () => {
         [scalePlugin, contrastPlugin],
       );
       r.bind('primary', 'scale', { familyName: 'accent', scalePosition: 5 });
-      r.bind('primary-fg', 'contrast', { familyName: 'accent', basePosition: 5 });
+      r.bind('primary-fg', 'contrast', { against: 'primary', level: 'AAA' });
 
       const downstreamBefore = r.get('primary-fg')?.value;
-      r.set('primary', { family: 'override', position: 'manual' }, { reason: 'manual' });
+      // Override primary to a valid position; the WCAG pair list has [5,0]
+      // so contrast partner of position 5 is position 0. Move primary to
+      // position 8 (which the family's pair list also covers: [8, 0]).
+      r.set('primary', { family: 'accent', position: '800' }, { reason: 'manual' });
       expect(r.get('primary')?.userOverride?.reason).toBe('manual');
       const downstreamAfter = r.get('primary-fg')?.value;
+      // Both positions 5 and 8 pair with position 0 in the test family.
       expect(downstreamAfter).toEqual(downstreamBefore);
     });
   });
@@ -209,11 +217,7 @@ describe('cascade integration', () => {
       );
       r.bind('primary', 'scale', { familyName: 'accent', scalePosition: 5 });
       // primary-hover depends on accent (basePosition + offset → '600' position)
-      r.bind('primary-hover', 'state', {
-        familyName: 'accent',
-        basePosition: 5,
-        stateType: 'hover',
-      });
+      r.bind('primary-hover', 'state', { from: 'primary', stateType: 'hover' });
       r.set('accent', buildAccentFamily('mutated'), { reason: 'test' });
       expect(r.get('primary')?.value).toEqual({ family: 'accent', position: '500' });
       expect(r.get('primary-hover')?.value).toEqual({ family: 'accent', position: '600' });

--- a/packages/design-tokens/test/exporters-parity.test.ts
+++ b/packages/design-tokens/test/exporters-parity.test.ts
@@ -7,14 +7,18 @@ import {
 import { describe, expect, it } from 'vitest';
 import { registryToTailwind, registryToTypeScript, toDTCG } from '../src/exporters/index.js';
 import { generateBaseSystem as generateNew } from '../src/generators/index.js';
-import { scalePlugin } from '../src/plugins/index.js';
+import { contrastPlugin, scalePlugin, statePlugin } from '../src/plugins/index.js';
 import { TokenRegistry } from '../src/registry.js';
 
 describe('exporters parity vs v1', () => {
   it('Tailwind exporter produces output of comparable shape', () => {
     const next = generateNew();
     const v1Registry = new V1TokenRegistry(next.allTokens);
-    const newRegistry = new TokenRegistry(next.allTokens, [scalePlugin]);
+    const newRegistry = new TokenRegistry(next.allTokens, [
+      scalePlugin,
+      contrastPlugin,
+      statePlugin,
+    ]);
 
     const v1Output = v1RegistryToTailwind(v1Registry);
     const newOutput = registryToTailwind(newRegistry);
@@ -32,7 +36,11 @@ describe('exporters parity vs v1', () => {
   it('TypeScript exporter produces output of comparable shape', () => {
     const next = generateNew();
     const v1Registry = new V1TokenRegistry(next.allTokens);
-    const newRegistry = new TokenRegistry(next.allTokens, [scalePlugin]);
+    const newRegistry = new TokenRegistry(next.allTokens, [
+      scalePlugin,
+      contrastPlugin,
+      statePlugin,
+    ]);
 
     const v1Output = v1RegistryToTypeScript(v1Registry);
     const newOutput = registryToTypeScript(newRegistry);

--- a/packages/design-tokens/test/generators-parity.test.ts
+++ b/packages/design-tokens/test/generators-parity.test.ts
@@ -8,12 +8,26 @@ function stripVolatile(t: AnyToken): AnyToken {
   const {
     generatedAt: _generatedAt,
     binding: _binding,
+    dependsOn: _dependsOn,
+    generationRule: _generationRule,
     value,
     ...rest
-  } = t as AnyToken & { generatedAt?: string; binding?: unknown; value?: unknown };
-  // Color family values now carry `accessibility` (new package only, see #1496).
-  // Strip it from the parity comparison so the rest of the token contract
-  // stays comparable to v1's output.
+  } = t as AnyToken & {
+    generatedAt?: string;
+    binding?: unknown;
+    dependsOn?: unknown;
+    generationRule?: unknown;
+    value?: unknown;
+  };
+  // Two legitimate divergences from v1 (PR #1495 / #1496):
+  // - new package emits binding (state@parent, contrast@parent, scale@family)
+  //   where v1 emitted a generationRule string. Different graph encoding,
+  //   same observable cascade behaviour. Both fields stripped.
+  // - new package emits dependsOn=[parent] for derived semantics where v1
+  //   emitted [family, dark-counterpart]. Real graph relationship in the new
+  //   package; cosmetic typed convention in v1. Strip from comparison.
+  // - color family values now carry `accessibility` in the new package only.
+  //   Strip from the inner value object.
   if (value && typeof value === 'object' && 'accessibility' in value) {
     const { accessibility: _accessibility, ...valueRest } = value as Record<string, unknown>;
     return { ...rest, value: valueRest };

--- a/packages/design-tokens/test/plugins/contrast.test.ts
+++ b/packages/design-tokens/test/plugins/contrast.test.ts
@@ -3,22 +3,17 @@ import { describe, expect, it } from 'vitest';
 import { contrastPlugin, TokenGraph } from '../../src/index.js';
 import { MINIMAL_SCALE as minimalScale } from './_fixtures.js';
 
+const ACCENT_AAA_PAIR = {
+  wcagAAA: { normal: [[5, 0]] as number[][], large: [] as number[][] },
+  wcagAA: { normal: [] as number[][], large: [] as number[][] },
+};
+
 describe('contrastPlugin', () => {
-  it('declares dependency on the family name', () => {
-    expect(contrastPlugin.dependsOn({ familyName: 'accent', basePosition: 5 })).toEqual(['accent']);
+  it('declares dependency on the parent token (against)', () => {
+    expect(contrastPlugin.dependsOn({ against: 'primary', level: 'AAA' })).toEqual(['primary']);
   });
 
-  it('declares dependency on neutral family when present', () => {
-    expect(
-      contrastPlugin.dependsOn({
-        familyName: 'accent',
-        basePosition: 5,
-        neutralFamilyName: 'gray',
-      }),
-    ).toEqual(['accent', 'gray']);
-  });
-
-  it('uses pre-computed foregroundReferences.auto when present', () => {
+  it('uses pre-computed foregroundReferences.auto when present on the parent family', () => {
     const family = {
       name: 'accent',
       scale: minimalScale,
@@ -26,26 +21,25 @@ describe('contrastPlugin', () => {
     } as ColorValue;
     const g = new TokenGraph([contrastPlugin]);
     g.seed('accent', family);
-    g.bind('accent-fg', 'contrast', { familyName: 'accent', basePosition: 5 });
-    expect(g.get('accent-fg')).toEqual({ family: 'gray', position: '50' });
+    g.seed('primary', { family: 'accent', position: '500' });
+    g.bind('primary-fg', 'contrast', { against: 'primary', level: 'AAA' });
+    expect(g.get('primary-fg')).toEqual({ family: 'gray', position: '50' });
   });
 
-  it('uses WCAG AAA pair from family accessibility data', () => {
+  it('uses WCAG AAA pair from the parent family accessibility data', () => {
     const family: ColorValue = {
       name: 'accent',
       scale: minimalScale,
-      accessibility: {
-        wcagAAA: { normal: [[5, 0]], large: [] },
-        wcagAA: { normal: [], large: [] },
-      },
+      accessibility: ACCENT_AAA_PAIR,
     };
     const g = new TokenGraph([contrastPlugin]);
     g.seed('accent', family);
-    g.bind('accent-fg', 'contrast', { familyName: 'accent', basePosition: 5 });
-    expect(g.get('accent-fg')).toEqual({ family: 'accent', position: '50' });
+    g.seed('primary', { family: 'accent', position: '500' });
+    g.bind('primary-fg', 'contrast', { against: 'primary', level: 'AAA' });
+    expect(g.get('primary-fg')).toEqual({ family: 'accent', position: '50' });
   });
 
-  it('falls back to WCAG AA when no AAA pair', () => {
+  it('falls back to WCAG AA when no AAA pair (level=AAA tries AAA then AA)', () => {
     const family: ColorValue = {
       name: 'accent',
       scale: minimalScale,
@@ -56,53 +50,50 @@ describe('contrastPlugin', () => {
     };
     const g = new TokenGraph([contrastPlugin]);
     g.seed('accent', family);
-    g.bind('accent-fg', 'contrast', { familyName: 'accent', basePosition: 5 });
-    expect(g.get('accent-fg')).toEqual({ family: 'accent', position: '950' });
+    g.seed('primary', { family: 'accent', position: '500' });
+    g.bind('primary-fg', 'contrast', { against: 'primary', level: 'AAA' });
+    expect(g.get('primary-fg')).toEqual({ family: 'accent', position: '950' });
   });
 
-  it('falls back to neutral family AAA when source has no usable contrast', () => {
-    const family: ColorValue = { name: 'accent', scale: minimalScale };
-    const neutral: ColorValue = {
-      name: 'gray',
+  it('cascade: foreground recomputes when parent value remaps to a different family', () => {
+    const accent: ColorValue = {
+      name: 'accent',
+      scale: minimalScale,
+      accessibility: ACCENT_AAA_PAIR,
+    };
+    const yellow: ColorValue = {
+      name: 'yellow',
       scale: minimalScale,
       accessibility: {
-        wcagAAA: { normal: [], large: [] },
+        wcagAAA: { normal: [[5, 10]], large: [] },
         wcagAA: { normal: [], large: [] },
-        onWhite: { aaa: [9], aa: [], normal: [], large: [] },
       },
     };
     const g = new TokenGraph([contrastPlugin]);
-    g.seed('accent', family);
-    g.seed('gray', neutral);
-    g.bind('accent-fg', 'contrast', {
-      familyName: 'accent',
-      basePosition: 5,
-      neutralFamilyName: 'gray',
-    });
-    expect(g.get('accent-fg')).toEqual({ family: 'gray', position: '900' });
+    g.seed('accent', accent);
+    g.seed('yellow', yellow);
+    g.seed('primary', { family: 'accent', position: '500' });
+    g.bind('primary-fg', 'contrast', { against: 'primary', level: 'AAA' });
+    expect(g.get('primary-fg')).toEqual({ family: 'accent', position: '50' });
+    g.set('primary', { family: 'yellow', position: '500' }, { reason: 'remap' });
+    expect(g.get('primary-fg')).toEqual({ family: 'yellow', position: '950' });
   });
 
-  it('throws when neutral family has no accessibility.onWhite data', () => {
-    const family: ColorValue = { name: 'accent', scale: minimalScale };
-    const neutral: ColorValue = { name: 'gray', scale: minimalScale };
+  it('throws when the parent token did not resolve to a ColorReference', () => {
     const g = new TokenGraph([contrastPlugin]);
-    g.seed('accent', family);
-    g.seed('gray', neutral);
-    expect(() =>
-      g.bind('light-fg', 'contrast', {
-        familyName: 'accent',
-        basePosition: 3,
-        neutralFamilyName: 'gray',
-      }),
-    ).toThrow(/no accessibility\.onWhite data/);
+    g.seed('not-a-color-ref', 'some-string');
+    expect(() => g.bind('fg', 'contrast', { against: 'not-a-color-ref', level: 'AAA' })).toThrow(
+      /did not resolve to a ColorReference/,
+    );
   });
 
-  it('throws when family has no foregroundReferences and no WCAG pairs', () => {
+  it('throws when the parent family has neither foregroundReferences nor WCAG pairs', () => {
     const family: ColorValue = { name: 'accent', scale: minimalScale };
     const g = new TokenGraph([contrastPlugin]);
     g.seed('accent', family);
-    expect(() => g.bind('fg-light', 'contrast', { familyName: 'accent', basePosition: 2 })).toThrow(
-      /no foregroundReferences and no accessibility WCAG pairs/,
+    g.seed('primary', { family: 'accent', position: '500' });
+    expect(() => g.bind('primary-fg', 'contrast', { against: 'primary', level: 'AAA' })).toThrow(
+      /no foregroundReferences and no accessibility/,
     );
   });
 });

--- a/packages/design-tokens/test/plugins/state.test.ts
+++ b/packages/design-tokens/test/plugins/state.test.ts
@@ -3,9 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { statePlugin, TokenGraph } from '../../src/index.js';
 import { MINIMAL_SCALE as minimalScale } from './_fixtures.js';
 
-// Realistic-ish accessibility metadata: every position pairs with every position
-// that has at least a 4-step lightness gap. The set of positions in the ladder
-// is {0, 1, 2, ..., 10} (all positions show up in some pair).
+// Ladder positions sorted: [0, 1, 2, 3, 7, 8, 9, 10].
 const fullLadderAccessibility = {
   wcagAAA: {
     normal: [
@@ -30,111 +28,121 @@ const fullLadderAccessibility = {
   onBlack: { wcagAA: true, wcagAAA: true, contrastRatio: 7, aa: [], aaa: [] },
 };
 
+function seedFamily(g: TokenGraph, name: string, opts?: Partial<ColorValue>): void {
+  g.seed(name, { name, scale: minimalScale, ...opts } as ColorValue);
+}
+
 describe('statePlugin', () => {
-  it('declares dependency on the family name', () => {
-    expect(
-      statePlugin.dependsOn({ familyName: 'accent', basePosition: 5, stateType: 'hover' }),
-    ).toEqual(['accent']);
+  it('declares dependency on the parent token (from)', () => {
+    expect(statePlugin.dependsOn({ from: 'primary', stateType: 'hover' })).toEqual(['primary']);
   });
 
-  it('uses pre-computed stateReferences when present', () => {
-    const family = {
-      name: 'accent',
-      scale: minimalScale,
+  it('uses pre-computed stateReferences on the parent family when present', () => {
+    const g = new TokenGraph([statePlugin]);
+    seedFamily(g, 'accent', {
       stateReferences: {
         hover: { family: 'accent', position: '700' },
         active: { family: 'accent', position: '800' },
       },
-    } as ColorValue;
-    const g = new TokenGraph([statePlugin]);
-    g.seed('accent', family);
-    g.bind('hover', 'state', { familyName: 'accent', basePosition: 5, stateType: 'hover' });
-    g.bind('active', 'state', { familyName: 'accent', basePosition: 5, stateType: 'active' });
-    expect(g.get('hover')).toEqual({ family: 'accent', position: '700' });
-    expect(g.get('active')).toEqual({ family: 'accent', position: '800' });
+    });
+    g.seed('primary', { family: 'accent', position: '500' });
+    g.bind('primary-hover', 'state', { from: 'primary', stateType: 'hover' });
+    g.bind('primary-active', 'state', { from: 'primary', stateType: 'active' });
+    expect(g.get('primary-hover')).toEqual({ family: 'accent', position: '700' });
+    expect(g.get('primary-active')).toEqual({ family: 'accent', position: '800' });
   });
 
   it('walks the WCAG-AAA ladder for hover/active/focus', () => {
-    // Ladder positions sorted: [0, 1, 2, 3, 7, 8, 9, 10].
-    // Base 8 has rank 5 in the ladder.
+    // Ladder = [0, 1, 2, 3, 7, 8, 9, 10]. Parent at position 8 has rank 5.
     // hover  rank +1 -> rank 6 -> position 9.
     // active rank +2 -> rank 7 -> position 10.
-    // focus  rank +1 -> rank 6 -> position 9 (same as hover).
-    const family = {
-      name: 'accent',
-      scale: minimalScale,
-      accessibility: fullLadderAccessibility,
-    } as ColorValue;
+    // focus  rank +1 -> rank 6 -> position 9.
     const g = new TokenGraph([statePlugin]);
-    g.seed('accent', family);
-    g.bind('hover', 'state', { familyName: 'accent', basePosition: 8, stateType: 'hover' });
-    g.bind('active', 'state', { familyName: 'accent', basePosition: 8, stateType: 'active' });
-    g.bind('focus', 'state', { familyName: 'accent', basePosition: 8, stateType: 'focus' });
-    expect(g.get('hover')).toEqual({ family: 'accent', position: '900' });
-    expect(g.get('active')).toEqual({ family: 'accent', position: '950' });
-    expect(g.get('focus')).toEqual({ family: 'accent', position: '900' });
+    seedFamily(g, 'accent', { accessibility: fullLadderAccessibility });
+    g.seed('primary', { family: 'accent', position: '800' });
+    g.bind('primary-hover', 'state', { from: 'primary', stateType: 'hover' });
+    g.bind('primary-active', 'state', { from: 'primary', stateType: 'active' });
+    g.bind('primary-focus', 'state', { from: 'primary', stateType: 'focus' });
+    expect(g.get('primary-hover')).toEqual({ family: 'accent', position: '900' });
+    expect(g.get('primary-active')).toEqual({ family: 'accent', position: '950' });
+    expect(g.get('primary-focus')).toEqual({ family: 'accent', position: '900' });
   });
 
   it('disabled returns the ladder rank closest to the family midpoint (position 5)', () => {
-    // Ladder positions sorted: [0, 1, 2, 3, 7, 8, 9, 10]. Closest to 5 is 3 (distance 2)
-    // or 7 (distance 2) -- first hit wins, which is rank 3 -> position 3.
-    const family = {
-      name: 'accent',
-      scale: minimalScale,
-      accessibility: fullLadderAccessibility,
-    } as ColorValue;
     const g = new TokenGraph([statePlugin]);
-    g.seed('accent', family);
-    g.bind('disabled', 'state', { familyName: 'accent', basePosition: 8, stateType: 'disabled' });
-    expect(g.get('disabled')).toEqual({ family: 'accent', position: '300' });
+    seedFamily(g, 'accent', { accessibility: fullLadderAccessibility });
+    g.seed('primary', { family: 'accent', position: '800' });
+    g.bind('primary-disabled', 'state', { from: 'primary', stateType: 'disabled' });
+    expect(g.get('primary-disabled')).toEqual({ family: 'accent', position: '300' });
   });
 
   it('clamps ladder steps at the top boundary', () => {
-    const family = {
-      name: 'accent',
-      scale: minimalScale,
-      accessibility: fullLadderAccessibility,
-    } as ColorValue;
     const g = new TokenGraph([statePlugin]);
-    g.seed('accent', family);
-    // Base at position 10 has the top rank. hover +1 clamps to top -> position 10.
-    g.bind('top-hover', 'state', { familyName: 'accent', basePosition: 10, stateType: 'hover' });
-    expect(g.get('top-hover')).toEqual({ family: 'accent', position: '950' });
+    seedFamily(g, 'accent', { accessibility: fullLadderAccessibility });
+    g.seed('primary', { family: 'accent', position: '950' });
+    g.bind('primary-hover', 'state', { from: 'primary', stateType: 'hover' });
+    expect(g.get('primary-hover')).toEqual({ family: 'accent', position: '950' });
   });
 
-  it('throws when the family has no accessibility.wcagAAA ladder', () => {
-    const family: ColorValue = { name: 'accent', scale: minimalScale };
+  it('cascade: state recomputes when parent remaps to a different family', () => {
+    // Both families have a ladder. After remap, hover walks yellow's ladder.
     const g = new TokenGraph([statePlugin]);
-    g.seed('accent', family);
-    expect(() =>
-      g.bind('hover', 'state', { familyName: 'accent', basePosition: 5, stateType: 'hover' }),
-    ).toThrow(/no accessibility\.wcagAAA\.normal ladder/);
+    seedFamily(g, 'accent', { accessibility: fullLadderAccessibility });
+    seedFamily(g, 'yellow', {
+      accessibility: {
+        wcagAAA: {
+          normal: [
+            [5, 0],
+            [5, 1],
+            [6, 0],
+            [7, 0],
+          ],
+          large: [],
+        },
+        wcagAA: { normal: [], large: [] },
+        onWhite: { wcagAA: true, wcagAAA: true, contrastRatio: 7, aa: [], aaa: [] },
+        onBlack: { wcagAA: true, wcagAAA: true, contrastRatio: 7, aa: [], aaa: [] },
+      },
+    });
+    g.seed('primary', { family: 'accent', position: '800' });
+    g.bind('primary-hover', 'state', { from: 'primary', stateType: 'hover' });
+    expect(g.get('primary-hover')).toEqual({ family: 'accent', position: '900' });
+    g.set('primary', { family: 'yellow', position: '500' }, { reason: 'remap to yellow' });
+    // Yellow ladder = [0, 1, 5, 6, 7]; rank of 5 is 2; hover +1 -> rank 3 -> position 6 -> '600'.
+    expect(g.get('primary-hover')).toEqual({ family: 'yellow', position: '600' });
   });
 
-  it('throws when basePosition is not on the ladder', () => {
-    // Ladder = [0, 1, 2, 3, 7, 8, 9, 10]; 5 is not on it.
-    const family = {
-      name: 'accent',
-      scale: minimalScale,
-      accessibility: fullLadderAccessibility,
-    } as ColorValue;
+  it('throws when the parent token did not resolve to a ColorReference', () => {
     const g = new TokenGraph([statePlugin]);
-    g.seed('accent', family);
-    expect(() =>
-      g.bind('hover', 'state', { familyName: 'accent', basePosition: 5, stateType: 'hover' }),
-    ).toThrow(/not in the WCAG-AAA ladder/);
+    g.seed('not-a-color-ref', 'some-string');
+    expect(() => g.bind('x', 'state', { from: 'not-a-color-ref', stateType: 'hover' })).toThrow(
+      /did not resolve to a ColorReference/,
+    );
+  });
+
+  it('throws when the parent family has no accessibility.wcagAAA ladder', () => {
+    const g = new TokenGraph([statePlugin]);
+    seedFamily(g, 'accent');
+    g.seed('primary', { family: 'accent', position: '500' });
+    expect(() => g.bind('primary-hover', 'state', { from: 'primary', stateType: 'hover' })).toThrow(
+      /no accessibility\.wcagAAA\.normal ladder/,
+    );
+  });
+
+  it('snaps to the nearest ladder rank when parent position is not directly on the ladder', () => {
+    // Ladder = [0, 1, 2, 3, 7, 8, 9, 10]. Position 5 is off the ladder.
+    // Nearest is 3 (distance 2) -- first hit wins. hover +1 rank -> rank 4 -> position 7.
+    const g = new TokenGraph([statePlugin]);
+    seedFamily(g, 'accent', { accessibility: fullLadderAccessibility });
+    g.seed('primary', { family: 'accent', position: '500' });
+    g.bind('primary-hover', 'state', { from: 'primary', stateType: 'hover' });
+    expect(g.get('primary-hover')).toEqual({ family: 'accent', position: '700' });
   });
 
   it('rejects invalid stateType via Zod', () => {
-    const family = {
-      name: 'accent',
-      scale: minimalScale,
-      accessibility: fullLadderAccessibility,
-    } as ColorValue;
     const g = new TokenGraph([statePlugin]);
-    g.seed('accent', family);
-    expect(() =>
-      g.bind('x', 'state', { familyName: 'accent', basePosition: 5, stateType: 'pressed' }),
-    ).toThrow();
+    seedFamily(g, 'accent', { accessibility: fullLadderAccessibility });
+    g.seed('primary', { family: 'accent', position: '500' });
+    expect(() => g.bind('x', 'state', { from: 'primary', stateType: 'pressed' })).toThrow();
   });
 });

--- a/packages/design-tokens/test/registry.test.ts
+++ b/packages/design-tokens/test/registry.test.ts
@@ -125,7 +125,7 @@ describe('TokenRegistry', () => {
         [scalePlugin, contrastPlugin],
       );
       r.bind('accent-500', 'scale', { familyName: 'accent', scalePosition: 5 });
-      r.bind('accent-fg', 'contrast', { familyName: 'accent', basePosition: 5 });
+      r.bind('accent-fg', 'contrast', { against: 'accent-500', level: 'AAA' });
       expect(r.get('accent-500')?.value).toEqual({ family: 'accent', position: '500' });
       expect(r.get('accent-fg')?.value).toBeDefined();
     });
@@ -136,11 +136,7 @@ describe('TokenRegistry', () => {
         [scalePlugin, statePlugin],
       );
       r.bind('accent-500', 'scale', { familyName: 'accent', scalePosition: 5 });
-      r.bind('accent-hover', 'state', {
-        familyName: 'accent',
-        basePosition: 5,
-        stateType: 'hover',
-      });
+      r.bind('accent-hover', 'state', { from: 'accent-500', stateType: 'hover' });
       const newAccent = { ...accentToken.value, name: 'mutated' } as ColorValue;
       r.set('accent', newAccent, { reason: 'test mutation' });
       expect(r.get('accent')?.value).toEqual(newAccent);


### PR DESCRIPTION
## Summary

Closes #1495. Last piece of the cascade story: the semantic generator describes what each token IS and how it derives, so the cascade has a real chain to walk.

End-to-end: `rafters set primary-hover '{family:silver-true-citrine,position:500}' --reason "..."` -> primary-hover-foreground recomputes via WCAG-AAA contrast against the new yellow value. Subsequent `rafters set neutral <green>` -> primary re-derives in green, primary-hover (override) holds at citrine, primary-hover-foreground stays cascaded from the anchor.

## What changed

**1. Semantic generator emits a derivation tree.** `packages/design-tokens/src/generators/semantic.ts` pattern-matches the token name:

| Suffix | Plugin | Parent |
|---|---|---|
| `-hover` / `-active` / `-focus` / `-disabled` | state | parent semantic |
| `-foreground` / `-text` / `-contrast` | contrast | parent semantic (foreground branch matches FIRST so `-hover-foreground` resolves to contrast against `primary-hover`, not as a state variant) |
| everything else (base, `-ring`, etc.) | scale | family at mapped position |

`Token.dependsOn[0]` is the actual cascade parent. The dark-counterpart token stays at `dependsOn[1]` for the Tailwind exporter typed convention.

**2. Contrast and state plugins read a parent TOKEN.**

- Contrast input: `{against: <tokenName>, level?: 'AA' | 'AAA'}`. `dependsOn = [against]`. Reads `get(against)` → ColorReference, resolves family, walks `wcagAAA.normal` pair list (falls back to AA), returns partner. If no exact partner, walks the nearest position with a partner -- families whose pair list has gaps don't throw.
- State input: `{from: <tokenName>, stateType}`. `dependsOn = [from]`. Reads `get(from)` → ColorReference, resolves family, walks `wcagAAA.normal` ladder by rank. If parent position isn't on the ladder, snaps to nearest ladder rank.

Cascade behaviour: when a parent's value changes, `cascadeFrom(parent)` walks dependents -- contrast/state bindings re-run with `get(parent)` returning the new value, plugin computes against the new family's accessibility data.

**3. CLI `set` rebakes accessibility on family ColorValue sets.** `packages/cli/src/commands/set.ts`: `bakeAccessibility()` runs `generateAccessibilityMetadata` over the new scale and computes `onWhite`/`onBlack` ratios. Without this, `rafters set neutral <new-scale>` lands a ColorValue without accessibility, and the next cascade throws because contrast/state plugins can't find pair data. No-op for string and ColorReference values.

`init.ts`: `REGISTRY_PLUGINS = [scalePlugin, contrastPlugin, statePlugin, invertPlugin]` is the canonical plugin set everywhere a registry is constructed or loaded. The new tree exercises all four at init time.

## End-to-end smoke (apps/demo)

```bash
rafters init --framework astro
# primary:                  neutral-900    binding scale@neutral@9
# primary-foreground:       neutral-50     binding contrast@primary
# primary-hover:            neutral-950    binding state@primary,hover
# primary-hover-foreground: neutral-50     binding contrast@primary-hover

rafters set primary-hover '{family:silver-true-citrine,position:500}' \
  --reason "designer wants yellow hover"
# primary-hover:            silver-true-citrine-500  userOverride={previous:neutral-950, reason}
# primary-hover-foreground: silver-true-citrine-900  CASCADED via contrast against yellow

rafters set neutral <green-scale> --reason "remap to green"
# primary:                  neutral-900    re-derived in green
# primary-foreground:       neutral-50     re-derived via contrast against green primary
# primary-hover:            silver-true-citrine-500  override HOLDS
# primary-hover-foreground: silver-true-citrine-900  downstream of anchor, still yellow
```

## Test plan

- [x] `pnpm --filter @rafters/design-tokens typecheck` -- clean
- [x] `pnpm --filter @rafters/design-tokens test` -- 103 passing (plugin tests rewritten for new input shapes, parity tests strip dependsOn + generationRule for legitimate new-package divergence)
- [x] `pnpm --filter rafters typecheck` -- clean
- [x] `pnpm --filter rafters test:unit` -- 349 passing + 12 skipped
- [x] apps/demo end-to-end smoke -- the table above
- [x] Pre-push preflight -- green
- [x] `legion-simplify` quality gate -- clean

## Out of scope (follow-ups, lower priority)

- Family-set cascade doesn't reach tokens that override INTO that family (e.g. primary-hover overridden to yellow, then yellow family itself changes -- primary-hover-foreground doesn't recompute because the binding tracks dependents statically by token name, not by current-value family). The architecture trades dynamic dependency tracking for static cascade walks; this is the accepted simplification per the architecture discussion. If it becomes a real pain point, file a follow-up.
- Per-generator `DEFAULT_<NS>_CONFIG` breakout for the semantic mappings (so designers can shift the derivation tree without editing defaults.ts). Already an open item from the original snooze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)