### PR TITLE
docs(ui): frame framework files as decorators over the behavior

### DIFF
--- a/packages/ui/docs/spec/05-authoring.md
+++ b/packages/ui/docs/spec/05-authoring.md
@@ -5,7 +5,7 @@ across the seven control-group components, the reference the sweep follows.
 Read a reference implementation alongside this: `navigation-menu` (compound)
 and `dialog` (overlay) are the richest; `container`/`card` are the simplest.
 
-## The one rule: model, view, controllers
+## The one rule: a behavior, and its decorators
 
 Per component, three kinds of file and nothing else:
 
@@ -14,10 +14,22 @@ Per component, three kinds of file and nothing else:
   The score never *performs*; it describes. It is a total function from state
   to attributes, so it survives contact with any framework.
 - **`x.classes.ts` = the view.** Class strings. No logic.
-- **`x.tsx` / `x.element.ts` / `x.astro` = the controllers.** As thin as the
-  framework allows. React reads the projections declaratively; the WC and Astro
-  performances import the *same* `bindX`. One binding, three performances, zero
-  drift -- because there is only one behavior file.
+- **`x.tsx` / `x.element.ts` / `x.astro` = decorators over the behavior.**
+  Each is a thin wrapper that adds exactly two things around the invariant
+  behavior core, and nothing else: the **view** (`x.classes.ts`) and the
+  framework **wiring** (the runtime adapter). React reads the projections
+  declaratively via `useMemory`; the WC decorates with the custom-element
+  lifecycle, Astro with SSR markup -- both call the *same* `bindX`. One
+  behavior, three decorators, zero drift, because there is only one behavior
+  file.
+
+  Decorator in *spirit*, not GoF-strict -- read the word as the shape, not the
+  taxonomy. The framework file **adapts one runtime to the one behavior** and
+  paints on the classes; it does NOT re-implement the behavior's interface, and
+  decorators never stack (you never wrap a framework file in another). If you
+  find yourself putting a decision -- a reducer, an aria rule, a keymap -- in
+  the framework file, it belongs in the behavior; the decorator only wires and
+  views.
 
 There is no `useBehavior`, no `behavior-element`, no per-component adapter, no
 shared "binder". The substrate the score composes is in `lib/` and
@@ -75,7 +87,7 @@ Lives in the behavior file. Shape (see `bindNavigationMenu`, `bindDialog`):
 
 ## Honest costs (do not pretend these away)
 
