### PR TITLE
fix(#1861): radio-group composes roving-focus primitive directly

### DIFF
--- a/packages/ui/src/components/radio-group/radio-group.behavior.ts
+++ b/packages/ui/src/components/radio-group/radio-group.behavior.ts
@@ -5,8 +5,8 @@ import {
   type BehaviorSpec,
   type PartIds,
 } from '../../lib/contract';
-import { createEffectRunner, type EffectHost, type EffectSpec } from '../../lib/effects';
 import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { createRovingFocus } from '../../primitives/roving-focus';
 
 /**
  * Radio group: an exclusive set of options where exactly one (or none) is
@@ -15,7 +15,7 @@ import { updateAriaAttribute } from '../../primitives/aria-manager';
  *
  * The score's only state axis is the selected value. Focus movement across
  * items is NOT state -- it is ephemeral DOM state owned by the roving-focus
- * effect (mirroring navigation-menu). Selection follows focus per the WAI-ARIA
+ * primitive (mirroring navigation-menu). Selection follows focus per the WAI-ARIA
  * radio pattern: an arrow key moves focus AND selects the newly focused item;
  * Space/Enter select the focused item; Tab enters the group without selecting.
  *
@@ -91,12 +91,9 @@ const radio: Slice<RadioGroupConfig, RadioGroupState, RadioGroupActions, RadioGr
     },
   }),
   // Space/Enter select the focused item. Arrow keys are owned by the
-  // roving-focus effect for movement; the bind adds select-follows-focus.
+  // roving-focus primitive for movement; the bind adds select-follows-focus.
   keymap: (event, _state, part) =>
     part === 'item' && (event.key === 'Enter' || event.key === ' ') ? 'select' : null,
-  effects: (_state, config): EffectSpec[] => [
-    { type: 'roving-focus', part: 'root', orientation: orientationOf(config) },
-  ],
 };
 
 export const radioGroup: BehaviorSpec<
@@ -141,13 +138,12 @@ const MOVEMENT_KEYS: ReadonlySet<string> = new Set([
  * The DOM-native binding of the radio-group score -- the client. The Web
  * Component and the Astro <script> both import THIS; only React (retained-mode)
  * reads the projections above declaratively instead. Composes the substrate the
- * same way the React controller does: createBehavior is the model, the effect
- * runner drives the roving-focus primitive, aria-manager applies the
- * projection, and the DOM is the part registry.
+ * same way the React controller does: createBehavior is the model,
+ * createRovingFocus drives arrow/Home/End movement and the roving tabindex,
+ * aria-manager applies the projection, and the DOM is the part registry.
  *
- * Select-follows-focus: the roving-focus effect registers its keydown listener
- * during the immediate first paint (subscribe -> render -> runner.apply), which
- * runs BEFORE this bind attaches its own keydown listener. So on an arrow key
+ * Select-follows-focus: createRovingFocus registers its keydown listener during
+ * bind (before this bind attaches its own keydown listener). So on an arrow key
  * roving moves focus first, and by the time the bind's handler runs
  * document.activeElement is already the newly focused radio -- which it then
  * selects. Tab-in never routes through keydown, so it focuses without selecting.
@@ -170,16 +166,15 @@ export function bindRadioGroup(root: HTMLElement): () => void {
     part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
 
   const { memory, dispatch } = createBehavior(radioGroup, config);
-  const runner = createEffectRunner();
+
+  // Compose the roving-focus primitive directly -- it owns the roving tabindex
+  // and arrow/Home/End movement across the [role="radio"] items. Registered
+  // here, before the bind's own keydown listener below, so on an arrow key
+  // roving moves focus first and the bind then selects whatever now has focus.
+  const stopRoving = createRovingFocus(root, { orientation: orientationOf(config) });
 
   const request = (action: keyof RadioGroupActions, payload: string): boolean =>
     dispatch(action, config, payload);
-
-  const host: EffectHost = {
-    getPart,
-    dispatch: (action, payload) =>
-      void request(action as keyof RadioGroupActions, payload as string),
-  };
 
   // ids are READ from the markup (server- or author-minted), never generated.
   const ids = {} as PartIds<RadioGroupPart>;
@@ -209,7 +204,6 @@ export function bindRadioGroup(root: HTMLElement): () => void {
       if (value === undefined) continue;
       applyProjection(el, radioItemAria(value, state, config));
     }
-    runner.apply(radioGroup.effects(state, config), host);
   };
   const unsubscribe = memory.subscribe(render); // fires immediately: first paint
 
@@ -244,7 +238,7 @@ export function bindRadioGroup(root: HTMLElement): () => void {
 
   return () => {
     unsubscribe();
-    runner.stop();
+    stopRoving();
     root.removeEventListener('click', onClick);
     root.removeEventListener('keydown', onKeyDown);
   };

--- a/packages/ui/src/components/radio-group/radio-group.tsx
+++ b/packages/ui/src/components/radio-group/radio-group.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { createBehavior, type PartIds } from '../../lib/contract';
-import { useBehaviorEffects } from '../../hooks/use-behavior-effects';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
+import { createRovingFocus } from '../../primitives/roving-focus';
 import {
   radioGroup,
   radioItemAria,
@@ -96,8 +96,8 @@ export function RadioGroup({
   const config: RadioGroupConfig = { value, defaultValue, orientation, disabled, required, name };
 
   // The controller composes the score with the substrate -- no useBehavior.
-  // createBehavior is the model; useMemory subscribes React to it;
-  // useBehaviorEffects runs the roving-focus effect through the neutral runner.
+  // createBehavior is the model; useMemory subscribes React to it; a useEffect
+  // below composes the roving-focus primitive directly against the root.
   const { memory, dispatch } = React.useMemo(() => createBehavior(radioGroup, config), []);
   const state = useMemory(memory);
 
@@ -111,13 +111,6 @@ export function RadioGroup({
   }, [uid]);
 
   const rootRef = React.useRef<HTMLDivElement>(null);
-  const getPart = React.useCallback(
-    (part: string): HTMLElement | null =>
-      part === 'root'
-        ? rootRef.current
-        : (rootRef.current?.querySelector<HTMLElement>(`[data-part="${part}"]`) ?? null),
-    [],
-  );
 
   // Gotcha #1: the controlled callback compares the EFFECTIVE value before
   // against the INTRINSIC value after the reducer -- a controlled group's
@@ -137,17 +130,22 @@ export function RadioGroup({
     [memory, dispatch],
   );
 
-  useBehaviorEffects(radioGroup.effects(state, config), {
-    getPart,
-    dispatch: (_action, payload) => void request(payload as string),
-  });
+  // Compose the roving-focus primitive directly against the root -- it owns the
+  // roving tabindex and arrow/Home/End movement across the [role="radio"] items.
+  // Declared ABOVE the selection effect so its native keydown listener registers
+  // first and moves focus before the selection handler reads activeElement.
+  React.useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    return createRovingFocus(root, { orientation });
+  }, [orientation]);
 
   // Selection is wired as a NATIVE keydown listener, registered in an effect
-  // that runs AFTER useBehaviorEffects -- so it fires after the roving-focus
-  // effect's own native listener has already moved focus. This is the same
-  // registration order the DOM-native bind relies on; a React synthetic
-  // onKeyDown would fire before roving and read stale focus. Space/Enter select
-  // the focused item; arrows/Home/End select whatever item roving just focused.
+  // that runs AFTER the roving-focus effect above -- so it fires after roving's
+  // own native listener has already moved focus. This is the same registration
+  // order the DOM-native bind relies on; a React synthetic onKeyDown would fire
+  // before roving and read stale focus. Space/Enter select the focused item;
+  // arrows/Home/End select whatever item roving just focused.
   React.useEffect(() => {
     const root = rootRef.current;
     if (!root) return;

--- a/packages/ui/test/components/radio-group/radio-group.behavior.test.ts
+++ b/packages/ui/test/components/radio-group/radio-group.behavior.test.ts
@@ -1,7 +1,7 @@
 /**
  * Pure behavior test for the radio-group score. No DOM: exercises reducers,
- * aria/keymap projections, canDispatch gates, effects-as-data, and the
- * per-instance radioItemAria projection directly.
+ * aria/keymap projections, canDispatch gates, and the per-instance
+ * radioItemAria projection directly.
  */
 import { describe, expect, it } from 'vitest';
 import { createBehavior } from '../../../src/lib/contract';
@@ -141,13 +141,9 @@ describe('radio-group keymap', () => {
   });
 });
 
