### PR TITLE
feat(#1717): Container colSpan/rowSpan for self-placing grid children

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to `@rafters/ui` are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- **Container grid placement.** Container now accepts `colSpan` (1-12) and
+  `rowSpan` (1-3), the same span vocabulary as `Grid.Item`. A Container placed
+  directly inside a `Grid` can carry its own placement, so content no longer
+  needs a `Grid.Item` wrapper. Available across all three render targets
+  (React, Astro, and the `<rafters-container>` web component via `col-span` /
+  `row-span` attributes).

--- a/packages/ui/src/components/ui/container.astro
+++ b/packages/ui/src/components/ui/container.astro
@@ -25,6 +25,7 @@ import {
   containerSizeClasses,
   containerSizeGapScale,
 } from './container.classes';
+import { gridColSpanClasses, gridRowSpanClasses } from './grid.classes';
 
 interface Props extends HTMLAttributes<'div'> {
   as?: 'div' | 'main' | 'header' | 'footer' | 'section' | 'article' | 'aside';
@@ -33,6 +34,10 @@ interface Props extends HTMLAttributes<'div'> {
   gap?: boolean | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '8' | '10' | '12' | '16' | '20' | '24';
   query?: boolean;
   queryName?: string;
+  /** Column span when placed directly in a Grid (no Grid.Item wrapper). */
+  colSpan?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+  /** Row span when placed directly in a Grid. */
+  rowSpan?: 1 | 2 | 3;
   position?: ContainerPosition;
   depth?: ContainerDepth;
   /** @deprecated Prefer the `fill` prop. */
@@ -52,6 +57,8 @@ const {
   gap,
   query = true,
   queryName,
+  colSpan,
+  rowSpan,
   position,
   depth,
   background,
@@ -77,6 +84,8 @@ const classes = classy(
   size && size !== 'full' && 'mx-auto',
   padding ? containerPaddingClasses[padding] : size && size !== 'full' && containerAutoEdgePadding,
   resolvedGap && containerGapClasses[resolvedGap],
+  colSpan && gridColSpanClasses[colSpan],
+  rowSpan && gridRowSpanClasses[rowSpan],
   fillClasses,
   !fillClasses && background && containerBackgroundClasses[background],
   position && containerPositionClasses[position],

--- a/packages/ui/src/components/ui/container.element.test.ts
+++ b/packages/ui/src/components/ui/container.element.test.ts
@@ -12,6 +12,7 @@ import {
   containerSizeClasses,
 } from './container.classes';
 import { composeContainerClasses, RaftersContainer } from './container.element';
+import { gridColSpanClasses, gridRowSpanClasses } from './grid.classes';
 
 afterEach(() => {
   while (document.body.firstChild) {
@@ -141,6 +142,30 @@ describe('rafters-container', () => {
     expect(innerClass(el)).not.toContain(containerBackgroundClasses.muted);
   });
 
+  it('applies the column span utility when placed in a grid', () => {
+    const el = mount('rafters-container', { 'col-span': '2' });
+    expect(innerClass(el)).toContain(gridColSpanClasses[2]);
+  });
+
+  it('applies the row span utility', () => {
+    const el = mount('rafters-container', { 'row-span': '2' });
+    expect(innerClass(el)).toContain(gridRowSpanClasses[2]);
+  });
+
+  it('ignores out-of-range span values', () => {
+    const el = mount('rafters-container', { 'col-span': '99', 'row-span': '7' });
+    expect(innerClass(el)).not.toContain('col-span-99');
+    expect(innerClass(el)).not.toContain('row-span-7');
+  });
+
+  it('recomposes the span when col-span changes', () => {
+    const el = mount('rafters-container', { 'col-span': '2' });
+    expect(innerClass(el)).toContain(gridColSpanClasses[2]);
+    el.setAttribute('col-span', '4');
+    expect(innerClass(el)).toContain(gridColSpanClasses[4]);
+    expect(innerClass(el)).not.toContain(gridColSpanClasses[2]);
+  });
+
   it('article applies the typography utilities', () => {
     const el = mount('rafters-container', { as: 'article' });
     expect(innerClass(el)).toContain(containerArticleTypography);
@@ -206,6 +231,8 @@ describe('rafters-container', () => {
       'size',
       'padding',
       'gap',
+      'col-span',
+      'row-span',
       'position',
       'depth',
       'background',

--- a/packages/ui/src/components/ui/container.element.ts
+++ b/packages/ui/src/components/ui/container.element.ts
@@ -24,6 +24,8 @@
  *  - size: 'sm'..'7xl' | 'full'
  *  - padding: '0' | '1' | ... | '24'
  *  - gap: same as padding scale, OR bare/empty -> derive from size
+ *  - col-span: 1..12 -- grid column span when placed directly in a grid
+ *  - row-span: 1..3 -- grid row span when placed directly in a grid
  *  - position: 'sticky' | 'fixed' | 'relative' | 'absolute' | 'static'
  *  - depth: 'base' | 'dropdown' | 'sticky' | 'navigation' | 'fixed' | 'modal' | 'popover' | 'tooltip' | 'overlay' | 'below' | 'max'
  *  - background: 'none' | 'muted' | 'accent' | 'card' | 'primary'
@@ -47,8 +49,12 @@ import {
   containerSizeClasses,
   containerSizeGapScale,
 } from './container.classes';
+import { gridColSpanClasses, gridRowSpanClasses } from './grid.classes';
 
 export type ContainerAs = 'div' | 'main' | 'header' | 'footer' | 'section' | 'article' | 'aside';
+
+export type ContainerColSpan = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+export type ContainerRowSpan = 1 | 2 | 3;
 
 export type ContainerSize =
   | 'sm'
@@ -148,6 +154,10 @@ const BACKGROUNDS: ReadonlyArray<ContainerBackground> = [
   'primary',
 ];
 
+const COL_SPANS: ReadonlyArray<ContainerColSpan> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+const ROW_SPANS: ReadonlyArray<ContainerRowSpan> = [1, 2, 3];
+
 function isContainerSize(value: string | null): value is ContainerSize {
   return value !== null && (SIZES as ReadonlyArray<string>).includes(value);
 }
@@ -200,6 +210,15 @@ function parseDepth(value: string | null): ContainerDepth | undefined {
   return undefined;
 }
 
+function parseSpan<T extends number>(
+  value: string | null,
+  allowed: ReadonlyArray<T>,
+): T | undefined {
+  if (value === null) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return (allowed as ReadonlyArray<number>).includes(parsed) ? (parsed as T) : undefined;
+}
+
 export interface ContainerClassOptions {
   size?: ContainerSize | undefined;
   padding?: ContainerSpacing | undefined;
@@ -207,6 +226,8 @@ export interface ContainerClassOptions {
   position?: ContainerPosition | undefined;
   depth?: ContainerDepth | undefined;
   background?: ContainerBackground | undefined;
+  colSpan?: ContainerColSpan | undefined;
+  rowSpan?: ContainerRowSpan | undefined;
   article?: boolean | undefined;
   editable?: boolean | undefined;
 }
@@ -223,7 +244,8 @@ function resolveDerivedGap(size: ContainerSize | undefined): ContainerSpacing {
 }
 
 export function composeContainerClasses(options: ContainerClassOptions): string {
-  const { size, padding, gap, position, depth, background, article, editable } = options;
+  const { size, padding, gap, position, depth, background, colSpan, rowSpan, article, editable } =
+    options;
   const parts: string[] = [];
   parts.push(containerQueryClasses);
   if (size) parts.push(containerSizeClasses[size] as string);
@@ -242,6 +264,8 @@ export function composeContainerClasses(options: ContainerClassOptions): string 
   if (resolvedGap !== null) {
     parts.push(containerGapClasses[resolvedGap] as string);
   }
+  if (colSpan) parts.push(gridColSpanClasses[colSpan] as string);
+  if (rowSpan) parts.push(gridRowSpanClasses[rowSpan] as string);
   if (position) parts.push(containerPositionClasses[position]);
   if (depth) parts.push(containerDepthClasses[depth]);
   if (background && background !== 'none') {
@@ -256,6 +280,8 @@ const OBSERVED_ATTRIBUTES: ReadonlyArray<string> = [
   'size',
   'padding',
   'gap',
+  'col-span',
+  'row-span',
   'position',
   'depth',
   'background',
@@ -294,6 +320,8 @@ export class RaftersContainer extends RaftersElement {
       position: parsePosition(this.getAttribute('position')),
       depth: parseDepth(this.getAttribute('depth')),
       background: parseBackground(this.getAttribute('background')),
+      colSpan: parseSpan(this.getAttribute('col-span'), COL_SPANS),
+      rowSpan: parseSpan(this.getAttribute('row-span'), ROW_SPANS),
       article: this.getAs() === 'article',
       editable: this.hasAttribute('editable'),
     });

--- a/packages/ui/src/components/ui/container.tsx
+++ b/packages/ui/src/components/ui/container.tsx
@@ -15,6 +15,7 @@
  * DO: Use article for readable content - typography is automatic
  * DO: Use aside for supplementary content, add surface classes for depth
  * DO: Spacing happens inside (padding), not outside (no margins)
+ * DO: Place a Container directly in a Grid and give it colSpan/rowSpan -- no Grid.Item wrapper needed
  * NEVER: Nest containers unnecessarily
  * NEVER: Use margins for spacing - let parent Grid handle gaps
  * NEVER: Use @container without w-full in flex/grid contexts (causes width collapse in Tailwind v4)
@@ -34,6 +35,12 @@
  * <Container as="footer" padding="6">
  *   <p>Footer content</p>
  * </Container>
+ *
+ * // Self-placing grid children -- no Grid.Item wrappers
+ * <Grid columns={3} gap="6">
+ *   <Container as="article" size="5xl" colSpan={2} queryName="main">…</Container>
+ *   <Container as="aside" colSpan={1} queryName="rail">…</Container>
+ * </Grid>
  * ```
  */
 import * as React from 'react';
@@ -53,6 +60,7 @@ import {
   containerSizeClasses,
   containerSizeGapScale,
 } from './container.classes';
+import { gridColSpanClasses, gridRowSpanClasses } from './grid.classes';
 
 type ContainerElement = 'div' | 'main' | 'header' | 'footer' | 'section' | 'article' | 'aside';
 
@@ -94,6 +102,20 @@ export interface ContainerProps extends React.HTMLAttributes<HTMLElement> {
    * Use with @container/name in child styles
    */
   queryName?: string;
+
+  /**
+   * Column span when this Container is a direct child of a Grid.
+   * Lets the Container carry its own grid placement instead of being
+   * wrapped in a Grid.Item. Same vocabulary as Grid.Item's colSpan.
+   * No effect outside a grid context.
+   */
+  colSpan?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+
+  /**
+   * Row span when this Container is a direct child of a Grid.
+   * Pairs with colSpan for self-placing grid children.
+   */
+  rowSpan?: 1 | 2 | 3;
 
   // ============================================================================
   // Editable Props (R-202)
@@ -183,6 +205,8 @@ export const Container = React.forwardRef<HTMLElement, ContainerProps>(
       gap,
       query = true,
       queryName,
+      colSpan,
+      rowSpan,
       position,
       depth,
       editable,
@@ -225,6 +249,11 @@ export const Container = React.forwardRef<HTMLElement, ContainerProps>(
 
       // Vertical flow with gap
       resolvedGap && gapClasses[resolvedGap],
+
+      // Grid placement -- applies when this Container is a grid child,
+      // folding Grid.Item's span vocabulary onto the Container itself.
+      colSpan && gridColSpanClasses[colSpan],
+      rowSpan && gridRowSpanClasses[rowSpan],
 
       // Fill signature (surface context) takes precedence over legacy background
       fillClasses,


### PR DESCRIPTION
## Summary

A `Container` placed directly inside a `Grid` can now declare its own grid placement via
`colSpan` (1-12) and `rowSpan` (1-3), so page authors stop wrapping each content Container in a
`Grid.Item`. The spans reuse Grid.Item's existing class vocabulary and are wired identically
across all three render targets, so behavior cannot drift between React, Astro, and the web
component.

## Acceptance criteria mapping

### 1. colSpan/rowSpan on Container across React + Astro + WC, reusing grid.classes span maps
Each target imports `gridColSpanClasses` / `gridRowSpanClasses` from `grid.classes.ts` (the same
maps `grid-item.astro` already uses) and appends `colSpan && gridColSpanClasses[colSpan]` /
`rowSpan && gridRowSpanClasses[rowSpan]` to its existing class composition -- no parallel class
table was introduced. React adds the typed props to `ContainerProps`; Astro adds them to its
`Props`; the WC parses kebab `col-span`/`row-span` attributes into `composeContainerClasses`.
Evidence: `container.tsx`, `container.astro`, and `container.element.ts` each import from
`./grid.classes` and add the two span lines to their shared composition.

### 2. Out-of-range / absent span values emit no class
The WC parsers `parseColSpan` / `parseRowSpan` validate the integer against the allowed set
(COL_SPANS 1-12 / ROW_SPANS 1-3) and return `undefined` otherwise; the React/Astro props are
literal unions so the type system rejects out-of-range at the source. An undefined span
contributes nothing to the class string.
Evidence: test "ignores out-of-range span values" asserts the inner class contains neither
`col-span-99` nor `row-span-7`.

### 3. Web-component tests cover apply / out-of-range / recompose
Four tests were added to `container.element.test.ts`: applying `col-span`, applying `row-span`,
ignoring out-of-range values, and recomposing the class when `col-span` changes from 2 to 4. The
`observedAttributes` exact-match assertion was extended to include `col-span` and `row-span` so
the WC re-renders on attribute change.
Evidence: `container.element.test.ts` -- the four span tests plus the updated
`observedAttributes` assertion; full WC suite passes (33 tests).

### 4. TypeScript strict; noUncheckedIndexedAccess handled
`gridColSpanClasses[colSpan]` / `gridRowSpanClasses[rowSpan]` are typed `string | undefined`
under `noUncheckedIndexedAccess`, so the WC `composeContainerClasses` casts them `as string` --
matching the sibling lookups already in that function (size/padding/gap). No `any`.
Evidence: `container.element.ts` `composeContainerClasses` span pushes use `as string`; typecheck
passes in preflight.

### 5. Biome clean; preflight green
Lint (biome import-order autofix applied), typecheck, unit + a11y tests, and build all pass.
Evidence: `pnpm preflight` exits 0 on HEAD; lefthook pre-commit (unit/lint/typecheck) passed on commit.

## Not done

- No `priority` prop (bento hierarchy) on Container -- this PR adds spans only, as scoped.
- No changes to `Grid` or `Grid.Item` -- the span maps are reused, not modified.
- The `<rafters-container>` web component itself was not otherwise expanded; this is not the
  separate WC-port work. `index.scip` (a generated artifact) is intentionally not part of this diff.