### PR TITLE
feat(composites): rule runtime validation engine (#1574)

### DIFF
--- a/packages/composites/src/index.ts
+++ b/packages/composites/src/index.ts
@@ -50,10 +50,17 @@ export {
   register as registerComposite,
   search as searchComposites,
 } from './registry';
-export type { RuleMatch } from './rules';
+export type {
+  BlockValidationError,
+  RuleMatch,
+  RuleRegistry,
+  ValidatableBlock,
+} from './rules';
 export {
+  builtInRules,
   findCompatibleConsumers,
   findCompatibleProducers,
   matchRules,
+  validateBlocks,
 } from './rules';
 export { toMdx } from './serializer';

--- a/packages/composites/src/rules.ts
+++ b/packages/composites/src/rules.ts
@@ -5,7 +5,9 @@
  * Matching is by exact name, not structural type comparison.
  */
 
-import type { CompositeFile } from './manifest';
+import type { z } from 'zod';
+import { credentials, email, password, required, url } from './built-in-rules';
+import type { AppliedRule, CompositeFile } from './manifest';
 
 export interface RuleMatch {
   /** Rules that match between output and input */
@@ -64,4 +66,84 @@ export function findCompatibleProducers(
   candidates: CompositeFile[],
 ): CompositeFile[] {
   return candidates.filter((candidate) => matchRules(candidate, consumer).compatible);
+}
+
+// =============================================================================
+// Runtime validation
+// =============================================================================
+
+/** Maps a rule name to the Zod schema its block content must satisfy. */
+export type RuleRegistry = Record<string, z.ZodTypeAny>;
+
+/** The built-in rule schemas, keyed by name. The default validation registry. */
+export const builtInRules: RuleRegistry = { credentials, email, password, required, url };
+
+/** A single block-level rule validation failure. */
+export interface BlockValidationError {
+  blockId: string;
+  rule: string;
+  message: string;
+}
+
+/** A block carrying applied rules whose content can be validated. */
+export interface ValidatableBlock {
+  id: string;
+  content?: unknown;
+  rules?: AppliedRule[];
+}
+
+/** Coerce a block's content into the plain string the rule schemas validate. */
+function contentToText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((segment) =>
+        segment && typeof segment === 'object' && 'text' in segment
+          ? String((segment as { text: unknown }).text)
+          : '',
+      )
+      .join('');
+  }
+  return '';
+}
+
+/**
+ * Validate each block's content against the Zod schemas of the rules attached
+ * to it. Walks the blocks, resolves every rule name to a schema in the registry
+ * (built-in by default), runs `safeParse` against the block's text content, and
+ * accumulates per-block failures. A rule with no schema in the registry is
+ * reported rather than silently passed -- the previous behavior was name-only
+ * matching with no runtime check at all.
+ */
+export function validateBlocks(
+  blocks: ValidatableBlock[],
+  registry: RuleRegistry = builtInRules,
+): BlockValidationError[] {
+  const errors: BlockValidationError[] = [];
+
+  for (const block of blocks) {
+    if (!block.rules) continue;
+    const text = contentToText(block.content);
+
+    for (const applied of block.rules) {
+      const rule = typeof applied === 'string' ? applied : applied.name;
+      const schema = registry[rule];
+
+      if (!schema) {
+        errors.push({ blockId: block.id, rule, message: `Unknown rule: "${rule}"` });
+        continue;
+      }
+
+      const result = schema.safeParse(text);
+      if (!result.success) {
+        errors.push({
+          blockId: block.id,
+          rule,
+          message: result.error.issues[0]?.message ?? 'Validation failed',
+        });
+      }
+    }
+  }
+
+  return errors;
 }

