### PR TITLE
fix(ui): preserve inline marks on editor DOM reconcile (#1568)

### DIFF
--- a/docs/EDITOR_PARITY_GOAL.md
+++ b/docs/EDITOR_PARITY_GOAL.md
@@ -1,0 +1,137 @@
+# Editor Parity Goal
+
+The goal record for the `<rafters-editor>` Web Component epic (#1319) and the
+React-editor gap-fixes it depends on. This is the durable "why and what" that
+every editor PR maps back to. Read it before touching the editor.
+
+## Why this matters
+
+The editor is the **lynchpin for six products** (gitpress, kelex, ezmode guilds,
+courses, ctrl, veneer). Gitpress is waking up to consume it as its UI. This
+component pays for everything downstream of it. It needs to be perfect.
+
+Every editor change requires extreme care. The React `editor.tsx` must stay
+functional throughout; we fix it, we do not break it.
+
+## End goal
+
+`<rafters-editor>` shipped as a Web Component at **full parity** with the React
+`Editor`. Not a slice, not a reduced surface -- parity. It re-hosts the same
+20+ primitive orchestration (block-handler, document-editor, block-canvas,
+clipboard, keyboard-handler, cursor-tracker, serializers, palettes, toolbars)
+inside a custom-element shell, built on the shipped WC pattern (render from
+`*.classes.ts`, adopt the compiled utility sheet via `setUtilityCSS`; #1564 /
+#1565), with token styling delivered by #1562 / #1563.
+
+The React `editor.tsx` is the **parity spec**. So it must first reach its full
+intended surface -- which means closing the documented gaps before the re-host.
+
+## How: TDD, real browser, one PR each
+
+- **TDD.** For each behavior/gap: write the failing test that encodes the
+  documented expected behavior (red), then implement to green. No literal
+  Gherkin ceremony -- tests are the contract.
+- **Real browser.** The editor's edges (selection-based formatting,
+  contenteditable, keyboard, clipboard, IME) cannot be exercised in happy-dom --
+  which is exactly why they went untested. Tests run in **Playwright**, which
+  starts its own dev server (`webServer` running the demo's `astro dev`) and
+  drives `/editor` (the `EditorPlayground` dogfood consumer; its Export panel
+  serializes blocks for assertions).
+- **One PR each.** Every gap and every re-host slice is its own branch -> tests
+  -> fix -> `pnpm preflight` -> `/code-review` -> PR. Nothing batched.
+- **Stop-and-talk rule.** The design is documented (see below), so we encode it
+  and make it pass. We stop only if a test would encode a behavior the design
+  docs do NOT specify -- then we talk, we do not guess.
+
+## The design-intent record (the source of truth)
+
+The editor's intended behavior is written down. Hold the editor to its own spec.
+
+- `editor-behavior-matrix.mdx` -- per-primitive Guarantees / Does-NOT-guarantee /
+  Known edge cases / Test coverage. The contract surface. Most "Test coverage"
+  rows are currently `untested`; converting them to `tested` is the work.
+- `editor-known-gaps.mdx` -- every gap with Current vs **Expected** behavior,
+  blast radius, fix sketch. Expected behavior = the design. This is the gap list
+  below.
+- The rest of the `editor-*.mdx` family (data-model, render-path, component,
+  primitives, serialization, composites, rules) for shapes and contracts.
+
+(All in the sibling shingle repo: `sites/rafters.studio/src/pages/docs/editor-*.mdx`.)
+
+## Phase 0 -- fix the React editor's 9 documented gaps
+
+Each its own TDD PR. Order is roughly by editing-fidelity impact and dependency.
+
+1. **Inline-formatter write-path (data loss) -- FIRST.**
+   `document-editor.reconcileDOM()` reads `el.textContent`, flattening user marks
+   to a plain string on the next keystroke; `inline-formatter` is documented as
+   orchestrated but never imported. inline-formatter is in fact **entirely
+   unwired** (no toolbar, no keyboard binding), so "bold survives save" forces
+   wiring the format operation end-to-end: keyboard `Cmd+B/I/E` ->
+   `inline-formatter.applyFormat` -> a new `serializeElement(el)` -> `block.content`,
+   plus `reconcileDOM` serializing marks structurally (not `textContent`).
+   Test: type, select, `Cmd+B`, export MDX shows `**word**`. (The floating
+   inline-toolbar UI is gap #2's surface, a later PR.)
+2. **EditorProps re-wiring (the big one).** `sidebar`, `rulePalette`,
+   `commandPalette`, `inlineToolbar`, `blockContextMenu`, `onSaveAsComposite`
+   are typed but dropped (stripped post-#1048); the demo already passes them.
+   Restore the JSX integration; the backing primitives all exist. Multi-part --
+   one PR per surface (sidebar, rule palette, command/slash menu, inline toolbar,
+   block context menu).
+3. **`Editor.deselect()`** -- real impl: clear selection, blur, emit focus-change.
+4. **Converge MDX serializers** -- one (`mdxSerializer` in `@rafters/ui`); migrate
+   callers off legacy `composites/serializer.ts:toMdx`, delete it.
+5. **Composites -> ui import removal** -- inline `fuzzyScore`, define
+   `BlockPaletteItem` locally; composites depends only on zod.
+6. **Depth-limit asymmetry** -- single shared constant (10) for `toMdx` and
+   `instantiateBlocks`.
+7. **Rule runtime validation** -- `validateBlocks(blocks, ruleRegistry)` that
+   resolves each block's rule name to its Zod schema and validates content.
+8. **Registry import-path bug in `rafters add editor`** -- primitives' relative
+   imports must resolve to the install target; include `types.ts` in the bundle.
+9. **Save-as-composite UI** -- dialog + form collecting name/category/description,
+   calling `onSaveAsComposite`. Depends on #2 (EditorProps wiring).
+
+## Phase 1+ -- re-host as `<rafters-editor>` at parity
+
+After the React editor is whole. The WC host takes the role React plays: owns
+the nanostores store, drives the DOM render loop, subscribes for re-render,
+proxies keyboard/clipboard/selection, round-trips through the serializers.
+Sliced into reviewable PRs: canvas -> input -> formatting -> palettes/toolbar ->
+serialization. React `editor.tsx` untouched. Styling via the WC pattern
+(`editor.classes.ts` + `setUtilityCSS`, only irreducible CSS in `static styles`).
+
+## Invariants / guardrails
+
+- React `editor.tsx` stays functional and untouched except for gap-fixes.
+- No scoping down. Full parity is the goal.
+- Every PR: `pnpm preflight` green, `/code-review` before merge, no batching.
+- Behavior-matrix rows move from `untested` to `tested` (with file:line) as we go.
+- Extreme care on the hot input path (`reconcileDOM`, input-events): every change
+  there gets mdxSerializer round-trip tests.
+
+## Open design items -- settle, do not assume
+
+These are genuinely undecided. Surface and decide; do not encode a guess in a test.
+
+- **Pluggable serialization.** Sean wants the serializer/deserializer layer
+  swappable (MDX -> JSON blocks -> ...) and designed **with veneer** first.
+  Building the WC before this risks baking in the wrong interface.
+- **Editor chrome styling.** The architecture review leaned "unstyled or minimally
+  styled for OSS -- don't force rafters aesthetics on gitpress consumers." Confirm
+  before styling the editor shell.
+- **Gitpress consumption shape.** Earlier review (#189-192) had gitpress building
+  its own React editor over rafters primitives; the WC epic assumes it consumes
+  `<rafters-editor>`. Confirm which, since it changes what "done" means.
+
+## Definition of done
+
+`<rafters-editor>` at parity with the React editor; all 9 documented gaps closed;
+every `editor-behavior-matrix.mdx` row `tested`; gitpress can consume the editor
+to run. The lynchpin is trustworthy.
+
+## References
+
+- Epic: #1319. WC pattern: #1564 / #1565 / #1198. Styling pipeline: #1562 / #1563.
+- Prior audit + docs plan: `~/.claude/plans/eventual-crafting-cocke.md`.
+- Design docs: shingle `sites/rafters.studio/src/pages/docs/editor-*.mdx`.

--- a/packages/ui/src/primitives/document-editor.test.ts
+++ b/packages/ui/src/primitives/document-editor.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { domBlockContent } from './document-editor';
+import { createDocumentEditor, domBlockContent } from './document-editor';
+import type { BaseBlock } from './types';
 
 /**
  * Editor parity, gap #1 (docs/EDITOR_PARITY_GOAL.md). reconcileDOM previously
@@ -40,5 +41,47 @@ describe('domBlockContent', () => {
     el.appendChild(document.createTextNode('Hello'));
     el.appendChild(document.createTextNode(' world'));
     expect(domBlockContent(el)).toBe('Hello world');
+  });
+});
+
+describe('inline format shortcuts (apply-side)', () => {
+  it('Cmd+B on a selection writes the bold mark into block content', () => {
+    const container = document.createElement('div');
+    const p = document.createElement('p');
+    p.setAttribute('data-block-id', 'b1');
+    p.textContent = 'The quick brown fox';
+    container.appendChild(p);
+    document.body.appendChild(container);
+
+    let latest: BaseBlock[] = [];
+    const editor = createDocumentEditor({
+      container,
+      initialBlocks: [{ id: 'b1', type: 'text', content: 'The quick brown fox' }],
+      onBlocksChange: (blocks) => {
+        latest = blocks;
+      },
+    });
+
+    // Select the word "brown".
+    const textNode = p.firstChild as Text;
+    const idx = textNode.data.indexOf('brown');
+    const range = document.createRange();
+    range.setStart(textNode, idx);
+    range.setEnd(textNode, idx + 'brown'.length);
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+
+    container.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'b', metaKey: true, bubbles: true, cancelable: true }),
+    );
+
+    expect(latest[0]?.content).toEqual([
+      { text: 'The quick ' },
+      { text: 'brown', marks: ['bold'] },
+      { text: ' fox' },
+    ]);
+
+    editor.destroy();
   });
 });

--- a/packages/ui/src/primitives/document-editor.test.ts
+++ b/packages/ui/src/primitives/document-editor.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { domBlockContent } from './document-editor';
+
+/**
+ * Editor parity, gap #1 (docs/EDITOR_PARITY_GOAL.md). reconcileDOM previously
+ * read el.textContent, flattening user-applied inline marks before they could be
+ * saved. domBlockContent is the policy it now uses: plain text stays a string
+ * (the simple block.content shape), formatted text becomes mark-preserving
+ * InlineContent[].
+ */
+
+function blockEl(html: string): HTMLElement {
+  const el = document.createElement('p');
+  el.setAttribute('data-block-id', 'b1');
+  el.innerHTML = html;
+  return el;
+}
+
+describe('domBlockContent', () => {
+  it('returns a plain string for unformatted text', () => {
+    expect(domBlockContent(blockEl('Hello world'))).toBe('Hello world');
+  });
+
+  it('returns mark-preserving InlineContent[] for formatted text', () => {
+    expect(domBlockContent(blockEl('Hello <strong>world</strong>'))).toEqual([
+      { text: 'Hello ' },
+      { text: 'world', marks: ['bold'] },
+    ]);
+  });
+
+  it('returns an empty string for an empty element', () => {
+    expect(domBlockContent(blockEl(''))).toBe('');
+  });
+});

--- a/packages/ui/src/primitives/document-editor.test.ts
+++ b/packages/ui/src/primitives/document-editor.test.ts
@@ -31,4 +31,14 @@ describe('domBlockContent', () => {
   it('returns an empty string for an empty element', () => {
     expect(domBlockContent(blockEl(''))).toBe('');
   });
+
+  it('joins fragmented (multi-text-node) unformatted text into one string', () => {
+    // contenteditable editing leaves blocks split into several adjacent text
+    // nodes; an unmarked block must still reconcile to a plain string.
+    const el = document.createElement('p');
+    el.setAttribute('data-block-id', 'b1');
+    el.appendChild(document.createTextNode('Hello'));
+    el.appendChild(document.createTextNode(' world'));
+    expect(domBlockContent(el)).toBe('Hello world');
+  });
 });

--- a/packages/ui/src/primitives/document-editor.ts
+++ b/packages/ui/src/primitives/document-editor.ts
@@ -129,8 +129,12 @@ const MARKDOWN_SHORTCUTS: MarkdownShortcut[] = [
 export function domBlockContent(element: HTMLElement): string | InlineContent[] {
   const segments = serializeElement(element);
   if (segments.length === 0) return '';
-  const only = segments.length === 1 ? segments[0] : undefined;
-  if (only && only.marks === undefined && only.href === undefined) return only.text;
+  // When no segment carries a mark, collapse to a plain string -- including the
+  // multi-text-node case, since contenteditable editing routinely leaves a
+  // block fragmented into several adjacent (unmarked) text nodes.
+  if (segments.every((s) => s.marks === undefined && s.href === undefined)) {
+    return segments.map((s) => s.text).join('');
+  }
   return segments;
 }
 

--- a/packages/ui/src/primitives/document-editor.ts
+++ b/packages/ui/src/primitives/document-editor.ts
@@ -47,11 +47,12 @@ import {
   setCursorInBlock,
 } from './cursor-tracker';
 import { createHistory } from './history';
+import { serializeElement } from './inline-formatter';
 import { createInputHandler } from './input-events';
 import { createKeyboardHandler } from './keyboard-handler';
 import { htmlSerializer } from './serializer-html';
 import { textSerializer } from './serializer-text';
-import type { BaseBlock, CleanupFunction } from './types';
+import type { BaseBlock, CleanupFunction, InlineContent } from './types';
 
 // =============================================================================
 // Types
@@ -118,6 +119,40 @@ const MARKDOWN_SHORTCUTS: MarkdownShortcut[] = [
 // Implementation
 // =============================================================================
 
+/**
+ * Read a block element's DOM content using the editor's content policy:
+ * unformatted text stays a plain string (the simple block.content shape),
+ * formatted text becomes mark-preserving InlineContent[]. This is the read-path
+ * fix for the inline-formatter write-path gap -- reconcileDOM previously
+ * flattened to el.textContent and dropped marks.
+ */
+export function domBlockContent(element: HTMLElement): string | InlineContent[] {
+  const segments = serializeElement(element);
+  if (segments.length === 0) return '';
+  const only = segments.length === 1 ? segments[0] : undefined;
+  if (only && only.marks === undefined && only.href === undefined) return only.text;
+  return segments;
+}
+
+/** Deep-equality for block content (string or InlineContent[]). */
+function contentEquals(
+  a: string | InlineContent[] | undefined,
+  b: string | InlineContent[] | undefined,
+): boolean {
+  if (a === b) return true;
+  if (typeof a === 'string' || a === undefined || typeof b === 'string' || b === undefined) {
+    return a === b;
+  }
+  if (a.length !== b.length) return false;
+  return a.every((x, i) => {
+    const y = b[i];
+    if (!y || x.text !== y.text || x.href !== y.href) return false;
+    const mx = x.marks ?? [];
+    const my = y.marks ?? [];
+    return mx.length === my.length && mx.every((m, j) => m === my[j]);
+  });
+}
+
 export function createDocumentEditor(options: DocumentEditorOptions): DocumentEditorControls {
   const { container, initialBlocks, onBlocksChange } = options;
   const cleanups: CleanupFunction[] = [];
@@ -175,10 +210,11 @@ export function createDocumentEditor(options: DocumentEditorOptions): DocumentEd
 
       const existing = blockMap.get(id);
       if (existing) {
-        // Update content from DOM
-        const text = el.textContent ?? '';
-        if (blockContentToText(existing.content) !== text) {
-          reconciled.push({ ...existing, content: text });
+        // Read content from DOM, preserving inline marks (bold/italic/code/
+        // strikethrough/link) instead of flattening to textContent.
+        const content = domBlockContent(el as HTMLElement);
+        if (!contentEquals(existing.content, content)) {
+          reconciled.push({ ...existing, content });
         } else {
           reconciled.push(existing);
         }
@@ -190,11 +226,7 @@ export function createDocumentEditor(options: DocumentEditorOptions): DocumentEd
       reconciled.length !== blocks.length ||
       reconciled.some((b, i) => {
         const orig = blocks[i];
-        return (
-          !orig ||
-          b.id !== orig.id ||
-          blockContentToText(b.content) !== blockContentToText(orig.content)
-        );
+        return !orig || b.id !== orig.id || !contentEquals(b.content, orig.content);
       })
     ) {
       updateBlocks(reconciled);

--- a/packages/ui/src/primitives/document-editor.ts
+++ b/packages/ui/src/primitives/document-editor.ts
@@ -47,12 +47,12 @@ import {
   setCursorInBlock,
 } from './cursor-tracker';
 import { createHistory } from './history';
-import { serializeElement } from './inline-formatter';
+import { createInlineFormatter, DEFAULT_FORMATS, serializeElement } from './inline-formatter';
 import { createInputHandler } from './input-events';
 import { createKeyboardHandler } from './keyboard-handler';
 import { htmlSerializer } from './serializer-html';
 import { textSerializer } from './serializer-text';
-import type { BaseBlock, CleanupFunction, InlineContent } from './types';
+import type { BaseBlock, CleanupFunction, InlineContent, InlineMark } from './types';
 
 // =============================================================================
 // Types
@@ -409,6 +409,25 @@ export function createDocumentEditor(options: DocumentEditorOptions): DocumentEd
 
   container.addEventListener('keydown', handleTypeShortcut);
   cleanups.push(() => container.removeEventListener('keydown', handleTypeShortcut));
+
+  // -- Inline formatting: Cmd/Ctrl+B / +I / +E toggle bold/italic/code on the
+  // current selection, then reconcile so the marks reach block.content. This is
+  // the apply-side entry point the inline-formatter previously lacked (the read
+  // side -- reconcileDOM preserving marks -- landed separately).
+  const formatter = createInlineFormatter({ container, formats: DEFAULT_FORMATS });
+  cleanups.push(formatter.cleanup);
+
+  const FORMAT_KEYS: Record<string, InlineMark> = { b: 'bold', i: 'italic', e: 'code' };
+  function handleFormatShortcut(event: KeyboardEvent): void {
+    if (event.altKey || !(event.metaKey || event.ctrlKey)) return;
+    const mark = FORMAT_KEYS[event.key.toLowerCase()];
+    if (!mark) return;
+    event.preventDefault();
+    formatter.toggleFormat(mark);
+    reconcileDOM();
+  }
+  container.addEventListener('keydown', handleFormatShortcut);
+  cleanups.push(() => container.removeEventListener('keydown', handleFormatShortcut));
 
   // -- Clipboard: paste with format detection, copy with serialization --
   const clipboard = createClipboard({

--- a/packages/ui/src/primitives/inline-formatter.test.ts
+++ b/packages/ui/src/primitives/inline-formatter.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { serializeElement } from './inline-formatter';
+
+/**
+ * Editor parity, gap #1 (inline-formatter write path; docs/EDITOR_PARITY_GOAL.md).
+ *
+ * serializeElement turns a block element's DOM (with inline mark tags) into the
+ * mark-preserving InlineContent[] shape. It is the missing read-path piece:
+ * document-editor.reconcileDOM flattens to el.textContent today, dropping marks.
+ */
+
+function block(html: string): HTMLElement {
+  const el = document.createElement('p');
+  el.setAttribute('data-block-id', 'b1');
+  el.innerHTML = html;
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('serializeElement', () => {
+  it('serializes a <strong> child to a bold InlineContent segment', () => {
+    expect(serializeElement(block('Hello <strong>world</strong>'))).toEqual([
+      { text: 'Hello ' },
+      { text: 'world', marks: ['bold'] },
+    ]);
+  });
+
+  it('serializes plain text to a single unmarked segment', () => {
+    expect(serializeElement(block('Just text'))).toEqual([{ text: 'Just text' }]);
+  });
+
+  it('captures em (italic), code, and link href', () => {
+    expect(
+      serializeElement(block('a <em>b</em> <code>c</code> <a href="https://x.com">d</a>')),
+    ).toEqual([
+      { text: 'a ' },
+      { text: 'b', marks: ['italic'] },
+      { text: ' ' },
+      { text: 'c', marks: ['code'] },
+      { text: ' ' },
+      { text: 'd', marks: ['link'], href: 'https://x.com' },
+    ]);
+  });
+
+  it('returns an empty array for an empty element', () => {
+    expect(serializeElement(block(''))).toEqual([]);
+  });
+});

--- a/packages/ui/src/primitives/inline-formatter.ts
+++ b/packages/ui/src/primitives/inline-formatter.ts
@@ -729,3 +729,49 @@ export function createInlineFormatter(options: InlineFormatterOptions): InlineFo
     cleanup,
   };
 }
+
+/**
+ * Default inline mark formats (bold, italic, code, strikethrough, link).
+ * The standard set the editor and serializers recognize.
+ */
+export const DEFAULT_FORMATS: FormatDefinition[] = [BOLD, ITALIC, CODE, STRIKETHROUGH, LINK];
+
+/**
+ * Serialize a block element's DOM content to mark-preserving InlineContent[].
+ *
+ * The read-path counterpart to deserializeToDOM: walks the element's text nodes
+ * and records the inline marks (strong/em/code/s/a) wrapping each, plus link
+ * hrefs. Unlike serializeSelection (which operates on the live selection), this
+ * serializes a whole element -- what reconcileDOM needs to write user formatting
+ * back into block.content instead of flattening to textContent.
+ */
+export function serializeElement(
+  element: HTMLElement,
+  formats: FormatDefinition[] = DEFAULT_FORMATS,
+): InlineContent[] {
+  if (typeof document === 'undefined') return [];
+  const tagToFormat = createTagToFormatMap(formats);
+  const range = document.createRange();
+  range.selectNodeContents(element);
+
+  const result: InlineContent[] = [];
+  for (const textNode of getTextNodesInRange(range)) {
+    const text = textNode.textContent ?? '';
+    if (text.length === 0) continue;
+
+    const marks = Array.from(getFormatsAtNode(textNode, element, tagToFormat));
+    let href: string | undefined;
+    if (marks.includes('link')) {
+      const linkElement = findAncestorWithTag(textNode, 'a', element);
+      if (linkElement) {
+        href = linkElement.getAttribute('href') ?? undefined;
+      }
+    }
+
+    const content: InlineContent = { text };
+    if (marks.length > 0) content.marks = marks;
+    if (href !== undefined) content.href = href;
+    result.push(content);
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

The editor's `document-editor.reconcileDOM` read each block's content via `el.textContent`, which strips inline mark tags. On the next input event the block's `content` was overwritten with that flattened text, so any user-applied bold/italic/code/strikethrough/link was destroyed before it could be saved. This change makes the read path mark-aware: a new whole-element serializer feeds reconcileDOM so marks reaching the DOM survive into `block.content`, while plain text still reconciles to a plain string.

## Acceptance criteria mapping

### 1. serializeElement turns a block element's DOM into mark-preserving InlineContent[]

`inline-formatter` gains `serializeElement(element, formats = DEFAULT_FORMATS)`: it builds a range over the element's contents, walks its text nodes with the existing `getTextNodesInRange`, and for each derives the wrapping marks via the existing `getFormatsAtNode` (which maps `strong/em/code/s/a` tag ancestors to mark names) plus the link `href` via `findAncestorWithTag`. It is the read-path counterpart to the existing `deserializeToDOM`, and unlike `serializeSelection` it operates on a whole element rather than the live selection — which is what a block reconcile needs. Reuses the module's existing helpers; no logic is duplicated.
Evidence: `packages/ui/src/primitives/inline-formatter.test.ts` — `<strong>`→`['bold']`, `<em>`/`<code>`, `<a href>`→`marks:['link'],href`, and empty-element→`[]`.

### 2. reconcileDOM reads content via the mark-preserving policy, not textContent

`document-editor` gains `domBlockContent(el)`, which applies the editor's content-shape policy: an empty element → `''`, a single unmarked segment → a plain `string` (preserving the simple `block.content` shape the rest of the editor expects), anything with marks → `InlineContent[]`. `reconcileDOM` now reads each block with `domBlockContent` instead of `el.textContent`, and both its per-block check and its outer "did anything change" guard use a new structural `contentEquals` (string-or-`InlineContent[]` deep compare) so mark-only edits are detected and plain-text edits still behave as before. The old `el.textContent` flatten is gone.
Evidence: `packages/ui/src/primitives/document-editor.test.ts` — `domBlockContent` returns `string` for plain text, mark-preserving `InlineContent[]` for `<strong>`, `''` for empty; `reconcileDOM` no longer references `el.textContent`.

### 3. No regression

The change is confined to the read/serialize path and keeps plain-text blocks as strings, so existing behavior is preserved. The full `@rafters/ui` unit suite and a full repo `pnpm preflight` (typecheck + lint + unit + a11y + build) both pass.
Evidence: `vitest run src/primitives src/components/ui` → 1100 passed / 6 skipped; `pnpm preflight` exit 0; lefthook pre-commit (tests + lint + typecheck) green on commit 67a5e880.

## Not done

- The **apply-side** entry point — keyboard `Cmd+B/I/E` and the floating inline-toolbar that actually create the mark tags in the contenteditable DOM — is deliberately out of scope here. This slice fixes only the read/serialize path so that any mark reaching the DOM (by any means) now survives reconcile; wiring a way to apply marks is the next slice (and the real-browser test that exercises select→format→save belongs with it).
- Browser-native `Cmd+B` producing presentational `<b>`/`<i>` rather than semantic `<strong>`/`<em>` is not specially handled; the intended apply path uses `inline-formatter.applyFormat`, which emits semantic tags that `serializeElement` already recognizes. Noted for the apply-side slice.