### PR TITLE
fix(ui): implement Editor.deselect (#1572)

### DIFF
--- a/packages/ui/src/components/ui/editor.tsx
+++ b/packages/ui/src/components/ui/editor.tsx
@@ -405,7 +405,11 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
       updateBlock,
       getBlocks: () => blocksAtomRef.current.get(),
       focus: () => canvasRef.current?.focus(),
-      deselect: () => {},
+      deselect: () => {
+        window.getSelection()?.removeAllRanges();
+        canvasRef.current?.blur();
+        setFocusedBlockId(null);
+      },
     };
     React.useImperativeHandle(ref, () => controlsRef.current as EditorControls, []);
 

--- a/packages/ui/test/components/editor-deselect.test.tsx
+++ b/packages/ui/test/components/editor-deselect.test.tsx
@@ -1,0 +1,41 @@
+import { cleanup, render } from '@testing-library/react';
+import { createRef } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Editor, type EditorControls } from '../../src/components/ui/editor';
+
+/**
+ * Editor parity gap #3 (docs/EDITOR_PARITY_GOAL.md; editor-known-gaps.mdx
+ * "Editor.deselect Is A Stub"). deselect() was an empty function; consumers
+ * that programmatically drop selection (after save/navigation) had no working
+ * way to do it. It must clear the selection and blur the active contenteditable.
+ */
+afterEach(cleanup);
+
+describe('Editor.deselect', () => {
+  it('clears the selection and blurs the canvas', () => {
+    const ref = createRef<EditorControls>();
+    const { container } = render(
+      <Editor ref={ref} defaultValue={[{ id: '1', type: 'text', content: 'hello' }]} />,
+    );
+
+    const canvas = container.querySelector('[contenteditable="true"]') as HTMLElement | null;
+    expect(canvas).not.toBeNull();
+
+    // Focus the canvas and place a selection inside it.
+    canvas?.focus();
+    const textNode = container.querySelector('[data-block-id]')?.firstChild as Text | null;
+    if (textNode) {
+      const range = document.createRange();
+      range.selectNodeContents(textNode);
+      const sel = window.getSelection();
+      sel?.removeAllRanges();
+      sel?.addRange(range);
+    }
+    expect(window.getSelection()?.rangeCount ?? 0).toBeGreaterThan(0);
+
+    ref.current?.deselect();
+
+    expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
+    expect(document.activeElement).not.toBe(canvas);
+  });
+});


### PR DESCRIPTION
## Summary

`EditorControls.deselect()` was an empty function — consumers calling it to drop the editor's selection (after a save, after navigating away) got a no-op while believing they had a working API. This implements it: clear the selection, blur the canvas, reset the focused-block state.

## Acceptance criteria mapping

### 1. deselect clears selection and blurs the canvas

`deselect()` now runs `window.getSelection()?.removeAllRanges()` (drops the active selection), `canvasRef.current?.blur()` (removes focus from the contenteditable surface), and `setFocusedBlockId(null)` (resets the toolbar's focused-block state so dependent UI updates). It closes over the same `canvasRef`/`setFocusedBlockId` the rest of the component uses, so it stays correct across renders.
Evidence: `editor.tsx` — the `deselect` entry in `controlsRef.current` is no longer `() => {}`. The RTL test in `editor-deselect.test.tsx` renders `<Editor>`, focuses the canvas and selects a word inside it (asserting `rangeCount > 0` first), calls `ref.current.deselect()`, then asserts `getSelection().rangeCount === 0` and `document.activeElement !== canvas`.

### 2. No regression

The change is confined to the `deselect` control; the rest of `editor.tsx` is untouched, and no other control or render path changes. The full `@rafters/ui` suite and a repo `pnpm preflight` pass.
Evidence: `pnpm preflight` exit 0; the new RTL test passes; lefthook pre-commit (tests + lint + typecheck) green on commit f06a906a.

## Not done

- Wiring `deselect` to a `document-editor` primitive method — the primitive has no `deselect`, and the React-level clear-selection-and-blur fully satisfies the documented expected behavior, so no primitive change was needed.
- Emitting a dedicated focus-change *callback* to subscribers: the editor surfaces focus state via `focusedBlockId` (now reset), not a separate subscription API, so there is no additional callback to fire.