### PR TITLE
feat(plugin): assembly-only consumer surface (v0.2.0)

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rafters",
   "description": "Design intelligence enforcement for Rafters projects. Prevents guessing at design decisions by enforcing MCP tool usage, Container/Grid layout, classy(), and design token compliance.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Sean Silvius",
     "email": "sean@silvius.me"

--- a/plugin/hooks/pre-edit.sh
+++ b/plugin/hooks/pre-edit.sh
@@ -38,13 +38,35 @@ case "$FILE_PATH" in
 esac
 
 case "$FILE_PATH" in
-  *packages/ui/*|*apps/*|*packages/cli/src/mcp/*|*sites/*|*src/pages/*|*src/components/*|*src/layouts/*) ;;
+  *packages/ui/*|*apps/*|*packages/cli/src/mcp/*|*sites/*|*src/pages/*|*src/app/*|*src/routes/*|*src/components/*|*src/layouts/*) ;;
   *) exit 0 ;;
 esac
 
 # Skip test files
 case "$FILE_PATH" in
   *.test.*|*.spec.*|*.a11y.*|*.e2e.*) exit 0 ;;
+esac
+
+# CONTEXT: authoring vs assembly.
+#
+# Custom component authoring lives in `src/components/` (excluding the
+# rafters-owned `components/ui/` subtree, which is read-only and already
+# guarded above). When authoring, consumers DO need to write class
+# strings, DO use classy() for conditional merging, and DO reference
+# semantic tokens via Tailwind utilities (bg-primary etc.) -- that is
+# how custom components hook into the rafters token system.
+#
+# Assembly (pages, layouts, app code, routes) is the opposite: zero
+# class authoring, pure composition of pre-made composites and
+# components. The visual-utility deny rules below apply there.
+#
+# Hard rules (no var(--rafters-), no arbitrary values, no cn()/twMerge,
+# no className on rafters components, no wrapper divs, no raw <h1>/<p>
+# with classes) apply in BOTH contexts and are checked unconditionally.
+IS_AUTHORING=0
+case "$FILE_PATH" in
+  */src/components/ui/*) ;;  # rafters-installed, already gated above
+  */src/components/*) IS_AUTHORING=1 ;;
 esac
 
 # Get the content being written
@@ -81,39 +103,38 @@ fi
 # class-bearing destination. Catching strings in any of these contexts
 # without overfitting on a specific attribute syntax.
 
-# LAYOUT IS SOLVED - Container and Grid handle layout
-if echo "$CONTENT" | grep -qE '\b(flex|grid|items-|justify-|gap-[0-9])\b' | grep -qvE '^\s*//|^\s*\*'; then
+# Visual-utility rules apply only in ASSEMBLY context. Authoring custom
+# components in src/components/ needs to reference these utilities --
+# that's how a custom component hooks into the rafters token system.
+if [ "$IS_AUTHORING" != "1" ]; then
+  # LAYOUT IS SOLVED - Container and Grid handle layout
   if echo "$CONTENT" | grep -qE '(className|class)=|classy\(' && echo "$CONTENT" | grep -qE '\b(flex|grid|items-(start|center|end|baseline|stretch)|justify-(start|center|end|between|around|evenly)|gap-[0-9])\b'; then
     VIOLATIONS+="LAYOUT IS SOLVED: Found raw layout utility (flex/grid/items-/justify-/gap-). Use Container/Grid components.\n"
   fi
-fi
 
-# CONTAINER OWNS SPACING
-if echo "$CONTENT" | grep -qE '(className|class)=|classy\(' && echo "$CONTENT" | grep -qE '\b(p-[0-9]|px-[0-9]|py-[0-9]|m-[0-9]|mx-[0-9]|my-[0-9]|mt-[0-9]|mb-[0-9]|ml-[0-9]|mr-[0-9]|pt-[0-9]|pb-[0-9]|pl-[0-9]|pr-[0-9])\b'; then
-  VIOLATIONS+="CONTAINER OWNS SPACING: Found direct spacing utility in a class-bearing context. Container handles spacing.\n"
-fi
+  # CONTAINER OWNS SPACING
+  if echo "$CONTENT" | grep -qE '(className|class)=|classy\(' && echo "$CONTENT" | grep -qE '\b(p-[0-9]|px-[0-9]|py-[0-9]|m-[0-9]|mx-[0-9]|my-[0-9]|mt-[0-9]|mb-[0-9]|ml-[0-9]|mr-[0-9]|pt-[0-9]|pb-[0-9]|pl-[0-9]|pr-[0-9])\b'; then
+    VIOLATIONS+="CONTAINER OWNS SPACING: Found direct spacing utility in a class-bearing context. Container handles spacing.\n"
+  fi
 
