### PR TITLE
feat(ui): migrate resizable panel state onto createMemory (#1698)

### DIFF
--- a/packages/ui/src/components/ui/resizable.test.ts
+++ b/packages/ui/src/components/ui/resizable.test.ts
@@ -1,0 +1,70 @@
+/**
+ * resizable.test.ts - the panels cell behavior extracted onto createMemory.
+ *
+ * These cover the state-plumbing invariants the migration must hold: idempotent
+ * register-by-id (no StrictMode double-invoke duplicates), sequential writes that do
+ * not lose updates, a read-only derived sizes atom, and equality-gated persistence.
+ * Drag interaction and visuals are unchanged and exercised in the browser, not here.
+ */
+import { describe, expect, it } from 'vitest';
+import { createMemory } from '../../primitives/memory';
+import { sizesEqual } from './resizable';
+
+interface PanelData {
+  id: string;
+  size: number;
+}
+
+describe('resizable panels cell', () => {
+  it('idempotent register-by-id: double-invoke yields no duplicate, order stable', () => {
+    const m = createMemory<PanelData[]>(() => []);
+    const register = (p: PanelData) => m.set([...m.get().filter((x) => x.id !== p.id), p]);
+    register({ id: 'a', size: 50 });
+    register({ id: 'a', size: 50 }); // StrictMode double-invoke
+    register({ id: 'b', size: 50 });
+    expect(m.get().map((p) => p.id)).toEqual(['a', 'b']);
+  });
+
+  it('sequential register keeps both (nanostores set is immediate, no lost update)', () => {
+    const m = createMemory<PanelData[]>(() => []);
+    m.set([...m.get(), { id: 'a', size: 50 }]);
+    m.set([...m.get(), { id: 'b', size: 50 }]);
+    expect(m.get().length).toBe(2);
+  });
+
+  it('derive exposes a reactive read-only sizes atom', () => {
+    const m = createMemory<PanelData[]>(() => [{ id: 'a', size: 30 }]);
+    const sizes = m.derive((list) => list.map((p) => p.size));
+    const seen: number[][] = [];
+    sizes.subscribe((s) => seen.push(s));
+    m.set([{ id: 'a', size: 70 }]);
+    expect(seen.at(-1)).toEqual([70]);
+  });
+
+  it('persistence subscriber fires only on size change (equality-gated)', () => {
+    const m = createMemory<PanelData[]>(() => [{ id: 'a', size: 50 }]);
+    const saved: number[][] = [];
+    m.select(
+      (list) => list.map((p) => p.size),
+      (s) => saved.push(s),
+      sizesEqual,
+    );
+    m.set([{ id: 'a', size: 50 }]); // same sizes -> no fire
+    m.set([{ id: 'a', size: 60 }]); // changed -> fire
+    expect(saved).toEqual([[60]]);
+  });
+});
+
+describe('sizesEqual', () => {
+  it('is true for element-wise equal arrays of equal length', () => {
+    expect(sizesEqual([10, 20, 30], [10, 20, 30])).toBe(true);
+  });
+
+  it('is false when lengths differ', () => {
+    expect(sizesEqual([10, 20], [10, 20, 30])).toBe(false);
+  });
+
+  it('is false when any element differs', () => {
+    expect(sizesEqual([10, 20, 30], [10, 25, 30])).toBe(false);
+  });
+});

--- a/packages/ui/src/components/ui/resizable.tsx
+++ b/packages/ui/src/components/ui/resizable.tsx
@@ -31,8 +31,11 @@
  * ```
  */
 
+import type { ReadableAtom } from 'nanostores';
 import * as React from 'react';
+import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
+import { createMemory, type Memory } from '../../primitives/memory';
 import {
   resizableHandleClasses,
   resizableHandleDisabledClasses,
@@ -61,11 +64,23 @@ interface PanelData {
   collapsedSize: number;
 }
 
+/**
+ * Shallow equality for the persisted sizes slice. The persistence subscriber selects
+ * `list.map((p) => p.size)` - a fresh array on every change - so the default `Object.is`
+ * gate would never dedupe. This compares element-wise so saveSizes fires only when a
+ * size actually changes, not on unrelated panel mutations.
+ */
+export function sizesEqual(a: number[], b: number[]): boolean {
+  return a.length === b.length && a.every((size, index) => size === b[index]);
+}
+
 // ==================== Context ====================
 
 interface ResizableContextValue {
   direction: Direction;
   panels: PanelData[];
+  /** Read-only reactive sizes atom for downstream / imperative consumers. */
+  sizes: ReadableAtom<number[]>;
   registerPanel: (panel: PanelData) => void;
   unregisterPanel: (id: string) => void;
   resizePanels: (handleIndex: number, delta: number) => void;
@@ -103,163 +118,172 @@ export function ResizablePanelGroup({
   children,
   ...props
 }: ResizablePanelGroupProps) {
-  const [panels, setPanels] = React.useState<PanelData[]>([]);
+  // Panel state lives in a per-instance createMemory cell (factory form for a clean
+  // reset). React subscribes via useMemory; actions read/replace the cell directly.
+  const panelsRef = React.useRef<Memory<PanelData[]> | null>(null);
+  if (panelsRef.current === null) {
+    panelsRef.current = createMemory<PanelData[]>(() => []);
+  }
+  const panelsMemory = panelsRef.current;
+  const panels = useMemory(panelsMemory);
+
+  // Read-only sizes atom for downstream / imperative consumers (created once).
+  const sizesRef = React.useRef<ReadableAtom<number[]> | null>(null);
+  if (sizesRef.current === null) {
+    sizesRef.current = panelsMemory.derive((list) => list.map((p) => p.size));
+  }
+  const sizes = sizesRef.current;
+
   const [handleIds, setHandleIds] = React.useState<string[]>([]);
 
-  // Load saved sizes from localStorage
+  // Load saved sizes from localStorage, then persist via an equality-gated subscriber.
+  // Persistence is no longer inlined into the action callbacks; the cell is the single
+  // source of truth and the subscriber fires only when a size actually changes.
   React.useEffect(() => {
     if (!autoSaveId || typeof window === 'undefined') return;
 
     const saved = localStorage.getItem(`resizable:${autoSaveId}`);
     if (saved) {
       try {
-        const sizes = JSON.parse(saved) as number[];
-        setPanels((prev) =>
-          prev.map((panel, i) => ({
+        const savedSizes = JSON.parse(saved) as number[];
+        panelsMemory.set(
+          panelsMemory.get().map((panel, i) => ({
             ...panel,
-            size: sizes[i] ?? panel.size,
+            size: savedSizes[i] ?? panel.size,
           })),
         );
       } catch {
         // Invalid data, ignore
       }
     }
-  }, [autoSaveId]);
 
-  // Save sizes to localStorage
-  const saveSizes = React.useCallback(
-    (newPanels: PanelData[]) => {
-      if (!autoSaveId || typeof window === 'undefined') return;
-      const sizes = newPanels.map((p) => p.size);
-      localStorage.setItem(`resizable:${autoSaveId}`, JSON.stringify(sizes));
+    return panelsMemory.select(
+      (list) => list.map((p) => p.size),
+      (nextSizes) => {
+        localStorage.setItem(`resizable:${autoSaveId}`, JSON.stringify(nextSizes));
+      },
+      sizesEqual,
+    );
+  }, [autoSaveId, panelsMemory]);
+
+  // Idempotent register-by-id: drop any existing entry, then append. Calling this twice
+  // for the same id (StrictMode double-invocation) yields one entry, never a duplicate.
+  const registerPanel = React.useCallback(
+    (panel: PanelData) => {
+      const rest = panelsMemory.get().filter((p) => p.id !== panel.id);
+      panelsMemory.set([...rest, panel]);
     },
-    [autoSaveId],
+    [panelsMemory],
   );
 
-  const registerPanel = React.useCallback((panel: PanelData) => {
-    setPanels((prev) => {
-      // Don't duplicate
-      if (prev.some((p) => p.id === panel.id)) {
-        return prev.map((p) => (p.id === panel.id ? panel : p));
-      }
-      return [...prev, panel];
-    });
-  }, []);
-
-  const unregisterPanel = React.useCallback((id: string) => {
-    setPanels((prev) => prev.filter((p) => p.id !== id));
-  }, []);
+  const unregisterPanel = React.useCallback(
+    (id: string) => {
+      panelsMemory.set(panelsMemory.get().filter((p) => p.id !== id));
+    },
+    [panelsMemory],
+  );
 
   const resizePanels = React.useCallback(
     (handleIndex: number, delta: number) => {
-      setPanels((prev) => {
-        const panelBefore = prev[handleIndex];
-        const panelAfter = prev[handleIndex + 1];
+      const prev = panelsMemory.get();
+      const panelBefore = prev[handleIndex];
+      const panelAfter = prev[handleIndex + 1];
 
-        if (!panelBefore || !panelAfter) return prev;
+      if (!panelBefore || !panelAfter) return;
 
-        // Calculate new sizes
-        let newSizeBefore = panelBefore.size + delta;
-        let newSizeAfter = panelAfter.size - delta;
+      // Calculate new sizes
+      let newSizeBefore = panelBefore.size + delta;
+      let newSizeAfter = panelAfter.size - delta;
 
-        // Apply constraints
-        if (newSizeBefore < panelBefore.minSize) {
-          const diff = panelBefore.minSize - newSizeBefore;
-          newSizeBefore = panelBefore.minSize;
-          newSizeAfter -= diff;
-        }
+      // Apply constraints
+      if (newSizeBefore < panelBefore.minSize) {
+        const diff = panelBefore.minSize - newSizeBefore;
+        newSizeBefore = panelBefore.minSize;
+        newSizeAfter -= diff;
+      }
 
-        if (newSizeAfter < panelAfter.minSize) {
-          const diff = panelAfter.minSize - newSizeAfter;
-          newSizeAfter = panelAfter.minSize;
-          newSizeBefore -= diff;
-        }
+      if (newSizeAfter < panelAfter.minSize) {
+        const diff = panelAfter.minSize - newSizeAfter;
+        newSizeAfter = panelAfter.minSize;
+        newSizeBefore -= diff;
+      }
 
-        if (newSizeBefore > panelBefore.maxSize) {
-          newSizeBefore = panelBefore.maxSize;
-        }
+      if (newSizeBefore > panelBefore.maxSize) {
+        newSizeBefore = panelBefore.maxSize;
+      }
 
-        if (newSizeAfter > panelAfter.maxSize) {
-          newSizeAfter = panelAfter.maxSize;
-        }
+      if (newSizeAfter > panelAfter.maxSize) {
+        newSizeAfter = panelAfter.maxSize;
+      }
 
-        const newPanels = prev.map((p, i) => {
-          if (i === handleIndex) return { ...p, size: newSizeBefore, collapsed: false };
-          if (i === handleIndex + 1) return { ...p, size: newSizeAfter, collapsed: false };
-          return p;
-        });
-
-        onLayout?.(newPanels.map((p) => p.size));
-        saveSizes(newPanels);
-
-        return newPanels;
+      const newPanels = prev.map((p, i) => {
+        if (i === handleIndex) return { ...p, size: newSizeBefore, collapsed: false };
+        if (i === handleIndex + 1) return { ...p, size: newSizeAfter, collapsed: false };
+        return p;
       });
+
+      onLayout?.(newPanels.map((p) => p.size));
+      panelsMemory.set(newPanels);
     },
-    [onLayout, saveSizes],
+    [onLayout, panelsMemory],
   );
 
   const collapsePanel = React.useCallback(
     (id: string) => {
-      setPanels((prev) => {
-        const panelIndex = prev.findIndex((p) => p.id === id);
-        if (panelIndex === -1) return prev;
+      const prev = panelsMemory.get();
+      const panelIndex = prev.findIndex((p) => p.id === id);
+      if (panelIndex === -1) return;
 
-        const panel = prev[panelIndex];
-        if (!panel || !panel.collapsible || panel.collapsed) return prev;
+      const panel = prev[panelIndex];
+      if (!panel || !panel.collapsible || panel.collapsed) return;
 
-        // Find adjacent panel to take the space
-        const adjacentIndex = panelIndex === 0 ? 1 : panelIndex - 1;
-        const adjacent = prev[adjacentIndex];
-        if (!adjacent) return prev;
+      // Find adjacent panel to take the space
+      const adjacentIndex = panelIndex === 0 ? 1 : panelIndex - 1;
+      const adjacent = prev[adjacentIndex];
+      if (!adjacent) return;
 
-        const sizeToGive = panel.size - panel.collapsedSize;
+      const sizeToGive = panel.size - panel.collapsedSize;
 
-        const newPanels = prev.map((p, i) => {
-          if (i === panelIndex) return { ...p, size: p.collapsedSize, collapsed: true };
-          if (i === adjacentIndex) return { ...p, size: p.size + sizeToGive };
-          return p;
-        });
-
-        onLayout?.(newPanels.map((p) => p.size));
-        saveSizes(newPanels);
-
-        return newPanels;
+      const newPanels = prev.map((p, i) => {
+        if (i === panelIndex) return { ...p, size: p.collapsedSize, collapsed: true };
+        if (i === adjacentIndex) return { ...p, size: p.size + sizeToGive };
+        return p;
       });
+
+      onLayout?.(newPanels.map((p) => p.size));
+      panelsMemory.set(newPanels);
     },
-    [onLayout, saveSizes],
+    [onLayout, panelsMemory],
   );
 
   const expandPanel = React.useCallback(
     (id: string) => {
-      setPanels((prev) => {
-        const panelIndex = prev.findIndex((p) => p.id === id);
-        if (panelIndex === -1) return prev;
+      const prev = panelsMemory.get();
+      const panelIndex = prev.findIndex((p) => p.id === id);
+      if (panelIndex === -1) return;
 
-        const panel = prev[panelIndex];
-        if (!panel || !panel.collapsed) return prev;
+      const panel = prev[panelIndex];
+      if (!panel || !panel.collapsed) return;
 
-        // Find adjacent panel to take space from
-        const adjacentIndex = panelIndex === 0 ? 1 : panelIndex - 1;
-        const adjacent = prev[adjacentIndex];
-        if (!adjacent) return prev;
+      // Find adjacent panel to take space from
+      const adjacentIndex = panelIndex === 0 ? 1 : panelIndex - 1;
+      const adjacent = prev[adjacentIndex];
+      if (!adjacent) return;
 
-        // Restore to default size (use minSize as baseline)
-        const targetSize = Math.max(panel.minSize, 20); // Reasonable default
-        const sizeToTake = targetSize - panel.collapsedSize;
+      // Restore to default size (use minSize as baseline)
+      const targetSize = Math.max(panel.minSize, 20); // Reasonable default
+      const sizeToTake = targetSize - panel.collapsedSize;
 
-        const newPanels = prev.map((p, i) => {
-          if (i === panelIndex) return { ...p, size: targetSize, collapsed: false };
-          if (i === adjacentIndex) return { ...p, size: Math.max(p.minSize, p.size - sizeToTake) };
-          return p;
-        });
-
-        onLayout?.(newPanels.map((p) => p.size));
-        saveSizes(newPanels);
-
-        return newPanels;
+      const newPanels = prev.map((p, i) => {
+        if (i === panelIndex) return { ...p, size: targetSize, collapsed: false };
+        if (i === adjacentIndex) return { ...p, size: Math.max(p.minSize, p.size - sizeToTake) };
+        return p;
       });
+
+      onLayout?.(newPanels.map((p) => p.size));
+      panelsMemory.set(newPanels);
     },
-    [onLayout, saveSizes],
+    [onLayout, panelsMemory],
   );
 
   const registerHandle = React.useCallback((id: string) => {
@@ -293,6 +317,7 @@ export function ResizablePanelGroup({
     () => ({
       direction,
       panels,
+      sizes,
       registerPanel,
       unregisterPanel,
       resizePanels,
@@ -306,6 +331,7 @@ export function ResizablePanelGroup({
     [
       direction,
       panels,
+      sizes,
       registerPanel,
       unregisterPanel,
       resizePanels,


### PR DESCRIPTION
Closes #1698. Part of epic #1690.

## What changed

`packages/ui/src/components/ui/resizable.tsx`:
- Replaced the per-instance `useState<PanelData[]>` with a `createMemory<PanelData[]>(() => [])` cell held in a ref (factory form for a clean reset). React subscribes via `useMemory`; the action callbacks read/replace the cell directly with `panels.get()`/`panels.set()`.
- `registerPanel` is now idempotent by id (filter-then-append): calling it twice for the same id yields one entry, defeating StrictMode double-invocation duplicates. Order stays stable across distinct ids.
- `resizePanels`/`collapsePanel`/`expandPanel` update the cell by id and no longer inline `saveSizes`.
- localStorage persistence is now a single equality-gated `panels.select(list => list.map(p => p.size), saveSizes, sizesEqual)` subscriber, set up alongside the initial load in one effect. It fires only when a size actually changes.
- Exposed a read-only derived sizes atom (`panels.derive(list => list.map(p => p.size))`) on the context for downstream/imperative consumers.
- `isDragging` (per-handle) and `handleIds` remain local per-instance state, unchanged.
- Added exported `sizesEqual` shallow-array equality helper (the selected sizes slice is a fresh array each change, so the default `Object.is` gate would never dedupe).

`packages/ui/src/components/ui/resizable.test.ts` (new): covers idempotent register-by-id, sequential writes with no lost update, the reactive derived sizes atom, and equality-gated persistence, plus `sizesEqual`.

No `resizable.astro` exists and the Web Component port is out of scope (#1335). No behavior change beyond state plumbing; drag interaction and visuals unchanged.

## Verification
- `pnpm --filter @rafters/ui typecheck` green.
- `pnpm --filter @rafters/ui test` green (221 files, 4589 passed).
- `biome check` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)