### PR TITLE
fix(cli): error instead of silent .tsx fallback for WC targets (#1746)

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -164,9 +164,17 @@ function isSharedFile(path: string): boolean {
 }
 
 /**
+ * Targets where falling back to .tsx is reasonable -- the framework can render
+ * React components (Astro with @astrojs/react, future Vue/Svelte wrappers).
+ * WC projects cannot use React components, so a missing .element.ts must error,
+ * not silently install unusable .tsx files.
+ */
+const REACT_FALLBACK_TARGETS = new Set<ComponentTarget>(['astro', 'vue', 'svelte']);
+
+/**
  * Select files matching the target framework from a registry item's file list.
  * Keeps shared auxiliary files (.classes.ts etc.) regardless of target.
- * Falls back to .tsx if no framework-matching files exist.
+ * Falls back to .tsx only for targets that can render React components.
  *
  * Returns { files, fallback } where fallback is true if .tsx was used as fallback.
  */
@@ -186,15 +194,23 @@ export function selectFilesForFramework(
     return { files: [...matched, ...shared], fallback: false };
   }
 
-  // Fallback: use .tsx files (React is the universal fallback)
-  if (target !== 'react') {
+  // Fallback: use .tsx files only for targets that can render React components.
+  // WC projects cannot use React components -- return only shared files so the
+  // caller can detect the missing component and error.
+  if (REACT_FALLBACK_TARGETS.has(target)) {
     const fallbackFiles = files.filter((f) => f.path.endsWith('.tsx'));
     if (fallbackFiles.length > 0) {
       return { files: [...fallbackFiles, ...shared], fallback: true };
     }
   }
 
-  // No files matched at all -- return everything
+  // Target has no matching files and no React fallback -- return only shared
+  // files. For targets like `wc`, this signals the component is unavailable.
+  if (target !== 'react' && !REACT_FALLBACK_TARGETS.has(target)) {
+    return { files: shared, fallback: false };
+  }
+
+  // React target or react-fallback target with no .tsx either -- return everything
   return { files, fallback: false };
 }
 
@@ -435,6 +451,15 @@ async function installItem(
         target,
         message: `No ${targetToExtension(target)} version available for ${item.name}. Installing React version.`,
       });
+    }
+
+    // No framework-specific files and no fallback -- the component doesn't
+    // support this target. Error instead of installing unrelated files.
+    const hasComponentFile = selection.files.some((f) => !isSharedFile(f.path));
+    if (!hasComponentFile) {
+      throw new Error(
+        `No ${targetToExtension(target)} version available for "${item.name}" and no compatible fallback exists.`,
+      );
     }
   } else if (item.type === 'composite') {
     filesToInstall = selectCompositeFiles(item.files, getComponentTarget(config));

--- a/packages/cli/test/commands/add-framework-select.test.ts
+++ b/packages/cli/test/commands/add-framework-select.test.ts
@@ -77,6 +77,37 @@ describe('selectFilesForFramework', () => {
     );
   });
 
