### PR TITLE
feat(ui): dialog/alert-dialog/drawer/sheet/collapsible delegate open state to createDisclosure (#1692)

### DIFF
--- a/packages/ui/src/components/ui/alert-dialog.tsx
+++ b/packages/ui/src/components/ui/alert-dialog.tsx
@@ -54,7 +54,7 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
-import { createDisclosure } from '../../primitives/create-disclosure';
+import { createDisclosure } from '../../primitives/disclosure';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap';
 import { getPortalContainer } from '../../primitives/portal';

--- a/packages/ui/src/components/ui/alert-dialog.tsx
+++ b/packages/ui/src/components/ui/alert-dialog.tsx
@@ -52,7 +52,9 @@
 
 import * as React from 'react';
 import { createPortal } from 'react-dom';
+import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
+import { createDisclosure } from '../../primitives/create-disclosure';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap';
 import { getPortalContainer } from '../../primitives/portal';
@@ -111,24 +113,33 @@ export function AlertDialog({
   defaultOpen = false,
   onOpenChange,
 }: AlertDialogProps) {
-  // Uncontrolled state
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+  // One disclosure cell per mounted root; seeded from the controlled value or defaultOpen.
+  const disclosureRef = React.useRef(
+    createDisclosure({ initialOpen: controlledOpen ?? defaultOpen }),
+  );
+  const disclosure = disclosureRef.current;
 
   // Reference to cancel button for initial focus
   const cancelRef = React.useRef<HTMLButtonElement | null>(null);
 
   // Determine if controlled
   const isControlled = controlledOpen !== undefined;
-  const open = isControlled ? controlledOpen : uncontrolledOpen;
 
+  // Controlled: reflect the incoming prop into the cell (programmatic, no callback).
+  React.useEffect(() => {
+    if (isControlled) disclosure.setOpen(controlledOpen);
+  }, [isControlled, controlledOpen, disclosure]);
+
+  // Current value for render.
+  const open = useMemory(disclosure.memory).open;
+
+  // User action: fire the callback; in uncontrolled mode also drive the cell.
   const handleOpenChange = React.useCallback(
     (newOpen: boolean) => {
-      if (!isControlled) {
-        setUncontrolledOpen(newOpen);
-      }
       onOpenChange?.(newOpen);
+      if (!isControlled) disclosure.setOpen(newOpen);
     },
-    [isControlled, onOpenChange],
+    [isControlled, onOpenChange, disclosure],
   );
 
   // Generate stable IDs for ARIA relationships

--- a/packages/ui/src/components/ui/collapsible.tsx
+++ b/packages/ui/src/components/ui/collapsible.tsx
@@ -28,7 +28,7 @@
 import * as React from 'react';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
-import { createDisclosure } from '../../primitives/create-disclosure';
+import { createDisclosure } from '../../primitives/disclosure';
 import { mergeProps } from '../../primitives/slot';
 import { collapsibleContentClasses } from './collapsible.classes';
 

--- a/packages/ui/src/components/ui/collapsible.tsx
+++ b/packages/ui/src/components/ui/collapsible.tsx
@@ -26,7 +26,9 @@
  */
 
 import * as React from 'react';
+import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
+import { createDisclosure } from '../../primitives/create-disclosure';
 import { mergeProps } from '../../primitives/slot';
 import { collapsibleContentClasses } from './collapsible.classes';
 
@@ -71,23 +73,32 @@ export function Collapsible({
   children,
   ...props
 }: CollapsibleProps) {
-  // Uncontrolled state
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+  // One disclosure cell per mounted root; seeded from the controlled value or defaultOpen.
+  const disclosureRef = React.useRef(
+    createDisclosure({ initialOpen: controlledOpen ?? defaultOpen }),
+  );
+  const disclosure = disclosureRef.current;
 
   // Determine if controlled
   const isControlled = controlledOpen !== undefined;
-  const open = isControlled ? controlledOpen : uncontrolledOpen;
 
+  // Controlled: reflect the incoming prop into the cell (programmatic, no callback).
+  React.useEffect(() => {
+    if (isControlled) disclosure.setOpen(controlledOpen);
+  }, [isControlled, controlledOpen, disclosure]);
+
+  // Current value for render.
+  const open = useMemory(disclosure.memory).open;
+
+  // User action: fire the callback; in uncontrolled mode also drive the cell.
   const handleOpenChange = React.useCallback(
     (newOpen: boolean) => {
       if (disabled) return;
 
-      if (!isControlled) {
-        setUncontrolledOpen(newOpen);
-      }
       onOpenChange?.(newOpen);
+      if (!isControlled) disclosure.setOpen(newOpen);
     },
-    [isControlled, disabled, onOpenChange],
+    [isControlled, disabled, onOpenChange, disclosure],
   );
 
   // Generate stable IDs for ARIA relationships

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -49,7 +49,7 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
-import { createDisclosure } from '../../primitives/create-disclosure';
+import { createDisclosure } from '../../primitives/disclosure';
 import {
   getDialogAriaProps,
   getOverlayAriaProps,

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -49,12 +49,12 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
-import { createDisclosure } from '../../primitives/disclosure';
 import {
   getDialogAriaProps,
   getOverlayAriaProps,
   getTriggerAriaProps,
 } from '../../primitives/dialog-aria';
+import { createDisclosure } from '../../primitives/disclosure';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap';
 import { onPointerDownOutside } from '../../primitives/outside-click';

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -47,7 +47,9 @@
 
 import * as React from 'react';
 import { createPortal } from 'react-dom';
+import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
+import { createDisclosure } from '../../primitives/create-disclosure';
 import {
   getDialogAriaProps,
   getOverlayAriaProps,
@@ -114,21 +116,30 @@ export function Dialog({
   onOpenChange,
   modal = true,
 }: DialogProps) {
-  // Uncontrolled state
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+  // One disclosure cell per mounted root; seeded from the controlled value or defaultOpen.
+  const disclosureRef = React.useRef(
+    createDisclosure({ initialOpen: controlledOpen ?? defaultOpen }),
+  );
+  const disclosure = disclosureRef.current;
 
   // Determine if controlled
   const isControlled = controlledOpen !== undefined;
-  const open = isControlled ? controlledOpen : uncontrolledOpen;
 
+  // Controlled: reflect the incoming prop into the cell (programmatic, no callback).
+  React.useEffect(() => {
+    if (isControlled) disclosure.setOpen(controlledOpen);
+  }, [isControlled, controlledOpen, disclosure]);
+
+  // Current value for render.
+  const open = useMemory(disclosure.memory).open;
+
+  // User action: fire the callback; in uncontrolled mode also drive the cell.
   const handleOpenChange = React.useCallback(
     (newOpen: boolean) => {
-      if (!isControlled) {
-        setUncontrolledOpen(newOpen);
-      }
       onOpenChange?.(newOpen);
+      if (!isControlled) disclosure.setOpen(newOpen);
     },
-    [isControlled, onOpenChange],
+    [isControlled, onOpenChange, disclosure],
   );
 
   // Generate stable IDs for ARIA relationships using React 19 useId

--- a/packages/ui/src/components/ui/drawer.tsx
+++ b/packages/ui/src/components/ui/drawer.tsx
@@ -60,7 +60,9 @@
 
 import * as React from 'react';
 import { createPortal } from 'react-dom';
+import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
+import { createDisclosure } from '../../primitives/create-disclosure';
 import {
   getDialogAriaProps,
   getOverlayAriaProps,
@@ -122,21 +124,30 @@ export function Drawer({
   modal = true,
   side = 'bottom',
 }: DrawerProps): React.JSX.Element {
-  // Uncontrolled state
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+  // One disclosure cell per mounted root; seeded from the controlled value or defaultOpen.
+  const disclosureRef = React.useRef(
+    createDisclosure({ initialOpen: controlledOpen ?? defaultOpen }),
+  );
+  const disclosure = disclosureRef.current;
 
   // Determine if controlled
   const isControlled = controlledOpen !== undefined;
-  const open = isControlled ? controlledOpen : uncontrolledOpen;
 
+  // Controlled: reflect the incoming prop into the cell (programmatic, no callback).
+  React.useEffect(() => {
+    if (isControlled) disclosure.setOpen(controlledOpen);
+  }, [isControlled, controlledOpen, disclosure]);
+
+  // Current value for render.
+  const open = useMemory(disclosure.memory).open;
+
+  // User action: fire the callback; in uncontrolled mode also drive the cell.
   const handleOpenChange = React.useCallback(
     (newOpen: boolean) => {
-      if (!isControlled) {
-        setUncontrolledOpen(newOpen);
-      }
       onOpenChange?.(newOpen);
+      if (!isControlled) disclosure.setOpen(newOpen);
     },
-    [isControlled, onOpenChange],
+    [isControlled, onOpenChange, disclosure],
   );
 
   // Generate stable IDs for ARIA relationships using React 19 useId

--- a/packages/ui/src/components/ui/drawer.tsx
+++ b/packages/ui/src/components/ui/drawer.tsx
@@ -62,12 +62,12 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
-import { createDisclosure } from '../../primitives/disclosure';
 import {
   getDialogAriaProps,
   getOverlayAriaProps,
   getTriggerAriaProps,
 } from '../../primitives/dialog-aria';
+import { createDisclosure } from '../../primitives/disclosure';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap';
 import { onPointerDownOutside } from '../../primitives/outside-click';

--- a/packages/ui/src/components/ui/drawer.tsx
+++ b/packages/ui/src/components/ui/drawer.tsx
@@ -62,7 +62,7 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
-import { createDisclosure } from '../../primitives/create-disclosure';
+import { createDisclosure } from '../../primitives/disclosure';
 import {
   getDialogAriaProps,
   getOverlayAriaProps,

--- a/packages/ui/src/components/ui/sheet.tsx
+++ b/packages/ui/src/components/ui/sheet.tsx
@@ -48,7 +48,9 @@
 
 import * as React from 'react';
 import { createPortal } from 'react-dom';
+import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
+import { createDisclosure } from '../../primitives/create-disclosure';
 import {
   getDialogAriaProps,
   getOverlayAriaProps,
@@ -114,21 +116,30 @@ export function Sheet({
   onOpenChange,
   modal = true,
 }: SheetProps) {
-  // Uncontrolled state
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+  // One disclosure cell per mounted root; seeded from the controlled value or defaultOpen.
+  const disclosureRef = React.useRef(
+    createDisclosure({ initialOpen: controlledOpen ?? defaultOpen }),
+  );
+  const disclosure = disclosureRef.current;
 
   // Determine if controlled
   const isControlled = controlledOpen !== undefined;
-  const open = isControlled ? controlledOpen : uncontrolledOpen;
 
+  // Controlled: reflect the incoming prop into the cell (programmatic, no callback).
+  React.useEffect(() => {
+    if (isControlled) disclosure.setOpen(controlledOpen);
+  }, [isControlled, controlledOpen, disclosure]);
+
+  // Current value for render.
+  const open = useMemory(disclosure.memory).open;
+
+  // User action: fire the callback; in uncontrolled mode also drive the cell.
   const handleOpenChange = React.useCallback(
     (newOpen: boolean) => {
-      if (!isControlled) {
-        setUncontrolledOpen(newOpen);
-      }
       onOpenChange?.(newOpen);
+      if (!isControlled) disclosure.setOpen(newOpen);
     },
-    [isControlled, onOpenChange],
+    [isControlled, onOpenChange, disclosure],
   );
 
   // Generate stable IDs for ARIA relationships using React 19 useId

--- a/packages/ui/src/components/ui/sheet.tsx
+++ b/packages/ui/src/components/ui/sheet.tsx
@@ -50,7 +50,7 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
-import { createDisclosure } from '../../primitives/create-disclosure';
+import { createDisclosure } from '../../primitives/disclosure';
 import {
   getDialogAriaProps,
   getOverlayAriaProps,

--- a/packages/ui/src/components/ui/sheet.tsx
+++ b/packages/ui/src/components/ui/sheet.tsx
@@ -50,12 +50,12 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
-import { createDisclosure } from '../../primitives/disclosure';
 import {
   getDialogAriaProps,
   getOverlayAriaProps,
   getTriggerAriaProps,
 } from '../../primitives/dialog-aria';
+import { createDisclosure } from '../../primitives/disclosure';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap';
 import { onPointerDownOutside } from '../../primitives/outside-click';

--- a/packages/ui/test/components/alert-dialog.test.tsx
+++ b/packages/ui/test/components/alert-dialog.test.tsx
@@ -309,6 +309,44 @@ describe('AlertDialog - Controlled Mode', () => {
       expect(onOpenChange).toHaveBeenCalledWith(false);
     });
   });
+
+  it('controlled prop drives open; cell does not self-open (disclosure delegation)', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const { rerender } = render(
+      <AlertDialog open={false} onOpenChange={onOpenChange}>
+        <AlertDialogTrigger>Open</AlertDialogTrigger>
+        <AlertDialogPortal>
+          <AlertDialogContent>
+            <AlertDialogTitle>Body</AlertDialogTitle>
+          </AlertDialogContent>
+        </AlertDialogPortal>
+      </AlertDialog>,
+    );
+
+    await user.click(screen.getByText('Open'));
+
+    // Callback fired, but the cell did NOT self-open while controlled.
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(screen.queryByText('Body')).not.toBeInTheDocument();
+
+    // The owning prop reflects in.
+    rerender(
+      <AlertDialog open onOpenChange={onOpenChange}>
+        <AlertDialogTrigger>Open</AlertDialogTrigger>
+        <AlertDialogPortal>
+          <AlertDialogContent>
+            <AlertDialogTitle>Body</AlertDialogTitle>
+          </AlertDialogContent>
+        </AlertDialogPortal>
+      </AlertDialog>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Body')).toBeInTheDocument();
+    });
+  });
 });
 
 describe('AlertDialog - ARIA Attributes', () => {

--- a/packages/ui/test/components/collapsible.test.tsx
+++ b/packages/ui/test/components/collapsible.test.tsx
@@ -96,6 +96,31 @@ describe('Collapsible', () => {
     expect(screen.getByText('Controlled Content')).toBeInTheDocument();
   });
 
+  it('controlled prop drives open; cell does not self-open (disclosure delegation)', () => {
+    const onOpenChange = vi.fn();
+    const { rerender } = render(
+      <Collapsible open={false} onOpenChange={onOpenChange}>
+        <CollapsibleTrigger>Toggle</CollapsibleTrigger>
+        <CollapsibleContent>Controlled Content</CollapsibleContent>
+      </Collapsible>,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    // Callback fired, but the cell did NOT self-open while controlled.
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(screen.queryByText('Controlled Content')).not.toBeInTheDocument();
+
+    // The owning prop reflects in.
+    rerender(
+      <Collapsible open onOpenChange={onOpenChange}>
+        <CollapsibleTrigger>Toggle</CollapsibleTrigger>
+        <CollapsibleContent>Controlled Content</CollapsibleContent>
+      </Collapsible>,
+    );
+    expect(screen.getByText('Controlled Content')).toBeInTheDocument();
+  });
+
   it('calls onOpenChange callback', () => {
     const handleChange = vi.fn();
 

--- a/packages/ui/test/components/dialog.test.tsx
+++ b/packages/ui/test/components/dialog.test.tsx
@@ -279,6 +279,44 @@ describe('Dialog - Controlled Mode', () => {
       expect(onOpenChange).toHaveBeenCalledWith(false);
     });
   });
+
+  it('controlled prop drives open; cell does not self-open (disclosure delegation)', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const { rerender } = render(
+      <Dialog open={false} onOpenChange={onOpenChange}>
+        <DialogTrigger>Open</DialogTrigger>
+        <DialogPortal>
+          <DialogContent>
+            <DialogTitle>Body</DialogTitle>
+          </DialogContent>
+        </DialogPortal>
+      </Dialog>,
+    );
+
+    await user.click(screen.getByText('Open'));
+
+    // Callback fired, but the cell did NOT self-open while controlled.
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(screen.queryByText('Body')).not.toBeInTheDocument();
+
+    // The owning prop reflects in.
+    rerender(
+      <Dialog open onOpenChange={onOpenChange}>
+        <DialogTrigger>Open</DialogTrigger>
+        <DialogPortal>
+          <DialogContent>
+            <DialogTitle>Body</DialogTitle>
+          </DialogContent>
+        </DialogPortal>
+      </Dialog>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Body')).toBeInTheDocument();
+    });
+  });
 });
 
 describe('Dialog - ARIA Attributes', () => {

--- a/packages/ui/test/components/drawer.test.tsx
+++ b/packages/ui/test/components/drawer.test.tsx
@@ -278,6 +278,44 @@ describe('Drawer - Controlled Mode', () => {
       expect(onOpenChange).toHaveBeenCalledWith(false);
     });
   });
+
+  it('controlled prop drives open; cell does not self-open (disclosure delegation)', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const { rerender } = render(
+      <Drawer open={false} onOpenChange={onOpenChange}>
+        <DrawerTrigger>Open</DrawerTrigger>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Body</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await user.click(screen.getByText('Open'));
+
+    // Callback fired, but the cell did NOT self-open while controlled.
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(screen.queryByText('Body')).not.toBeInTheDocument();
+
+    // The owning prop reflects in.
+    rerender(
+      <Drawer open onOpenChange={onOpenChange}>
+        <DrawerTrigger>Open</DrawerTrigger>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Body</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Body')).toBeInTheDocument();
+    });
+  });
 });
 
 describe('Drawer - Side Variants', () => {

--- a/packages/ui/test/components/sheet.test.tsx
+++ b/packages/ui/test/components/sheet.test.tsx
@@ -278,6 +278,44 @@ describe('Sheet - Controlled Mode', () => {
       expect(onOpenChange).toHaveBeenCalledWith(false);
     });
   });
+
+  it('controlled prop drives open; cell does not self-open (disclosure delegation)', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const { rerender } = render(
+      <Sheet open={false} onOpenChange={onOpenChange}>
+        <SheetTrigger>Open</SheetTrigger>
+        <SheetPortal>
+          <SheetContent>
+            <SheetTitle>Body</SheetTitle>
+          </SheetContent>
+        </SheetPortal>
+      </Sheet>,
+    );
+
+    await user.click(screen.getByText('Open'));
+
+    // Callback fired, but the cell did NOT self-open while controlled.
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(screen.queryByText('Body')).not.toBeInTheDocument();
+
+    // The owning prop reflects in.
+    rerender(
+      <Sheet open onOpenChange={onOpenChange}>
+        <SheetTrigger>Open</SheetTrigger>
+        <SheetPortal>
+          <SheetContent>
+            <SheetTitle>Body</SheetTitle>
+          </SheetContent>
+        </SheetPortal>
+      </Sheet>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Body')).toBeInTheDocument();
+    });
+  });
 });
 
 describe('Sheet - Side Variants', () => {


### PR DESCRIPTION
Closes #1692.

Depends on #1691 (createDisclosure); rebase onto main after #1691 merges.

## What changed

Migrates the five single-open-boolean roots off component-local `useState(defaultOpen)` and onto the `createDisclosure` cell, bridged to React via `useMemory`. One open/close state shape, written once on `createMemory`, ready for the pending Web Component ports.

Per root (`dialog.tsx`, `alert-dialog.tsx`, `drawer.tsx`, `sheet.tsx`, `collapsible.tsx`):
- A single `createDisclosure({ initialOpen: controlledOpen ?? defaultOpen })` cell per mounted root, held in a ref.
- Controlled mode reflects the incoming `open` prop into the cell via `disclosure.setOpen` in an effect (programmatic, no callback).
- Render reads `useMemory(disclosure.memory).open`.
- User actions fire `onOpenChange` and, when uncontrolled, drive the cell via `setOpen`.

Dual-mode lives entirely at the React boundary; `createDisclosure` takes no `controlled` flag and fires no callback. Public API, the context value shape, ARIA ids (`useId`), and mount/portal/focus-trap/escape/outside-click semantics are unchanged. `alert-dialog`'s `cancelRef` and `collapsible`'s `disabled` guard are preserved.

## Tests

Each component's test file gains a 'controlled prop drives open; cell does not self-open (disclosure delegation)' case: clicking the trigger while `open={false}` fires `onOpenChange(true)` but does NOT mount content, and a rerender with `open` reflects the prop in.

## Verification

- `pnpm --filter @rafters/ui typecheck` green.
- `pnpm --filter @rafters/ui test` green (220 files, 4587 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)