-# THE SYSTEM OWNS SEMANTIC COLOR
-# bg-primary / text-destructive / border-success means the agent is
-# picking a visual hierarchy choice. That belongs to the composite
-# (block.meta.variant) or component (variant prop, dictated by JSDoc),
-# never to consumer-side className. Catches both className="..." and
-# classy("...") forms.
-if echo "$CONTENT" | grep -qE '(className|class)=|classy\(' && echo "$CONTENT" | grep -qE '\b(bg|text|border)-(primary|secondary|tertiary|accent|highlight|destructive|success|warning|info|muted|foreground|background|card|popover|sidebar|chart-[0-9]|ring|input)\b'; then
-  VIOLATIONS+="THE SYSTEM OWNS VISUAL VALUES: Found semantic color utility (bg-primary / text-destructive / etc.) in a class-bearing context. The composite manifest (block.meta.variant) or component (variant prop per JSDoc) owns variant choice -- never consumer className/classy(). Query rafters_pattern / rafters_composite / rafters_component.\n"
-fi
+  # THE SYSTEM OWNS SEMANTIC COLOR
+  # In assembly: bg-primary / text-destructive / border-success means the
+  # agent is picking a visual hierarchy choice. That belongs to the
+  # composite (block.meta.variant) or component (variant prop, dictated
+  # by JSDoc), never to consumer-side className.
+  if echo "$CONTENT" | grep -qE '(className|class)=|classy\(' && echo "$CONTENT" | grep -qE '\b(bg|text|border)-(primary|secondary|tertiary|accent|highlight|destructive|success|warning|info|muted|foreground|background|card|popover|sidebar|chart-[0-9]|ring|input)\b'; then
+    VIOLATIONS+="THE SYSTEM OWNS VISUAL VALUES: Found semantic color utility (bg-primary / text-destructive / etc.) in a class-bearing context. The composite manifest (block.meta.variant) or component (variant prop per JSDoc) owns variant choice -- never consumer className/classy(). Query rafters_pattern / rafters_composite / rafters_component. (If you are authoring a custom component, put it in src/components/ where these utilities are allowed.)\n"
+  fi
 
-# THE SYSTEM OWNS TYPOGRAPHY SIZE + WEIGHT
-# Inside <Container as="article">, bare native HTML is correctly styled
-# by the composite system. text-* / font-weight-* in any class-bearing
-# context means the agent is reaching past the system.
-if echo "$CONTENT" | grep -qE '(className|class)=|classy\(' && echo "$CONTENT" | grep -qE '\b(text-(xs|sm|base|lg|xl|[0-9]+xl)|font-(thin|light|normal|medium|semibold|bold|extrabold|black))\b'; then
-  VIOLATIONS+="THE SYSTEM OWNS TYPOGRAPHY: Found text-* size or font-weight-* utility. Wrap content in <Container as=\"article\"> and use bare native HTML, or render the composite the manifest specifies.\n"
-fi
+  # THE SYSTEM OWNS TYPOGRAPHY SIZE + WEIGHT
+  if echo "$CONTENT" | grep -qE '(className|class)=|classy\(' && echo "$CONTENT" | grep -qE '\b(text-(xs|sm|base|lg|xl|[0-9]+xl)|font-(thin|light|normal|medium|semibold|bold|extrabold|black))\b'; then
+    VIOLATIONS+="THE SYSTEM OWNS TYPOGRAPHY: Found text-* size or font-weight-* utility. Wrap content in <Container as=\"article\"> and use bare native HTML, or render the composite the manifest specifies.\n"
+  fi
 