+  it('does not fall back to .tsx for wc target', () => {
+    const reactOnly: RegistryFile[] = [
+      makeFile('components/ui/dialog.tsx'),
+      makeFile('components/ui/dialog.classes.ts'),
+    ];
+    const result = selectFilesForFramework(reactOnly, 'wc');
+    expect(result.fallback).toBe(false);
+    // Only shared files -- no .tsx fallback
+    expect(result.files).toHaveLength(1);
+    expect(result.files[0].path).toBe('components/ui/dialog.classes.ts');
+  });
+
+  it('selects .element.ts files for wc target', () => {
+    const wcFiles: RegistryFile[] = [
+      makeFile('components/ui/button.tsx'),
+      makeFile('components/ui/button.element.ts'),
+      makeFile('components/ui/button.classes.ts'),
+    ];
+    const result = selectFilesForFramework(wcFiles, 'wc');
+    expect(result.fallback).toBe(false);
+    expect(result.files).toContainEqual(
+      expect.objectContaining({ path: 'components/ui/button.element.ts' }),
+    );
+    expect(result.files).toContainEqual(
+      expect.objectContaining({ path: 'components/ui/button.classes.ts' }),
+    );
+    expect(result.files).not.toContainEqual(
+      expect.objectContaining({ path: 'components/ui/button.tsx' }),
+    );
+  });
+
   it('returns all files when nothing matches and target is react', () => {
     const oddFiles: RegistryFile[] = [makeFile('components/ui/widget.svelte')];
     const result = selectFilesForFramework(oddFiles, 'react');


### PR DESCRIPTION
## Summary

When a WC project installed a component with no `.element.ts` variant in the registry, `selectFilesForFramework` silently fell back to `.tsx` React files. React components are unusable in WC projects. This change gates the `.tsx` fallback to only targets that can actually render React (astro, vue, svelte), and adds a guard in `installItem` that errors when no usable component file survives framework selection.

## Acceptance criteria mapping

### 1. selectFilesForFramework does not fall back to .tsx for wc targets

The old condition `if (target !== 'react')` included `wc` in the fallback path. The new code introduces `REACT_FALLBACK_TARGETS` (a `Set<ComponentTarget>` containing `astro`, `vue`, `svelte`) at `add.ts:171` and gates the `.tsx` fallback on membership in that set (`add.ts:197`). Since `wc` is not in the set, the fallback branch is unreachable for WC targets. A second guard at `add.ts:203` catches WC specifically: when no preferred-extension files matched and the target is not react-fallback-eligible, only shared files (`.classes.ts` etc.) are returned -- no `.tsx` leaks through.
Evidence: `add.ts:171` (`REACT_FALLBACK_TARGETS`), `add.ts:197` (`REACT_FALLBACK_TARGETS.has(target)`), `add.ts:200-203` (shared-only return for non-fallback targets)

### 2. selectFilesForFramework still falls back to .tsx for React-compatible targets

The `REACT_FALLBACK_TARGETS` set at `add.ts:171` explicitly includes `astro`, `vue`, and `svelte`. The fallback branch at `add.ts:197-201` is unchanged in behavior for these targets -- it filters for `.tsx` files and returns them with `fallback: true`. The existing test at `add-framework-select.test.ts:69` ("handles vue target with fallback") continues to pass, confirming the fallback path is preserved for these targets.
Evidence: existing test "handles vue target with fallback" (`add-framework-select.test.ts:69`), existing test "falls back to .tsx when target extension not available" for astro (`add-framework-select.test.ts:45`)

### 3. installItem throws a clear error when no component file survives selection

After framework file selection in `installItem`, a new guard at `add.ts:456-461` checks whether any non-shared component file exists in the selection. `isSharedFile` (already defined at `add.ts:159`) identifies auxiliary files like `.classes.ts`. If every file in the selection is shared (meaning no actual component file survived), the guard throws with a message naming the missing extension and the component. This error propagates to the existing catch block in the install loop at `add.ts:735`, which logs the warning and continues to the next component -- so one missing WC variant doesn't abort the entire multi-component install.
Evidence: `add.ts:456-461` (hasComponentFile guard + throw)

### 4. Unit tests cover both WC paths

Two new tests in `add-framework-select.test.ts`. The first ("does not fall back to .tsx for wc target", line 80) creates a fixture with only `.tsx` and `.classes.ts` files, calls `selectFilesForFramework` with target `wc`, and asserts `fallback` is false, only one file is returned, and that file is the shared `.classes.ts` -- confirming `.tsx` was excluded. The second ("selects .element.ts files for wc target", line 93) creates a fixture with `.tsx`, `.element.ts`, and `.classes.ts`, calls with target `wc`, and asserts the `.element.ts` and `.classes.ts` are selected while `.tsx` is excluded.
Evidence: `add-framework-select.test.ts:80` ("does not fall back to .tsx for wc target"), `add-framework-select.test.ts:93` ("selects .element.ts files for wc target")

## Not done

No changes to how the error is surfaced in interactive vs agent mode. The existing structured logging (`add:fallback` event) and the catch-and-continue pattern in the install loop handle both modes. A future improvement could distinguish "component not yet ported to WC" from "component will never have a WC variant" with registry metadata, but that's out of scope for this fix.