### PR TITLE
fix(cli): derive rafters-add import-rewrite type per-file, not per-item

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rafters
 
+## 0.0.60
+
+### Bug Fixes
+
+- fix(cli): `rafters add` derives a file's import-rewrite type (component vs primitive) from the file's registry path rather than the item's type. A registry item can bundle files of both kinds -- a UI component that ships the shared primitives it imports. Previously every file in such an item was rewritten with the item's type, so a primitive bundled inside a `ui` item landed in `lib/primitives/` (correct path) but had its `./sibling` imports rewritten to `@/components/ui/` instead of `@/lib/primitives/`, leaving the install broken on first run. Import rewriting now keys off the same per-file path signal `transformPath` already uses to choose the destination directory. The shared `types.ts` primitive continues to ride along via the generator's sibling-import bundling. Refs editor parity gap #8.
+
 ## 0.0.59
 
 ### Bug Fixes

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -246,6 +246,27 @@ function transformPath(registryPath: string, config: RaftersConfig | null, cwd: 
 }
 
 /**
+ * Decide whether a registry file's imports are rewritten as a component's or a
+ * primitive's, keyed off the file's registry path rather than the item's type.
+ *
+ * A single registry item can bundle files of both kinds (e.g. a UI component
+ * that ships the shared primitives it imports), and `transformPath` already
+ * routes each file to its destination by path prefix. Import rewriting must use
+ * the same per-file signal, otherwise a primitive bundled inside a `ui` item
+ * lands in `lib/primitives/` but has its `./sibling` imports rewritten to
+ * `@/components/ui/` -- the `rafters add editor` bug. Falls back to the item's
+ * own type for paths without a recognized prefix.
+ */
+export function fileTypeForRegistryPath(
+  registryPath: string,
+  itemType: RegistryItem['type'],
+): 'component' | 'primitive' {
+  if (registryPath.startsWith('lib/primitives/')) return 'primitive';
+  if (registryPath.startsWith('components/ui/')) return 'component';
+  return itemType === 'primitive' ? 'primitive' : 'component';
+}
+
+/**
  * Check if a file already exists at the target path
  */
 function fileExists(cwd: string, relativePath: string): boolean {
@@ -375,8 +396,10 @@ async function installItem(
     // Ensure directory exists
     await mkdir(dirname(targetPath), { recursive: true });
 
-    // Transform and write the file
-    const fileType = item.type === 'primitive' ? 'primitive' : 'component';
+    // Transform and write the file. fileType is derived per-file from the
+    // registry path (not the item's type) so primitives bundled inside a
+    // component item still get their sibling imports rewritten to lib/primitives.
+    const fileType = fileTypeForRegistryPath(file.path, item.type);
     const transformedContent = transformFileContent(file.content, config, fileType, cwd);
     await writeFile(targetPath, transformedContent, 'utf-8');
 

--- a/packages/cli/test/commands/add.test.ts
+++ b/packages/cli/test/commands/add.test.ts
@@ -12,6 +12,7 @@ import { zocker } from 'zocker';
 import { z } from 'zod';
 import {
   collectDependencies,
+  fileTypeForRegistryPath,
   getInstalledNames,
   isAlreadyInstalled,
   trackInstalled,
@@ -126,6 +127,38 @@ import * as Dialog from '@radix-ui/react-dialog';`;
     const input = `import classy from "../../primitives/classy";`;
     const result = transformFileContent(input, null);
     expect(result).toBe(`import classy from '@/lib/primitives/classy';`);
+  });
+});
+
+describe('fileTypeForRegistryPath', () => {
+  it('treats lib/primitives/ files as primitives regardless of item type', () => {
+    expect(fileTypeForRegistryPath('lib/primitives/block-handler.ts', 'ui')).toBe('primitive');
+    expect(fileTypeForRegistryPath('lib/primitives/types.ts', 'composite')).toBe('primitive');
+  });
+
+  it('treats components/ui/ files as components regardless of item type', () => {
+    expect(fileTypeForRegistryPath('components/ui/editor.tsx', 'primitive')).toBe('component');
+  });
+
+  it('falls back to the item type for paths without a recognized prefix', () => {
+    expect(fileTypeForRegistryPath('composites/login-form.json', 'composite')).toBe('component');
+    expect(fileTypeForRegistryPath('rules/email.ts', 'primitive')).toBe('primitive');
+  });
+
+  it('rewrites a bundled primitive file to lib/primitives even inside a non-primitive item', () => {
+    // The `rafters add editor` bug: a primitive shipped to lib/primitives must
+    // import its siblings from @/lib/primitives, not @/components/ui -- even when
+    // it rides along inside a `ui` item rather than a standalone primitive item.
+    const path = 'lib/primitives/block-handler.ts';
+    const content = [
+      `import type { CleanupFunction } from './types';`,
+      `import { createBlockCanvas } from './block-canvas';`,
+    ].join('\n');
+    const fileType = fileTypeForRegistryPath(path, 'ui');
+    const result = transformFileContent(content, null, fileType);
+    expect(result).toContain(`from '@/lib/primitives/types'`);
+    expect(result).toContain(`from '@/lib/primitives/block-canvas'`);
+    expect(result).not.toContain('@/components/ui/');
   });
 });
 


### PR DESCRIPTION
## Summary

Editor parity gap #8 (`docs/EDITOR_PARITY_GOAL.md`; `editor-known-gaps.mdx` "Registry Import-Path Bug In `rafters add editor`"). `installItem` derived the component-vs-primitive `fileType` from the registry **item's** type and applied it to every file in the item, while `transformPath` already routes each file to its destination directory by **path** prefix. A registry item that bundles both kinds -- a UI component shipping the shared primitives it imports -- therefore wrote a primitive to `lib/primitives/` (correct path) but rewrote its `./sibling` imports to `@/components/ui/` instead of `@/lib/primitives/`, leaving the install broken on first run.

Import rewriting now keys off the same per-file path signal `transformPath` uses, via a new pure helper `fileTypeForRegistryPath`. This is the doc's literal fix sketch ("Track the registry path through the build instead of hard-coding `components/ui/`"). The `types.ts` half of the gap is already satisfied by the generator and is documented rather than re-implemented. `pnpm preflight` is green.

## Acceptance criteria mapping

### 1. Per-file import-rewrite type

`fileTypeForRegistryPath(registryPath, itemType)` (exported from `add.ts`): returns `primitive` for `lib/primitives/*`, `component` for `components/ui/*`, else falls back to the item's own type. `installItem` calls it per-file (`fileTypeForRegistryPath(file.path, item.type)`) in place of the former per-item `item.type === 'primitive' ? ...`. Unit tests in `add.test.ts` cover all three routing branches.

### 2. Regression: bundled primitive resolves to lib/primitives

`add.test.ts` "rewrites a bundled primitive file to lib/primitives even inside a non-primitive item": a `lib/primitives/block-handler.ts` file with `./types` and `./block-canvas` imports, typed via `fileTypeForRegistryPath(path, 'ui')`, rewrites both to `@/lib/primitives/...` and asserts the result contains no `@/components/ui/`.

### 3. types.ts installed

Already satisfied by the registry generator, so documented rather than re-implemented: `apps/registry`'s `loadPrimitive` bundles `./types` via `extractSiblingImports`, and `types` is additionally served as its own registry primitive (`/registry/primitives/types.json`, visible in the preflight website build), so the CLI resolves `types.ts` whether it arrives bundled or as a resolved dependency. Adding a test here would require bolting a vitest harness onto a test-less Astro app -- out of scope for a CLI fix; noted in the commit body.

### 4. No regression

Full `pnpm preflight` green (lefthook unit-tests + lint + typecheck on commit, plus the standalone preflight run, 252 CLI tests passing). `CHANGELOG.md` gains a `## 0.0.60` Bug Fixes entry for the behavior change.

## Not done

- The per-item -> per-file change is defense-in-depth for the documented symptom: today's generator emits homogeneous items (all `components/ui/*` or all `lib/primitives/*`), so the bug only triggers for a mixed-file item. The fix removes that latent fragility and makes the CLI correct regardless of how the generator bundles in future. Stated plainly so reviewers know the current generator does not yet produce the failing shape.
- No change to the registry generator (`apps/registry`); the `types.ts` bundling there already works.