### PR TITLE
feat(ui): wire Editor sidebar block-palette (parity gap #2, surface 1/5)

### DIFF
--- a/packages/ui/src/components/ui/editor.classes.ts
+++ b/packages/ui/src/components/ui/editor.classes.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared editor class definitions
+ *
+ * Co-located utility strings for the editor's composed surfaces (sidebar block
+ * palette, and future command palette / context menu / inline toolbar). Kept
+ * here so the React `editor.tsx` and the planned `<rafters-editor>` Web
+ * Component re-host bind to one source of truth, the same way every other
+ * triple-target component shares a `*.classes.ts`.
+ */
+
+/** Flex row wrapping the block-palette sidebar and the canvas. */
+export const editorSidebarLayoutClasses = 'flex h-full min-h-0';
+
+/** The sidebar panel itself: fixed-width, scrollable column beside the canvas. */
+export const editorSidebarAsideClasses =
+  'flex w-64 shrink-0 flex-col overflow-hidden border-r border-border';
+
+/** The sidebar search input. */
+export const editorSidebarSearchClasses = 'border-b border-border px-3 py-2 text-sm outline-none';
+
+/** Scrollable list region that the block-palette primitive mounts into. */
+export const editorSidebarListClasses = 'flex-1 overflow-y-auto p-2';
+
+/** Category header above each group of palette items. */
+export const editorSidebarCategoryClasses = 'px-1 py-1 text-xs font-medium text-muted-foreground';
+
+/** A single palette item row. */
+export const editorSidebarItemClasses = 'cursor-pointer rounded px-2 py-1 text-sm hover:bg-accent';

--- a/packages/ui/src/components/ui/editor.tsx
+++ b/packages/ui/src/components/ui/editor.tsx
@@ -17,6 +17,11 @@
 import { atom } from 'nanostores';
 import * as React from 'react';
 import { convertBlockType } from '../../primitives/block-operations';
+import {
+  type BlockPaletteControls,
+  type BlockPaletteItem,
+  createBlockPalette,
+} from '../../primitives/block-palette';
 import classy from '../../primitives/classy';
 import { findBlockElement } from '../../primitives/cursor-tracker';
 import {
@@ -26,6 +31,14 @@ import {
 import type { BaseBlock, CleanupFunction, Direction, InlineContent } from '../../primitives/types';
 import { Button } from './button';
 import { Container } from './container';
+import {
+  editorSidebarAsideClasses,
+  editorSidebarCategoryClasses,
+  editorSidebarItemClasses,
+  editorSidebarLayoutClasses,
+  editorSidebarListClasses,
+  editorSidebarSearchClasses,
+} from './editor.classes';
 import { Separator } from './separator';
 
 // =============================================================================
@@ -49,6 +62,9 @@ export interface EditorProps
   disabled?: boolean;
   dir?: Direction;
   className?: string;
+  /** Block-palette sidebar. When provided, mounts a categorized, searchable
+   *  list of insertable blocks beside the canvas. */
+  sidebar?: EditorSidebarConfig;
 }
 
 export interface EditorControls {
@@ -301,6 +317,7 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
       emptyState,
       disabled = false,
       dir,
+      sidebar,
       ...props
     },
     ref,
@@ -317,9 +334,18 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
     // -- Refs --
     const canvasRef = React.useRef<HTMLDivElement>(null);
     const docEditorRef = React.useRef<DocumentEditorControls | null>(null);
+    const sidebarRef = React.useRef<HTMLDivElement>(null);
+    const paletteRef = React.useRef<BlockPaletteControls | null>(null);
+    const [paletteGroups, setPaletteGroups] = React.useState<Map<string, BlockPaletteItem[]>>(
+      () => new Map(),
+    );
 
     // -- Toolbar state --
     const [focusedBlockId, setFocusedBlockId] = React.useState<string | null>(null);
+    // Mirror of focusedBlockId for the palette's activation closure, so insert
+    // position stays current without re-running the palette mount effect.
+    const focusedBlockIdRef = React.useRef<string | null>(null);
+    focusedBlockIdRef.current = focusedBlockId;
     const [canUndo, setCanUndo] = React.useState(false);
     const [canRedo, setCanRedo] = React.useState(false);
 
@@ -460,7 +486,57 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
       }
     }, [isControlled, controlledValue]);
 
