### PR TITLE
fix(cli): serve composites runtime from registry, resolve dep chains (#1605)

### DIFF
--- a/apps/website/src/lib/registry/componentService.ts
+++ b/apps/website/src/lib/registry/componentService.ts
@@ -115,7 +115,7 @@ export function listPrimitiveNames(): string[] {
 }
 
 /**
- * List all available composite names
+ * List available composite data file names (from .composite.json files)
  */
 export function listCompositeNames(): string[] {
   const compositesDir = getCompositesPath();
@@ -129,6 +129,10 @@ export function listCompositeNames(): string[] {
     }
     throw err;
   }
+}
+
+export function listAllCompositeKeys(): string[] {
+  return [...listCompositeNames(), 'composites'];
 }
 
 /**
@@ -696,7 +700,7 @@ export function getRegistryIndex(): RegistryIndex {
     homepage: 'https://rafters.studio',
     components: listComponentNames(),
     primitives: listPrimitiveNames(),
-    composites: [...listCompositeNames(), 'composites'],
+    composites: listAllCompositeKeys(),
     rules: [],
   };
 }

--- a/apps/website/src/lib/registry/componentService.ts
+++ b/apps/website/src/lib/registry/componentService.ts
@@ -134,16 +134,40 @@ export function listCompositeNames(): string[] {
 /**
  * Load a single composite by name
  */
