### PR TITLE
feat(ui): wire Editor block context menu (parity gap #2, surface 4/5)

### DIFF
--- a/packages/ui/src/components/ui/editor.classes.ts
+++ b/packages/ui/src/components/ui/editor.classes.ts
@@ -46,3 +46,14 @@ export const editorSlashItemClasses = 'cursor-pointer rounded px-2 py-1 text-sm 
 
 /** The selected slash-menu command row. */
 export const editorSlashItemSelectedClasses = 'bg-accent';
+
+/** Block right-click context menu (positioned fixed by the primitive). */
+export const editorContextMenuClasses =
+  'z-50 min-w-40 rounded border border-border bg-popover p-1 shadow-md';
+
+/** A single context-menu item. */
+export const editorContextMenuItemClasses =
+  'cursor-pointer rounded px-2 py-1 text-sm outline-none hover:bg-accent focus:bg-accent';
+
+/** A destructive context-menu item (e.g. delete). */
+export const editorContextMenuDestructiveClasses = 'text-destructive';

--- a/packages/ui/src/components/ui/editor.tsx
+++ b/packages/ui/src/components/ui/editor.tsx
@@ -16,6 +16,10 @@
 
 import { atom } from 'nanostores';
 import * as React from 'react';
+import {
+  type BlockContextMenuControls,
+  createBlockContextMenu,
+} from '../../primitives/block-context-menu';
 import { convertBlockType } from '../../primitives/block-operations';
 import {
   type BlockPaletteControls,
@@ -42,6 +46,9 @@ import type {
 import { Button } from './button';
 import { Container } from './container';
 import {
+  editorContextMenuClasses,
+  editorContextMenuDestructiveClasses,
+  editorContextMenuItemClasses,
   editorPaletteCategoryClasses,
   editorPaletteItemClasses,
   editorPaletteLayoutClasses,
@@ -87,6 +94,9 @@ export interface EditorProps
   /** Slash commands. When provided, typing `/` at the start of a block (or after
    *  whitespace) opens a caret-anchored command menu with its own search input. */
   commandPalette?: SlashCommand[];
+  /** Block context menu. When true, right-clicking a block opens a menu of
+   *  block actions (move up/down, duplicate, delete). */
+  blockContextMenu?: boolean;
 }
 
 export interface EditorControls {
@@ -390,6 +400,20 @@ function EditorToolbar({
   );
 }
 
+interface ContextMenuItemDef {
+  id: string;
+  label: string;
+  destructive?: boolean;
+}
+
+/** Default block right-click actions. */
+const CONTEXT_MENU_ITEMS: ContextMenuItemDef[] = [
+  { id: 'move-up', label: 'Move up' },
+  { id: 'move-down', label: 'Move down' },
+  { id: 'duplicate', label: 'Duplicate' },
+  { id: 'delete', label: 'Delete', destructive: true },
+];
+
 // =============================================================================
 // Editor component
 // =============================================================================
@@ -409,6 +433,7 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
       sidebar,
       rulePalette,
       commandPalette,
+      blockContextMenu,
       ...props
     },
     ref,
@@ -444,6 +469,9 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
       top: 0,
       left: 0,
     });
+    const contextMenuRef = React.useRef<HTMLDivElement>(null);
+    const contextMenuControllerRef = React.useRef<BlockContextMenuControls | null>(null);
+    const [contextMenuOpen, setContextMenuOpen] = React.useState(false);
 
     // -- Toolbar state --
     const [focusedBlockId, setFocusedBlockId] = React.useState<string | null>(null);
@@ -706,6 +734,53 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
       if (slashOpen) slashInputRef.current?.focus();
     }, [slashOpen]);
 
