### PR TITLE
feat(ui): createDisclosure - framework-free open/close state primitive on createMemory (#1691)

### DIFF
--- a/packages/ui/src/primitives/disclosure.test.ts
+++ b/packages/ui/src/primitives/disclosure.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { createDisclosure } from './disclosure';
+
+describe('createDisclosure', () => {
+  it('subscribe fires immediately, then on change; stops after unsubscribe', () => {
+    const d = createDisclosure({ initialOpen: false });
+    const seen: boolean[] = [];
+    const stop = d.subscribe((o) => seen.push(o));
+    d.open();
+    d.close();
+    stop();
+    d.open(); // after unsubscribe -> not observed
+    expect(seen).toEqual([false, true, false]);
+  });
+
+  it('toggle reads the live cell', () => {
+    const t = createDisclosure();
+    t.toggle();
+    expect(t.isOpen()).toBe(true);
+    t.toggle();
+    expect(t.isOpen()).toBe(false);
+  });
+
+  it('open and close set the cell explicitly', () => {
+    const d = createDisclosure();
+    d.open();
+    expect(d.isOpen()).toBe(true);
+    d.close();
+    expect(d.isOpen()).toBe(false);
+  });
+
+  it('setOpen reflects without a callback (controlled-sync path)', () => {
+    const c = createDisclosure({ initialOpen: false });
+    c.setOpen(true);
+    expect(c.isOpen()).toBe(true);
+    c.setOpen(false);
+    expect(c.isOpen()).toBe(false);
+  });
+
+  it('defaults initialOpen to false', () => {
+    expect(createDisclosure().isOpen()).toBe(false);
+    expect(createDisclosure({ initialOpen: true }).isOpen()).toBe(true);
+  });
+
+  it('reset returns to a fresh initial', () => {
+    const r = createDisclosure({ initialOpen: false });
+    r.open();
+    r.memory.reset();
+    expect(r.isOpen()).toBe(false);
+
+    const r2 = createDisclosure({ initialOpen: true });
+    r2.close();
+    r2.memory.reset();
+    expect(r2.isOpen()).toBe(true);
+  });
+
+  it('select on the memory is equality-gated (no fire on unrelated patch)', () => {
+    const e = createDisclosure();
+    const fires: boolean[] = [];
+    e.memory.select(
+      (s) => s.open,
+      (o) => fires.push(o),
+    );
+    e.open();
+    e.open();
+    expect(fires).toEqual([true]);
+  });
+});

--- a/packages/ui/src/primitives/disclosure.ts
+++ b/packages/ui/src/primitives/disclosure.ts
@@ -1,0 +1,82 @@
+/**
+ * disclosure.ts - framework-agnostic single open/close boolean cell.
+ *
+ * Nine components (dialog, alert-dialog, drawer, sheet, collapsible,
+ * dropdown-menu, context-menu, hover-card, tooltip) hand-roll the identical
+ * `useState(defaultOpen)` + controlled/uncontrolled dance. This writes that
+ * open/close state ONCE on createMemory, parallel to createSelectionGroup, so
+ * every framework wrapper stays thin:
+ *
+ *   - React:  useMemory(disclosure.memory) + disclosure.toggle/open/close
+ *   - Astro:  a small <script> that imports this and disclosure.subscribe(...)
+ *   - WC/Vue: the same import
+ *
+ * The cell is the single source of truth. createDisclosure takes NO `controlled`
+ * flag and fires NO `onOpenChange`: the controlled/uncontrolled dual-mode lives
+ * at the React boundary (the wrapper reflects a controlled prop in via `setOpen`,
+ * and fires `onOpenChange` on user actions) - the same split tabs uses
+ * (`setValue` programmatic vs `select` + onChange).
+ *
+ * Visibility / forceMount is NOT disclosure's concern - components reflect open
+ * onto the DOM and keep content mounted+hidden (matching the selection family).
+ *
+ * @example
+ * ```ts
+ * const d = createDisclosure({ initialOpen: false });
+ * const stop = d.subscribe((open) => {
+ *   // reflect onto the DOM
+ * });
+ * d.toggle();
+ * stop();
+ * ```
+ */
+import { createMemory, type Memory } from './memory';
+
+export interface DisclosureState {
+  open: boolean;
+}
+
+export interface DisclosureOptions {
+  /** Initial open state. Default false. */
+  initialOpen?: boolean;
+}
+
+export interface Disclosure {
+  /** The reactive cell - for useMemory, select, derive. */
+  readonly memory: Memory<DisclosureState>;
+  /** Current open state. */
+  isOpen(): boolean;
+  /** Open. */
+  open(): void;
+  /** Close. */
+  close(): void;
+  /** Toggle (reads the live cell). */
+  toggle(): void;
+  /** Set open to an explicit value (programmatic reflect - the controlled-sync path). */
+  setOpen(open: boolean): void;
+  /** Subscribe to open changes (fires immediately with current value). */
+  subscribe(listener: (open: boolean) => void): () => void;
+}
+
+export function createDisclosure(options: DisclosureOptions = {}): Disclosure {
+  const { initialOpen = false } = options;
+  const memory = createMemory<DisclosureState>(() => ({ open: initialOpen }));
+
+  return {
+    memory,
+    isOpen: () => memory.get().open,
+    open: () => {
+      memory.set({ open: true });
+    },
+    close: () => {
+      memory.set({ open: false });
+    },
+    toggle: () => {
+      memory.set({ open: !memory.get().open });
+    },
+    setOpen: (open) => {
+      memory.set({ open });
+    },
+    subscribe: (listener) => memory.subscribe((state) => listener(state.open)),
+  };
+}


### PR DESCRIPTION
Closes #1691. Part of #1690.

Adds `createDisclosure`, a framework-free single open/close boolean cell built on `createMemory`, parallel in shape to `createSelectionGroup`. This writes the `useState(defaultOpen)` + controlled/uncontrolled dance once so the React, Astro, and pending Web Component disclosure ports (dialog, alert-dialog, drawer, sheet, collapsible, dropdown-menu, context-menu, hover-card, tooltip) share it.

## What changed
- New `packages/ui/src/primitives/disclosure.ts` implementing `DisclosureState`, `DisclosureOptions`, `Disclosure`, and `createDisclosure` to the issue's exact signature.
- New `packages/ui/src/primitives/disclosure.test.ts` mirroring `selection-group.test.ts`.

## Design
- Controlled-agnostic: the cell is the single source of truth. No `controlled` flag, no `onOpenChange` - the dual-mode lives at the React boundary (`setOpen` programmatic vs user actions firing `onOpenChange`), the same split tabs uses.
- `open()`/`close()` set the cell; `toggle()` flips `memory.get().open` (live read, no stale closure); `setOpen(v)` is the controlled-sync path; `subscribe(cb)` projects to the boolean and fires immediately (nanostores semantics); `memory.reset()` returns to a fresh initial.
- Leaf primitive (composes only `createMemory`), reached via the `./primitives/*` exports map - no barrel edit, no `@registry-*` JSDoc tags, matching `selection-group.ts`.
- No component was modified - migrations are the per-component sub-issues of #1690.

## Verification
- `pnpm --filter @rafters/ui typecheck` - clean.
- `pnpm --filter @rafters/ui test run disclosure` - 7 passed.
- `biome check` on both files - clean.