### PR TITLE
feat(ui): context-menu delegates open + pointer state to createDisclosure (#1694)

### DIFF
--- a/packages/ui/src/components/ui/context-menu.tsx
+++ b/packages/ui/src/components/ui/context-menu.tsx
@@ -32,8 +32,11 @@
 
 import * as React from 'react';
 import { createPortal } from 'react-dom';
+import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
+import { createDisclosure } from '../../primitives/create-disclosure';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
+import { createMemory } from '../../primitives/memory';
 import { onPointerDownOutside } from '../../primitives/outside-click';
 import { getPortalContainer } from '../../primitives/portal';
 import { createRovingFocus } from '../../primitives/roving-focus';
@@ -136,20 +139,34 @@ export function ContextMenu({
   defaultOpen = false,
   onOpenChange,
 }: ContextMenuProps) {
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
-  const [position, setPosition] = React.useState({ x: 0, y: 0 });
+  // Open lives on createDisclosure; the right-click pointer {x,y} lives on a
+  // tiny per-root createMemory cell. Both are the single source of truth - no
+  // component-local useState. The controlled/uncontrolled dual-mode stays at
+  // this React boundary (reflect the prop in via setOpen, fire onOpenChange on
+  // user actions), exactly as the disclosure batch prescribes.
+  const disclosure = React.useRef(createDisclosure({ initialOpen: defaultOpen })).current;
+  const point = React.useRef(createMemory(() => ({ x: 0, y: 0 }))).current;
 
   const isControlled = controlledOpen !== undefined;
+  const uncontrolledOpen = useMemory(disclosure.memory).open;
   const open = isControlled ? controlledOpen : uncontrolledOpen;
+  const position = useMemory(point);
 
   const handleOpenChange = React.useCallback(
     (newOpen: boolean) => {
       if (!isControlled) {
-        setUncontrolledOpen(newOpen);
+        disclosure.setOpen(newOpen);
       }
       onOpenChange?.(newOpen);
     },
-    [isControlled, onOpenChange],
+    [isControlled, onOpenChange, disclosure],
+  );
+
+  const setPosition = React.useCallback(
+    (next: { x: number; y: number }) => {
+      point.set(next);
+    },
+    [point],
   );
 
   const id = React.useId();
@@ -163,7 +180,7 @@ export function ContextMenu({
       position,
       setPosition,
     }),
-    [open, handleOpenChange, contentId, position],
+    [open, handleOpenChange, contentId, position, setPosition],
   );
 
   return <ContextMenuContext.Provider value={contextValue}>{children}</ContextMenuContext.Provider>;
@@ -777,19 +794,22 @@ export function ContextMenuSub({
   defaultOpen = false,
   onOpenChange,
 }: ContextMenuSubProps) {
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+  // Submenu open uses the same createDisclosure boundary as the root - the
+  // controlled/uncontrolled dual-mode stays here, no component-local useState.
+  const disclosure = React.useRef(createDisclosure({ initialOpen: defaultOpen })).current;
 
   const isControlled = controlledOpen !== undefined;
+  const uncontrolledOpen = useMemory(disclosure.memory).open;
   const open = isControlled ? controlledOpen : uncontrolledOpen;
 
   const handleOpenChange = React.useCallback(
     (newOpen: boolean) => {
       if (!isControlled) {
-        setUncontrolledOpen(newOpen);
+        disclosure.setOpen(newOpen);
       }
       onOpenChange?.(newOpen);
     },
-    [isControlled, onOpenChange],
+    [isControlled, onOpenChange, disclosure],
   );
 
   const id = React.useId();

--- a/packages/ui/src/components/ui/context-menu.tsx
+++ b/packages/ui/src/components/ui/context-menu.tsx
@@ -34,7 +34,7 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
-import { createDisclosure } from '../../primitives/create-disclosure';
+import { createDisclosure } from '../../primitives/disclosure';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { createMemory } from '../../primitives/memory';
 import { onPointerDownOutside } from '../../primitives/outside-click';

--- a/packages/ui/test/components/context-menu.test.tsx
+++ b/packages/ui/test/components/context-menu.test.tsx
@@ -265,6 +265,58 @@ describe('ContextMenu - Position at Cursor', () => {
       expect(style.position).toBe('fixed');
     });
   });
+
+  it('opens at the pointer and positions content at the captured coordinates', async () => {
+    render(
+      <ContextMenu>
+        <ContextMenuTrigger>Right-click me</ContextMenuTrigger>
+        <ContextMenuPortal>
+          <ContextMenuContent>
+            <ContextMenuItem>Item 1</ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenuPortal>
+      </ContextMenu>,
+    );
+
+    fireEvent.contextMenu(screen.getByText('Right-click me'), {
+      clientX: 120,
+      clientY: 80,
+    });
+
+    const menu = await screen.findByRole('menu');
+    expect(menu).toBeVisible();
+    await waitFor(() => {
+      expect(menu).toHaveStyle({ left: '120px', top: '80px' });
+    });
+  });
+
+  it('closes on Escape after opening at the pointer', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ContextMenu>
+        <ContextMenuTrigger>Right-click me</ContextMenuTrigger>
+        <ContextMenuPortal>
+          <ContextMenuContent>
+            <ContextMenuItem>Item 1</ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenuPortal>
+      </ContextMenu>,
+    );
+
+    fireEvent.contextMenu(screen.getByText('Right-click me'), {
+      clientX: 120,
+      clientY: 80,
+    });
+
+    await screen.findByRole('menu');
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+  });
 });
 
 describe('ContextMenu - Controlled Mode', () => {


### PR DESCRIPTION
Closes #1694.

## What changed

Migrates `context-menu` state off component-local `useState` onto the memory core:

- **Root open** (`ContextMenu`) now lives on `createDisclosure({ initialOpen: defaultOpen })` via `useMemory(disclosure.memory).open`.
- **Right-click pointer `{x,y}`** moves to a tiny per-root `createMemory(() => ({ x: 0, y: 0 }))` cell, read with `useMemory(point)`.
- **Submenu open** (`ContextMenuSub`) also moves onto `createDisclosure`, since it held the same hand-rolled `useState` open dance.
- The controlled/uncontrolled dual-mode stays at the React boundary (reflect the controlled prop in via `setOpen`, fire `onOpenChange` on user actions) — the disclosure batch pattern. The `ContextMenuContext` value shape (`open`, `onOpenChange`, `contentId`, `position`, `setPosition`) is unchanged.

No changes to the contextmenu event wiring, dismissable-layer, or collision/positioning math — only the open + point state source moved. WC port (#1352) not included.

## Tests

Added to the co-located test file: a right-click-opens-at-pointer test asserting content is visible and positioned at the captured coordinates (`left: 120px; top: 80px`), plus an Escape-dismiss-after-pointer-open test.

## Verification

- `pnpm --filter @rafters/ui typecheck` — green.
- `pnpm --filter @rafters/ui test` — 4584 passed, 6 pre-existing skips.

Depends on #1691 (createDisclosure); rebase onto main after #1691 merges.