### PR TITLE
feat(ui): wire Editor save-as-composite dialog (parity gap #9)

### DIFF
--- a/packages/ui/src/components/ui/editor.classes.ts
+++ b/packages/ui/src/components/ui/editor.classes.ts
@@ -68,3 +68,25 @@ export const editorInlineToolbarButtonClasses =
 
 /** An active (applied) inline-toolbar format button. */
 export const editorInlineToolbarButtonActiveClasses = 'bg-accent';
+
+/** The "Save as composite" trigger button. */
+export const editorSaveTriggerClasses =
+  'cursor-pointer self-start rounded border border-border px-2 py-1 text-sm hover:bg-accent';
+
+/** Backdrop overlay behind the save-as-composite dialog. */
+export const editorSaveOverlayClasses =
+  'fixed inset-0 z-50 flex items-center justify-center bg-black/50';
+
+/** The save-as-composite dialog panel. */
+export const editorSaveDialogClasses =
+  'flex w-80 flex-col gap-2 rounded border border-border bg-popover p-4 shadow-md';
+
+/** A field input inside the save dialog. */
+export const editorSaveFieldClasses = 'rounded border border-border px-2 py-1 text-sm outline-none';
+
+/** The save dialog's action row. */
+export const editorSaveActionsClasses = 'flex justify-end gap-2';
+
+/** A save dialog action button. */
+export const editorSaveActionClasses =
+  'cursor-pointer rounded border border-border px-3 py-1 text-sm hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50';

--- a/packages/ui/src/components/ui/editor.tsx
+++ b/packages/ui/src/components/ui/editor.tsx
@@ -69,6 +69,12 @@ import {
   editorPaletteListClasses,
   editorPaletteSearchClasses,
   editorRulePaletteAsideClasses,
+  editorSaveActionClasses,
+  editorSaveActionsClasses,
+  editorSaveDialogClasses,
+  editorSaveFieldClasses,
+  editorSaveOverlayClasses,
+  editorSaveTriggerClasses,
   editorSidebarAsideClasses,
   editorSlashItemClasses,
   editorSlashItemSelectedClasses,
@@ -114,6 +120,10 @@ export interface EditorProps
   /** Inline format toolbar. When true, selecting text shows a floating toolbar
    *  to toggle bold/italic/code/strikethrough/link on the selection. */
   inlineToolbar?: boolean;
+  /** Save-as-composite handler. When provided, a "Save as composite" action
+   *  opens a dialog collecting name/category/description and fires this with the
+   *  current blocks. */
+  onSaveAsComposite?: (data: SaveCompositeData) => void | Promise<void>;
 }
 
 export interface EditorControls {
@@ -455,6 +465,7 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
       commandPalette,
       blockContextMenu,
       inlineToolbar,
+      onSaveAsComposite,
       ...props
     },
     ref,
@@ -493,6 +504,10 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
     const contextMenuRef = React.useRef<HTMLDivElement>(null);
     const contextMenuControllerRef = React.useRef<BlockContextMenuControls | null>(null);
     const [contextMenuOpen, setContextMenuOpen] = React.useState(false);
+    const [saveDialogOpen, setSaveDialogOpen] = React.useState(false);
+    const [saveName, setSaveName] = React.useState('');
+    const [saveCategory, setSaveCategory] = React.useState('');
+    const [saveDescription, setSaveDescription] = React.useState('');
     const inlineFormatterRef = React.useRef<InlineFormatterController | null>(null);
     const [toolbarOpen, setToolbarOpen] = React.useState(false);
     const [toolbarPosition, setToolbarPosition] = React.useState<{ top: number; left: number }>({
@@ -894,6 +909,16 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
             onChangeBlockType={handleChangeBlockType}
           />
         )}
+        {onSaveAsComposite && (
+          <button
+            type="button"
+            aria-label="Save as composite"
+            className={classy(editorSaveTriggerClasses)}
+            onClick={() => setSaveDialogOpen(true)}
+          >
+            Save as composite
+          </button>
+        )}
         {sidebar || rulePalette ? (
           <div className={classy(editorPaletteLayoutClasses)}>
             {sidebar && (
@@ -1057,6 +1082,66 @@ export const Editor = React.forwardRef<EditorControls, EditorProps>(
                 {button.label}
               </button>
             ))}
+          </div>
+        )}
+        {onSaveAsComposite && saveDialogOpen && (
+          <div className={classy(editorSaveOverlayClasses)}>
+            <div
+              role="dialog"
+              aria-modal="true"
+              aria-label="Save as composite"
+              className={classy(editorSaveDialogClasses)}
+            >
+              <input
+                aria-label="Composite name"
+                placeholder="Name"
+                value={saveName}
+                onChange={(event) => setSaveName(event.target.value)}
+                className={classy(editorSaveFieldClasses)}
+              />
+              <input
+                aria-label="Composite category"
+                placeholder="Category"
+                value={saveCategory}
+                onChange={(event) => setSaveCategory(event.target.value)}
+                className={classy(editorSaveFieldClasses)}
+              />
+              <textarea
+                aria-label="Composite description"
+                placeholder="Description"
+                value={saveDescription}
+                onChange={(event) => setSaveDescription(event.target.value)}
+                className={classy(editorSaveFieldClasses)}
+              />
+              <div className={classy(editorSaveActionsClasses)}>
+                <button
+                  type="button"
+                  className={classy(editorSaveActionClasses)}
+                  onClick={() => setSaveDialogOpen(false)}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  disabled={saveName.trim() === ''}
+                  className={classy(editorSaveActionClasses)}
+                  onClick={() => {
+                    void onSaveAsComposite({
+                      name: saveName.trim(),
+                      category: saveCategory.trim(),
+                      description: saveDescription.trim(),
+                      blocks: blocksAtomRef.current.get(),
+                    });
+                    setSaveDialogOpen(false);
+                    setSaveName('');
+                    setSaveCategory('');
+                    setSaveDescription('');
+                  }}
+                >
+                  Save
+                </button>
+              </div>
+            </div>
           </div>
         )}
       </Container>

--- a/packages/ui/test/components/editor.test.tsx
+++ b/packages/ui/test/components/editor.test.tsx
@@ -731,3 +731,53 @@ describe('Editor inline toolbar', () => {
     stub.mockRestore();
   });
 });