-# THE SYSTEM OWNS RADIUS / SHADOW / SIZING
-if echo "$CONTENT" | grep -qE '(className|class)=|classy\(' && echo "$CONTENT" | grep -qE '\b(rounded-|shadow-|w-[0-9]|h-[0-9]|max-w-|min-w-|max-h-|min-h-)'; then
-  VIOLATIONS+="THE SYSTEM OWNS RADIUS / SHADOW / SIZING: Found rounded-/shadow-/w-/h-/max-/min- utility. These are component-owned design choices.\n"
+  # THE SYSTEM OWNS RADIUS / SHADOW / SIZING
+  if echo "$CONTENT" | grep -qE '(className|class)=|classy\(' && echo "$CONTENT" | grep -qE '\b(rounded-|shadow-|w-[0-9]|h-[0-9]|max-w-|min-w-|max-h-|min-h-)'; then
+    VIOLATIONS+="THE SYSTEM OWNS RADIUS / SHADOW / SIZING: Found rounded-/shadow-/w-/h-/max-/min- utility. These are component-owned design choices.\n"
+  fi
 fi
 
 # NEVER var() IN COMPONENTS - exporter handles var()

--- a/plugin/hooks/pre-edit.sh
+++ b/plugin/hooks/pre-edit.sh
@@ -76,19 +76,49 @@ if echo "$CONTENT" | grep -qE '(className|class|classy).*(bg|text|border)-\[#'; 
   VIOLATIONS+="NO ARBITRARY VALUES: Found arbitrary color. Use semantic tokens (bg-primary, text-foreground, etc).\n"
 fi
 
+# Class-bearing contexts: `class=` / `className=` attributes (string OR JSX
+# expression), `classy(...)` calls, and template literals assigned to a
+# class-bearing destination. Catching strings in any of these contexts
+# without overfitting on a specific attribute syntax.
+
 # LAYOUT IS SOLVED - Container and Grid handle layout
-if echo "$CONTENT" | grep -qE '(className|class)="[^"]*\b(flex|grid|items-|justify-|gap-)[^"]*"'; then
-  VIOLATIONS+="LAYOUT IS SOLVED: Found raw layout utility. Use Container/Grid components.\n"
+if echo "$CONTENT" | grep -qE '\b(flex|grid|items-|justify-|gap-[0-9])\b' | grep -qvE '^\s*//|^\s*\*'; then
+  if echo "$CONTENT" | grep -qE '(className|class)=|classy\(' && echo "$CONTENT" | grep -qE '\b(flex|grid|items-(start|center|end|baseline|stretch)|justify-(start|center|end|between|around|evenly)|gap-[0-9])\b'; then
+    VIOLATIONS+="LAYOUT IS SOLVED: Found raw layout utility (flex/grid/items-/justify-/gap-). Use Container/Grid components.\n"
+  fi
 fi
 
 # CONTAINER OWNS SPACING
