### PR TITLE
feat(importers): loop classified colors into parsed OKLCH

### DIFF
--- a/packages/design-tokens/src/importers/colors.ts
+++ b/packages/design-tokens/src/importers/colors.ts
@@ -1,0 +1,30 @@
+/**
+ * Enrich color- and semantic-namespace declarations with their OKLCH
+ * representation. The classifier has already verified each value parses
+ * (via `tryParseColor`); this pass calls `hexToOKLCH` from
+ * `@rafters/color-utils` -- which accepts every CSS color format that
+ * colorjs.io parses -- to extract the OKLCH. Throws if a value fails to
+ * parse here; that would be a classifier-invariant bug worth surfacing.
+ */
+
+import { hexToOKLCH } from '@rafters/color-utils';
+import type { ClassificationResult, ColorDeclaration } from './shapes.js';
+
+/**
+ * Loop over color and semantic declarations from a `ClassificationResult`
+ * and return each one enriched with its parsed OKLCH. The two namespaces
+ * are concatenated in classification order: color primitives first, then
+ * semantic role tokens.
+ */
+export function colorsFromClassification(
+  classification: ClassificationResult,
+): readonly ColorDeclaration[] {
+  const result: ColorDeclaration[] = [];
+  for (const decl of classification.byNamespace.color) {
+    result.push({ ...decl, namespace: 'color', oklch: hexToOKLCH(decl.value) });
+  }
+  for (const decl of classification.byNamespace.semantic) {
+    result.push({ ...decl, namespace: 'semantic', oklch: hexToOKLCH(decl.value) });
+  }
+  return result;
+}

--- a/packages/design-tokens/src/importers/index.ts
+++ b/packages/design-tokens/src/importers/index.ts
@@ -9,11 +9,13 @@
  */
 
 export { classifyDeclarations } from './classify.js';
