### PR TITLE
feat(ui): land createDisclosure migration (dialogs, dropdown, context-menu, hover-card, tooltip)

### DIFF
--- a/packages/ui/src/components/ui/alert-dialog.tsx
+++ b/packages/ui/src/components/ui/alert-dialog.tsx
@@ -54,7 +54,7 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
-import { createDisclosure } from '../../primitives/create-disclosure';
+import { createDisclosure } from '../../primitives/disclosure';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap';
 import { getPortalContainer } from '../../primitives/portal';

--- a/packages/ui/src/components/ui/alert-dialog.tsx
+++ b/packages/ui/src/components/ui/alert-dialog.tsx
@@ -52,7 +52,9 @@
 
 import * as React from 'react';
 import { createPortal } from 'react-dom';
+import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
+import { createDisclosure } from '../../primitives/create-disclosure';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap';
 import { getPortalContainer } from '../../primitives/portal';
@@ -111,24 +113,33 @@ export function AlertDialog({
   defaultOpen = false,
   onOpenChange,
 }: AlertDialogProps) {
-  // Uncontrolled state
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+  // One disclosure cell per mounted root; seeded from the controlled value or defaultOpen.
+  const disclosureRef = React.useRef(
+    createDisclosure({ initialOpen: controlledOpen ?? defaultOpen }),
+  );
+  const disclosure = disclosureRef.current;
 
   // Reference to cancel button for initial focus
   const cancelRef = React.useRef<HTMLButtonElement | null>(null);
 
   // Determine if controlled
   const isControlled = controlledOpen !== undefined;
-  const open = isControlled ? controlledOpen : uncontrolledOpen;
 
+  // Controlled: reflect the incoming prop into the cell (programmatic, no callback).
+  React.useEffect(() => {
+    if (isControlled) disclosure.setOpen(controlledOpen);
+  }, [isControlled, controlledOpen, disclosure]);
+
+  // Current value for render.
+  const open = useMemory(disclosure.memory).open;
+
+  // User action: fire the callback; in uncontrolled mode also drive the cell.
   const handleOpenChange = React.useCallback(
     (newOpen: boolean) => {
-      if (!isControlled) {
-        setUncontrolledOpen(newOpen);
-      }
       onOpenChange?.(newOpen);
+      if (!isControlled) disclosure.setOpen(newOpen);
     },
-    [isControlled, onOpenChange],
+    [isControlled, onOpenChange, disclosure],
   );
 
   // Generate stable IDs for ARIA relationships

--- a/packages/ui/src/components/ui/collapsible.tsx
+++ b/packages/ui/src/components/ui/collapsible.tsx
@@ -28,7 +28,7 @@
 import * as React from 'react';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
-import { createDisclosure } from '../../primitives/create-disclosure';
+import { createDisclosure } from '../../primitives/disclosure';
 import { mergeProps } from '../../primitives/slot';
 import { collapsibleContentClasses } from './collapsible.classes';
 

--- a/packages/ui/src/components/ui/collapsible.tsx
+++ b/packages/ui/src/components/ui/collapsible.tsx
@@ -26,7 +26,9 @@
  */
 
 import * as React from 'react';
+import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
+import { createDisclosure } from '../../primitives/create-disclosure';
 import { mergeProps } from '../../primitives/slot';
 import { collapsibleContentClasses } from './collapsible.classes';
 
@@ -71,23 +73,32 @@ export function Collapsible({
   children,
   ...props
 }: CollapsibleProps) {
-  // Uncontrolled state
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+  // One disclosure cell per mounted root; seeded from the controlled value or defaultOpen.
+  const disclosureRef = React.useRef(
+    createDisclosure({ initialOpen: controlledOpen ?? defaultOpen }),
+  );
+  const disclosure = disclosureRef.current;
 
   // Determine if controlled
   const isControlled = controlledOpen !== undefined;
-  const open = isControlled ? controlledOpen : uncontrolledOpen;
 
+  // Controlled: reflect the incoming prop into the cell (programmatic, no callback).
+  React.useEffect(() => {
+    if (isControlled) disclosure.setOpen(controlledOpen);
+  }, [isControlled, controlledOpen, disclosure]);
+
+  // Current value for render.
+  const open = useMemory(disclosure.memory).open;
+
+  // User action: fire the callback; in uncontrolled mode also drive the cell.
   const handleOpenChange = React.useCallback(
     (newOpen: boolean) => {
       if (disabled) return;
 
-      if (!isControlled) {
-        setUncontrolledOpen(newOpen);
-      }
       onOpenChange?.(newOpen);
+      if (!isControlled) disclosure.setOpen(newOpen);
     },
-    [isControlled, disabled, onOpenChange],
+    [isControlled, disabled, onOpenChange, disclosure],
   );
 
   // Generate stable IDs for ARIA relationships

--- a/packages/ui/src/components/ui/context-menu.tsx
+++ b/packages/ui/src/components/ui/context-menu.tsx
@@ -32,8 +32,11 @@
 
 import * as React from 'react';
 import { createPortal } from 'react-dom';
+import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
+import { createDisclosure } from '../../primitives/create-disclosure';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
+import { createMemory } from '../../primitives/memory';
 import { onPointerDownOutside } from '../../primitives/outside-click';
 import { getPortalContainer } from '../../primitives/portal';
 import { createRovingFocus } from '../../primitives/roving-focus';
@@ -136,20 +139,34 @@ export function ContextMenu({
   defaultOpen = false,
   onOpenChange,
 }: ContextMenuProps) {
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
-  const [position, setPosition] = React.useState({ x: 0, y: 0 });
+  // Open lives on createDisclosure; the right-click pointer {x,y} lives on a
+  // tiny per-root createMemory cell. Both are the single source of truth - no
+  // component-local useState. The controlled/uncontrolled dual-mode stays at
+  // this React boundary (reflect the prop in via setOpen, fire onOpenChange on
+  // user actions), exactly as the disclosure batch prescribes.
+  const disclosure = React.useRef(createDisclosure({ initialOpen: defaultOpen })).current;
+  const point = React.useRef(createMemory(() => ({ x: 0, y: 0 }))).current;
 
   const isControlled = controlledOpen !== undefined;
+  const uncontrolledOpen = useMemory(disclosure.memory).open;
   const open = isControlled ? controlledOpen : uncontrolledOpen;
+  const position = useMemory(point);
 
   const handleOpenChange = React.useCallback(
     (newOpen: boolean) => {
       if (!isControlled) {
-        setUncontrolledOpen(newOpen);
+        disclosure.setOpen(newOpen);
       }
       onOpenChange?.(newOpen);
     },
-    [isControlled, onOpenChange],
+    [isControlled, onOpenChange, disclosure],
+  );
+
+  const setPosition = React.useCallback(
+    (next: { x: number; y: number }) => {
+      point.set(next);
+    },
+    [point],
   );
 
   const id = React.useId();
@@ -163,7 +180,7 @@ export function ContextMenu({
       position,
       setPosition,
     }),
-    [open, handleOpenChange, contentId, position],
+    [open, handleOpenChange, contentId, position, setPosition],
   );
 
   return <ContextMenuContext.Provider value={contextValue}>{children}</ContextMenuContext.Provider>;
@@ -777,19 +794,22 @@ export function ContextMenuSub({
   defaultOpen = false,
   onOpenChange,
 }: ContextMenuSubProps) {
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+  // Submenu open uses the same createDisclosure boundary as the root - the
+  // controlled/uncontrolled dual-mode stays here, no component-local useState.
+  const disclosure = React.useRef(createDisclosure({ initialOpen: defaultOpen })).current;
 
   const isControlled = controlledOpen !== undefined;
+  const uncontrolledOpen = useMemory(disclosure.memory).open;
   const open = isControlled ? controlledOpen : uncontrolledOpen;
 
   const handleOpenChange = React.useCallback(
     (newOpen: boolean) => {
       if (!isControlled) {
-        setUncontrolledOpen(newOpen);
+        disclosure.setOpen(newOpen);
       }
       onOpenChange?.(newOpen);
     },
-    [isControlled, onOpenChange],
+    [isControlled, onOpenChange, disclosure],
   );
 
   const id = React.useId();

--- a/packages/ui/src/components/ui/context-menu.tsx
+++ b/packages/ui/src/components/ui/context-menu.tsx
@@ -34,7 +34,7 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
-import { createDisclosure } from '../../primitives/create-disclosure';
+import { createDisclosure } from '../../primitives/disclosure';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { createMemory } from '../../primitives/memory';
 import { onPointerDownOutside } from '../../primitives/outside-click';

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -49,7 +49,7 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
-import { createDisclosure } from '../../primitives/create-disclosure';
+import { createDisclosure } from '../../primitives/disclosure';
 import {
   getDialogAriaProps,
   getOverlayAriaProps,

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -49,12 +49,12 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
-import { createDisclosure } from '../../primitives/disclosure';
 import {
   getDialogAriaProps,
   getOverlayAriaProps,
   getTriggerAriaProps,
 } from '../../primitives/dialog-aria';
+import { createDisclosure } from '../../primitives/disclosure';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap';
 import { onPointerDownOutside } from '../../primitives/outside-click';

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -47,7 +47,9 @@
 
 import * as React from 'react';
 import { createPortal } from 'react-dom';
+import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
+import { createDisclosure } from '../../primitives/create-disclosure';
 import {
   getDialogAriaProps,
   getOverlayAriaProps,
@@ -114,21 +116,30 @@ export function Dialog({
   onOpenChange,
   modal = true,
 }: DialogProps) {
-  // Uncontrolled state
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+  // One disclosure cell per mounted root; seeded from the controlled value or defaultOpen.
+  const disclosureRef = React.useRef(
+    createDisclosure({ initialOpen: controlledOpen ?? defaultOpen }),
+  );
+  const disclosure = disclosureRef.current;
 
   // Determine if controlled
   const isControlled = controlledOpen !== undefined;
-  const open = isControlled ? controlledOpen : uncontrolledOpen;
 
+  // Controlled: reflect the incoming prop into the cell (programmatic, no callback).
+  React.useEffect(() => {
+    if (isControlled) disclosure.setOpen(controlledOpen);
+  }, [isControlled, controlledOpen, disclosure]);
+
+  // Current value for render.
+  const open = useMemory(disclosure.memory).open;
+
+  // User action: fire the callback; in uncontrolled mode also drive the cell.
   const handleOpenChange = React.useCallback(
     (newOpen: boolean) => {
-      if (!isControlled) {
-        setUncontrolledOpen(newOpen);
-      }
       onOpenChange?.(newOpen);
+      if (!isControlled) disclosure.setOpen(newOpen);
     },
-    [isControlled, onOpenChange],
+    [isControlled, onOpenChange, disclosure],
   );
 
   // Generate stable IDs for ARIA relationships using React 19 useId

--- a/packages/ui/src/components/ui/drawer.tsx
+++ b/packages/ui/src/components/ui/drawer.tsx
@@ -60,7 +60,9 @@
 
 import * as React from 'react';
 import { createPortal } from 'react-dom';
+import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
+import { createDisclosure } from '../../primitives/create-disclosure';
 import {
   getDialogAriaProps,
   getOverlayAriaProps,
@@ -122,21 +124,30 @@ export function Drawer({
   modal = true,
   side = 'bottom',
 }: DrawerProps): React.JSX.Element {
-  // Uncontrolled state
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+  // One disclosure cell per mounted root; seeded from the controlled value or defaultOpen.
+  const disclosureRef = React.useRef(
+    createDisclosure({ initialOpen: controlledOpen ?? defaultOpen }),
+  );
+  const disclosure = disclosureRef.current;
 
   // Determine if controlled
   const isControlled = controlledOpen !== undefined;
-  const open = isControlled ? controlledOpen : uncontrolledOpen;
 
+  // Controlled: reflect the incoming prop into the cell (programmatic, no callback).
+  React.useEffect(() => {
+    if (isControlled) disclosure.setOpen(controlledOpen);
+  }, [isControlled, controlledOpen, disclosure]);
+
+  // Current value for render.
+  const open = useMemory(disclosure.memory).open;
+
+  // User action: fire the callback; in uncontrolled mode also drive the cell.
   const handleOpenChange = React.useCallback(
     (newOpen: boolean) => {
-      if (!isControlled) {
-        setUncontrolledOpen(newOpen);
-      }
       onOpenChange?.(newOpen);
+      if (!isControlled) disclosure.setOpen(newOpen);
     },
-    [isControlled, onOpenChange],
+    [isControlled, onOpenChange, disclosure],
   );
 
   // Generate stable IDs for ARIA relationships using React 19 useId

--- a/packages/ui/src/components/ui/drawer.tsx
+++ b/packages/ui/src/components/ui/drawer.tsx
@@ -62,12 +62,12 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
-import { createDisclosure } from '../../primitives/disclosure';
 import {
   getDialogAriaProps,
   getOverlayAriaProps,
   getTriggerAriaProps,
 } from '../../primitives/dialog-aria';
+import { createDisclosure } from '../../primitives/disclosure';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap';
 import { onPointerDownOutside } from '../../primitives/outside-click';

--- a/packages/ui/src/components/ui/drawer.tsx
+++ b/packages/ui/src/components/ui/drawer.tsx
@@ -62,7 +62,7 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
-import { createDisclosure } from '../../primitives/create-disclosure';
+import { createDisclosure } from '../../primitives/disclosure';
 import {
   getDialogAriaProps,
   getOverlayAriaProps,

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -32,8 +32,10 @@
 
 import * as React from 'react';
 import { createPortal } from 'react-dom';
+import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
 import { computePosition } from '../../primitives/collision-detector';
+import { createDisclosure } from '../../primitives/create-disclosure';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { onPointerDownOutside } from '../../primitives/outside-click';
 import { getPortalContainer } from '../../primitives/portal';
@@ -137,19 +139,25 @@ export function DropdownMenu({
   defaultOpen = false,
   onOpenChange,
 }: DropdownMenuProps) {
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
-
+  const disclosure = React.useRef(
+    createDisclosure({ initialOpen: controlledOpen ?? defaultOpen ?? false }),
+  ).current;
   const isControlled = controlledOpen !== undefined;
-  const open = isControlled ? controlledOpen : uncontrolledOpen;
+
+  React.useEffect(() => {
+    if (isControlled) disclosure.setOpen(controlledOpen);
+  }, [isControlled, controlledOpen, disclosure]);
+
+  const open = useMemory(disclosure.memory).open;
 
   const handleOpenChange = React.useCallback(
     (newOpen: boolean) => {
-      if (!isControlled) {
-        setUncontrolledOpen(newOpen);
-      }
       onOpenChange?.(newOpen);
+      if (!isControlled) {
+        disclosure.setOpen(newOpen);
+      }
     },
-    [isControlled, onOpenChange],
+    [isControlled, onOpenChange, disclosure],
   );
 
   const id = React.useId();
@@ -817,19 +825,25 @@ export function DropdownMenuSub({
   defaultOpen = false,
   onOpenChange,
 }: DropdownMenuSubProps) {
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
-
+  const disclosure = React.useRef(
+    createDisclosure({ initialOpen: controlledOpen ?? defaultOpen ?? false }),
+  ).current;
   const isControlled = controlledOpen !== undefined;
-  const open = isControlled ? controlledOpen : uncontrolledOpen;
+
+  React.useEffect(() => {
+    if (isControlled) disclosure.setOpen(controlledOpen);
+  }, [isControlled, controlledOpen, disclosure]);
+
+  const open = useMemory(disclosure.memory).open;
 
   const handleOpenChange = React.useCallback(
     (newOpen: boolean) => {
-      if (!isControlled) {
-        setUncontrolledOpen(newOpen);
-      }
       onOpenChange?.(newOpen);
+      if (!isControlled) {
+        disclosure.setOpen(newOpen);
+      }
     },
-    [isControlled, onOpenChange],
+    [isControlled, onOpenChange, disclosure],
   );
 
   const id = React.useId();

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -35,7 +35,7 @@ import { createPortal } from 'react-dom';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
 import { computePosition } from '../../primitives/collision-detector';
-import { createDisclosure } from '../../primitives/create-disclosure';
+import { createDisclosure } from '../../primitives/disclosure';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { onPointerDownOutside } from '../../primitives/outside-click';
 import { getPortalContainer } from '../../primitives/portal';

--- a/packages/ui/src/components/ui/hover-card.tsx
+++ b/packages/ui/src/components/ui/hover-card.tsx
@@ -40,7 +40,7 @@ import { createPortal } from 'react-dom';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
 import { type CollisionOptions, computePosition } from '../../primitives/collision-detector';
-import { createDisclosure } from '../../primitives/create-disclosure';
+import { createDisclosure } from '../../primitives/disclosure';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { getPortalContainer } from '../../primitives/portal';
 import { mergeProps } from '../../primitives/slot';

--- a/packages/ui/src/components/ui/hover-card.tsx
+++ b/packages/ui/src/components/ui/hover-card.tsx
@@ -37,8 +37,10 @@
 
 import * as React from 'react';
 import { createPortal } from 'react-dom';
+import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
 import { type CollisionOptions, computePosition } from '../../primitives/collision-detector';
+import { createDisclosure } from '../../primitives/create-disclosure';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { getPortalContainer } from '../../primitives/portal';
 import { mergeProps } from '../../primitives/slot';
@@ -130,10 +132,22 @@ export function HoverCard({
   closeDelay = 300,
   children,
 }: HoverCardProps): React.JSX.Element {
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+  // Open state lives on the shared createDisclosure cell (issue #1695). The
+  // controlled/uncontrolled dual-mode stays at the React boundary: a controlled
+  // prop is reflected in via setOpen, and user actions fire onOpenChange.
+  const disclosure = React.useRef(
+    createDisclosure({ initialOpen: controlledOpen ?? defaultOpen ?? false }),
+  ).current;
 
   const isControlled = controlledOpen !== undefined;
-  const open = isControlled ? controlledOpen : uncontrolledOpen;
+
+  React.useEffect(() => {
+    if (isControlled) {
+      disclosure.setOpen(controlledOpen);
+    }
+  }, [isControlled, controlledOpen, disclosure]);
+
+  const open = useMemory(disclosure.memory).open;
 
   const handleOpenChange = React.useCallback(
     (newOpen: boolean) => {
@@ -141,11 +155,11 @@ export function HoverCard({
         globalOpenTimestamp = Date.now();
       }
       if (!isControlled) {
-        setUncontrolledOpen(newOpen);
+        disclosure.setOpen(newOpen);
       }
       onOpenChange?.(newOpen);
     },
-    [isControlled, onOpenChange],
+    [isControlled, onOpenChange, disclosure],
   );
 
   const triggerRef = React.useRef<HTMLElement | null>(null);

--- a/packages/ui/src/components/ui/sheet.tsx
+++ b/packages/ui/src/components/ui/sheet.tsx
@@ -48,7 +48,9 @@
 
 import * as React from 'react';
 import { createPortal } from 'react-dom';
+import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
+import { createDisclosure } from '../../primitives/create-disclosure';
 import {
   getDialogAriaProps,
   getOverlayAriaProps,
@@ -114,21 +116,30 @@ export function Sheet({
   onOpenChange,
   modal = true,
 }: SheetProps) {
-  // Uncontrolled state
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+  // One disclosure cell per mounted root; seeded from the controlled value or defaultOpen.
+  const disclosureRef = React.useRef(
+    createDisclosure({ initialOpen: controlledOpen ?? defaultOpen }),
+  );
+  const disclosure = disclosureRef.current;
 
   // Determine if controlled
   const isControlled = controlledOpen !== undefined;
-  const open = isControlled ? controlledOpen : uncontrolledOpen;
 
+  // Controlled: reflect the incoming prop into the cell (programmatic, no callback).
+  React.useEffect(() => {
+    if (isControlled) disclosure.setOpen(controlledOpen);
+  }, [isControlled, controlledOpen, disclosure]);
+
+  // Current value for render.
+  const open = useMemory(disclosure.memory).open;
+
+  // User action: fire the callback; in uncontrolled mode also drive the cell.
   const handleOpenChange = React.useCallback(
     (newOpen: boolean) => {
-      if (!isControlled) {
-        setUncontrolledOpen(newOpen);
-      }
       onOpenChange?.(newOpen);
+      if (!isControlled) disclosure.setOpen(newOpen);
     },
-    [isControlled, onOpenChange],
+    [isControlled, onOpenChange, disclosure],
   );
 
   // Generate stable IDs for ARIA relationships using React 19 useId

--- a/packages/ui/src/components/ui/sheet.tsx
+++ b/packages/ui/src/components/ui/sheet.tsx
@@ -50,7 +50,7 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
-import { createDisclosure } from '../../primitives/create-disclosure';
+import { createDisclosure } from '../../primitives/disclosure';
 import {
   getDialogAriaProps,
   getOverlayAriaProps,

--- a/packages/ui/src/components/ui/sheet.tsx
+++ b/packages/ui/src/components/ui/sheet.tsx
@@ -50,12 +50,12 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
-import { createDisclosure } from '../../primitives/disclosure';
 import {
   getDialogAriaProps,
   getOverlayAriaProps,
   getTriggerAriaProps,
 } from '../../primitives/dialog-aria';
+import { createDisclosure } from '../../primitives/disclosure';
 import { onEscapeKeyDown } from '../../primitives/escape-keydown';
 import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap';
 import { onPointerDownOutside } from '../../primitives/outside-click';

--- a/packages/ui/src/components/ui/tooltip.tsx
+++ b/packages/ui/src/components/ui/tooltip.tsx
@@ -34,7 +34,7 @@ import { createPortal } from 'react-dom';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
 import { type CollisionOptions, computePosition } from '../../primitives/collision-detector';
-import { createDisclosure } from '../../primitives/create-disclosure';
+import { createDisclosure } from '../../primitives/disclosure';
 import { getPortalContainer } from '../../primitives/portal';
 import { mergeProps } from '../../primitives/slot';
 import { tooltipContentClasses } from './tooltip.classes';

--- a/packages/ui/src/components/ui/tooltip.tsx
+++ b/packages/ui/src/components/ui/tooltip.tsx
@@ -31,8 +31,10 @@
 
 import * as React from 'react';
 import { createPortal } from 'react-dom';
+import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
 import { type CollisionOptions, computePosition } from '../../primitives/collision-detector';
+import { createDisclosure } from '../../primitives/create-disclosure';
 import { getPortalContainer } from '../../primitives/portal';
 import { mergeProps } from '../../primitives/slot';
 import { tooltipContentClasses } from './tooltip.classes';
@@ -141,10 +143,23 @@ export function Tooltip({
   children,
 }: TooltipProps) {
   const providerContext = useTooltipProviderContext();
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+
+  // Open state lives on the shared createDisclosure cell (issue #1695) - the
+  // same framework-free core the Astro target can drive. The controlled/
+  // uncontrolled dual-mode stays at the React boundary.
+  const disclosure = React.useRef(
+    createDisclosure({ initialOpen: controlledOpen ?? defaultOpen ?? false }),
+  ).current;
 
   const isControlled = controlledOpen !== undefined;
-  const open = isControlled ? controlledOpen : uncontrolledOpen;
+
+  React.useEffect(() => {
+    if (isControlled) {
+      disclosure.setOpen(controlledOpen);
+    }
+  }, [isControlled, controlledOpen, disclosure]);
+
+  const open = useMemory(disclosure.memory).open;
 
   const delayDuration = delayDurationProp ?? providerContext.delayDuration;
 
@@ -154,11 +169,11 @@ export function Tooltip({
         globalOpenTimestamp = Date.now();
       }
       if (!isControlled) {
-        setUncontrolledOpen(newOpen);
+        disclosure.setOpen(newOpen);
       }
       onOpenChange?.(newOpen);
     },
-    [isControlled, onOpenChange],
+    [isControlled, onOpenChange, disclosure],
   );
 
   const triggerRef = React.useRef<HTMLElement | null>(null);

--- a/packages/ui/test/components/alert-dialog.test.tsx
+++ b/packages/ui/test/components/alert-dialog.test.tsx
@@ -309,6 +309,44 @@ describe('AlertDialog - Controlled Mode', () => {
       expect(onOpenChange).toHaveBeenCalledWith(false);
     });
   });
+
+  it('controlled prop drives open; cell does not self-open (disclosure delegation)', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const { rerender } = render(
+      <AlertDialog open={false} onOpenChange={onOpenChange}>
+        <AlertDialogTrigger>Open</AlertDialogTrigger>
+        <AlertDialogPortal>
+          <AlertDialogContent>
+            <AlertDialogTitle>Body</AlertDialogTitle>
+          </AlertDialogContent>
+        </AlertDialogPortal>
+      </AlertDialog>,
+    );
+
+    await user.click(screen.getByText('Open'));
+
+    // Callback fired, but the cell did NOT self-open while controlled.
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(screen.queryByText('Body')).not.toBeInTheDocument();
+
+    // The owning prop reflects in.
+    rerender(
+      <AlertDialog open onOpenChange={onOpenChange}>
+        <AlertDialogTrigger>Open</AlertDialogTrigger>
+        <AlertDialogPortal>
+          <AlertDialogContent>
+            <AlertDialogTitle>Body</AlertDialogTitle>
+          </AlertDialogContent>
+        </AlertDialogPortal>
+      </AlertDialog>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Body')).toBeInTheDocument();
+    });
+  });
 });
 
 describe('AlertDialog - ARIA Attributes', () => {

--- a/packages/ui/test/components/collapsible.test.tsx
+++ b/packages/ui/test/components/collapsible.test.tsx
@@ -96,6 +96,31 @@ describe('Collapsible', () => {
     expect(screen.getByText('Controlled Content')).toBeInTheDocument();
   });
 
+  it('controlled prop drives open; cell does not self-open (disclosure delegation)', () => {
+    const onOpenChange = vi.fn();
+    const { rerender } = render(
+      <Collapsible open={false} onOpenChange={onOpenChange}>
+        <CollapsibleTrigger>Toggle</CollapsibleTrigger>
+        <CollapsibleContent>Controlled Content</CollapsibleContent>
+      </Collapsible>,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    // Callback fired, but the cell did NOT self-open while controlled.
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(screen.queryByText('Controlled Content')).not.toBeInTheDocument();
+
+    // The owning prop reflects in.
+    rerender(
+      <Collapsible open onOpenChange={onOpenChange}>
+        <CollapsibleTrigger>Toggle</CollapsibleTrigger>
+        <CollapsibleContent>Controlled Content</CollapsibleContent>
+      </Collapsible>,
+    );
+    expect(screen.getByText('Controlled Content')).toBeInTheDocument();
+  });
+
   it('calls onOpenChange callback', () => {
     const handleChange = vi.fn();
 

--- a/packages/ui/test/components/context-menu.test.tsx
+++ b/packages/ui/test/components/context-menu.test.tsx
@@ -265,6 +265,58 @@ describe('ContextMenu - Position at Cursor', () => {
       expect(style.position).toBe('fixed');
     });
   });
+
+  it('opens at the pointer and positions content at the captured coordinates', async () => {
+    render(
+      <ContextMenu>
+        <ContextMenuTrigger>Right-click me</ContextMenuTrigger>
+        <ContextMenuPortal>
+          <ContextMenuContent>
+            <ContextMenuItem>Item 1</ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenuPortal>
+      </ContextMenu>,
+    );
+
+    fireEvent.contextMenu(screen.getByText('Right-click me'), {
+      clientX: 120,
+      clientY: 80,
+    });
+
+    const menu = await screen.findByRole('menu');
+    expect(menu).toBeVisible();
+    await waitFor(() => {
+      expect(menu).toHaveStyle({ left: '120px', top: '80px' });
+    });
+  });
+
+  it('closes on Escape after opening at the pointer', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ContextMenu>
+        <ContextMenuTrigger>Right-click me</ContextMenuTrigger>
+        <ContextMenuPortal>
+          <ContextMenuContent>
+            <ContextMenuItem>Item 1</ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenuPortal>
+      </ContextMenu>,
+    );
+
+    fireEvent.contextMenu(screen.getByText('Right-click me'), {
+      clientX: 120,
+      clientY: 80,
+    });
+
+    await screen.findByRole('menu');
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+  });
 });
 
 describe('ContextMenu - Controlled Mode', () => {

--- a/packages/ui/test/components/dialog.test.tsx
+++ b/packages/ui/test/components/dialog.test.tsx
@@ -279,6 +279,44 @@ describe('Dialog - Controlled Mode', () => {
       expect(onOpenChange).toHaveBeenCalledWith(false);
     });
   });
+
+  it('controlled prop drives open; cell does not self-open (disclosure delegation)', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const { rerender } = render(
+      <Dialog open={false} onOpenChange={onOpenChange}>
+        <DialogTrigger>Open</DialogTrigger>
+        <DialogPortal>
+          <DialogContent>
+            <DialogTitle>Body</DialogTitle>
+          </DialogContent>
+        </DialogPortal>
+      </Dialog>,
+    );
+
+    await user.click(screen.getByText('Open'));
+
+    // Callback fired, but the cell did NOT self-open while controlled.
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(screen.queryByText('Body')).not.toBeInTheDocument();
+
+    // The owning prop reflects in.
+    rerender(
+      <Dialog open onOpenChange={onOpenChange}>
+        <DialogTrigger>Open</DialogTrigger>
+        <DialogPortal>
+          <DialogContent>
+            <DialogTitle>Body</DialogTitle>
+          </DialogContent>
+        </DialogPortal>
+      </Dialog>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Body')).toBeInTheDocument();
+    });
+  });
 });
 
 describe('Dialog - ARIA Attributes', () => {

--- a/packages/ui/test/components/drawer.test.tsx
+++ b/packages/ui/test/components/drawer.test.tsx
@@ -278,6 +278,44 @@ describe('Drawer - Controlled Mode', () => {
       expect(onOpenChange).toHaveBeenCalledWith(false);
     });
   });
+
+  it('controlled prop drives open; cell does not self-open (disclosure delegation)', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const { rerender } = render(
+      <Drawer open={false} onOpenChange={onOpenChange}>
+        <DrawerTrigger>Open</DrawerTrigger>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Body</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await user.click(screen.getByText('Open'));
+
+    // Callback fired, but the cell did NOT self-open while controlled.
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(screen.queryByText('Body')).not.toBeInTheDocument();
+
+    // The owning prop reflects in.
+    rerender(
+      <Drawer open onOpenChange={onOpenChange}>
+        <DrawerTrigger>Open</DrawerTrigger>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>Body</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Body')).toBeInTheDocument();
+    });
+  });
 });
 
 describe('Drawer - Side Variants', () => {

--- a/packages/ui/test/components/dropdown-menu.test.tsx
+++ b/packages/ui/test/components/dropdown-menu.test.tsx
@@ -854,6 +854,45 @@ describe('DropdownMenu - Submenus', () => {
     );
   });
 
+  it('should keep root open when a nested submenu opens (independent state)', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <DropdownMenu defaultOpen>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuPortal>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Root Item</DropdownMenuItem>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>More</DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                <DropdownMenuItem>Sub Item</DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          </DropdownMenuContent>
+        </DropdownMenuPortal>
+      </DropdownMenu>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('More')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Sub Item')).not.toBeInTheDocument();
+
+    await user.hover(screen.getByText('More'));
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('Sub Item')).toBeInTheDocument();
+      },
+      { timeout: 500 },
+    );
+
+    // Opening the submenu does not collapse the root menu.
+    expect(screen.getByText('Root Item')).toBeInTheDocument();
+  });
+
   it('submenu trigger should have aria-haspopup="menu"', async () => {
     render(
       <DropdownMenu defaultOpen>

--- a/packages/ui/test/components/hover-card.test.tsx
+++ b/packages/ui/test/components/hover-card.test.tsx
@@ -836,3 +836,24 @@ describe('HoverCard - forceMount', () => {
     });
   });
 });
