### PR TITLE
feat(#1721): wire surface cascade into WCAG system, fix surface ladder

### DIFF
--- a/packages/color-utils/src/index.ts
+++ b/packages/color-utils/src/index.ts
@@ -109,6 +109,7 @@ export {
   type PairUse,
   type SemanticContext,
   SemanticSelectionError,
+  STATE_USES,
   type StateUse,
   semanticFor,
   statusAnchor,

--- a/packages/color-utils/src/semantic.ts
+++ b/packages/color-utils/src/semantic.ts
@@ -30,7 +30,7 @@ import { roundOKLCH } from './conversion.js';
 import { toNearestGamut } from './gamut.js';
 import { POSITION_TO_INDEX, SCALE_POSITIONS } from './scale-positions.js';
 
-export type StateUse = 'hover' | 'active' | 'focus' | 'disabled';
+export type StateUse = 'hover' | 'active' | 'focus' | 'disabled' | 'border' | 'ring' | 'subtle';
 export type PairUse = 'foreground' | StateUse;
 
 /** Which strategy produced the pair. Ordered roughly best -> worst. */
@@ -73,7 +73,15 @@ export class SemanticSelectionError extends Error {
   }
 }
 
-const STATE_USES: readonly StateUse[] = ['hover', 'active', 'focus', 'disabled'];
+const STATE_USES: readonly StateUse[] = [
+  'hover',
+  'active',
+  'focus',
+  'disabled',
+  'border',
+  'ring',
+  'subtle',
+];
 
 /** Rank step per state on the AAA ladder. sign: 1 for light (darker), -1 for dark (lighter). */
 const STATE_RANK_STEP: Record<
@@ -84,6 +92,9 @@ const STATE_RANK_STEP: Record<
   active: (rank, _l, s) => rank + 2 * s,
   focus: (rank, _l, s) => rank + s,
   disabled: (_rank, ladder) => closestRankTo(ladder, 5),
+  border: (rank, _l, s) => rank + 2 * s,
+  ring: (rank) => rank,
+  subtle: (rank, _l, s) => rank - 2 * s,
 };
 
 /** Escape hatches the generators may precompute onto a family. */

--- a/packages/color-utils/src/semantic.ts
+++ b/packages/color-utils/src/semantic.ts
@@ -73,7 +73,7 @@ export class SemanticSelectionError extends Error {
   }
 }
 
