### PR TITLE
feat(ui): wire Editor slash command menu (parity gap #2, surface 3/5)

### DIFF
--- a/packages/ui/src/components/ui/editor.classes.ts
+++ b/packages/ui/src/components/ui/editor.classes.ts
@@ -30,3 +30,19 @@ export const editorPaletteCategoryClasses = 'px-1 py-1 text-xs font-medium text-
 
 /** A single palette item row. */
 export const editorPaletteItemClasses = 'cursor-pointer rounded px-2 py-1 text-sm hover:bg-accent';
+
+/** Floating slash-command menu, caret-anchored (viewport position via inline style). */
+export const editorSlashMenuClasses =
+  'fixed z-50 flex w-64 flex-col overflow-hidden rounded border border-border bg-popover shadow-md';
+
+/** The slash menu's command search input. */
+export const editorSlashSearchClasses = 'border-b border-border px-3 py-2 text-sm outline-none';
+
+/** The slash menu's scrollable command list. */
+export const editorSlashListClasses = 'max-h-64 overflow-y-auto p-1';
+
+/** A single slash-menu command row. */
+export const editorSlashItemClasses = 'cursor-pointer rounded px-2 py-1 text-sm hover:bg-accent';
+
+/** The selected slash-menu command row. */
+export const editorSlashItemSelectedClasses = 'bg-accent';

--- a/packages/ui/src/components/ui/editor.tsx
+++ b/packages/ui/src/components/ui/editor.tsx
@@ -23,12 +23,22 @@ import {
   createBlockPalette,
 } from '../../primitives/block-palette';
 import classy from '../../primitives/classy';
+import {
+  type CommandPaletteController,
+  createCommandPalette,
+} from '../../primitives/command-palette';
 import { findBlockElement } from '../../primitives/cursor-tracker';
 import {
   createDocumentEditor,
   type DocumentEditorControls,
 } from '../../primitives/document-editor';
-import type { BaseBlock, CleanupFunction, Direction, InlineContent } from '../../primitives/types';
+import type {
+  BaseBlock,
+  CleanupFunction,
+  Command,
+  Direction,
+  InlineContent,
+} from '../../primitives/types';
 import { Button } from './button';
 import { Container } from './container';
 import {
@@ -39,6 +49,11 @@ import {
   editorPaletteSearchClasses,
   editorRulePaletteAsideClasses,
   editorSidebarAsideClasses,
+  editorSlashItemClasses,
+  editorSlashItemSelectedClasses,
+  editorSlashListClasses,
+  editorSlashMenuClasses,
+  editorSlashSearchClasses,
 } from './editor.classes';
 import { Separator } from './separator';
 
@@ -69,6 +84,9 @@ export interface EditorProps
   /** Rule palette. When provided, mounts a categorized, searchable list of
    *  rules that apply to the focused block, on the opposite side of the canvas. */
   rulePalette?: EditorRulePaletteConfig;
+  /** Slash commands. When provided, typing `/` at the start of a block (or after
+   *  whitespace) opens a caret-anchored command menu with its own search input. */
+  commandPalette?: SlashCommand[];
 }
 
 export interface EditorControls {
@@ -390,6 +408,7 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
       dir,
       sidebar,
       rulePalette,
+      commandPalette,
       ...props
     },
     ref,
@@ -416,6 +435,15 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
     const [rulePaletteGroups, setRulePaletteGroups] = React.useState<
       Map<string, BlockPaletteItem[]>
     >(() => new Map());
+    const slashControllerRef = React.useRef<CommandPaletteController | null>(null);
+    const slashInputRef = React.useRef<HTMLInputElement>(null);
+    const [slashOpen, setSlashOpen] = React.useState(false);
+    const [slashCommands, setSlashCommands] = React.useState<Command[]>([]);
+    const [slashSelectedIndex, setSlashSelectedIndex] = React.useState(-1);
+    const [slashPosition, setSlashPosition] = React.useState<{ top: number; left: number }>({
+      top: 0,
+      left: 0,
+    });
 
     // -- Toolbar state --
     const [focusedBlockId, setFocusedBlockId] = React.useState<string | null>(null);
@@ -625,6 +653,59 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
       };
     }, [rulePalette, disabled]);
 
