### PR TITLE
feat(ui): wire Editor inline format toolbar (parity gap #2, surface 5/5)

### DIFF
--- a/packages/ui/src/components/ui/editor.classes.ts
+++ b/packages/ui/src/components/ui/editor.classes.ts
@@ -57,3 +57,14 @@ export const editorContextMenuItemClasses =
 
 /** A destructive context-menu item (e.g. delete). */
 export const editorContextMenuDestructiveClasses = 'text-destructive';
+
+/** Floating inline format toolbar, anchored at the selection (viewport position via inline style). */
+export const editorInlineToolbarClasses =
+  'fixed z-50 flex items-center gap-0.5 rounded border border-border bg-popover p-1 shadow-md';
+
+/** An inline-toolbar format button. */
+export const editorInlineToolbarButtonClasses =
+  'cursor-pointer rounded px-2 py-1 text-sm hover:bg-accent';
+
+/** An active (applied) inline-toolbar format button. */
+export const editorInlineToolbarButtonActiveClasses = 'bg-accent';

--- a/packages/ui/src/components/ui/editor.tsx
+++ b/packages/ui/src/components/ui/editor.tsx
@@ -36,12 +36,23 @@ import {
   createDocumentEditor,
   type DocumentEditorControls,
 } from '../../primitives/document-editor';
+import {
+  BOLD,
+  CODE,
+  createInlineFormatter,
+  type InlineFormatterController,
+  ITALIC,
+  LINK,
+  STRIKETHROUGH,
+} from '../../primitives/inline-formatter';
+import { adjustToolbarPosition, getFormatButtons } from '../../primitives/inline-toolbar';
 import type {
   BaseBlock,
   CleanupFunction,
   Command,
   Direction,
   InlineContent,
+  InlineMark,
 } from '../../primitives/types';
 import { Button } from './button';
 import { Container } from './container';
@@ -49,6 +60,9 @@ import {
   editorContextMenuClasses,
   editorContextMenuDestructiveClasses,
   editorContextMenuItemClasses,
+  editorInlineToolbarButtonActiveClasses,
+  editorInlineToolbarButtonClasses,
+  editorInlineToolbarClasses,
   editorPaletteCategoryClasses,
   editorPaletteItemClasses,
   editorPaletteLayoutClasses,
@@ -97,6 +111,9 @@ export interface EditorProps
   /** Block context menu. When true, right-clicking a block opens a menu of
    *  block actions (move up/down, duplicate, delete). */
   blockContextMenu?: boolean;
+  /** Inline format toolbar. When true, selecting text shows a floating toolbar
+   *  to toggle bold/italic/code/strikethrough/link on the selection. */
+  inlineToolbar?: boolean;
 }
 
 export interface EditorControls {
@@ -414,6 +431,9 @@ const CONTEXT_MENU_ITEMS: ContextMenuItemDef[] = [
   { id: 'delete', label: 'Delete', destructive: true },
 ];
 
+/** Inline marks the format toolbar can toggle. */
+const INLINE_FORMATS = [BOLD, ITALIC, CODE, STRIKETHROUGH, LINK];
+
 // =============================================================================
 // Editor component
 // =============================================================================
@@ -434,6 +454,7 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
       rulePalette,
       commandPalette,
       blockContextMenu,
+      inlineToolbar,
       ...props
     },
     ref,
@@ -472,6 +493,13 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
     const contextMenuRef = React.useRef<HTMLDivElement>(null);
     const contextMenuControllerRef = React.useRef<BlockContextMenuControls | null>(null);
     const [contextMenuOpen, setContextMenuOpen] = React.useState(false);
+    const inlineFormatterRef = React.useRef<InlineFormatterController | null>(null);
+    const [toolbarOpen, setToolbarOpen] = React.useState(false);
+    const [toolbarPosition, setToolbarPosition] = React.useState<{ top: number; left: number }>({
+      top: 0,
+      left: 0,
+    });
+    const [activeFormats, setActiveFormats] = React.useState<InlineMark[]>([]);
 
     // -- Toolbar state --
     const [focusedBlockId, setFocusedBlockId] = React.useState<string | null>(null);
@@ -781,6 +809,48 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
       };
     }, [blockContextMenu, disabled]);
 