+export { colorsFromClassification } from './colors.js';
 export { senseShadcnCss } from './sense.js';
 export { extractShadcnRoot } from './shadcn.js';
 export {
   type ClassificationResult,
   type ClassifiedDeclaration,
+  type ColorDeclaration,
   type CssDeclaration,
   RAFTERS_IMPORT_NAMESPACES,
   type RaftersImportNamespace,

--- a/packages/design-tokens/src/importers/shapes.ts
+++ b/packages/design-tokens/src/importers/shapes.ts
@@ -2,6 +2,8 @@
  * Shared types across importers.
  */
 
+import type { OKLCH } from '@rafters/shared';
+
 /**
  * Rafters namespaces the importer can classify into. A curated subset of the
  * full rafters namespace set -- only the ones a designer typically authors
@@ -32,6 +34,17 @@ export interface CssDeclaration {
 /** A declaration that has been classified into a rafters namespace. */
 export interface ClassifiedDeclaration extends CssDeclaration {
   readonly namespace: RaftersImportNamespace;
+}
+
+/**
+ * A color- or semantic-namespace declaration with its source value parsed
+ * to OKLCH via `@rafters/color-utils`. The raw `value` is preserved for
+ * display (the designer wrote it; the prompt should show it back); the
+ * `oklch` field is what `registry.set` consumes.
+ */
+export interface ColorDeclaration extends ClassifiedDeclaration {
+  readonly namespace: 'color' | 'semantic';
+  readonly oklch: OKLCH;
 }
 
 /**

--- a/packages/design-tokens/test/importers/colors.test.ts
+++ b/packages/design-tokens/test/importers/colors.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { classifyDeclarations } from '../../src/importers/classify.js';
+import { colorsFromClassification } from '../../src/importers/colors.js';
+
+describe('colorsFromClassification', () => {
+  it('enriches color and semantic declarations with parsed OKLCH', () => {
+    const classification = classifyDeclarations([
+      { name: 'primary', value: 'oklch(0.5 0.2 30)' },
+      { name: 'background', value: '#ffffff' },
+      { name: 'brand-empire', value: 'oklch(0.4 0.2 240)' },
+    ]);
+    const colors = colorsFromClassification(classification);
+
+    expect(colors).toHaveLength(3);
+
+    // Order: color primitives first, then semantic.
+    expect(colors[0]?.name).toBe('brand-empire');
+    expect(colors[0]?.namespace).toBe('color');
+    expect(colors[0]?.oklch.l).toBeCloseTo(0.4, 3);
+    expect(colors[0]?.oklch.c).toBeCloseTo(0.2, 3);
+    expect(colors[0]?.oklch.h).toBeCloseTo(240, 0);
+
+    expect(colors[1]?.name).toBe('primary');
+    expect(colors[1]?.namespace).toBe('semantic');
+    expect(colors[1]?.oklch.l).toBeCloseTo(0.5, 3);
+
+    expect(colors[2]?.name).toBe('background');
+    expect(colors[2]?.namespace).toBe('semantic');
+    // White: lightness 1, no chroma, hue is NaN -> normalized to 0
+    expect(colors[2]?.oklch.l).toBeCloseTo(1, 3);
+    expect(colors[2]?.oklch.c).toBeCloseTo(0, 3);
+  });
+
+  it('parses hex, hsl, oklch, and named colors uniformly', () => {
+    const classification = classifyDeclarations([
+      { name: 'primary', value: 'oklch(0.5 0.2 30)' },
+      { name: 'background', value: 'hsl(0 0% 100%)' },
+      { name: 'destructive', value: '#ff0000' },
+      { name: 'accent', value: 'red' },
+    ]);
+    const colors = colorsFromClassification(classification);
+
+    expect(colors).toHaveLength(4);
+    // Each input format produced a non-null OKLCH with the expected lightness
+    // band. `toBeCloseTo` handles tiny floating-point drift across formats
+    // (hsl(0 0% 100%) round-trips to OKLCH lightness 1.0000000000000002).
+    expect(colors[0]?.oklch.l).toBeCloseTo(0.5, 3); // oklch literal
+    expect(colors[1]?.oklch.l).toBeCloseTo(1, 3); // hsl white
+    expect(colors[2]?.oklch.l).toBeCloseTo(0.628, 2); // hex red
+    expect(colors[3]?.oklch.l).toBeCloseTo(0.628, 2); // named red
+  });
+
+  it('preserves the original source value alongside the OKLCH', () => {
+    const classification = classifyDeclarations([{ name: 'primary', value: 'hsl(20 50% 50%)' }]);
+    const colors = colorsFromClassification(classification);
+
+    expect(colors).toHaveLength(1);
+    expect(colors[0]?.value).toBe('hsl(20 50% 50%)');
+    expect(colors[0]?.oklch).toBeDefined();
+  });
+
+  it('returns empty when there are no color or semantic declarations', () => {
+    const classification = classifyDeclarations([
+      { name: 'radius', value: '0.5rem' },
+      { name: 'font-sans', value: '"Inter", sans-serif' },
+    ]);
+    expect(colorsFromClassification(classification)).toEqual([]);
+  });
+
+  it('returns empty for empty classification', () => {
+    const classification = classifyDeclarations([]);
+    expect(colorsFromClassification(classification)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

After the classifier splits declarations into rafters namespaces, the next step needs each color-bearing declaration as a parsed OKLCH so the registry can consume it via `registry.set`. Adds `colorsFromClassification(classification)` -- walks the `color` and `semantic` buckets, calls `hexToOKLCH` from `@rafters/color-utils` on each value, returns the enriched list.

No new color-parsing code: `hexToOKLCH` already accepts every CSS color format colorjs.io parses (hex, rgb, hsl, oklch, lab, lch, named) -- despite the historical name. The classifier already verified each value parses (via `tryParseColor`), so a throw here would surface a classifier-invariant bug.

## Shape

- New `ColorDeclaration` type in `importers/shapes.ts` -- extends `ClassifiedDeclaration` with the namespace narrowed to `'color' | 'semantic'` and a parsed `oklch: OKLCH` field.
- New `colorsFromClassification(classification): readonly ColorDeclaration[]` in `importers/colors.ts`. Color primitives first, then semantic role tokens.
- Original source `value` preserved alongside `oklch` -- the prompt will show the designer what they wrote; the registry consumes the OKLCH.

## Scope

- No CLI wire-up yet. The prompt + apply step that consumes this output is the next piece.

## Test plan

- [x] 5 unit tests at `packages/design-tokens/test/importers/colors.test.ts` cover OKLCH parsing across formats (hex / hsl / oklch / named), color-vs-semantic ordering, value preservation, and the two empty cases.
- [x] Full `@rafters/design-tokens` suite green (130 / 130).
- [x] Workspace typecheck clean.
- [x] `pnpm preflight` green (lint + format + typecheck).