+
+
+describe("HoverCard - open state delegates to createDisclosure (migration)", () => {
+  afterEach(() => cleanup());
+  it("reflects a controlled open prop through the disclosure cell", () => {
+    const { rerender } = render(
+      <HoverCard open={false}>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardContent>Reflected hovercard</HoverCardContent>
+      </HoverCard>,
+    );
+    expect(screen.queryByText("Reflected hovercard")).not.toBeInTheDocument();
+    rerender(
+      <HoverCard open={true}>
+        <HoverCardTrigger>Trigger</HoverCardTrigger>
+        <HoverCardContent>Reflected hovercard</HoverCardContent>
+      </HoverCard>,
+    );
+    expect(screen.getByText("Reflected hovercard")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/test/components/hover-card.test.tsx
+++ b/packages/ui/test/components/hover-card.test.tsx
@@ -837,23 +837,22 @@ describe('HoverCard - forceMount', () => {
   });
 });
 
-
-describe("HoverCard - open state delegates to createDisclosure (migration)", () => {
+describe('HoverCard - open state delegates to createDisclosure (migration)', () => {
   afterEach(() => cleanup());
-  it("reflects a controlled open prop through the disclosure cell", () => {
+  it('reflects a controlled open prop through the disclosure cell', () => {
     const { rerender } = render(
       <HoverCard open={false}>
         <HoverCardTrigger>Trigger</HoverCardTrigger>
         <HoverCardContent>Reflected hovercard</HoverCardContent>
       </HoverCard>,
     );
-    expect(screen.queryByText("Reflected hovercard")).not.toBeInTheDocument();
+    expect(screen.queryByText('Reflected hovercard')).not.toBeInTheDocument();
     rerender(
       <HoverCard open={true}>
         <HoverCardTrigger>Trigger</HoverCardTrigger>
         <HoverCardContent>Reflected hovercard</HoverCardContent>
       </HoverCard>,
     );
-    expect(screen.getByText("Reflected hovercard")).toBeInTheDocument();
+    expect(screen.getByText('Reflected hovercard')).toBeInTheDocument();
   });
 });

--- a/packages/ui/test/components/sheet.test.tsx
+++ b/packages/ui/test/components/sheet.test.tsx
@@ -278,6 +278,44 @@ describe('Sheet - Controlled Mode', () => {
       expect(onOpenChange).toHaveBeenCalledWith(false);
     });
   });
+
+  it('controlled prop drives open; cell does not self-open (disclosure delegation)', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const { rerender } = render(
+      <Sheet open={false} onOpenChange={onOpenChange}>
+        <SheetTrigger>Open</SheetTrigger>
+        <SheetPortal>
+          <SheetContent>
+            <SheetTitle>Body</SheetTitle>
+          </SheetContent>
+        </SheetPortal>
+      </Sheet>,
+    );
+
+    await user.click(screen.getByText('Open'));
+
+    // Callback fired, but the cell did NOT self-open while controlled.
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(screen.queryByText('Body')).not.toBeInTheDocument();
+
+    // The owning prop reflects in.
+    rerender(
+      <Sheet open onOpenChange={onOpenChange}>
+        <SheetTrigger>Open</SheetTrigger>
+        <SheetPortal>
+          <SheetContent>
+            <SheetTitle>Body</SheetTitle>
+          </SheetContent>
+        </SheetPortal>
+      </Sheet>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Body')).toBeInTheDocument();
+    });
+  });
 });
 
 describe('Sheet - Side Variants', () => {

--- a/packages/ui/test/components/tooltip.test.tsx
+++ b/packages/ui/test/components/tooltip.test.tsx
@@ -608,9 +608,8 @@ describe('Tooltip - forceMount', () => {
   });
 });
 
-
-describe("Tooltip - open state delegates to createDisclosure (migration)", () => {
-  it("reflects a controlled open prop through the disclosure cell", () => {
+describe('Tooltip - open state delegates to createDisclosure (migration)', () => {
+  it('reflects a controlled open prop through the disclosure cell', () => {
     const { rerender } = render(
       <TooltipProvider>
         <Tooltip open={false}>
@@ -619,7 +618,7 @@ describe("Tooltip - open state delegates to createDisclosure (migration)", () =>
         </Tooltip>
       </TooltipProvider>,
     );
-    expect(screen.queryByText("Reflected tooltip")).not.toBeInTheDocument();
+    expect(screen.queryByText('Reflected tooltip')).not.toBeInTheDocument();
     rerender(
       <TooltipProvider>
         <Tooltip open={true}>
@@ -628,6 +627,6 @@ describe("Tooltip - open state delegates to createDisclosure (migration)", () =>
         </Tooltip>
       </TooltipProvider>,
     );
-    expect(screen.getByText("Reflected tooltip")).toBeInTheDocument();
+    expect(screen.getByText('Reflected tooltip')).toBeInTheDocument();
   });
 });

--- a/packages/ui/test/components/tooltip.test.tsx
+++ b/packages/ui/test/components/tooltip.test.tsx
@@ -607,3 +607,27 @@ describe('Tooltip - forceMount', () => {
     });
   });
 });
+
+
+describe("Tooltip - open state delegates to createDisclosure (migration)", () => {
+  it("reflects a controlled open prop through the disclosure cell", () => {
+    const { rerender } = render(
+      <TooltipProvider>
+        <Tooltip open={false}>
+          <TooltipTrigger>Trigger</TooltipTrigger>
+          <TooltipContent>Reflected tooltip</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+    expect(screen.queryByText("Reflected tooltip")).not.toBeInTheDocument();
+    rerender(
+      <TooltipProvider>
+        <Tooltip open={true}>
+          <TooltipTrigger>Trigger</TooltipTrigger>
+          <TooltipContent>Reflected tooltip</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+    expect(screen.getByText("Reflected tooltip")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Consolidates the four remaining open children of the createDisclosure migration (#1742, #1743, #1744, #1745). Their base pointed at the already-merged foundation branch `feat/1691-create-disclosure`, so they could not merge to main directly. This branch replays their changes -- which touch disjoint files -- onto current main as a single integration (zero conflicts).

Components migrated to delegate open/pointer state to `createDisclosure`: dialog, alert-dialog, drawer, sheet, collapsible, dropdown-menu, context-menu, hover-card, tooltip. Per-component tests included.

Net diff vs main: 9 component files + 9 test files, 492 insertions / 63 deletions. No foundation files (disclosure.ts already on main).

Closes #1692
Closes #1693
Closes #1694
Closes #1695

Supersedes #1742, #1743, #1744, #1745 (closed in favor of this consolidation).