-- **React compound controllers carry real hook weight.** A static (button,
+- **React compound decorators carry real hook weight.** A static (button,
   badge) is a couple lines; a compound controlled component is ~40-50 lines of
   genuine wiring (instance, ids, the dispatch protocol, effect host). That is
   retained-mode's floor, not fat.

--- a/packages/ui/docs/spec/05-authoring.md
+++ b/packages/ui/docs/spec/05-authoring.md
@@ -31,6 +31,13 @@ Per component, three kinds of file and nothing else:
   the framework file, it belongs in the behavior; the decorator only wires and
   views.
 
+  Reconciled with the frozen contract: Spec 01 ratified these three roles as
+  **score** (the behavior), **performances** (the framework files), and
+  **decoration** (`classes.ts`). "Decorator" is not a rename -- it is the
+  *shape* a performance takes: a performance decorates the score with its
+  decoration (the classes) plus the framework wiring. The role names are frozen
+  in Spec 01; the pattern name is this guide's teaching lens on top of them.
+
 There is no `useBehavior`, no `behavior-element`, no per-component adapter, no
 shared "binder". The substrate the score composes is in `lib/` and
 `primitives/`; **check the primitives matrix (`docs/spec/matrix/primitives.jsonl`)
@@ -49,7 +56,7 @@ before writing any primitive** -- `aria-manager`, `focus-trap`, `roving-focus`,
   React effect.
 - `primitives/rafters-element.ts` -- the shadow-DOM WC base (for pure statics).
 
-## `bindX` -- the DOM-native controller (WC + Astro share it)
+## `bindX` -- the DOM-native client (WC + Astro share it)
 
 Lives in the behavior file. Shape (see `bindNavigationMenu`, `bindDialog`):
 
@@ -68,7 +75,7 @@ Lives in the behavior file. Shape (see `bindNavigationMenu`, `bindDialog`):
 
 | archetype | reference | shape |
 |---|---|---|
-| pure static | `container`, `card` | no `bindX`, no `useBehavior`/`useMemory`; controllers are markup + classes + slots only. WC = `RaftersElement` shadow + `<slot>`. |
+| pure static | `container`, `card` | no `bindX`, no `useBehavior`/`useMemory`; the decorators are markup + classes + slots only. WC = `RaftersElement` shadow + `<slot>`. |
 | simple-interactive | `button` | `bindButton`; native `<button>` fulfils Enter/Space, so wire `click` only. One-shot `announce` effect is edge-triggered. |
 | static + effect | `grid` | static except a conditional effect (grid-roving when `role=grid`). |
 | text-input | `input` | primary state is a **value**; `setValue` gated by disabled/readonly; native input owns caret/IME/selection -- do not re-implement. |
@@ -116,7 +123,7 @@ Lives in the behavior file. Shape (see `bindNavigationMenu`, `bindDialog`):
 ## Open contract gap (settle before the next compound wave)
 
 Many-part instance projections (`navTriggerAria`/`navContentAria`) live
-*outside* `BehaviorSpec.aria` as bespoke functions the controllers call by
+*outside* `BehaviorSpec.aria` as bespoke functions the decorators call by
 name, because `aria` returns one `AriaAttrs` per part *name* and cannot express
 N instances. First-class them (`instanceAria(part, value, state, config, ids)`)
 so the many-part loop goes generic -- before tabs/accordion/menubar/select.


### PR DESCRIPTION
Closes #1829.

Renames the authoring guide's framework-file framing from controllers/performances to a decorator pattern, so the upcoming `old/` port sweep recognizes the shape -- anchored so the word doesn't carry the GoF misread.

## Acceptance criteria mapping

### 05-authoring.md frames the three framework files as decorators over the behavior: each adds exactly the view (classes) and the framework wiring, nothing else
The `x.tsx`/`x.element.ts`/`x.astro` bullet (05-authoring.md:17) now reads "decorators over the behavior" and states the two-and-only-two things a decorator adds -- the view (`x.classes.ts`) and the framework wiring (runtime adapter) -- with React reading projections via `useMemory`, WC/Astro calling the same `bindX`. The section title (05-authoring.md:8) becomes "a behavior, and its decorators."

### The framing is anchored against the GoF misread: decorator in spirit not taxonomy -- it adapts one runtime to the one behavior, does not re-implement the behavior's interface, and does not stack
The bullet carries an explicit anchoring paragraph: "Decorator in *spirit*, not GoF-strict -- read the word as the shape, not the taxonomy. The framework file adapts one runtime to the one behavior and paints on the classes; it does NOT re-implement the behavior's interface, and decorators never stack." This closes the two misreads (shared interface, recursive stacking) a bare "decorator" would invite.

### It restates the invariant that any decision (reducer, aria, keymap) belongs in the behavior, never the framework file
The same paragraph ends: "If you find yourself putting a decision -- a reducer, an aria rule, a keymap -- in the framework file, it belongs in the behavior; the decorator only wires and views." In-context restatement of boundary 5, which is pedagogically intended in a how-to guide.

### Terminology is consistent -- no stray 'controllers' left contradicting the decorator framing
Now met, after review caught that it wasn't. The first pass fixed one "controller" (honest-costs) but a too-narrow search missed three more, and the body wrongly claimed none remained. All four framework-file references now read "decorator" (bullet :17, archetype row :78, honest-costs :97, open-gap :126); the one mislabel of `bindX` as a "controller" is corrected to "client" (:59), matching :13. Verified by reading the whole file end to end, not a scoped grep. Additionally reconciled with the FROZEN Spec 01 vocabulary (review MED): a paragraph at :34 maps "decorator" onto the ratified score/performances/decoration names so it collides with neither "decoration" nor "performances" -- it is the shape a performance takes, a teaching lens, not a rename. Evidence: `05-authoring.md:17` / `:78` / `:97` / `:126` all read "decorator", `05-authoring.md:59` reads "client", and the reconciliation is at `05-authoring.md:34`.

## Not done
No code, tests, or sibling specs (00-04) touched -- this is a single-file doc metaphor change; the model/view split and zero-drift contract are unchanged. The port sweep the framing serves is separate downstream work.