+    // -- Inline format toolbar lifecycle --
+    // On a non-collapsed selection within the canvas, show a floating toolbar at
+    // the selection rect; buttons toggle marks via the inline-formatter. (The
+    // applied marks persist to block.content through the document-editor
+    // reconcile read-path.)
+    React.useEffect(() => {
+      const canvasEl = canvasRef.current;
+      if (!canvasEl || disabled || !inlineToolbar) return;
+
+      const formatter = createInlineFormatter({ container: canvasEl, formats: INLINE_FORMATS });
+      inlineFormatterRef.current = formatter;
+
+      const handleSelectionChange = () => {
+        const selection = window.getSelection();
+        if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+          setToolbarOpen(false);
+          return;
+        }
+        const range = selection.getRangeAt(0);
+        if (!canvasEl.contains(range.commonAncestorContainer)) {
+          setToolbarOpen(false);
+          return;
+        }
+        const rect = range.getBoundingClientRect();
+        const buttons = getFormatButtons();
+        const pos = adjustToolbarPosition(
+          { x: rect.left, y: rect.top },
+          { width: buttons.length * 40, height: 40 },
+        );
+        setToolbarPosition({ top: pos.y, left: pos.x });
+        setActiveFormats(formatter.getActiveFormats());
+        setToolbarOpen(true);
+      };
+      document.addEventListener('selectionchange', handleSelectionChange);
+
+      return () => {
+        document.removeEventListener('selectionchange', handleSelectionChange);
+        formatter.cleanup();
+        inlineFormatterRef.current = null;
+      };
+    }, [inlineToolbar, disabled]);
+
     const focusedBlock = focusedBlockId ? blocks.find((b) => b.id === focusedBlockId) : undefined;
 
     const canvas = (
@@ -952,6 +1022,40 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
               >
                 {item.label}
               </div>
+            ))}
+          </div>
+        )}
+        {toolbarOpen && (
+          <div
+            role="toolbar"
+            aria-label="Text formatting"
+            className={classy(editorInlineToolbarClasses)}
+            style={{ top: toolbarPosition.top, left: toolbarPosition.left }}
+          >
+            {getFormatButtons().map((button) => (
+              <button
+                key={button.format}
+                type="button"
+                aria-label={button.label}
+                aria-pressed={activeFormats.includes(button.format)}
+                className={classy(
+                  editorInlineToolbarButtonClasses,
+                  activeFormats.includes(button.format)
+                    ? editorInlineToolbarButtonActiveClasses
+                    : '',
+                )}
+                onMouseDown={(event) => {
+                  // mousedown + preventDefault so the selection survives while the
+                  // format is toggled.
+                  event.preventDefault();
+                  const formatter = inlineFormatterRef.current;
+                  if (!formatter) return;
+                  formatter.toggleFormat(button.format);
+                  setActiveFormats(formatter.getActiveFormats());
+                }}
+              >
+                {button.label}
+              </button>
             ))}
           </div>
         )}

--- a/packages/ui/test/components/editor.test.tsx
+++ b/packages/ui/test/components/editor.test.tsx
@@ -664,3 +664,70 @@ describe('Editor block context menu', () => {
     expect(next.map((b) => b.id)).toEqual(['2', '1', '3']);
   });
 });
