### PR TITLE
feat(ui): dropdown-menu delegates root + submenu open state to createDisclosure (#1693)

### DIFF
--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -32,8 +32,10 @@
 
 import * as React from 'react';
 import { createPortal } from 'react-dom';
+import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
 import { computePosition } from '../../primitives/collision-detector';
+import { createDisclosure } from '../../primitives/create-disclosure';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { onPointerDownOutside } from '../../primitives/outside-click';
 import { getPortalContainer } from '../../primitives/portal';
@@ -137,19 +139,25 @@ export function DropdownMenu({
   defaultOpen = false,
   onOpenChange,
 }: DropdownMenuProps) {
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
-
+  const disclosure = React.useRef(
+    createDisclosure({ initialOpen: controlledOpen ?? defaultOpen ?? false }),
+  ).current;
   const isControlled = controlledOpen !== undefined;
-  const open = isControlled ? controlledOpen : uncontrolledOpen;
+
+  React.useEffect(() => {
+    if (isControlled) disclosure.setOpen(controlledOpen);
+  }, [isControlled, controlledOpen, disclosure]);
+
+  const open = useMemory(disclosure.memory).open;
 
   const handleOpenChange = React.useCallback(
     (newOpen: boolean) => {
-      if (!isControlled) {
-        setUncontrolledOpen(newOpen);
-      }
       onOpenChange?.(newOpen);
+      if (!isControlled) {
+        disclosure.setOpen(newOpen);
+      }
     },
-    [isControlled, onOpenChange],
+    [isControlled, onOpenChange, disclosure],
   );
 
   const id = React.useId();
@@ -817,19 +825,25 @@ export function DropdownMenuSub({
   defaultOpen = false,
   onOpenChange,
 }: DropdownMenuSubProps) {
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
-
+  const disclosure = React.useRef(
+    createDisclosure({ initialOpen: controlledOpen ?? defaultOpen ?? false }),
+  ).current;
   const isControlled = controlledOpen !== undefined;
-  const open = isControlled ? controlledOpen : uncontrolledOpen;
+
+  React.useEffect(() => {
+    if (isControlled) disclosure.setOpen(controlledOpen);
+  }, [isControlled, controlledOpen, disclosure]);
+
+  const open = useMemory(disclosure.memory).open;
 
   const handleOpenChange = React.useCallback(
     (newOpen: boolean) => {
-      if (!isControlled) {
-        setUncontrolledOpen(newOpen);
-      }
       onOpenChange?.(newOpen);
+      if (!isControlled) {
+        disclosure.setOpen(newOpen);
+      }
     },
-    [isControlled, onOpenChange],
+    [isControlled, onOpenChange, disclosure],
   );
 
   const id = React.useId();

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -35,7 +35,7 @@ import { createPortal } from 'react-dom';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
 import { computePosition } from '../../primitives/collision-detector';
-import { createDisclosure } from '../../primitives/create-disclosure';
+import { createDisclosure } from '../../primitives/disclosure';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { onPointerDownOutside } from '../../primitives/outside-click';
 import { getPortalContainer } from '../../primitives/portal';

--- a/packages/ui/test/components/dropdown-menu.test.tsx
+++ b/packages/ui/test/components/dropdown-menu.test.tsx
@@ -854,6 +854,45 @@ describe('DropdownMenu - Submenus', () => {
     );
   });
 
+  it('should keep root open when a nested submenu opens (independent state)', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <DropdownMenu defaultOpen>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuPortal>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Root Item</DropdownMenuItem>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>More</DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                <DropdownMenuItem>Sub Item</DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          </DropdownMenuContent>
+        </DropdownMenuPortal>
+      </DropdownMenu>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('More')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Sub Item')).not.toBeInTheDocument();
+
+    await user.hover(screen.getByText('More'));
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('Sub Item')).toBeInTheDocument();
+      },
+      { timeout: 500 },
+    );
+
+    // Opening the submenu does not collapse the root menu.
+    expect(screen.getByText('Root Item')).toBeInTheDocument();
+  });
+
   it('submenu trigger should have aria-haspopup="menu"', async () => {
     render(
       <DropdownMenu defaultOpen>


### PR DESCRIPTION
Closes #1693.

Migrates dropdown-menu open state onto `createDisclosure`, removing the hand-rolled `useState(defaultOpen)` + controlled/uncontrolled dance from both the root and every submenu.

## What changed (`packages/ui/src/components/ui/dropdown-menu.tsx`)
- **`DropdownMenu` root**: replaced `useState` with a per-mount `createDisclosure({ initialOpen: controlledOpen ?? defaultOpen ?? false })` held in a ref. `open` now reads from `useMemory(disclosure.memory)`; a controlled prop is reflected in via `disclosure.setOpen` in an effect; `onOpenChange` fires on user action and the uncontrolled path drives the cell. Same dual-mode-at-the-boundary split tabs uses.
- **`DropdownMenuSub`**: identical treatment with its own independent `createDisclosure` instance + `DropdownMenuSubContext`. Each mounted sub owns its own cell, so root and sub open state stay independent.
- **`DropdownMenuRadioGroup`**: untouched (already fully controlled).
- Hover-open, roving focus, dismissable-layer, escape, and positioning are unchanged - only the open-state source moved.

The public API of `DropdownMenu`/`DropdownMenuSub` (`open`/`defaultOpen`/`onOpenChange`) is unchanged.

## Tests
- Added a nested-independence test: opening a submenu on hover keeps the root menu open.
- Verified: `pnpm --filter @rafters/ui typecheck` green; `pnpm --filter @rafters/ui test` green (220 files, 4583 passed).

Depends on #1691 (createDisclosure); rebase onto main after #1691 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)