### PR TITLE
feat(ui): wire Editor rule palette (parity gap #2, surface 2/5)

### DIFF
--- a/packages/ui/src/components/ui/editor.classes.ts
+++ b/packages/ui/src/components/ui/editor.classes.ts
@@ -1,28 +1,32 @@
 /**
  * Shared editor class definitions
  *
- * Co-located utility strings for the editor's composed surfaces (sidebar block
- * palette, and future command palette / context menu / inline toolbar). Kept
- * here so the React `editor.tsx` and the planned `<rafters-editor>` Web
- * Component re-host bind to one source of truth, the same way every other
- * triple-target component shares a `*.classes.ts`.
+ * Co-located utility strings for the editor's composed palette surfaces (block
+ * sidebar, rule palette, and future command palette / context menu / inline
+ * toolbar). Kept here so the React `editor.tsx` and the planned
+ * `<rafters-editor>` Web Component re-host bind to one source of truth, the same
+ * way every other triple-target component shares a `*.classes.ts`.
  */
 
-/** Flex row wrapping the block-palette sidebar and the canvas. */
-export const editorSidebarLayoutClasses = 'flex h-full min-h-0';
+/** Flex row wrapping the palette panes and the canvas. */
+export const editorPaletteLayoutClasses = 'flex h-full min-h-0';
 
-/** The sidebar panel itself: fixed-width, scrollable column beside the canvas. */
+/** Block sidebar pane (left of the canvas). */
 export const editorSidebarAsideClasses =
   'flex w-64 shrink-0 flex-col overflow-hidden border-r border-border';
 
-/** The sidebar search input. */
-export const editorSidebarSearchClasses = 'border-b border-border px-3 py-2 text-sm outline-none';
+/** Rule palette pane (right of the canvas). */
+export const editorRulePaletteAsideClasses =
+  'flex w-64 shrink-0 flex-col overflow-hidden border-l border-border';
 
-/** Scrollable list region that the block-palette primitive mounts into. */
-export const editorSidebarListClasses = 'flex-1 overflow-y-auto p-2';
+/** A palette pane's search input. */
+export const editorPaletteSearchClasses = 'border-b border-border px-3 py-2 text-sm outline-none';
+
+/** Scrollable list region a block-palette primitive mounts into. */
+export const editorPaletteListClasses = 'flex-1 overflow-y-auto p-2';
 
 /** Category header above each group of palette items. */
-export const editorSidebarCategoryClasses = 'px-1 py-1 text-xs font-medium text-muted-foreground';
+export const editorPaletteCategoryClasses = 'px-1 py-1 text-xs font-medium text-muted-foreground';
 
 /** A single palette item row. */
-export const editorSidebarItemClasses = 'cursor-pointer rounded px-2 py-1 text-sm hover:bg-accent';
+export const editorPaletteItemClasses = 'cursor-pointer rounded px-2 py-1 text-sm hover:bg-accent';

--- a/packages/ui/src/components/ui/editor.tsx
+++ b/packages/ui/src/components/ui/editor.tsx
@@ -32,12 +32,13 @@ import type { BaseBlock, CleanupFunction, Direction, InlineContent } from '../..
 import { Button } from './button';
 import { Container } from './container';
 import {
+  editorPaletteCategoryClasses,
+  editorPaletteItemClasses,
+  editorPaletteLayoutClasses,
+  editorPaletteListClasses,
+  editorPaletteSearchClasses,
+  editorRulePaletteAsideClasses,
   editorSidebarAsideClasses,
-  editorSidebarCategoryClasses,
-  editorSidebarItemClasses,
-  editorSidebarLayoutClasses,
-  editorSidebarListClasses,
-  editorSidebarSearchClasses,
 } from './editor.classes';
 import { Separator } from './separator';
 
@@ -65,6 +66,9 @@ export interface EditorProps
   /** Block-palette sidebar. When provided, mounts a categorized, searchable
    *  list of insertable blocks beside the canvas. */
   sidebar?: EditorSidebarConfig;
+  /** Rule palette. When provided, mounts a categorized, searchable list of
+   *  rules that apply to the focused block, on the opposite side of the canvas. */
+  rulePalette?: EditorRulePaletteConfig;
 }
 
 export interface EditorControls {
@@ -214,6 +218,73 @@ function DefaultEmptyState() {
   );
 }
 