-if echo "$CONTENT" | grep -qE '(className|class)="[^"]*\b(p-[0-9]|px-[0-9]|py-[0-9]|m-[0-9]|mx-[0-9]|my-[0-9]|mt-|mb-|ml-|mr-|pt-|pb-|pl-|pr-)[^"]*"'; then
-  VIOLATIONS+="CONTAINER OWNS SPACING: Found direct spacing in className. Container handles spacing.\n"
+if echo "$CONTENT" | grep -qE '(className|class)=|classy\(' && echo "$CONTENT" | grep -qE '\b(p-[0-9]|px-[0-9]|py-[0-9]|m-[0-9]|mx-[0-9]|my-[0-9]|mt-[0-9]|mb-[0-9]|ml-[0-9]|mr-[0-9]|pt-[0-9]|pb-[0-9]|pl-[0-9]|pr-[0-9])\b'; then
+  VIOLATIONS+="CONTAINER OWNS SPACING: Found direct spacing utility in a class-bearing context. Container handles spacing.\n"
+fi
+
+# THE SYSTEM OWNS SEMANTIC COLOR
+# bg-primary / text-destructive / border-success means the agent is
+# picking a visual hierarchy choice. That belongs to the composite
+# (block.meta.variant) or component (variant prop, dictated by JSDoc),
+# never to consumer-side className. Catches both className="..." and
+# classy("...") forms.
+if echo "$CONTENT" | grep -qE '(className|class)=|classy\(' && echo "$CONTENT" | grep -qE '\b(bg|text|border)-(primary|secondary|tertiary|accent|highlight|destructive|success|warning|info|muted|foreground|background|card|popover|sidebar|chart-[0-9]|ring|input)\b'; then
+  VIOLATIONS+="THE SYSTEM OWNS VISUAL VALUES: Found semantic color utility (bg-primary / text-destructive / etc.) in a class-bearing context. The composite manifest (block.meta.variant) or component (variant prop per JSDoc) owns variant choice -- never consumer className/classy(). Query rafters_pattern / rafters_composite / rafters_component.\n"
+fi
+
+# THE SYSTEM OWNS TYPOGRAPHY SIZE + WEIGHT
+# Inside <Container as="article">, bare native HTML is correctly styled
+# by the composite system. text-* / font-weight-* in any class-bearing
+# context means the agent is reaching past the system.
+if echo "$CONTENT" | grep -qE '(className|class)=|classy\(' && echo "$CONTENT" | grep -qE '\b(text-(xs|sm|base|lg|xl|[0-9]+xl)|font-(thin|light|normal|medium|semibold|bold|extrabold|black))\b'; then
+  VIOLATIONS+="THE SYSTEM OWNS TYPOGRAPHY: Found text-* size or font-weight-* utility. Wrap content in <Container as=\"article\"> and use bare native HTML, or render the composite the manifest specifies.\n"
+fi
+
+# THE SYSTEM OWNS RADIUS / SHADOW / SIZING
+if echo "$CONTENT" | grep -qE '(className|class)=|classy\(' && echo "$CONTENT" | grep -qE '\b(rounded-|shadow-|w-[0-9]|h-[0-9]|max-w-|min-w-|max-h-|min-h-)'; then
+  VIOLATIONS+="THE SYSTEM OWNS RADIUS / SHADOW / SIZING: Found rounded-/shadow-/w-/h-/max-/min- utility. These are component-owned design choices.\n"
 fi
 
 # NEVER var() IN COMPONENTS - exporter handles var()
 if echo "$CONTENT" | grep -qE 'var\(--rafters' ; then
-  VIOLATIONS+="NEVER var() IN COMPONENTS: Found var(--rafters-...). Use Tailwind utilities. The exporter handles var().\n"
+  VIOLATIONS+="NEVER var() IN COMPONENTS: Found var(--rafters-...). The exporter wires the CSS variables; consumers never reference them directly.\n"
 fi
 
 # COMPONENTS ARE COMPLETE - no wrapper divs

--- a/plugin/skills/rafters-frontend/SKILL.md
+++ b/plugin/skills/rafters-frontend/SKILL.md
@@ -94,6 +94,46 @@ When falling through to `rafters_component`:
 - **No arbitrary values.** No `text-[14px]`, no `bg-[#hex]`, no `w-[300px]`.
 - **No raw `<h1>` / `<p>` / `<span>` with classes.** Either you are inside `<Container as="article">` (where bare native HTML is correct) or you are using a component.
 
+## Authoring Custom Components
+
+When rafters doesn't ship the affordance you need, custom components live in `src/components/` (NOT `src/components/ui/` -- that subtree is rafters-installed and read-only). Inside `src/components/`, the rules relax: you DO author class strings, DO call `classy()` for conditional merging, DO reference semantic tokens via Tailwind utilities (`bg-primary`, `text-foreground`, etc.). That is how a custom component hooks into the rafters token system.
+
+```tsx
+// src/components/FeatureTile.tsx -- authoring
+import { classy } from '@rafters/ui/classy';
+import type { ReactNode } from 'react';
+
+interface FeatureTileProps {
+  variant?: 'default' | 'highlighted';
+  children: ReactNode;
+}
+
+/**
+ * Compact feature card for marketing layouts.
+ * @cognitive-load 2/10
+ * @accessibility AAA
+ */
+export function FeatureTile({ variant = 'default', children }: FeatureTileProps) {
+  return (
+    <div
+      className={classy(
+        'rounded-lg p-6',
+        variant === 'highlighted' ? 'bg-primary text-primary-foreground' : 'bg-card text-foreground',
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+```
+
+**Authoring still bans:**
+- `var(--rafters-*)` -- use the Tailwind utility, never the raw CSS variable
+- Arbitrary values -- `bg-[#hex]`, `text-[14px]`, `w-[300px]` all forbidden
+- `cn()` / `twMerge()` -- `classy()` only
+
+**A scaffolding MCP tool (`rafters_scaffold_component`) is planned** -- see issue #1548 -- that will generate this boilerplate, check similarity against existing components first to prevent duplication, and tag the output so the plugin can identify scaffolded files. Until that lands, follow the conventions above.
+
 ## What the Agent Actually Decides
 
 - Information architecture: what content goes on a page, in what order