-describe('radio-group effects', () => {
-  it('always requests roving-focus on the root at the configured orientation', () => {
-    expect(radioGroup.effects({ value: null }, { orientation: 'horizontal' })).toEqual([
-      { type: 'roving-focus', part: 'root', orientation: 'horizontal' },
-    ]);
-    expect(radioGroup.effects({ value: null }, {})).toEqual([
-      { type: 'roving-focus', part: 'root', orientation: 'vertical' },
-    ]);
-  });
-});
+// Roving keyboard navigation is no longer a declarative effect on the score --
+// the WC/Astro bind and the React controller each compose the roving-focus
+// primitive directly. Its behavior (arrow/Home/End move focus AND select the
+// newly focused item, horizontal orientation, roving skips disabled items) is
+// asserted end to end in the react/wc/astro conformance suites, which drive the
+// real DOM the primitive operates on.


### PR DESCRIPTION
## Summary

radio-group composes the `roving-focus` primitive directly at both framework
boundaries, dropping the redundant `roving-focus` `EffectSpec` and the
`createEffectRunner` indirection. The effect arm was a 1:1 wrapper over
`createRovingFocus`; the runner bought nothing over calling the primitive. Both
the DOM-native bind (WC + Astro) and the React controller now call the primitive
directly, so `lib/effects` loses an importer on each side ahead of teardown #1867.

