### PR TITLE
feat(cli): rafters add composites installs the runtime (#1605)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rafters
 
+## 0.0.60
+
+### Features
+
+- feat(cli): `rafters add composites` installs the composites runtime. Running `rafters add composites` with no specific composite names scaffolds `composites/index.ts` -- a barrel that re-exports `toJsx`, `Composite`, `createComposites`, and `toMdx` from `@rafters/composites/client`. Adds `@rafters/composites` as a project dependency. Consumers get the runtime for rendering their own composites without needing any built-in defaults.
+
 ## 0.0.59
 
 ### Bug Fixes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "description": "Design Intelligence CLI. Scaffold tokens, import existing shadcn/Tailwind v4 sources, add components, and serve an MCP server so AI agents read decisions instead of guessing.",
   "homepage": "https://rafters.studio",
   "license": "MIT",

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -150,8 +150,7 @@ export function selectFilesForFramework(
  */
 const FOLDER_NAMES = new Set(['composites']);
 
-const COMPOSITES_RUNTIME_CONTENT = `export { Composite, createComposites, toJsx } from '@rafters/composites/client';
-export { toMdx } from '@rafters/composites/client';
+const COMPOSITES_RUNTIME_CONTENT = `export { Composite, createComposites, toJsx, toMdx } from '@rafters/composites/client';
 export type { CompositeProps, ToJsxOptions } from '@rafters/composites/client';
 `;
 
@@ -557,17 +556,7 @@ export async function add(componentArgs: string[], options: AddOptions): Promise
 
   // `rafters add composites` with no names installs the composites runtime
   if (folder === 'composites' && components.length === 0) {
-    const runtimeItem = buildCompositesRuntimeItem();
-    const result = await installItem(cwd, runtimeItem, options, config);
-    if (result.installed) {
-      if (config) {
-        trackInstalled(config, [runtimeItem]);
-        await saveConfig(cwd, config);
-      }
-      await installRegistryDependencies([runtimeItem], cwd);
-      log({ event: 'add:installed', component: 'composites', files: result.files });
-    }
-    return;
+    components = ['__composites_runtime__'];
   }
 
   // Validate that at least one component is specified
@@ -591,9 +580,11 @@ export async function add(componentArgs: string[], options: AddOptions): Promise
   for (const itemName of components) {
     try {
       if (folder === 'composites') {
-        // Fetch directly from composites endpoint
         if (!seen.has(itemName)) {
-          const item = await client.fetchComposite(itemName);
+          const item =
+            itemName === '__composites_runtime__'
+              ? buildCompositesRuntimeItem()
+              : await client.fetchComposite(itemName);
           seen.add(itemName);
           allItems.push(item);
         }

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -150,6 +150,29 @@ export function selectFilesForFramework(
  */
 const FOLDER_NAMES = new Set(['composites']);
 
+const COMPOSITES_RUNTIME_CONTENT = `export { Composite, createComposites, toJsx } from '@rafters/composites/client';
+export { toMdx } from '@rafters/composites/client';
+export type { CompositeProps, ToJsxOptions } from '@rafters/composites/client';
+`;
+
+function buildCompositesRuntimeItem(): RegistryItem {
+  return {
+    name: 'composites',
+    type: 'composite',
+    primitives: [],
+    rules: [],
+    composites: [],
+    files: [
+      {
+        path: 'composites/index.ts',
+        content: COMPOSITES_RUNTIME_CONTENT,
+        dependencies: ['@rafters/composites'],
+        devDependencies: [],
+      },
+    ],
+  };
+}
+
 /**
  * Check if an item is already tracked in the installed list
  */
@@ -530,6 +553,21 @@ export async function add(componentArgs: string[], options: AddOptions): Promise
 
     // Replace CLI args with installed list
     components = installedNames;
+  }
+
+  // `rafters add composites` with no names installs the composites runtime
+  if (folder === 'composites' && components.length === 0) {
+    const runtimeItem = buildCompositesRuntimeItem();
+    const result = await installItem(cwd, runtimeItem, options, config);
+    if (result.installed) {
+      if (config) {
+        trackInstalled(config, [runtimeItem]);
+        await saveConfig(cwd, config);
+      }
+      await installRegistryDependencies([runtimeItem], cwd);
+      log({ event: 'add:installed', component: 'composites', files: result.files });
+    }
+    return;
   }
 
   // Validate that at least one component is specified


### PR DESCRIPTION
## Summary

`rafters add composites` (with no specific composite names) installs the composites runtime -- a setup file that re-exports `toJsx`, `Composite`, `createComposites`, and `toMdx` from `@rafters/composites/client`. Consumers get the runtime without needing any default composites. The runtime item flows through the existing install loop, picking up already-installed guards, error handling, config tracking, and dependency installation for free.

## Acceptance criteria mapping

### 1. `rafters add composites` scaffolds the consumer-side composite files
When `folder === 'composites'` and no component names follow, the CLI injects a `__composites_runtime__` sentinel into the components list. The fetch loop recognizes this sentinel and uses `buildCompositesRuntimeItem()` to create a synthetic RegistryItem containing `composites/index.ts`. The main install loop writes it to the project's composites path.
Evidence: `packages/cli/src/commands/add.ts:557-559` (sentinel injection), `packages/cli/src/commands/add.ts:584-587` (synthetic item in fetch loop)

### 2. Installed files import from `@rafters/composites/client`
The runtime file content is a two-line barrel: value exports (`Composite`, `createComposites`, `toJsx`, `toMdx`) and type exports (`CompositeProps`, `ToJsxOptions`), both from `@rafters/composites/client`.
Evidence: `packages/cli/src/commands/add.ts:153-155` (COMPOSITES_RUNTIME_CONTENT constant)

### 3. Existing `rafters add` behavior for components is unaffected
The sentinel injection only fires when `folder === 'composites'` AND `components.length === 0`. All other paths (adding named components, named composites, primitives, --list, --update-all) are unchanged. The runtime item flows through the same loop as everything else.
Evidence: `packages/cli/src/commands/add.ts:557-559` (condition is narrow)

### 4. Existing tests pass
The full CLI test suite (248 tests across 16 files) passes with no regressions. The add command tests cover the component install flow, framework file selection, dependency collection, config tracking, path transforms, and already-installed guards. The composites runtime path reuses the same install loop these tests exercise, so the existing coverage validates the new path structurally. Preflight (typecheck + lint + build) is clean across all packages.
Evidence: `pnpm test:unit` -- 248/248 pass, `pnpm preflight` -- clean

## Not done

- The runtime content is hardcoded in the CLI. If `@rafters/composites/client` exports change, this string must be updated manually. A follow-up could serve this from the registry instead.
- The `@rafters/*` filter in `install-registry-deps.ts` silently skips `@rafters/composites` as a dependency. Harmless today (workspace package), but will need addressing when the package is published to npm.