--- a/packages/composites/test/rule-validation.test.ts
+++ b/packages/composites/test/rule-validation.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { validateBlocks } from '../src/rules';
+
+/**
+ * Editor parity gap #7 (docs/EDITOR_PARITY_GOAL.md; editor-known-gaps.mdx
+ * "Rule Runtime Validation Gap"). Blocks declare rules, and built-in-rules/*
+ * are Zod schemas, but nothing ever validated a block's content against the
+ * schema of its rules. validateBlocks is that engine.
+ */
+describe('validateBlocks', () => {
+  it('passes a block whose content satisfies its rule', () => {
+    expect(validateBlocks([{ id: 'b1', content: 'a@b.com', rules: ['email'] }])).toEqual([]);
+  });
+
+  it('flags a block whose content violates its rule', () => {
+    const errors = validateBlocks([{ id: 'b1', content: 'not-an-email', rules: ['email'] }]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ blockId: 'b1', rule: 'email' });
+  });
+
+  it('flags a required field that is empty', () => {
+    const errors = validateBlocks([{ id: 'b2', content: '', rules: ['required'] }]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.rule).toBe('required');
+  });
+
+  it('reports unknown rules instead of silently passing them', () => {
+    const errors = validateBlocks([{ id: 'b3', content: 'x', rules: ['nonexistent'] }]);
+    expect(errors[0]?.message).toContain('Unknown rule');
+  });
+
+  it('resolves the rule name from a parameterized {name, config} rule', () => {
+    expect(
+      validateBlocks([{ id: 'b4', content: 'a@b.com', rules: [{ name: 'email', config: {} }] }]),
+    ).toEqual([]);
+  });
+
+  it('ignores blocks without rules', () => {
+    expect(validateBlocks([{ id: 'b5', content: 'whatever' }])).toEqual([]);
+  });
+
+  it('coerces InlineContent[] content to text before validating', () => {
+    expect(
+      validateBlocks([
+        { id: 'b6', content: [{ text: 'a@' }, { text: 'b.com' }], rules: ['email'] },
+      ]),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Blocks declare rules and `built-in-rules/*` are Zod schemas, but nothing ever ran those schemas against a block's content — `matchRules` only compared rule *names*. So a composite could claim it's compatible with a consumer by name while the actual data shapes disagree, and the mismatch only surfaces later in UI. This adds the missing engine: `validateBlocks` runs each block's rule schemas against its content and returns concrete per-block errors.

## Acceptance criteria mapping

### 1. validateBlocks resolves each rule to its schema and validates content

`validateBlocks(blocks, registry = builtInRules)` iterates the blocks; for each block with `rules`, it resolves every applied rule's name to a Zod schema in the registry and runs `schema.safeParse(text)` on the block's content, pushing a `{ blockId, rule, message }` on failure (message taken from the first Zod issue). The default registry is `builtInRules`, an object mapping the five built-in rule names to their existing schemas — so no schema logic is duplicated, just wired up.
Evidence: `rule-validation.test.ts` — `email` passes `a@b.com`, fails `not-an-email` with `{blockId:'b1', rule:'email'}`; `required` fails empty content.

### 2. Parameterized + unknown rules handled

An applied rule is `string | { name, config }`; the engine reads `typeof applied === 'string' ? applied : applied.name`, so parameterized rules resolve by name. A rule name absent from the registry pushes an "Unknown rule" error instead of being silently skipped — the previous name-only matching gave consumers false confidence, so unknown rules must be visible.
Evidence: tests for `{ name: 'email', config: {} }` (passes) and `'nonexistent'` (message contains "Unknown rule").

### 3. Content coercion + no-rules

`contentToText` coerces content to the string the schemas expect: a plain string passes through, an `InlineContent[]` joins its segment `text`, anything else is `''`. Blocks without a `rules` array are skipped entirely (no errors).
Evidence: tests — `content: [{text:'a@'},{text:'b.com'}]` validates as a valid email; a block with no `rules` yields `[]`.

### 4. composites stays zod-only; no regression

The engine imports only `zod` (type-only `z`) and the local `built-in-rules`; it adds no dependency and keeps composites consumable standalone. A full repo `pnpm preflight` passes.
Evidence: `pnpm preflight` exit 0; composites typecheck + 7 new tests green; lefthook pre-commit green.

## Not done

- Config-parameterized schema construction (e.g. a `min-length` rule that reads `config.min` to build its schema) — the built-in rules are all static schemas, so the registry holds schemas, not schema factories. When config-driven rules are added, the registry value type can widen to `schema | (config) => schema`; out of scope here.
- Choosing a non-content target (validating a specific `meta` field per rule) — v1 validates block content, which matches every current built-in rule.