### PR TITLE
feat(design-tokens): importers folder with shadcn :root parser

### DIFF
--- a/packages/color-utils/src/conversion.ts
+++ b/packages/color-utils/src/conversion.ts
@@ -42,6 +42,23 @@ export function hexToOKLCH(hex: string): OKLCH {
 }
 
 /**
+ * Predicate-form CSS color parser. Returns the parsed OKLCH on success and
+ * null on any parse failure (invalid format, missing channels, gibberish).
+ *
+ * Used by callers that need to test "is this string a color?" without a
+ * try/catch around `hexToOKLCH` (which throws). Despite the historical name,
+ * `hexToOKLCH` already accepts every CSS color format via colorjs.io --
+ * `tryParseColor` is just the null-on-failure wrapper.
+ */
+export function tryParseColor(css: string): OKLCH | null {
+  try {
+    return hexToOKLCH(css);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Round OKLCH values to standard precision for consistency
  * L and C: 3 decimal places (perceptually meaningful differentiation)
  * H: whole degrees, Alpha: 2 decimal places

--- a/packages/color-utils/src/index.ts
+++ b/packages/color-utils/src/index.ts
@@ -29,7 +29,7 @@ export {
 } from './color-wheel.js';
 
 // Conversion
-export { hexToOKLCH, oklchToCSS, oklchToHex, roundOKLCH } from './conversion.js';
+export { hexToOKLCH, oklchToCSS, oklchToHex, roundOKLCH, tryParseColor } from './conversion.js';
 
 // Gamut
 export {

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -20,10 +20,12 @@
     "@rafters/color-utils": "workspace:*",
     "@rafters/math-utils": "workspace:*",
     "@rafters/shared": "workspace:*",
+    "css-tree": "^3.2.1",
     "zod": "catalog:"
   },
   "devDependencies": {
     "@rafters/design-tokens-v1": "workspace:*",
+    "@types/css-tree": "^2.3.11",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/design-tokens/src/importers/classify.ts
+++ b/packages/design-tokens/src/importers/classify.ts
@@ -82,46 +82,49 @@ function looksLikeFontStack(value: string): boolean {
   return parts.some((p) => GENERIC_FONT_KEYWORDS.has(p.toLowerCase()));
 }
 
+/**
+ * Name-pattern -> namespace map. Used both when a length value confirms a
+ * size-shaped namespace and when no value signal is available (bare numbers,
+ * complex shadow expressions, named keywords) and we fall back to the name
+ * alone.
+ */
+function nameToNamespace(name: string): RaftersImportNamespace | null {
+  if (name === 'radius' || name.startsWith('radius-') || name.startsWith('border-radius'))
+    return 'radius';
+  if (name.startsWith('spacing') || name.startsWith('space-')) return 'spacing';
+  if (name === 'shadow' || name.startsWith('shadow-') || name.startsWith('box-shadow'))
+    return 'shadow';
+  if (
+    name.startsWith('font-') ||
+    name.startsWith('text-') ||
+    name === 'line-height' ||
+    name.startsWith('letter-spacing')
+  )
+    return 'typography';
+  return null;
+}
+
 function classifyOne(decl: CssDeclaration): RaftersImportNamespace | null {
   const { name } = decl;
   const value = decl.value.trim();
 
-  // Color value -> color (or semantic, if the name is a shadcn convention).
   if (tryParseColor(value) !== null) {
     return SHADCN_SEMANTIC_NAMES.has(name) ? 'semantic' : 'color';
   }
 
-  // Length value: disambiguate by name pattern. Bare numbers parse as
-  // UNITLESS via `tryParseUnit`; treat them as not-a-length so the name
-  // fallback below can route things like `--font-weight: 700`.
+  // Length value: trust the name's namespace, or null if the name has no
+  // size-shaped pattern (`--brand-empire-size: 1rem` would be ambiguous).
+  // Bare unitless numbers (`--font-weight: 700`) parse via `tryParseUnit` as
+  // UNITLESS -- gate on a non-empty unit suffix so they fall through to the
+  // name-only path below.
   const unit = tryParseUnit(value);
   if (unit !== null && unit.unit.name !== '') {
-    if (name === 'radius' || name.startsWith('radius-') || name.startsWith('border-radius'))
-      return 'radius';
-    if (name.startsWith('spacing') || name.startsWith('space-')) return 'spacing';
-    if (
-      name === 'line-height' ||
-      name.startsWith('font-size') ||
-      name.startsWith('text-') ||
-      name.startsWith('letter-spacing')
-    )
-      return 'typography';
-    return null;
+    return nameToNamespace(name);
   }
 
-  // Font-family stacks.
   if (looksLikeFontStack(value)) return 'typography';
 
-  // Name-only fallback for values we cannot otherwise classify (e.g. complex
-  // box-shadow expressions, font-weight as bare number, named typography
-  // values like `bold`).
-  if (name.startsWith('font-') || name.startsWith('text-')) return 'typography';
-  if (name === 'shadow' || name.startsWith('shadow-') || name.startsWith('box-shadow'))
-    return 'shadow';
-  if (name === 'radius' || name.startsWith('radius-')) return 'radius';
-  if (name.startsWith('spacing') || name.startsWith('space-')) return 'spacing';
-
-  return null;
+  return nameToNamespace(name);
 }
 
 /**

--- a/packages/design-tokens/src/importers/classify.ts
+++ b/packages/design-tokens/src/importers/classify.ts
@@ -1,0 +1,150 @@
+/**
+ * Classify CSS custom-property declarations into rafters namespaces.
+ *
+ * Reads each declaration two ways:
+ *   - **value shape** via color-utils (`tryParseColor`) and math-utils
+ *     (`tryParseUnit`)
+ *   - **name pattern** as a fallback when the value alone is ambiguous
+ *     (e.g. `--font-weight: 700` -- `700` is a unitless number with no
+ *     length, the name resolves it)
+ *
+ * Anything that does not match an in-scope namespace lands in `unclassified`
+ * -- those are Tailwind internals (`--tw-*`), third-party widget vars, and
+ * other noise the importer leaves alone.
+ */
+
+import { tryParseColor } from '@rafters/color-utils';
+import { tryParseUnit } from '@rafters/math-utils';
+import {
+  type ClassificationResult,
+  type ClassifiedDeclaration,
+  type CssDeclaration,
+  RAFTERS_IMPORT_NAMESPACES,
+  type RaftersImportNamespace,
+} from './shapes.js';
+
+/**
+ * Shadcn's canonical `:root` semantic vocabulary. Declarations with these
+ * names (and a color value) map to the `semantic` namespace; color-valued
+ * declarations with other names map to `color` (palette primitive).
+ */
+const SHADCN_SEMANTIC_NAMES: ReadonlySet<string> = new Set([
+  'background',
+  'foreground',
+  'card',
+  'card-foreground',
+  'popover',
+  'popover-foreground',
+  'primary',
+  'primary-foreground',
+  'secondary',
+  'secondary-foreground',
+  'muted',
+  'muted-foreground',
+  'accent',
+  'accent-foreground',
+  'destructive',
+  'destructive-foreground',
+  'border',
+  'input',
+  'ring',
+  'chart-1',
+  'chart-2',
+  'chart-3',
+  'chart-4',
+  'chart-5',
+  'sidebar',
+  'sidebar-foreground',
+  'sidebar-primary',
+  'sidebar-primary-foreground',
+  'sidebar-accent',
+  'sidebar-accent-foreground',
+  'sidebar-border',
+  'sidebar-ring',
+]);
+
+const GENERIC_FONT_KEYWORDS: ReadonlySet<string> = new Set([
+  'sans-serif',
+  'serif',
+  'monospace',
+  'cursive',
+  'fantasy',
+  'system-ui',
+  'ui-sans-serif',
+  'ui-serif',
+  'ui-monospace',
+  'ui-rounded',
+]);
+
+function looksLikeFontStack(value: string): boolean {
+  if (value.startsWith('"') || value.startsWith("'")) return true;
+  const parts = value.split(',').map((p) => p.trim().replace(/^['"]|['"]$/g, ''));
+  return parts.some((p) => GENERIC_FONT_KEYWORDS.has(p.toLowerCase()));
+}
+
+function classifyOne(decl: CssDeclaration): RaftersImportNamespace | null {
+  const { name } = decl;
+  const value = decl.value.trim();
+
+  // Color value -> color (or semantic, if the name is a shadcn convention).
+  if (tryParseColor(value) !== null) {
+    return SHADCN_SEMANTIC_NAMES.has(name) ? 'semantic' : 'color';
+  }
+
+  // Length value: disambiguate by name pattern. Bare numbers parse as
+  // UNITLESS via `tryParseUnit`; treat them as not-a-length so the name
+  // fallback below can route things like `--font-weight: 700`.
+  const unit = tryParseUnit(value);
+  if (unit !== null && unit.unit.name !== '') {
+    if (name === 'radius' || name.startsWith('radius-') || name.startsWith('border-radius'))
+      return 'radius';
+    if (name.startsWith('spacing') || name.startsWith('space-')) return 'spacing';
+    if (
+      name === 'line-height' ||
+      name.startsWith('font-size') ||
+      name.startsWith('text-') ||
+      name.startsWith('letter-spacing')
+    )
+      return 'typography';
+    return null;
+  }
+
+  // Font-family stacks.
+  if (looksLikeFontStack(value)) return 'typography';
+
+  // Name-only fallback for values we cannot otherwise classify (e.g. complex
+  // box-shadow expressions, font-weight as bare number, named typography
+  // values like `bold`).
+  if (name.startsWith('font-') || name.startsWith('text-')) return 'typography';
+  if (name === 'shadow' || name.startsWith('shadow-') || name.startsWith('box-shadow'))
+    return 'shadow';
+  if (name === 'radius' || name.startsWith('radius-')) return 'radius';
+  if (name.startsWith('spacing') || name.startsWith('space-')) return 'spacing';
+
+  return null;
+}
+
+/**
+ * Split a list of CSS declarations into per-namespace buckets and a
+ * leftover `unclassified` list. Order within each bucket matches source
+ * order; duplicate names are preserved (consumers decide cascade winners).
+ */
+export function classifyDeclarations(
+  declarations: readonly CssDeclaration[],
+): ClassificationResult {
+  const buckets = Object.fromEntries(
+    RAFTERS_IMPORT_NAMESPACES.map((ns) => [ns, [] as ClassifiedDeclaration[]]),
+  ) as Record<RaftersImportNamespace, ClassifiedDeclaration[]>;
+  const unclassified: CssDeclaration[] = [];
+
+  for (const decl of declarations) {
+    const namespace = classifyOne(decl);
+    if (namespace === null) {
+      unclassified.push(decl);
+    } else {
+      buckets[namespace].push({ ...decl, namespace });
+    }
+  }
+
+  return { byNamespace: buckets, unclassified };
+}

--- a/packages/design-tokens/src/importers/index.ts
+++ b/packages/design-tokens/src/importers/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Design Token Importers
+ *
+ * Pure parsers: source bytes -> structured declarations the registry write
+ * path (`registry.set`) can consume. Importers do not call into the
+ * registry; the caller (CLI / Studio) prompts the designer for assignment
+ * and translates declarations into `set(name, value, {reason})` calls.
+ */
+
+export { extractShadcnRoot } from './shadcn.js';
+export type { CssDeclaration } from './shapes.js';

--- a/packages/design-tokens/src/importers/index.ts
+++ b/packages/design-tokens/src/importers/index.ts
@@ -1,11 +1,19 @@
 /**
  * Design Token Importers
  *
- * Pure parsers: source bytes -> structured declarations the registry write
- * path (`registry.set`) can consume. Importers do not call into the
- * registry; the caller (CLI / Studio) prompts the designer for assignment
- * and translates declarations into `set(name, value, {reason})` calls.
+ * Pure parsers + classifiers: source bytes -> structured declarations the
+ * registry write path (`registry.set`) can consume. Importers do not call
+ * into the registry; the caller (CLI / Studio) prompts the designer for
+ * assignment and translates declarations into `set(name, value, {reason})`
+ * calls.
  */
 
+export { classifyDeclarations } from './classify.js';
 export { extractShadcnRoot } from './shadcn.js';
-export type { CssDeclaration } from './shapes.js';
+export {
+  type ClassificationResult,
+  type ClassifiedDeclaration,
+  type CssDeclaration,
+  RAFTERS_IMPORT_NAMESPACES,
+  type RaftersImportNamespace,
+} from './shapes.js';

--- a/packages/design-tokens/src/importers/shadcn.ts
+++ b/packages/design-tokens/src/importers/shadcn.ts
@@ -1,0 +1,43 @@
+/**
+ * shadcn importer.
+ *
+ * Extracts every `--name: value` declaration from top-level `:root { ... }`
+ * rules in source CSS. `.dark { ... }` blocks are skipped -- dark mode is
+ * computed by the system from light values via the invert plugin + the
+ * Tailwind exporter's `dependsOn[1]` convention.
+ */
+
+import * as csstree from 'css-tree';
+import type { CssDeclaration } from './shapes.js';
+
+/**
+ * Read every `--name: value` declaration inside top-level `:root { ... }`
+ * rules. Returns one entry per declaration in source order; duplicates are
+ * preserved -- consumers decide cascade winners.
+ *
+ * Strict selector match (`:root` exactly). Compound selectors like
+ * `:root, html` or `:root.foo` are intentionally not matched in this first
+ * cut. Malformed CSS is parsed permissively by css-tree; unrecognized nodes
+ * are skipped rather than thrown on.
+ */
+export function extractShadcnRoot(css: string): readonly CssDeclaration[] {
+  const ast = csstree.parse(css);
+  const out: CssDeclaration[] = [];
+  csstree.walk(ast, {
+    visit: 'Rule',
+    enter(rule) {
+      if (csstree.generate(rule.prelude).trim() !== ':root') return;
+      csstree.walk(rule.block, {
+        visit: 'Declaration',
+        enter(decl) {
+          if (!decl.property.startsWith('--')) return;
+          out.push({
+            name: decl.property.slice(2),
+            value: csstree.generate(decl.value).trim(),
+          });
+        },
+      });
+    },
+  });
+  return out;
+}

--- a/packages/design-tokens/src/importers/shapes.ts
+++ b/packages/design-tokens/src/importers/shapes.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared types across importers.
+ */
+
+/**
+ * One `--name: value` declaration extracted from source CSS. The leading `--`
+ * is stripped from `name`; `value` is the raw text after the colon, trimmed.
+ * Order preserved from source so cascade winners can be derived downstream.
+ */
+export interface CssDeclaration {
+  readonly name: string;
+  readonly value: string;
+}

--- a/packages/design-tokens/src/importers/shapes.ts
+++ b/packages/design-tokens/src/importers/shapes.ts
@@ -3,6 +3,23 @@
  */
 
 /**
+ * Rafters namespaces the importer can classify into. A curated subset of the
+ * full rafters namespace set -- only the ones a designer typically authors
+ * explicitly in source CSS. Stock radius and shadow values are derived from
+ * the spacing scale via math-utils progressions and are NOT independently
+ * imported unless the designer wrote explicit values.
+ */
+export const RAFTERS_IMPORT_NAMESPACES = [
+  'color',
+  'semantic',
+  'typography',
+  'spacing',
+  'radius',
+  'shadow',
+] as const;
+export type RaftersImportNamespace = (typeof RAFTERS_IMPORT_NAMESPACES)[number];
+
+/**
  * One `--name: value` declaration extracted from source CSS. The leading `--`
  * is stripped from `name`; `value` is the raw text after the colon, trimmed.
  * Order preserved from source so cascade winners can be derived downstream.
@@ -10,4 +27,20 @@
 export interface CssDeclaration {
   readonly name: string;
   readonly value: string;
+}
+
+/** A declaration that has been classified into a rafters namespace. */
+export interface ClassifiedDeclaration extends CssDeclaration {
+  readonly namespace: RaftersImportNamespace;
+}
+
+/**
+ * Output of `classifyDeclarations`. `byNamespace` carries the declarations
+ * the importer recognized; `unclassified` carries the leftovers (Tailwind
+ * internals, third-party widget variables, etc.) that the consumer reports
+ * as "leaving N entries from stock settings."
+ */
+export interface ClassificationResult {
+  readonly byNamespace: Readonly<Record<RaftersImportNamespace, readonly ClassifiedDeclaration[]>>;
+  readonly unclassified: readonly CssDeclaration[];
 }

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -9,6 +9,7 @@ export {
   UnknownPluginError,
   UserOverrideSchema,
 } from './graph.js';
+export * from './importers/index.js';
 export {
   findTokenFile,
   loadRegistryFromDir,

--- a/packages/design-tokens/test/importers/classify.test.ts
+++ b/packages/design-tokens/test/importers/classify.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { classifyDeclarations } from '../../src/importers/classify.js';
+
+describe('classifyDeclarations', () => {
+  it('routes shadcn semantic names with color values to semantic', () => {
+    const result = classifyDeclarations([
+      { name: 'primary', value: 'oklch(0.21 0.006 285)' },
+      { name: 'background', value: '#ffffff' },
+      { name: 'destructive', value: 'hsl(0 70% 50%)' },
+    ]);
+    expect(result.byNamespace.semantic.map((d) => d.name)).toEqual([
+      'primary',
+      'background',
+      'destructive',
+    ]);
+    expect(result.byNamespace.color).toEqual([]);
+    expect(result.unclassified).toEqual([]);
+  });
+
+  it('routes non-shadcn color names to color (palette primitive)', () => {
+    const result = classifyDeclarations([
+      { name: 'brand-empire', value: 'oklch(0.4 0.2 240)' },
+      { name: 'brand-empire-500', value: '#a31515' },
+    ]);
+    expect(result.byNamespace.color.map((d) => d.name)).toEqual([
+      'brand-empire',
+      'brand-empire-500',
+    ]);
+    expect(result.byNamespace.semantic).toEqual([]);
+  });
+
+  it('routes radius declarations by name + length value', () => {
+    const result = classifyDeclarations([
+      { name: 'radius', value: '0.5rem' },
+      { name: 'radius-lg', value: '1rem' },
+    ]);
+    expect(result.byNamespace.radius.map((d) => d.name)).toEqual(['radius', 'radius-lg']);
+  });
+
+  it('routes spacing declarations by name + length value', () => {
+    const result = classifyDeclarations([
+      { name: 'spacing', value: '0.25rem' },
+      { name: 'spacing-4', value: '1rem' },
+      { name: 'space-x', value: '8px' },
+    ]);
+    expect(result.byNamespace.spacing.map((d) => d.name)).toEqual([
+      'spacing',
+      'spacing-4',
+      'space-x',
+    ]);
+  });
+
+  it('routes typography by font-stack value or font- name prefix', () => {
+    const result = classifyDeclarations([
+      { name: 'font-sans', value: '"Inter", system-ui, sans-serif' },
+      { name: 'font-mono', value: 'ui-monospace, monospace' },
+      { name: 'font-weight-bold', value: '700' },
+      { name: 'line-height', value: '1.5rem' },
+    ]);
+    expect(result.byNamespace.typography.map((d) => d.name)).toEqual([
+      'font-sans',
+      'font-mono',
+      'font-weight-bold',
+      'line-height',
+    ]);
+  });
+
+  it('routes shadow declarations by name prefix when value is complex', () => {
+    const result = classifyDeclarations([
+      { name: 'shadow', value: '0 1px 2px 0 rgb(0 0 0 / 0.05)' },
+      { name: 'shadow-lg', value: '0 10px 15px -3px rgb(0 0 0 / 0.1)' },
+    ]);
+    expect(result.byNamespace.shadow.map((d) => d.name)).toEqual(['shadow', 'shadow-lg']);
+  });
+
+  it('sends Tailwind internals and unknown vars to unclassified', () => {
+    const result = classifyDeclarations([
+      { name: 'tw-ring-color', value: 'oklch(0.5 0.2 240)' },
+      { name: 'some-app-internal', value: '42' },
+      { name: 'random-thing', value: 'auto' },
+    ]);
+    // tw-ring-color has a color value, so it lands in `color` (not `semantic`,
+    // because the name is not in the shadcn vocabulary). That is correct --
+    // the importer cannot tell that `--tw-*` is internal; the consumer
+    // filters those at prompt time if desired.
+    expect(result.byNamespace.color.map((d) => d.name)).toEqual(['tw-ring-color']);
+    expect(result.unclassified.map((d) => d.name)).toEqual(['some-app-internal', 'random-thing']);
+  });
+
+  it('returns empty buckets for empty input', () => {
+    const result = classifyDeclarations([]);
+    for (const ns of ['color', 'semantic', 'typography', 'spacing', 'radius', 'shadow'] as const) {
+      expect(result.byNamespace[ns]).toEqual([]);
+    }
+    expect(result.unclassified).toEqual([]);
+  });
+
+  it('preserves order within each bucket', () => {
+    const result = classifyDeclarations([
+      { name: 'primary', value: '#000' },
+      { name: 'radius', value: '0.5rem' },
+      { name: 'background', value: '#fff' },
+    ]);
+    expect(result.byNamespace.semantic.map((d) => d.name)).toEqual(['primary', 'background']);
+    expect(result.byNamespace.radius.map((d) => d.name)).toEqual(['radius']);
+  });
+
+  it('attaches namespace to each classified declaration', () => {
+    const result = classifyDeclarations([
+      { name: 'primary', value: '#000' },
+      { name: 'radius', value: '0.5rem' },
+    ]);
+    expect(result.byNamespace.semantic[0]).toEqual({
+      name: 'primary',
+      value: '#000',
+      namespace: 'semantic',
+    });
+    expect(result.byNamespace.radius[0]).toEqual({
+      name: 'radius',
+      value: '0.5rem',
+      namespace: 'radius',
+    });
+  });
+});

--- a/packages/design-tokens/test/importers/shadcn.test.ts
+++ b/packages/design-tokens/test/importers/shadcn.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { extractShadcnRoot } from '../../src/importers/shadcn.js';
+
+describe('extractShadcnRoot', () => {
+  it('extracts custom properties from a :root block', () => {
+    const css = `
+      :root {
+        --primary: oklch(0.5 0.2 30);
+        --background: oklch(1 0 0);
+      }
+    `;
+    expect(extractShadcnRoot(css)).toEqual([
+      { name: 'primary', value: 'oklch(0.5 0.2 30)' },
+      { name: 'background', value: 'oklch(1 0 0)' },
+    ]);
+  });
+
+  it('skips .dark blocks (dark is computed)', () => {
+    const css = `
+      :root { --primary: oklch(0.5 0.2 30); }
+      .dark { --primary: oklch(0.8 0.2 30); }
+    `;
+    expect(extractShadcnRoot(css)).toEqual([{ name: 'primary', value: 'oklch(0.5 0.2 30)' }]);
+  });
+
+  it('skips non-custom-property declarations inside :root', () => {
+    const css = `
+      :root {
+        color: red;
+        --primary: oklch(0.5 0.2 30);
+      }
+    `;
+    expect(extractShadcnRoot(css)).toEqual([{ name: 'primary', value: 'oklch(0.5 0.2 30)' }]);
+  });
+
+  it('preserves duplicate declarations in source order', () => {
+    const css = `
+      :root { --primary: oklch(0.5 0.2 30); }
+      :root { --primary: oklch(0.7 0.2 30); }
+    `;
+    expect(extractShadcnRoot(css)).toEqual([
+      { name: 'primary', value: 'oklch(0.5 0.2 30)' },
+      { name: 'primary', value: 'oklch(0.7 0.2 30)' },
+    ]);
+  });
+
+  it('returns empty when no :root block is present', () => {
+    expect(extractShadcnRoot('.button { color: red; }')).toEqual([]);
+  });
+
+  it('returns empty for empty input', () => {
+    expect(extractShadcnRoot('')).toEqual([]);
+  });
+
+  it('does not match compound selectors involving :root', () => {
+    const css = `
+      :root.dark { --primary: oklch(0.5 0.2 30); }
+      :root, html { --background: oklch(1 0 0); }
+    `;
+    expect(extractShadcnRoot(css)).toEqual([]);
+  });
+
+  it('handles HSL, hex, and named color values uniformly as raw strings', () => {
+    const css = `
+      :root {
+        --a: hsl(20 50% 50%);
+        --b: #ff5500;
+        --c: red;
+      }
+    `;
+    expect(extractShadcnRoot(css)).toEqual([
+      { name: 'a', value: 'hsl(20 50% 50%)' },
+      { name: 'b', value: '#ff5500' },
+      { name: 'c', value: 'red' },
+    ]);
+  });
+});

--- a/packages/math-utils/src/units.ts
+++ b/packages/math-utils/src/units.ts
@@ -80,6 +80,23 @@ export function parseUnitString(
   return { value, unit };
 }
 
+/**
+ * Predicate-form parser. Returns the parsed `UnitValue` on success and null
+ * on any failure (unknown suffix, malformed input). Use this when the caller
+ * needs to test "is this string a length / unit value?" without a try/catch
+ * around `parseUnitString` (which throws).
+ */
+export function tryParseUnit(
+  cssValue: string,
+  registry: readonly Unit[] = DEFAULT_UNITS,
+): UnitValue | null {
+  try {
+    return parseUnitString(cssValue, registry);
+  } catch {
+    return null;
+  }
+}
+
 /** Format a `UnitValue` back to a CSS string. */
 export const formatUnit = (uv: UnitValue): string => `${uv.value}${uv.unit.name}`;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -468,6 +468,9 @@ importers:
       '@rafters/shared':
         specifier: workspace:*
         version: link:../shared
+      css-tree:
+        specifier: ^3.2.1
+        version: 3.2.1
       zod:
         specifier: 'catalog:'
         version: 4.1.12
@@ -475,6 +478,9 @@ importers:
       '@rafters/design-tokens-v1':
         specifier: workspace:*
         version: link:../design-tokens-v1
+      '@types/css-tree':
+        specifier: ^2.3.11
+        version: 2.3.11
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.0


### PR DESCRIPTION
## Summary

- First piece of the import path. Mirrors the `exporters/` layout: `src/importers/` holds pure parsers that read source bytes and return structured declarations. The caller (CLI / Studio) prompts the designer for assignment and translates declarations into `registry.set(name, value, {reason})` calls -- the importers themselves never touch the registry.
- `shapes.ts` declares `CssDeclaration` (`name`, `value` strings).
- `shadcn.ts` exports `extractShadcnRoot(css)` -- a css-tree walk that collects every `--name: value` declaration inside top-level `:root { ... }` rules.
- `.dark { ... }` is intentionally skipped for this iteration. Dark is computed from light via the invert plugin + the Tailwind exporter's `dependsOn[1]` convention; revisit when there's a real case for designer-divergent dark values the cascade cannot derive.
- Strict `:root` selector match -- compound selectors like `:root, html` and `:root.foo` are not matched in this first cut. Expand when a real consumer needs it.

## Scope

- No CLI behavior change. The wire-up into `rafters init` (Phase B: sense, prompt, set) lands in a follow-up.
- Adds `css-tree@^3.2.1` + `@types/css-tree@^2.3.11` to `@rafters/design-tokens` -- same versions already used by `@rafters/cli`.

## Test plan

- [x] 8 unit tests at `packages/design-tokens/test/importers/shadcn.test.ts` cover OKLCH / hex / HSL / named values, duplicate declarations preserved in source order, `.dark` skipped, non-custom-property declarations skipped inside `:root`, compound selectors rejected, empty input.
- [x] Full `@rafters/design-tokens` suite green (111 / 111).
- [x] Workspace typecheck green.
- [x] `pnpm preflight` green (lefthook pre-commit + pre-push).