+    // -- Block context menu lifecycle --
+    // The primitive listens for right-clicks on the canvas, resolves the block
+    // via [data-block-id], and shows/positions the consumer-rendered menu. The
+    // menu element is always rendered (the primitive toggles its hidden state);
+    // onAction maps the chosen item to a block mutation via the editor controls.
+    React.useEffect(() => {
+      const canvasEl = canvasRef.current;
+      const menuEl = contextMenuRef.current;
+      if (!canvasEl || !menuEl || disabled || !blockContextMenu) return;
+
+      const controller = createBlockContextMenu({
+        container: canvasEl,
+        menu: menuEl,
+        onOpen: () => setContextMenuOpen(true),
+        onClose: () => setContextMenuOpen(false),
+        onAction: (itemId, blockId) => {
+          const controls = controlsRef.current;
+          if (!controls) return;
+          const current = blocksAtomRef.current.get();
+          const index = current.findIndex((b) => b.id === blockId);
+          if (index === -1) return;
+          switch (itemId) {
+            case 'delete':
+              controls.removeBlocks(new Set([blockId]));
+              break;
+            case 'duplicate': {
+              const block = current[index];
+              if (block) controls.addBlock({ ...block, id: crypto.randomUUID() }, index + 1);
+              break;
+            }
+            case 'move-up':
+              controls.moveBlock(blockId, index - 1);
+              break;
+            case 'move-down':
+              controls.moveBlock(blockId, index + 1);
+              break;
+          }
+        },
+      });
+      contextMenuControllerRef.current = controller;
+
+      return () => {
+        controller.destroy();
+        contextMenuControllerRef.current = null;
+      };
+    }, [blockContextMenu, disabled]);
+
     const focusedBlock = focusedBlockId ? blocks.find((b) => b.id === focusedBlockId) : undefined;
 
     const canvas = (
@@ -856,6 +931,28 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
                 </div>
               ))}
             </div>
+          </div>
+        )}
+        {blockContextMenu && (
+          <div
+            ref={contextMenuRef}
+            hidden={!contextMenuOpen}
+            className={classy(editorContextMenuClasses)}
+          >
+            {CONTEXT_MENU_ITEMS.map((item) => (
+              <div
+                key={item.id}
+                role="menuitem"
+                data-menu-item-id={item.id}
+                tabIndex={-1}
+                className={classy(
+                  editorContextMenuItemClasses,
+                  item.destructive ? editorContextMenuDestructiveClasses : '',
+                )}
+              >
+                {item.label}
+              </div>
+            ))}
           </div>
         )}
       </Container>

--- a/packages/ui/test/components/editor.test.tsx
+++ b/packages/ui/test/components/editor.test.tsx
@@ -604,3 +604,63 @@ describe('Editor slash menu', () => {
     expect(screen.queryByRole('dialog', { name: 'Slash commands' })).not.toBeInTheDocument();
   });
 });
+
+describe('Editor block context menu', () => {
+  function rightClickBlock(container: HTMLElement, blockId: string): void {
+    const block = container.querySelector(`[data-block-id="${blockId}"]`);
+    if (!block) throw new Error(`block ${blockId} not found`);
+    fireEvent.contextMenu(block, { clientX: 10, clientY: 10 });
+  }
+
+  it('does not show a menu before a right-click', () => {
+    render(<Editor defaultValue={BLOCKS} blockContextMenu />);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('opens a block actions menu on right-click', () => {
+    const { container } = render(<Editor defaultValue={BLOCKS} blockContextMenu />);
+    rightClickBlock(container, '2');
+    expect(screen.getByRole('menu', { name: 'Block actions' })).toBeInTheDocument();
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+    expect(screen.getByText('Duplicate')).toBeInTheDocument();
+    expect(screen.getByText('Move up')).toBeInTheDocument();
+    expect(screen.getByText('Move down')).toBeInTheDocument();
+  });
+
+  it('deletes the right-clicked block', () => {
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <Editor defaultValue={BLOCKS} blockContextMenu onValueChange={onValueChange} />,
+    );
+    rightClickBlock(container, '2');
+    fireEvent.click(screen.getByText('Delete'));
+    expect(onValueChange).toHaveBeenLastCalledWith([
+      expect.objectContaining({ id: '1' }),
+      expect.objectContaining({ id: '3' }),
+    ]);
+  });
+
+  it('duplicates the right-clicked block after it', () => {
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <Editor defaultValue={BLOCKS} blockContextMenu onValueChange={onValueChange} />,
+    );
+    rightClickBlock(container, '2');
+    fireEvent.click(screen.getByText('Duplicate'));
+    const next = onValueChange.mock.lastCall?.[0] as EditorBlock[];
+    expect(next).toHaveLength(4);
+    expect(next[2]?.content).toBe('Second block');
+    expect(next[2]?.id).not.toBe('2');
+  });
+
+  it('moves the right-clicked block up', () => {
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <Editor defaultValue={BLOCKS} blockContextMenu onValueChange={onValueChange} />,
+    );
+    rightClickBlock(container, '2');
+    fireEvent.click(screen.getByText('Move up'));
+    const next = onValueChange.mock.lastCall?.[0] as EditorBlock[];
+    expect(next.map((b) => b.id)).toEqual(['2', '1', '3']);
+  });
+});