-const STATE_USES: readonly StateUse[] = [
+export const STATE_USES: readonly StateUse[] = [
   'hover',
   'active',
   'focus',

--- a/packages/color-utils/test/semantic.test.ts
+++ b/packages/color-utils/test/semantic.test.ts
@@ -176,7 +176,15 @@ describe('semanticFor — state pairs (parity with state plugin)', () => {
   it('states() returns one pair per state type', () => {
     const sem = semanticFor(family(blue), { name: 'blue' });
     const all = sem.states('500');
-    expect(Object.keys(all).sort()).toEqual(['active', 'disabled', 'focus', 'hover']);
+    expect(Object.keys(all).sort()).toEqual([
+      'active',
+      'border',
+      'disabled',
+      'focus',
+      'hover',
+      'ring',
+      'subtle',
+    ]);
     for (const state of states) {
       expect(all[state]).toEqual(sem.pair({ use: state, from: '500' }));
     }
@@ -241,6 +249,59 @@ describe('semanticFor — dark state stepping (#1646: direction-aware)', () => {
       table[name] = row;
     }
     expect(table).toMatchSnapshot();
+  });
+});
+
+describe('semanticFor — surface derivations (border, ring, subtle)', () => {
+  it('border steps +2 from base (same as active)', () => {
+    for (const [name, seed] of Object.entries(seeds)) {
+      const sem = semanticFor(family(seed), { name });
+      for (const position of SCALE_POSITIONS) {
+        const border = sem.pair({ use: 'border', from: position });
+        const active = sem.pair({ use: 'active', from: position });
+        expect(
+          POSITION_TO_INDEX[border.to.position],
+          `${name}@${position}: border should equal active (+2)`,
+        ).toBe(POSITION_TO_INDEX[active.to.position]);
+      }
+    }
+  });
+
+  it('ring stays at the same ladder rank as base (no step)', () => {
+    for (const [name, seed] of Object.entries(seeds)) {
+      const sem = semanticFor(family(seed), { name });
+      const hover = sem.pair({ use: 'hover', from: '100' });
+      const ring = sem.pair({ use: 'ring', from: '100' });
+      const hoverIdx = POSITION_TO_INDEX[hover.to.position] as number;
+      const ringIdx = POSITION_TO_INDEX[ring.to.position] as number;
+      const baseIdx = POSITION_TO_INDEX['100'] as number;
+      expect(hoverIdx, `${name}: hover should step away from base`).toBeGreaterThan(baseIdx);
+      expect(ringIdx, `${name}: ring should stay at or near base`).toBeLessThanOrEqual(baseIdx);
+    }
+  });
+
+  it('subtle steps opposite direction from hover (toward lighter in light mode)', () => {
+    for (const [name, seed] of Object.entries(seeds)) {
+      const sem = semanticFor(family(seed), { name });
+      const hover = sem.pair({ use: 'hover', from: '500' });
+      const subtle = sem.pair({ use: 'subtle', from: '500' });
+      const hoverIdx = POSITION_TO_INDEX[hover.to.position] as number;
+      const subtleIdx = POSITION_TO_INDEX[subtle.to.position] as number;
+      expect(subtleIdx, `${name}: subtle should be lighter than base (500)`).toBeLessThan(5);
+      expect(hoverIdx, `${name}: hover should be darker than base (500)`).toBeGreaterThan(5);
+    }
+  });
+
+  it('dark border steps toward lighter (opposite of light mode)', () => {
+    for (const [name, seed] of Object.entries(seeds)) {
+      const sem = semanticFor(family(seed), { name });
+      const lightBorder = sem.pair({ use: 'border', from: '200' });
+      const darkBorder = sem.pair({ use: 'border', from: '200', dark: true });
+      const lightIdx = POSITION_TO_INDEX[lightBorder.to.position] as number;
+      const darkIdx = POSITION_TO_INDEX[darkBorder.to.position] as number;
+      expect(lightIdx, `${name}: light border should be darker than 200`).toBeGreaterThan(2);
+      expect(darkIdx, `${name}: dark border should be lighter than 200`).toBeLessThan(2);
+    }
   });
 });
 

--- a/packages/color-utils/test/semantic.test.ts
+++ b/packages/color-utils/test/semantic.test.ts
@@ -267,16 +267,20 @@ describe('semanticFor — surface derivations (border, ring, subtle)', () => {
     }
   });
 
-  it('ring stays at the same ladder rank as base (no step)', () => {
+  it('ring is always closer to base than hover (zero step vs one step)', () => {
     for (const [name, seed] of Object.entries(seeds)) {
       const sem = semanticFor(family(seed), { name });
-      const hover = sem.pair({ use: 'hover', from: '100' });
-      const ring = sem.pair({ use: 'ring', from: '100' });
-      const hoverIdx = POSITION_TO_INDEX[hover.to.position] as number;
-      const ringIdx = POSITION_TO_INDEX[ring.to.position] as number;
-      const baseIdx = POSITION_TO_INDEX['100'] as number;
-      expect(hoverIdx, `${name}: hover should step away from base`).toBeGreaterThan(baseIdx);
-      expect(ringIdx, `${name}: ring should stay at or near base`).toBeLessThanOrEqual(baseIdx);
+      for (const position of SCALE_POSITIONS) {
+        const hover = sem.pair({ use: 'hover', from: position });
+        const ring = sem.pair({ use: 'ring', from: position });
+        const hoverIdx = POSITION_TO_INDEX[hover.to.position] as number;
+        const ringIdx = POSITION_TO_INDEX[ring.to.position] as number;
+        const baseIdx = POSITION_TO_INDEX[position] as number;
+        expect(
+          Math.abs(ringIdx - baseIdx),
+          `${name}@${position}: ring should be no further from base than hover`,
+        ).toBeLessThanOrEqual(Math.abs(hoverIdx - baseIdx));
+      }
     }
   });
 

--- a/packages/design-tokens/src/generators/defaults.ts
+++ b/packages/design-tokens/src/generators/defaults.ts
@@ -1099,12 +1099,12 @@ export const DEFAULT_SEMANTIC_COLOR_MAPPINGS: Record<string, SemanticColorMappin
     never: ['Use for dividers within cards'],
   },
   panel: {
-    light: { family: 'neutral', position: '100' },
+    light: { family: 'neutral', position: '200' },
     dark: { family: 'neutral', position: '800' },
-    meaning: 'Elevated panel surface -- one level above the page',
+    meaning: 'Persistent elevated chrome -- headers, docks, fixed toolbars',
     contexts: ['panels', 'toolbars', 'headers', 'docks'],
     do: ['Use for persistent elevated chrome', 'Pair with panel-foreground'],
-    never: ['Use for page-level backgrounds', 'Stack directly on card without a border'],
+    never: ['Use for page-level backgrounds', 'Use for transient surfaces'],
   },
   'panel-foreground': {
     light: { family: 'neutral', position: '950' },
@@ -1159,12 +1159,12 @@ export const DEFAULT_SEMANTIC_COLOR_MAPPINGS: Record<string, SemanticColorMappin
 
   // Generic surface
   surface: {
-    light: { family: 'neutral', position: '50' },
+    light: { family: 'neutral', position: '100' },
     dark: { family: 'neutral', position: '900' },
-    meaning: 'Elevated surface background',
-    contexts: ['elevated-elements'],
-    do: ['Use for elevated surfaces'],
-    never: ['Use for page background'],
+    meaning: 'Base chrome surface -- toolbars, app shell, UI frame',
+    contexts: ['chrome', 'app-shell', 'toolbars'],
+    do: ['Use for application chrome'],
+    never: ['Use for page background', 'Use for content containers'],
   },
   'surface-foreground': {
     light: { family: 'neutral', position: '950' },
@@ -2265,9 +2265,9 @@ export const DEFAULT_SEMANTIC_COLOR_MAPPINGS: Record<string, SemanticColorMappin
   // SIDEBAR TOKENS (shadcn compatible + extended)
   // ============================================================================
   sidebar: {
-    light: { family: 'neutral', position: '50' },
+    light: { family: 'neutral', position: '100' },
     dark: { family: 'neutral', position: '900' },
-    meaning: 'Sidebar background',
+    meaning: 'Sidebar background -- almost on the surface',
     contexts: ['navigation-sidebar', 'side-panels'],
     do: ['Use for sidebar backgrounds'],
     never: ['Use for main content areas'],

--- a/packages/design-tokens/src/generators/semantic.ts
+++ b/packages/design-tokens/src/generators/semantic.ts
@@ -29,12 +29,24 @@ import { DEFAULT_SEMANTIC_COLOR_MAPPINGS, type SemanticColorMapping } from './de
 import type { GeneratorResult, ResolvedSystemConfig } from './types.js';
 
 const FOREGROUND_SUFFIXES = ['-foreground', '-text', '-contrast'] as const;
-const STATE_SUFFIXES = ['-hover', '-active', '-focus', '-disabled'] as const;
+const STATE_SUFFIXES = [
+  '-hover',
+  '-active',
+  '-focus',
+  '-disabled',
+  '-border',
+  '-ring',
+  '-subtle',
+] as const;
 type StateSuffix = (typeof STATE_SUFFIXES)[number];
 
 type Derivation =
   | { kind: 'scale'; family: string; scalePosition: number }
-  | { kind: 'state'; from: string; stateType: 'hover' | 'active' | 'focus' | 'disabled' }
+  | {
+      kind: 'state';
+      from: string;
+      stateType: 'hover' | 'active' | 'focus' | 'disabled' | 'border' | 'ring' | 'subtle';
+    }
   | { kind: 'contrast'; against: string; level: 'AAA' };
 
 function toColorRef(mapping: SemanticColorMapping): ColorReference {

--- a/packages/design-tokens/src/generators/semantic.ts
+++ b/packages/design-tokens/src/generators/semantic.ts
@@ -23,30 +23,17 @@
  * to get the current dark ColorReference (cascade-derived, not static).
  */
 
-import { POSITION_TO_INDEX } from '@rafters/color-utils';
+import { POSITION_TO_INDEX, STATE_USES, type StateUse } from '@rafters/color-utils';
 import type { Binding, ColorReference, Token } from '@rafters/shared';
 import { DEFAULT_SEMANTIC_COLOR_MAPPINGS, type SemanticColorMapping } from './defaults.js';
 import type { GeneratorResult, ResolvedSystemConfig } from './types.js';
 
 const FOREGROUND_SUFFIXES = ['-foreground', '-text', '-contrast'] as const;
-const STATE_SUFFIXES = [
-  '-hover',
-  '-active',
-  '-focus',
-  '-disabled',
-  '-border',
-  '-ring',
-  '-subtle',
-] as const;
-type StateSuffix = (typeof STATE_SUFFIXES)[number];
+const STATE_SUFFIXES = STATE_USES.map((s) => `-${s}` as const);
 
 type Derivation =
   | { kind: 'scale'; family: string; scalePosition: number }
-  | {
-      kind: 'state';
-      from: string;
-      stateType: 'hover' | 'active' | 'focus' | 'disabled' | 'border' | 'ring' | 'subtle';
-    }
+  | { kind: 'state'; from: string; stateType: StateUse }
   | { kind: 'contrast'; against: string; level: 'AAA' };
 
 function toColorRef(mapping: SemanticColorMapping): ColorReference {
@@ -89,7 +76,7 @@ function deriveDerivation(
         return {
           kind: 'state',
           from: parent,
-          stateType: suffix.slice(1) as StateSuffix extends `-${infer S}` ? S : never,
+          stateType: suffix.slice(1) as StateUse,
         };
       }
     }

--- a/packages/design-tokens/src/plugins/state.ts
+++ b/packages/design-tokens/src/plugins/state.ts
@@ -2,7 +2,15 @@ import { type ColorReference, ColorReferenceSchema } from '@rafters/shared';
 import { z } from 'zod';
 import { definePlugin, requireSemanticParent } from '../plugin.js';
 
-const StateTypeSchema = z.enum(['hover', 'active', 'focus', 'disabled']);
+const StateTypeSchema = z.enum([
+  'hover',
+  'active',
+  'focus',
+  'disabled',
+  'border',
+  'ring',
+  'subtle',
+]);
 
 const StateInputSchema = z.object({
   from: z.string(),

--- a/packages/design-tokens/src/plugins/state.ts
+++ b/packages/design-tokens/src/plugins/state.ts
@@ -1,16 +1,9 @@
+import { STATE_USES, type StateUse } from '@rafters/color-utils';
 import { type ColorReference, ColorReferenceSchema } from '@rafters/shared';
 import { z } from 'zod';
 import { definePlugin, requireSemanticParent } from '../plugin.js';
 
-const StateTypeSchema = z.enum([
-  'hover',
-  'active',
-  'focus',
-  'disabled',
-  'border',
-  'ring',
-  'subtle',
-]);
+const StateTypeSchema = z.enum(STATE_USES as unknown as readonly [StateUse, ...StateUse[]]);
 
 const StateInputSchema = z.object({
   from: z.string(),

--- a/packages/design-tokens/test/__snapshots__/elevation-ladder.test.ts.snap
+++ b/packages/design-tokens/test/__snapshots__/elevation-ladder.test.ts.snap
@@ -20,7 +20,7 @@ exports[`elevation ladder -- designed dark positions (#1638) > snapshot: the def
   },
   "panel": {
     "dark": "800",
-    "light": "100",
+    "light": "200",
   },
   "popover": {
     "dark": "700",
@@ -28,11 +28,11 @@ exports[`elevation ladder -- designed dark positions (#1638) > snapshot: the def
   },
   "sidebar": {
     "dark": "900",
-    "light": "50",
+    "light": "100",
   },
   "surface": {
     "dark": "900",
-    "light": "50",
+    "light": "100",
   },
   "table-header": {
     "dark": "800",

--- a/packages/design-tokens/test/cascade.test.ts
+++ b/packages/design-tokens/test/cascade.test.ts
@@ -297,4 +297,83 @@ describe('cascade integration', () => {
       expect((dark as { family: string }).family).toBe('mud');
     });
   });
+
+  describe('border, ring, subtle cascade through the state plugin', () => {
+    function setupSurfaceChain(): TokenRegistry {
+      const r = new TokenRegistry(
+        [
+          buildAccentToken(buildAccentFamily()),
+          semanticToken('surface'),
+          semanticToken('surface-border'),
+          semanticToken('surface-ring'),
+          semanticToken('surface-subtle'),
+          semanticToken('surface-hover'),
+        ],
+        [scalePlugin, contrastPlugin, statePlugin, invertPlugin],
+      );
+      r.bind('surface', 'scale', { familyName: 'accent', scalePosition: 1 });
+      r.bind('surface-border', 'state', { from: 'surface', stateType: 'border' });
+      r.bind('surface-ring', 'state', { from: 'surface', stateType: 'ring' });
+      r.bind('surface-subtle', 'state', { from: 'surface', stateType: 'subtle' });
+      r.bind('surface-hover', 'state', { from: 'surface', stateType: 'hover' });
+      return r;
+    }
+
+    it('border derives from parent, not hardcoded', () => {
+      const r = setupSurfaceChain();
+      const surface = r.get('surface')?.value as { family: string; position: string };
+      const border = r.get('surface-border')?.value as { family: string; position: string };
+      expect(border.family).toBe(surface.family);
+      expect(border.position).not.toBe(surface.position);
+    });
+
+    it('ring stays at the same position as parent', () => {
+      const r = setupSurfaceChain();
+      const surface = r.get('surface')?.value as { family: string; position: string };
+      const ring = r.get('surface-ring')?.value as { family: string; position: string };
+      expect(ring.family).toBe(surface.family);
+      expect(ring.position).toBe(surface.position);
+    });
+
+    it('subtle steps opposite direction from hover', () => {
+      const r = setupSurfaceChain();
+      const surface = r.get('surface')?.value as { family: string; position: string };
+      const hover = r.get('surface-hover')?.value as { family: string; position: string };
+      const subtle = r.get('surface-subtle')?.value as { family: string; position: string };
+      const surfaceIdx = Number.parseInt(surface.position);
+      const hoverIdx = Number.parseInt(hover.position);
+      const subtleIdx = Number.parseInt(subtle.position);
+      expect(hoverIdx).toBeGreaterThan(surfaceIdx);
+      expect(subtleIdx).toBeLessThan(surfaceIdx);
+    });
+
+    it('border cascades when parent is remapped', () => {
+      const r = setupSurfaceChain();
+      const beforeBorder = r.get('surface-border')?.value as { family: string; position: string };
+      expect(beforeBorder.family).toBe('accent');
+
+      const newFamily = buildAccentFamily('sky');
+      r.define({
+        name: 'sky',
+        namespace: 'color',
+        category: 'color',
+        value: newFamily,
+        userOverride: null,
+      });
+      r.set('surface', { family: 'sky', position: '200' }, { reason: 'remap to sky' });
+
+      const afterBorder = r.get('surface-border')?.value as { family: string; position: string };
+      expect(afterBorder.family).toBe('sky');
+    });
+
+    it('userOverride on border anchors it against parent remap', () => {
+      const r = setupSurfaceChain();
+      const pinned = { family: 'accent', position: '800' };
+      r.set('surface-border', pinned, { reason: 'designer override' });
+      expect(r.get('surface-border')?.value).toEqual(pinned);
+
+      r.set('surface', { family: 'accent', position: '500' }, { reason: 'remap' });
+      expect(r.get('surface-border')?.value).toEqual(pinned);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

46 semantic tokens with -border, -ring, and -subtle suffixes were pinned to hardcoded scale positions instead of cascading through the WCAG system. When a designer remapped a parent token (e.g., `set surface {family: sky, position: 200}`), the border/ring/subtle variants stayed on their static neutral values. This wires them into the same state-plugin cascade that already handles -hover, -active, -focus, and -disabled, and fixes the surface ladder so surfaces are visually distinguishable from the background.

## Acceptance criteria mapping

### 1. Suffixes recognized and wired to state plugin
The semantic generator's `STATE_SUFFIXES` array in `packages/design-tokens/src/generators/semantic.ts:32` now includes `-border`, `-ring`, `-subtle`. The `deriveDerivation` function's existing suffix-matching loop picks them up and creates `{ kind: 'state', stateType: 'border'|'ring'|'subtle' }` bindings instead of falling through to the hardcoded `scale` derivation. The state plugin's `StateTypeSchema` in `packages/design-tokens/src/plugins/state.ts:6` accepts the new types. Evidence: `pnpm --filter @rafters/design-tokens test` passes 191 tests including the new cascade tests.

### 2. Ladder step values match the design
`STATE_RANK_STEP` in `packages/color-utils/src/semantic.ts:95-97` defines: border = rank + 2*sign (same magnitude as active, toward darker in light mode), ring = rank + 0 (same ladder position as parent), subtle = rank - 2*sign (opposite direction, toward lighter). Evidence: test "border steps +2 from base (same as active)" in `packages/color-utils/test/semantic.test.ts` exhaustively verifies border equals active across all 4 seed families and all 11 scale positions.

### 3. Surface ladder differentiation
`packages/design-tokens/src/generators/defaults.ts` changes: surface light position 50->100, sidebar 50->100, panel 100->200. Card, table, popover remain at 50 (differentiated by border+shadow, not color). Tooltip (900) and overlay (950) unchanged. Evidence: elevation-ladder snapshot in `packages/design-tokens/test/__snapshots__/elevation-ladder.test.ts.snap` records the new positions.

### 4. Cascade propagates on remap
Test "border cascades when parent is remapped" in `packages/design-tokens/test/cascade.test.ts:356` sets surface to `{family: 'sky', position: '200'}` and verifies surface-border's family changes from 'accent' to 'sky'. The cascade path: `graph.set` -> `cascadeFrom` -> collects dependents via `plugin.dependsOn(binding.input)` -> state plugin's `transform` re-runs with the new parent value -> WCAG ladder walk produces the new position in the sky family.

### 5. userOverride anchors hold
Test "userOverride on border anchors it against parent remap" in `packages/design-tokens/test/cascade.test.ts:368` pins surface-border to a specific value via `set`, remaps the parent surface, and verifies the pinned value survives. The mechanism: `graph.cascadeFrom` at line 164 skips nodes with `node.userOverride` -- the override is an anchor that blocks re-derivation.

### 6. Single source of truth for state types
`STATE_USES` is now exported from `packages/color-utils/src/index.ts:112`. The semantic generator derives its suffix array via `STATE_USES.map(s => \`-${s}\`)` at `packages/design-tokens/src/generators/semantic.ts:32`. The state plugin derives its Zod schema via `z.enum(STATE_USES as ...)` at `packages/design-tokens/src/plugins/state.ts:6`. The `Derivation` union's `stateType` field references the imported `StateUse` type. Previously: four independent copies of the same list. Now: one source (color-utils), two consumers (generator, plugin), one type (StateUse). Adding a state to color-utils without adding a `STATE_RANK_STEP` entry is a compile error because the record is keyed by `StateUse`.

### 7. Tests verify real behavior
9 new tests across two packages. color-utils (4): border=active step exhaustive, ring closer-to-base-than-hover across all positions, subtle opposite direction from hover, dark border direction-aware. design-tokens (5): border derives from parent, ring matches parent, subtle opposes hover, cascade propagates on remap, userOverride anchors. The ring test was revised twice during development -- first version only tested position 100 (on-ladder by luck), final version tests all positions and verifies ring is always closer to base than hover.

### 8. All tests pass, preflight clean
232 color-utils tests, 191 design-tokens tests, full preflight (typecheck + lint + test:unit + test:a11y + build) clean. Evidence: `pnpm preflight` exit code 0.

## Not done

- **Stale hardcoded variant values in defaults.ts**: The `-border`, `-ring`, `-subtle` entries in `DEFAULT_SEMANTIC_COLOR_MAPPINGS` still carry hardcoded light/dark positions (e.g., `surface-border: {family: 'neutral', position: '200'}`). These are overridden at registry construction time by the state-plugin bindings, making them dead code. Removing them requires making `SemanticColorMapping.light`/`.dark` optional, which changes the interface for all ~200 token entries -- separate PR scope.
- **Subtle step math**: Current subtle = rank - 2 steps. For branded families (destructive at position 600), subtle should arguably go to the extreme light end (position 50) rather than just -2 steps (position 400). This needs a design decision on whether subtle is "slightly lighter" or "lightest possible."
- **Dead tokens**: ~85 tokens in defaults.ts are unused by any component (entire alert family, link family, selection family, many sidebar compound tokens, etc.). Removing them is a separate cleanup PR.
- **border-primary-border naming**: The `-border` token suffix creates utility classes like `border-primary-border` where "border" appears twice. This is a naming/architecture issue that requires rethinking how per-role colors map to Tailwind's --color-* namespace.