+    // -- Sidebar block-palette lifecycle --
+    // Mirrors the document-editor mount pattern: React renders the item groups
+    // into sidebarRef, the primitive owns ARIA + event delegation on the same
+    // container. Activation inserts after the focused block (or appends).
+    React.useEffect(() => {
+      const sidebarEl = sidebarRef.current;
+      if (!sidebarEl || !sidebar) return;
+
+      const palette = createBlockPalette({
+        container: sidebarEl,
+        items: sidebar.items,
+        categories: sidebar.categories,
+        disabled,
+        onActivate: (item) => {
+          const focusedId = focusedBlockIdRef.current;
+          const current = blocksAtomRef.current.get();
+          const insertIndex = focusedId
+            ? current.findIndex((b) => b.id === focusedId) + 1
+            : undefined;
+          sidebar.onItemInsert?.(item, controlsRef.current as EditorControls, insertIndex);
+        },
+      });
+      paletteRef.current = palette;
+      setPaletteGroups(palette.getGroupedItems());
+
+      return () => {
+        palette.destroy();
+        paletteRef.current = null;
+      };
+    }, [sidebar, disabled]);
+
     const focusedBlock = focusedBlockId ? blocks.find((b) => b.id === focusedBlockId) : undefined;
+
+    const canvas = (
+      <Container
+        as="div"
+        padding="4"
+        ref={canvasRef}
+        role="textbox"
+        aria-multiline="true"
+        aria-label="Document editor"
+        tabIndex={disabled ? -1 : 0}
+        suppressContentEditableWarning
+        className={classy('outline-none h-full')}
+      >
+        {blocks.length === 0 && (emptyState ?? <DefaultEmptyState />)}
+        {blocks.map((block) => (
+          <DocumentBlock key={block.id} block={block} />
+        ))}
+      </Container>
+    );
 
     // -- Render --
     return (
@@ -484,22 +560,50 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
             onChangeBlockType={handleChangeBlockType}
           />
         )}
-        <Container
-          as="div"
-          padding="4"
-          ref={canvasRef}
-          role="textbox"
-          aria-multiline="true"
-          aria-label="Document editor"
-          tabIndex={disabled ? -1 : 0}
-          suppressContentEditableWarning
-          className={classy('outline-none h-full')}
-        >
-          {blocks.length === 0 && (emptyState ?? <DefaultEmptyState />)}
-          {blocks.map((block) => (
-            <DocumentBlock key={block.id} block={block} />
-          ))}
-        </Container>
+        {sidebar ? (
+          <div className={classy(editorSidebarLayoutClasses)}>
+            <aside aria-label="Block palette" className={classy(editorSidebarAsideClasses)}>
+              {sidebar.searchable && (
+                <input
+                  type="search"
+                  aria-label="Search blocks"
+                  placeholder="Search blocks"
+                  className={classy(editorSidebarSearchClasses)}
+                  onChange={(event) => {
+                    const palette = paletteRef.current;
+                    if (!palette) return;
+                    palette.setSearchQuery(event.target.value);
+                    setPaletteGroups(palette.getGroupedItems());
+                  }}
+                />
+              )}
+              <div ref={sidebarRef} className={classy(editorSidebarListClasses)}>
+                {Array.from(paletteGroups.entries()).map(([category, categoryItems]) => (
+                  <div key={category} role="presentation">
+                    <div className={classy(editorSidebarCategoryClasses)}>{category}</div>
+                    {categoryItems.map((item) => (
+                      <div
+                        key={item.id}
+                        data-palette-item=""
+                        data-palette-id={item.id}
+                        role="option"
+                        aria-selected="false"
+                        draggable
+                        tabIndex={-1}
+                        className={classy(editorSidebarItemClasses)}
+                      >
+                        {sidebar.renderItem ? sidebar.renderItem(item) : item.label}
+                      </div>
+                    ))}
+                  </div>
+                ))}
+              </div>
+            </aside>
+            {canvas}
+          </div>
+        ) : (
+          canvas
+        )}
       </Container>
     );
   },

