### PR TITLE
feat(cli): importers detect color ramps as palettes (#1402)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Minor Changes
+
+- feat(onboard): importers now detect complete color ramps (`--name-50` ... `--name-950`) as palettes instead of flat-lifting each step into an unrelated token (#1402). A ramp is recognised when at least seven Tailwind scale positions of a single family are present; partial ramps stay flat. Detection runs across the Tailwind v4, shadcn, and generic CSS importers via a shared `ramp-detector` utility. `.rafters/import-pending.json` gains an optional `palettes[]` block alongside `tokens[]`; tokens promoted into a palette do not also appear in `tokens[]`. Downstream registry materialization is a separate follow-up.
+
 ### Breaking Changes
 
 - breaking(set): every `rafters set <name> <value>` records a `userOverride` diary entry (previousValue + reason) on the token, and the resulting node becomes a cascade anchor -- future upstream changes do not clobber it. Downstream dependents still re-derive against the anchor's new value. The `--no-cascade` flag is removed; the only meaningful flag is now `--reason "..."` (required in `--agent` mode; interactive prompt otherwise). This fixes a silent-clobber bug where cascade-mode sets saved a value, left the binding pointing at the old upstream, and got reverted the next time the upstream changed. Matches the registry's new `set(name, value, { reason })` signature -- the `cascade` option is gone from the public API.

--- a/packages/cli/src/onboard/importers/generic-css.ts
+++ b/packages/cli/src/onboard/importers/generic-css.ts
@@ -9,6 +9,7 @@ import { readFile } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import type { Token } from '@rafters/shared';
 import { type CSSVariable, parseCSSFile } from '../css-parser.js';
+import { detectRamps } from './ramp-detector.js';
 import type { Importer, ImporterDetection, ImportResult, ImportWarning } from './types.js';
 
 // Common CSS file locations to scan
@@ -237,6 +238,7 @@ export const genericCSSImporter: Importer = {
       if (!sourcePath) {
         return {
           tokens: [],
+          palettes: [],
           warnings: [{ level: 'error', message: 'No source path found' }],
           source: 'generic-css',
           variablesProcessed: 0,
@@ -252,6 +254,7 @@ export const genericCSSImporter: Importer = {
         const message = err instanceof Error ? err.message : String(err);
         return {
           tokens: [],
+          palettes: [],
           warnings: [{ level: 'error', message: `Failed to read CSS file: ${message}` }],
           source: 'generic-css',
           variablesProcessed: 0,
@@ -266,6 +269,7 @@ export const genericCSSImporter: Importer = {
         const message = err instanceof Error ? err.message : String(err);
         return {
           tokens: [],
+          palettes: [],
           warnings: [{ level: 'error', message: `Failed to parse CSS: ${message}` }],
           source: 'generic-css',
           variablesProcessed: 0,
@@ -297,12 +301,15 @@ export const genericCSSImporter: Importer = {
       }
     }
 
+    const { palettes, remaining } = detectRamps(tokens);
+
     return {
-      tokens,
+      tokens: remaining,
+      palettes,
       warnings,
       source: 'generic-css',
       variablesProcessed,
-      tokensCreated: tokens.length,
+      tokensCreated: remaining.length + palettes.reduce((n, p) => n + p.steps.length, 0),
       skipped,
     };
   },

--- a/packages/cli/src/onboard/importers/ramp-detector.ts
+++ b/packages/cli/src/onboard/importers/ramp-detector.ts
@@ -1,0 +1,135 @@
+/**
+ * Color Ramp Detector
+ *
+ * Shared utility used by importers to recover palette structure that is
+ * otherwise lost when CSS custom properties are flat-lifted into tokens.
+ *
+ * A ramp is a set of sibling tokens whose names share a common prefix and
+ * differ only by a trailing Tailwind-scale position (50/100/.../900/950).
+ * When at least MIN_RAMP_STEPS contiguous-ish positions of a family are
+ * present, they are grouped into a single DetectedPalette and removed from
+ * the flat token list. Partial ramps (fewer steps) stay flat.
+ *
+ * Spacing-style numeric suffixes (--spacing-4, --spacing-8) are not picked
+ * up because their positions are not in the Tailwind color scale set.
+ */
+
+import type { Token } from '@rafters/shared';
+
+/**
+ * Tailwind v4 color scale positions in canonical ascending order.
+ * Used both for membership tests and for sorting palette steps.
+ */
+export const TAILWIND_RAMP_POSITIONS = [
+  '50',
+  '100',
+  '200',
+  '300',
+  '400',
+  '500',
+  '600',
+  '700',
+  '800',
+  '900',
+  '950',
+] as const;
+
+export type TailwindRampPosition = (typeof TAILWIND_RAMP_POSITIONS)[number];
+
+const POSITION_INDEX: Map<string, number> = new Map(TAILWIND_RAMP_POSITIONS.map((p, i) => [p, i]));
+
+/**
+ * Minimum number of Tailwind positions required for a ramp to be recognised.
+ *
+ * Aligned with the brand-system heuristic in #1401: seven steps is enough to
+ * imply intentional ramp design (matches the 50, 100, 300, 500, 700, 900, 950
+ * subset and any superset). Below this we treat the variables as incidental
+ * and keep them flat.
+ */
+export const MIN_RAMP_STEPS = 7;
+
+const NAME_PATTERN = /^(.+)-(\d+)$/;
+
+export interface DetectedPaletteStep {
+  position: TailwindRampPosition;
+  token: Token;
+}
+
+export interface DetectedPalette {
+  /** Family prefix shared by every step (e.g. "empire"). */
+  name: string;
+  /** Detected scale type. Only Tailwind is supported in #1402. */
+  scale: 'tailwind';
+  /** Steps ordered ascending by Tailwind position. */
+  steps: DetectedPaletteStep[];
+}
+
+export interface RampDetectionResult {
+  /** Palettes detected from the input. Empty if no ramps reached the threshold. */
+  palettes: DetectedPalette[];
+  /** Tokens that did not participate in any palette, preserved in input order. */
+  remaining: Token[];
+}
+
+interface Candidate {
+  prefix: string;
+  steps: Map<TailwindRampPosition, Token>;
+}
+
+function isTailwindPosition(value: string): value is TailwindRampPosition {
+  return POSITION_INDEX.has(value);
+}
+
+function splitName(name: string): { prefix: string; position: TailwindRampPosition } | null {
+  const match = name.match(NAME_PATTERN);
+  if (!match) return null;
+  const [, prefix, positionRaw] = match;
+  if (!prefix || !positionRaw) return null;
+  if (!isTailwindPosition(positionRaw)) return null;
+  return { prefix, position: positionRaw };
+}
+
+/**
+ * Group tokens by `(prefix, tailwindPosition)` and emit palettes for any
+ * group that reaches MIN_RAMP_STEPS. Tokens not promoted to a palette are
+ * returned in `remaining`, preserving their original ordering.
+ */
+export function detectRamps(tokens: readonly Token[]): RampDetectionResult {
+  const candidates: Map<string, Candidate> = new Map();
+  const consumed: Set<Token> = new Set();
+
+  for (const token of tokens) {
+    const split = splitName(token.name);
+    if (!split) continue;
+
+    let candidate = candidates.get(split.prefix);
+    if (!candidate) {
+      candidate = { prefix: split.prefix, steps: new Map() };
+      candidates.set(split.prefix, candidate);
+    }
+    if (!candidate.steps.has(split.position)) {
+      candidate.steps.set(split.position, token);
+    }
+  }
+
+  const palettes: DetectedPalette[] = [];
+  for (const candidate of candidates.values()) {
+    if (candidate.steps.size < MIN_RAMP_STEPS) continue;
+
+    const steps: DetectedPaletteStep[] = [...candidate.steps.entries()]
+      .map(([position, token]) => ({ position, token }))
+      .sort(
+        (a, b) => (POSITION_INDEX.get(a.position) ?? 0) - (POSITION_INDEX.get(b.position) ?? 0),
+      );
+
+    palettes.push({ name: candidate.prefix, scale: 'tailwind', steps });
+    for (const step of steps) {
+      consumed.add(step.token);
+    }
+  }
+
+  palettes.sort((a, b) => a.name.localeCompare(b.name));
+
+  const remaining = tokens.filter((t) => !consumed.has(t));
+  return { palettes, remaining };
+}

--- a/packages/cli/src/onboard/importers/shadcn.ts
+++ b/packages/cli/src/onboard/importers/shadcn.ts
@@ -9,6 +9,7 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { Token } from '@rafters/shared';
 import { type CSSVariable, parseCSSFile } from '../css-parser.js';
+import { detectRamps } from './ramp-detector.js';
 import type { Importer, ImporterDetection, ImportResult, ImportWarning } from './types.js';
 
 // Common shadcn CSS file locations
@@ -277,6 +278,7 @@ export const shadcnImporter: Importer = {
       if (!sourcePath) {
         return {
           tokens: [],
+          palettes: [],
           warnings: [{ level: 'error', message: 'No source path found' }],
           source: 'shadcn',
           variablesProcessed: 0,
@@ -292,6 +294,7 @@ export const shadcnImporter: Importer = {
         const message = err instanceof Error ? err.message : String(err);
         return {
           tokens: [],
+          palettes: [],
           warnings: [{ level: 'error', message: `Failed to read CSS file: ${message}` }],
           source: 'shadcn',
           variablesProcessed: 0,
@@ -306,6 +309,7 @@ export const shadcnImporter: Importer = {
         const message = err instanceof Error ? err.message : String(err);
         return {
           tokens: [],
+          palettes: [],
           warnings: [{ level: 'error', message: `Failed to parse CSS: ${message}` }],
           source: 'shadcn',
           variablesProcessed: 0,
@@ -332,12 +336,15 @@ export const shadcnImporter: Importer = {
       }
     }
 
+    const { palettes, remaining } = detectRamps(tokens);
+
     return {
-      tokens,
+      tokens: remaining,
+      palettes,
       warnings,
       source: 'shadcn',
       variablesProcessed,
-      tokensCreated: tokens.length,
+      tokensCreated: remaining.length + palettes.reduce((n, p) => n + p.steps.length, 0),
       skipped,
     };
   },

--- a/packages/cli/src/onboard/importers/tailwind-v4.ts
+++ b/packages/cli/src/onboard/importers/tailwind-v4.ts
@@ -10,6 +10,7 @@ import { readFile } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import type { Token } from '@rafters/shared';
 import { type CSSVariable, parseCSSFile } from '../css-parser.js';
+import { detectRamps } from './ramp-detector.js';
 import type { Importer, ImporterDetection, ImportResult, ImportWarning } from './types.js';
 
 // CSS files where Tailwind v4 @theme blocks live
@@ -112,6 +113,7 @@ function errorResult(message: string, file?: string): ImportResult {
     : { level: 'error', message };
   return {
     tokens: [],
+    palettes: [],
     warnings: [warning],
     source: 'tailwind-v4',
     variablesProcessed: 0,
@@ -258,12 +260,15 @@ export const tailwindV4Importer: Importer = {
       tokens.push(token);
     }
 
+    const { palettes, remaining } = detectRamps(tokens);
+
     return {
-      tokens,
+      tokens: remaining,
+      palettes,
       warnings,
       source: 'tailwind-v4',
       variablesProcessed,
-      tokensCreated: tokens.length,
+      tokensCreated: remaining.length + palettes.reduce((n, p) => n + p.steps.length, 0),
       skipped,
     };
   },

--- a/packages/cli/src/onboard/importers/types.ts
+++ b/packages/cli/src/onboard/importers/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Token } from '@rafters/shared';
+import type { DetectedPalette } from './ramp-detector.js';
 
 /**
  * Metadata about an importer
@@ -63,6 +64,11 @@ export interface ImportWarning {
 export interface ImportResult {
   /** Imported tokens (valid Token[] per @rafters/shared) */
   tokens: Token[];
+  /**
+   * Palettes recovered from CSS ramps (e.g. --empire-50 ... --empire-950).
+   * Tokens emitted as part of a palette do NOT appear in `tokens`.
+   */
+  palettes: DetectedPalette[];
   /** Warnings generated during import */
   warnings: ImportWarning[];
   /** Which importer produced this result */

--- a/packages/cli/src/onboard/orchestrator.ts
+++ b/packages/cli/src/onboard/orchestrator.ts
@@ -14,6 +14,7 @@ import {
   type ImportResult,
   registerImporter,
 } from './importers/index.js';
+import type { DetectedPalette } from './importers/ramp-detector.js';
 import { shadcnImporter } from './importers/shadcn.js';
 import { tailwindV4Importer } from './importers/tailwind-v4.js';
 
@@ -34,8 +35,10 @@ function ensureImportersRegistered(): void {
 export interface OnboardResult {
   /** Whether the onboarding succeeded */
   success: boolean;
-  /** Imported tokens (empty if failed) */
+  /** Imported tokens (empty if failed). Tokens promoted into a palette are excluded. */
   tokens: Token[];
+  /** Color palettes recovered from CSS ramps (e.g. --empire-50 ... --empire-950). */
+  palettes: DetectedPalette[];
   /** Which importer was used */
   source: string | null;
   /** Detection confidence (0-1) */
@@ -96,6 +99,7 @@ export async function onboard(
       return {
         success: false,
         tokens: [],
+        palettes: [],
         source: null,
         confidence: 0,
         detectedBy: [],
@@ -117,6 +121,7 @@ export async function onboard(
       return {
         success: false,
         tokens: [],
+        palettes: [],
         source: null,
         confidence: 0,
         detectedBy: [],
@@ -138,6 +143,7 @@ export async function onboard(
     return {
       success: false,
       tokens: [],
+      palettes: [],
       source: match.importer.metadata.id,
       confidence: match.detection.confidence,
       detectedBy: match.detection.detectedBy,
@@ -157,10 +163,12 @@ export async function onboard(
 
   // Check for import errors
   const hasErrors = result.warnings.some((w) => w.level === 'error');
+  const producedOutput = result.tokens.length > 0 || result.palettes.length > 0;
 
   return {
-    success: !hasErrors && result.tokens.length > 0,
+    success: !hasErrors && producedOutput,
     tokens: result.tokens,
+    palettes: result.palettes,
     source: result.source,
     confidence: match.detection.confidence,
     detectedBy: match.detection.detectedBy,

--- a/packages/cli/src/onboard/writer.ts
+++ b/packages/cli/src/onboard/writer.ts
@@ -7,7 +7,12 @@
 
 import { mkdir, rename, writeFile } from 'node:fs/promises';
 import { dirname, relative } from 'node:path';
-import { type ImportPending, ImportPendingSchema, type PendingToken } from '@rafters/shared';
+import {
+  type ImportPending,
+  ImportPendingSchema,
+  type PendingPalette,
+  type PendingToken,
+} from '@rafters/shared';
 import type { OnboardResult } from './orchestrator.js';
 
 /**
@@ -60,8 +65,34 @@ export function toImportPending(
     };
   });
 
+  const palettes: PendingPalette[] = result.palettes.map((palette) => ({
+    name: palette.name,
+    scale: palette.scale,
+    source: primarySource ?? '',
+    steps: palette.steps.map((step) => {
+      if (typeof step.token.value !== 'string') {
+        throw new Error(
+          `Cannot build ImportPending palette step "${palette.name}-${step.position}": ` +
+            `token.value is a ${typeof step.token.value === 'object' ? 'structured object' : typeof step.token.value}, not a source string. ` +
+            'Importers must produce string values for tokens that map back to source CSS.',
+        );
+      }
+      return {
+        position: step.position,
+        original: {
+          name: extractSourceVarName(step.token.semanticMeaning) ?? step.token.name,
+          value: step.token.value,
+          source: primarySource ?? '',
+        },
+        proposed: step.token,
+      };
+    }),
+    decision: 'pending' as const,
+    confidence: result.confidence,
+  }));
+
   const warnings = result.warnings
-    .filter((w) => w.level !== 'error' || result.tokens.length > 0)
+    .filter((w) => w.level !== 'error' || result.tokens.length > 0 || palettes.length > 0)
     .map((w) => ({ level: w.level, message: w.message }));
 
   const doc: ImportPending = {
@@ -73,6 +104,7 @@ export function toImportPending(
     ...(additionalSources.length > 0 ? { additionalSources } : {}),
     ...(warnings.length > 0 ? { warnings } : {}),
     tokens,
+    ...(palettes.length > 0 ? { palettes } : {}),
   };
 
   // Validate before returning so any schema drift fails loudly

--- a/packages/cli/test/onboard/importers/ramp-detector.test.ts
+++ b/packages/cli/test/onboard/importers/ramp-detector.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for the shared ramp detector used by importers to recover palette
+ * structure from CSS custom properties (#1402).
+ */
+
+import type { Token } from '@rafters/shared';
+import { describe, expect, it } from 'vitest';
+import {
+  detectRamps,
+  MIN_RAMP_STEPS,
+  TAILWIND_RAMP_POSITIONS,
+} from '../../../src/onboard/importers/ramp-detector.js';
+
+function tokenFor(name: string, value = 'oklch(0.5 0.1 0)'): Token {
+  return {
+    name,
+    value,
+    category: 'color',
+    namespace: 'color',
+    userOverride: null,
+    semanticMeaning: `Imported from CSS variable --${name}`,
+    usageContext: ['light mode', 'default'],
+    containerQueryAware: true,
+  };
+}
+
+function fullRamp(family: string): Token[] {
+  return TAILWIND_RAMP_POSITIONS.map((position, i) =>
+    tokenFor(`${family}-${position}`, `oklch(${(0.97 - i * 0.07).toFixed(2)} 0.1 250)`),
+  );
+}
+
+describe('detectRamps', () => {
+  it('groups huttspawn 8 faction scales into palettes with zero flat color tokens', () => {
+    const families = [
+      'empire',
+      'republic',
+      'jedi',
+      'sith',
+      'hutt',
+      'mandalorian',
+      'bounty-hunter',
+      'gsf',
+    ];
+    const tokens = families.flatMap(fullRamp);
+
+    const result = detectRamps(tokens);
+
+    expect(result.palettes).toHaveLength(8);
+    expect(result.remaining).toHaveLength(0);
+
+    for (const family of families) {
+      const palette = result.palettes.find((p) => p.name === family);
+      expect(palette, `palette ${family} missing`).toBeDefined();
+      expect(palette?.steps).toHaveLength(11);
+      expect(palette?.scale).toBe('tailwind');
+    }
+  });
+
+  it('keeps a partial 3-step ramp flat instead of promoting it to a palette', () => {
+    const tokens = [tokenFor('cherry-100'), tokenFor('cherry-500'), tokenFor('cherry-900')];
+
+    const result = detectRamps(tokens);
+
+    expect(result.palettes).toHaveLength(0);
+    expect(result.remaining).toHaveLength(3);
+    expect(result.remaining.map((t) => t.name)).toEqual(['cherry-100', 'cherry-500', 'cherry-900']);
+  });
+
+  it('mixes one full ramp with unrelated flat tokens correctly', () => {
+    const tokens = [
+      ...fullRamp('empire'),
+      tokenFor('background'),
+      tokenFor('foreground'),
+      tokenFor('border'),
+      tokenFor('radius-md', '0.5rem'),
+      tokenFor('spacing-4', '1rem'),
+    ];
+
+    const result = detectRamps(tokens);
+
+    expect(result.palettes).toHaveLength(1);
+    expect(result.palettes[0]?.name).toBe('empire');
+    expect(result.palettes[0]?.steps).toHaveLength(11);
+
+    expect(result.remaining.map((t) => t.name)).toEqual([
+      'background',
+      'foreground',
+      'border',
+      'radius-md',
+      'spacing-4',
+    ]);
+  });
+
+  it('emits palette steps ordered ascending by Tailwind position', () => {
+    // Insert in reversed and shuffled order to verify sort
+    const order = ['950', '50', '500', '100', '900', '200', '800', '300', '700', '400', '600'];
+    const tokens = order.map((p) => tokenFor(`hutt-${p}`));
+
+    const { palettes } = detectRamps(tokens);
+    const palette = palettes.find((p) => p.name === 'hutt');
+    expect(palette?.steps.map((s) => s.position)).toEqual([
+      '50',
+      '100',
+      '200',
+      '300',
+      '400',
+      '500',
+      '600',
+      '700',
+      '800',
+      '900',
+      '950',
+    ]);
+  });
+
+  it(`detects a ramp at the exact MIN_RAMP_STEPS threshold (${MIN_RAMP_STEPS} steps)`, () => {
+    const positions = TAILWIND_RAMP_POSITIONS.slice(0, MIN_RAMP_STEPS);
+    const tokens = positions.map((p) => tokenFor(`brand-${p}`));
+
+    const { palettes, remaining } = detectRamps(tokens);
+    expect(palettes).toHaveLength(1);
+    expect(palettes[0]?.steps).toHaveLength(MIN_RAMP_STEPS);
+    expect(remaining).toHaveLength(0);
+  });
+
+  it(`leaves a ramp at MIN_RAMP_STEPS - 1 flat`, () => {
+    const positions = TAILWIND_RAMP_POSITIONS.slice(0, MIN_RAMP_STEPS - 1);
+    const tokens = positions.map((p) => tokenFor(`brand-${p}`));
+
+    const { palettes, remaining } = detectRamps(tokens);
+    expect(palettes).toHaveLength(0);
+    expect(remaining).toHaveLength(MIN_RAMP_STEPS - 1);
+  });
+
+  it('ignores spacing-style numeric suffixes (4, 8, 16) that are not Tailwind color positions', () => {
+    // spacing-1..spacing-12 is 12 vars but none of those positions are Tailwind color stops
+    const tokens = Array.from({ length: 12 }, (_, i) => tokenFor(`spacing-${i + 1}`));
+
+    const { palettes, remaining } = detectRamps(tokens);
+    expect(palettes).toHaveLength(0);
+    expect(remaining).toHaveLength(12);
+  });
+
+  it('preserves the original Token reference in each palette step', () => {
+    const empireTokens = fullRamp('empire');
+    const { palettes } = detectRamps(empireTokens);
+    const palette = palettes[0];
+    expect(palette).toBeDefined();
+
+    const step500 = palette?.steps.find((s) => s.position === '500');
+    const original500 = empireTokens.find((t) => t.name === 'empire-500');
+    expect(step500?.token).toBe(original500);
+  });
+
+  it('handles hyphenated family names like bounty-hunter', () => {
+    const tokens = fullRamp('bounty-hunter');
+    const { palettes } = detectRamps(tokens);
+    expect(palettes).toHaveLength(1);
+    expect(palettes[0]?.name).toBe('bounty-hunter');
+  });
+
+  it('returns deterministic palette ordering (alphabetical by name)', () => {
+    const tokens = [...fullRamp('zulu'), ...fullRamp('alpha'), ...fullRamp('mike')];
+    const { palettes } = detectRamps(tokens);
+    expect(palettes.map((p) => p.name)).toEqual(['alpha', 'mike', 'zulu']);
+  });
+});

--- a/packages/cli/test/onboard/importers/tailwind-v4.test.ts
+++ b/packages/cli/test/onboard/importers/tailwind-v4.test.ts
@@ -163,12 +163,16 @@ describe('Tailwind v4 Importer', () => {
       const detection = await tailwindV4Importer.detect(testDir);
       const result = await tailwindV4Importer.import(testDir, detection);
 
-      const colorTokens = result.tokens.filter((t) => t.category === 'color');
-      const primaryTokens = colorTokens.filter((t) => t.name.startsWith('primary-'));
-      expect(primaryTokens.length).toBe(11); // 50-950
+      // Complete 50-950 ramps are promoted to palettes (#1402)
+      const primary = result.palettes.find((p) => p.name === 'primary');
+      expect(primary).toBeDefined();
+      expect(primary?.steps.length).toBe(11); // 50-950
+      const primary500 = primary?.steps.find((s) => s.position === '500');
+      expect(primary500?.token.value).toBe('oklch(0.55 0.15 250)');
 
-      const primary500 = primaryTokens.find((t) => t.name === 'primary-500');
-      expect(primary500?.value).toBe('oklch(0.55 0.15 250)');
+      // Tokens used in palettes should not also appear in the flat list
+      const primaryFlat = result.tokens.filter((t) => t.name.startsWith('primary-'));
+      expect(primaryFlat).toHaveLength(0);
     });
 
     it('maps spacing tokens', async () => {
@@ -276,7 +280,9 @@ describe('Tailwind v4 Importer', () => {
       const detection = await tailwindV4Importer.detect(testDir);
       const result = await tailwindV4Importer.import(testDir, detection);
 
-      expect(result.tokensCreated).toBe(result.tokens.length);
+      // tokensCreated counts both flat tokens and palette steps (#1402)
+      const paletteSteps = result.palettes.reduce((n, p) => n + p.steps.length, 0);
+      expect(result.tokensCreated).toBe(result.tokens.length + paletteSteps);
       expect(result.variablesProcessed).toBe(result.tokensCreated + result.skipped);
     });
   });

--- a/packages/cli/test/onboard/writer.test.ts
+++ b/packages/cli/test/onboard/writer.test.ts
@@ -18,6 +18,7 @@ const token: Token = {
 const successfulResult: OnboardResult = {
   success: true,
   tokens: [token],
+  palettes: [],
   source: 'tailwind-v4',
   confidence: 0.95,
   detectedBy: ['@theme block'],
@@ -96,6 +97,7 @@ describe('toImportPending', () => {
     const failed: OnboardResult = {
       success: false,
       tokens: [],
+      palettes: [],
       source: null,
       confidence: 0,
       detectedBy: [],
@@ -114,6 +116,66 @@ describe('toImportPending', () => {
     };
     const result: OnboardResult = { ...successfulResult, tokens: [colorRef] };
     expect(() => toImportPending(result, projectRoot)).toThrow(/not a source string/);
+  });
+
+  it('emits a palettes[] block when the orchestrator reports palettes', () => {
+    const empireSteps = [
+      '50',
+      '100',
+      '200',
+      '300',
+      '400',
+      '500',
+      '600',
+      '700',
+      '800',
+      '900',
+      '950',
+    ] as const;
+    const empireTokens: Token[] = empireSteps.map((position) => ({
+      name: `empire-${position}`,
+      value: `oklch(0.5 0.1 350)`,
+      category: 'color',
+      namespace: 'color',
+      userOverride: null,
+      semanticMeaning: `Imported from Tailwind v4 --color-empire-${position}`,
+      usageContext: ['light mode', 'default'],
+      containerQueryAware: true,
+    }));
+
+    const result: OnboardResult = {
+      ...successfulResult,
+      tokens: [],
+      palettes: [
+        {
+          name: 'empire',
+          scale: 'tailwind',
+          steps: empireSteps.map((position, i) => ({
+            position,
+            token: empireTokens[i] as Token,
+          })),
+        },
+      ],
+    };
+
+    const doc = toImportPending(result, projectRoot);
+
+    expect(doc.palettes).toHaveLength(1);
+    const palette = doc.palettes?.[0];
+    expect(palette?.name).toBe('empire');
+    expect(palette?.scale).toBe('tailwind');
+    expect(palette?.steps).toHaveLength(11);
+    expect(palette?.decision).toBe('pending');
+    expect(palette?.steps[0]?.position).toBe('50');
+    expect(palette?.steps[0]?.original.name).toBe('--color-empire-50');
+
+    // Round-trip through the schema (palettes[] is now part of ImportPendingSchema)
+    expect(() => ImportPendingSchema.parse(doc)).not.toThrow();
+  });
+
+  it('omits palettes[] when no palettes were detected', () => {
+    const doc = toImportPending(successfulResult, projectRoot);
+    expect(doc.palettes).toBeUndefined();
   });
 });
 

--- a/packages/shared/src/import-pending.ts
+++ b/packages/shared/src/import-pending.ts
@@ -101,6 +101,60 @@ export const PendingTokenSchema = z
   });
 
 /**
+ * A single step in a detected color palette.
+ *
+ * Each step carries both the original source variable (so the user can audit
+ * where the value came from) and the proposed Rafters token (so accepting the
+ * palette can materialize tokens directly). Position is the Tailwind scale
+ * stop the variable occupies in its source CSS.
+ */
+export const PendingPaletteStepSchema = z
+  .object({
+    /** Tailwind scale position: "50", "100", ..., "900", "950" */
+    position: z.string(),
+
+    /** Original source variable */
+    original: ImportOriginalSchema,
+
+    /** Proposed Rafters token for this step */
+    proposed: TokenSchema,
+  })
+  .strict();
+
+/**
+ * A color palette recovered by the ramp detector. Replaces what would
+ * otherwise be N flat PendingTokens for the same family.
+ *
+ * Invariants enforced:
+ *   - decision === 'modified' is not allowed at the palette level (#1402
+ *     leaves per-step editing to the existing tokens[] flow)
+ */
+export const PendingPaletteSchema = z
+  .object({
+    /** Palette family name (e.g. "empire") -- the var-name prefix shared by every step */
+    name: z.string(),
+
+    /** Detected scale type. Only Tailwind is supported in #1402. */
+    scale: z.literal('tailwind'),
+
+    /** Source file path relative to project root */
+    source: z.string(),
+
+    /** Ramp steps ordered ascending by Tailwind position */
+    steps: z.array(PendingPaletteStepSchema).min(2),
+
+    /** User decision -- pending until reviewed. Applies to the whole palette. */
+    decision: z.enum(['pending', 'accepted', 'rejected']).default('pending'),
+
+    /** Detection confidence 0-1 */
+    confidence: z.number().min(0).max(1),
+
+    /** Optional rationale for why this was grouped as a palette */
+    rationale: z.string().optional(),
+  })
+  .strict();
+
+/**
  * Import-pending document written to `.rafters/import-pending.json`
  */
 export const ImportPendingSchema = z
@@ -137,6 +191,13 @@ export const ImportPendingSchema = z
 
     /** Tokens awaiting review */
     tokens: z.array(PendingTokenSchema),
+
+    /**
+     * Color palettes recovered from CSS ramps (e.g. --empire-50 ... --empire-950).
+     * Tokens emitted as part of a palette do NOT appear in `tokens` -- the
+     * palette is the source of truth for the family.
+     */
+    palettes: z.array(PendingPaletteSchema).optional(),
   })
   .strict();
 
@@ -144,4 +205,6 @@ export type ImportDecision = z.infer<typeof ImportDecisionSchema>;
 export type ImportOriginal = z.infer<typeof ImportOriginalSchema>;
 export type ImportModifications = z.infer<typeof ImportModificationsSchema>;
 export type PendingToken = z.infer<typeof PendingTokenSchema>;
+export type PendingPaletteStep = z.infer<typeof PendingPaletteStepSchema>;
+export type PendingPalette = z.infer<typeof PendingPaletteSchema>;
 export type ImportPending = z.infer<typeof ImportPendingSchema>;


### PR DESCRIPTION
## Summary

- After parsing CSS custom properties, importers now run a shared `detectRamps` pass that recovers palette structure that would otherwise be lost when `--empire-50` ... `--empire-950` vars get flat-lifted into eleven unrelated tokens.
- A ramp is recognised when at least seven Tailwind scale positions of a single family are present. Partial ramps stay flat. Spacing-style numeric suffixes (`--spacing-4`, `--spacing-8`) are ignored because their positions are not in the Tailwind color scale set.
- Detection runs across all three importers (Tailwind v4, shadcn, generic CSS) via a single utility under `packages/cli/src/onboard/importers/ramp-detector.ts`.
- `ImportPending` schema gains an optional `palettes[]` block alongside `tokens[]` (`PendingPaletteSchema` in `@rafters/shared`). Tokens promoted into a palette do **not** also appear in `tokens[]` -- the palette is the source of truth for that family.
- Downstream registry materialization is out of scope here (covered by the umbrella #1501 and follow-ups).

## Test plan

- [x] `pnpm preflight` green
- [x] New unit tests in `test/onboard/importers/ramp-detector.test.ts` cover:
  - huttspawn 8-faction scenario (all detected, zero flat color tokens)
  - 3-step partial ramp (stays flat)
  - mixed file (one palette + unrelated flat tokens, in input order)
  - threshold edge cases (exactly `MIN_RAMP_STEPS`, `MIN_RAMP_STEPS - 1`)
  - spacing-style numeric suffixes ignored
  - hyphenated family names (`bounty-hunter`)
  - deterministic ordering (alphabetical by name)
  - palette steps ordered ascending by position
  - original Token reference preserved
- [x] Writer test covers schema round-trip when palettes are emitted, and that `palettes` is omitted when none detected.
- [x] Updated `tailwind-v4.test.ts` to reflect that complete ramps now land in `result.palettes` rather than `result.tokens`.

Closes #1402. Toward #1501.