### PR DESCRIPTION
## Summary

Editor parity gap #2 (`docs/EDITOR_PARITY_GOAL.md`; `editor-known-gaps.mdx` "EditorProps Missing Wiring"). Wires the dropped `blockContextMenu` prop: right-clicking a block opens a menu of block actions (move up/down, duplicate, delete) that mutate the document through the editor controls. The `block-context-menu` primitive already existed; only the wiring was missing. Built ahead of the inline toolbar (the last gap #2 surface), which depends on the gap #1 reconcile in #1569 so applied marks persist. Stacked on the slash-menu surface (#1585); all 66 editor tests and `pnpm preflight` green.

## Acceptance criteria mapping

### 1. blockContextMenu prop wired
`EditorProps` gains `blockContextMenu?: boolean`, added to the destructure so it leaves `...props`. When set, the render emits a `role="menu"` element (the primitive sets the role + the "Block actions" aria-label on open) containing `role="menuitem"` rows from `CONTEXT_MENU_ITEMS`, each carrying `data-menu-item-id`. The element is always present and the primitive toggles its `hidden` state (React mirrors it via `hidden={!contextMenuOpen}`), so the menu is absent from the accessibility tree until a right-click opens it.
Evidence: tests "does not show a menu before a right-click" and "opens a block actions menu on right-click" in `editor.test.tsx`.

### 2. Right-click opens the menu
The mount effect (deps `[blockContextMenu, disabled]`) constructs `createBlockContextMenu({ container: canvas, menu, onOpen, onClose, onAction })`. The primitive attaches a `contextmenu` listener to the canvas, resolves the block via `findBlockId` walking up to `[data-block-id]`, and opens/positions the menu (it owns the focus trap, escape, outside-click dismissal, arrow-key navigation, and Shift+F10). `onOpen`/`onClose` flip `contextMenuOpen` so React's `hidden` mirror agrees with the primitive.
Evidence: test "opens a block actions menu on right-click" asserts the menu and all four action labels appear after `fireEvent.contextMenu` on a block.

### 3. Actions mutate via controls
`onAction(itemId, blockId)` resolves the block's index from the atom and dispatches through the editor controls: `delete` -> `removeBlocks(new Set([blockId]))`, `duplicate` -> `addBlock({ ...block, id: crypto.randomUUID() }, index + 1)`, `move-up` -> `moveBlock(blockId, index - 1)`, `move-down` -> `moveBlock(blockId, index + 1)`. The editor never mutates state outside its own controls.
Evidence: tests "deletes the right-clicked block" (onValueChange called with the other two blocks), "duplicates the right-clicked block after it" (4 blocks; the copy at index 2 has the source content and a different id), and "moves the right-clicked block up" (id order `['2','1','3']`).

### 4. No regression
React `editor.tsx` stays functional; the change is additive (a new optional boolean prop and an effect that early-returns when `blockContextMenu` is unset). Lefthook unit-tests + lint + typecheck pass on commit and the standalone `pnpm preflight` is green.
Evidence: all 61 pre-existing editor tests pass alongside the 5 new ones (66 total); `pnpm preflight` completed green.

## Not done

- The inline toolbar (the remaining gap #2 surface) is intentionally deferred: it applies inline marks via the inline-formatter, which only persist through the gap #1 reconcile fix in unmerged #1569, so it should follow that PR.
- `onSaveAsComposite` (gap #9) is a separate PR.
- Menu pixel position is not unit-tested (happy-dom has no layout); the open/action/close behaviour is.