### PR TITLE
fix(design-tokens): wire dark mode into the cascade graph (#1615)

### DIFF
--- a/packages/design-tokens/src/exporters/tailwind.ts
+++ b/packages/design-tokens/src/exporters/tailwind.ts
@@ -80,11 +80,14 @@ function getSemanticMappingsFromTokens(
   semanticTokens: Token[],
 ): Record<string, { light: string; dark: string }> {
   const mappings: Record<string, { light: string; dark: string }> = {};
+  const tokensByName = new Map<string, Token>();
+  for (const t of semanticTokens) tokensByName.set(t.name, t);
 
   for (const token of semanticTokens) {
     const { name, value, dependsOn } = token;
 
-    // Skip non-ColorReference values (state variants like primary-hover have string values)
+    if (name.endsWith('--dark')) continue;
+
     if (typeof value !== 'object' || value === null || !('family' in value)) {
       continue;
     }
@@ -92,14 +95,19 @@ function getSemanticMappingsFromTokens(
     const colorRef = value as ColorReference;
     const lightRef = `${colorRef.family}-${colorRef.position}`;
 
-    // Dark mode is in dependsOn[1] as string like 'neutral-50'
-    // If not available, use light mode as fallback
-    const darkRef = dependsOn?.[1] ?? lightRef;
+    let darkRef = lightRef;
+    const darkTokenName = dependsOn?.[1];
+    if (darkTokenName) {
+      const darkToken = tokensByName.get(darkTokenName);
+      if (darkToken?.value && typeof darkToken.value === 'object' && 'family' in darkToken.value) {
+        const darkColorRef = darkToken.value as ColorReference;
+        darkRef = `${darkColorRef.family}-${darkColorRef.position}`;
+      }
+    }
 
     mappings[name] = { light: lightRef, dark: darkRef };
   }
 
-  // Fill in any missing mappings from defaults (for completeness)
   for (const [name, mapping] of Object.entries(DEFAULT_SEMANTIC_COLOR_MAPPINGS)) {
     if (!mappings[name]) {
       mappings[name] = {

--- a/packages/design-tokens/src/generators/semantic.ts
+++ b/packages/design-tokens/src/generators/semantic.ts
@@ -138,6 +138,37 @@ function derivationParent(derivation: Derivation): string {
   }
 }
 
+function deriveDarkBinding(derivation: Derivation): Binding {
+  switch (derivation.kind) {
+    case 'scale':
+      return {
+        plugin: 'invert',
+        input: { familyName: derivation.family, basePosition: derivation.scalePosition },
+      };
+    case 'state':
+      return {
+        plugin: 'state',
+        input: { from: `${derivation.from}--dark`, stateType: derivation.stateType },
+      };
+    case 'contrast':
+      return {
+        plugin: 'contrast',
+        input: { against: `${derivation.against}--dark`, level: derivation.level },
+      };
+  }
+}
+
+function deriveDarkParent(derivation: Derivation): string {
+  switch (derivation.kind) {
+    case 'scale':
+      return derivation.family;
+    case 'state':
+      return `${derivation.from}--dark`;
+    case 'contrast':
+      return `${derivation.against}--dark`;
+  }
+}
+
 export function generateSemanticTokens(_config: ResolvedSystemConfig): GeneratorResult {
   const tokens: Token[] = [];
   const timestamp = new Date().toISOString();
@@ -151,15 +182,11 @@ export function generateSemanticTokens(_config: ResolvedSystemConfig): Generator
     const binding = derivationToBinding(derivation);
     const parent = derivationParent(derivation);
 
-    // dependsOn[0] = the actual upstream node in the cascade graph (parent
-    // semantic or family).
-    // dependsOn[1] = dark-mode position token for the Tailwind exporter's
-    // typed convention. Preserved verbatim from the v1 generator.
-    const darkTokenName = `${darkRef.family}-${darkRef.position}`;
-    const dependsOn: string[] = [parent];
-    if (darkTokenName !== parent) {
-      dependsOn.push(darkTokenName);
-    }
+    const darkName = `${name}--dark`;
+    const darkBinding = deriveDarkBinding(derivation);
+    const darkParent = deriveDarkParent(derivation);
+
+    const dependsOn: string[] = [parent, darkName];
 
     tokens.push({
       name,
@@ -172,7 +199,7 @@ export function generateSemanticTokens(_config: ResolvedSystemConfig): Generator
       trustLevel: mapping.trustLevel,
       consequence: mapping.consequence,
       dependsOn,
-      description: `${mapping.meaning}. Light: ${lightRef.family}-${lightRef.position}, Dark: ${darkRef.family}-${darkRef.position}.`,
+      description: `${mapping.meaning}. Light: ${lightRef.family}-${lightRef.position}.`,
       generatedAt: timestamp,
       containerQueryAware: true,
       userOverride: null,
@@ -182,6 +209,19 @@ export function generateSemanticTokens(_config: ResolvedSystemConfig): Generator
       },
       requiresConfirmation:
         mapping.consequence === 'destructive' || mapping.consequence === 'permanent',
+    });
+
+    tokens.push({
+      name: darkName,
+      value: darkRef,
+      category: 'color',
+      namespace: 'semantic',
+      binding: darkBinding,
+      dependsOn: [darkParent],
+      description: `Dark mode counterpart of ${name}.`,
+      generatedAt: timestamp,
+      containerQueryAware: true,
+      userOverride: null,
     });
   }
 

--- a/packages/design-tokens/src/generators/semantic.ts
+++ b/packages/design-tokens/src/generators/semantic.ts
@@ -19,8 +19,8 @@
  * recomputes via contrast against yellow's accessibility ladder; primary-hover
  * itself anchors because the override is recorded as userOverride.
  *
- * dependsOn[1] keeps the dark-counterpart token name for the Tailwind exporter
- * convention (typed: dependsOn[1] is the dark-mode position token).
+ * dependsOn[1] is the {name}--dark token. The Tailwind exporter resolves it
+ * to get the current dark ColorReference (cascade-derived, not static).
  */
 
 import type { Binding, ColorReference, Token } from '@rafters/shared';
@@ -127,14 +127,14 @@ function derivationToBinding(derivation: Derivation): Binding {
   }
 }
 
-function derivationParent(derivation: Derivation): string {
+function derivationParent(derivation: Derivation, suffix = ''): string {
   switch (derivation.kind) {
     case 'scale':
       return derivation.family;
     case 'state':
-      return derivation.from;
+      return `${derivation.from}${suffix}`;
     case 'contrast':
-      return derivation.against;
+      return `${derivation.against}${suffix}`;
   }
 }
 
@@ -158,17 +158,6 @@ function deriveDarkBinding(derivation: Derivation): Binding {
   }
 }
 
-function deriveDarkParent(derivation: Derivation): string {
-  switch (derivation.kind) {
-    case 'scale':
-      return derivation.family;
-    case 'state':
-      return `${derivation.from}--dark`;
-    case 'contrast':
-      return `${derivation.against}--dark`;
-  }
-}
-
 export function generateSemanticTokens(_config: ResolvedSystemConfig): GeneratorResult {
   const tokens: Token[] = [];
   const timestamp = new Date().toISOString();
@@ -184,7 +173,7 @@ export function generateSemanticTokens(_config: ResolvedSystemConfig): Generator
 
     const darkName = `${name}--dark`;
     const darkBinding = deriveDarkBinding(derivation);
-    const darkParent = deriveDarkParent(derivation);
+    const darkParent = derivationParent(derivation, '--dark');
 
     const dependsOn: string[] = [parent, darkName];
 


### PR DESCRIPTION
## Summary

Dark mode counterparts are now cascade-derived graph nodes instead of static metadata. When a color family changes, the invert plugin re-runs using the family's WCAG pair data to pick the correct dark position. Previously dark values were frozen at generation-time defaults regardless of the actual color.

## Acceptance criteria mapping

### 1. After `rafters set` changes a color family, the dark counterpart reflects the new color's WCAG pairs
Each semantic token now has a corresponding `{name}--dark` token with an `invert` binding. The invert plugin reads the family's accessibility data (`wcagAAA.normal`, `wcagAA.normal` pair matrices) via `findDarkCounterpartIndex` to pick the position with highest contrast distance. When `set()` changes a family, the cascade fires `cascadeFrom` which re-runs the invert plugin on all dependent dark tokens, updating their `ColorReference` value to reflect the new family's WCAG pairs.
Evidence: `packages/design-tokens/src/generators/semantic.ts:141-158` (deriveDarkBinding creates invert binding), `packages/design-tokens/src/plugins/invert.ts:18-31` (transform reads family accessibility data), `packages/design-tokens/src/graph.ts:158-170` (cascadeFrom re-derives dependents)

### 2. The Tailwind exporter emits correct dark values derived from the cascade
`getSemanticMappingsFromTokens` in the exporter now resolves `dependsOn[1]` as a token name — looks up the `{name}--dark` token in the token list to get its current `ColorReference` value, then formats it as `{family}-{position}`. Previously it used `dependsOn[1]` as a literal CSS string that never changed.
Evidence: `packages/design-tokens/src/exporters/tailwind.ts:83-107` (builds tokensByName map, resolves dark token value)

### 3. Existing tests pass
All 167 design-tokens tests and 248 CLI tests pass. Full preflight clean. The change is structurally compatible — the graph, cascade, and invert plugin are unchanged. Only the token generation (adds --dark nodes) and exporter consumption (resolves names instead of literals) changed.
Evidence: `pnpm test` — 167/167 design-tokens, 248/248 CLI, preflight clean

## Not done

- Existing `.rafters/tokens/semantic.rafters.json` files from prior inits don't have the --dark tokens. Users need to re-run `rafters init` (or a future `rafters regenerate`) to get the dark tokens created. This is a one-time migration, not a runtime concern.
- The `toDarkColorRef(mapping)` initial value is still used as the seed for the --dark token. On first generation this matches the defaults. After `set()`, the cascade overrides it with the correct value. The seed is only meaningful at generation time.