--- a/plugin/skills/rafters-frontend/SKILL.md
+++ b/plugin/skills/rafters-frontend/SKILL.md
@@ -1,111 +1,105 @@
 ---
 name: rafters-frontend
-description: Use when building frontend UI in a Rafters project -- enforces Container, Grid, typography components, and design token usage.
-version: 1.0.0
+description: Use when building frontend UI in a Rafters project -- enforces the assembly model (composites first, components second, native HTML inside Container article-mode) and prohibits any agent-side design choice.
+version: 2.0.0
 user-invocable: true
 allowed-tools: Read, Edit, Write, Glob, Grep, Bash, Agent
 ---
 
-## Layout Is Solved
+## Core Rule
 
-Container and Grid handle ALL layout. You do not write layout code.
+**The system makes design choices. The agent assembles.**
+
+This is the entire reason Rafters exists. Color, spacing, size, weight, radius, shadow, hierarchy, layout rhythm -- all owned by the system. The agent's job is to pick the right pre-made piece for the content and intent. Not to author visual decisions.
+
+## Assembly Order
+
+1. **`rafters_pattern`** -- start here. Search by what the page or section SOLVES (e.g. `solves: "authentication"`, `solves: "data entry"`, `solves: "navigation"`). Returns composites with designer intent + do/never + block structure.
+2. **`rafters_composite`** -- get a specific composite by ID, category, or fuzzy query. The composite's blocks carry their own `variant`, `size`, layout meta -- render them verbatim.
+3. **`rafters_component`** -- only when no composite covers the case. Returns component intelligence with do/never and the JSDoc guidance for variant/size choice in that exact situation.
+4. **`rafters_rule`** -- validation rules for forms (required, email, password, credentials, etc.).
+
+If a question has a composite answer, the answer is the composite. Do not reach for `rafters_component` to assemble a custom version of something a composite already covers.
+
+## Content Goes Inside `Container as="article">`
+
+Native HTML, no classes, no Typography imports:
 
 ```tsx
-// WRONG
-<div className={classy("flex gap-4 p-6")}>
-
-// RIGHT
-<Container>
-  <Grid preset="sidebar-main">
-    <aside>Sidebar</aside>
-    <main>Content</main>
-  </Grid>
+<Container as="article">
+  <h1>Page Title</h1>
+  <p>Body paragraph.</p>
+  <blockquote>A pull quote.</blockquote>
+  <ul>
+    <li>List item</li>
+  </ul>
+  <p>Inline <code>code</code> in prose.</p>
 </Container>
 ```
 
-**Never use:** flex, grid, gap-*, p-*, m-*, items-*, justify-*
+The container's typography composite system styles every native element correctly via the token system. You do not need to import `H1`, `P`, `Small`, `Code` -- those exist for narrow edge cases outside content regions. Inside an article container, native HTML is the right path.
 
-### Grid Presets
+**Never:**
+- `<h1 className="text-4xl font-bold">` -- the class is the bug; bare `<h1>` is correct
+- `<P size="sm" color="muted">` -- depromoted; write `<p>` inside an article container instead
+- `<H1>` imports for content
 
-| Preset | Use for |
+## Layout: Container + Grid
+
+```tsx
+<Container as="main">
+  <Container as="section">
+    <h2>Section title</h2>
+    <Grid preset="cards">
+      <Card>...</Card>
+      <Card>...</Card>
+      <Card>...</Card>
+    </Grid>
+  </Container>
+</Container>
+```
+
+Container owns max-width, padding, and gap. Grid owns column structure and column gap. No flex utilities, no grid utilities, no gap/p/m utilities. The components handle it.
+
+| Grid preset | Use for |
 |---|---|
