### PR TITLE
fix(ui): reject prototype-chain keys in WC variant/size validation (#1566)

### DIFF
--- a/packages/ui/src/components/ui/button-group.classes.ts
+++ b/packages/ui/src/components/ui/button-group.classes.ts
@@ -1,10 +1,11 @@
 /**
  * Shared button-group layout class definitions
  *
- * Imported by button-group.tsx (React) to keep the connected-border and
- * focus-stacking rules in one place. The Web Component target consumes
- * button-group.styles.ts for the shadow-DOM CSS equivalent; this file
- * exists so framework targets share the same semantic surface.
+ * Imported by button-group.tsx (React), button-group.astro (Astro), and the
+ * button-group Web Component to keep the connected-border and focus-stacking
+ * rules in one place, so every framework target shares the same semantic
+ * surface. The Web Component renders its inner markup from these strings and
+ * keeps only its irreducible :host / ::slotted shadow CSS inline.
  */
 
 // ============================================================================

--- a/packages/ui/src/components/ui/checkbox.element.test.ts
+++ b/packages/ui/src/components/ui/checkbox.element.test.ts
@@ -202,6 +202,20 @@ describe('rafters-checkbox', () => {
     expect(RaftersCheckbox.formAssociated).toBe(true);
   });
 
+  it('falls back to default for prototype-chain attribute values (no undefined classes)', async () => {
+    await loadElement();
+    const mod = await import('./checkbox.element');
+    const el = document.createElement('rafters-checkbox');
+    // `constructor` / `toString` live on Object.prototype: an `in` check would
+    // pass them through and inject `undefined` tokens. Object.hasOwn rejects them.
+    el.setAttribute('variant', 'constructor');
+    el.setAttribute('size', 'toString');
+    document.body.appendChild(el);
+    const inner = el.shadowRoot?.querySelector('button');
+    expect(inner?.className).toBe(mod.composeCheckboxClasses('default', 'default'));
+    expect(inner?.className).not.toContain('undefined');
+  });
+
   it('declares the documented observedAttributes', async () => {
     const RaftersCheckbox = await loadElement();
     expect(RaftersCheckbox.observedAttributes).toEqual([

--- a/packages/ui/src/components/ui/checkbox.element.ts
+++ b/packages/ui/src/components/ui/checkbox.element.ts
@@ -74,14 +74,14 @@ const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = [
 const VALUE_MISSING_MESSAGE = 'Please check this box.';
 
 function parseVariant(value: string | null): CheckboxVariant {
-  if (value && value in checkboxVariantClasses) {
+  if (value && Object.hasOwn(checkboxVariantClasses, value)) {
     return value as CheckboxVariant;
   }
   return 'default';
 }
 
 function parseSize(value: string | null): CheckboxSize {
-  if (value && value in checkboxSizeClasses) {
+  if (value && Object.hasOwn(checkboxSizeClasses, value)) {
     return value as CheckboxSize;
   }
   return 'default';

--- a/packages/ui/src/components/ui/field.classes.ts
+++ b/packages/ui/src/components/ui/field.classes.ts
@@ -1,8 +1,9 @@
 /**
  * Shared class definitions for Field component
  *
- * Imported by field.tsx (React) to ensure visual parity with the Web Component
- * target at field.styles.ts. Field is a layout-composition wrapper: container
+ * Imported by field.tsx (React), field.astro (Astro), and the field Web
+ * Component (which renders its inner nodes from these strings) to ensure
+ * visual parity across targets. Field is a layout-composition wrapper: container
  * stacks label + control + helper/error with consistent spacing; the helper
  * and error variants share the small label type ramp but flip color.
  */

--- a/packages/ui/src/components/ui/input-otp.element.ts
+++ b/packages/ui/src/components/ui/input-otp.element.ts
@@ -3,8 +3,11 @@
  * and verification-code segmented input.
  *
  * Mirrors the semantics of input-otp.tsx (segmented display, paste, auto-
- * advance, keyboard navigation) using shadow-DOM-scoped CSS composed via
- * classy-wc. Auto-registers on import and is idempotent against double-define.
+ * advance, keyboard navigation). The inner segments carry the SAME utility
+ * class strings the React/Astro targets use, imported from input-otp.classes.ts;
+ * presentation resolves from the shared compiled utility sheet adopted by
+ * RaftersElement (setUtilityCSS). Auto-registers on import and is idempotent
+ * against double-define.
  *
  * Form-associated: participates in <form> submission, validation, reset,
  * disabled propagation, and state restoration via ElementInternals. The

--- a/packages/ui/src/components/ui/input.element.ts
+++ b/packages/ui/src/components/ui/input.element.ts
@@ -76,14 +76,14 @@ function parseType(value: string | null): InputType {
 }
 
 function parseVariant(value: string | null): InputVariant {
-  if (value && value in inputVariantClasses) {
+  if (value && Object.hasOwn(inputVariantClasses, value)) {
     return value as InputVariant;
   }
   return 'default';
 }
 
 function parseSize(value: string | null): InputSize {
-  if (value && value in inputSizeClasses) {
+  if (value && Object.hasOwn(inputSizeClasses, value)) {
     return value as InputSize;
   }
   return 'default';

--- a/packages/ui/src/components/ui/radio-group.element.ts
+++ b/packages/ui/src/components/ui/radio-group.element.ts
@@ -3,9 +3,11 @@
  * Component pair for mutually exclusive selection.
  *
  * Mirrors the semantics of radio-group.tsx (value, orientation,
- * disabled, required, name) using shadow-DOM-scoped CSS composed via
- * classy-wc. Both elements auto-register on import and are idempotent
- * against double-define.
+ * disabled, required, name). The inner nodes carry the SAME utility class
+ * strings the React/Astro targets use, imported from radio-group.classes.ts;
+ * presentation resolves from the shared compiled utility sheet adopted by
+ * RaftersElement (setUtilityCSS). Both elements auto-register on import and are
+ * idempotent against double-define.
  *
  * The group is form-associated via ElementInternals: it participates
  * in <form> submission as `name=value`, reports `valueMissing`

--- a/packages/ui/src/components/ui/slider.element.ts
+++ b/packages/ui/src/components/ui/slider.element.ts
@@ -113,14 +113,14 @@ function parseOrientation(value: string | null): SliderOrientation {
 }
 
 function parseVariant(value: string | null): SliderVariant {
-  if (value && value in sliderVariantClasses) {
+  if (value && Object.hasOwn(sliderVariantClasses, value)) {
     return value as SliderVariant;
   }
   return 'default';
 }
 
 function parseSize(value: string | null): SliderSize {
-  if (value && value in sliderSizeClasses) {
+  if (value && Object.hasOwn(sliderSizeClasses, value)) {
     return value as SliderSize;
   }
   return 'default';

--- a/packages/ui/src/components/ui/switch.element.ts
+++ b/packages/ui/src/components/ui/switch.element.ts
@@ -70,14 +70,14 @@ const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = [
 ] as const;
 
 function parseVariant(value: string | null): SwitchVariant {
-  if (value && value in switchVariantClasses) {
+  if (value && Object.hasOwn(switchVariantClasses, value)) {
     return value as SwitchVariant;
   }
   return 'default';
 }
 
 function parseSize(value: string | null): SwitchSize {
-  if (value && value in switchSizeClasses) {
+  if (value && Object.hasOwn(switchSizeClasses, value)) {
     return value as SwitchSize;
   }
   return 'default';

--- a/packages/ui/src/components/ui/textarea.element.ts
+++ b/packages/ui/src/components/ui/textarea.element.ts
@@ -2,9 +2,11 @@
  * <rafters-textarea> -- Form-associated Web Component for multi-line text.
  *
  * Mirrors the semantics of textarea.tsx (variant, size, resize, native
- * textarea attributes) using shadow-DOM-scoped CSS composed via
- * classy-wc. Auto-registers on import and is idempotent against
- * double-define.
+ * textarea attributes). The inner textarea carries the SAME utility class
+ * strings the React/Astro targets use, imported from textarea.classes.ts;
+ * presentation resolves from the shared compiled utility sheet adopted by
+ * RaftersElement (setUtilityCSS). Auto-registers on import and is idempotent
+ * against double-define.
  *
  * Form-associated: participates in <form> submission, validation,
  * reset, disabled propagation, and state restoration via
@@ -114,14 +116,14 @@ function parseResize(value: string | null): TextareaResize {
 }
 
 function parseVariant(value: string | null): TextareaVariant {
-  if (value && value in textareaVariantClasses) {
+  if (value && Object.hasOwn(textareaVariantClasses, value)) {
     return value as TextareaVariant;
   }
   return 'default';
 }
 
 function parseSize(value: string | null): TextareaSize {
-  if (value && value in textareaSizeClasses) {
+  if (value && Object.hasOwn(textareaSizeClasses, value)) {
     return value as TextareaSize;
   }
   return 'default';

--- a/packages/ui/src/components/ui/toggle-group.element.ts
+++ b/packages/ui/src/components/ui/toggle-group.element.ts
@@ -90,7 +90,7 @@ function parseVariant(value: string | null): ToggleGroupVariant {
 }
 
 function parseSize(value: string | null): ToggleGroupSize {
-  if (value && value in toggleGroupItemSizeClasses) {
+  if (value && Object.hasOwn(toggleGroupItemSizeClasses, value)) {
     return value as ToggleGroupSize;
   }
   return 'default';

--- a/packages/ui/src/components/ui/toggle.element.ts
+++ b/packages/ui/src/components/ui/toggle.element.ts
@@ -56,14 +56,14 @@ const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = [
 ] as const;
 
 function parseVariant(value: string | null): ToggleVariant {
-  if (value && value in toggleVariantClasses) {
+  if (value && Object.hasOwn(toggleVariantClasses, value)) {
     return value as ToggleVariant;
   }
   return 'default';
 }
 
 function parseSize(value: string | null): ToggleSize {
-  if (value && value in toggleSizeClasses) {
+  if (value && Object.hasOwn(toggleSizeClasses, value)) {
     return value as ToggleSize;
   }
   return 'default';


### PR DESCRIPTION
## Summary

Post-merge review of the WC migration (#1565) found that seven Web Component elements validated their `variant`/`size` attribute with `value in map`. Because the `in` operator walks the prototype chain, an attribute like `variant="constructor"` passed the guard, the map lookup then returned a truthy prototype value (e.g. `Object.prototype.constructor`), the compose helper's `?? default` fallback never fired on that truthy value, and property reads like `v.border` resolved to `undefined` — emitting literal `undefined` tokens into the rendered class string. This change closes that hole.

## Acceptance criteria mapping

### 1. No parse guard uses bare `value in map`

Each `parseVariant`/`parseSize` guard in the seven affected elements now calls `Object.hasOwn(map, value)` instead of `value in map`. `Object.hasOwn` only consults the object's own enumerable keys, so inherited `Object.prototype` members (`constructor`, `toString`, `__proto__`, `hasOwnProperty`, `valueOf`) no longer satisfy the guard and the function returns its `'default'` literal. Valid keys are own properties of the class-map object literals, so their behavior is unchanged. This is the same protection button/badge/alert already had via explicit array `.includes`.
Evidence: 13 call sites changed across `checkbox.element.ts` (lines 77, 84), `switch.element.ts` (73, 80), `slider.element.ts` (116, 123), `toggle.element.ts` (59, 66), `toggle-group.element.ts` (93), `input.element.ts` (79, 86), `textarea.element.ts` (117, 124); no `value in *Classes` pattern remains in those files.

### 2. Prototype-key attributes fall back to default with no `undefined` in the class string

With the guard fixed, `parseVariant('constructor')` and `parseSize('toString')` both return `'default'`, so `render()` composes the default class string and never reads a property off a prototype value. The added regression test mounts a `<rafters-checkbox>` with `variant="constructor"` and `size="toString"` and asserts the inner button's `className` is exactly `composeCheckboxClasses('default','default')` and contains no substring `undefined`.
Evidence: new test "falls back to default for prototype-chain attribute values (no undefined classes)" in `checkbox.element.test.ts`; passes under `pnpm --filter @rafters/ui exec vitest run`.

### 3. No regression

The change is limited to the validation operator plus a regression test and five doc-comment corrections; no compose logic, fallback literal, or behavior path changed. Full preflight (build + 4539 tests + lint + typecheck) passes.
Evidence: `pnpm preflight` exit 0; lefthook pre-commit (unit-tests + lint + typecheck) green on commit 8c67e2e4.

## Not done

- The compose helpers' `?? { ...empty literal }` fallbacks are deliberately left in place as defense-in-depth (they now only ever guard genuine map gaps, not prototype keys).
- Elements already using explicit array `.includes` (button, badge, alert) are untouched — they were never vulnerable.
- The pre-existing React inline-copy drift documented on #1564/#1565 (token-pass divergence) is out of scope here; this PR is only the validation hardening.