### PR TITLE
fix(ui): dialog composes the overlay trio directly, dropping effects.ts

### DIFF
--- a/packages/ui/src/components/dialog/dialog.behavior.ts
+++ b/packages/ui/src/components/dialog/dialog.behavior.ts
@@ -5,8 +5,9 @@ import {
   type BehaviorSpec,
   type PartIds,
 } from '../../lib/contract';
-import { createEffectRunner, type EffectHost } from '../../lib/effects';
 import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap';
+import { onPointerDownOutside } from '../../primitives/outside-click';
 import {
   disclosable,
   isOpen,
@@ -52,8 +53,9 @@ const dialogSurface: Slice<
   initialState: () => ({}),
 };
 
-/** The dialog glue: ARIA identity, the Escape contract, and the modal
- *  effect set, written over the merged state. */
+/** The dialog glue: ARIA identity and the Escape contract, written over the
+ *  merged state. The modal overlay concerns (focus-trap, scroll-lock,
+ *  outside-dismiss) are composed directly by the bindings, not declared here. */
 const dialogGlue: GlueSlice<DialogConfig, DialogState, { close: undefined }, DialogPart> = {
   kind: 'glue',
   name: 'dialog',
@@ -81,22 +83,47 @@ const dialogGlue: GlueSlice<DialogConfig, DialogState, { close: undefined }, Dia
     };
   },
   keymap: (event, _state, part) => (part === 'content' && event.key === 'Escape' ? 'close' : null),
-  effects: (state, config) => {
-    if (!isOpen(state, config) || !isModal(config)) return [];
-    return [
-      { type: 'focus-trap', part: 'content' },
-      { type: 'scroll-lock' },
-      {
-        type: 'dismiss-on-outside',
-        part: 'content',
-        action: 'close',
-        // Without this, pointerdown on the trigger dismisses the layer and
-        // the same gesture's click re-opens it (live defect in the oracle).
-        exceptParts: ['trigger'],
-      },
-    ];
-  },
 };