-| sidebar-main | Navigation + content |
+| linear | Equal-priority columns |
+| golden | Hierarchical (2:1 ratio) |
+| bento | Asymmetric showcase |
+| cards | Responsive card flow |
+| sidebar | Sidebar + main |
 | form | Label/input pairs |
-| cards | Responsive card grid |
 | row | Horizontal group |
 | stack | Vertical sequence |
 | split | Equal columns |
 
-## Typography -- Components, Not Utilities
+## Components: Affordances
 
-| Instead of | Use |
-|---|---|
-| `<p className="text-sm text-muted-foreground">` | `<P size="sm" color="muted">` |
-| `<p>` | `<P>` |
-| `<h1 className="text-4xl font-bold">` | `<H1>` |
-| `<h2>` | `<H2>` |
-| `<h3>` | `<H3>` |
-| `<span className="text-xs">` | `<Small>` |
-| `<span className="text-lg font-semibold">` | `<P size="lg" weight="semibold">` |
+`Card`, `Button`, `Alert`, `Empty`, `Badge`, `Input`, `Field`, `Tabs`, `Tooltip`, `Dialog`, etc. -- these are the affordances composites assemble from. Use them WHEN there is no composite. When a composite exists, the composite's block list tells you which components to render and which `variant` / `size` to pass.
 
-### Astro Typography
+When falling through to `rafters_component`:
+- The component's JSDoc + `usagePatterns` tell you when each variant is correct
+- `variant` is a SEMANTIC choice driven by the JSDoc -- not an aesthetic preference (no choosing "ghost vs link" because you like it; the JSDoc tells you which fits the situation)
+- Wrong: "Let's make this Button look subtle, so `variant=ghost`"
+- Right: "This is the secondary action in a card footer; the Button JSDoc says secondary actions in card footers use `variant=secondary`"
 
-For .astro files, use the individual tag components:
+## Hard Rules -- Never
 