+
+describe('Editor inline toolbar', () => {
+  // happy-dom does not reflect a programmatic Range through getSelection, so
+  // stub it: a non-collapsed selection over a block triggers the toolbar.
+  function selectBlockText(container: HTMLElement, blockId: string): ReturnType<typeof vi.spyOn> {
+    const block = container.querySelector(`[data-block-id="${blockId}"]`);
+    if (!block) throw new Error(`block ${blockId} not found`);
+    const range = document.createRange();
+    range.selectNodeContents(block);
+    return vi.spyOn(window, 'getSelection').mockReturnValue({
+      isCollapsed: false,
+      rangeCount: 1,
+      getRangeAt: () => range,
+      removeAllRanges: () => {},
+      addRange: () => {},
+      anchorNode: block,
+    } as unknown as Selection);
+  }
+
+  it('does not show a toolbar without a selection', () => {
+    render(<Editor defaultValue={BLOCKS} inlineToolbar />);
+    expect(screen.queryByRole('toolbar', { name: 'Text formatting' })).not.toBeInTheDocument();
+  });
+
+  it('shows a format toolbar on a non-collapsed selection', () => {
+    const { container } = render(<Editor defaultValue={BLOCKS} inlineToolbar />);
+    const stub = selectBlockText(container, '1');
+    act(() => {
+      document.dispatchEvent(new Event('selectionchange'));
+    });
+    expect(screen.getByRole('toolbar', { name: 'Text formatting' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Bold' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Italic' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Code' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Strikethrough' })).toBeInTheDocument();
+    stub.mockRestore();
+  });
+
+  it('hides the toolbar when the selection collapses', () => {
+    const { container } = render(<Editor defaultValue={BLOCKS} inlineToolbar />);
+    const stub = selectBlockText(container, '1');
+    act(() => {
+      document.dispatchEvent(new Event('selectionchange'));
+    });
+    expect(screen.getByRole('toolbar', { name: 'Text formatting' })).toBeInTheDocument();
+    stub.mockRestore();
+    const collapsed = vi.spyOn(window, 'getSelection').mockReturnValue({
+      isCollapsed: true,
+      rangeCount: 0,
+    } as unknown as Selection);
+    act(() => {
+      document.dispatchEvent(new Event('selectionchange'));
+    });
+    expect(screen.queryByRole('toolbar', { name: 'Text formatting' })).not.toBeInTheDocument();
+    collapsed.mockRestore();
+  });
+
+  it('toggles a format from the toolbar without error', () => {
+    const { container } = render(<Editor defaultValue={BLOCKS} inlineToolbar />);
+    const stub = selectBlockText(container, '1');
+    act(() => {
+      document.dispatchEvent(new Event('selectionchange'));
+    });
+    expect(() => fireEvent.mouseDown(screen.getByRole('button', { name: 'Bold' }))).not.toThrow();
+    stub.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Editor parity gap #2 (`docs/EDITOR_PARITY_GOAL.md`; `editor-known-gaps.mdx` "EditorProps Missing Wiring"), the final surface. Wires the dropped `inlineToolbar` prop: selecting text shows a floating toolbar that toggles bold/italic/code/strikethrough on the selection. This completes gap #2 (sidebar, rule palette, slash menu, context menu, inline toolbar). The `inline-toolbar` (positioning + button config) and `inline-formatter` (mark application) primitives already existed; only the wiring was missing. Stacked on the context-menu surface (#1587); all 70 editor tests and `pnpm preflight` green.

## Acceptance criteria mapping

### 1. inlineToolbar prop wired
`EditorProps` gains `inlineToolbar?: boolean`, added to the destructure so it leaves `...props`. A mount effect (deps `[inlineToolbar, disabled]`) creates an `inline-formatter` over the canvas and registers a `selectionchange` listener; when the selection is non-collapsed and inside the canvas it sets `toolbarOpen`, rendering a `role="toolbar"` ("Text formatting").
Evidence: tests "does not show a toolbar without a selection" and "shows a format toolbar on a non-collapsed selection" in `editor.test.tsx`.

### 2. Selection-anchored, hides on collapse
On each `selectionchange` the handler reads the range's `getBoundingClientRect`, runs it through the primitive's `adjustToolbarPosition`, and stores the result as the toolbar's inline `top`/`left` (the class is `fixed`). When the selection is collapsed, empty, or its `commonAncestorContainer` is outside the canvas, `toolbarOpen` is set false and the toolbar unmounts.
Evidence: test "hides the toolbar when the selection collapses" (toolbar present after a non-collapsed selection, gone after a collapsed one).

### 3. Format buttons toggle marks
The toolbar maps the primitive's `getFormatButtons()` (bold/italic/code/strikethrough) to buttons. Clicking one fires on `mousedown` with `preventDefault` (so the selection survives), calls `inlineFormatter.toggleFormat(button.format)`, and refreshes `activeFormats` from `getActiveFormats()` so the button's `aria-pressed` reflects state. The formats are composed from the inline-formatter's `BOLD`/`ITALIC`/`CODE`/`STRIKETHROUGH`/`LINK` exports.
Evidence: test "shows a format toolbar on a non-collapsed selection" asserts the four named buttons; test "toggles a format from the toolbar without error" exercises the click -> `toggleFormat` path.

### 4. No regression
React `editor.tsx` stays functional; the change is additive (a new optional boolean prop and an effect that early-returns when `inlineToolbar` is unset). Lefthook unit-tests + lint + typecheck pass on commit and the standalone `pnpm preflight` is green.
Evidence: all 66 pre-existing editor tests pass alongside the 4 new ones (70 total); `pnpm preflight` completed green.

## Not done

- Mark persistence to `block.content`: the toolbar applies marks to the DOM via the inline-formatter, but those marks only persist through the gap #1 reconcile read-path (`domBlockContent`/`serializeElement`) in unmerged #1569. This surface composes with that PR once both land on main; the toggle behaviour itself is wired and tested here.
- The link button is not surfaced (the primitive's `getFormatButtons()` exposes bold/italic/code/strikethrough; link application via the formatter remains available but without a toolbar affordance — a follow-up if a link popover is wanted).
- Toolbar pixel position is not unit-tested (happy-dom has no layout); its visibility/anchoring behaviour is.