## Acceptance criteria mapping

### 1. `radio-group.behavior.ts` no longer imports from `lib/effects`

The `import { createEffectRunner, type EffectHost, type EffectSpec } from
'../../lib/effects'` line is deleted and the slice's `effects: (_state, config)
=> [...]` arm is removed, so nothing in the score references the EffectSpec
vocabulary; the only added import is `createRovingFocus` from
`../../primitives/roving-focus`. Removed at BOTH consumers, not just the bind:
`radio-group.tsx` also drops `useBehaviorEffects` and composes the primitive in a
`useEffect`, so effects() has no remaining caller on either side.
Evidence: git diff of radio-group.behavior.ts (import line and `effects:` arm
gone) and radio-group.tsx (`useBehaviorEffects` import and call gone); preflight
typecheck passes, proving no dangling `EffectSpec`/`EffectHost` reference remains.

### 2. Roving keyboard nav (Arrow/Home/End, correct orientation)

`bindRadioGroup` calls `createRovingFocus(root, { orientation: orientationOf(config) })`
once during bind (line 174), and React `RadioGroup` calls the same in a `useEffect`
keyed on `[orientation]` (line 137). Both compose it BEFORE the component's own
select keydown listener so roving moves focus first and selection follows focus.
Evidence: unchanged conformance tests pass in all three performances -- `arrow
keys move focus AND select the newly focused item`, `horizontal orientation
moves+selects with left/right arrows`, `roving skips a disabled item` in
radio-group.conformance.test.tsx (react), radio-group.element.conformance.test.ts
(wc), radio-group.astro.conformance.test.ts (astro).

### 3. Focus/tabindex stays in the primitive; no tabindex leaks into the projection

`createRovingFocus` owns the roving tabindex internally via its `updateTabindex`,
set at bind and updated on keydown/focusin. The score's `radioItemAria` projection
still emits only `aria-checked`/`data-state`, never `tabindex`, so the asserted
aria contract is unchanged.
Evidence: behavior test `carries no tabindex (roving owns it as ephemeral DOM
state)` passes; `assertContractFulfillment`/`assertInstanceContractFulfillment` in
the react conformance test pass against the unchanged projection.

### 4. `pnpm --filter @rafters/ui test:unit` + preflight green

Evidence: `test:unit` passes (components run: 32 files / 169 tests; full ui suite
5981 passed, 6 pre-existing skips untouched). `pnpm preflight` exits 0 (lint,
format, typecheck, build all clean).

## Not done

- Did not touch `lib/effects.ts` or `hooks/use-behavior-effects.ts` -- those are
  removed wholesale by teardown #1867; this PR only stops radio-group importing them.
- Did not alter the aria projection, exclusive-selection state, canDispatch
  group-disabled gate, or the controlled/uncontrolled ownership boundary.
- Did not change grid, navigation-menu, or select, which carry their own
  roving/grid-roving effect arms -- radio-group is the reference; those land separately.
- Removed the `describe('radio-group effects')` data-assertion block from
  radio-group.behavior.test.ts (the effects() data no longer exists); the behavior
  it stood for is covered by the react/wc/astro conformance suites.

Closes #1861