+const BLOCK_TYPE_TO_COMPONENT: Record<string, string> = {
+  heading: 'typography',
+  text: 'typography',
+  button: 'button',
+  input: 'input',
+  grid: 'grid',
+  divider: 'separator',
+  blockquote: 'typography',
+};
+
+function extractComponentDeps(blocks: Array<{ type: string }>): string[] {
+  const deps = new Set<string>();
+  deps.add('composites');
+  for (const block of blocks) {
+    const component = BLOCK_TYPE_TO_COMPONENT[block.type];
+    if (component) deps.add(component);
+  }
+  return [...deps];
+}
+
 export function loadComposite(name: string): RegistryItem | null {
+  if (name === 'composites') return loadCompositesRuntime();
+
   const filePath = join(getCompositesPath(), `${name}.composite.json`);
 
   try {
     const content = readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(content) as { blocks?: Array<{ type: string }> };
+    const componentDeps = extractComponentDeps(parsed.blocks ?? []);
 
     return {
       name,
       type: 'composite',
-      primitives: [],
+      primitives: componentDeps,
       files: [
         {
           path: `composites/${name}.composite.json`,
@@ -159,6 +183,42 @@ export function loadComposite(name: string): RegistryItem | null {
     }
     throw err;
   }
+}
+
+function getCompositesPackagePath(): string {
+  return join(process.cwd(), '../../packages/composites/src');
+}
+
+const COMPOSITES_RUNTIME_FILES = [
+  'manifest.ts',
+  'walk-blocks.ts',
+  'to-jsx.tsx',
+  'to-mdx.ts',
+  'bridge.ts',
+  'registry.ts',
+  'rules.ts',
+];
+
+export function loadCompositesRuntime(): RegistryItem {
+  const srcDir = getCompositesPackagePath();
+  const files: RegistryFile[] = COMPOSITES_RUNTIME_FILES.map((filename) => {
+    const content = readFileSync(join(srcDir, filename), 'utf-8');
+    return {
+      path: `composites/${filename}`,
+      content,
+      dependencies: filename === 'manifest.ts' ? ['zod'] : [],
+      devDependencies: [],
+    };
+  });
+
+  return {
+    name: 'composites',
+    type: 'composite' as RegistryItemType,
+    description:
+      'Composites runtime: block tree walker, JSX/MDX serializers, registry, bridge, and manifest types.',
+    primitives: [],
+    files,
+  };
 }
 
 /**
@@ -636,7 +696,7 @@ export function getRegistryIndex(): RegistryIndex {
     homepage: 'https://rafters.studio',
     components: listComponentNames(),
     primitives: listPrimitiveNames(),
-    composites: listCompositeNames(),
+    composites: [...listCompositeNames(), 'composites'],
     rules: [],
   };
 }

--- a/apps/website/src/pages/registry/composites/[name].json.ts
+++ b/apps/website/src/pages/registry/composites/[name].json.ts
@@ -4,12 +4,12 @@
  */
 
 import type { APIRoute, GetStaticPaths } from 'astro';
-import { listCompositeNames, loadComposite } from '../../../lib/registry/componentService';
+import { listAllCompositeKeys, loadComposite } from '../../../lib/registry/componentService';
 
 export const prerender = true;
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const names = [...listCompositeNames(), 'composites'];
+  const names = listAllCompositeKeys();
   return names.map((name) => ({ params: { name } }));
 };
 

--- a/apps/website/src/pages/registry/composites/[name].json.ts
+++ b/apps/website/src/pages/registry/composites/[name].json.ts
@@ -9,7 +9,7 @@ import { listCompositeNames, loadComposite } from '../../../lib/registry/compone
 export const prerender = true;
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const names = listCompositeNames();
+  const names = [...listCompositeNames(), 'composites'];
   return names.map((name) => ({ params: { name } }));
 };
 

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -558,15 +558,15 @@ export async function add(componentArgs: string[], options: AddOptions): Promise
   for (const itemName of components) {
     try {
       if (folder === 'composites') {
-        const composite = await client.fetchComposite(itemName);
         if (!seen.has(itemName)) {
+          const composite = await client.fetchComposite(itemName);
           seen.add(itemName);
           allItems.push(composite);
-        }
-        for (const dep of composite.primitives) {
-          if (!seen.has(dep)) {
-            const depItems = await client.resolveDependencies(dep, seen);
-            allItems.push(...depItems);
+          for (const dep of composite.primitives) {
+            if (!seen.has(dep)) {
+              const depItems = await client.resolveDependencies(dep, seen);
+              allItems.push(...depItems);
+            }
           }
         }
       } else {

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -150,28 +150,6 @@ export function selectFilesForFramework(
  */
 const FOLDER_NAMES = new Set(['composites']);
 
-const COMPOSITES_RUNTIME_CONTENT = `export { Composite, createComposites, toJsx, toMdx } from '@rafters/composites/client';
-export type { CompositeProps, ToJsxOptions } from '@rafters/composites/client';
-`;
-
-function buildCompositesRuntimeItem(): RegistryItem {
-  return {
-    name: 'composites',
-    type: 'composite',
-    primitives: [],
-    rules: [],
-    composites: [],
-    files: [
-      {
-        path: 'composites/index.ts',
-        content: COMPOSITES_RUNTIME_CONTENT,
-        dependencies: ['@rafters/composites'],
-        devDependencies: [],
-      },
-    ],
-  };
-}
-
 /**
  * Check if an item is already tracked in the installed list
  */
@@ -556,7 +534,7 @@ export async function add(componentArgs: string[], options: AddOptions): Promise
 
   // `rafters add composites` with no names installs the composites runtime
   if (folder === 'composites' && components.length === 0) {
-    components = ['__composites_runtime__'];
+    components = ['composites'];
   }
 
   // Validate that at least one component is specified
@@ -580,13 +558,16 @@ export async function add(componentArgs: string[], options: AddOptions): Promise
   for (const itemName of components) {
     try {
       if (folder === 'composites') {
+        const composite = await client.fetchComposite(itemName);
         if (!seen.has(itemName)) {
-          const item =
-            itemName === '__composites_runtime__'
-              ? buildCompositesRuntimeItem()
-              : await client.fetchComposite(itemName);
           seen.add(itemName);
-          allItems.push(item);
+          allItems.push(composite);
+        }
+        for (const dep of composite.primitives) {
+          if (!seen.has(dep)) {
+            const depItems = await client.resolveDependencies(dep, seen);
+            allItems.push(...depItems);
+          }
         }
       } else {
         const items = await client.resolveDependencies(itemName, seen);

--- a/packages/cli/src/registry/client.ts
+++ b/packages/cli/src/registry/client.ts
@@ -137,20 +137,22 @@ export class RegistryClient {
   }
 
   /**
-   * Fetch a registry item (component or primitive) by name
-   * Tries component first, then primitive
+   * Fetch a registry item by name
+   * Tries component, then primitive, then composite
    */
   async fetchItem(name: string): Promise<RegistryItem> {
     try {
       return await this.fetchComponent(name);
     } catch (err) {
-      // If component not found, try primitive
       if (err instanceof Error && err.message.includes('not found')) {
         try {
           return await this.fetchPrimitive(name);
         } catch {
-          // Re-throw original error if primitive also not found
-          throw err;
+          try {
+            return await this.fetchComposite(name);
+          } catch {
+            throw err;
+          }
         }
       }
       throw err;


### PR DESCRIPTION
## Summary

Fixes `rafters add composites` to serve the runtime from the registry instead of hardcoding it in the CLI. Composites now declare their block types as component dependencies, so `rafters add composites login-form` installs the login-form data + the composites runtime + every component its blocks reference (typography, input, button) + their primitives.

## Acceptance criteria mapping

### 1. `rafters add composites` scaffolds the consumer-side composite files
The registry serves the composites runtime at `/registry/composites/composites.json`. `loadCompositesRuntime()` in `componentService.ts:202` reads 7 source files from `packages/composites/src/` (manifest, walk-blocks, to-jsx, to-mdx, bridge, registry, rules) and bundles them as a RegistryItem. The CLI fetches this via `client.fetchComposite('composites')` and writes the files through the standard install loop — same path as every other registry item.
Evidence: `apps/website/src/lib/registry/componentService.ts:202-222`, `packages/cli/src/commands/add.ts:534-538`

### 2. Installed files import from `@rafters/composites/client`
The runtime files ARE the `@rafters/composites` package source, vendored into the consumer project. They import from each other via relative paths (e.g. `to-jsx.tsx` imports from `./walk-blocks` and `./manifest`). The CLI's `transformFileContent` rewrites these relative imports to match the consumer's configured composites path. No `@rafters/*` package imports in the installed files.
Evidence: `packages/composites/src/to-jsx.tsx:3` imports `./walk-blocks`, `packages/composites/src/to-mdx.ts:2` imports `./walk-blocks`

### 3. Existing `rafters add` behavior for components is unaffected
The composites-specific logic is gated behind `folder === 'composites'`. The default component path (`client.resolveDependencies`) is unchanged. The `FOLDER_NAMES` set and folder detection are unchanged from the prior release.
Evidence: `packages/cli/src/commands/add.ts:560-575` — composites branch, `packages/cli/src/commands/add.ts:576` — else branch unchanged

### 4. Existing tests pass
248 CLI tests pass, 12 skipped. Full preflight clean across all packages.
Evidence: `pnpm test:unit` — 248/248 pass, `pnpm preflight` — clean

## Not done

- `to-jsx.tsx` depends on `react` but the dependency is not declared on the runtime RegistryItem's files. Consumers using toJsx will need react installed independently (which they will have if they're rendering React components, but the dep chain doesn't enforce it).
- The `BLOCK_TYPE_TO_COMPONENT` map is hardcoded. New block types require a manual update. Acceptable for now — the set of built-in block types is small and stable.