### PR TITLE
fix(ui): dialog composes overlay primitives directly -- drop lib/effects import

### DIFF
--- a/packages/ui/src/components/dialog/dialog.behavior.ts
+++ b/packages/ui/src/components/dialog/dialog.behavior.ts
@@ -5,8 +5,9 @@ import {
   type BehaviorSpec,
   type PartIds,
 } from '../../lib/contract';
-import { createEffectRunner, type EffectHost } from '../../lib/effects';
 import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap';
+import { onPointerDownOutside } from '../../primitives/outside-click';
 import {
   disclosable,
   isOpen,
@@ -110,10 +111,15 @@ export const dialog: BehaviorSpec<DialogConfig, DialogState, DialogActions, Dial
  * and the Astro <script> both import THIS; only React reads the projections
  * declaratively. Same shape as bindNavigationMenu, plus the two overlay
  * concerns: PRESENCE (content/overlay are present-but-hidden, toggled on the
- * open axis -- effect-observed parts must be light DOM so focus-trap's
+ * open axis -- the trapped/dismiss-observed parts must be light DOM so focus-trap's
  * activeElement read and dismiss's document .contains work) and the ONGOING
- * effects runner (focus-trap, scroll-lock, dismiss-on-outside run while open
- * and modal, stopped on close). Enter-only; exit animation waits on Presence.
+ * overlay lifecycle. The bind OWNS that lifecycle directly: on the open(+modal)
+ * transition it starts the trio -- createFocusTrap(content), preventBodyScroll(),
+ * onPointerDownOutside(content) sparing the trigger -- and tears all three down
+ * on close/unbind (focus restore rides on the trap's teardown). Level-triggered:
+ * started once when it should be active, stopped once when it should not, so the
+ * render tick (which fires on every state change) never re-arms a live trap.
+ * Enter-only; exit animation waits on Presence.
  */
 export function bindDialog(root: HTMLElement): () => void {
   const config: DialogConfig = {
@@ -127,12 +133,38 @@ export function bindDialog(root: HTMLElement): () => void {
     part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
 
   const { memory, dispatch } = createBehavior(dialog, config);
-  const runner = createEffectRunner();
 
   const request = (action: keyof DialogActions): boolean => dispatch(action, config);
-  const host: EffectHost = {
-    getPart,
-    dispatch: (action) => void request(action as keyof DialogActions),
+
+  // The modal overlay lifecycle, composed directly from the primitives (no
+  // effect runner). While open+modal the trio is live; its cleanups are held
+  // here so the level-triggered guard in render() starts it exactly once and
+  // stops it exactly once. Teardown runs the cleanups in start order, so the
+  // focus-trap's focus restore fires first -- matching the runner it replaces.
+  let overlay: Array<() => void> | null = null;
+  const startOverlay = () => {
+    const content = getPart('content');
+    if (!content) return;
+    overlay = [
+      createFocusTrap(content),
+      preventBodyScroll(),
+      onPointerDownOutside(content, (event) => {
+        const target = event.target as Node;
+        // Spare the trigger: without this, pointerdown on it dismisses the
+        // layer and the same gesture's click re-opens it (exceptParts).
+        if (getPart('trigger')?.contains(target)) return;
+        // The native event is in hand here so a binding could veto BEFORE the
+        // close dispatch (React's dismissVetoRef path); the DOM-native bind has
+        // no veto consumer, so it dispatches close directly -- as it did when
+        // the dismiss executor's host.dispatch dropped the event.
+        request('close');
+      }),
+    ];
+  };
+  const stopOverlay = () => {
+    if (!overlay) return;
+    for (const cleanup of overlay) cleanup();
+    overlay = null;
   };
 
   // ids READ from the server/author markup, never generated.
@@ -162,7 +194,12 @@ export function bindDialog(root: HTMLElement): () => void {
       const el = getPart(part);
       if (el) el.hidden = !open;
     }
-    runner.apply(dialog.effects(state, config), host);
+    // Level-triggered: present only while open+modal. Start on the false->true
+    // transition (after content is un-hidden, so focus-trap can focus into it),
+    // tear down on true->false. The overlay handle is the transition guard.
+    const shouldBeActive = open && isModal(config);
+    if (shouldBeActive && !overlay) startOverlay();
+    else if (!shouldBeActive && overlay) stopOverlay();
   };
   const unsubscribe = memory.subscribe(render); // fires immediately: first paint
 
@@ -204,7 +241,7 @@ export function bindDialog(root: HTMLElement): () => void {
 
   return () => {
     unsubscribe();
-    runner.stop();
+    stopOverlay();
     root.removeEventListener('click', onClick);
     root.removeEventListener('keydown', onKeydown);
   };


### PR DESCRIPTION
## Summary

`bindDialog` now composes the modal overlay concerns directly from the primitives
instead of routing them through `createEffectRunner`. On the open(+modal)
transition it starts the trio -- `createFocusTrap(content)`, `preventBodyScroll()`,
and `onPointerDownOutside(content, ...)` sparing the trigger -- and tears all three
down on close/unbind, with focus restore riding on the trap's teardown.
`dialog.behavior.ts` no longer imports from `lib/effects`. The `effects()` score
fn is left intact because React (`dialog.tsx`, out of scope) still consumes it via
`useBehaviorEffects`; only `bindDialog` (WC + Astro) is migrated. Scope is exactly
one file.

## Acceptance criteria mapping

### dialog.behavior.ts no longer imports from lib/effects

The `import { createEffectRunner, type EffectHost } from '../../lib/effects'` line
is deleted. `bindDialog` instead imports and composes the primitives directly:
`createFocusTrap` + `preventBodyScroll` from `primitives/focus-trap` and
`onPointerDownOutside` from `primitives/outside-click`. The old `runner` and `host`
locals are gone; the returned teardown calls `stopOverlay()` instead of
`runner.stop()`; the render tick's `runner.apply(dialog.effects(...))` is replaced
by a level-triggered `startOverlay`/`stopOverlay` guard. `pnpm preflight` typecheck
passes with zero residual `lib/effects` references in the file -- the `EffectSpec`
type `effects()` returns resolves through `GlueSlice` in `lib/contract`, not a
behavior.ts import, exactly as before.
Evidence: packages/ui/src/components/dialog/dialog.behavior.ts:9

### Modal behavior unchanged across React/WC/Astro (focus trapped + restored, body scroll locked)

WC and Astro drive `bindDialog` (dialog.element.ts and the Astro `<script>` both
import it); `dialog.astro.conformance.test.ts` binds `bindDialog` directly and
asserts trigger-opens -> focus trapped into content -> `document.body.style.overflow
=== 'hidden'` -> Escape closes + restores focus to the trigger + scroll released --
all green. React drives its own adapter (`dialog.tsx` ->
`useBehaviorEffects(dialog.effects(...))`), left untouched, so
`dialog.conformance.test.tsx` (focus trapped and Tab-cycled, scroll locked while
open, outside-pointerdown dismissal sparing the trigger, `onPointerDownOutside`
consumer veto via `dismissVetoRef`, defaultOpen mounts with the trap live) stays
green. `dialog.behavior.test.ts` still asserts `effects()` returns the three specs
open+modal and `[]` otherwise. The lifecycle preserves the runner's start-once
(false->true) / stop-once (true->false) semantics via the `overlay` cleanup-handle
guard, so the render tick never re-arms a live trap and re-captures
`previouslyFocused`; teardown runs cleanups in start order so the focus-trap restore
fires first, matching the runner's insertion-order `stop()`. `pnpm --filter
@rafters/ui test:unit` and `pnpm preflight` both exit 0.
Evidence: packages/ui/test/components/dialog/dialog.astro.conformance.test.ts:45

## Not done

- Did NOT gut `effects()` to return `[]`. React reads `effects()` via
  `useBehaviorEffects`, so gutting it would regress React conformance; unifying the
  React path requires editing `dialog.tsx`, out of this PR's single-file scope. The
  React-adapter migration is separate from this behavior-file change -- only the
  "no lib/effects import" criterion is claimed here.
- Did NOT touch `lib/effects.ts` or its executors; the whole-file teardown is a
  separate tracked issue.
- The DOM-native `bindDialog` never had a functional dismiss veto (its old
  `host.dispatch` dropped the native event), so the direct composition dispatches
  close after sparing the trigger -- behaviorally identical -- with a comment
  marking where the native event is available for a future veto surface. No new
  veto surface was invented for WC/Astro.

Closes #1866