### PR TITLE
fix(#1733): cross-component shared import is a phantom primitive

### DIFF
--- a/apps/registry/src/lib/registry/componentService.ts
+++ b/apps/registry/src/lib/registry/componentService.ts
@@ -546,10 +546,15 @@ export function loadComponent(name: string): RegistryItem | null {
       });
 
       // Merge primitive/internal deps from all variants.
-      // Filter out shared auxiliary files (e.g. button.classes) -- they are bundled
-      // with the component's files, not standalone primitives.
+      // Filter out shared auxiliary files -- they are bundled with the
+      // component's files, never fetched as standalone primitives. This must
+      // match ANY shared sibling, not just this component's own: a component
+      // can import a sibling's shared file (e.g. container imports
+      // ./grid.classes for shared column classes), and that file is bundled by
+      // name (see the sibling-import bundling below), so it must not leak into
+      // primitives as a phantom item (which would 404 on install).
       const realPrimitives = analysis.importDeps.internal.filter(
-        (dep) => !SHARED_SUFFIXES.some((suffix) => dep === name + suffix.replace(/\.ts$/, '')),
+        (dep) => !SHARED_SUFFIXES.some((suffix) => dep.endsWith(suffix.replace(/\.ts$/, ''))),
       );
       primitivesAll = [
         ...new Set([...primitivesAll, ...realPrimitives, ...analysis.primitiveDeps]),


### PR DESCRIPTION
## Summary

Fixes a registry-generation bug where a component that imports a sibling's shared `.classes`/`.types`/`.constants`/`.styles` file emitted that file as a fetchable `primitive`, causing a "<x>.classes not found" 404 on `rafters add` / `--update-all`. Container imports `./grid.classes` (#1718), so `grid.classes` leaked into `container.primitives`; `resolveDependencies` then tried to fetch a registry item named `grid.classes` that does not exist. Latent for ~half a year because no installed component cross-imported another component's shared file until #1718. Closes #1733.

## Acceptance criteria mapping

### Filter matches any shared-suffix sibling, not just the component's own name
`loadComponent`'s `realPrimitives` filter changed from `dep === name + suffix.replace(/\.ts$/, '')` (exact, name-specific) to `dep.endsWith(suffix.replace(/\.ts$/, ''))` (any `.classes`/`.types`/`.constants`/`.styles` sibling). Shared aux files are bundled into `files`, never fetched as standalone primitives.
Evidence: `apps/registry/src/lib/registry/componentService.ts`, the `realPrimitives` const in `loadComponent`.

### container.json primitives drop grid.classes; grid.classes.ts stays bundled
After rebuild, `container.primitives` is `["classy","fill-resolver","rafters-element"]` and `grid.classes.ts` remains in `container.files` (via the sibling-import bundling). So container installed alone still receives `grid.classes.ts` and the relative import resolves -- the dependency travels as a file, not a primitive.
Evidence: rebuilt `apps/registry/dist/registry/components/container.json` (primitives + files inspected).

### add / --update-all resolve cleanly
With `grid.classes` gone from primitives, `resolveDependencies("container")` no longer fetches a non-existent item; `--update-all` (which re-fetches every installed component, container included) resolves.
Evidence: root cause is `registry/client.ts:58` throwing on the phantom name; removing it from primitives removes the fetch.

### No phantom shared-file primitives anywhere
A scan of every component JSON after rebuild shows zero primitives matching `/\.(classes|types|constants|styles)$/` -- this also pre-empts the same break for any future cross-component shared import.
Evidence: full-registry scan over `apps/registry/dist/registry/components/*.json`.

### Verification
Biome clean on the changed file; lefthook pre-commit (lint + typecheck + unit) green. Merge auto-deploys the corrected registry, so consumers fetch the fixed JSON.
Evidence: lefthook pre-commit summary on commit 33f9f6c3 (unit-tests, lint, typecheck all passing); `biome check apps/registry/src/lib/registry/componentService.ts` reports no fixes.

## Not done

- No vitest regression test: `apps/registry` has no test harness today (no vitest, no test script). Standing one up is a separate follow-up; the fix is verified by the full-registry scan above.
- No change to the install side (`add.ts`) or the `rafters` CLI npm package -- those are unaffected; this is registry-generation only.
- The demo `rafters@0.0.71` devDependency change (from the in-progress studio verification) is intentionally excluded from this branch.
