### PR TITLE
feat(ui): migrate select onto createSelect controller (#1696)

### DIFF
--- a/packages/ui/src/components/ui/select.controller.test.ts
+++ b/packages/ui/src/components/ui/select.controller.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSelect } from './select.controller';
+
+describe('createSelect', () => {
+  it('single-select value replaces; selectValue fires onValueChange and closes', () => {
+    const onValueChange = vi.fn();
+    const c = createSelect({ initialOpen: true, onValueChange });
+    c.selectValue('banana');
+    expect(c.group.get()).toEqual(['banana']);
+    expect(onValueChange).toHaveBeenCalledWith('banana');
+    expect(c.cell.get().open).toBe(false);
+  });
+
+  it('replaces the previous value (single-select semantics)', () => {
+    const c = createSelect({ initialValue: 'apple' });
+    expect(c.group.get()).toEqual(['apple']);
+    c.selectValue('banana');
+    expect(c.group.get()).toEqual(['banana']);
+  });
+
+  it('setValue is programmatic (no callback) - controlled-sync path', () => {
+    const onValueChange = vi.fn();
+    const c2 = createSelect({ onValueChange });
+    onValueChange.mockClear();
+    c2.setValue('apple');
+    expect(c2.group.get()).toEqual(['apple']);
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it('setOpen(false) clears highlight (ported handleOpenChange reset)', () => {
+    const c3 = createSelect({ initialOpen: true });
+    c3.setHighlighted('cherry');
+    c3.setOpen(false);
+    expect(c3.cell.get().highlightedValue).toBeUndefined();
+  });
+
+  it('setOpen fires onOpenChange', () => {
+    const onOpenChange = vi.fn();
+    const c = createSelect({ onOpenChange });
+    c.setOpen(true);
+    c.setOpen(false);
+    expect(onOpenChange.mock.calls).toEqual([[true], [false]]);
+  });
+
+  it('selectValue also fires onOpenChange(false) on close', () => {
+    const onOpenChange = vi.fn();
+    const c = createSelect({ initialOpen: true, onOpenChange });
+    c.selectValue('banana');
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('registerLabel bumps labelVersion but does NOT churn open/highlight watchers', () => {
+    const c4 = createSelect();
+    const openFires: boolean[] = [];
+    c4.cell.select(
+      (s) => s.open,
+      (o) => openFires.push(o),
+    );
+    c4.registerLabel('a', 'Apple');
+    c4.registerLabel('b', 'Banana');
+    expect(c4.getLabel('b')).toBe('Banana');
+    expect(c4.cell.get().labelVersion).toBe(2);
+    expect(openFires).toEqual([]); // label mounts never re-render open consumers
+  });
+
+  it('registerLabel is idempotent - no bump when label is unchanged', () => {
+    const c = createSelect();
+    c.registerLabel('a', 'Apple');
+    c.registerLabel('a', 'Apple');
+    expect(c.cell.get().labelVersion).toBe(1);
+  });
+
+  it('getLabel returns undefined for unregistered values', () => {
+    const c = createSelect();
+    expect(c.getLabel('missing')).toBeUndefined();
+  });
+
+  it('honors initial value and open', () => {
+    const c = createSelect({ initialValue: 'apple', initialOpen: true });
+    expect(c.group.get()).toEqual(['apple']);
+    expect(c.cell.get().open).toBe(true);
+  });
+
+  it('destroy is safe to call', () => {
+    const c = createSelect();
+    expect(() => c.destroy()).not.toThrow();
+  });
+});

--- a/packages/ui/src/components/ui/select.controller.ts
+++ b/packages/ui/src/components/ui/select.controller.ts
@@ -1,0 +1,114 @@
+/**
+ * select.controller.ts - the single source of truth for select *behavior*.
+ *
+ * Anti-drift mechanism: select state is written ONCE here, framework-free. React
+ * (and the pending web component, #1337) render their own markup and delegate runtime
+ * state to createSelect() - so behavior can never diverge between frameworks.
+ *
+ * Thin GLUE that composes existing primitives, not a reimplementation:
+ *   - createSelectionGroup -> the selected VALUE (single-select: select replaces)
+ *   - createMemory cell    -> open + keyboard highlight + a label version counter
+ *
+ * The bottom-up label registry (each item registers its display text on mount, the
+ * trigger's value reads it back) lives in a plain Map behind a `labelVersion` counter
+ * on the cell. Putting the Map itself in the cell would re-render EVERY cell consumer
+ * on every child mount; bumping a counter lets the value display re-render via
+ * `select(s => s.labelVersion, ...)` without churning open/highlight consumers.
+ *
+ * Roving focus and typeahead already compose as their own primitives; the framework
+ * wrapper wires their callbacks to setHighlighted. Floating position, refs, and ids
+ * stay local to the wrapper - they are not state.
+ *
+ * @example
+ * ```ts
+ * const select = createSelect({ initialValue: 'apple', onValueChange: save });
+ * select.setOpen(true);
+ * select.selectValue('banana'); // fires onValueChange, closes, value replaced
+ * select.destroy();
+ * ```
+ */
+import { createMemory, type Memory } from '../../primitives/memory';
+import { createSelectionGroup, type SelectionGroup } from '../../primitives/selection-group';
+
+export interface SelectCellState {
+  open: boolean;
+  highlightedValue: string | undefined;
+  /** Bumped on each registerLabel; labels themselves live in a ref, not the cell. */
+  labelVersion: number;
+}
+
+export interface SelectControllerOptions {
+  initialValue?: string;
+  initialOpen?: boolean;
+  onValueChange?: (value: string) => void;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export interface SelectController {
+  /** Single-select value state. */
+  readonly group: SelectionGroup;
+  /** Open + highlight + label-version cell. */
+  readonly cell: Memory<SelectCellState>;
+  /** Programmatic value set (controlled-sync path). Does NOT fire onValueChange. */
+  setValue(value: string): void;
+  /** User selection: replaces value, fires onValueChange, then closes. */
+  selectValue(value: string): void;
+  /** Set open. Closing also clears the keyboard highlight. Fires onOpenChange. */
+  setOpen(open: boolean): void;
+  /** Set the keyboard-highlighted value. */
+  setHighlighted(value: string | undefined): void;
+  /** Register an item's display label. Bumps labelVersion only when it changes. */
+  registerLabel(value: string, label: string): void;
+  /** Read a registered display label. */
+  getLabel(value: string): string | undefined;
+  /** Tear down (no-op today; present for API symmetry with DOM-bound controllers). */
+  destroy(): void;
+}
+
+export function createSelect(options: SelectControllerOptions = {}): SelectController {
+  const { onValueChange, onOpenChange } = options;
+
+  // Single-select: select() replaces the current value.
+  const group = createSelectionGroup(
+    options.initialValue === undefined ? {} : { initial: options.initialValue },
+  );
+
+  const cell = createMemory<SelectCellState>(() => ({
+    open: options.initialOpen ?? false,
+    highlightedValue: undefined,
+    labelVersion: 0,
+  }));
+
+  // Bottom-up label registry. A plain Map behind labelVersion - see file header.
+  const labels = new Map<string, string>();
+
+  const setOpen = (open: boolean): void => {
+    // Porting handleOpenChange's reset: closing clears the keyboard highlight.
+    cell.patch(open ? { open: true } : { open: false, highlightedValue: undefined });
+    onOpenChange?.(open);
+  };
+
+  return {
+    group,
+    cell,
+    setValue: (value) => {
+      group.select(value);
+    },
+    selectValue: (value) => {
+      group.select(value);
+      onValueChange?.(value);
+      setOpen(false);
+    },
+    setOpen,
+    setHighlighted: (value) => {
+      cell.patch({ highlightedValue: value });
+    },
+    registerLabel: (value, label) => {
+      if (labels.get(value) === label) return;
+      labels.set(value, label);
+      cell.patch({ labelVersion: cell.get().labelVersion + 1 });
+    },
+    getLabel: (value) => labels.get(value),
+    destroy: () => {},
+  };
+}

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -47,9 +47,11 @@ import { createPortal } from 'react-dom';
 import classy from '../../primitives/classy';
 import { computePosition } from '../../primitives/collision-detector';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
+import type { Memory } from '../../primitives/memory';
 import { onPointerDownOutside } from '../../primitives/outside-click';
 import { getPortalContainer } from '../../primitives/portal';
 import { createRovingFocus } from '../../primitives/roving-focus';
+import type { SelectionGroupState } from '../../primitives/selection-group';
 import { mergeProps } from '../../primitives/slot';
 import { createTypeahead } from '../../primitives/typeahead';
 import type { Align, Side } from '../../primitives/types';
@@ -78,24 +80,41 @@ import {
   selectValuePlaceholderClasses,
   selectViewportClasses,
 } from './select.classes';
+import { createSelect, type SelectCellState, type SelectController } from './select.controller';
+
+// ==================== Slice subscription ====================
+
+// Subscribe a component to one slice of a Memory cell. Re-renders only when the
+// selected slice changes (useSyncExternalStore bails out via Object.is), so an
+// open consumer never re-renders on a labelVersion bump and vice versa.
+function useMemorySlice<T, S>(memory: Memory<T>, selector: (value: T) => S): S {
+  const subscribe = React.useCallback(
+    (onStoreChange: () => void) => memory.subscribe(() => onStoreChange()),
+    [memory],
+  );
+  const getSnapshot = React.useCallback(() => selector(memory.get()), [memory, selector]);
+  return React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+const selectOpen = (state: SelectCellState): boolean => state.open;
+const selectHighlighted = (state: SelectCellState): string | undefined => state.highlightedValue;
+const selectLabelVersion = (state: SelectCellState): number => state.labelVersion;
+const selectFirstValue = (state: SelectionGroupState): string | undefined => state.selected[0];
 
 // ==================== Context ====================
 
+// Context carries the framework-free controller plus the static plumbing (ids, refs,
+// disabled, name). Reactive state (open / value / highlight / labels) is read by each
+// leaf via useMemorySlice, so a label registration re-renders SelectValue without
+// churning the open/highlight consumers.
 interface SelectContextValue {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  value: string | undefined;
-  onValueChange: (value: string) => void;
+  controller: SelectController;
   disabled: boolean;
   contentId: string;
   triggerId: string;
   triggerRef: React.RefObject<HTMLButtonElement | null>;
   contentRef: React.RefObject<HTMLDivElement | null>;
   name: string | undefined;
-  highlightedValue: string | undefined;
-  onHighlightChange: (value: string | undefined) => void;
-  registerLabel: (value: string, label: string) => void;
-  getLabel: (value: string) => string | undefined;
 }
 
 const SelectContext = React.createContext<SelectContextValue | null>(null);
@@ -133,63 +152,55 @@ export function Select({
   disabled = false,
   name,
 }: SelectProps) {
-  // Uncontrolled state for value
-  const [uncontrolledValue, setUncontrolledValue] = React.useState(defaultValue);
   const isValueControlled = controlledValue !== undefined;
-  const value = isValueControlled ? controlledValue : uncontrolledValue;
-
-  // Uncontrolled state for open
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
   const isOpenControlled = controlledOpen !== undefined;
-  const open = isOpenControlled ? controlledOpen : uncontrolledOpen;
 
-  // Highlighted item for keyboard navigation
-  const [highlightedValue, setHighlightedValue] = React.useState<string | undefined>(undefined);
+  // Capture the initial value/open once; the controller owns state thereafter.
+  const initialValueRef = React.useRef(isValueControlled ? controlledValue : defaultValue);
+  const initialOpenRef = React.useRef(isOpenControlled ? controlledOpen : defaultOpen);
 
-  // Label registry: maps item values to their display labels.
-  // Uses state so SelectValue re-renders when labels are first registered.
-  const [labelMap, setLabelMap] = React.useState<Map<string, string>>(() => new Map());
+  // Keep the latest callbacks reachable without re-creating the controller.
+  const onValueChangeRef = React.useRef(onValueChange);
+  const onOpenChangeRef = React.useRef(onOpenChange);
+  React.useEffect(() => {
+    onValueChangeRef.current = onValueChange;
+    onOpenChangeRef.current = onOpenChange;
+  });
 
-  const registerLabel = React.useCallback((itemValue: string, label: string) => {
-    setLabelMap((prev) => {
-      if (prev.get(itemValue) === label) return prev;
-      const next = new Map(prev);
-      next.set(itemValue, label);
-      return next;
+  // The framework-free controller is the single source of truth for state. Lazily
+  // created once (no DOM root needed - roving/typeahead are wired as effects below).
+  const controllerRef = React.useRef<SelectController | null>(null);
+  if (controllerRef.current === null) {
+    controllerRef.current = createSelect({
+      // Empty string means "no selection" - omit so the group starts empty.
+      ...(initialValueRef.current === '' ? {} : { initialValue: initialValueRef.current }),
+      initialOpen: initialOpenRef.current,
+      onValueChange: (next) => onValueChangeRef.current?.(next),
+      onOpenChange: (next) => onOpenChangeRef.current?.(next),
     });
-  }, []);
+  }
+  const controller = controllerRef.current;
 
-  const getLabel = React.useCallback(
-    (itemValue: string): string | undefined => {
-      return labelMap.get(itemValue);
-    },
-    [labelMap],
-  );
+  React.useEffect(() => () => controller.destroy(), [controller]);
 
-  const handleValueChange = React.useCallback(
-    (newValue: string) => {
-      if (!isValueControlled) {
-        setUncontrolledValue(newValue);
-      }
-      onValueChange?.(newValue);
-    },
-    [isValueControlled, onValueChange],
-  );
+  // Controlled value: mirror the prop into the group (no callback re-fire).
+  React.useEffect(() => {
+    if (!isValueControlled) return;
+    const next = controlledValue ?? '';
+    if (controller.group.get()[0] !== next) {
+      controller.setValue(next);
+    }
+  }, [isValueControlled, controlledValue, controller]);
 
-  const handleOpenChange = React.useCallback(
-    (newOpen: boolean) => {
-      if (disabled) return;
-      if (!isOpenControlled) {
-        setUncontrolledOpen(newOpen);
-      }
-      onOpenChange?.(newOpen);
-      // Reset highlight when closing
-      if (!newOpen) {
-        setHighlightedValue(undefined);
-      }
-    },
-    [isOpenControlled, onOpenChange, disabled],
-  );
+  // Controlled open: mirror the prop into the cell directly (no onOpenChange re-fire),
+  // preserving the close-clears-highlight reset.
+  React.useEffect(() => {
+    if (!isOpenControlled) return;
+    const next = controlledOpen ?? false;
+    if (controller.cell.get().open !== next) {
+      controller.cell.patch(next ? { open: true } : { open: false, highlightedValue: undefined });
+    }
+  }, [isOpenControlled, controlledOpen, controller]);
 
   // Generate stable IDs
   const id = React.useId();
@@ -202,34 +213,15 @@ export function Select({
 
   const contextValue = React.useMemo(
     () => ({
-      open,
-      onOpenChange: handleOpenChange,
-      value,
-      onValueChange: handleValueChange,
+      controller,
       disabled,
       contentId,
       triggerId,
       triggerRef,
       contentRef,
       name,
-      highlightedValue,
-      onHighlightChange: setHighlightedValue,
-      registerLabel,
-      getLabel,
     }),
-    [
-      open,
-      handleOpenChange,
-      value,
-      handleValueChange,
-      disabled,
-      contentId,
-      triggerId,
-      name,
-      highlightedValue,
-      registerLabel,
-      getLabel,
-    ],
+    [controller, disabled, contentId, triggerId, name],
   );
 
   return <SelectContext.Provider value={contextValue}>{children}</SelectContext.Provider>;
@@ -250,35 +242,28 @@ export function SelectTrigger({
   size = 'default',
   ...props
 }: SelectTriggerProps) {
-  const {
-    open,
-    onOpenChange,
-    disabled,
-    contentId,
-    triggerId,
-    triggerRef,
-    value,
-    onHighlightChange,
-  } = useSelectContext();
+  const { controller, disabled, contentId, triggerId, triggerRef } = useSelectContext();
+  const open = useMemorySlice(controller.cell, selectOpen);
+  const value = useMemorySlice(controller.group.memory, selectFirstValue);
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     props.onClick?.(event);
-    if (!event.defaultPrevented) {
-      onOpenChange(!open);
+    if (!event.defaultPrevented && !disabled) {
+      controller.setOpen(!open);
     }
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
     props.onKeyDown?.(event);
-    if (event.defaultPrevented) return;
+    if (event.defaultPrevented || disabled) return;
 
     // Open on ArrowDown, ArrowUp, Enter, or Space
     if (['ArrowDown', 'ArrowUp', 'Enter', ' '].includes(event.key) && !open) {
       event.preventDefault();
-      onOpenChange(true);
+      controller.setOpen(true);
       // Highlight current value when opening with keyboard
       if (value) {
-        onHighlightChange(value);
+        controller.setHighlighted(value);
       }
     }
   };
@@ -371,12 +356,15 @@ export function SelectValue({
   children,
   ...props
 }: SelectValueProps) {
-  const { value, getLabel } = useSelectContext();
+  const { controller } = useSelectContext();
+  const value = useMemorySlice(controller.group.memory, selectFirstValue);
+  // Re-render when labels are (re)registered without churning open/highlight consumers.
+  useMemorySlice(controller.cell, selectLabelVersion);
 
   // Look up the human-readable label registered by the selected SelectItem.
   // Falls back to the raw value if no label has been registered yet.
   const hasValue = value !== undefined && value !== '';
-  const label = hasValue ? getLabel(value) : undefined;
+  const label = hasValue ? controller.getLabel(value) : undefined;
   const displayValue = label ?? (hasValue ? value : placeholder);
   const isPlaceholder = !hasValue;
 
@@ -410,7 +398,8 @@ export interface SelectPortalProps {
 }
 
 export function SelectPortal({ children, container }: SelectPortalProps) {
-  const { open } = useSelectContext();
+  const { controller } = useSelectContext();
+  const open = useMemorySlice(controller.cell, selectOpen);
   const [mounted, setMounted] = React.useState(false);
 
   React.useEffect(() => {
@@ -449,17 +438,10 @@ export function SelectContent({
   asChild,
   ...props
 }: SelectContentProps) {
-  const {
-    open,
-    onOpenChange,
-    contentId,
-    triggerRef,
-    contentRef,
-    value,
-    onValueChange,
-    onHighlightChange,
-    highlightedValue,
-  } = useSelectContext();
+  const { controller, contentId, triggerRef, contentRef } = useSelectContext();
+  const open = useMemorySlice(controller.cell, selectOpen);
+  const highlightedValue = useMemorySlice(controller.cell, selectHighlighted);
+  const value = useMemorySlice(controller.group.memory, selectFirstValue);
 
   const [positionState, setPositionState] = React.useState<{
     x: number;
@@ -516,12 +498,12 @@ export function SelectContent({
     if (!open) return;
 
     const cleanup = onEscapeKeyDown(() => {
-      onOpenChange(false);
+      controller.setOpen(false);
       triggerRef.current?.focus();
     });
 
     return cleanup;
-  }, [open, onOpenChange, triggerRef]);
+  }, [open, controller, triggerRef]);
 
   // Outside click handler
   React.useEffect(() => {
@@ -532,11 +514,11 @@ export function SelectContent({
       if (triggerRef.current?.contains(target)) {
         return;
       }
-      onOpenChange(false);
+      controller.setOpen(false);
     });
 
     return cleanup;
-  }, [open, onOpenChange, triggerRef, contentRef]);
+  }, [open, controller, triggerRef, contentRef]);
 
   // Roving focus for keyboard navigation
   React.useEffect(() => {
@@ -548,13 +530,13 @@ export function SelectContent({
       onNavigate: (element) => {
         const itemValue = element.getAttribute('data-value');
         if (itemValue) {
-          onHighlightChange(itemValue);
+          controller.setHighlighted(itemValue);
         }
       },
     });
 
     return cleanup;
-  }, [open, contentRef, onHighlightChange]);
+  }, [open, contentRef, controller]);
 
   // Typeahead search
   React.useEffect(() => {
@@ -567,13 +549,13 @@ export function SelectContent({
         item.focus();
         const itemValue = item.getAttribute('data-value');
         if (itemValue) {
-          onHighlightChange(itemValue);
+          controller.setHighlighted(itemValue);
         }
       },
     });
 
     return cleanup;
-  }, [open, contentRef, onHighlightChange]);
+  }, [open, contentRef, controller]);
 
   // Focus first item on open
   React.useEffect(() => {
@@ -603,14 +585,14 @@ export function SelectContent({
         targetItem.focus();
         const itemValue = targetItem.getAttribute('data-value');
         if (itemValue) {
-          onHighlightChange(itemValue);
+          controller.setHighlighted(itemValue);
         }
       }
     };
 
     const frame = requestAnimationFrame(focusInitialItem);
     return () => cancelAnimationFrame(frame);
-  }, [open, contentRef, value, onHighlightChange]);
+  }, [open, contentRef, value, controller]);
 
   // Handle keyboard selection
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -620,8 +602,8 @@ export function SelectContent({
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
       if (highlightedValue) {
-        onValueChange(highlightedValue);
-        onOpenChange(false);
+        // selectValue replaces the value, fires onValueChange, and closes.
+        controller.selectValue(highlightedValue);
         triggerRef.current?.focus();
       }
     }
@@ -802,15 +784,9 @@ export function SelectItem({
   asChild,
   ...props
 }: SelectItemProps) {
-  const {
-    value,
-    onValueChange,
-    onOpenChange,
-    triggerRef,
-    highlightedValue,
-    onHighlightChange,
-    registerLabel,
-  } = useSelectContext();
+  const { controller, triggerRef } = useSelectContext();
+  const value = useMemorySlice(controller.group.memory, selectFirstValue);
+  const highlightedValue = useMemorySlice(controller.cell, selectHighlighted);
 
   const isSelected = value === itemValue;
   const isHighlighted = highlightedValue === itemValue;
@@ -822,7 +798,7 @@ export function SelectItem({
     if (labelTextRef.current) {
       const text = labelTextRef.current.textContent?.trim();
       if (text) {
-        registerLabel(itemValue, text);
+        controller.registerLabel(itemValue, text);
       }
     }
   });
@@ -831,8 +807,8 @@ export function SelectItem({
     props.onClick?.(event);
     if (event.defaultPrevented || disabled) return;
 
-    onValueChange(itemValue);
-    onOpenChange(false);
+    // selectValue replaces the value, fires onValueChange, and closes.
+    controller.selectValue(itemValue);
     triggerRef.current?.focus();
   };
 
@@ -842,15 +818,14 @@ export function SelectItem({
 
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
-      onValueChange(itemValue);
-      onOpenChange(false);
+      controller.selectValue(itemValue);
       triggerRef.current?.focus();
     }
   };
 
   const handlePointerMove = () => {
     if (!disabled && highlightedValue !== itemValue) {
-      onHighlightChange(itemValue);
+      controller.setHighlighted(itemValue);
     }
   };
 


### PR DESCRIPTION
Closes #1696.

## What changed

Adds a framework-free `createSelect` controller (mirroring `tabs.controller.ts`) and migrates the React Select onto it, so the React component and the pending Web Component (#1337) can share one state implementation.

- **`select.controller.ts`** — `createSelect` composes `createSelectionGroup` (single-select value) + a `createMemory` cell holding `{ open, highlightedValue, labelVersion }`. The bottom-up label registry is a plain `Map` behind a `labelVersion` counter so registrations re-render only the value display, not every cell consumer.
  - `setValue` = programmatic value sync (no `onValueChange`); `selectValue` = user action (fires `onValueChange`, then closes).
  - `setOpen(false)` clears `highlightedValue` (ported `handleOpenChange` reset) and fires `onOpenChange`.
  - `registerLabel` is idempotent — bumps `labelVersion` only when the label changes (prevents render loops, since the item effect runs every render).
- **`select.controller.test.ts`** — 11 vitest cases covering the issue's required assertions plus single-select replace, idempotent registerLabel, and open-callback firing.
- **`select.tsx`** — removed the four root `useState` (value/open/highlight/labelMap). Context now carries the controller + static plumbing (ids/refs/disabled/name). Each leaf subscribes to just the slice it needs via a local `useMemorySlice` (useSyncExternalStore), so SelectValue re-renders on `labelVersion` without churning open/highlight consumers. Controlled value/open mirror props into the controller without re-firing callbacks. `positionState`, refs, and ids stay local. No Web Component / Astro port (out of scope; #1337).

## How verified

- `pnpm --filter @rafters/ui typecheck` — clean.
- `pnpm --filter @rafters/ui test` — 221 files / 4593 passed (incl. 11 new controller tests).
- Biome clean on the three changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)