+
+describe('Editor save as composite', () => {
+  it('does not render the save trigger when no handler is provided', () => {
+    render(<Editor defaultValue={BLOCKS} />);
+    expect(screen.queryByRole('button', { name: 'Save as composite' })).not.toBeInTheDocument();
+  });
+
+  it('opens a save dialog from the trigger', () => {
+    render(<Editor defaultValue={BLOCKS} onSaveAsComposite={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Save as composite' }));
+    expect(screen.getByRole('dialog', { name: 'Save as composite' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Composite name')).toBeInTheDocument();
+  });
+
+  it('disables Save until a name is entered', () => {
+    render(<Editor defaultValue={BLOCKS} onSaveAsComposite={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Save as composite' }));
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    fireEvent.change(screen.getByLabelText('Composite name'), { target: { value: 'My Form' } });
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+  });
+
+  it('calls onSaveAsComposite with the metadata and current blocks', () => {
+    const onSave = vi.fn();
+    render(<Editor defaultValue={BLOCKS} onSaveAsComposite={onSave} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Save as composite' }));
+    fireEvent.change(screen.getByLabelText('Composite name'), { target: { value: 'My Form' } });
+    fireEvent.change(screen.getByLabelText('Composite category'), { target: { value: 'forms' } });
+    fireEvent.change(screen.getByLabelText('Composite description'), {
+      target: { value: 'A reusable form' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onSave).toHaveBeenCalledWith({
+      name: 'My Form',
+      category: 'forms',
+      description: 'A reusable form',
+      blocks: BLOCKS,
+    });
+    expect(screen.queryByRole('dialog', { name: 'Save as composite' })).not.toBeInTheDocument();
+  });
+
+  it('closes without saving on Cancel', () => {
+    const onSave = vi.fn();
+    render(<Editor defaultValue={BLOCKS} onSaveAsComposite={onSave} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Save as composite' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.queryByRole('dialog', { name: 'Save as composite' })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Editor parity gap #9 (`docs/EDITOR_PARITY_GOAL.md`; `editor-known-gaps.mdx` "Save-As-Composite UI Missing"). The `onSaveAsComposite` callback and `SaveCompositeData` type were exported but no UI invoked them. This wires a save-as-composite flow: a trigger button opens a modal dialog collecting name/category/description and fires the handler with the current blocks. Depends on the gap #2 EditorProps wiring (now complete). The consumer's handler does the rest — composites' `serializeToComposite` turns blocks + metadata into a `CompositeFile`. Stacked on the inline-toolbar surface (#1589); all 75 editor tests and `pnpm preflight` green.

## Acceptance criteria mapping

### 1. onSaveAsComposite prop wired
`EditorProps` gains `onSaveAsComposite?: (data: SaveCompositeData) => void | Promise<void>`, added to the destructure so it leaves `...props`. When the handler is provided, the render emits a `Save as composite` trigger button; when it is absent, no trigger (and no dialog) renders.
Evidence: tests "does not render the save trigger when no handler is provided" and "opens a save dialog from the trigger" in `editor.test.tsx`.

### 2. Dialog collects metadata
Clicking the trigger sets `saveDialogOpen`, rendering a `role="dialog"` (`aria-modal`, "Save as composite") containing three controlled fields — name and category `input`s and a description `textarea`, each `aria-label`led. The Save button is `disabled` while `saveName.trim()` is empty.
Evidence: tests "opens a save dialog from the trigger" (dialog + name field present) and "disables Save until a name is entered" (Save disabled, then enabled after typing a name).

### 3. Submit fires with blocks
The Save button's handler calls `onSaveAsComposite({ name, category, description, blocks: blocksAtomRef.current.get() })` with the trimmed field values and the live block list, then closes the dialog and clears the fields. Cancel sets `saveDialogOpen` false without calling the handler.
Evidence: tests "calls onSaveAsComposite with the metadata and current blocks" (asserts the exact payload incl. blocks, and the dialog closes) and "closes without saving on Cancel" (handler not called, dialog gone).

### 4. No regression
React `editor.tsx` stays functional; the change is additive (a new optional callback prop, dialog state, and conditionally-rendered UI). Lefthook unit-tests + lint + typecheck pass on commit and the standalone `pnpm preflight` is green.
Evidence: all 70 pre-existing editor tests pass alongside the 5 new ones (75 total); `pnpm preflight` completed green.

## Not done

- Category is a free-text field (the composite manifest's `CompositeCategory` is `z.string().min(1)`); a curated category picker is a follow-up if a fixed taxonomy is wanted.
- The dialog has no backdrop-click or Escape dismissal (Cancel closes it) to keep the markup a11y-lint-clean without a focus-trap; that can be added with the design-system Dialog later.
- This completes gap #9; gap #4 (MDX serializer convergence) is the only remaining Phase 0 gap and is blocked on the composites PRs (#1571/#1577) merging.