+
+/** The parts and dispatch the modal overlay trio composes against. */
+export interface DialogModalPorts {
+  /** The dialog surface: focus is trapped inside it and a pointerdown landing
+   *  outside it dismisses. */
+  content: HTMLElement;
+  /** Resolves the trigger so the opening gesture's pointerdown is spared --
+   *  otherwise it would both dismiss the layer and re-open it. */
+  getTrigger: () => HTMLElement | null;
+  /** Outside-pointerdown handler, already spared of the trigger. Receives the
+   *  native event so a boundary can offer a consumer veto before closing. */
+  onDismiss: (event: Event) => void;
+}
+
+/**
+ * The modal overlay trio, composed directly (replacing the effects runner):
+ * trap Tab focus inside `content`, lock body scroll, and dismiss on a
+ * pointerdown outside `content` -- sparing the trigger. Level-triggered:
+ * BOTH the DOM-native bindDialog and the React Dialog start this on the
+ * open+modal transition and call the returned cleanup on close/unmount.
+ * Focus restore rides the trap teardown, so the cleanup releases LIFO.
+ */
+export function startDialogModalEffects({
+  content,
+  getTrigger,
+  onDismiss,
+}: DialogModalPorts): () => void {
+  const releaseTrap = createFocusTrap(content);
+  const releaseScroll = preventBodyScroll();
+  const releaseDismiss = onPointerDownOutside(content, (event) => {
+    const target = event.target as Node;
+    if (getTrigger()?.contains(target)) return;
+    onDismiss(event);
+  });
+  return () => {
+    releaseDismiss();
+    releaseScroll();
+    releaseTrap();
+  };
+}
 
 export const dialog: BehaviorSpec<DialogConfig, DialogState, DialogActions, DialogPart> = compose(
   'dialog',
@@ -110,10 +137,11 @@ export const dialog: BehaviorSpec<DialogConfig, DialogState, DialogActions, Dial
  * and the Astro <script> both import THIS; only React reads the projections
  * declaratively. Same shape as bindNavigationMenu, plus the two overlay
  * concerns: PRESENCE (content/overlay are present-but-hidden, toggled on the
- * open axis -- effect-observed parts must be light DOM so focus-trap's
- * activeElement read and dismiss's document .contains work) and the ONGOING
- * effects runner (focus-trap, scroll-lock, dismiss-on-outside run while open
- * and modal, stopped on close). Enter-only; exit animation waits on Presence.
+ * open axis -- the trapped/dismissable parts must be light DOM so focus-trap's
+ * activeElement read and dismiss's document .contains work) and the modal
+ * overlay trio (focus-trap, scroll-lock, dismiss-on-outside), composed
+ * directly and level-triggered: started on the open+modal transition and torn
+ * down on close/unbind. Enter-only; exit animation waits on Presence.
  */
 export function bindDialog(root: HTMLElement): () => void {
   const config: DialogConfig = {
@@ -127,13 +155,12 @@ export function bindDialog(root: HTMLElement): () => void {
     part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
 
   const { memory, dispatch } = createBehavior(dialog, config);
-  const runner = createEffectRunner();
 
   const request = (action: keyof DialogActions): boolean => dispatch(action, config);
-  const host: EffectHost = {
-    getPart,
-    dispatch: (action) => void request(action as keyof DialogActions),
-  };
+
+  // The modal overlay trio is level-triggered: present only while open+modal.
+  // render() starts it on the transition and this cleanup stops it on close.
+  let modalCleanup: (() => void) | null = null;
 
   // ids READ from the server/author markup, never generated.
   const ids = {} as PartIds<DialogPart>;
@@ -162,7 +189,25 @@ export function bindDialog(root: HTMLElement): () => void {
       const el = getPart(part);
       if (el) el.hidden = !open;
     }
-    runner.apply(dialog.effects(state, config), host);
+    // Compose the modal overlay trio directly, level-triggered: start it once
+    // on the open+modal transition (content is now un-hidden above so the trap
+    // can read its focusables), tear it down when it should no longer be present.
+    const wantModal = open && isModal(config);
+    if (wantModal && !modalCleanup) {
+      const content = getPart('content');
+      if (content) {
+        modalCleanup = startDialogModalEffects({
+          content,
+          getTrigger: () => getPart('trigger'),
+          onDismiss: () => {
+            request('close');
+          },
+        });
+      }
+    } else if (!wantModal && modalCleanup) {
+      modalCleanup();
+      modalCleanup = null;
+    }
   };
   const unsubscribe = memory.subscribe(render); // fires immediately: first paint
 
@@ -204,7 +249,8 @@ export function bindDialog(root: HTMLElement): () => void {
 
   return () => {
     unsubscribe();
-    runner.stop();
+    modalCleanup?.();
+    modalCleanup = null;
     root.removeEventListener('click', onClick);
     root.removeEventListener('keydown', onKeydown);
   };

--- a/packages/ui/src/components/dialog/dialog.tsx
+++ b/packages/ui/src/components/dialog/dialog.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { createBehavior, type AriaAttrs, type PartIds } from '../../lib/contract';
 import { keyInputOf } from '../../hooks/key-input';
-import { useBehaviorEffects } from '../../hooks/use-behavior-effects';
 import { useMemory } from '../../hooks/use-memory';
 import { usePresence } from '../../hooks/use-presence';
 import classy from '../../primitives/classy';
@@ -10,6 +9,7 @@ import { mergeProps } from '../../primitives/slot';
 import {
   dialog,
   isOpen,
+  startDialogModalEffects,
   type DialogActions,
   type DialogConfig,
   type DialogPart,
@@ -127,26 +127,29 @@ export function Dialog({
     [dispatch],
   );
 
-  const host = React.useMemo(
-    () => ({
-      getPart,
+  // The modal overlay trio, composed directly on the open+modal transition
+  // (replacing the effects runner). Level-triggered via the dependency array;
+  // the cleanup tears the trio down (focus restore rides the trap teardown).
+  React.useEffect(() => {
+    if (!effectiveOpen || !modal) return;
+    const content = getPart('content');
+    if (!content) return;
+    return startDialogModalEffects({
+      content,
+      getTrigger: () => getPart('trigger'),
       // Outside-pointerdown dismissals offer the consumer veto first (oracle
-      // protocol: callback runs, close proceeds unless defaultPrevented).
-      dispatch: (action: string, _payload?: unknown, nativeEvent?: Event) => {
-        if (action === 'close' && nativeEvent) {
-          const veto = dismissVetoRef.current;
-          if (veto) {
-            veto.onPointerDownOutside?.(nativeEvent);
-            veto.onInteractOutside?.(nativeEvent);
-            if (nativeEvent.defaultPrevented) return;
-          }
+      // protocol: callbacks run, close proceeds unless defaultPrevented).
+      onDismiss: (event) => {
+        const veto = dismissVetoRef.current;
+        if (veto) {
+          veto.onPointerDownOutside?.(event);
+          veto.onInteractOutside?.(event);
+          if (event.defaultPrevented) return;
         }
-        request(action as keyof DialogActions);
+        request('close');
       },
-    }),
-    [getPart, request],
-  );
-  useBehaviorEffects(dialog.effects(state, config), host);
+    });
+  }, [effectiveOpen, modal, getPart, request]);
 
   const aria = dialog.aria(state, config, ids);
 

--- a/packages/ui/test/components/dialog/dialog.behavior.test.ts
+++ b/packages/ui/test/components/dialog/dialog.behavior.test.ts
@@ -142,32 +142,7 @@ describe('dialog keymap', () => {
   });
 });
 
-describe('dialog effects', () => {
-  it('closed: no effects', () => {
-    expect(dialog.effects(dialog.initialState(closed), closed)).toEqual([]);
-  });
-
-  it('open modal: focus trap, scroll lock, outside dismissal sparing the trigger', () => {
-    const config = openUncontrolled;
-    expect(dialog.effects(dialog.initialState(config), config)).toEqual([
-      { type: 'focus-trap', part: 'content' },
-      { type: 'scroll-lock' },
-      {
-        type: 'dismiss-on-outside',
-        part: 'content',
-        action: 'close',
-        exceptParts: ['trigger'],
-      },
-    ]);
-  });
-
-  it('open non-modal: no modal effects', () => {
-    const config: DialogConfig = { ...openUncontrolled, modal: false };
-    expect(dialog.effects(dialog.initialState(config), config)).toEqual([]);
-  });
-
-  it('controlled open drives effects without touching intrinsic state', () => {
-    const config: DialogConfig = { open: true };
-    expect(dialog.effects({ open: false }, config)).toHaveLength(3);
-  });
-});
+// The modal overlay trio (focus-trap, scroll-lock, trigger-spared outside
+// dismissal) is no longer a declarative effect-spec on the score; the bindings
+// compose the primitives directly. The BEHAVIOR is asserted end to end in the
+// conformance suites (dialog.conformance.test.tsx / .astro. / .element.).


### PR DESCRIPTION
## What & why

dialog declared `focus-trap` + `scroll-lock` + `dismiss-on-outside` as declarative `EffectSpec`s that the effect runner performed at both framework boundaries (the WC/Astro `bindDialog` via `createEffectRunner`, and React via `useBehaviorEffects(dialog.effects(...))`). Those effects are thin wraps of primitives, and `lib/effects.ts` is being torn down wholesale (#1867). This PR composes the primitives directly at BOTH boundaries and drops dialog's dependence on the runner.

Scope is exactly `dialog.behavior.ts` + `dialog.tsx` (+ dialog's own tests) -- disjoint from every other component, queue-parallel-safe. `lib/effects.ts` and `hooks/use-behavior-effects.ts` are untouched (they belong to #1867).

## Acceptance criteria mapping

### 1. dialog.behavior.ts no longer imports from lib/effects

The `import { createEffectRunner, type EffectHost } from '../../lib/effects'` line is gone, replaced by direct imports of `createFocusTrap`, `preventBodyScroll` (primitives/focus-trap) and `onPointerDownOutside` (primitives/outside-click). The glue's `effects()` method is removed, so nothing in the file references the effect vocabulary. The composed score still exposes a synthetic `.effects` returning `[]` (compose.ts always synthesizes it) -- that residue is invisible and required by `BehaviorSpec`; I did not touch compose.ts/contract.ts, which would widen scope.
Evidence: `git grep 'lib/effects' packages/ui/src/components/dialog/dialog.behavior.ts` returns nothing; the file now imports focus-trap/outside-click primitives instead.

### 2. Modal behavior unchanged across React/WC/Astro -- focus trapped + restored, body scroll locked

Asserted by the untouched conformance oracle in all three performances:
- New shared `startDialogModalEffects({ content, getTrigger, onDismiss })` composes the trio: `createFocusTrap(content)` + `preventBodyScroll()` + `onPointerDownOutside(content, ...)` sparing the trigger, returning LIFO cleanup (focus restore rides the trap teardown).
- WC/Astro `bindDialog`: `render()` starts the trio on the open+modal transition (`wantModal && !modalCleanup`) after content is un-hidden, and tears it down on close/unbind. Proven by `dialog.element.conformance.test.ts` and `dialog.astro.conformance.test.ts` ("focus trapped, scroll locked; Escape closes + restores focus").
- React `Dialog`: a `useEffect` keyed on `[effectiveOpen, modal, getPart, request]` composes the SAME shared trio directly against the portaled part elements. Proven by `dialog.conformance.test.tsx` ("focus moves into the dialog and Tab is trapped", "Escape closes and restores focus to the trigger", "scroll is locked while open and released on close", "defaultOpen mounts open with the trap live").

**Consumer-veto path preserved (issue scope note).**
The React `onDismiss` reproduces the runner's veto protocol: it reads `dismissVetoRef.current`, fires `onPointerDownOutside`/`onInteractOutside` with the native event, and short-circuits on `defaultPrevented` before dispatching `close`. Proven by "onPointerDownOutside veto keeps the dialog open; without veto it closes".

**Trigger-spare preserved.**
The old `exceptParts: ['trigger']` is reproduced as `getTrigger()?.contains(target)` so the opening gesture does not both dismiss and re-open. Proven by "pointerdown outside dismisses; on the trigger it toggles closed, not closed-then-open" (React and WC).

Evidence: all three conformance suites pass unchanged -- `dialog.conformance.test.tsx` (trap/scroll/restore/veto/trigger-toggle), `dialog.element.conformance.test.ts` and `dialog.astro.conformance.test.ts` (bind: trap + scroll-lock + Escape restore) -- under the direct composition.

## Test change

`dialog.behavior.test.ts` `describe('dialog effects')` asserted the effect-spec DATA, a contract that no longer exists. Deleted -- not a coverage cut: the BEHAVIOR it proxied is asserted directly in the React/WC/Astro conformance suites listed above.

## Not done

What I deliberately did NOT do:

- Did not edit `lib/effects.ts` or `hooks/use-behavior-effects.ts` (owned by teardown #1867).
- Did not touch `compose.ts`/`contract.ts` to "properly" remove the synthetic `.effects`.
- Did not add a CHANGELOG entry: behavior is unchanged (the point of the refactor) and this is not a CLI change.

## Verification

`pnpm --filter @rafters/ui test:unit` green (React + WC + Astro conformance); `pnpm preflight` green.

Closes #1866