### PR TITLE
fix(plugin): only apply hooks in rafters projects (v0.2.1)

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rafters",
   "description": "Design intelligence enforcement for Rafters projects. Prevents guessing at design decisions by enforcing MCP tool usage, Container/Grid layout, classy(), and design token compliance.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {
     "name": "Sean Silvius",
     "email": "sean@silvius.me"

--- a/plugin/hooks/lib.sh
+++ b/plugin/hooks/lib.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Shared helpers for Rafters hooks.
+
+# find_rafters_root <start-dir>
+# Walks up from <start-dir> looking for the .rafters/config.rafters.json
+# marker -- the same marker the CLI's discoverProjectRoot uses. Prints the
+# project root on stdout and returns 0 if found; prints nothing and returns
+# 1 if <start-dir> is empty or no ancestor contains the marker.
+find_rafters_root() {
+  local dir="$1"
+  [ -n "$dir" ] || return 1
+  while [ "$dir" != "/" ]; do
+    if [ -f "$dir/.rafters/config.rafters.json" ]; then
+      printf '%s\n' "$dir"
+      return 0
+    fi
+    local parent
+    parent=$(dirname "$dir")
+    [ "$parent" != "$dir" ] || break
+    dir="$parent"
+  done
+  return 1
+}

--- a/plugin/hooks/lib.sh
+++ b/plugin/hooks/lib.sh
@@ -5,10 +5,13 @@
 # Walks up from <start-dir> looking for the .rafters/config.rafters.json
 # marker -- the same marker the CLI's discoverProjectRoot uses. Prints the
 # project root on stdout and returns 0 if found; prints nothing and returns
