### PR TITLE
refactor(composites): share one recursion-depth constant (COMPOSITE_MAX_DEPTH)

### DIFF
--- a/packages/composites/src/bridge.ts
+++ b/packages/composites/src/bridge.ts
@@ -8,6 +8,7 @@
  */
 
 import type { BlockPaletteItem } from '@rafters/ui/primitives/block-palette';
+import { COMPOSITE_MAX_DEPTH } from './constants';
 import type {
   AppliedRule,
   CompositeBlock,
@@ -23,7 +24,7 @@ export type InstantiatedBlock = CompositeBlock;
 export interface InstantiateOptions {
   /** Resolve nested `composite:*` block types. Return null if not found. */
   resolveComposite?: (compositeId: string) => CompositeFile | null;
-  /** Maximum recursion depth for nested composites (default 10). */
+  /** Maximum recursion depth for nested composites (default COMPOSITE_MAX_DEPTH). */
   maxDepth?: number;
 }
 
@@ -92,7 +93,7 @@ function expandBlocks(
   options: InstantiateOptions,
   depth: number,
 ): InstantiatedBlock[] {
-  const maxDepth = options.maxDepth ?? 10;
+  const maxDepth = options.maxDepth ?? COMPOSITE_MAX_DEPTH;
   if (depth >= maxDepth) return [];
 
   // Build old-ID -> new-ID map

--- a/packages/composites/src/constants.ts
+++ b/packages/composites/src/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared recursion limit for nested composites.
+ *
+ * Both the composite serializer and the block instantiator cap how deep they
+ * recurse into nested `composite:*` blocks. Deep nesting indicates misuse, so a
+ * single conservative limit applies to both -- previously they diverged (50 vs
+ * 10), which let a pathological composite serialize but not instantiate.
+ */
+export const COMPOSITE_MAX_DEPTH = 10;

--- a/packages/composites/src/index.ts
+++ b/packages/composites/src/index.ts
@@ -26,6 +26,7 @@ export {
   required,
   url,
 } from './built-in-rules/index';
+export { COMPOSITE_MAX_DEPTH } from './constants';
 export type {
   AppliedRule,
   CompositeBlock,

--- a/packages/composites/src/serializer.ts
+++ b/packages/composites/src/serializer.ts
@@ -6,9 +6,8 @@
  * Child blocks render inline within their parent.
  */
 
+import { COMPOSITE_MAX_DEPTH } from './constants';
 import type { CompositeBlock } from './manifest';
-
-const MAX_DEPTH = 50;
 
 function kebabToPascal(kebab: string): string {
   const parts = kebab.split('-').filter((p) => p.length > 0);
@@ -22,7 +21,7 @@ function serializeBlock(
   visited = new Set<string>(),
   depth = 0,
 ): string {
-  if (depth > MAX_DEPTH) return '<!-- max nesting depth exceeded -->';
+  if (depth > COMPOSITE_MAX_DEPTH) return '<!-- max nesting depth exceeded -->';
   if (visited.has(block.id)) return '<!-- circular reference detected -->';
   visited.add(block.id);
 

--- a/packages/composites/test/depth-constant.test.ts
+++ b/packages/composites/test/depth-constant.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { COMPOSITE_MAX_DEPTH } from '../src/constants';
+
+/**
+ * Editor parity gap #6 (docs/EDITOR_PARITY_GOAL.md; editor-known-gaps.mdx
+ * "Asymmetric Circular-Reference Depth Limits"). The serializer (toMdx,
+ * MAX_DEPTH=50) and the instantiator (instantiateBlocks, maxDepth=10) capped
+ * recursion at different depths -- a pathological composite could serialize but
+ * not instantiate. Both now share one constant.
+ */
+describe('composite recursion depth is a single shared constant', () => {
+  it('COMPOSITE_MAX_DEPTH is 10', () => {
+    expect(COMPOSITE_MAX_DEPTH).toBe(10);
+  });
+
+  it('serializer and bridge use the shared constant, not divergent hard-coded limits', () => {
+    const read = (f: string) => readFileSync(join(__dirname, '..', 'src', f), 'utf8');
+    const serializer = read('serializer.ts');
+    const bridge = read('bridge.ts');
+
+    expect(serializer).toContain('COMPOSITE_MAX_DEPTH');
+    expect(serializer).not.toMatch(/MAX_DEPTH\s*=\s*50/);
+    expect(bridge).toContain('COMPOSITE_MAX_DEPTH');
+    expect(bridge).not.toMatch(/maxDepth\s*\?\?\s*10\b/);
+  });
+});


### PR DESCRIPTION
## Summary

Editor parity gap #6 (`docs/EDITOR_PARITY_GOAL.md`; `editor-known-gaps.mdx` "Asymmetric Circular-Reference Depth Limits"). The composite serializer (`toMdx`) capped recursion at `MAX_DEPTH = 50` while the block instantiator (`instantiateBlocks`) used `maxDepth = 10`. A pathologically deep nested composite could serialize but not instantiate (or render shallower than it serialized) -- a code smell rather than a crash, but worth removing.

Both sites now share one constant, `COMPOSITE_MAX_DEPTH` (10), in a new `composites/src/constants.ts`. A guard test pins the value and asserts neither file reintroduces a divergent hard-coded limit. composites stays zod-only; `pnpm preflight` is green.

## Acceptance criteria mapping

### 1. Single shared constant

`COMPOSITE_MAX_DEPTH = 10` lives in `packages/composites/src/constants.ts` and is exported from the package index. `serializer.ts` (`serializeBlock`, `depth > COMPOSITE_MAX_DEPTH`) and `bridge.ts` (`expandBlocks`, `options.maxDepth ?? COMPOSITE_MAX_DEPTH`) both consume it; neither hard-codes its own limit. `depth-constant.test.ts` reads both source files and asserts each contains `COMPOSITE_MAX_DEPTH` and matches neither `MAX_DEPTH = 50` nor `maxDepth ?? 10`.

### 2. No regression

Full `pnpm preflight` green (lefthook unit-tests + lint + typecheck on commit, plus the standalone preflight run). composites declares no `@rafters/ui` runtime dependency -- the change touches only the depth limit, so the zod-only boundary is unaffected.

## Not done

- The `instantiateBlocks` `maxDepth` option is retained for callers that want a lower bound; only the default diverged and is now unified. Raising or making the limit configurable per call is out of scope.
- Other editor-parity gaps (#2 EditorProps re-wiring, #4 MDX serializer convergence, #8 registry import-path) are tracked separately under the goal record.