+    // -- Slash command menu lifecycle --
+    // The command-palette primitive owns '/'-trigger detection (preventDefaulted,
+    // so '/' never enters the document), filtering, and execute. The rendered
+    // menu carries its own search input, so typing never touches the canvas; it
+    // is anchored at the caret.
+    React.useEffect(() => {
+      const canvasEl = canvasRef.current;
+      if (!canvasEl || disabled || !commandPalette) return;
+
+      const toCommand = (sc: SlashCommand): Command => {
+        const command: Command = {
+          id: sc.id,
+          label: sc.label,
+          action: () => sc.action(controlsRef.current as EditorControls),
+        };
+        if (sc.keywords) command.keywords = sc.keywords;
+        return command;
+      };
+
+      const controller = createCommandPalette({
+        container: canvasEl,
+        trigger: '/',
+        commands: commandPalette.map(toCommand),
+        onOpen: () => {
+          const selection = window.getSelection();
+          if (selection && selection.rangeCount > 0) {
+            const rect = selection.getRangeAt(0).getBoundingClientRect();
+            setSlashPosition({ top: rect.bottom, left: rect.left });
+          }
+          const state = controller.getState();
+          setSlashCommands(state.filteredCommands);
+          setSlashSelectedIndex(state.selectedIndex);
+          setSlashOpen(true);
+        },
+        onClose: () => setSlashOpen(false),
+        onSelect: (_command, index) => {
+          setSlashCommands(controller.getState().filteredCommands);
+          setSlashSelectedIndex(index);
+        },
+      });
+      slashControllerRef.current = controller;
+
+      return () => {
+        controller.cleanup();
+        slashControllerRef.current = null;
+      };
+    }, [commandPalette, disabled]);
+
+    // Focus the slash menu's search input when it opens.
+    React.useEffect(() => {
+      if (slashOpen) slashInputRef.current?.focus();
+    }, [slashOpen]);
+
     const focusedBlock = focusedBlockId ? blocks.find((b) => b.id === focusedBlockId) : undefined;
 
     const canvas = (
@@ -710,6 +791,72 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
           </div>
         ) : (
           canvas
+        )}
+        {slashOpen && (
+          <div
+            role="dialog"
+            aria-label="Slash commands"
+            className={classy(editorSlashMenuClasses)}
+            style={{ top: slashPosition.top, left: slashPosition.left }}
+          >
+            <input
+              ref={slashInputRef}
+              type="search"
+              aria-label="Search commands"
+              placeholder="Search commands"
+              className={classy(editorSlashSearchClasses)}
+              onChange={(event) => {
+                const controller = slashControllerRef.current;
+                if (!controller) return;
+                controller.setQuery(event.target.value);
+                const state = controller.getState();
+                setSlashCommands(state.filteredCommands);
+                setSlashSelectedIndex(state.selectedIndex);
+              }}
+              onKeyDown={(event) => {
+                const controller = slashControllerRef.current;
+                if (!controller) return;
+                if (event.key === 'ArrowDown') {
+                  event.preventDefault();
+                  controller.selectNext();
+                  setSlashSelectedIndex(controller.getState().selectedIndex);
+                } else if (event.key === 'ArrowUp') {
+                  event.preventDefault();
+                  controller.selectPrevious();
+                  setSlashSelectedIndex(controller.getState().selectedIndex);
+                } else if (event.key === 'Enter') {
+                  event.preventDefault();
+                  controller.execute();
+                } else if (event.key === 'Escape') {
+                  event.preventDefault();
+                  controller.close();
+                }
+              }}
+            />
+            <div role="listbox" aria-label="Commands" className={classy(editorSlashListClasses)}>
+              {slashCommands.map((command, index) => (
+                <div
+                  key={command.id}
+                  role="option"
+                  aria-selected={index === slashSelectedIndex}
+                  tabIndex={-1}
+                  className={classy(
+                    editorSlashItemClasses,
+                    index === slashSelectedIndex ? editorSlashItemSelectedClasses : '',
+                  )}
+                  onMouseDown={(event) => {
+                    // mousedown (not click) so the input's blur doesn't close the
+                    // menu before the command runs.
+                    event.preventDefault();
+                    command.action();
+                    slashControllerRef.current?.close();
+                  }}
+                >
+                  {command.label}
+                </div>
+              ))}
+            </div>
+          </div>
         )}
       </Container>
     );