-```astro
----
-import H1 from '@/components/ui/typography-h1.astro'
-import P from '@/components/ui/typography-p.astro'
-import Code from '@/components/ui/typography-code.astro'
----
+- **No utility classes for visual properties.** No `bg-*`, `text-*`, `border-*`, `font-*`, `rounded-*`, `shadow-*`, `w-*`, `h-*`, `p-*`, `m-*`, `gap-*`, `flex`, `grid`, `items-*`, `justify-*`. None.
+- **No `var(--rafters-*)` in any file.** The exporter wires the CSS variables; the consumer NEVER references them directly.
+- **No `cn()` / `twMerge()`.** Use `classy()` if you need conditional classes (rare; usually means you are reaching for something a component should own).
+- **No `class=` / `className=` on Rafters components.** Use the component's token props (`variant`, `size`, etc.) -- AS DICTATED by the composite manifest or the component's JSDoc, not as a free choice.
+- **No wrapper `<div>` around Rafters components.** Components include their own spacing and sizing.
+- **No editing files in `lib/primitives/` or `components/ui/*.classes.ts`.** These are installed by `rafters add`. Fix consuming code or file an upstream bug.
+- **No arbitrary values.** No `text-[14px]`, no `bg-[#hex]`, no `w-[300px]`.
+- **No raw `<h1>` / `<p>` / `<span>` with classes.** Either you are inside `<Container as="article">` (where bare native HTML is correct) or you are using a component.
 
-<H1>Page Title</H1>
-<P size="xl" color="muted">Lead paragraph.</P>
-<P>Use the <Code>useState</Code> hook.</P>
-```
+## What the Agent Actually Decides
 
-All Astro typography components support token props: size, weight, color, line, tracking, family.
+- Information architecture: what content goes on a page, in what order
+- Composite selection: which pre-made pattern fits this content and intent
+- Component selection (fallback): which affordance when no composite exists
+- Interaction flow: routing, state transitions, data wiring
+- Content: the actual words and data the user reads
 
-## Color -- Tokens, Not Values
-
-Use semantic tokens as Tailwind classes: `bg-primary`, `text-destructive`, `border-success`.
-Never use hex, HSL, OKLCH, or palette internals directly. Never use `var(--rafters-...)` in components.
-
-## MCP Tools -- Ask, Don't Guess
-
-Before making design decisions, query the Rafters MCP tools:
-
-| Question | Tool |
-|---|---|
-| What colors/spacing/components exist? | `rafters_vocabulary` |
-| How should I implement this pattern? | `rafters_pattern` |
-| Full intelligence for a component? | `rafters_component` |
-| Token derivation and overrides? | `rafters_token` |
-
-## A Correct Page
-
-```tsx
-import { Container, Grid } from "@rafters/ui"
-import { H1, P } from "@rafters/ui/components/ui/typography"
-import { Card } from "@rafters/ui/components/ui/card"
-import { Button } from "@rafters/ui/components/ui/button"
-
-export default function Page() {
-  return (
-    <Container>
-      <H1>Title</H1>
-      <P size="xl">Description.</P>
-      <Grid preset="cards">
-        <Card>...</Card>
-        <Card>...</Card>
-      </Grid>
-      <Grid preset="row">
-        <Button variant="secondary">Cancel</Button>
-        <Button>Save</Button>
-      </Grid>
-    </Container>
-  )
-}
-```
-
-No flex. No gap. No padding. No text utilities. No var().
+Everything else -- size, color, spacing, weight, radius, shadow, hierarchy, layout rhythm, variant aesthetics -- the system owns.


### PR DESCRIPTION
## Summary

The plugin's SKILL.md and hook were both documenting / enforcing a pre-Option-C, pre-MCP-tool-rename world. This brings them in line with what actually shipped.

**Rafters' actual consumer model:** the SYSTEM owns all design choices (color, spacing, size, weight, hierarchy, variant aesthetics). The AGENT picks composites for compound patterns, falls through to components when no composite covers it, writes bare native HTML inside \`<Container as=\"article\">\` for content. Composites own variant/size/layout via \`block.meta\`.

## SKILL.md changes (v1.0 → v2.0)

- Removes the \`<H1>\` / \`<P size=\"sm\" color=\"muted\">\` Typography-component teaching. Option C (#1161-#1170) made Container as=\"article\" + native HTML the path; the typography composite system styles native elements via the token system.
- Removes references to \`rafters_vocabulary\` and \`rafters_token\` -- those MCP tools were deleted. The actual surface: \`rafters_pattern\` (search by what page solves), \`rafters_composite\` (specific pattern), \`rafters_component\` (when no composite covers it), \`rafters_rule\` (validation).
- Reframes color section: not \"use bg-primary in className\" but \"the composite manifest owns variant choice via block.meta; fall through to component only when no composite covers; even then, JSDoc dictates variant, not aesthetic preference.\"
- Adds explicit assembly order + hard-rules list.

## pre-edit.sh changes

The previous regex anchored on \`(className|class)=\"...\"\` -- missed the \`className={classy(\"bg-primary\")}\` form. New patterns catch both contexts.

Three new deny rules:
- **Semantic color utilities**: \`bg-primary\` / \`text-destructive\` / \`border-success\` etc. The composite manifest's \`block.meta.variant\` owns this choice.
- **Typography size/weight**: \`text-4xl\` / \`font-bold\` etc. Bare native HTML inside \`<Container as=\"article\">\` is the correct path.
- **Radius / shadow / sizing**: \`rounded-md\` / \`shadow-lg\` / \`w-64\` / \`max-w-md\` etc. Component-owned.

Existing rules preserved (spacing, layout, var(--rafters-), arbitrary values, classes on rafters components, wrapper divs, raw \`<h1>/<p>\` with classes).

## Smoke test

| Case | Expected | Result |
|---|---|---|
| className=\"bg-primary text-foreground\" | DENY | ✓ |
| classy(\"bg-primary text-foreground\") | DENY | ✓ |
| className=\"text-4xl font-bold\" | DENY | ✓ |
| className=\"rounded-md shadow-lg\" | DENY | ✓ |
| var(--rafters-foreground) | DENY | ✓ |
| Container as=\"article\" + bare \<h1\>/\<p\> | ALLOW | ✓ |
| Button variant=\"destructive\" | ALLOW | ✓ |

## Version

Plugin bumps to 0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)