### PR TITLE
feat(cli): rafters import --apply merges accepted pending tokens (#1411)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Minor Changes
 
 - feat(onboard): importers now detect complete color ramps (`--name-50` ... `--name-950`) as palettes instead of flat-lifting each step into an unrelated token (#1402). A ramp is recognised when at least seven Tailwind scale positions of a single family are present; partial ramps stay flat. Detection runs across the Tailwind v4, shadcn, and generic CSS importers via a shared `ramp-detector` utility. `.rafters/import-pending.json` gains an optional `palettes[]` block alongside `tokens[]`; tokens promoted into a palette do not also appear in `tokens[]`. Downstream registry materialization is a separate follow-up.
+- feat(import): `rafters import --apply` merges accepted (and modified) tokens from `.rafters/import-pending.json` into the registry, regenerates outputs, and archives the pending file to `.rafters/import-pending.applied-<ISO>.json` (#1411). Pending tokens are skipped (preserved for the next `--apply`); rejected tokens are skipped (dropped after archive). Modifications overlay the four allowed fields (`name`, `value`, `category`, `namespace`) onto the proposed token; everything else flows through unchanged. Output regeneration shares `generateOutputs` with `init` so the resulting `rafters.css` / `rafters.ts` / `rafters.json` are byte-identical to a fresh init given the same exports config. The nextStep message at the end of `rafters import` and the in-init detection prompt now point at `rafters import --apply` instead of the misleading `rafters init --rebuild` (the latter never read the pending file).
 
 ### Breaking Changes
 

--- a/packages/cli/src/commands/import.ts
+++ b/packages/cli/src/commands/import.ts
@@ -12,17 +12,21 @@
  */
 
 import { existsSync } from 'node:fs';
-import { rename } from 'node:fs/promises';
+import { mkdir, readFile, rename } from 'node:fs/promises';
 import { relative } from 'node:path';
+import { applyPending } from '../onboard/apply.js';
 import { onboard, previewOnboard } from '../onboard/orchestrator.js';
 import { toImportPending, writeImportPending } from '../onboard/writer.js';
+import { DEFAULT_EXPORTS, type ExportConfig } from '../utils/exports.js';
 import { getRaftersPaths } from '../utils/paths.js';
 import { log, setAgentMode } from '../utils/ui.js';
+import { generateOutputs, type RaftersConfig } from './init.js';
 
 interface ImportOptions {
   force?: boolean;
   agent?: boolean;
   importer?: string;
+  apply?: boolean;
 }
 
 export async function importCommand(options: ImportOptions): Promise<void> {
@@ -39,6 +43,11 @@ export async function importCommand(options: ImportOptions): Promise<void> {
       message: 'No .rafters/ directory found. Run `rafters init` first.',
     });
     process.exitCode = 1;
+    return;
+  }
+
+  if (options.apply) {
+    await runApply(cwd, paths);
     return;
   }
 
@@ -100,6 +109,51 @@ export async function importCommand(options: ImportOptions): Promise<void> {
     tokensCreated: result.stats.tokensCreated,
     skipped: result.stats.skipped,
     nextStep:
-      'Review and accept tokens in .rafters/import-pending.json, then run `rafters init --rebuild`',
+      'Review and accept tokens in .rafters/import-pending.json, then run `rafters import --apply`',
+  });
+}
+
+/**
+ * Read the project's RaftersConfig if present, falling back to default exports.
+ * `import --apply` needs the exports config so it can regenerate the same
+ * files `init` originally produced (Tailwind CSS, TS, DTCG, compiled).
+ */
+async function loadExportConfig(configPath: string): Promise<ExportConfig> {
+  if (!existsSync(configPath)) {
+    return DEFAULT_EXPORTS;
+  }
+  try {
+    const raw = await readFile(configPath, 'utf-8');
+    const parsed = JSON.parse(raw) as RaftersConfig;
+    return parsed.exports ?? DEFAULT_EXPORTS;
+  } catch {
+    // Malformed config -- fall back to defaults rather than blocking the apply.
+    return DEFAULT_EXPORTS;
+  }
+}
+
+/**
+ * Run `rafters import --apply`: merge accepted pending tokens into the
+ * registry, regenerate outputs, archive the pending file, and report counts.
+ */
+async function runApply(cwd: string, paths: ReturnType<typeof getRaftersPaths>): Promise<void> {
+  log({ event: 'import:applying' });
+
+  const result = await applyPending(paths);
+
+  await mkdir(paths.output, { recursive: true });
+  const exports = await loadExportConfig(paths.config);
+  // `import --apply` does not have shadcn detection plumbed in; use null. If a
+  // shadcn project applies, the resulting Tailwind CSS includes the @import
+  // line -- safe to override at the consumer's css entry.
+  const outputs = await generateOutputs(cwd, paths, result.registry, exports, null);
+
+  log({
+    event: 'import:applied',
+    applied: result.stats.applied,
+    skippedPending: result.stats.skippedPending,
+    skippedRejected: result.stats.skippedRejected,
+    archive: relative(cwd, result.archivedTo),
+    outputs,
   });
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -362,9 +362,13 @@ export async function ensureTailwindCli(cwd: string): Promise<void> {
 }
 
 /**
- * Generate output files based on export config
+ * Generate output files based on export config.
+ *
+ * Exported so `rafters import --apply` (and any other command that materialises
+ * tokens into outputs) can share the exact same emission path -- the contract
+ * is: same registry + same exports config = same files on disk.
  */
-async function generateOutputs(
+export async function generateOutputs(
   cwd: string,
   paths: ReturnType<typeof getRaftersPaths>,
   registry: TokenRegistry,
@@ -990,6 +994,6 @@ async function maybeOnboardExisting(cwd: string, importPendingPath: string): Pro
     tokensCreated: result.stats.tokensCreated,
     skipped: result.stats.skipped,
     nextStep:
-      'Review and accept tokens in .rafters/import-pending.json, then run `rafters init --rebuild`',
+      'Review and accept tokens in .rafters/import-pending.json, then run `rafters import --apply`',
   });
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,6 +38,10 @@ program
   .description('Import existing design tokens (Tailwind v4, shadcn, generic CSS)')
   .option('--force', 'Overwrite existing .rafters/import-pending.json')
   .option('--importer <id>', 'Force a specific importer (tailwind-v4, shadcn, generic-css)')
+  .option(
+    '--apply',
+    'Merge accepted tokens from .rafters/import-pending.json into the registry and regenerate outputs',
+  )
   .option('--agent', 'Output JSON for machine consumption')
   .action(withErrorHandler(importCommand));
 

--- a/packages/cli/src/onboard/apply.ts
+++ b/packages/cli/src/onboard/apply.ts
@@ -1,0 +1,167 @@
+/**
+ * Apply Pending Imports
+ *
+ * Merges accepted (and modified) tokens from `.rafters/import-pending.json`
+ * into `.rafters/tokens/`, archives the pending file, and reports counts.
+ *
+ * This is the "land the tokens" step in the import flow. `rafters import`
+ * writes pending tokens for the user to review; the user (or Studio, when
+ * it ships) marks each `accepted` / `rejected` / `modified`; then this
+ * apply pass realises the accepted set into the registry. Studio will call
+ * the same code path once it can drive the same review gesture.
+ *
+ * Out of scope here: palette acceptance (added by #1402 to ImportPending
+ * but not yet routed through the registry layer -- a separate follow-up
+ * handles palette materialisation).
+ */
+
+import { existsSync } from 'node:fs';
+import { readFile, rename } from 'node:fs/promises';
+import {
+  contrastPlugin,
+  invertPlugin,
+  loadRegistryFromDir,
+  saveRegistryToDir,
+  scalePlugin,
+  statePlugin,
+  TokenRegistry,
+} from '@rafters/design-tokens';
+import { type ImportPending, ImportPendingSchema, type Token } from '@rafters/shared';
+import type { RaftersPaths } from '../utils/paths.js';
+
+const REGISTRY_PLUGINS = [scalePlugin, contrastPlugin, statePlugin, invertPlugin];
+
+export interface ApplyStats {
+  /** Tokens whose decision was `accepted` or `modified` and were merged. */
+  applied: number;
+  /** Tokens whose decision was `pending` and therefore left alone. */
+  skippedPending: number;
+  /** Tokens whose decision was `rejected`. */
+  skippedRejected: number;
+}
+
+export interface ApplyResult {
+  registry: TokenRegistry;
+  stats: ApplyStats;
+  /** Absolute path of the archived pending file. */
+  archivedTo: string;
+}
+
+/**
+ * Read .rafters/import-pending.json and validate it.
+ * Throws if the file is missing or the schema does not match.
+ */
+async function readPending(pendingPath: string): Promise<ImportPending> {
+  if (!existsSync(pendingPath)) {
+    throw new Error(`No import-pending.json at ${pendingPath}. Run \`rafters import\` first.`);
+  }
+
+  const raw = await readFile(pendingPath, 'utf-8');
+  const parsed: unknown = JSON.parse(raw);
+  return ImportPendingSchema.parse(parsed);
+}
+
+/**
+ * Build the final Token for a pending entry by overlaying any modifications
+ * onto the proposed token. Only the four fields allowed by
+ * ImportModificationsSchema (name, value, category, namespace) are touched;
+ * everything else (userOverride, semanticMeaning, usageContext, ...) flows
+ * through from the proposed token unchanged.
+ */
+function applyModifications(pending: ImportPending['tokens'][number]): Token {
+  if (pending.decision !== 'modified' || !pending.modifications) {
+    return pending.proposed;
+  }
+
+  const m = pending.modifications;
+  return {
+    ...pending.proposed,
+    ...(m.name !== undefined ? { name: m.name } : {}),
+    ...(m.value !== undefined ? { value: m.value } : {}),
+    ...(m.category !== undefined ? { category: m.category } : {}),
+    ...(m.namespace !== undefined ? { namespace: m.namespace } : {}),
+  };
+}
+
+/**
+ * Archive the pending file to `.rafters/import-pending.applied-<ISO>.json`
+ * so the audit trail survives and a fresh `rafters import` can run without
+ * the existing-file guard tripping.
+ *
+ * Returns the archive path.
+ */
+async function archivePending(pendingPath: string, now: Date): Promise<string> {
+  const timestamp = now.toISOString().replace(/[:.]/g, '-');
+  const archivePath = pendingPath.replace(/\.json$/, `.applied-${timestamp}.json`);
+  await rename(pendingPath, archivePath);
+  return archivePath;
+}
+
+export interface ApplyPendingOptions {
+  /**
+   * Override the clock used to stamp the archive filename. Tests rely on
+   * this; production calls let it default to `new Date()`.
+   */
+  now?: Date;
+}
+
+/**
+ * Merge accepted (and modified) tokens from `.rafters/import-pending.json`
+ * into the registry under `.rafters/tokens/` and archive the pending file.
+ *
+ * Pending and rejected tokens are left in the archive untouched.
+ *
+ * Output regeneration is intentionally NOT done here. The caller composes
+ * `applyPending` with `generateOutputs` (or chooses to skip outputs when
+ * Studio handles its own emission path).
+ */
+export async function applyPending(
+  paths: RaftersPaths,
+  options: ApplyPendingOptions = {},
+): Promise<ApplyResult> {
+  const pending = await readPending(paths.importPending);
+
+  let applied = 0;
+  let skippedPending = 0;
+  let skippedRejected = 0;
+  const toMerge: Token[] = [];
+
+  for (const entry of pending.tokens) {
+    switch (entry.decision) {
+      case 'accepted':
+      case 'modified':
+        toMerge.push(applyModifications(entry));
+        applied += 1;
+        break;
+      case 'pending':
+        skippedPending += 1;
+        break;
+      case 'rejected':
+        skippedRejected += 1;
+        break;
+    }
+  }
+
+  // Load the registry the same way init.ts does so semantic bindings resolve
+  // through the plugin set (otherwise re-saved tokens carrying a binding
+  // throw `Unknown plugin: scale` on next load).
+  const registry = existsSync(paths.tokens)
+    ? loadRegistryFromDir(paths.tokens, REGISTRY_PLUGINS)
+    : new TokenRegistry([], REGISTRY_PLUGINS);
+
+  for (const token of toMerge) {
+    // Overwrite-on-collision: imported intent wins over the existing token.
+    // `define` is idempotent on name -- it re-seeds metadata + graph value.
+    registry.define(token);
+  }
+
+  saveRegistryToDir(paths.tokens, registry);
+
+  const archivedTo = await archivePending(paths.importPending, options.now ?? new Date());
+
+  return {
+    registry,
+    stats: { applied, skippedPending, skippedRejected },
+    archivedTo,
+  };
+}

--- a/packages/cli/test/onboard/apply.test.ts
+++ b/packages/cli/test/onboard/apply.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests for `applyPending` -- the merge engine behind `rafters import --apply`
+ * (#1411). Verifies that accepted/modified tokens land in the registry,
+ * pending/rejected tokens are skipped with accurate counts, modifications
+ * overlay the allowed fields, and the pending file is archived.
+ */
+
+import { existsSync } from 'node:fs';
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { loadRegistryFromDir, saveRegistryToDir, TokenRegistry } from '@rafters/design-tokens';
+import type { ImportPending, Token } from '@rafters/shared';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { applyPending } from '../../src/onboard/apply.js';
+import { getRaftersPaths } from '../../src/utils/paths.js';
+
+function tokenFor(overrides: Partial<Token> = {}): Token {
+  return {
+    name: 'brand',
+    value: 'oklch(0.5 0.1 250)',
+    category: 'color',
+    namespace: 'color',
+    userOverride: null,
+    semanticMeaning: 'Imported from Tailwind v4 --color-brand',
+    usageContext: ['light mode', 'default'],
+    containerQueryAware: true,
+    ...overrides,
+  };
+}
+
+function pendingFor(overrides: Partial<ImportPending> = {}): ImportPending {
+  return {
+    version: '1.0',
+    createdAt: '2026-05-15T12:00:00.000Z',
+    detectedSystem: 'tailwind-v4',
+    systemConfidence: 0.95,
+    source: 'src/styles/global.css',
+    tokens: [],
+    ...overrides,
+  };
+}
+
+describe('applyPending', () => {
+  const testDir = join(process.cwd(), '.test-apply');
+  const paths = getRaftersPaths(testDir);
+
+  beforeEach(async () => {
+    await mkdir(testDir, { recursive: true });
+    await mkdir(paths.root, { recursive: true });
+    await mkdir(paths.tokens, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writePending(doc: ImportPending): Promise<void> {
+    await writeFile(paths.importPending, `${JSON.stringify(doc, null, 2)}\n`);
+  }
+
+  it('merges accepted tokens into the registry and counts them', async () => {
+    const proposed = tokenFor({ name: 'brand', value: 'oklch(0.7 0.2 280)' });
+    await writePending(
+      pendingFor({
+        tokens: [
+          {
+            original: {
+              name: '--color-brand',
+              value: 'oklch(0.7 0.2 280)',
+              source: 'src/styles/global.css',
+            },
+            proposed,
+            decision: 'accepted',
+            confidence: 0.95,
+          },
+        ],
+      }),
+    );
+
+    const result = await applyPending(paths);
+
+    expect(result.stats).toEqual({ applied: 1, skippedPending: 0, skippedRejected: 0 });
+    expect(result.registry.get('brand')?.value).toBe('oklch(0.7 0.2 280)');
+  });
+
+  it('overlays modifications onto the proposed token before merging', async () => {
+    const proposed = tokenFor({
+      name: 'brand',
+      value: 'oklch(0.7 0.2 280)',
+      category: 'color',
+      namespace: 'color',
+    });
+    await writePending(
+      pendingFor({
+        tokens: [
+          {
+            original: {
+              name: '--color-brand',
+              value: 'oklch(0.7 0.2 280)',
+              source: 'src/styles/global.css',
+            },
+            proposed,
+            decision: 'modified',
+            modifications: { name: 'primary-500', value: 'oklch(0.6 0.25 280)' },
+            confidence: 0.95,
+          },
+        ],
+      }),
+    );
+
+    const result = await applyPending(paths);
+
+    expect(result.stats.applied).toBe(1);
+    // Original `brand` should not be present; the modified `primary-500` should be.
+    expect(result.registry.get('brand')).toBeUndefined();
+    const primary = result.registry.get('primary-500');
+    expect(primary?.value).toBe('oklch(0.6 0.25 280)');
+    // Untouched fields flow through from the proposed token.
+    expect(primary?.category).toBe('color');
+    expect(primary?.namespace).toBe('color');
+    expect(primary?.semanticMeaning).toBe('Imported from Tailwind v4 --color-brand');
+  });
+
+  it('skips pending tokens and counts them separately from rejected', async () => {
+    await writePending(
+      pendingFor({
+        tokens: [
+          {
+            original: { name: '--a', value: '1', source: 'x.css' },
+            proposed: tokenFor({ name: 'a', value: 'a-val' }),
+            decision: 'pending',
+            confidence: 0.9,
+          },
+          {
+            original: { name: '--b', value: '2', source: 'x.css' },
+            proposed: tokenFor({ name: 'b', value: 'b-val' }),
+            decision: 'rejected',
+            confidence: 0.9,
+          },
+          {
+            original: { name: '--c', value: '3', source: 'x.css' },
+            proposed: tokenFor({ name: 'c', value: 'c-val' }),
+            decision: 'accepted',
+            confidence: 0.9,
+          },
+        ],
+      }),
+    );
+
+    const result = await applyPending(paths);
+
+    expect(result.stats).toEqual({ applied: 1, skippedPending: 1, skippedRejected: 1 });
+    expect(result.registry.get('a')).toBeUndefined();
+    expect(result.registry.get('b')).toBeUndefined();
+    expect(result.registry.get('c')?.value).toBe('c-val');
+  });
+
+  it('archives the pending file with a timestamped applied suffix', async () => {
+    await writePending(
+      pendingFor({
+        tokens: [
+          {
+            original: { name: '--brand', value: 'v', source: 'x.css' },
+            proposed: tokenFor(),
+            decision: 'accepted',
+            confidence: 0.9,
+          },
+        ],
+      }),
+    );
+
+    const frozenNow = new Date('2026-05-15T19:30:00.000Z');
+    const result = await applyPending(paths, { now: frozenNow });
+
+    expect(result.archivedTo).toMatch(/import-pending\.applied-[\d-T]+Z\.json$/);
+    expect(existsSync(paths.importPending)).toBe(false);
+    expect(existsSync(result.archivedTo)).toBe(true);
+
+    const archived = JSON.parse(await readFile(result.archivedTo, 'utf-8'));
+    expect(archived.tokens[0]?.decision).toBe('accepted');
+  });
+
+  it('overwrites existing tokens on name collision (imported intent wins)', async () => {
+    // Pre-seed the registry with a stale brand token
+    const seed = new TokenRegistry([tokenFor({ name: 'brand', value: 'old-value' })]);
+    saveRegistryToDir(paths.tokens, seed);
+
+    await writePending(
+      pendingFor({
+        tokens: [
+          {
+            original: { name: '--brand', value: 'new-value', source: 'x.css' },
+            proposed: tokenFor({ name: 'brand', value: 'new-value' }),
+            decision: 'accepted',
+            confidence: 0.9,
+          },
+        ],
+      }),
+    );
+
+    const result = await applyPending(paths);
+
+    expect(result.registry.get('brand')?.value).toBe('new-value');
+
+    // Re-load from disk to confirm persistence
+    const fromDisk = loadRegistryFromDir(paths.tokens);
+    expect(fromDisk.get('brand')?.value).toBe('new-value');
+  });
+
+  it('throws a helpful error when import-pending.json is missing', async () => {
+    await expect(applyPending(paths)).rejects.toThrow(/No import-pending\.json/);
+  });
+
+  it('writes the merged registry to disk under .rafters/tokens/', async () => {
+    await writePending(
+      pendingFor({
+        tokens: [
+          {
+            original: { name: '--brand', value: 'v', source: 'x.css' },
+            proposed: tokenFor({ name: 'brand', namespace: 'color' }),
+            decision: 'accepted',
+            confidence: 0.9,
+          },
+        ],
+      }),
+    );
+
+    await applyPending(paths);
+
+    const files = await readdir(paths.tokens);
+    expect(files).toContain('color.rafters.json');
+    const contents = await readFile(join(paths.tokens, 'color.rafters.json'), 'utf-8');
+    expect(contents).toContain('"name": "brand"');
+  });
+});


### PR DESCRIPTION
## Summary

- New \`rafters import --apply\` command merges accepted (and modified) tokens from \`.rafters/import-pending.json\` into the registry, regenerates outputs, and archives the pending file to \`.rafters/import-pending.applied-<ISO>.json\`.
- Modifications overlay the four allowed fields (\`name\`, \`value\`, \`category\`, \`namespace\`) onto the proposed token. Everything else (\`userOverride\`, \`semanticMeaning\`, \`usageContext\`, ...) flows through unchanged.
- Pending tokens are preserved for the next \`--apply\`. Rejected tokens are dropped at archive time.
- Pending file is read through the same \`ImportPendingSchema\` boundary the writer uses, so any drift surfaces immediately.
- Output regen reuses \`init.ts\`'s \`generateOutputs\` (now exported). Same registry + same exports config = byte-identical files on disk.
- Fixes the misleading nextStep messages in both \`import.ts\` and the in-init detection prompt in \`init.ts\` -- they used to point at \`rafters init --rebuild\`, which never read the pending file.
- Out of scope here: palette acceptance. #1402 added \`palettes[]\` to ImportPending; routing those through the registry materialiser is a separate follow-up.

## Test plan

- [x] \`pnpm preflight\` green
- [x] New unit tests in \`test/onboard/apply.test.ts\` cover:
  - Merges accepted tokens into the registry; \`applied\` count matches
  - Overlays \`modifications\` onto the proposed token; untouched fields (\`semanticMeaning\`, etc.) flow through
  - Skips pending and rejected with separate counts
  - Archives the pending file with a timestamped suffix; original is gone after apply
  - Overwrites existing tokens on name collision (imported intent wins)
  - Throws a helpful error when \`.rafters/import-pending.json\` is missing
  - Writes the merged registry to disk under \`.rafters/tokens/\`

## Background

huttspawn's dogfood run (bullpen 019da2f9): 161 SWTOR tokens accepted via \`jq\`-hack, zero merged because \`rafters init --rebuild\` never read the pending file. \`--apply\` closes the loop.

Closes #1411. Toward #1501.