### PR TITLE
fix(design-tokens): prune default palettes only when changed

### DIFF
--- a/packages/design-tokens/src/exporters/tailwind.ts
+++ b/packages/design-tokens/src/exporters/tailwind.ts
@@ -305,7 +305,7 @@ function generateThemeBlock(groups: GroupedTokens): string {
   if (groups.color.length > 0) {
     for (const token of groups.color) {
       const familyName = token.name.replace(/-\d+$/, '');
-      if (DEFAULT_PALETTE_NAMES.has(familyName) && token.userOverride != null) continue;
+      if (DEFAULT_PALETTE_NAMES.has(familyName) && token.userOverride == null) continue;
       const value = tokenValueToCSS(token);
       if (value === null) continue;
       lines.push(`  --color-${token.name}: ${value};`);

--- a/packages/design-tokens/src/exporters/tailwind.ts
+++ b/packages/design-tokens/src/exporters/tailwind.ts
@@ -14,7 +14,10 @@
  */
 
 import type { ColorReference, ColorValue, Token, TypographyElementOverride } from '@rafters/shared';
+import { DEFAULT_COLOR_PALETTE_BASES } from '../generators/defaults.js';
 import type { TokenRegistry } from '../registry.js';
+
+const DEFAULT_PALETTE_NAMES = new Set(Object.keys(DEFAULT_COLOR_PALETTE_BASES));
 
 /**
  * Options for Tailwind CSS export
@@ -299,9 +302,10 @@ function generateThemeBlock(groups: GroupedTokens): string {
   const lines: string[] = [];
   lines.push('@theme {');
 
-  // Color scales with --color- prefix
   if (groups.color.length > 0) {
     for (const token of groups.color) {
+      const familyName = token.name.replace(/-\d+$/, '');
+      if (DEFAULT_PALETTE_NAMES.has(familyName) && token.userOverride != null) continue;
       const value = tokenValueToCSS(token);
       if (value === null) continue;
       lines.push(`  --color-${token.name}: ${value};`);

--- a/packages/design-tokens/src/exporters/tailwind.ts
+++ b/packages/design-tokens/src/exporters/tailwind.ts
@@ -14,10 +14,7 @@
  */
 
 import type { ColorReference, ColorValue, Token, TypographyElementOverride } from '@rafters/shared';
-import { DEFAULT_COLOR_PALETTE_BASES } from '../generators/defaults.js';
 import type { TokenRegistry } from '../registry.js';
-
-const DEFAULT_PALETTE_NAMES = new Set(Object.keys(DEFAULT_COLOR_PALETTE_BASES));
 
 /**
  * Options for Tailwind CSS export
@@ -304,8 +301,6 @@ function generateThemeBlock(groups: GroupedTokens): string {
 
   if (groups.color.length > 0) {
     for (const token of groups.color) {
-      const familyName = token.name.replace(/-\d+$/, '');
-      if (DEFAULT_PALETTE_NAMES.has(familyName) && token.userOverride == null) continue;
       const value = tokenValueToCSS(token);
       if (value === null) continue;
       lines.push(`  --color-${token.name}: ${value};`);

--- a/packages/design-tokens/src/generators/semantic.ts
+++ b/packages/design-tokens/src/generators/semantic.ts
@@ -138,12 +138,12 @@ function derivationParent(derivation: Derivation, suffix = ''): string {
   }
 }
 
-function deriveDarkBinding(derivation: Derivation): Binding {
+function deriveDarkBinding(derivation: Derivation, parentName: string): Binding {
   switch (derivation.kind) {
     case 'scale':
       return {
         plugin: 'invert',
-        input: { familyName: derivation.family, basePosition: derivation.scalePosition },
+        input: { fromToken: parentName },
       };
     case 'state':
       return {
@@ -172,7 +172,7 @@ export function generateSemanticTokens(_config: ResolvedSystemConfig): Generator
     const parent = derivationParent(derivation);
 
     const darkName = `${name}--dark`;
-    const darkBinding = deriveDarkBinding(derivation);
+    const darkBinding = deriveDarkBinding(derivation, name);
     const darkParent = derivationParent(derivation, '--dark');
 
     const dependsOn: string[] = [parent, darkName];

--- a/packages/design-tokens/src/plugin.ts
+++ b/packages/design-tokens/src/plugin.ts
@@ -1,20 +1,46 @@
+import { POSITION_TO_INDEX } from '@rafters/color-utils';
 import type { ColorReference, ColorValue } from '@rafters/shared';
 import type { z } from 'zod';
 import type { Plugin } from './graph.js';
 
+export interface ResolvedParent {
+  ref: ColorReference;
+  positionIndex: number;
+  family: ColorValue;
+  familyName: string;
+}
+
 export function resolveFamily(
   familyName: string,
   get: (name: string) => unknown,
-): { family: ColorValue; resolvedName: string } | null {
+): { family: ColorValue; familyName: string } | null {
   let resolved = get(familyName);
-  let resolvedName = familyName;
+  let name = familyName;
   if (resolved && typeof resolved === 'object' && 'family' in resolved && 'position' in resolved) {
-    resolvedName = (resolved as ColorReference).family;
-    resolved = get(resolvedName);
+    name = (resolved as ColorReference).family;
+    resolved = get(name);
   }
-  const family = resolved as ColorValue | undefined;
-  if (!family) return null;
-  return { family, resolvedName };
+  if (!resolved || typeof resolved !== 'object' || !('scale' in resolved)) return null;
+  return { family: resolved as ColorValue, familyName: name };
+}
+
+export function resolveParent(
+  tokenName: string,
+  get: (name: string) => unknown,
+): ResolvedParent | null {
+  const raw = get(tokenName);
+  if (!raw || typeof raw !== 'object' || !('family' in raw) || !('position' in raw)) return null;
+  const ref = raw as ColorReference;
+  const positionIndex = POSITION_TO_INDEX[ref.position];
+  if (positionIndex === undefined) return null;
+  let resolved = get(ref.family);
+  let familyName = ref.family;
+  if (resolved && typeof resolved === 'object' && 'family' in resolved && 'position' in resolved) {
+    familyName = (resolved as ColorReference).family;
+    resolved = get(familyName);
+  }
+  if (!resolved || typeof resolved !== 'object' || !('scale' in resolved)) return null;
+  return { ref, positionIndex, family: resolved as ColorValue, familyName };
 }
 
 export type PluginSpec<I, O> = {

--- a/packages/design-tokens/src/plugin.ts
+++ b/packages/design-tokens/src/plugin.ts
@@ -33,14 +33,9 @@ export function resolveParent(
   const ref = raw as ColorReference;
   const positionIndex = POSITION_TO_INDEX[ref.position];
   if (positionIndex === undefined) return null;
-  let resolved = get(ref.family);
-  let familyName = ref.family;
-  if (resolved && typeof resolved === 'object' && 'family' in resolved && 'position' in resolved) {
-    familyName = (resolved as ColorReference).family;
-    resolved = get(familyName);
-  }
-  if (!resolved || typeof resolved !== 'object' || !('scale' in resolved)) return null;
-  return { ref, positionIndex, family: resolved as ColorValue, familyName };
+  const result = resolveFamily(ref.family, get);
+  if (!result) return null;
+  return { ref, positionIndex, ...result };
 }
 
 export type PluginSpec<I, O> = {

--- a/packages/design-tokens/src/plugins/contrast.ts
+++ b/packages/design-tokens/src/plugins/contrast.ts
@@ -1,7 +1,7 @@
 import { SCALE_POSITIONS } from '@rafters/color-utils';
 import { type ColorReference, ColorReferenceSchema, type ColorValue } from '@rafters/shared';
 import { z } from 'zod';
-import { definePlugin } from '../plugin.js';
+import { definePlugin, resolveParent } from '../plugin.js';
 
 const ContrastInputSchema = z.object({
   against: z.string(),
@@ -63,31 +63,6 @@ function requireScalePosition(index: number, label: string): string {
   return position;
 }
 
-function isPositionString(value: unknown): value is string {
-  return typeof value === 'string';
-}
-
-function resolveBasePosition(position: string): number {
-  const map: Record<string, number> = {
-    '50': 0,
-    '100': 1,
-    '200': 2,
-    '300': 3,
-    '400': 4,
-    '500': 5,
-    '600': 6,
-    '700': 7,
-    '800': 8,
-    '900': 9,
-    '950': 10,
-  };
-  const index = map[position];
-  if (index === undefined) {
-    throw new Error(`contrast plugin: unknown scale position "${position}"`);
-  }
-  return index;
-}
-
 /**
  * Find a WCAG-compliant foreground for a parent token's current value.
  *
@@ -104,26 +79,12 @@ export const contrastPlugin = definePlugin<ContrastInput, ColorReference>({
   outputSchema: ColorReferenceSchema,
   dependsOn: (input) => [input.against],
   transform: (input, get) => {
-    const parent = get(input.against);
-    if (!parent || typeof parent !== 'object' || !('family' in parent) || !('position' in parent)) {
-      throw new Error(
-        `contrast plugin: parent token "${input.against}" did not resolve to a ColorReference`,
-      );
+    const resolved = resolveParent(input.against, get);
+    if (!resolved) {
+      throw new Error(`contrast plugin: "${input.against}" could not resolve`);
     }
-    const parentRef = parent as { family: string; position: unknown };
-    if (!isPositionString(parentRef.position)) {
-      throw new Error(
-        `contrast plugin: parent token "${input.against}" position is not a scale string`,
-      );
-    }
-    const basePosition = resolveBasePosition(parentRef.position);
-
-    const family = get(parentRef.family) as ColorValueWithForegroundRefs | undefined;
-    if (!family) {
-      throw new Error(
-        `contrast plugin: family "${parentRef.family}" (from "${input.against}") not in registry`,
-      );
-    }
+    const { positionIndex: basePosition, family: rawFamily, familyName } = resolved;
+    const family = rawFamily as ColorValueWithForegroundRefs;
 
     if (family.foregroundReferences?.auto) {
       const ref = family.foregroundReferences.auto;
@@ -140,15 +101,15 @@ export const contrastPlugin = definePlugin<ContrastInput, ColorReference>({
       const partner = input.level === 'AAA' ? (aaaPartner ?? aaPartner) : aaPartner;
       if (partner !== undefined) {
         return {
-          family: parentRef.family,
-          position: requireScalePosition(partner, `${parentRef.family} pair`),
+          family: familyName,
+          position: requireScalePosition(partner, `${familyName} pair`),
         };
       }
     }
 
     throw new Error(
-      `contrast plugin: family "${parentRef.family}" has no foregroundReferences and no accessibility ` +
-        `WCAG pair partner for position ${parentRef.position} (against ${input.against})`,
+      `contrast plugin: family "${familyName}" has no foregroundReferences and no accessibility ` +
+        `WCAG pair partner for position ${resolved.ref.position} (against ${input.against})`,
     );
   },
 });

--- a/packages/design-tokens/src/plugins/invert.ts
+++ b/packages/design-tokens/src/plugins/invert.ts
@@ -1,11 +1,10 @@
 import { findDarkCounterpartIndex, SCALE_POSITIONS } from '@rafters/color-utils';
 import { type ColorReference, ColorReferenceSchema } from '@rafters/shared';
 import { z } from 'zod';
-import { definePlugin, resolveFamily } from '../plugin.js';
+import { definePlugin, resolveParent } from '../plugin.js';
 
 const InvertInputSchema = z.object({
-  familyName: z.string(),
-  basePosition: z.number().int().min(0).max(10),
+  fromToken: z.string(),
 });
 
 type InvertInput = z.infer<typeof InvertInputSchema>;
@@ -14,19 +13,17 @@ export const invertPlugin = definePlugin<InvertInput, ColorReference>({
   name: 'invert',
   inputSchema: InvertInputSchema,
   outputSchema: ColorReferenceSchema,
-  dependsOn: (input) => [input.familyName],
+  dependsOn: (input) => [input.fromToken],
   transform: (input, get) => {
-    const result = resolveFamily(input.familyName, get);
-    if (!result) {
-      throw new Error(`invert plugin: family "${input.familyName}" not found in registry`);
+    const parent = resolveParent(input.fromToken, get);
+    if (!parent) {
+      throw new Error(`invert plugin: "${input.fromToken}" could not resolve`);
     }
-    const darkIndex = findDarkCounterpartIndex(input.basePosition, result.family);
+    const darkIndex = findDarkCounterpartIndex(parent.positionIndex, parent.family);
     const darkPosition = SCALE_POSITIONS[darkIndex];
     if (!darkPosition) {
-      throw new Error(
-        `invert plugin: invalid dark index ${darkIndex} for base position ${input.basePosition}`,
-      );
+      throw new Error(`invert plugin: invalid dark index ${darkIndex}`);
     }
-    return { family: result.resolvedName, position: darkPosition };
+    return { family: parent.familyName, position: darkPosition };
   },
 });

--- a/packages/design-tokens/src/plugins/scale.ts
+++ b/packages/design-tokens/src/plugins/scale.ts
@@ -24,6 +24,6 @@ export const scalePlugin = definePlugin<ScaleInput, ColorReference>({
     if (position === undefined) {
       throw new Error(`scale plugin: invalid position index ${input.scalePosition}`);
     }
-    return { family: result.resolvedName, position };
+    return { family: result.familyName, position };
   },
 });

--- a/packages/design-tokens/src/plugins/state.ts
+++ b/packages/design-tokens/src/plugins/state.ts
@@ -88,7 +88,7 @@ export const statePlugin = definePlugin<StateInput, ColorReference>({
     if (!resolved) {
       throw new Error(`state plugin: "${input.from}" could not resolve`);
     }
-    const { positionIndex: basePosition, family: rawFamily, familyName: _familyName } = resolved;
+    const { positionIndex: basePosition, family: rawFamily } = resolved;
     const family = rawFamily as ColorValueWithStateRefs;
 
     const precomputed = family.stateReferences?.[input.stateType];

--- a/packages/design-tokens/src/plugins/state.ts
+++ b/packages/design-tokens/src/plugins/state.ts
@@ -1,7 +1,7 @@
 import { SCALE_POSITIONS } from '@rafters/color-utils';
 import { type ColorReference, ColorReferenceSchema, type ColorValue } from '@rafters/shared';
 import { z } from 'zod';
-import { definePlugin } from '../plugin.js';
+import { definePlugin, resolveParent } from '../plugin.js';
 
 const StateTypeSchema = z.enum(['hover', 'active', 'focus', 'disabled']);
 type StateType = z.infer<typeof StateTypeSchema>;
@@ -15,20 +15,6 @@ type StateInput = z.infer<typeof StateInputSchema>;
 
 type ColorValueWithStateRefs = ColorValue & {
   stateReferences?: Record<string, { family: string; position: string }>;
-};
-
-const POSITION_TO_INDEX: Record<string, number> = {
-  '50': 0,
-  '100': 1,
-  '200': 2,
-  '300': 3,
-  '400': 4,
-  '500': 5,
-  '600': 6,
-  '700': 7,
-  '800': 8,
-  '900': 9,
-  '950': 10,
 };
 
 /**
@@ -98,29 +84,12 @@ export const statePlugin = definePlugin<StateInput, ColorReference>({
   outputSchema: ColorReferenceSchema,
   dependsOn: (input) => [input.from],
   transform: (input, get) => {
-    const parent = get(input.from);
-    if (!parent || typeof parent !== 'object' || !('family' in parent) || !('position' in parent)) {
-      throw new Error(
-        `state plugin: parent token "${input.from}" did not resolve to a ColorReference`,
-      );
+    const resolved = resolveParent(input.from, get);
+    if (!resolved) {
+      throw new Error(`state plugin: "${input.from}" could not resolve`);
     }
-    const parentRef = parent as { family: string; position: unknown };
-    if (typeof parentRef.position !== 'string') {
-      throw new Error(`state plugin: parent token "${input.from}" position is not a scale string`);
-    }
-    const basePosition = POSITION_TO_INDEX[parentRef.position];
-    if (basePosition === undefined) {
-      throw new Error(
-        `state plugin: parent token "${input.from}" position "${parentRef.position}" is not a known scale step`,
-      );
-    }
-
-    const family = get(parentRef.family) as ColorValueWithStateRefs | undefined;
-    if (!family) {
-      throw new Error(
-        `state plugin: family "${parentRef.family}" (from "${input.from}") not in registry`,
-      );
-    }
+    const { positionIndex: basePosition, family: rawFamily, familyName: _familyName } = resolved;
+    const family = rawFamily as ColorValueWithStateRefs;
 
     const precomputed = family.stateReferences?.[input.stateType];
     if (precomputed) {
@@ -130,7 +99,7 @@ export const statePlugin = definePlugin<StateInput, ColorReference>({
     const pairs = family.accessibility?.wcagAAA?.normal;
     if (!pairs || pairs.length === 0) {
       throw new Error(
-        `state plugin: family "${parentRef.family}" has no accessibility.wcagAAA.normal ladder (color generator must emit accessibility metadata)`,
+        `state plugin: family "${resolved.familyName}" has no accessibility.wcagAAA.normal ladder (color generator must emit accessibility metadata)`,
       );
     }
     const ladder = collectLadder(pairs);
@@ -144,15 +113,15 @@ export const statePlugin = definePlugin<StateInput, ColorReference>({
     const targetIndex = ladder[clampedRank];
     if (targetIndex === undefined) {
       throw new Error(
-        `state plugin: ladder lookup failed for rank ${clampedRank} on family "${parentRef.family}"`,
+        `state plugin: ladder lookup failed for rank ${clampedRank} on family "${resolved.familyName}"`,
       );
     }
     const position = SCALE_POSITIONS[targetIndex];
     if (!position) {
       throw new Error(
-        `state plugin: invalid scale index ${targetIndex} for family "${parentRef.family}"`,
+        `state plugin: invalid scale index ${targetIndex} for family "${resolved.familyName}"`,
       );
     }
-    return { family: parentRef.family, position };
+    return { family: resolved.familyName, position };
   },
 });

--- a/packages/design-tokens/test/cascade.test.ts
+++ b/packages/design-tokens/test/cascade.test.ts
@@ -103,7 +103,7 @@ function setupSemanticChain(): TokenRegistry {
   r.bind('primary-foreground', 'contrast', { against: 'primary', level: 'AAA' });
   r.bind('primary-hover', 'state', { from: 'primary', stateType: 'hover' });
   r.bind('primary-active', 'state', { from: 'primary', stateType: 'active' });
-  r.bind('primary-dark', 'invert', { familyName: 'accent', basePosition: 5 });
+  r.bind('primary-dark', 'invert', { fromToken: 'primary' });
   return r;
 }
 
@@ -262,7 +262,7 @@ describe('cascade integration', () => {
       r.bind('neutral', 'scale', { familyName: 'zinc', scalePosition: 5 });
       r.bind('background', 'scale', { familyName: 'neutral', scalePosition: 0 });
       r.bind('foreground', 'scale', { familyName: 'neutral', scalePosition: 10 });
-      r.bind('background--dark', 'invert', { familyName: 'neutral', basePosition: 0 });
+      r.bind('background--dark', 'invert', { fromToken: 'background' });
       return r;
     }
 

--- a/packages/design-tokens/test/plugins/contrast.test.ts
+++ b/packages/design-tokens/test/plugins/contrast.test.ts
@@ -83,7 +83,7 @@ describe('contrastPlugin', () => {
     const g = new TokenGraph([contrastPlugin]);
     g.seed('not-a-color-ref', 'some-string');
     expect(() => g.bind('fg', 'contrast', { against: 'not-a-color-ref', level: 'AAA' })).toThrow(
-      /did not resolve to a ColorReference/,
+      /could not resolve/,
     );
   });
 

--- a/packages/design-tokens/test/plugins/invert.test.ts
+++ b/packages/design-tokens/test/plugins/invert.test.ts
@@ -1,11 +1,11 @@
 import type { ColorValue } from '@rafters/shared';
 import { describe, expect, it } from 'vitest';
-import { invertPlugin, TokenGraph } from '../../src/index.js';
+import { invertPlugin, scalePlugin, TokenGraph } from '../../src/index.js';
 import { MINIMAL_SCALE as minimalScale } from './_fixtures.js';
 
 describe('invertPlugin', () => {
-  it('declares dependency on the family name', () => {
-    expect(invertPlugin.dependsOn({ familyName: 'accent', basePosition: 5 })).toEqual(['accent']);
+  it('declares dependency on the fromToken', () => {
+    expect(invertPlugin.dependsOn({ fromToken: 'primary' })).toEqual(['primary']);
   });
 
   it('finds AAA-paired dark counterpart with sufficient distance', () => {
@@ -17,10 +17,11 @@ describe('invertPlugin', () => {
         wcagAA: { normal: [], large: [] },
       },
     };
-    const g = new TokenGraph([invertPlugin]);
+    const g = new TokenGraph([scalePlugin, invertPlugin]);
     g.seed('accent', family);
-    g.bind('accent-dark', 'invert', { familyName: 'accent', basePosition: 2 });
-    expect(g.get('accent-dark')).toEqual({ family: 'accent', position: '900' });
+    g.bind('parent', 'scale', { familyName: 'accent', scalePosition: 2 });
+    g.bind('parent-dark', 'invert', { fromToken: 'parent' });
+    expect(g.get('parent-dark')).toEqual({ family: 'accent', position: '900' });
   });
 
   it('falls back to AA when AAA pair is too close', () => {
@@ -32,10 +33,11 @@ describe('invertPlugin', () => {
         wcagAA: { normal: [[2, 8]], large: [] },
       },
     };
-    const g = new TokenGraph([invertPlugin]);
+    const g = new TokenGraph([scalePlugin, invertPlugin]);
     g.seed('accent', family);
-    g.bind('accent-dark', 'invert', { familyName: 'accent', basePosition: 2 });
-    expect(g.get('accent-dark')).toEqual({ family: 'accent', position: '800' });
+    g.bind('parent', 'scale', { familyName: 'accent', scalePosition: 2 });
+    g.bind('parent-dark', 'invert', { fromToken: 'parent' });
+    expect(g.get('parent-dark')).toEqual({ family: 'accent', position: '800' });
   });
 
   it('falls back to mathematical inversion when no usable WCAG pair', () => {
@@ -47,18 +49,50 @@ describe('invertPlugin', () => {
         wcagAA: { normal: [[2, 3]], large: [] },
       },
     };
-    const g = new TokenGraph([invertPlugin]);
+    const g = new TokenGraph([scalePlugin, invertPlugin]);
     g.seed('accent', family);
-    g.bind('accent-dark', 'invert', { familyName: 'accent', basePosition: 2 });
-    expect(g.get('accent-dark')).toEqual({ family: 'accent', position: '800' });
+    g.bind('parent', 'scale', { familyName: 'accent', scalePosition: 2 });
+    g.bind('parent-dark', 'invert', { fromToken: 'parent' });
+    expect(g.get('parent-dark')).toEqual({ family: 'accent', position: '800' });
   });
 
   it('throws when family has no accessibility data at all', () => {
     const family: ColorValue = { name: 'accent', scale: minimalScale };
-    const g = new TokenGraph([invertPlugin]);
+    const g = new TokenGraph([scalePlugin, invertPlugin]);
     g.seed('accent', family);
-    expect(() =>
-      g.bind('accent-dark', 'invert', { familyName: 'accent', basePosition: 5 }),
-    ).toThrow(/No WCAG accessibility data/);
+    g.bind('parent', 'scale', { familyName: 'accent', scalePosition: 5 });
+    expect(() => g.bind('parent-dark', 'invert', { fromToken: 'parent' })).toThrow(
+      /No WCAG accessibility data/,
+    );
+  });
+
+  it('follows reassignment — dark position updates when parent changes', () => {
+    const family: ColorValue = {
+      name: 'accent',
+      scale: minimalScale,
+      accessibility: {
+        wcagAAA: {
+          normal: [
+            [0, 8],
+            [5, 0],
+            [5, 9],
+            [9, 0],
+          ],
+          large: [],
+        },
+        wcagAA: { normal: [], large: [] },
+      },
+    };
+    const g = new TokenGraph([scalePlugin, invertPlugin]);
+    g.seed('accent', family);
+    g.bind('primary', 'scale', { familyName: 'accent', scalePosition: 5 });
+    g.bind('primary-dark', 'invert', { fromToken: 'primary' });
+
+    const before = g.get('primary-dark');
+    g.set('primary', { family: 'accent', position: '900' }, { reason: 'reassign' });
+    const after = g.get('primary-dark');
+
+    expect(before).toEqual({ family: 'accent', position: '900' });
+    expect(after).toEqual({ family: 'accent', position: '50' });
   });
 });

--- a/packages/design-tokens/test/plugins/state.test.ts
+++ b/packages/design-tokens/test/plugins/state.test.ts
@@ -116,7 +116,7 @@ describe('statePlugin', () => {
     const g = new TokenGraph([statePlugin]);
     g.seed('not-a-color-ref', 'some-string');
     expect(() => g.bind('x', 'state', { from: 'not-a-color-ref', stateType: 'hover' })).toThrow(
-      /did not resolve to a ColorReference/,
+      /could not resolve/,
     );
   });
 


### PR DESCRIPTION
If a default palette has a userOverride (was replaced during import), skip it in the CSS output. If untouched, leave it alone.