### PR TITLE
feat(ui): toggle-group + radio-group delegate to createSelectionGroup controllers (#1703)

### DIFF
--- a/packages/ui/src/components/ui/radio-group.classes.ts
+++ b/packages/ui/src/components/ui/radio-group.classes.ts
@@ -18,3 +18,12 @@ export const radioGroupItemBaseClasses =
   'disabled:cursor-not-allowed disabled:opacity-50';
 
 export const radioGroupItemIndicatorClasses = 'block h-2 w-2 rounded-full bg-current';
+
+// State-driven indicator visibility: the controller toggles data-state=checked|unchecked
+// on each item button (marked `group`), so the dot shows only when checked - no
+// conditional rendering. The compound `group-data-[state=unchecked]` selector outranks
+// the indicator's own `block`, so the dot hides reliably when unchecked. The web
+// component renders the dot only when checked and is intentionally left untouched.
+export const radioGroupItemGroupClass = 'group';
+
+export const radioGroupItemIndicatorStateClasses = 'group-data-[state=unchecked]:hidden';

--- a/packages/ui/src/components/ui/radio-group.controller.test.ts
+++ b/packages/ui/src/components/ui/radio-group.controller.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for createRadioGroup - the framework-free behavior controller.
+ *
+ * Mirrors selection-group.test.ts: drives a real (happy-dom) DOM root with
+ * [role="radio"][data-value] buttons and asserts single-select (non-collapsible)
+ * semantics, ARIA / data-state reflection, onChange firing on user interaction
+ * only, and that setValue is a silent programmatic write.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { createRadioGroup } from './radio-group.controller';
+
+function mountRadioGroup(values: string[]): HTMLElement {
+  const root = document.createElement('div');
+  root.setAttribute('role', 'radiogroup');
+  for (const value of values) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.setAttribute('role', 'radio');
+    button.setAttribute('data-value', value);
+    const indicator = document.createElement('span');
+    indicator.setAttribute('data-radio-indicator', '');
+    button.appendChild(indicator);
+    root.appendChild(button);
+  }
+  document.body.appendChild(root);
+  return root;
+}
+
+function radioFor(root: HTMLElement, value: string): HTMLButtonElement {
+  const button = root.querySelector<HTMLButtonElement>(`[data-value="${value}"]`);
+  if (!button) throw new Error(`no radio for ${value}`);
+  return button;
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('createRadioGroup', () => {
+  it('re-selecting a radio does NOT deselect it', () => {
+    const r = createRadioGroup(mountRadioGroup(['x', 'y']), { initial: 'x' });
+    r.group.toggle('x');
+    expect(r.group.get()).toEqual(['x']);
+  });
+
+  it('select switches the active value', () => {
+    const r = createRadioGroup(mountRadioGroup(['x', 'y']), { initial: 'x' });
+    r.group.select('y');
+    expect(r.group.get()).toEqual(['y']);
+  });
+
+  it('reflects aria-checked and data-state on items', () => {
+    const root = mountRadioGroup(['x', 'y']);
+    const r = createRadioGroup(root, { initial: 'x' });
+    expect(radioFor(root, 'x').getAttribute('aria-checked')).toBe('true');
+    expect(radioFor(root, 'x').getAttribute('data-state')).toBe('checked');
+    expect(radioFor(root, 'y').getAttribute('aria-checked')).toBe('false');
+    expect(radioFor(root, 'y').getAttribute('data-state')).toBe('unchecked');
+    r.group.select('y');
+    expect(radioFor(root, 'x').getAttribute('data-state')).toBe('unchecked');
+    expect(radioFor(root, 'y').getAttribute('data-state')).toBe('checked');
+  });
+
+  it("treats a '' initial as nothing selected", () => {
+    const r = createRadioGroup(mountRadioGroup(['x', 'y']), { initial: '' });
+    expect(r.group.get()).toEqual([]);
+  });
+
+  describe('click + keyboard selection', () => {
+    it('click selects and fires onChange', () => {
+      const root = mountRadioGroup(['x', 'y']);
+      const seen: string[] = [];
+      createRadioGroup(root, { onChange: (v) => seen.push(v) });
+      radioFor(root, 'y').click();
+      expect(seen).toEqual(['y']);
+    });
+
+    it('Space selects the focused radio', () => {
+      const root = mountRadioGroup(['x', 'y']);
+      const r = createRadioGroup(root);
+      const y = radioFor(root, 'y');
+      y.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+      expect(r.group.get()).toEqual(['y']);
+    });
+
+    it('Enter selects the focused radio', () => {
+      const root = mountRadioGroup(['x', 'y']);
+      const r = createRadioGroup(root);
+      const x = radioFor(root, 'x');
+      x.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      expect(r.group.get()).toEqual(['x']);
+    });
+
+    it('ignores clicks on disabled radios', () => {
+      const root = mountRadioGroup(['x']);
+      radioFor(root, 'x').disabled = true;
+      const r = createRadioGroup(root);
+      radioFor(root, 'x').click();
+      expect(r.group.get()).toEqual([]);
+    });
+  });
+
+  describe('setValue (programmatic)', () => {
+    it('does not fire onChange', () => {
+      const root = mountRadioGroup(['x', 'y']);
+      const seen: string[] = [];
+      const r = createRadioGroup(root, { onChange: (v) => seen.push(v) });
+      r.setValue('y');
+      expect(r.group.get()).toEqual(['y']);
+      expect(seen).toEqual([]);
+    });
+
+    it('clears with an empty string', () => {
+      const root = mountRadioGroup(['x', 'y']);
+      const r = createRadioGroup(root, { initial: 'x' });
+      r.setValue('');
+      expect(r.group.get()).toEqual([]);
+    });
+  });
+
+  describe('destroy', () => {
+    it('stops reflecting after teardown', () => {
+      const root = mountRadioGroup(['x']);
+      const r = createRadioGroup(root);
+      r.destroy();
+      radioFor(root, 'x').click();
+      expect(r.group.get()).toEqual([]);
+    });
+  });
+});

--- a/packages/ui/src/components/ui/radio-group.controller.ts
+++ b/packages/ui/src/components/ui/radio-group.controller.ts
@@ -1,0 +1,121 @@
+/**
+ * radio-group.controller.ts - the single source of truth for radio-group *behavior*.
+ *
+ * Anti-drift: written once, framework-free, against a DOM root. React, Astro, and the
+ * web component render their own markup and delegate to createRadioGroup(root) - so
+ * behavior can never diverge between frameworks. Thin GLUE that composes existing
+ * primitives, not a reimplementation:
+ *   - createSelectionGroup -> single-select state, NOT collapsible (a radio cannot be
+ *                             deselected by re-clicking it)
+ *   - createRovingFocus    -> arrow / Home / End navigation + roving tabindex
+ * The controller only adds click/Space/Enter selection and ARIA/data-state reflection.
+ *
+ * Markup contract (each framework renders this, controller drives it):
+ *   - items:     [role="radio"][data-value]  (buttons inside the [role="radiogroup"] root)
+ *   - indicator: [data-radio-indicator]      (a child of each item; shown via data-state CSS)
+ *
+ * @example
+ * ```ts
+ * const rg = createRadioGroup(rootEl, { initial: 'a', onChange: (v) => save(v) });
+ * rg.setValue('b'); // programmatic (no onChange)
+ * rg.destroy();
+ * ```
+ */
+import { createRovingFocus } from '../../primitives/roving-focus';
+import { createSelectionGroup, type SelectionGroup } from '../../primitives/selection-group';
+import type { CleanupFunction } from '../../primitives/types';
+
+export interface RadioGroupControllerOptions {
+  /** Initially selected value. A '' value is treated as nothing selected. */
+  initial?: string;
+  /** Arrow-key navigation axis. Default 'vertical'. */
+  orientation?: 'horizontal' | 'vertical';
+  /** Called when the selection changes via user interaction (not programmatic setValue). */
+  onChange?: (value: string) => void;
+}
+
+export interface RadioGroupController {
+  /** The underlying selection state cell. */
+  readonly group: SelectionGroup;
+  /** Programmatically set the selected value. Does NOT fire onChange (for controlled sync). */
+  setValue(value: string): void;
+  /** Tear down listeners and subscriptions. */
+  destroy: CleanupFunction;
+}
+
+export function createRadioGroup(
+  root: HTMLElement,
+  options: RadioGroupControllerOptions = {},
+): RadioGroupController {
+  const { orientation = 'vertical', onChange } = options;
+  const initial =
+    options.initial !== undefined && options.initial !== '' ? options.initial : undefined;
+  // Single mode, NOT collapsible: re-selecting a radio keeps it selected.
+  const group = createSelectionGroup(initial === undefined ? {} : { initial });
+
+  const radios = (): HTMLElement[] =>
+    Array.from(root.querySelectorAll<HTMLElement>('[role="radio"][data-value]'));
+
+  // Reflect selection onto the DOM. roving-focus owns tabindex; this owns
+  // aria-checked / data-state and indicator visibility. Fires immediately.
+  const unsubscribe = group.subscribe((selected) => {
+    for (const radio of radios()) {
+      const on = radio.dataset.value !== undefined && selected.includes(radio.dataset.value);
+      radio.setAttribute('aria-checked', String(on));
+      radio.setAttribute('data-state', on ? 'checked' : 'unchecked');
+    }
+  });
+
+  const select = (value: string): void => {
+    group.select(value);
+    onChange?.(value);
+  };
+
+  // Arrow / Home / End navigation + roving tabindex via the shared primitive.
+  // Start focus on the checked radio so Tab enters at the active choice.
+  const focusable = Array.from(
+    root.querySelectorAll<HTMLElement>('[role="radio"]:not([disabled])'),
+  );
+  const startIndex = Math.max(
+    0,
+    focusable.findIndex((radio) => radio.dataset.value === group.get()[0]),
+  );
+  const stopRoving = createRovingFocus(root, { orientation, loop: true, currentIndex: startIndex });
+
+  const onClick = (event: MouseEvent): void => {
+    const radio = (event.target as HTMLElement).closest<HTMLElement>(
+      '[role="radio"][data-value]:not([disabled])',
+    );
+    if (radio?.dataset.value !== undefined && root.contains(radio)) {
+      select(radio.dataset.value);
+    }
+  };
+
+  // Space / Enter select the focused radio (roving-focus owns arrow keys).
+  const onKeyDown = (event: KeyboardEvent): void => {
+    if (event.key !== ' ' && event.key !== 'Enter') return;
+    const radio = (event.target as HTMLElement).closest<HTMLElement>(
+      '[role="radio"][data-value]:not([disabled])',
+    );
+    if (radio?.dataset.value !== undefined && root.contains(radio)) {
+      event.preventDefault();
+      select(radio.dataset.value);
+    }
+  };
+
+  root.addEventListener('click', onClick);
+  root.addEventListener('keydown', onKeyDown);
+
+  return {
+    group,
+    setValue: (value) => {
+      group.set(value === '' ? [] : [value]);
+    },
+    destroy: () => {
+      unsubscribe();
+      stopRoving();
+      root.removeEventListener('click', onClick);
+      root.removeEventListener('keydown', onKeyDown);
+    },
+  };
+}

--- a/packages/ui/src/components/ui/radio-group.tsx
+++ b/packages/ui/src/components/ui/radio-group.tsx
@@ -31,13 +31,15 @@
 
 import * as React from 'react';
 import classy from '../../primitives/classy';
-import { createRovingFocus } from '../../primitives/roving-focus';
 import {
   radioGroupHorizontalClasses,
   radioGroupItemBaseClasses,
+  radioGroupItemGroupClass,
   radioGroupItemIndicatorClasses,
+  radioGroupItemIndicatorStateClasses,
   radioGroupVerticalClasses,
 } from './radio-group.classes';
+import { createRadioGroup, type RadioGroupController } from './radio-group.controller';
 
 // ==================== Types ====================
 
@@ -61,11 +63,11 @@ export interface RadioGroupItemProps extends React.ButtonHTMLAttributes<HTMLButt
 
 // ==================== Context ====================
 
+// Context carries only group-level presentation (disabled) and the generated radio
+// `name` for native grouping. Selection state and keyboard behavior live in the
+// controller, so no value/dispatch is threaded.
 interface RadioGroupContextValue {
-  value: string;
-  onValueChange: (value: string) => void;
   disabled: boolean;
-  orientation: 'horizontal' | 'vertical';
   name: string;
 }
 
@@ -95,64 +97,54 @@ export const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(
     },
     ref,
   ) => {
-    // State management (controlled vs uncontrolled)
-    const [uncontrolledValue, setUncontrolledValue] = React.useState(defaultValue);
     const isControlled = controlledValue !== undefined;
-    const value = isControlled ? controlledValue : uncontrolledValue;
 
-    // Ref for the container
-    const containerRef = React.useRef<HTMLDivElement>(null);
+    // Capture the initial selected value once; the controller owns state thereafter.
+    const initialRef = React.useRef(isControlled ? controlledValue : defaultValue);
+    // Keep the latest onValueChange reachable without re-mounting the controller.
+    const onChangeRef = React.useRef(onValueChange);
+    React.useEffect(() => {
+      onChangeRef.current = onValueChange;
+    });
 
-    // Merge refs
-    React.useImperativeHandle(ref, () => containerRef.current as HTMLDivElement);
+    const controllerRef = React.useRef<RadioGroupController | null>(null);
 
-    // Generate stable name for grouping
+    // Generate a stable name for native <input type="radio"> grouping. This is markup
+    // identity, not selection state, so it stays in the React layer.
     const name = React.useId();
 
-    const handleValueChange = React.useCallback(
-      (newValue: string) => {
-        if (!isControlled) {
-          setUncontrolledValue(newValue);
+    // Mount the controller via a callback ref (also forwarding the node to `ref`):
+    // runs during commit before paint, so initial selection is reflected with no flash.
+    const setRoot = React.useCallback(
+      (node: HTMLDivElement | null) => {
+        if (typeof ref === 'function') {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
         }
-        onValueChange?.(newValue);
+        if (!node) return;
+        const controller = createRadioGroup(node, {
+          initial: initialRef.current,
+          orientation,
+          onChange: (value) => onChangeRef.current?.(value),
+        });
+        controllerRef.current = controller;
+        return () => {
+          controller.destroy();
+          controllerRef.current = null;
+        };
       },
-      [isControlled, onValueChange],
+      [ref, orientation],
     );
 
-    // Setup roving focus - re-initialize when orientation changes
-    // biome-ignore lint/correctness/useExhaustiveDependencies: value dependency needed to re-compute currentIndex when selection changes
+    // Controlled mode: mirror the prop into the controller.
     React.useEffect(() => {
-      const container = containerRef.current;
-      if (!container) return;
+      if (isControlled && controlledValue !== undefined) {
+        controllerRef.current?.setValue(controlledValue);
+      }
+    }, [isControlled, controlledValue]);
 
-      const cleanup = createRovingFocus(container, {
-        orientation,
-        loop: true,
-        // Find the currently checked item to set as initial index
-        currentIndex: (() => {
-          const items = Array.from(
-            container.querySelectorAll<HTMLButtonElement>('[role="radio"]:not([disabled])'),
-          );
-          const checkedIndex = items.findIndex(
-            (item) => item.getAttribute('aria-checked') === 'true',
-          );
-          return checkedIndex >= 0 ? checkedIndex : 0;
-        })(),
-      });
-
-      return cleanup;
-    }, [orientation, value]);
-
-    const contextValue = React.useMemo(
-      () => ({
-        value,
-        onValueChange: handleValueChange,
-        disabled,
-        orientation,
-        name,
-      }),
-      [value, handleValueChange, disabled, orientation, name],
-    );
+    const contextValue = React.useMemo(() => ({ disabled, name }), [disabled, name]);
 
     const baseClasses =
       orientation === 'horizontal' ? radioGroupHorizontalClasses : radioGroupVerticalClasses;
@@ -160,7 +152,7 @@ export const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(
     return (
       <RadioGroupContext.Provider value={contextValue}>
         <div
-          ref={containerRef}
+          ref={setRoot}
           role="radiogroup"
           aria-orientation={orientation}
           className={classy(baseClasses, className)}
@@ -179,53 +171,34 @@ RadioGroup.displayName = 'RadioGroup';
 
 export const RadioGroupItem = React.forwardRef<HTMLButtonElement, RadioGroupItemProps>(
   ({ value, className, children, disabled: itemDisabled, ...props }, ref) => {
-    const {
-      value: selectedValue,
-      onValueChange,
-      disabled: groupDisabled,
-      name,
-    } = useRadioGroupContext();
+    const { disabled: groupDisabled, name } = useRadioGroupContext();
 
-    const isChecked = value === selectedValue;
     const isDisabled = groupDisabled || itemDisabled;
 
-    const handleClick = React.useCallback(() => {
-      if (!isDisabled) {
-        onValueChange(value);
-      }
-    }, [isDisabled, onValueChange, value]);
-
-    const handleKeyDown = React.useCallback(
-      (event: React.KeyboardEvent<HTMLButtonElement>) => {
-        // Space and Enter select the radio
-        if (event.key === ' ' || event.key === 'Enter') {
-          event.preventDefault();
-          if (!isDisabled) {
-            onValueChange(value);
-          }
-        }
-      },
-      [isDisabled, onValueChange, value],
-    );
-
-    // Base styles
-
+    // No data-state / onClick / onKeyDown here: the controller reflects checked state
+    // (and toggles the indicator via data-state CSS) and handles selection (click +
+    // Space/Enter delegation + roving focus) on the root. aria-checked is rendered as a
+    // constant `false` baseline only to satisfy the radio role's required ARIA prop;
+    // React never re-asserts an unchanged prop, so the controller's runtime value (set
+    // before paint) is not clobbered on re-render.
     return (
       // biome-ignore lint/a11y/useSemanticElements: Custom radio with visual styling not possible with native input
       <button
         type="button"
         ref={ref}
         role="radio"
-        aria-checked={isChecked}
-        data-state={isChecked ? 'checked' : 'unchecked'}
+        aria-checked={false}
+        data-value={value}
         disabled={isDisabled}
         name={name}
-        className={classy(radioGroupItemBaseClasses, className)}
-        onClick={handleClick}
-        onKeyDown={handleKeyDown}
+        className={classy(radioGroupItemBaseClasses, radioGroupItemGroupClass, className)}
         {...props}
       >
-        {isChecked && <span className={radioGroupItemIndicatorClasses} aria-hidden="true" />}
+        <span
+          data-radio-indicator
+          className={classy(radioGroupItemIndicatorClasses, radioGroupItemIndicatorStateClasses)}
+          aria-hidden="true"
+        />
         {children}
       </button>
     );

--- a/packages/ui/src/components/ui/toggle-group.classes.ts
+++ b/packages/ui/src/components/ui/toggle-group.classes.ts
@@ -32,3 +32,14 @@ export const toggleGroupItemOutlinePressedClasses = 'bg-accent text-accent-foreg
 export const toggleGroupItemDefaultClasses = 'bg-transparent';
 
 export const toggleGroupItemDefaultPressedClasses = 'bg-background text-foreground shadow-sm';
+
+// State-driven pressed styling: the controller toggles data-state=on|off on each
+// item, so the same class string works for React (and any controller-driven target)
+// with no conditional application. Mirrors the pressed strings above as data-state
+// variants. The web component composes the plain pressed strings imperatively and
+// is intentionally left untouched.
+export const toggleGroupItemDefaultStateClasses =
+  'data-[state=on]:bg-background data-[state=on]:text-foreground data-[state=on]:shadow-sm';
+
+export const toggleGroupItemOutlineStateClasses =
+  'data-[state=on]:bg-accent data-[state=on]:text-accent-foreground';

--- a/packages/ui/src/components/ui/toggle-group.controller.test.ts
+++ b/packages/ui/src/components/ui/toggle-group.controller.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for createToggleGroup - the framework-free behavior controller.
+ *
+ * Mirrors selection-group.test.ts: drives a real (happy-dom) DOM root with
+ * [data-roving-item][data-value] buttons and asserts selection state, ARIA /
+ * data-state reflection, onChange firing on user interaction only, and that
+ * setValue is a silent programmatic write.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { createToggleGroup } from './toggle-group.controller';
+
+function mountToggleGroup(values: string[]): HTMLElement {
+  const root = document.createElement('div');
+  root.setAttribute('role', 'group');
+  for (const value of values) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.setAttribute('data-roving-item', '');
+    button.setAttribute('data-value', value);
+    root.appendChild(button);
+  }
+  document.body.appendChild(root);
+  return root;
+}
+
+function buttonFor(root: HTMLElement, value: string): HTMLButtonElement {
+  const button = root.querySelector<HTMLButtonElement>(`[data-value="${value}"]`);
+  if (!button) throw new Error(`no button for ${value}`);
+  return button;
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('createToggleGroup', () => {
+  describe('multiple mode', () => {
+    it('toggles items independently', () => {
+      const root = mountToggleGroup(['bold', 'italic', 'underline']);
+      const c = createToggleGroup(root, { type: 'multiple' });
+      c.group.toggle('bold');
+      c.group.toggle('italic');
+      expect(c.group.get()).toEqual(['bold', 'italic']);
+      c.group.toggle('bold');
+      expect(c.group.get()).toEqual(['italic']);
+    });
+
+    it('reflects aria-pressed and data-state on items', () => {
+      const root = mountToggleGroup(['bold', 'italic']);
+      const c = createToggleGroup(root, { type: 'multiple' });
+      c.group.toggle('bold');
+      const bold = buttonFor(root, 'bold');
+      const italic = buttonFor(root, 'italic');
+      expect(bold.getAttribute('aria-pressed')).toBe('true');
+      expect(bold.getAttribute('data-state')).toBe('on');
+      expect(italic.getAttribute('aria-pressed')).toBe('false');
+      expect(italic.getAttribute('data-state')).toBe('off');
+    });
+
+    it('honors a string[] initial', () => {
+      const root = mountToggleGroup(['a', 'b', 'c']);
+      const c = createToggleGroup(root, { type: 'multiple', initial: ['a', 'c'] });
+      expect(c.group.get()).toEqual(['a', 'c']);
+      expect(buttonFor(root, 'a').getAttribute('data-state')).toBe('on');
+      expect(buttonFor(root, 'b').getAttribute('data-state')).toBe('off');
+    });
+  });
+
+  describe('single mode (collapsible)', () => {
+    it('toggling the active value off clears the selection', () => {
+      const single = createToggleGroup(mountToggleGroup(['a', 'b']), { type: 'single' });
+      single.group.toggle('a');
+      single.group.toggle('a');
+      expect(single.group.get()).toEqual([]);
+    });
+
+    it('swaps selection between items', () => {
+      const single = createToggleGroup(mountToggleGroup(['a', 'b']), { type: 'single' });
+      single.group.toggle('a');
+      single.group.toggle('b');
+      expect(single.group.get()).toEqual(['b']);
+    });
+
+    it("treats a '' initial as nothing selected", () => {
+      const c = createToggleGroup(mountToggleGroup(['a', 'b']), { type: 'single', initial: '' });
+      expect(c.group.get()).toEqual([]);
+    });
+
+    it('honors a string initial', () => {
+      const c = createToggleGroup(mountToggleGroup(['a', 'b']), { type: 'single', initial: 'b' });
+      expect(c.group.get()).toEqual(['b']);
+    });
+  });
+
+  describe('click activation + onChange', () => {
+    it('fires onChange with a string in single mode on click', () => {
+      const root = mountToggleGroup(['a', 'b']);
+      const seen: Array<string | string[]> = [];
+      createToggleGroup(root, { type: 'single', onChange: (v) => seen.push(v) });
+      buttonFor(root, 'a').click();
+      expect(seen).toEqual(['a']);
+      buttonFor(root, 'a').click();
+      expect(seen).toEqual(['a', '']);
+    });
+
+    it('fires onChange with a string[] in multiple mode on click', () => {
+      const root = mountToggleGroup(['a', 'b']);
+      const seen: Array<string | string[]> = [];
+      createToggleGroup(root, { type: 'multiple', onChange: (v) => seen.push(v) });
+      buttonFor(root, 'a').click();
+      buttonFor(root, 'b').click();
+      expect(seen).toEqual([['a'], ['a', 'b']]);
+    });
+
+    it('ignores clicks on disabled items', () => {
+      const root = mountToggleGroup(['a']);
+      buttonFor(root, 'a').disabled = true;
+      const c = createToggleGroup(root, { type: 'single' });
+      buttonFor(root, 'a').click();
+      expect(c.group.get()).toEqual([]);
+    });
+  });
+
+  describe('setValue (programmatic)', () => {
+    it('does not fire onChange', () => {
+      const root = mountToggleGroup(['a', 'b']);
+      const seen: Array<string | string[]> = [];
+      const c = createToggleGroup(root, { type: 'multiple', onChange: (v) => seen.push(v) });
+      c.setValue(['a', 'b']);
+      expect(c.group.get()).toEqual(['a', 'b']);
+      expect(seen).toEqual([]);
+    });
+
+    it('clamps to one value in single mode', () => {
+      const root = mountToggleGroup(['a', 'b', 'c']);
+      const c = createToggleGroup(root, { type: 'single' });
+      c.setValue(['a', 'b', 'c']);
+      expect(c.group.get()).toEqual(['a']);
+    });
+  });
+
+  describe('destroy', () => {
+    it('stops reflecting after teardown', () => {
+      const root = mountToggleGroup(['a']);
+      const c = createToggleGroup(root, { type: 'single' });
+      c.destroy();
+      buttonFor(root, 'a').click();
+      expect(c.group.get()).toEqual([]);
+    });
+  });
+});

--- a/packages/ui/src/components/ui/toggle-group.controller.ts
+++ b/packages/ui/src/components/ui/toggle-group.controller.ts
@@ -1,0 +1,108 @@
+/**
+ * toggle-group.controller.ts - the single source of truth for toggle-group *behavior*.
+ *
+ * Anti-drift: written once, framework-free, against a DOM root. React, Astro, and the
+ * web component render their own markup and delegate to createToggleGroup(root) - so
+ * behavior can never diverge between frameworks. Thin GLUE that composes existing
+ * primitives, not a reimplementation:
+ *   - createSelectionGroup -> selection state (single allows toggling off; multiple holds N)
+ *   - createRovingFocus    -> arrow / Home / End navigation + roving tabindex
+ * The controller only adds click toggling and ARIA/data-state reflection.
+ *
+ * Markup contract (each framework renders this, controller drives it):
+ *   - items: [data-roving-item][data-value]  (buttons inside the [role="group"] root)
+ *
+ * @example
+ * ```ts
+ * const tg = createToggleGroup(rootEl, { type: 'multiple', onChange: (v) => save(v) });
+ * tg.setValue(['bold']); // programmatic (no onChange)
+ * tg.destroy();
+ * ```
+ */
+import { createRovingFocus } from '../../primitives/roving-focus';
+import { createSelectionGroup, type SelectionGroup } from '../../primitives/selection-group';
+import type { CleanupFunction } from '../../primitives/types';
+
+export interface ToggleGroupControllerOptions {
+  /** single = mutually exclusive (collapsible: re-click clears); multiple = independent toggles. */
+  type: 'single' | 'multiple';
+  /** Initially pressed value(s). A '' entry is treated as nothing selected. */
+  initial?: string | string[];
+  /** Arrow-key navigation axis. Default 'horizontal'. */
+  orientation?: 'horizontal' | 'vertical';
+  /** Called when the pressed set changes via user interaction (not programmatic setValue). */
+  onChange?: (value: string | string[]) => void;
+}
+
+export interface ToggleGroupController {
+  /** The underlying selection state cell. */
+  readonly group: SelectionGroup;
+  /** Programmatically set the pressed value(s). Does NOT fire onChange (for controlled sync). */
+  setValue(value: string | string[]): void;
+  /** Tear down listeners and subscriptions. */
+  destroy: CleanupFunction;
+}
+
+/** Normalize a value to an array, dropping empty-string placeholders (single uncontrolled). */
+function toValues(value: string | string[] | undefined): string[] {
+  if (value === undefined) return [];
+  const list = Array.isArray(value) ? value : [value];
+  return list.filter((entry) => entry !== '');
+}
+
+export function createToggleGroup(
+  root: HTMLElement,
+  options: ToggleGroupControllerOptions,
+): ToggleGroupController {
+  const { type, orientation = 'horizontal', onChange } = options;
+  const group = createSelectionGroup(
+    type === 'multiple'
+      ? { multiple: true, initial: toValues(options.initial) }
+      : { collapsible: true, initial: toValues(options.initial) },
+  );
+
+  // single mode exposes a string; multiple mode exposes a string[].
+  const currentValue = (): string | string[] =>
+    type === 'single' ? (group.get()[0] ?? '') : group.get();
+
+  const items = (): HTMLElement[] =>
+    Array.from(root.querySelectorAll<HTMLElement>('[data-roving-item][data-value]'));
+
+  // Reflect selection onto the DOM. roving-focus owns tabindex; this owns
+  // aria-pressed / data-state. Fires immediately with the current value.
+  const unsubscribe = group.subscribe((selected) => {
+    for (const item of items()) {
+      const on = item.dataset.value !== undefined && selected.includes(item.dataset.value);
+      item.setAttribute('aria-pressed', String(on));
+      item.setAttribute('data-state', on ? 'on' : 'off');
+    }
+  });
+
+  // Arrow / Home / End navigation + roving tabindex via the shared primitive.
+  // Toggle groups use manual activation (click / Space / Enter toggle the focused
+  // item via the native button), so navigation only moves focus.
+  const stopRoving = createRovingFocus(root, { orientation, loop: true });
+
+  const onClick = (event: MouseEvent): void => {
+    const item = (event.target as HTMLElement).closest<HTMLElement>(
+      '[data-roving-item][data-value]:not([disabled])',
+    );
+    if (item?.dataset.value !== undefined && root.contains(item)) {
+      group.toggle(item.dataset.value);
+      onChange?.(currentValue());
+    }
+  };
+  root.addEventListener('click', onClick);
+
+  return {
+    group,
+    setValue: (value) => {
+      group.set(toValues(value));
+    },
+    destroy: () => {
+      unsubscribe();
+      stopRoving();
+      root.removeEventListener('click', onClick);
+    },
+  };
+}

--- a/packages/ui/src/components/ui/toggle-group.tsx
+++ b/packages/ui/src/components/ui/toggle-group.tsx
@@ -32,24 +32,23 @@
 
 import * as React from 'react';
 import classy from '../../primitives/classy';
-import { createRovingFocus } from '../../primitives/roving-focus';
 import {
   toggleGroupClasses,
   toggleGroupDefaultVariantClasses,
   toggleGroupItemBaseClasses,
   toggleGroupItemDefaultClasses,
-  toggleGroupItemDefaultPressedClasses,
+  toggleGroupItemDefaultStateClasses,
   toggleGroupItemOutlineClasses,
-  toggleGroupItemOutlinePressedClasses,
+  toggleGroupItemOutlineStateClasses,
   toggleGroupItemSizeClasses,
 } from './toggle-group.classes';
+import { createToggleGroup, type ToggleGroupController } from './toggle-group.controller';
 
 // ==================== Context ====================
 
+// Context carries only group-level presentation (variant, size, disabled). Selection
+// state and keyboard behavior live in the controller, so no value/dispatch is threaded.
 interface ToggleGroupContextValue {
-  type: 'single' | 'multiple';
-  value: string | string[];
-  onItemToggle: (itemValue: string) => void;
   variant: 'default' | 'outline';
   size: 'default' | 'sm' | 'lg';
   disabled: boolean;
@@ -99,69 +98,50 @@ export function ToggleGroup({
   children,
   ...props
 }: ToggleGroupProps) {
-  // Derive initial value based on type
-  const getInitialValue = (): string | string[] => {
-    if (defaultValue !== undefined) {
-      return defaultValue;
-    }
-    return type === 'single' ? '' : [];
-  };
-
-  // State management (controlled vs uncontrolled)
-  const [uncontrolledValue, setUncontrolledValue] = React.useState(getInitialValue);
   const isControlled = controlledValue !== undefined;
-  const value = isControlled ? controlledValue : uncontrolledValue;
 
-  const groupRef = React.useRef<HTMLDivElement>(null);
-
-  // Set up roving focus
+  // Capture the initial pressed value once; the controller owns state thereafter.
+  const initialRef = React.useRef(isControlled ? controlledValue : defaultValue);
+  // Keep the latest onValueChange reachable without re-mounting the controller.
+  const onChangeRef = React.useRef(onValueChange);
   React.useEffect(() => {
-    const container = groupRef.current;
-    if (!container) return;
+    onChangeRef.current = onValueChange;
+  });
 
-    const cleanup = createRovingFocus(container, {
-      orientation: orientation === 'vertical' ? 'vertical' : 'horizontal',
-      loop: true,
-    });
+  const controllerRef = React.useRef<ToggleGroupController | null>(null);
 
-    return cleanup;
-  }, [orientation]);
-
-  const handleItemToggle = React.useCallback(
-    (itemValue: string) => {
-      let newValue: string | string[];
-
-      if (type === 'single') {
-        // In single mode, clicking selected item deselects it
-        newValue = value === itemValue ? '' : itemValue;
-      } else {
-        // In multiple mode, toggle the item in the array
-        const currentArray = Array.isArray(value) ? value : [];
-        if (currentArray.includes(itemValue)) {
-          newValue = currentArray.filter((v) => v !== itemValue);
-        } else {
-          newValue = [...currentArray, itemValue];
-        }
-      }
-
-      if (!isControlled) {
-        setUncontrolledValue(newValue);
-      }
-      onValueChange?.(newValue);
+  // Mount the controller via a callback ref: runs during commit (before paint), so
+  // initial selection is reflected with no flash, and React renders no
+  // selection-derived attributes, so re-renders cannot clobber the controller.
+  const setRoot = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!node) return;
+      const initial = initialRef.current;
+      const controller = createToggleGroup(node, {
+        type,
+        orientation,
+        onChange: (value) => onChangeRef.current?.(value),
+        ...(initial === undefined ? {} : { initial }),
+      });
+      controllerRef.current = controller;
+      return () => {
+        controller.destroy();
+        controllerRef.current = null;
+      };
     },
-    [type, value, isControlled, onValueChange],
+    [type, orientation],
   );
 
+  // Controlled mode: mirror the prop into the controller.
+  React.useEffect(() => {
+    if (isControlled && controlledValue !== undefined) {
+      controllerRef.current?.setValue(controlledValue);
+    }
+  }, [isControlled, controlledValue]);
+
   const contextValue = React.useMemo(
-    () => ({
-      type,
-      value,
-      onItemToggle: handleItemToggle,
-      variant,
-      size,
-      disabled,
-    }),
-    [type, value, handleItemToggle, variant, size, disabled],
+    () => ({ variant, size, disabled }),
+    [variant, size, disabled],
   );
 
   // Group styling
@@ -175,7 +155,7 @@ export function ToggleGroup({
     <ToggleGroupContext.Provider value={contextValue}>
       {/* biome-ignore lint/a11y/useSemanticElements: role="group" is correct for toggle groups per WAI-ARIA APG, fieldset is for form elements */}
       <div
-        ref={groupRef}
+        ref={setRoot}
         role="group"
         data-orientation={orientation}
         className={groupClasses}
@@ -203,68 +183,35 @@ export function ToggleGroupItem({
   disabled: itemDisabled,
   className,
   children,
-  onClick,
   ...props
 }: ToggleGroupItemProps) {
-  const {
-    type,
-    value: groupValue,
-    onItemToggle,
-    variant,
-    size,
-    disabled: groupDisabled,
-  } = useToggleGroupContext();
+  const { variant, size, disabled: groupDisabled } = useToggleGroupContext();
 
   const disabled = groupDisabled || itemDisabled;
 
-  // Determine if this item is pressed
-  const isPressed = React.useMemo(() => {
-    if (type === 'single') {
-      return groupValue === value;
-    }
-    return Array.isArray(groupValue) && groupValue.includes(value);
-  }, [type, groupValue, value]);
-
-  const handleClick = React.useCallback(
-    (event: React.MouseEvent<HTMLButtonElement>) => {
-      if (!disabled) {
-        onItemToggle(value);
-      }
-      onClick?.(event);
-    },
-    [disabled, onItemToggle, value, onClick],
-  );
-
-  // Build variant-specific classes
-  const getVariantClasses = () => {
-    if (variant === 'outline') {
-      return classy(
-        toggleGroupItemOutlineClasses,
-        isPressed && toggleGroupItemOutlinePressedClasses,
-      );
-    }
-    // default variant
-    return classy(toggleGroupItemDefaultClasses, isPressed && toggleGroupItemDefaultPressedClasses);
-  };
+  // Pressed styling is data-state driven (the controller toggles data-state=on|off),
+  // so the class string is the same regardless of selection - no conditional application.
+  const variantClasses =
+    variant === 'outline'
+      ? classy(toggleGroupItemOutlineClasses, toggleGroupItemOutlineStateClasses)
+      : classy(toggleGroupItemDefaultClasses, toggleGroupItemDefaultStateClasses);
 
   const itemClasses = classy(
     toggleGroupItemBaseClasses,
-    // Size
     toggleGroupItemSizeClasses[size] ?? toggleGroupItemSizeClasses.default,
-    // Variant
-    getVariantClasses(),
+    variantClasses,
     className,
   );
 
+  // No aria-pressed / data-state / onClick here: the controller reflects pressed state
+  // and handles toggling (click delegation + roving focus) on the root.
   return (
     <button
       type="button"
-      aria-pressed={isPressed}
-      data-state={isPressed ? 'on' : 'off'}
       data-roving-item
+      data-value={value}
       disabled={disabled}
       className={itemClasses}
-      onClick={handleClick}
       {...props}
     >
       {children}

--- a/packages/ui/test/components/radio-group.test.tsx
+++ b/packages/ui/test/components/radio-group.test.tsx
@@ -257,10 +257,17 @@ describe('RadioGroup', () => {
     const radio1 = screen.getByRole('radio', { name: 'Option 1' });
     const radio2 = screen.getByRole('radio', { name: 'Option 2' });
 
-    // Radio 1 should have indicator (inner span)
-    expect(radio1.querySelector('span')).toBeInTheDocument();
-    // Radio 2 should not have indicator
-    expect(radio2.querySelector('span')).not.toBeInTheDocument();
+    // The indicator span is always rendered; visibility is data-state driven (the
+    // controller toggles data-state on the button and the dot hides via
+    // group-data-[state=unchecked]:hidden). Assert the reflection mechanism is wired:
+    // both items carry the indicator, and the checked button drives it visible.
+    expect(radio1.querySelector('[data-radio-indicator]')).toBeInTheDocument();
+    expect(radio2.querySelector('[data-radio-indicator]')).toBeInTheDocument();
+    expect(radio1).toHaveAttribute('data-state', 'checked');
+    expect(radio2).toHaveAttribute('data-state', 'unchecked');
+    expect(radio2.querySelector('[data-radio-indicator]')).toHaveClass(
+      'group-data-[state=unchecked]:hidden',
+    );
   });
 
   it('selects on Space key', () => {

--- a/packages/ui/test/components/toggle-group.test.tsx
+++ b/packages/ui/test/components/toggle-group.test.tsx
@@ -289,7 +289,12 @@ describe('ToggleGroup', () => {
       );
 
       expect(container.querySelector('[role="group"]')).toHaveClass('bg-muted', 'p-1');
-      expect(screen.getByRole('button')).toHaveClass('bg-background', 'shadow-sm');
+      // Pressed styling is now data-state driven (the controller toggles data-state),
+      // so the class string carries the state variants rather than the bare utilities.
+      expect(screen.getByRole('button')).toHaveClass(
+        'data-[state=on]:bg-background',
+        'data-[state=on]:shadow-sm',
+      );
     });
 
     it('applies outline variant styles', () => {
@@ -300,7 +305,7 @@ describe('ToggleGroup', () => {
       );
 
       const button = screen.getByRole('button');
-      expect(button).toHaveClass('border', 'bg-accent');
+      expect(button).toHaveClass('border', 'data-[state=on]:bg-accent');
     });
 
     it('applies size styles', () => {


### PR DESCRIPTION
Closes #1703.

Migrates `toggle-group` and `radio-group` onto the shared `createSelectionGroup` primitive via per-component framework-free behavior controllers, following the `tabs.controller.ts` shape. Selection state and keyboard behavior are now written once and reflected onto the DOM, so React holds no selection `useState` and no imperative roving-focus `useEffect`.

## What changed

**New controllers (framework-free glue, composing existing primitives):**
- `toggle-group.controller.ts` -> `createToggleGroup(root, { type, initial, orientation, onChange })`. `type=single` uses `createSelectionGroup({ collapsible: true })` (re-click clears, preserving today's nothing-selected-is-valid behavior); `type=multiple` uses `{ multiple: true }`. Click toggles via `group.toggle`; `onChange` fires on user interaction only, with a `string` in single mode and `string[]` in multiple. Reflects `aria-pressed` / `data-state=on|off`. Roving focus + tabindex via `createRovingFocus`.
- `radio-group.controller.ts` -> `createRadioGroup(root, { initial, orientation, onChange })`. Single mode, NOT collapsible (a radio cannot be deselected by re-click). Click and Space/Enter select and fire `onChange`; reflects `aria-checked` / `data-state=checked|unchecked`. Roving focus starts on the checked radio.
- `setValue` on both is a silent programmatic write (no `onChange`) used for controlled-prop sync.

**React layers delegate via callback ref (initialRef/onChangeRef/controllerRef triad, like `tabs.tsx`):**
- `toggle-group.tsx`: removed the `useState(getInitialValue)` selection state, the `handleItemToggle` reducer, and the roving-focus `useEffect`. Items render structural markup only (`data-roving-item`/`data-value`); pressed styling is now data-state driven.
- `radio-group.tsx`: removed the `useState(defaultValue)` selection state and the imperative roving `useEffect`. The generated `useId()` `name` stays in the React layer (markup identity, not selection state). The indicator dot is always rendered and shown via `group-data-[state=checked]` CSS. `aria-checked` is a constant `false` baseline only to satisfy the radio role's required ARIA prop; React never re-asserts an unchanged prop, so the controller's runtime value is not clobbered.

**Classes (additive, data-state variants; web-component compose paths untouched):**
- `toggle-group.classes.ts`: `toggleGroupItemDefaultStateClasses` / `toggleGroupItemOutlineStateClasses`.
- `radio-group.classes.ts`: `radioGroupItemGroupClass` + `radioGroupItemIndicatorStateClasses`.

**Tests:**
- New `toggle-group.controller.test.ts` / `radio-group.controller.test.ts` (happy-dom, mirroring `selection-group.test.ts`) cover single/multiple/collapsible toggling, ARIA/data-state reflection, click + Space/Enter, onChange-on-interaction-only, and silent `setValue`.
- Updated the two existing `test/components/*.test.tsx` style assertions to the data-state class form and the indicator-visibility mechanism.

Per the issue, the `.element.ts` web components are intentionally untouched; the controllers are framework-free so the WC port can adopt them next.

## Verification
- `pnpm --filter @rafters/ui typecheck`: clean.
- `pnpm --filter @rafters/ui test`: 222 files / 4606 tests passing (incl. the toggle-group/radio-group element + a11y suites).
- Biome clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)