### PR TITLE
feat(#1723): complete deterministic standalone CSS via one regen path

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,18 @@
 # rafters
 
+## 0.0.71
+
+### Features
+
+- feat(design-tokens, cli, studio): standalone CSS is complete, deterministic, and regenerated on every vocabulary change (epic #1723). The compiled `rafters.standalone.css` is the utility stylesheet every Web Component adopts into its shadow root, so it must contain a rule for every utility the installed components reference. It was previously a photograph of whatever content was reachable from the inherited process CWD -- non-deterministic and incomplete (a missing `bg-surface` was the visible symptom). Fixes:
+  - `registryToCompiled` now compiles `@import "tailwindcss" source(none)` plus an explicit `@source` per configured component path, with an explicit `cwd` (#1725). Output is a pure function of (registry values, content sources) -- identical regardless of where the command runs.
+  - `@tailwindcss/cli` ships as a `rafters` dependency (#1724), so the standalone export works in a consumer install with no Tailwind of their own -- the whole point of the standalone sheet.
+  - One regeneration path: `regenerateOutputs` is the single function that writes every output (`rafters.css` / `.ts` / `.json` / `.standalone.css`) and fires HMR. `init`'s `generateOutputs` and studio's `persistAndNotify` delegate to it (#1726); `rafters add` / `--update` / `--update-all` call it so a newly installed component's classes reach the sheet (#1727); and a single studio file watch over the token files, component `*.classes.ts`, and config regenerates on change (#1728).
+
+### Bug Fixes
+
+- fix(design-tokens): add `accent-subtle` / `accent-subtle-foreground` / `secondary-subtle` / `secondary-subtle-foreground` (#1729). Components (e.g. alert variants) reference these but they were absent from the semantic defaults, so the utilities resolved to nothing. Existing projects: `rafters init --rebuild`.
+
 ## 0.0.70
 
 ### Features

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.70",
+  "version": "0.0.71",
   "description": "Design Intelligence CLI. Scaffold tokens, import existing shadcn/Tailwind v4 sources, add components, and serve an MCP server so AI agents read decisions instead of guessing.",
   "homepage": "https://rafters.studio",
   "license": "MIT",
@@ -34,6 +34,7 @@
     "@antfu/ni": "^28.1.0",
     "@inquirer/prompts": "^8.2.0",
     "@modelcontextprotocol/sdk": "^1.25.1",
+    "@tailwindcss/cli": "^4.1.18",
     "commander": "^13.0.0",
     "css-tree": "^3.2.1",
     "execa": "^9.6.1",

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -8,6 +8,15 @@
 import { existsSync } from 'node:fs';
 import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import {
+  contrastPlugin,
+  invertPlugin,
+  loadRegistryFromDir,
+  regenerateOutputs,
+  resolveContentSources,
+  scalePlugin,
+  statePlugin,
+} from '@rafters/design-tokens';
 import { RegistryClient } from '../registry/client.js';
 import type { RegistryFile, RegistryItem, RegistryItemType } from '../registry/types.js';
 import {
@@ -31,6 +40,40 @@ export interface AddOptions {
   updateAll?: boolean;
   registryUrl?: string;
   agent?: boolean;
+}
+
+const REGISTRY_PLUGINS = [scalePlugin, contrastPlugin, statePlugin, invertPlugin];
+
+/**
+ * Regenerate the output artifacts after an install/update changes the installed
+ * component vocabulary, so the compiled standalone sheet (the WC utility sheet)
+ * reflects the new class strings. Delegates to the single regen path; failures
+ * here are logged but do not fail the install (the files are already on disk).
+ */
+async function regenerateAfterInstall(cwd: string, config: RaftersConfig): Promise<void> {
+  const paths = getRaftersPaths(cwd);
+  let registry: ReturnType<typeof loadRegistryFromDir>;
+  try {
+    registry = loadRegistryFromDir(paths.tokens, REGISTRY_PLUGINS);
+  } catch {
+    // No tokens on disk yet (project not initialized) -- nothing to regenerate.
+    return;
+  }
+  if (registry.size() === 0) return;
+  try {
+    await regenerateOutputs(registry, {
+      outputDir: paths.output,
+      exports: config.exports,
+      contentSources: resolveContentSources(cwd, config),
+      darkMode: config.darkMode ?? 'class',
+      includeImport: !config.shadcn,
+    });
+  } catch (err) {
+    log({
+      event: 'add:regen-failed',
+      message: `Output regeneration failed: ${err instanceof Error ? err.message : String(err)}`,
+    });
+  }
 }
 
 /**
@@ -730,10 +773,12 @@ export async function add(componentArgs: string[], options: AddOptions): Promise
     });
   }
 
-  // Update config with installed items
+  // Update config with installed items, then regenerate outputs so the new
+  // (or removed-on-update) component vocabulary reaches the compiled sheet.
   if (installedItems.length > 0 && config) {
     trackInstalled(config, installedItems);
     await saveConfig(cwd, config);
+    await regenerateAfterInstall(cwd, config);
   } else if (installedItems.length > 0 && !config) {
     // No config file yet -- create minimal installed tracking
     const newConfig: RaftersConfig = {
@@ -749,6 +794,7 @@ export async function add(componentArgs: string[], options: AddOptions): Promise
     };
     trackInstalled(newConfig, installedItems);
     await saveConfig(cwd, newConfig);
+    await regenerateAfterInstall(cwd, newConfig);
   }
 
   // Summary

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -30,15 +30,13 @@ import {
   importColorFamily,
   invertPlugin,
   loadRegistryFromDir,
-  registryToCompiled,
-  registryToTailwind,
-  registryToTypeScript,
+  regenerateOutputs,
+  resolveContentSources,
   saveRegistryToDir,
   scalePlugin,
   senseShadcnCss,
   statePlugin,
   TokenRegistry,
-  toDTCG,
 } from '@rafters/design-tokens';
 import type { OKLCH } from '@rafters/shared';
 
@@ -471,43 +469,30 @@ export async function generateOutputs(
   exports: ExportConfig,
   shadcn: ShadcnConfig | null,
   darkMode: 'class' | 'media' = 'class',
+  config?: RaftersConfig | null,
 ): Promise<string[]> {
-  const outputs: string[] = [];
+  // The compiled (standalone) sheet scans the configured component vocabulary.
+  // When no config is available yet (fresh init, nothing installed), the source
+  // set is empty and the sheet is theme-only -- it fills in once components land.
+  const contentSources = config ? resolveContentSources(cwd, config) : [];
 
-  // Tailwind CSS (with @import "tailwindcss")
-  if (exports.tailwind) {
-    const tailwindCss = registryToTailwind(registry, { includeImport: !shadcn, darkMode });
-    await writeFile(join(paths.output, 'rafters.css'), tailwindCss);
-    outputs.push('rafters.css');
+  // CLI-only concern: the compiled export needs @tailwindcss/cli present. Prompt
+  // (or throw in agent mode) before delegating to the shared regen path.
+  if (exports.compiled && !isTailwindCliInstalled()) {
+    log({ event: 'init:prompting_exports' }); // stop spinner before prompt
+    await ensureTailwindCli(cwd);
   }
-
-  // TypeScript constants
-  if (exports.typescript) {
-    const typescriptSrc = registryToTypeScript(registry, { includeJSDoc: true });
-    await writeFile(join(paths.output, 'rafters.ts'), typescriptSrc);
-    outputs.push('rafters.ts');
-  }
-
-  // DTCG JSON (W3C Design Tokens)
-  if (exports.dtcg) {
-    const dtcgJson = toDTCG([...registry.list()]);
-    await writeFile(join(paths.output, 'rafters.json'), JSON.stringify(dtcgJson, null, 2));
-    outputs.push('rafters.json');
-  }
-
-  // Compiled CSS (processed by Tailwind, no @import)
   if (exports.compiled) {
-    if (!isTailwindCliInstalled()) {
-      log({ event: 'init:prompting_exports' }); // stop spinner before prompt
-      await ensureTailwindCli(cwd);
-    }
     log({ event: 'init:compiling_css' });
-    const compiledCss = await registryToCompiled(registry, { includeImport: !shadcn });
-    await writeFile(join(paths.output, 'rafters.standalone.css'), compiledCss);
-    outputs.push('rafters.standalone.css');
   }
 
-  return outputs;
+  return regenerateOutputs(registry, {
+    outputDir: paths.output,
+    exports,
+    contentSources,
+    darkMode,
+    includeImport: !shadcn,
+  });
 }
 
 async function regenerateFromExisting(
@@ -576,8 +561,17 @@ async function regenerateFromExisting(
   // Ensure output directory exists
   await mkdir(paths.output, { recursive: true });
 
-  // Generate outputs
-  const outputs = await generateOutputs(cwd, paths, registry, exports, shadcn);
+  // Generate outputs (existingConfig carries the component paths the compiled
+  // sheet scans; null -> theme-only compiled until components are installed)
+  const outputs = await generateOutputs(
+    cwd,
+    paths,
+    registry,
+    exports,
+    shadcn,
+    'class',
+    existingConfig,
+  );
 
   // Update config with new export settings (create if missing)
   if (existingConfig) {
@@ -705,8 +699,17 @@ async function resetToDefaults(
   // Ensure output directory exists
   await mkdir(paths.output, { recursive: true });
 
-  // Generate outputs
-  const outputs = await generateOutputs(cwd, paths, registry, exports, shadcn);
+  // Generate outputs (existingConfig carries the component paths the compiled
+  // sheet scans; null -> theme-only compiled until components are installed)
+  const outputs = await generateOutputs(
+    cwd,
+    paths,
+    registry,
+    exports,
+    shadcn,
+    'class',
+    existingConfig,
+  );
 
   // Update config with new export settings (create if missing)
   if (existingConfig) {

--- a/packages/design-tokens/src/exporters/tailwind.ts
+++ b/packages/design-tokens/src/exporters/tailwind.ts
@@ -1047,8 +1047,16 @@ export function registryToTailwindStatic(registry: TokenRegistry): string {
 export interface CompiledCssOptions {
   /** Minify the output (default: true) */
   minify?: boolean;
-  /** Include @import "tailwindcss" in source (default: true) */
-  includeImport?: boolean;
+  /**
+   * Absolute paths (files or directories) Tailwind should scan for utility
+   * candidates, emitted as explicit `@source` directives. The compiled sheet
+   * is a standalone artifact, so it always uses `@import "tailwindcss"
+   * source(none)` to disable Tailwind's content auto-detection -- the output
+   * is then a pure function of (registry values, contentSources), never of
+   * the process CWD. When empty, only theme tokens and base layers are
+   * emitted (no utility rules).
+   */
+  contentSources?: string[];
 }
 
 /**
@@ -1076,10 +1084,17 @@ export async function registryToCompiled(
   registry: TokenRegistry,
   options: CompiledCssOptions = {},
 ): Promise<string> {
-  const { minify = true, includeImport = true } = options;
+  const { minify = true, contentSources = [] } = options;
 
-  // Generate the Tailwind theme CSS
-  const themeCss = registryToTailwind(registry, { includeImport });
+  // Theme body without its own @import -- the standalone sheet supplies the
+  // import with source(none) below so utilities come only from contentSources.
+  const themeBody = registryToTailwind(registry, { includeImport: false });
+
+  // source(none) disables Tailwind's CWD content auto-detection; each
+  // contentSource is scanned explicitly. Output is then independent of where
+  // this runs -- a pure function of (registry values, contentSources).
+  const sourceDirectives = contentSources.map((src) => `@source "${src}";`).join('\n');
+  const input = `@import "tailwindcss" source(none);\n${sourceDirectives}\n${themeBody}`;
 
   const { execFileSync } = await import('node:child_process');
   const { mkdtempSync, writeFileSync, readFileSync, rmSync } = await import('node:fs');
@@ -1099,29 +1114,30 @@ export async function registryToCompiled(
   // The bin is at dist/index.mjs relative to package.json
   const binPath = join(pkgDir, 'dist', 'index.mjs');
 
-  // Create temp dir in the package location where tailwindcss can be resolved
+  // The temp input lives inside the @tailwindcss/cli package so the CLI can
+  // resolve `@import "tailwindcss"` (the engine) via normal node resolution.
+  // With source(none) this location does NOT influence content scanning, so
+  // it has no effect on output -- only the explicit @source paths do.
   const tempDir = mkdtempSync(join(pkgDir, '.tmp-compile-'));
   const tempInput = join(tempDir, 'input.css');
   const tempOutput = join(tempDir, 'output.css');
 
   try {
-    // Write theme CSS to temp file
-    writeFileSync(tempInput, themeCss);
+    writeFileSync(tempInput, input);
 
-    // Run Tailwind CLI
     const args = [binPath, '-i', tempInput, '-o', tempOutput];
     if (minify) {
       args.push('--minify');
     }
-    execFileSync('node', args, { stdio: 'pipe', timeout: 30_000 });
+    // Explicit cwd = the package dir (not the inherited process CWD), so a
+    // stray Tailwind config or content root in the caller's tree cannot leak in.
+    execFileSync('node', args, { stdio: 'pipe', timeout: 30_000, cwd: pkgDir });
 
-    // Read and return compiled output
     return readFileSync(tempOutput, 'utf-8');
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to compile CSS: ${message}`);
   } finally {
-    // Clean up temp dir
     rmSync(tempDir, { recursive: true, force: true });
   }
 }

--- a/packages/design-tokens/src/generators/defaults.ts
+++ b/packages/design-tokens/src/generators/defaults.ts
@@ -1370,6 +1370,22 @@ export const DEFAULT_SEMANTIC_COLOR_MAPPINGS: Record<string, SemanticColorMappin
     do: ['Use for secondary element focus rings'],
     never: ['Use for decorative rings'],
   },
+  'secondary-subtle': {
+    light: { family: 'neutral', position: '100' },
+    dark: { family: 'neutral', position: '900' },
+    meaning: 'Subtle secondary background for badges/alerts',
+    contexts: ['secondary-badges', 'secondary-alerts'],
+    do: ['Use for subtle secondary backgrounds'],
+    never: ['Use for secondary buttons'],
+  },
+  'secondary-subtle-foreground': {
+    light: { family: 'neutral', position: '900' },
+    dark: { family: 'neutral', position: '100' },
+    meaning: 'Text on subtle secondary backgrounds',
+    contexts: ['secondary-subtle-text'],
+    do: ['Use for text on subtle secondary'],
+    never: ['Use without secondary-subtle background'],
+  },
 
   // ============================================================================
   // MUTED - Subdued elements (shadcn compatible + extended)
@@ -1489,6 +1505,22 @@ export const DEFAULT_SEMANTIC_COLOR_MAPPINGS: Record<string, SemanticColorMappin
     contexts: ['accent-focus-ring'],
     do: ['Use for accent element focus rings'],
     never: ['Use for decorative rings'],
+  },
+  'accent-subtle': {
+    light: { family: 'neutral', position: '100' },
+    dark: { family: 'neutral', position: '900' },
+    meaning: 'Subtle accent background for badges/alerts',
+    contexts: ['accent-badges', 'accent-alerts'],
+    do: ['Use for subtle accent backgrounds'],
+    never: ['Use for accent buttons'],
+  },
+  'accent-subtle-foreground': {
+    light: { family: 'neutral', position: '900' },
+    dark: { family: 'neutral', position: '100' },
+    meaning: 'Text on subtle accent backgrounds',
+    contexts: ['accent-subtle-text'],
+    do: ['Use for text on subtle accent'],
+    never: ['Use without accent-subtle background'],
   },
 
   // ============================================================================

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -32,6 +32,14 @@ export {
 } from './importers/shapes.js';
 export { extractThemeBlocks } from './importers/theme.js';
 export {
+  type ContentPathField,
+  type OutputExports,
+  type RegenerateOutputsHooks,
+  type RegenerateOutputsInput,
+  regenerateOutputs,
+  resolveContentSources,
+} from './outputs.js';
+export {
   findTokenFile,
   loadRegistryFromDir,
   type NamespaceFileEnvelope,

--- a/packages/design-tokens/src/outputs.ts
+++ b/packages/design-tokens/src/outputs.ts
@@ -1,0 +1,155 @@
+/**
+ * Output regeneration -- the single path that turns a TokenRegistry into the
+ * on-disk artifacts and signals consumers.
+ *
+ * Every trigger (CLI init, CLI add/update, studio token mutation, the file
+ * watch) funnels through {@link regenerateOutputs}. There is exactly one
+ * function that writes `rafters.css` / `rafters.ts` / `rafters.json` /
+ * `rafters.standalone.css` and fires the HMR notification, so the emitted set
+ * can never drift between callers and there is no second regen/HMR mechanism.
+ *
+ * Token persistence (saveRegistryToDir) stays the caller's concern -- it is a
+ * separate operation from projecting the registry to output bytes.
+ */
+
+import { existsSync, realpathSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { isAbsolute, join, resolve } from 'node:path';
+import { toDTCG } from './exporters/dtcg.js';
+import { registryToCompiled, registryToTailwind } from './exporters/tailwind.js';
+import { registryToTypeScript } from './exporters/typescript.js';
+import type { TokenRegistry } from './registry.js';
+
+/** Which output formats to emit. Mirrors the CLI's ExportConfig. */
+export interface OutputExports {
+  tailwind: boolean;
+  typescript: boolean;
+  dtcg: boolean;
+  compiled: boolean;
+}
+
+export interface RegenerateOutputsInput {
+  /** Directory the output files are written to (`.rafters/output`). */
+  outputDir: string;
+  /** Formats to emit. */
+  exports: OutputExports;
+  /**
+   * Absolute paths Tailwind scans for the compiled (standalone) sheet, emitted
+   * as explicit `@source` directives. Resolve via {@link resolveContentSources}.
+   * Only consulted when `exports.compiled` is true.
+   */
+  contentSources?: string[];
+  /** Dark-mode strategy for the Tailwind export. Default `class`. */
+  darkMode?: 'class' | 'media';
+  /**
+   * Whether `rafters.css` emits its own `@import "tailwindcss"`. False when the
+   * consumer's own CSS already imports Tailwind (shadcn layout).
+   */
+  includeImport?: boolean;
+}
+
+export interface RegenerateOutputsHooks {
+  /** Fired once after all outputs are written (e.g. studio HMR signal). */
+  notify?: () => void;
+}
+
+/**
+ * A path-field value as stored in config: a single path, or an array of
+ * entries (plain strings or `{ path }` objects for multi-folder layouts).
+ */
+export type ContentPathField = string | ReadonlyArray<string | { path: string }>;
+
+function fieldToPaths(field: ContentPathField | undefined): string[] {
+  if (!field) return [];
+  if (typeof field === 'string') return [field];
+  return field.map((entry) => (typeof entry === 'string' ? entry : entry.path));
+}
+
+/**
+ * Resolve the `@source` content roots for the compiled sheet from the
+ * configured component/primitive/composite path fields. Returns absolute,
+ * de-duplicated paths that currently exist on disk -- a missing path (e.g. a
+ * not-yet-installed namespace) is skipped rather than handed to Tailwind.
+ *
+ * This is the single content-source resolver shared by every caller, so the
+ * compiled sheet scans the same vocabulary regardless of which trigger ran.
+ */
+export function resolveContentSources(
+  cwd: string,
+  fields: {
+    componentsPath?: ContentPathField;
+    primitivesPath?: ContentPathField;
+    compositesPath?: ContentPathField;
+  },
+): string[] {
+  const raw = [
+    ...fieldToPaths(fields.componentsPath),
+    ...fieldToPaths(fields.primitivesPath),
+    ...fieldToPaths(fields.compositesPath),
+  ];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const entry of raw) {
+    const abs = isAbsolute(entry) ? entry : resolve(cwd, entry);
+    if (!existsSync(abs)) continue;
+    let real: string;
+    try {
+      real = realpathSync(abs);
+    } catch {
+      real = abs;
+    }
+    if (!seen.has(real)) {
+      seen.add(real);
+      out.push(real);
+    }
+  }
+  return out;
+}
+
+/**
+ * Write every configured output for `registry` into `input.outputDir`, then
+ * fire `hooks.notify`. Returns the filenames written. The ONLY code that writes
+ * rafters output files or triggers HMR.
+ */
+export async function regenerateOutputs(
+  registry: TokenRegistry,
+  input: RegenerateOutputsInput,
+  hooks: RegenerateOutputsHooks = {},
+): Promise<string[]> {
+  const {
+    outputDir,
+    exports,
+    contentSources = [],
+    darkMode = 'class',
+    includeImport = true,
+  } = input;
+  await mkdir(outputDir, { recursive: true });
+  const written: string[] = [];
+
+  if (exports.tailwind) {
+    const css = registryToTailwind(registry, { includeImport, darkMode });
+    await writeFile(join(outputDir, 'rafters.css'), css);
+    written.push('rafters.css');
+  }
+
+  if (exports.typescript) {
+    const ts = registryToTypeScript(registry, { includeJSDoc: true });
+    await writeFile(join(outputDir, 'rafters.ts'), ts);
+    written.push('rafters.ts');
+  }
+
+  if (exports.dtcg) {
+    const dtcg = toDTCG([...registry.list()]);
+    await writeFile(join(outputDir, 'rafters.json'), JSON.stringify(dtcg, null, 2));
+    written.push('rafters.json');
+  }
+
+  if (exports.compiled) {
+    const compiled = await registryToCompiled(registry, { contentSources });
+    await writeFile(join(outputDir, 'rafters.standalone.css'), compiled);
+    written.push('rafters.standalone.css');
+  }
+
+  hooks.notify?.();
+  return written;
+}

--- a/packages/design-tokens/test/exporters/assembly-parity.test.ts
+++ b/packages/design-tokens/test/exporters/assembly-parity.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Drift tripwire for the two Tailwind assembly functions (#1730).
+ *
+ * `registryToTailwind` (consumer + compiled path) and `registryToTailwindStatic`
+ * (studio static CSS) build the same theme from the same sections but diverge
+ * intentionally: the static path uses var() refs and omits the live `:root`
+ * cascade and the @utility groups. A section added to one and silently missed
+ * in the other is the failure this freezes: the marker set of each assembly is
+ * asserted explicitly, so adding a section forces a conscious update here and a
+ * decision about the other.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { generateBaseSystem } from '../../src/generators/index.js';
+import {
+  contrastPlugin,
+  invertPlugin,
+  registryToTailwind,
+  registryToTailwindStatic,
+  scalePlugin,
+  statePlugin,
+  TokenRegistry,
+} from '../../src/index.js';
+
+const CANDIDATE_MARKERS = [
+  '@import "tailwindcss"',
+  '@custom-variant dark',
+  '@theme inline {',
+  '@theme {',
+  ':root {',
+  '.dark {',
+  '@keyframes',
+  '@utility',
+  '@layer base',
+] as const;
+
+function markersOf(css: string): string[] {
+  return CANDIDATE_MARKERS.filter((m) => css.includes(m)).sort();
+}
+
+function baseRegistry(): TokenRegistry {
+  const system = generateBaseSystem({});
+  return new TokenRegistry(system.allTokens, [
+    scalePlugin,
+    contrastPlugin,
+    statePlugin,
+    invertPlugin,
+  ]);
+}
+
+// The frozen section contract. Update these ONLY when intentionally changing an
+// assembly -- and when you do, decide whether the other assembly needs the same
+// section. That decision is the whole point of this test.
+const DYNAMIC_SECTIONS = [
+  '.dark {',
+  ':root {',
+  '@custom-variant dark',
+  '@import "tailwindcss"',
+  '@keyframes',
+  '@layer base',
+  '@theme inline {',
+  '@theme {',
+  '@utility',
+];
+
+// Static (studio) intentionally omits the live `:root`/`.dark` cascade,
+// `@custom-variant dark`, and the @utility groups -- it references --rafters-*
+// vars instead. Any section added to registryToTailwind that ALSO belongs in the
+// static path must be added here, or this test documents the divergence.
+const STATIC_SECTIONS = [
+  '@import "tailwindcss"',
+  '@keyframes',
+  '@layer base',
+  '@theme inline {',
+  '@theme {',
+];
+
+describe('Tailwind assembly parity (#1730)', () => {
+  const registry = baseRegistry();
+
+  it('registryToTailwind emits exactly the frozen section set', () => {
+    expect(markersOf(registryToTailwind(registry))).toEqual(DYNAMIC_SECTIONS);
+  });
+
+  it('registryToTailwindStatic emits exactly the frozen section set', () => {
+    expect(markersOf(registryToTailwindStatic(registry))).toEqual(STATIC_SECTIONS);
+  });
+
+  it('sections in static are a subset of dynamic (static never invents a section)', () => {
+    const dynamic = new Set(markersOf(registryToTailwind(registry)));
+    for (const marker of markersOf(registryToTailwindStatic(registry))) {
+      expect(dynamic.has(marker), `static-only section: ${marker}`).toBe(true);
+    }
+  });
+});

--- a/packages/design-tokens/test/exporters/compiled-standalone.test.ts
+++ b/packages/design-tokens/test/exporters/compiled-standalone.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Completeness + determinism guard for the standalone (compiled) sheet (#1731).
+ *
+ * The standalone sheet is the utility stylesheet every Web Component adopts, so
+ * it must contain a rule for every utility the components reference -- and it
+ * must be reproducible regardless of where the compile runs. This test compiles
+ * against a fixture vocabulary and asserts both properties. It goes red if a
+ * referenced utility is dropped (the bg-surface-class regression) or if output
+ * becomes CWD-dependent (the inherited-CWD-scan regression).
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { generateBaseSystem } from '../../src/generators/index.js';
+import {
+  contrastPlugin,
+  invertPlugin,
+  registryToCompiled,
+  scalePlugin,
+  statePlugin,
+  TokenRegistry,
+} from '../../src/index.js';
+
+// A representative slice of the real component vocabulary: role colors, a
+// foreground pair, a variant-prefixed utility, a data-attribute variant,
+// slash-opacity, and structural utilities -- the classes that only ever appear
+// as literal strings in *.classes.ts, none of them registry-derivable.
+const FIXTURE_CLASSES =
+  'bg-surface text-surface-foreground border-card-border hover:bg-accent ' +
+  'data-[state=open]:bg-accent bg-foreground/80 inline-flex px-2.5 text-label-small';
+
+const EXPECTED_RULES = [
+  'bg-surface',
+  'text-surface-foreground',
+  'border-card-border',
+  'bg-accent', // base of the hover/data variants
+  'inline-flex',
+  'px-2',
+];
+
+function baseRegistry(): TokenRegistry {
+  const system = generateBaseSystem({});
+  return new TokenRegistry(system.allTokens, [
+    scalePlugin,
+    contrastPlugin,
+    statePlugin,
+    invertPlugin,
+  ]);
+}
+
+describe('standalone compiled sheet (#1731)', () => {
+  let fixtureDir: string;
+
+  beforeAll(() => {
+    fixtureDir = mkdtempSync(join(tmpdir(), 'rafters-classes-'));
+    writeFileSync(join(fixtureDir, 'card.classes.ts'), `export const x = '${FIXTURE_CLASSES}';\n`);
+  });
+
+  afterAll(() => {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  });
+
+  it('contains a rule for every utility the fixture references', async () => {
+    const css = await registryToCompiled(baseRegistry(), { contentSources: [fixtureDir] });
+    for (const rule of EXPECTED_RULES) {
+      expect(css, `missing utility: ${rule}`).toContain(rule);
+    }
+  });
+
+  it('emits @import "tailwindcss" source(none) so the CWD is not auto-scanned', async () => {
+    // source(none) lives in the pre-compile input; the compiled output proves
+    // determinism (next test). Here assert no utility leaks from unrelated CWD
+    // content: a class never referenced by the fixture must be absent.
+    const css = await registryToCompiled(baseRegistry(), { contentSources: [fixtureDir] });
+    expect(css).not.toContain('bg-warning-subtle');
+  });
+
+  it('output is identical regardless of process CWD (determinism)', async () => {
+    const fromRoot = await registryToCompiled(baseRegistry(), { contentSources: [fixtureDir] });
+    const original = process.cwd();
+    let fromElsewhere: string;
+    try {
+      process.chdir(tmpdir());
+      fromElsewhere = await registryToCompiled(baseRegistry(), { contentSources: [fixtureDir] });
+    } finally {
+      process.chdir(original);
+    }
+    expect(fromElsewhere).toBe(fromRoot);
+  });
+});

--- a/packages/studio/src/api/vite-plugin.ts
+++ b/packages/studio/src/api/vite-plugin.ts
@@ -9,14 +9,15 @@
  * Use `persist: true` (default) when enrichment is complete.
  */
 
-import { writeFile } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { buildColorValue, rebakeAccessibility } from '@rafters/color-utils';
 import {
   contrastPlugin,
   invertPlugin,
   loadRegistryFromDir,
-  registryToTailwind,
+  regenerateOutputs,
+  resolveContentSources,
   saveRegistryToDir,
   scalePlugin,
   statePlugin,
@@ -71,7 +72,30 @@ const ColorBuildOptionsSchema = z.object({
 });
 
 const projectPath = process.env.RAFTERS_PROJECT_PATH || process.cwd();
-const outputPath = join(projectPath, '.rafters', 'output', 'rafters.css');
+const outputDir = join(projectPath, '.rafters', 'output');
+const configPath = join(projectPath, '.rafters', 'config.rafters.json');
+
+/**
+ * The slice of config.rafters.json the regen path needs: which outputs to emit
+ * and the component paths the compiled sheet scans. Read fresh on each regen so
+ * a changed config (e.g. a newly added namespace) is honored.
+ */
+interface StudioConfig {
+  exports?: { tailwind: boolean; typescript: boolean; dtcg: boolean; compiled: boolean };
+  componentsPath?: string | Array<string | { path: string }>;
+  primitivesPath?: string | Array<string | { path: string }>;
+  compositesPath?: string | Array<string | { path: string }>;
+  shadcn?: boolean;
+  darkMode?: 'class' | 'media';
+}
+
+async function loadStudioConfig(): Promise<StudioConfig | null> {
+  try {
+    return JSON.parse(await readFile(configPath, 'utf8')) as StudioConfig;
+  } catch {
+    return null;
+  }
+}
 
 // Zod schema for incoming WebSocket messages
 const SetTokenMessageSchema = z.object({
@@ -610,21 +634,90 @@ export function studioApiPlugin(): Plugin {
         initialized = false;
       }
 
-      // Persist the registry to disk and signal HMR. Replaces v1's
-      // setChangeCallback / setAdapter wiring -- callers explicitly invoke
-      // this after each change instead of relying on a registry-internal
-      // callback chain.
+      // The one output+HMR step: project the current registry to disk outputs
+      // and signal HMR. Does NOT persist tokens -- that is the caller's choice,
+      // which is also what keeps the file watch below from looping (it never
+      // writes back into a watched path).
+      const regenerate = async (): Promise<void> => {
+        const config = await loadStudioConfig();
+        const exports = config?.exports ?? {
+          tailwind: true,
+          typescript: false,
+          dtcg: false,
+          compiled: false,
+        };
+        await regenerateOutputs(
+          registry,
+          {
+            outputDir,
+            exports,
+            contentSources: config ? resolveContentSources(projectPath, config) : [],
+            darkMode: config?.darkMode ?? 'class',
+            includeImport: !config?.shadcn,
+          },
+          { notify: () => server.ws.send({ type: 'custom', event: 'rafters:css-updated' }) },
+        );
+      };
+
+      // Persist the registry to disk, then regenerate outputs + signal HMR.
+      // Replaces v1's setChangeCallback / setAdapter wiring -- callers explicitly
+      // invoke this after each in-memory change.
       const persistAndNotify = async (): Promise<void> => {
         try {
           if (initialized) {
             saveRegistryToDir(tokensDir, registry);
           }
-          await writeFile(outputPath, registryToTailwind(registry));
-          server.ws.send({ type: 'custom', event: 'rafters:css-updated' });
+          await regenerate();
         } catch (error) {
           console.log(`[rafters] CSS regeneration failed: ${error}`);
         }
       };
+
+      // The single file watch: any change to the token files, the configured
+      // component/primitive/composite class sources, or the config reloads the
+      // registry from disk and regenerates (no token write -> no watch loop).
+      // This is the only filesystem-driven regen path; studio API edits share
+      // the same `regenerate` via persistAndNotify.
+      const reloadAndRegenerate = async (): Promise<void> => {
+        try {
+          registry = loadRegistryFromDir(tokensDir, REGISTRY_PLUGINS);
+          initialized = true;
+        } catch {
+          // Tokens unreadable mid-edit -- keep the current registry and still
+          // regenerate so a .classes.ts-only change is picked up.
+        }
+        try {
+          await regenerate();
+        } catch (error) {
+          console.log(`[rafters] CSS regeneration failed: ${error}`);
+        }
+      };
+
+      {
+        const watchConfig = await loadStudioConfig();
+        const classDirs = watchConfig ? resolveContentSources(projectPath, watchConfig) : [];
+        const watchTargets = [
+          join(tokensDir, '*.rafters.json'),
+          configPath,
+          ...classDirs.map((dir) => join(dir, '**/*.classes.ts')),
+        ];
+        server.watcher.add(watchTargets);
+        let debounce: ReturnType<typeof setTimeout> | null = null;
+        const onChange = (changed: string): void => {
+          const watched =
+            changed.endsWith('.classes.ts') ||
+            changed.endsWith('.rafters.json') ||
+            changed === configPath;
+          if (!watched) return;
+          if (debounce) clearTimeout(debounce);
+          debounce = setTimeout(() => {
+            void reloadAndRegenerate();
+          }, 150);
+        };
+        server.watcher.on('change', onChange);
+        server.watcher.on('add', onChange);
+        server.watcher.on('unlink', onChange);
+      }
 
       // Listen for token updates from client
       server.ws.on('rafters:set-token', async (rawData: unknown, client) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,7 +289,10 @@ importers:
         version: 8.2.0(@types/node@24.10.0)
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.1
-        version: 1.25.1(hono@4.11.0)(zod@4.3.6)
+        version: 1.25.1(hono@4.11.0)(zod@4.1.12)
+      '@tailwindcss/cli':
+        specifier: ^4.1.18
+        version: 4.1.18
       commander:
         specifier: ^13.0.0
         version: 13.1.0
@@ -350,7 +353,7 @@ importers:
         version: 4.1.0(@types/node@24.10.0)(@vitest/ui@4.1.0)(happy-dom@20.0.10)(jsdom@26.1.0)(msw@2.11.6(@types/node@24.10.0)(typescript@5.9.3))(vite@8.0.0(@types/node@24.10.0)(esbuild@0.27.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       zocker:
         specifier: 'catalog:'
-        version: 3.0.0(zod@4.3.6)
+        version: 3.0.0(zod@4.1.12)
 
   packages/color-utils:
     dependencies:
@@ -572,7 +575,7 @@ importers:
         version: 4.1.0(@types/node@24.10.0)(@vitest/ui@4.1.0)(happy-dom@20.0.10)(jsdom@26.1.0)(msw@2.11.6(@types/node@24.10.0)(typescript@5.9.3))(vite@8.0.0(@types/node@24.10.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       zocker:
         specifier: 'catalog:'
-        version: 3.0.0(zod@4.3.6)
+        version: 3.0.0(zod@4.1.12)
 
   packages/ui:
     dependencies:
@@ -5513,6 +5516,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -7499,7 +7503,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.25.1(hono@4.11.0)(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.25.1(hono@4.11.0)(zod@4.1.12)':
     dependencies:
       '@hono/node-server': 1.19.11(hono@4.11.0)
       ajv: 8.17.1
@@ -7515,8 +7519,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.0(zod@4.3.6)
+      zod: 4.1.12
+      zod-to-json-schema: 3.25.0(zod@4.1.12)
     transitivePeerDependencies:
       - hono
       - supports-color
@@ -8246,7 +8250,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@24.10.0)(@vitest/ui@4.1.0)(happy-dom@20.0.10)(jsdom@26.1.0)(msw@2.11.6(@types/node@24.10.0)(typescript@5.9.3))(vite@8.0.0(@types/node@24.10.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@types/node@24.10.0)(@vitest/ui@4.1.0)(happy-dom@20.0.10)(jsdom@26.1.0)(msw@2.11.6(@types/node@24.10.0)(typescript@5.9.3))(vite@8.0.0(@types/node@24.10.0)(esbuild@0.27.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/utils@4.1.0':
     dependencies:
@@ -11967,19 +11971,13 @@ snapshots:
       randexp: 0.5.3
       zod: 4.1.12
 
-  zocker@3.0.0(zod@4.3.6):
-    dependencies:
-      '@faker-js/faker': 10.1.0
-      randexp: 0.5.3
-      zod: 4.3.6
-
   zod-to-json-schema@3.25.0(zod@3.25.76):
     dependencies:
       zod: 3.25.76
 
-  zod-to-json-schema@3.25.0(zod@4.3.6):
+  zod-to-json-schema@3.25.0(zod@4.1.12):
     dependencies:
-      zod: 4.3.6
+      zod: 4.1.12
 
   zod-to-ts@1.2.0(typescript@5.9.3)(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
## Summary

Makes the compiled `rafters.standalone.css` -- the utility stylesheet every Web Component adopts into its shadow root -- complete, deterministic, and regenerated on every change to the installed component vocabulary, through a single regen+HMR path. Previously the sheet was a photograph of whatever content was reachable from the inherited process CWD (non-deterministic, incomplete -- a missing `bg-surface` was the visible symptom), the Tailwind compiler was not shipped (consumer installs threw), and only `rafters init` regenerated it (`add`/update/watch left it stale). Implements epic #1723, slices S1-S8.

## Acceptance criteria mapping

### S1 (#1724) -- ship @tailwindcss/cli with rafters
`@tailwindcss/cli@^4.1.18` added to `packages/cli/package.json` dependencies. `registryToCompiled` resolves the bin via `createRequire(import.meta.url)` from the rafters install, so a `pnpx rafters` consumer resolves it with no Tailwind of their own.
Evidence: `packages/cli/package.json` dependencies; verified `require.resolve('@tailwindcss/cli/package.json')` succeeds from `packages/cli/dist/index.js`.

### S2 (#1725) -- deterministic registryToCompiled
`registryToCompiled` now emits `@import "tailwindcss" source(none)` (disables CWD auto-scan) + one explicit `@source` per content path, generates the theme body with `includeImport:false`, and passes explicit `cwd` to `execFileSync`. `CompiledCssOptions` drops `includeImport` and gains `contentSources`.
Evidence: `packages/design-tokens/src/exporters/tailwind.ts` `registryToCompiled`; the determinism test in `compiled-standalone.test.ts` compiles from two CWDs and asserts byte-identical output.

### S3 (#1726) -- single regenerateOutputs(+HMR) path
New `regenerateOutputs(registry, input, hooks)` in `packages/design-tokens/src/outputs.ts` is the only code that writes the output files and fires HMR; `resolveContentSources` derives the `@source` set from configured component paths. `init`'s `generateOutputs` and studio's `persistAndNotify` both delegate to it.
Evidence: `outputs.ts` `regenerateOutputs`/`resolveContentSources`; `init.ts` `generateOutputs` returns `regenerateOutputs(...)`; `vite-plugin.ts` `regenerate`/`persistAndNotify`.

### S4 (#1727) -- regenerate on add / --update / --update-all
`add.ts` calls `regenerateAfterInstall` (load registry -> `regenerateOutputs`) after `trackInstalled` + `saveConfig` on both the existing-config and new-config branches, so a newly installed component's classes reach the sheet (and an update that drops a class removes it).
Evidence: `packages/cli/src/commands/add.ts` `regenerateAfterInstall` and its two call sites.

### S5 (#1728) -- one file watch
A single studio watcher over `.rafters/tokens/*.rafters.json`, the configured component `*.classes.ts`, and `config.rafters.json` calls `reloadAndRegenerate` (reload registry -> `regenerate`) on change. It never writes tokens, so it cannot loop with its own output; debounced 150ms.
Evidence: `vite-plugin.ts` `reloadAndRegenerate` + the `server.watcher.add`/`onChange` block in `configureServer`.

### S6 (#1729) -- missing subtle tokens
Added `secondary-subtle`, `secondary-subtle-foreground`, `accent-subtle`, `accent-subtle-foreground` to `DEFAULT_SEMANTIC_COLOR_MAPPINGS`, mirroring the existing `primary-subtle` shape. Components (alert variants) referenced these but they did not exist.
Evidence: `packages/design-tokens/src/generators/defaults.ts` new keys.

### S7 (#1730) -- registryToTailwindStatic drift tripwire
`assembly-parity.test.ts` freezes the section-marker set of `registryToTailwind` and `registryToTailwindStatic` as explicit arrays (not snapshots) and asserts static is a subset of dynamic, so adding a section to one forces a conscious cross-assembly decision.
Evidence: `packages/design-tokens/test/exporters/assembly-parity.test.ts`.

### S8 (#1731) -- completeness + determinism guard
`compiled-standalone.test.ts` compiles against a temp fixture vocabulary and asserts every referenced utility is present, a non-referenced utility is absent (scan-driven, not leaked), and output is CWD-independent (via `process.chdir` in try/finally).
Evidence: `packages/design-tokens/test/exporters/compiled-standalone.test.ts`.

### Verification
`pnpm preflight` green. Demo regenerated with the local build: installed components' utilities (`bg-card`, `bg-primary`, `border-card-border`) present in the standalone sheet; `bg-surface`/alert-subtle correctly absent (those components are not installed) -- install-scoped, deterministic behavior.

## Not done

- The REGISTRY_PLUGINS array (`[scalePlugin, contrastPlugin, statePlugin, invertPlugin]`) remains duplicated across init.ts, add.ts, and vite-plugin.ts (pre-existing convention; my diff follows it). Follow-up: export a canonical `DEFAULT_REGISTRY_PLUGINS` from design-tokens.
- `resolveContentSources` reimplements a slice of `cli/utils/paths.ts` `resolveReadSet` -- intentional, to avoid a CLI<->studio dependency cycle. Follow-up: relocate PathField resolution to a shared package.
- A sheet prebuilt from `packages/ui` and shipped with the published WC npm package (library-build artifact) is out of epic scope.
- The demo `.rafters` regeneration output is not committed (generated artifact, not source).
- This commit is unsigned -- the 1Password signing vault was locked at commit time; re-sign/amend before merge if branch protection requires signed commits.
