### PR TITLE
refactor(composites): make @rafters/composites zod-only (#1570)

### DIFF
--- a/packages/composites/package.json
+++ b/packages/composites/package.json
@@ -14,9 +14,6 @@
   "peerDependencies": {
     "zod": "catalog:"
   },
-  "dependencies": {
-    "@rafters/ui": "workspace:*"
-  },
   "devDependencies": {
     "@rafters/shared": "workspace:*",
     "@types/node": "catalog:",

--- a/packages/composites/src/bridge.ts
+++ b/packages/composites/src/bridge.ts
@@ -7,7 +7,6 @@
  * into CompositeFile format.
  */
 
-import type { BlockPaletteItem } from '@rafters/ui/primitives/block-palette';
 import type {
   AppliedRule,
   CompositeBlock,
@@ -15,6 +14,17 @@ import type {
   CompositeFile,
   UsagePatterns,
 } from './manifest';
+
+/**
+ * Editor sidebar palette item. Defined locally (structurally identical to the
+ * UI primitive's BlockPaletteItem) so @rafters/composites depends only on zod.
+ */
+export interface BlockPaletteItem {
+  id: string;
+  label: string;
+  category: string;
+  keywords?: string[];
+}
 
 /** A block ready for insertion into the editor canvas (same shape as CompositeBlock). */
 export type InstantiatedBlock = CompositeBlock;

--- a/packages/composites/src/registry.ts
+++ b/packages/composites/src/registry.ts
@@ -5,8 +5,36 @@
  * O(1) lookup by ID, category grouping, and fuzzy search.
  */
 
-import { fuzzyScore } from '@rafters/ui/primitives/typeahead';
 import type { CompositeCategory, CompositeFile } from './manifest';
+
+/**
+ * Subsequence fuzzy score: +1 per matched char, +2 for a consecutive match,
+ * +3 for a start-of-word match; 0 unless every query char is found. Inlined
+ * from the typeahead primitive so @rafters/composites depends only on zod.
+ */
+function fuzzyScore(query: string, target: string): number {
+  if (query.length === 0) return 1;
+  if (query.length > target.length) return 0;
+
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+
+  let score = 0;
+  let qi = 0;
+  let prevMatchIndex = -2; // -2 so the first match is never "consecutive"
+
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) {
+      score += 1;
+      if (ti === prevMatchIndex + 1) score += 2;
+      if (ti === 0 || t[ti - 1] === ' ' || t[ti - 1] === '-') score += 3;
+      prevMatchIndex = ti;
+      qi++;
+    }
+  }
+
+  return qi === q.length ? score : 0;
+}
 
 const composites = new Map<string, CompositeFile>();
 

--- a/packages/composites/test/zod-only.test.ts
+++ b/packages/composites/test/zod-only.test.ts
@@ -1,0 +1,31 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Editor parity gap #5 (docs/EDITOR_PARITY_GOAL.md; editor-known-gaps.mdx
+ * "Composites Imports From UI"). @rafters/composites is meant to be a pure
+ * data-and-validation package any consumer (a worker, a CLI pipeline, a
+ * non-React service) can pull in without dragging the UI primitive layer.
+ * It previously imported fuzzyScore + BlockPaletteItem from @rafters/ui; both
+ * are now local. This guard keeps it that way.
+ */
+function tsFilesUnder(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) out.push(...tsFilesUnder(p));
+    else if (p.endsWith('.ts')) out.push(p);
+  }
+  return out;
+}
+
+describe('composites is dependency-free except zod', () => {
+  it('no source file imports @rafters/ui', () => {
+    const srcDir = join(__dirname, '..', 'src');
+    const offenders = tsFilesUnder(srcDir).filter((p) =>
+      readFileSync(p, 'utf8').includes('@rafters/ui'),
+    );
+    expect(offenders).toEqual([]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,10 +433,6 @@ importers:
         version: 3.0.0(zod@4.1.12)
 
   packages/composites:
-    dependencies:
-      '@rafters/ui':
-        specifier: workspace:*
-        version: link:../ui
     devDependencies:
       '@rafters/shared':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

`@rafters/composites` is meant to be a pure data-and-validation package (zod only) that any consumer can bundle, but it imported two things from `@rafters/ui` — `fuzzyScore` and the `BlockPaletteItem` type — which drags the whole UI primitive layer into any non-React consumer. This change inlines both, drops the dependency, and adds a guard so it can't regress.

## Acceptance criteria mapping

### 1. fuzzyScore inlined into composites

`registry.ts` no longer imports `fuzzyScore` from `@rafters/ui/primitives/typeahead`; it defines a local `fuzzyScore(query, target)` copied verbatim from the typeahead primitive (the same subsequence scorer: +1 per matched char, +2 consecutive, +3 start-of-word, 0 unless all query chars match). `search()` calls the local one. Behavior is identical, so existing registry-search ordering is preserved.
Evidence: `registry.ts` top — local `function fuzzyScore`; no typeahead import remains.

### 2. BlockPaletteItem defined locally

`bridge.ts` no longer type-imports `BlockPaletteItem` from `@rafters/ui/primitives/block-palette`; it declares its own `export interface BlockPaletteItem { id; label; category; keywords? }` — structurally identical to the UI primitive's. `toBridgeItem`/`toBridgeItems` keep the same signatures, so consumers (e.g. an editor sidebar) are unaffected by structural typing.
Evidence: `bridge.ts` — local `export interface BlockPaletteItem`; no block-palette import.

### 3. @rafters/ui dependency removed + invariant guarded

`packages/composites/package.json` no longer has a `dependencies` block (its sole entry was `@rafters/ui`); composites now depends only on zod (peer) plus dev-only test deps. A new test walks every `.ts` under `src/` and fails if any imports `@rafters/ui`, so the decoupling can't silently regress.
Evidence: `package.json` diff (dependencies block removed); `test/zod-only.test.ts` passes.

### 4. No regression

The change is a mechanical decoupling with no logic change. A full repo `pnpm preflight` (typecheck across all packages + lint + unit + a11y + build of the website/registry which consume composites) passes, confirming composites' consumers still build and typecheck against the local `BlockPaletteItem`.
Evidence: `pnpm preflight` exit 0; composites typecheck + unit tests green; lefthook pre-commit green on commit 8d081958.

## Not done

- The asymmetric circular-reference depth limits (gap #6) also live in composites but are a separate issue/PR; not touched here.
- No change to composites' public API beyond newly *exporting* a local `BlockPaletteItem` (previously the type was imported and only used internally).