--- a/packages/ui/test/components/editor.test.tsx
+++ b/packages/ui/test/components/editor.test.tsx
@@ -1,7 +1,11 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import type { EditorBlock, EditorControls } from '../../src/components/ui/editor';
+import type {
+  EditorBlock,
+  EditorControls,
+  EditorSidebarConfig,
+} from '../../src/components/ui/editor';
 import { Editor } from '../../src/components/ui/editor';
 
 const BLOCKS: EditorBlock[] = [
@@ -323,5 +327,79 @@ describe('Editor', () => {
       const { container } = render(<Editor data-testid="editor" id="my-editor" />);
       expect(container.firstChild).toHaveAttribute('id', 'my-editor');
     });
+  });
+});
+
+describe('Editor sidebar', () => {
+  const SIDEBAR: EditorSidebarConfig = {
+    items: [
+      { id: 'heading', label: 'Heading', category: 'Text', keywords: ['h1'] },
+      { id: 'paragraph', label: 'Paragraph', category: 'Text' },
+      { id: 'image', label: 'Image', category: 'Media' },
+    ],
+    categories: ['Text', 'Media'],
+    searchable: true,
+  };
+
+  it('does not render a sidebar when the prop is omitted', () => {
+    render(<Editor />);
+    expect(screen.queryByRole('complementary', { name: 'Block palette' })).not.toBeInTheDocument();
+  });
+
+  it('renders the block-palette sidebar when the sidebar prop is passed', () => {
+    render(<Editor sidebar={SIDEBAR} />);
+    expect(screen.getByRole('complementary', { name: 'Block palette' })).toBeInTheDocument();
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('renders every configured item', () => {
+    render(<Editor sidebar={SIDEBAR} />);
+    expect(screen.getByText('Heading')).toBeInTheDocument();
+    expect(screen.getByText('Paragraph')).toBeInTheDocument();
+    expect(screen.getByText('Image')).toBeInTheDocument();
+  });
+
+  it('renders category headers in configured order', () => {
+    render(<Editor sidebar={SIDEBAR} />);
+    expect(screen.getByText('Text')).toBeInTheDocument();
+    expect(screen.getByText('Media')).toBeInTheDocument();
+  });
+
+  it('renders a search input when searchable is true', () => {
+    render(<Editor sidebar={SIDEBAR} />);
+    expect(screen.getByRole('searchbox', { name: 'Search blocks' })).toBeInTheDocument();
+  });
+
+  it('omits the search input when searchable is false', () => {
+    render(<Editor sidebar={{ ...SIDEBAR, searchable: false }} />);
+    expect(screen.queryByRole('searchbox')).not.toBeInTheDocument();
+  });
+
+  it('filters items as the search query changes', () => {
+    render(<Editor sidebar={SIDEBAR} />);
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search blocks' }), {
+      target: { value: 'imag' },
+    });
+    expect(screen.getByText('Image')).toBeInTheDocument();
+    expect(screen.queryByText('Heading')).not.toBeInTheDocument();
+    expect(screen.queryByText('Paragraph')).not.toBeInTheDocument();
+  });
+
+  it('calls onItemInsert with the editor controls when an item is clicked', () => {
+    const onItemInsert = vi.fn();
+    render(<Editor sidebar={{ ...SIDEBAR, onItemInsert }} />);
+    fireEvent.click(screen.getByText('Heading'));
+    expect(onItemInsert).toHaveBeenCalledTimes(1);
+    expect(onItemInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'heading' }),
+      expect.objectContaining({ addBlocks: expect.any(Function) }),
+      undefined,
+    );
+  });
+
+  it('uses a custom renderItem when provided', () => {
+    const renderItem = (item: { label: string }) => <span>Custom:{item.label}</span>;
+    render(<Editor sidebar={{ ...SIDEBAR, renderItem }} />);
+    expect(screen.getByText('Custom:Heading')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Editor parity gap #2 (`docs/EDITOR_PARITY_GOAL.md`; `editor-known-gaps.mdx` "EditorProps Missing Wiring"), surface 1 of 5. The editor exported `EditorSidebarConfig` but never referenced it in `EditorProps`, so a `sidebar` prop was silently dropped through the `HTMLDivAttributes` spread. This wires the first dropped surface — the block-palette sidebar — using the primitive (`block-palette`) that already existed. The remaining four surfaces (rule palette, command/slash menu, inline toolbar, block context menu) follow as their own PRs, per the goal's one-PR-per-surface rule.

The integration mirrors the existing document-editor mount pattern already in this file: React renders the item groups into a ref'd container, the primitive owns ARIA + event delegation on that same container. A new `editor.classes.ts` holds the sidebar's utility strings so the React editor and the planned `<rafters-editor>` WC re-host bind to one source (the standard triple-target `*.classes.ts` pattern). The no-sidebar render path is byte-identical (the canvas was extracted to a const and is rendered directly when no sidebar is set). `pnpm preflight` is green; all 47 editor tests pass (38 existing + 9 new).

## Acceptance criteria mapping

### 1. sidebar prop wired

`EditorProps` gains `sidebar?: EditorSidebarConfig` (`editor.tsx`), added to the destructure so it is removed from `...props`. When set, an `<aside aria-label="Block palette">` (implicit role `complementary`) mounts beside the canvas wrapping a `role="listbox"` region. Tests: "renders the block-palette sidebar when the sidebar prop is passed", "does not render a sidebar when the prop is omitted".

### 2. Items + categories render

The render maps `paletteGroups` (from the primitive's `getGroupedItems()`) to category groups, each item carrying `data-palette-item`/`data-palette-id`/`role="option"`, rendered via `sidebar.renderItem` when provided else `item.label`. Tests: "renders every configured item", "renders category headers in configured order", "uses a custom renderItem when provided".

### 3. Search filters

A `<input type="search">` (implicit role `searchbox`) calls `palette.setSearchQuery` + refreshes `paletteGroups` on change. Shown only when `searchable`. Tests: "filters items as the search query changes", "renders a search input when searchable is true", "omits the search input when searchable is false".

### 4. Activation inserts

The primitive's `onActivate` (fired on click and Enter/Space via its container delegation) calls `sidebar.onItemInsert(item, controls, insertIndex)`, where `insertIndex` is the focused block's position + 1 (read through a ref to stay current) or `undefined` to append. Test: "calls onItemInsert with the editor controls when an item is clicked" asserts the item, an object exposing `addBlocks`, and `undefined`.

### 5. No regression

React `editor.tsx` stays functional; lefthook unit-tests + lint + typecheck pass on commit and the standalone `pnpm preflight` is green. The 38 pre-existing editor tests still pass alongside the 9 new ones.

## Not done

- Only the sidebar surface. The other four dropped surfaces (rule palette, command/slash menu, inline toolbar, block context menu) and the `onSaveAsComposite` callback (gap #9) are out of scope and tracked separately; `editor.classes.ts` is seeded so they share the home.
- Sidebar chrome is intentionally minimal (the goal's open item leans "unstyled/minimally styled for OSS consumers"); visual polish is deferred.
- The shingle `editor-behavior-matrix.mdx` row flip (untested -> tested) lives in the sibling docs repo and is not part of this code PR.