-# 1 if <start-dir> is empty or no ancestor contains the marker.
+# 1 if <start-dir> is empty or no ancestor contains the marker. Relative
+# inputs are resolved against $PWD first, matching discoverProjectRoot's
+# resolve(startDir).
 find_rafters_root() {
   local dir="$1"
   [ -n "$dir" ] || return 1
+  case "$dir" in /*) ;; *) dir="$PWD/$dir" ;; esac
   while [ "$dir" != "/" ]; do
     if [ -f "$dir/.rafters/config.rafters.json" ]; then
       printf '%s\n' "$dir"

--- a/plugin/hooks/pre-edit.sh
+++ b/plugin/hooks/pre-edit.sh
@@ -3,31 +3,17 @@
 # Enforces: classy (not cn/twMerge), no arbitrary Tailwind, Container/Grid layout,
 # no raw spacing, no wrapper divs, no var() in components
 
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
 
-# Only enforce in projects that actually use rafters. Walk up from the
-# file's directory looking for .rafters/config.rafters.json (the marker
-# the CLI's discoverProjectRoot uses). If absent, this isn't a rafters
-# project -- exit silently so non-rafters sites aren't blocked.
-if [ -n "$FILE_PATH" ]; then
-  dir=$(dirname "$FILE_PATH")
-  found=""
-  while [ -n "$dir" ] && [ "$dir" != "/" ]; do
-    if [ -f "$dir/.rafters/config.rafters.json" ]; then
-      found="1"
-      break
-    fi
-    parent=$(dirname "$dir")
-    if [ "$parent" = "$dir" ]; then
-      break
-    fi
-    dir="$parent"
-  done
-  if [ -z "$found" ]; then
-    exit 0
-  fi
+# Only enforce in projects that actually use rafters. If the edited file
+# isn't inside a rafters project, exit silently so non-rafters sites aren't
+# blocked. (Empty FILE_PATH falls through to the registry checks below.)
+if [ -n "$FILE_PATH" ] && ! find_rafters_root "$(dirname "$FILE_PATH")" >/dev/null; then
+  exit 0
 fi
 
 # REGISTRY FILES ARE READ-ONLY

--- a/plugin/hooks/pre-edit.sh
+++ b/plugin/hooks/pre-edit.sh
@@ -3,7 +3,11 @@
 # Enforces: classy (not cn/twMerge), no arbitrary Tailwind, Container/Grid layout,
 # no raw spacing, no wrapper divs, no var() in components
 
-source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+LIB="$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+if ! source "$LIB" || ! declare -F find_rafters_root >/dev/null; then
+  echo "rafters pre-edit hook: cannot load $LIB -- enforcement skipped" >&2
+  exit 1
+fi
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')

--- a/plugin/hooks/pre-edit.sh
+++ b/plugin/hooks/pre-edit.sh
@@ -7,6 +7,29 @@ INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
 
+# Only enforce in projects that actually use rafters. Walk up from the
+# file's directory looking for .rafters/config.rafters.json (the marker
+# the CLI's discoverProjectRoot uses). If absent, this isn't a rafters
+# project -- exit silently so non-rafters sites aren't blocked.
+if [ -n "$FILE_PATH" ]; then
+  dir=$(dirname "$FILE_PATH")
+  found=""
+  while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+    if [ -f "$dir/.rafters/config.rafters.json" ]; then
+      found="1"
+      break
+    fi
+    parent=$(dirname "$dir")
+    if [ "$parent" = "$dir" ]; then
+      break
+    fi
+    dir="$parent"
+  done
+  if [ -z "$found" ]; then
+    exit 0
+  fi
+fi
+
 # REGISTRY FILES ARE READ-ONLY
 # Files installed by `rafters add` must never be edited in consumer sites.
 # Fix your consuming code, or file a bug upstream on rafters.

--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # Rafters SessionStart hook: inject design tool requirements
-source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+LIB="$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+if ! source "$LIB" || ! declare -F find_rafters_root >/dev/null; then
+  echo "rafters session-start hook: cannot load $LIB -- context injection skipped" >&2
+  exit 1
+fi
 
 INPUT=$(cat)
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')

--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -1,29 +1,13 @@
 #!/bin/bash
 # Rafters SessionStart hook: inject design tool requirements
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
 INPUT=$(cat)
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 
-if [ -z "$CWD" ]; then
-  exit 0
-fi
-
-# Only enforce in projects that actually use rafters. The marker is
-# .rafters/config.rafters.json, matching the CLI's discoverProjectRoot.
-# Walk up from CWD looking for it; exit silently if not found.
-dir="$CWD"
-while [ -n "$dir" ] && [ "$dir" != "/" ]; do
-  if [ -f "$dir/.rafters/config.rafters.json" ]; then
-    break
-  fi
-  parent=$(dirname "$dir")
-  if [ "$parent" = "$dir" ]; then
-    exit 0
-  fi
-  dir="$parent"
-done
-if [ ! -f "$dir/.rafters/config.rafters.json" ]; then
-  exit 0
-fi
+# Only inject in projects that actually use rafters. Walk up from CWD for
+# the .rafters/config.rafters.json marker; exit silently if not found.
+find_rafters_root "$CWD" >/dev/null || exit 0
 
 jq -n --arg ctx "[Rafters] You are working in a Rafters-powered frontend project. MANDATORY rules:
 

--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -7,13 +7,21 @@ if [ -z "$CWD" ]; then
   exit 0
 fi
 
-# Check if this is a site/frontend project (has .astro files or src/pages/)
-HAS_FRONTEND=""
-if [ -d "$CWD/src/pages" ] || [ -d "$CWD/src/components" ] || ls "$CWD"/*.astro >/dev/null 2>&1; then
-  HAS_FRONTEND="true"
-fi
-
-if [ -z "$HAS_FRONTEND" ]; then
+# Only enforce in projects that actually use rafters. The marker is
+# .rafters/config.rafters.json, matching the CLI's discoverProjectRoot.
+# Walk up from CWD looking for it; exit silently if not found.
+dir="$CWD"
+while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+  if [ -f "$dir/.rafters/config.rafters.json" ]; then
+    break
+  fi
+  parent=$(dirname "$dir")
+  if [ "$parent" = "$dir" ]; then
+    exit 0
+  fi
+  dir="$parent"
+done
+if [ ! -f "$dir/.rafters/config.rafters.json" ]; then
   exit 0
 fi
 


### PR DESCRIPTION
## What

Both Rafters plugin hooks now gate on the real project marker `.rafters/config.rafters.json` -- the same marker the CLI's `discoverProjectRoot` uses -- so the plugin and CLI agree on what counts as a rafters project.

- **session-start.sh**: replaced the frontend heuristic (`src/pages` | `src/components` | `*.astro` presence) with a walk-up from cwd for the marker. The heuristic fired the design-rule injection in *any* frontend repo, rafters or not.
- **pre-edit.sh**: walk up from the edited file's dir for the marker; exit 0 early if none is found so non-rafters sites are never blocked by the registry read-only enforcement.
- Extracted the shared walk-up into `hooks/lib.sh` as `find_rafters_root`, sourced by both hooks (one copy on the hook side instead of two).
- Plugin version bumped 0.2.0 -> 0.2.1.

## Why

The crash that started this: the SessionStart hook injected mandatory Rafters design rules into non-rafters frontend projects, and pre-edit could block edits in sites that don't use rafters at all. Gating on the actual marker scopes both hooks to real rafters projects.

## Note

Project-root detection now has three copies of the same walk-up: `discoverProjectRoot` (TS, source of truth) plus `find_rafters_root` in the shell hooks. The shell can't import the TS; the marker name must stay in sync across both or the hooks silently diverge from the CLI.

## Test

Verified silent exit on non-rafters dirs, injection at rafters root and nested subdirs, no blocking on files outside rafters projects, and empty-file-path fallthrough -- all behaviors identical before and after the helper extraction.