--- a/packages/ui/test/components/editor.test.tsx
+++ b/packages/ui/test/components/editor.test.tsx
@@ -6,6 +6,7 @@ import type {
   EditorControls,
   EditorRulePaletteConfig,
   EditorSidebarConfig,
+  SlashCommand,
 } from '../../src/components/ui/editor';
 import { Editor } from '../../src/components/ui/editor';
 
@@ -504,5 +505,102 @@ describe('Editor rule palette', () => {
     render(<Editor defaultValue={BLOCKS} sidebar={sidebar} rulePalette={RULE_PALETTE} />);
     expect(screen.getByRole('complementary', { name: 'Block palette' })).toBeInTheDocument();
     expect(screen.getByRole('complementary', { name: 'Rule palette' })).toBeInTheDocument();
+  });
+});
+
+describe('Editor slash menu', () => {
+  function makeCommands(): { commands: SlashCommand[]; heading: ReturnType<typeof vi.fn> } {
+    const heading = vi.fn();
+    const commands: SlashCommand[] = [
+      { id: 'heading', label: 'Heading', keywords: ['h1', 'title'], action: heading },
+      { id: 'divider', label: 'Divider', action: vi.fn() },
+    ];
+    return { commands, heading };
+  }
+
+  // Type '/' at a valid position. The command-palette primitive reads the
+  // collapsed selection via window.getSelection() to decide whether to trigger;
+  // happy-dom does not maintain one, so stub it to point at a block start.
+  function typeSlash(container: HTMLElement, blockId: string): void {
+    const canvas = screen.getByLabelText('Document editor');
+    const anchor = container.querySelector(`[data-block-id="${blockId}"]`);
+    if (!anchor) throw new Error(`block ${blockId} not found`);
+    const range = {
+      collapsed: true,
+      startContainer: anchor,
+      startOffset: 0,
+      getBoundingClientRect: () => ({
+        top: 0,
+        bottom: 20,
+        left: 10,
+        right: 10,
+        width: 0,
+        height: 20,
+      }),
+    };
+    const stub = vi.spyOn(window, 'getSelection').mockReturnValue({
+      rangeCount: 1,
+      getRangeAt: () => range,
+    } as unknown as Selection);
+    act(() => {
+      fireEvent.keyDown(canvas, { key: '/' });
+    });
+    stub.mockRestore();
+  }
+
+  it('does not open the menu before a slash is typed', () => {
+    const { commands } = makeCommands();
+    render(<Editor defaultValue={BLOCKS} commandPalette={commands} />);
+    expect(screen.queryByRole('dialog', { name: 'Slash commands' })).not.toBeInTheDocument();
+  });
+
+  it('opens a command menu with a search input when slash is typed', () => {
+    const { commands } = makeCommands();
+    const { container } = render(<Editor defaultValue={BLOCKS} commandPalette={commands} />);
+    typeSlash(container, '1');
+    expect(screen.getByRole('dialog', { name: 'Slash commands' })).toBeInTheDocument();
+    expect(screen.getByRole('searchbox', { name: 'Search commands' })).toBeInTheDocument();
+    expect(screen.getByText('Heading')).toBeInTheDocument();
+    expect(screen.getByText('Divider')).toBeInTheDocument();
+  });
+
+  it('filters commands via the menu search input', () => {
+    const { commands } = makeCommands();
+    const { container } = render(<Editor defaultValue={BLOCKS} commandPalette={commands} />);
+    typeSlash(container, '1');
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search commands' }), {
+      target: { value: 'head' },
+    });
+    expect(screen.getByText('Heading')).toBeInTheDocument();
+    expect(screen.queryByText('Divider')).not.toBeInTheDocument();
+  });
+
+  it('runs a command action with the editor controls when clicked', () => {
+    const { commands, heading } = makeCommands();
+    const { container } = render(<Editor defaultValue={BLOCKS} commandPalette={commands} />);
+    typeSlash(container, '1');
+    fireEvent.mouseDown(screen.getByText('Heading'));
+    expect(heading).toHaveBeenCalledWith(
+      expect.objectContaining({ addBlocks: expect.any(Function) }),
+    );
+    expect(screen.queryByRole('dialog', { name: 'Slash commands' })).not.toBeInTheDocument();
+  });
+
+  it('executes the selected command on Enter', () => {
+    const { commands, heading } = makeCommands();
+    const { container } = render(<Editor defaultValue={BLOCKS} commandPalette={commands} />);
+    typeSlash(container, '1');
+    fireEvent.keyDown(screen.getByRole('searchbox', { name: 'Search commands' }), { key: 'Enter' });
+    expect(heading).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the menu on Escape', () => {
+    const { commands } = makeCommands();
+    const { container } = render(<Editor defaultValue={BLOCKS} commandPalette={commands} />);
+    typeSlash(container, '1');
+    fireEvent.keyDown(screen.getByRole('searchbox', { name: 'Search commands' }), {
+      key: 'Escape',
+    });
+    expect(screen.queryByRole('dialog', { name: 'Slash commands' })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Editor parity gap #2 (`docs/EDITOR_PARITY_GOAL.md`; `editor-known-gaps.mdx` "EditorProps Missing Wiring"), surface 3 of 5. Wires the dropped `commandPalette` prop: typing `/` at the start of a block (or after whitespace) opens a caret-anchored command menu. The `command-palette` primitive owns `/`-trigger detection (the `/` is `preventDefault`ed, so it never enters the document), filtering, selection, and execute, but leaves query input and the typed-text lifecycle to the consumer. Per the decisions taken on this surface, the menu carries its own search input (the contenteditable is never mutated — no hot-path reconcile risk) and anchors at the caret rect. Stacked on the rule-palette surface (#1583); all 61 editor tests and `pnpm preflight` green.

## Acceptance criteria mapping

### 1. commandPalette prop wired
`EditorProps` gains `commandPalette?: SlashCommand[]`, added to the destructure so it leaves `...props`. A mount effect (deps `[commandPalette, disabled]`) constructs the `command-palette` primitive on the canvas element; its `onOpen` callback flips `slashOpen` state, which renders a `role="dialog"` menu labelled "Slash commands". Closed state renders nothing, so the menu is absent until `/` fires the primitive's trigger.
Evidence: tests "opens a command menu with a search input when slash is typed" and "does not open the menu before a slash is typed" in `editor.test.tsx`.

### 2. Own search input, document untouched
The menu renders a `type="search"` input (implicit role `searchbox`, aria-label "Search commands"), focused on open via an effect. Its `onChange` calls `controller.setQuery(value)` and re-reads `getState()`; the primitive `preventDefault`s the `/` and never tracks document keystrokes, so neither the trigger nor the query text reaches the contenteditable.
Evidence: test "filters commands via the menu search input" (typing in the menu input narrows the list); no canvas-mutation path exists in the slash effect.

### 3. Caret anchored
On `onOpen` the effect reads `window.getSelection().getRangeAt(0).getBoundingClientRect()` and stores `{ top: rect.bottom, left: rect.left }` in `slashPosition`, applied to the menu via inline `style`; the menu's class `editorSlashMenuClasses` is `fixed` so those viewport coordinates position it directly.
Evidence: `editor.tsx` slash mount-effect `onOpen` (setSlashPosition from `getBoundingClientRect`) and `editor.classes.ts` `editorSlashMenuClasses` (`fixed z-50 ...`). Position value is not unit-asserted because happy-dom returns no real layout rect.

### 4. Activation runs the command
Each `SlashCommand` maps to a `Command` whose `action` wraps `sc.action(controlsRef.current)`. Clicking an option fires on `mousedown` (with `preventDefault`, so the input's blur does not pre-close the menu), runs the action, and calls `controller.close()`. The menu input's `onKeyDown` routes `Enter` to `controller.execute()` (the selected command), `Escape` to `close()`, and Arrow keys to `selectNext`/`selectPrevious`.
Evidence: tests "runs a command action with the editor controls when clicked" (asserts the action receives controls exposing `addBlocks`, and the menu closes), "executes the selected command on Enter", and "closes the menu on Escape".

### 5. No regression
React `editor.tsx` stays functional; the change is additive (a new optional prop and an effect that early-returns when `commandPalette` is unset). Lefthook unit-tests + lint + typecheck pass on commit and the standalone `pnpm preflight` is green.
Evidence: all 55 pre-existing editor tests pass alongside the 6 new ones (61 total); `pnpm preflight` completed green.

## Not done

- Inline (in-document) slash typing with `/query` text removal was explicitly decided against for this surface, in favour of the menu-owned input, to keep the contenteditable hot path untouched.
- Remaining gap #2 surfaces (inline toolbar, block context menu) and `onSaveAsComposite` (gap #9) are separate PRs.
- The menu's pixel position is not unit-tested (happy-dom has no layout); only its open/filter/execute/close behaviour is.