### PR TITLE
feat(ui): sidebar open state onto createMemory (cookie as subscriber) (#1704)

### DIFF
--- a/packages/ui/src/components/ui/sidebar.tsx
+++ b/packages/ui/src/components/ui/sidebar.tsx
@@ -48,7 +48,9 @@
  */
 
 import * as React from 'react';
+import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
+import { createMemory } from '../../primitives/memory';
 import { mergeProps } from '../../primitives/slot';
 import {
   sidebarContentClasses,
@@ -105,6 +107,17 @@ type SidebarCollapsible = 'offcanvas' | 'icon' | 'none';
 
 // ==================== Context ====================
 
+/**
+ * Reactive open-state for one provider instance. The two booleans live in a single
+ * `createMemory` cell so persistence (the cookie) can be wired as a state subscriber
+ * rather than coupled into the setter. `isMobile` is intentionally excluded: it is a
+ * browser signal (media query), not application state.
+ */
+interface SidebarState {
+  open: boolean;
+  openMobile: boolean;
+}
+
 interface SidebarContextValue {
   state: 'expanded' | 'collapsed';
   open: boolean;
@@ -146,31 +159,60 @@ export function SidebarProvider({
   children,
   ...props
 }: SidebarProviderProps) {
-  const [openMobile, setOpenMobile] = React.useState(false);
-  const [_open, _setOpen] = React.useState(defaultOpen);
+  // Open-state lives in one reactive cell, created once per provider instance so it is
+  // stable across renders. Seed `open` with the controlled value when present so the
+  // first render reflects it without a flash; later controlled changes mirror in below.
+  const [memory] = React.useState(() =>
+    createMemory<SidebarState>(() => ({
+      open: controlledOpen ?? defaultOpen,
+      openMobile: false,
+    })),
+  );
+  const { open, openMobile } = useMemory(memory);
 
-  // Controlled vs uncontrolled
-  const open = controlledOpen ?? _open;
+  // Controlled mode: reflect the prop into the cell so the single source of truth for
+  // `open` is always the cell (consumers + the cookie subscriber read from it).
+  React.useEffect(() => {
+    if (controlledOpen !== undefined) {
+      memory.patch({ open: controlledOpen });
+    }
+  }, [controlledOpen, memory]);
+
+  // Persistence is a reaction to state, not a side effect baked into the setter.
+  // `select` is equality-gated and does not fire on subscribe, so the cookie is written
+  // only when `open` actually changes - never on an unrelated re-render.
+  React.useEffect(() => {
+    const writeCookie = (isOpen: boolean): void => {
+      if (typeof document !== 'undefined') {
+        // biome-ignore lint/suspicious/noDocumentCookie: Cookie is used for sidebar state persistence across page loads
+        document.cookie = `${SIDEBAR_COOKIE_NAME}=${isOpen}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+      }
+    };
+    return memory.select((state) => state.open, writeCookie);
+  }, [memory]);
+
   const setOpen = React.useCallback(
     (value: boolean | ((prev: boolean) => boolean)) => {
-      const nextOpen = typeof value === 'function' ? value(open) : value;
+      const nextOpen = typeof value === 'function' ? value(memory.get().open) : value;
 
       if (onOpenChange) {
         onOpenChange(nextOpen);
       } else {
-        _setOpen(nextOpen);
-      }
-
-      // Set cookie for persistence
-      if (typeof document !== 'undefined') {
-        // biome-ignore lint/suspicious/noDocumentCookie: Cookie is used for sidebar state persistence across page loads
-        document.cookie = `${SIDEBAR_COOKIE_NAME}=${nextOpen}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+        memory.patch({ open: nextOpen });
       }
     },
-    [open, onOpenChange],
+    [memory, onOpenChange],
   );
 
-  // Simple mobile detection via media query
+  const setOpenMobile = React.useCallback(
+    (value: boolean) => {
+      memory.patch({ openMobile: value });
+    },
+    [memory],
+  );
+
+  // Simple mobile detection via media query. This is a browser signal, not application
+  // state, so it stays a local `useState` and never enters the cell.
   const [isMobile, setIsMobile] = React.useState(false);
 
   React.useEffect(() => {
@@ -184,11 +226,11 @@ export function SidebarProvider({
 
   const toggleSidebar = React.useCallback(() => {
     if (isMobile) {
-      setOpenMobile((prev) => !prev);
+      memory.patch({ openMobile: !memory.get().openMobile });
     } else {
       setOpen((prev) => !prev);
     }
-  }, [isMobile, setOpen]);
+  }, [isMobile, memory, setOpen]);
 
   // Keyboard shortcut (Cmd/Ctrl + B)
   React.useEffect(() => {
@@ -215,7 +257,7 @@ export function SidebarProvider({
       setOpenMobile,
       toggleSidebar,
     }),
-    [state, open, setOpen, isMobile, openMobile, toggleSidebar],
+    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar],
   );
 
   return (

--- a/packages/ui/test/components/sidebar.test.tsx
+++ b/packages/ui/test/components/sidebar.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   Sidebar,
   SidebarContent,
@@ -199,6 +199,83 @@ describe('Sidebar - Open/Close State', () => {
     );
 
     expect(screen.getByTestId('open')).toHaveTextContent('false');
+  });
+});
+
+describe('Sidebar - Cookie Persistence', () => {
+  let cookieSpy: ReturnType<typeof vi.fn>;
+  let originalCookie: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    mockMatchMedia(false);
+    cookieSpy = vi.fn();
+    let store = '';
+    originalCookie = Object.getOwnPropertyDescriptor(Document.prototype, 'cookie');
+    Object.defineProperty(document, 'cookie', {
+      configurable: true,
+      get: () => store,
+      set: (value: string) => {
+        store = value;
+        cookieSpy(value);
+      },
+    });
+  });
+
+  afterEach(() => {
+    if (originalCookie) {
+      Object.defineProperty(document, 'cookie', originalCookie);
+    }
+  });
+
+  it('does not write the cookie on initial mount (subscriber is equality-gated)', () => {
+    render(
+      <SidebarProvider>
+        <SidebarTrigger data-testid="trigger" />
+      </SidebarProvider>,
+    );
+
+    expect(cookieSpy).not.toHaveBeenCalled();
+  });
+
+  it('writes the cookie once when open changes via toggle', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SidebarProvider>
+        <SidebarTrigger data-testid="trigger" />
+        <SidebarStateDisplay />
+      </SidebarProvider>,
+    );
+
+    expect(cookieSpy).not.toHaveBeenCalled();
+
+    await user.click(screen.getByTestId('trigger'));
+
+    expect(screen.getByTestId('state')).toHaveTextContent('collapsed');
+    expect(cookieSpy).toHaveBeenCalledTimes(1);
+    expect(cookieSpy).toHaveBeenCalledWith(expect.stringContaining('sidebar:state=false'));
+  });
+
+  it('does not write the cookie on an unrelated re-render', async () => {
+    const user = userEvent.setup();
+
+    const { rerender } = render(
+      <SidebarProvider data-foo="a">
+        <SidebarTrigger data-testid="trigger" />
+      </SidebarProvider>,
+    );
+
+    await user.click(screen.getByTestId('trigger'));
+    expect(cookieSpy).toHaveBeenCalledTimes(1);
+
+    // Re-render without changing open state: the subscriber must not fire again.
+    rerender(
+      <SidebarProvider data-foo="b">
+        <SidebarTrigger data-testid="trigger" />
+      </SidebarProvider>,
+    );
+
+    expect(cookieSpy).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
Closes #1704. Part of epic #1690.

## What changed

Migrated `SidebarProvider` (`packages/ui/src/components/ui/sidebar.tsx`) onto the `createMemory` reactive core — the **cell shape** (sidebar is React-only today; no controller/Astro/WC target, per the issue).

- The two open-state `useState` calls (`_open` and `openMobile`) collapse into a single `createMemory<SidebarState>` cell, created once per provider via a `useState(() => createMemory(...))` initializer so it is stable across renders. Open-state is consumed through `useMemory(memory)`.
- `setOpen` / `setOpenMobile` / `toggleSidebar` now write through `memory.patch(...)` instead of React setters.
- The cookie write that was inlined in the `setOpen` setter moves to a `memory.select(s => s.open, writeCookie)` subscriber registered in an effect. `select` is equality-gated and does not fire on subscribe, so the cookie is written only when `open` actually changes — never on an unrelated re-render.
- Controlled/uncontrolled `open` preserved: the cell is seeded with `controlledOpen ?? defaultOpen` (no first-render flash) and a small effect mirrors later controlled changes into the cell, so the cell is the single source of truth for both consumers and the cookie subscriber. `onOpenChange` still fires on user toggle.
- `isMobile` stays a local `useState` driven by the media-query effect — a browser signal, not application state, so it does NOT enter the cell. Keyboard shortcut (Cmd/Ctrl+B) and all markup unchanged.

## Tests

Extended `packages/ui/test/components/sidebar.test.tsx` with a "Cookie Persistence" suite that spies on `document.cookie`: asserts no write on initial mount (subscriber is equality-gated), exactly one write with `sidebar:state=false` on toggle, and no write on an unrelated re-render.

## Verification

- `pnpm --filter @rafters/ui typecheck` — green (no `any`, biome clean).
- `pnpm --filter @rafters/ui test` — full suite green; sidebar file 30/30 passing.