### PR TITLE
feat(ui): carousel + calendar navigation state onto createMemory (#1705)

### DIFF
--- a/packages/ui/src/components/ui/calendar.tsx
+++ b/packages/ui/src/components/ui/calendar.tsx
@@ -29,11 +29,25 @@
  */
 
 import * as React from 'react';
+import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
+import { createMemory } from '../../primitives/memory';
 
 // ==================== Types ====================
 
 type CalendarMode = 'single' | 'multiple' | 'range';
+
+/**
+ * Reactive navigation state for a calendar instance.
+ *
+ * `currentMonth` is the visible month (navigation); `focusedDate` is the keyboard
+ * focus within the grid. Selection is NOT here -- the calendar is selection-controlled
+ * (the consumer owns `selected`/`onSelect`).
+ */
+interface CalendarState {
+  currentMonth: Date;
+  focusedDate: Date | null;
+}
 
 interface DateRange {
   from: Date | undefined;
@@ -117,28 +131,34 @@ export function Calendar<T extends CalendarMode = 'single'>({
   className,
   ...props
 }: CalendarProps<T>) {
-  const [currentMonth, setCurrentMonth] = React.useState(() => {
-    if (defaultMonth) return defaultMonth;
-    if (mode === 'single' && selected instanceof Date) return selected;
-    if (mode === 'range' && (selected as DateRange)?.from) {
-      const rangeFrom = (selected as DateRange).from;
-      if (rangeFrom) return rangeFrom;
-    }
-    return new Date();
-  });
-
-  const [focusedDate, setFocusedDate] = React.useState<Date | null>(null);
+  // Navigation/transient state lives in one reactive cell per instance, created once
+  // with a stable initializer. Selection is intentionally absent: it stays controlled.
+  const [memory] = React.useState(() =>
+    createMemory<CalendarState>(() => ({
+      currentMonth: (() => {
+        if (defaultMonth) return defaultMonth;
+        if (mode === 'single' && selected instanceof Date) return selected;
+        if (mode === 'range' && (selected as DateRange)?.from) {
+          const rangeFrom = (selected as DateRange).from;
+          if (rangeFrom) return rangeFrom;
+        }
+        return new Date();
+      })(),
+      focusedDate: null,
+    })),
+  );
+  const { currentMonth, focusedDate } = useMemory(memory);
 
   const year = currentMonth.getFullYear();
   const month = currentMonth.getMonth();
 
   // Navigation handlers
   const goToPreviousMonth = () => {
-    setCurrentMonth(new Date(year, month - 1, 1));
+    memory.patch({ currentMonth: new Date(year, month - 1, 1) });
   };
 
   const goToNextMonth = () => {
-    setCurrentMonth(new Date(year, month + 1, 1));
+    memory.patch({ currentMonth: new Date(year, month + 1, 1) });
   };
 
   // Check if date is disabled
@@ -248,10 +268,14 @@ export function Calendar<T extends CalendarMode = 'single'>({
 
     if (newDate) {
       e.preventDefault();
-      setFocusedDate(newDate);
-      // Update month if needed
+      // Update month alongside focus in one patch when navigation crosses a boundary.
       if (newDate.getMonth() !== month || newDate.getFullYear() !== year) {
-        setCurrentMonth(new Date(newDate.getFullYear(), newDate.getMonth(), 1));
+        memory.patch({
+          focusedDate: newDate,
+          currentMonth: new Date(newDate.getFullYear(), newDate.getMonth(), 1),
+        });
+      } else {
+        memory.patch({ focusedDate: newDate });
       }
     }
   };
@@ -418,7 +442,7 @@ export function Calendar<T extends CalendarMode = 'single'>({
                         disabled={isDisabled}
                         onClick={() => handleDateSelect(day.date)}
                         onKeyDown={(e) => handleKeyDown(e, day.date)}
-                        onFocus={() => setFocusedDate(day.date)}
+                        onFocus={() => memory.patch({ focusedDate: day.date })}
                         className={classy(
                           'inline-flex items-center justify-center size-8 rounded-md text-sm',
                           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',

--- a/packages/ui/src/components/ui/carousel.tsx
+++ b/packages/ui/src/components/ui/carousel.tsx
@@ -32,11 +32,28 @@
  */
 
 import * as React from 'react';
+import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
+import { createMemory } from '../../primitives/memory';
 
 // ==================== Types ====================
 
 type Orientation = 'horizontal' | 'vertical';
+
+/**
+ * Reactive navigation/transient state for a carousel instance.
+ *
+ * `currentIndex` and `isPaused` are the shareable navigation state. `itemsVersion`
+ * is a bump counter incremented on register/unregister; the item count itself lives
+ * in a ref (see {@link Carousel}) so registration churn does not force a broad
+ * Map/array-in-cell re-render -- consumers re-render via the version bump, then read
+ * the live count from the ref.
+ */
+interface CarouselState {
+  currentIndex: number;
+  isPaused: boolean;
+  itemsVersion: number;
+}
 
 // ==================== Context ====================
 
@@ -49,8 +66,8 @@ interface CarouselContextValue {
   scrollPrevious: () => void;
   scrollNext: () => void;
   scrollTo: (index: number) => void;
-  registerItem: () => void;
-  unregisterItem: () => void;
+  registerItem: (id: string) => void;
+  unregisterItem: (id: string) => void;
   carouselRef: React.RefObject<HTMLDivElement | null>;
 }
 
@@ -82,46 +99,64 @@ export function Carousel({
   children,
   ...props
 }: CarouselProps) {
-  const [currentIndex, setCurrentIndex] = React.useState(0);
-  const [totalItems, setTotalItems] = React.useState(0);
-  const [isPaused, setIsPaused] = React.useState(false);
+  // Navigation/transient state lives in one reactive cell per instance. The whole
+  // value is subscribed via useMemory (state is small); a change to any field
+  // (including the itemsVersion bump) re-renders so totalItems is recomputed.
+  const [memory] = React.useState(() =>
+    createMemory<CarouselState>(() => ({ currentIndex: 0, isPaused: false, itemsVersion: 0 })),
+  );
+  const { currentIndex, isPaused } = useMemory(memory);
+
+  // The item registry is a bottom-up child registry keyed by id. The count lives
+  // here (a ref) instead of the cell; register/unregister bump itemsVersion to
+  // signal consumers without putting the array in the cell.
+  const itemIdsRef = React.useRef<string[]>([]);
+  const totalItems = itemIdsRef.current.length;
+
   const carouselRef = React.useRef<HTMLDivElement | null>(null);
 
   const canScrollPrevious = loop || currentIndex > 0;
   const canScrollNext = loop || currentIndex < totalItems - 1;
 
   const scrollPrevious = React.useCallback(() => {
-    setCurrentIndex((prev) => {
-      if (prev === 0) {
-        return loop ? totalItems - 1 : 0;
-      }
-      return prev - 1;
-    });
-  }, [loop, totalItems]);
+    const total = itemIdsRef.current.length;
+    const prev = memory.get().currentIndex;
+    const next = prev === 0 ? (loop ? total - 1 : 0) : prev - 1;
+    memory.patch({ currentIndex: next });
+  }, [loop, memory]);
 
   const scrollNext = React.useCallback(() => {
-    setCurrentIndex((prev) => {
-      if (prev === totalItems - 1) {
-        return loop ? 0 : totalItems - 1;
-      }
-      return prev + 1;
-    });
-  }, [loop, totalItems]);
+    const total = itemIdsRef.current.length;
+    const prev = memory.get().currentIndex;
+    const next = prev === total - 1 ? (loop ? 0 : total - 1) : prev + 1;
+    memory.patch({ currentIndex: next });
+  }, [loop, memory]);
 
   const scrollTo = React.useCallback(
     (index: number) => {
-      setCurrentIndex(Math.max(0, Math.min(index, totalItems - 1)));
+      const total = itemIdsRef.current.length;
+      memory.patch({ currentIndex: Math.max(0, Math.min(index, total - 1)) });
     },
-    [totalItems],
+    [memory],
   );
 
-  const registerItem = React.useCallback(() => {
-    setTotalItems((prev) => prev + 1);
-  }, []);
+  // Registration is idempotent-by-id (filter-then-set) so StrictMode's
+  // double-invoked mount effect does not double-count a single item.
+  const registerItem = React.useCallback(
+    (id: string) => {
+      itemIdsRef.current = [...itemIdsRef.current.filter((entry) => entry !== id), id];
+      memory.patch({ itemsVersion: memory.get().itemsVersion + 1 });
+    },
+    [memory],
+  );
 
-  const unregisterItem = React.useCallback(() => {
-    setTotalItems((prev) => Math.max(0, prev - 1));
-  }, []);
+  const unregisterItem = React.useCallback(
+    (id: string) => {
+      itemIdsRef.current = itemIdsRef.current.filter((entry) => entry !== id);
+      memory.patch({ itemsVersion: memory.get().itemsVersion + 1 });
+    },
+    [memory],
+  );
 
   // Auto-play
   React.useEffect(() => {
@@ -197,10 +232,10 @@ export function Carousel({
         // biome-ignore lint/a11y/noNoninteractiveTabindex: Carousel requires focus for keyboard navigation (arrow keys to switch slides)
         tabIndex={0}
         onKeyDown={handleKeyDown}
-        onMouseEnter={() => setIsPaused(true)}
-        onMouseLeave={() => setIsPaused(false)}
-        onFocus={() => setIsPaused(true)}
-        onBlur={() => setIsPaused(false)}
+        onMouseEnter={() => memory.patch({ isPaused: true })}
+        onMouseLeave={() => memory.patch({ isPaused: false })}
+        onFocus={() => memory.patch({ isPaused: true })}
+        onBlur={() => memory.patch({ isPaused: false })}
         data-carousel=""
         data-orientation={orientation}
         className={classy('relative', className)}
@@ -245,11 +280,12 @@ export interface CarouselItemProps extends React.HTMLAttributes<HTMLDivElement> 
 
 export function CarouselItem({ className, children, ...props }: CarouselItemProps) {
   const { registerItem, unregisterItem } = useCarouselContext();
+  const id = React.useId();
 
   React.useEffect(() => {
-    registerItem();
-    return () => unregisterItem();
-  }, [registerItem, unregisterItem]);
+    registerItem(id);
+    return () => unregisterItem(id);
+  }, [registerItem, unregisterItem, id]);
 
   return (
     // biome-ignore lint/a11y/useSemanticElements: role="group" with aria-roledescription="slide" is the standard pattern for carousel slides per WAI-ARIA practices

--- a/packages/ui/test/components/calendar.test.tsx
+++ b/packages/ui/test/components/calendar.test.tsx
@@ -413,17 +413,16 @@ describe('Calendar - Data Attributes', () => {
   });
 });
 
-
-describe("Calendar - navigation state (createMemory migration)", () => {
-  it("advances and rewinds the visible month through the cell", () => {
+describe('Calendar - navigation state (createMemory migration)', () => {
+  it('advances and rewinds the visible month through the cell', () => {
     render(<Calendar defaultMonth={new Date(2024, 5, 15)} />); // June 2024
-    expect(screen.getByText("June 2024")).toBeInTheDocument();
+    expect(screen.getByText('June 2024')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Next month" }));
-    expect(screen.getByText("July 2024")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Next month' }));
+    expect(screen.getByText('July 2024')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Previous month" }));
-    fireEvent.click(screen.getByRole("button", { name: "Previous month" }));
-    expect(screen.getByText("May 2024")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Previous month' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Previous month' }));
+    expect(screen.getByText('May 2024')).toBeInTheDocument();
   });
 });

--- a/packages/ui/test/components/calendar.test.tsx
+++ b/packages/ui/test/components/calendar.test.tsx
@@ -412,3 +412,18 @@ describe('Calendar - Data Attributes', () => {
     expect(screen.getByTestId('calendar')).toHaveAttribute('data-calendar');
   });
 });
+
+
+describe("Calendar - navigation state (createMemory migration)", () => {
+  it("advances and rewinds the visible month through the cell", () => {
+    render(<Calendar defaultMonth={new Date(2024, 5, 15)} />); // June 2024
+    expect(screen.getByText("June 2024")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next month" }));
+    expect(screen.getByText("July 2024")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Previous month" }));
+    fireEvent.click(screen.getByRole("button", { name: "Previous month" }));
+    expect(screen.getByText("May 2024")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/test/components/carousel.test.tsx
+++ b/packages/ui/test/components/carousel.test.tsx
@@ -1,5 +1,5 @@
-import { StrictMode } from "react";
 import { fireEvent, render, screen } from '@testing-library/react';
+import { StrictMode } from 'react';
 import { describe, expect, it } from 'vitest';
 import {
   Carousel,
@@ -459,14 +459,13 @@ describe('Carousel - Custom Button Content', () => {
   });
 });
 
-
-describe("Carousel - registration (createMemory migration)", () => {
+describe('Carousel - registration (createMemory migration)', () => {
   function ItemCountProbe() {
     const { totalItems } = useCarousel();
     return <span data-testid="item-count">{totalItems}</span>;
   }
 
-  it("counts each item exactly once under StrictMode (idempotent register-by-id)", () => {
+  it('counts each item exactly once under StrictMode (idempotent register-by-id)', () => {
     render(
       <StrictMode>
         <Carousel>
@@ -480,10 +479,10 @@ describe("Carousel - registration (createMemory migration)", () => {
       </StrictMode>,
     );
     // StrictMode double-invokes mount effects; idempotent register must not double-count.
-    expect(screen.getByTestId("item-count").textContent).toBe("3");
+    expect(screen.getByTestId('item-count').textContent).toBe('3');
   });
 
-  it("recomputes the count when the item set changes (itemsVersion bump)", () => {
+  it('recomputes the count when the item set changes (itemsVersion bump)', () => {
     const { rerender } = render(
       <Carousel>
         <CarouselContent>
@@ -493,7 +492,7 @@ describe("Carousel - registration (createMemory migration)", () => {
         <ItemCountProbe />
       </Carousel>,
     );
-    expect(screen.getByTestId("item-count").textContent).toBe("2");
+    expect(screen.getByTestId('item-count').textContent).toBe('2');
     rerender(
       <Carousel>
         <CarouselContent>
@@ -504,6 +503,6 @@ describe("Carousel - registration (createMemory migration)", () => {
         <ItemCountProbe />
       </Carousel>,
     );
-    expect(screen.getByTestId("item-count").textContent).toBe("3");
+    expect(screen.getByTestId('item-count').textContent).toBe('3');
   });
 });

--- a/packages/ui/test/components/carousel.test.tsx
+++ b/packages/ui/test/components/carousel.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from "react";
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import {
@@ -455,5 +456,54 @@ describe('Carousel - Custom Button Content', () => {
     );
 
     expect(screen.getByTestId('next')).toHaveTextContent('Forward');
+  });
+});
+
+
+describe("Carousel - registration (createMemory migration)", () => {
+  function ItemCountProbe() {
+    const { totalItems } = useCarousel();
+    return <span data-testid="item-count">{totalItems}</span>;
+  }
+
+  it("counts each item exactly once under StrictMode (idempotent register-by-id)", () => {
+    render(
+      <StrictMode>
+        <Carousel>
+          <CarouselContent>
+            <CarouselItem>Slide 1</CarouselItem>
+            <CarouselItem>Slide 2</CarouselItem>
+            <CarouselItem>Slide 3</CarouselItem>
+          </CarouselContent>
+          <ItemCountProbe />
+        </Carousel>
+      </StrictMode>,
+    );
+    // StrictMode double-invokes mount effects; idempotent register must not double-count.
+    expect(screen.getByTestId("item-count").textContent).toBe("3");
+  });
+
+  it("recomputes the count when the item set changes (itemsVersion bump)", () => {
+    const { rerender } = render(
+      <Carousel>
+        <CarouselContent>
+          <CarouselItem>Slide 1</CarouselItem>
+          <CarouselItem>Slide 2</CarouselItem>
+        </CarouselContent>
+        <ItemCountProbe />
+      </Carousel>,
+    );
+    expect(screen.getByTestId("item-count").textContent).toBe("2");
+    rerender(
+      <Carousel>
+        <CarouselContent>
+          <CarouselItem>Slide 1</CarouselItem>
+          <CarouselItem>Slide 2</CarouselItem>
+          <CarouselItem>Slide 3</CarouselItem>
+        </CarouselContent>
+        <ItemCountProbe />
+      </Carousel>,
+    );
+    expect(screen.getByTestId("item-count").textContent).toBe("3");
   });
 });


### PR DESCRIPTION
Closes #1705.

Migrates the navigation/transient state of carousel and calendar (both React-only) onto the `createMemory` reactive cell, consumed via `useMemory`. No behavior change -- pure state plumbing.

## carousel (`carousel.tsx`)
- `currentIndex` and `isPaused` now live in a per-instance `createMemory<CarouselState>` cell (stable lazy initializer via `useState(() => createMemory(...))`). `scrollPrevious`/`scrollNext`/`scrollTo` and the mouse/focus pause handlers call `memory.patch`.
- The item count is a bottom-up child registry held in a `useRef<string[]>`; register/unregister bump an `itemsVersion` integer in the cell rather than storing the array/count in the cell, scoping re-renders (per migration LEARNINGS). Each `CarouselItem` registers under a `useId()`; registration is idempotent-by-id (filter-then-set) so StrictMode's double-invoked mount effect does not double-count.
- `canScrollPrevious`/`canScrollNext` stay derived (computed in render from `currentIndex` + the live ref count), not stored.
- The autoplay effect reads `isPaused` from the cell.

## calendar (`calendar.tsx`)
- `currentMonth` and `focusedDate` move into a per-instance `createMemory<CalendarState>` cell with the same stable-initializer pattern (preserving the original month-resolution logic). `goToPreviousMonth`/`goToNextMonth`, keyboard nav, and the day `onFocus` call `memory.patch` (boundary-crossing keyboard nav patches focus + month in a single patch).
- Selection stays fully controlled -- no selection cell introduced; `selected`/`onSelect` untouched.

## Verification
- `pnpm --filter @rafters/ui typecheck`: green.
- `pnpm --filter @rafters/ui test`: 220 files / 4582 tests pass (6 pre-existing skips; the youtube-embed fetch logs are pre-existing network noise, not failures). Existing carousel and calendar suites pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)