+interface PaletteAsideProps {
+  label: string;
+  asideClasses: string;
+  searchable: boolean;
+  searchLabel: string;
+  searchPlaceholder: string;
+  groups: Map<string, BlockPaletteItem[]>;
+  listRef: React.RefObject<HTMLDivElement | null>;
+  renderItem?:
+    | ((item: { id: string; label: string; category: string }) => React.ReactNode)
+    | undefined;
+  onSearch: (query: string) => void;
+}
+
+/**
+ * A palette pane: an optional search input over a category-grouped, selectable
+ * item list. The block-palette primitive (mounted by the caller into listRef)
+ * owns ARIA + event delegation; this renders only the markup it scans. Shared
+ * by the block sidebar and the rule palette.
+ */
+function PaletteAside({
+  label,
+  asideClasses,
+  searchable,
+  searchLabel,
+  searchPlaceholder,
+  groups,
+  listRef,
+  renderItem,
+  onSearch,
+}: PaletteAsideProps) {
+  return (
+    <aside aria-label={label} className={classy(asideClasses)}>
+      {searchable && (
+        <input
+          type="search"
+          aria-label={searchLabel}
+          placeholder={searchPlaceholder}
+          className={classy(editorPaletteSearchClasses)}
+          onChange={(event) => onSearch(event.target.value)}
+        />
+      )}
+      <div ref={listRef} className={classy(editorPaletteListClasses)}>
+        {Array.from(groups.entries()).map(([category, items]) => (
+          <div key={category} role="presentation">
+            <div className={classy(editorPaletteCategoryClasses)}>{category}</div>
+            {items.map((item) => (
+              <div
+                key={item.id}
+                data-palette-item=""
+                data-palette-id={item.id}
+                role="option"
+                aria-selected="false"
+                draggable
+                tabIndex={-1}
+                className={classy(editorPaletteItemClasses)}
+              >
+                {renderItem ? renderItem(item) : item.label}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </aside>
+  );
+}
+
 // =============================================================================
 // Block type toolbar
 // =============================================================================
@@ -318,6 +389,7 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
       disabled = false,
       dir,
       sidebar,
+      rulePalette,
       ...props
     },
     ref,
@@ -339,6 +411,11 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
     const [paletteGroups, setPaletteGroups] = React.useState<Map<string, BlockPaletteItem[]>>(
       () => new Map(),
     );
+    const rulePaletteRef = React.useRef<HTMLDivElement>(null);
+    const rulePaletteControlsRef = React.useRef<BlockPaletteControls | null>(null);
+    const [rulePaletteGroups, setRulePaletteGroups] = React.useState<
+      Map<string, BlockPaletteItem[]>
+    >(() => new Map());
 
     // -- Toolbar state --
     const [focusedBlockId, setFocusedBlockId] = React.useState<string | null>(null);
@@ -517,6 +594,37 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
       };
     }, [sidebar, disabled]);
 
+    // -- Rule palette lifecycle --
+    // Same mount pattern as the sidebar, but activation applies a rule to the
+    // focused block (gated by compatibleBlockTypes) instead of inserting one.
+    React.useEffect(() => {
+      const listEl = rulePaletteRef.current;
+      if (!listEl || !rulePalette) return;
+
+      const palette = createBlockPalette({
+        container: listEl,
+        items: rulePalette.items,
+        categories: rulePalette.categories,
+        disabled,
+        onActivate: (item) => {
+          const focusedId = focusedBlockIdRef.current;
+          if (!focusedId) return;
+          const block = blocksAtomRef.current.get().find((b) => b.id === focusedId);
+          if (!block) return;
+          const compatible = rulePalette.items.find((r) => r.id === item.id)?.compatibleBlockTypes;
+          if (compatible && compatible.length > 0 && !compatible.includes(block.type)) return;
+          rulePalette.onRuleApplied?.(focusedId, item.id, controlsRef.current as EditorControls);
+        },
+      });
+      rulePaletteControlsRef.current = palette;
+      setRulePaletteGroups(palette.getGroupedItems());
+
+      return () => {
+        palette.destroy();
+        rulePaletteControlsRef.current = null;
+      };
+    }, [rulePalette, disabled]);
+
     const focusedBlock = focusedBlockId ? blocks.find((b) => b.id === focusedBlockId) : undefined;
 
     const canvas = (
@@ -560,46 +668,45 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
             onChangeBlockType={handleChangeBlockType}
           />
         )}
-        {sidebar ? (
-          <div className={classy(editorSidebarLayoutClasses)}>
-            <aside aria-label="Block palette" className={classy(editorSidebarAsideClasses)}>
-              {sidebar.searchable && (
-                <input
-                  type="search"
-                  aria-label="Search blocks"
-                  placeholder="Search blocks"
-                  className={classy(editorSidebarSearchClasses)}
-                  onChange={(event) => {
-                    const palette = paletteRef.current;
-                    if (!palette) return;
-                    palette.setSearchQuery(event.target.value);
-                    setPaletteGroups(palette.getGroupedItems());
-                  }}
-                />
-              )}
-              <div ref={sidebarRef} className={classy(editorSidebarListClasses)}>
-                {Array.from(paletteGroups.entries()).map(([category, categoryItems]) => (
-                  <div key={category} role="presentation">
-                    <div className={classy(editorSidebarCategoryClasses)}>{category}</div>
-                    {categoryItems.map((item) => (
-                      <div
-                        key={item.id}
-                        data-palette-item=""
-                        data-palette-id={item.id}
-                        role="option"
-                        aria-selected="false"
-                        draggable
-                        tabIndex={-1}
-                        className={classy(editorSidebarItemClasses)}
-                      >
-                        {sidebar.renderItem ? sidebar.renderItem(item) : item.label}
-                      </div>
-                    ))}
-                  </div>
-                ))}
-              </div>
-            </aside>
+        {sidebar || rulePalette ? (
+          <div className={classy(editorPaletteLayoutClasses)}>
+            {sidebar && (
+              <PaletteAside
+                label="Block palette"
+                asideClasses={editorSidebarAsideClasses}
+                searchable={sidebar.searchable ?? false}
+                searchLabel="Search blocks"
+                searchPlaceholder="Search blocks"
+                groups={paletteGroups}
+                listRef={sidebarRef}
+                renderItem={sidebar.renderItem}
+                onSearch={(query) => {
+                  const palette = paletteRef.current;
+                  if (!palette) return;
+                  palette.setSearchQuery(query);
+                  setPaletteGroups(palette.getGroupedItems());
+                }}
+              />
+            )}
             {canvas}
+            {rulePalette && (
+              <PaletteAside
+                label="Rule palette"
+                asideClasses={editorRulePaletteAsideClasses}
+                searchable={rulePalette.searchable ?? false}
+                searchLabel="Search rules"
+                searchPlaceholder="Search rules"
+                groups={rulePaletteGroups}
+                listRef={rulePaletteRef}
+                renderItem={rulePalette.renderItem}
+                onSearch={(query) => {
+                  const palette = rulePaletteControlsRef.current;
+                  if (!palette) return;
+                  palette.setSearchQuery(query);
+                  setRulePaletteGroups(palette.getGroupedItems());
+                }}
+              />
+            )}
           </div>
         ) : (
           canvas

--- a/packages/ui/test/components/editor.test.tsx
+++ b/packages/ui/test/components/editor.test.tsx
@@ -1,9 +1,10 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import type {
   EditorBlock,
   EditorControls,
+  EditorRulePaletteConfig,
   EditorSidebarConfig,
 } from '../../src/components/ui/editor';
 import { Editor } from '../../src/components/ui/editor';
@@ -401,5 +402,107 @@ describe('Editor sidebar', () => {
     const renderItem = (item: { label: string }) => <span>Custom:{item.label}</span>;
     render(<Editor sidebar={{ ...SIDEBAR, renderItem }} />);
     expect(screen.getByText('Custom:Heading')).toBeInTheDocument();
+  });
+});
+
+describe('Editor rule palette', () => {
+  const RULE_PALETTE: EditorRulePaletteConfig = {
+    items: [
+      { id: 'required', label: 'Required', category: 'Validation' },
+      { id: 'email', label: 'Email', category: 'Validation', compatibleBlockTypes: ['input'] },
+      { id: 'min-length', label: 'Min Length', category: 'Constraints' },
+    ],
+    categories: ['Validation', 'Constraints'],
+    searchable: true,
+  };
+
+  // Drive the editor's selectionchange-based focus tracking. happy-dom does not
+  // reflect a programmatic Range back through window.getSelection(), so stub the
+  // selection to point at the target block and fire selectionchange; trackFocus
+  // reads anchorNode and resolves the block id from it.
+  function focusBlock(container: HTMLElement, blockId: string): void {
+    const el = container.querySelector(`[data-block-id="${blockId}"]`);
+    if (!el) throw new Error(`block ${blockId} not found`);
+    const stub = vi.spyOn(window, 'getSelection').mockReturnValue({
+      anchorNode: el,
+      rangeCount: 1,
+      getRangeAt: () => document.createRange(),
+      removeAllRanges: () => {},
+      toString: () => '',
+    } as unknown as Selection);
+    act(() => {
+      document.dispatchEvent(new Event('selectionchange'));
+    });
+    stub.mockRestore();
+  }
+
+  it('does not render a rule palette when the prop is omitted', () => {
+    render(<Editor defaultValue={BLOCKS} />);
+    expect(screen.queryByRole('complementary', { name: 'Rule palette' })).not.toBeInTheDocument();
+  });
+
+  it('renders the rule palette when the prop is passed', () => {
+    render(<Editor defaultValue={BLOCKS} rulePalette={RULE_PALETTE} />);
+    expect(screen.getByRole('complementary', { name: 'Rule palette' })).toBeInTheDocument();
+  });
+
+  it('renders every configured rule and category', () => {
+    render(<Editor defaultValue={BLOCKS} rulePalette={RULE_PALETTE} />);
+    expect(screen.getByText('Required')).toBeInTheDocument();
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.getByText('Min Length')).toBeInTheDocument();
+    expect(screen.getByText('Validation')).toBeInTheDocument();
+    expect(screen.getByText('Constraints')).toBeInTheDocument();
+  });
+
+  it('filters rules as the search query changes', () => {
+    render(<Editor defaultValue={BLOCKS} rulePalette={RULE_PALETTE} />);
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search rules' }), {
+      target: { value: 'requir' },
+    });
+    expect(screen.getByText('Required')).toBeInTheDocument();
+    expect(screen.queryByText('Email')).not.toBeInTheDocument();
+  });
+
+  it('applies a rule to the focused block on activation', () => {
+    const onRuleApplied = vi.fn();
+    const { container } = render(
+      <Editor defaultValue={BLOCKS} rulePalette={{ ...RULE_PALETTE, onRuleApplied }} />,
+    );
+    focusBlock(container, '1');
+    fireEvent.click(screen.getByText('Required'));
+    expect(onRuleApplied).toHaveBeenCalledWith(
+      '1',
+      'required',
+      expect.objectContaining({ updateBlock: expect.any(Function) }),
+    );
+  });
+
+  it('does not apply a rule when no block is focused', () => {
+    const onRuleApplied = vi.fn();
+    render(<Editor defaultValue={BLOCKS} rulePalette={{ ...RULE_PALETTE, onRuleApplied }} />);
+    fireEvent.click(screen.getByText('Required'));
+    expect(onRuleApplied).not.toHaveBeenCalled();
+  });
+
+  it('gates application on compatibleBlockTypes', () => {
+    const onRuleApplied = vi.fn();
+    const { container } = render(
+      <Editor defaultValue={BLOCKS} rulePalette={{ ...RULE_PALETTE, onRuleApplied }} />,
+    );
+    // BLOCKS are 'text'; the Email rule only applies to 'input'.
+    focusBlock(container, '1');
+    fireEvent.click(screen.getByText('Email'));
+    expect(onRuleApplied).not.toHaveBeenCalled();
+  });
+
+  it('renders both panes when sidebar and rulePalette are set', () => {
+    const sidebar: EditorSidebarConfig = {
+      items: [{ id: 'heading', label: 'Heading', category: 'Text' }],
+      categories: ['Text'],
+    };
+    render(<Editor defaultValue={BLOCKS} sidebar={sidebar} rulePalette={RULE_PALETTE} />);
+    expect(screen.getByRole('complementary', { name: 'Block palette' })).toBeInTheDocument();
+    expect(screen.getByRole('complementary', { name: 'Rule palette' })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Editor parity gap #2 (`docs/EDITOR_PARITY_GOAL.md`; `editor-known-gaps.mdx` "EditorProps Missing Wiring"), surface 2 of 5. Wires the dropped `rulePalette` prop: a categorized, searchable list of rules that apply to the focused block, mounted on the opposite side of the canvas from the sidebar.

Activation applies a rule to the focused block (resolved through the existing `selectionchange` focus tracking), gated by the item's `compatibleBlockTypes`, routed through `onRuleApplied(blockId, rule, controls)` — the editor never mutates directly. This PR also extracts a shared `PaletteAside` component so the sidebar (surface 1) and rule palette render through one path instead of duplicated markup, with the class names generalized to `editorPalette*` plus left/right aside variants.

**Stacked on the sidebar surface** (`fix/editor-sidebar-wiring`, #1581) — this PR's base is that branch, so the diff shows only the rule-palette + shared-pane changes. It retargets to `main` once #1581 lands. All 55 editor tests pass (47 from surface 1 + 8 new); `pnpm preflight` is green.

## Acceptance criteria mapping

### 1. rulePalette prop wired

`EditorProps` gains `rulePalette?: EditorRulePaletteConfig` (`editor.tsx`), added to the destructure so it leaves `...props`. When set, a `<PaletteAside aria-label="Rule palette">` (implicit role `complementary`) with a `role="listbox"` mounts beside the canvas. Tests: "renders the rule palette when the prop is passed", "does not render a rule palette when the prop is omitted".

### 2. Items + categories + search

`PaletteAside` maps the primitive's grouped items to category groups (configured order), rendering `rulePalette.renderItem` when provided else the label, with a `type="search"` input (when `searchable`) calling `setSearchQuery`. Tests: "renders every configured rule and category", "filters rules as the search query changes".

### 3. Application to focused block, gated

The rule-palette mount effect's `onActivate` reads the focused block id (via the focus ref), looks up the rule's `compatibleBlockTypes`, and calls `rulePalette.onRuleApplied(focusedId, item.id, controls)` only when a block is focused and (if a compatibility list is set) the block's type is in it. Tests: "applies a rule to the focused block on activation" (asserts `'1'`, `'required'`, controls exposing `updateBlock`), "does not apply a rule when no block is focused", "gates application on compatibleBlockTypes". The focus path is driven by stubbing `getSelection` because happy-dom does not reflect a programmatic `Range`.

### 4. Shared pane, both surfaces coexist

The sidebar's inline markup is replaced by the shared `PaletteAside`; the rule palette uses the same component. The render wraps both in a flex row when either is set (sidebar left, rules right). Test: "renders both panes when sidebar and rulePalette are set".

### 5. No regression

React `editor.tsx` stays functional; lefthook unit-tests + lint + typecheck pass on commit, and the standalone `pnpm preflight` is green. All 47 prior editor tests still pass with the 8 new ones.

## Not done

- Inline config-field forms for `requiresConfig` rules: the rule is applied by name; rendering `configFields` is a follow-up.
- Remaining gap #2 surfaces (command/slash menu, inline toolbar, block context menu) and `onSaveAsComposite` (gap #9) are separate PRs.
- Sidebar/rule-palette chrome remains intentionally minimal pending the OSS-styling decision in the goal doc's open items.