### PR TITLE
docs(spec): retire Spec 03 effects-as-data -- behaviors compose primitives directly

### DIFF
--- a/packages/ui/docs/spec/01-behavior-contract.md
+++ b/packages/ui/docs/spec/01-behavior-contract.md
@@ -113,9 +113,12 @@ export interface BehaviorSpec<
     config: Config,
   ) => keyof Actions | null;
 
-  /** Declarative effect requests for the current state (Spec 03).
-   *  Executors diff consecutive results and start/stop accordingly. */
-  effects: (state: State, config: Config) => EffectSpec[];
+  /** RETIRED (Spec 03 retired 2026-07-19). Behaviors compose primitives
+   *  directly in a composition function the framework boundaries call; they no
+   *  longer return an effect list. This member is removed from the type by the
+   *  teardown (issue #1867) once no behavior declares it. Do NOT add it to a
+   *  new behavior -- compose the primitive. */
+  effects?: (state: State, config: Config) => EffectSpec[];
 
   /** Motion declarations per (transition, part) -- Spec 04. Motion is
    *  behavior: intent + axis + sizeClass only. Statics omit this. */

--- a/packages/ui/docs/spec/02-composer.md
+++ b/packages/ui/docs/spec/02-composer.md
@@ -25,9 +25,13 @@ export interface Slice<
   canDispatch?: (state: State, action: keyof Actions, config: Config) => boolean;
   aria?: (state: State, config: Config, ids: PartIds<Part>) => Partial<Record<Part, AriaAttrs>>;
   keymap?: (event: KeyInput, state: State, part: Part, config: Config) => keyof Actions | null;
-  effects?: (state: State, config: Config) => EffectSpec[];
+  effects?: (state: State, config: Config) => EffectSpec[]; // RETIRED -- see below; removed by teardown #1867
 }
 ```
+
+> **`effects` is retired (Spec 03 retired 2026-07-19).** Slices no longer contribute
+> effect lists; behaviors compose primitives directly. The composer stops synthesizing
+> `.effects` in the teardown (issue #1867). Do not declare `effects` on a new slice.
 
 Slices do NOT own memory cells. `compose` produces one `BehaviorSpec` whose
 `createBehavior` instance owns the single cell of the merged state type.

--- a/packages/ui/docs/spec/03-effects.md
+++ b/packages/ui/docs/spec/03-effects.md
@@ -1,71 +1,65 @@
-# Spec 03 — Effects
+# Spec 03 — Effects (RETIRED)
 
-Status: FROZEN 2026-07-09. Vocabulary v3 (rulings of 2026-07-08 applied).
+Status: **RETIRED 2026-07-19.** Supersedes FROZEN-2026-07-09. The effects-as-data
+vocabulary this spec defined (`EffectSpec[]` returned from `effects()`, reconciled by a
+runner, mapped to primitives by executors) is removed. Behaviors now compose the
+primitives **directly**. This file is kept as the record of what changed and why, and to
+carry forward the two rulings that are still true (temporal kinds, non-modal).
 
-Behaviors describe impure work; executors perform it. A behavior returns
-`EffectSpec[]` from `effects(state, config)` — pure data, computed from the
-current state and config. The runner reconciles consecutive lists and the
-executor maps each spec onto a primitive. A component that needs an effect
-the vocabulary cannot express is a change request against THIS spec — stop
-the line, never hack it locally (boundary 7).
+## Why it was retired
 
-## Temporal kinds
+Every `EffectSpec` arm wrapped a primitive that already existed (`sr-announcer`,
+`focus-trap`, `roving-focus`, `typeahead`, `outside-click`, `hover-delay`). The layer
+added nothing but a translation step — and its blank executor slot was a honeypot: two
+executors (`grid-roving`, `hover-intent`) **reimplemented** their primitives
+(`roving-focus`, `hover-delay`) instead of composing them, because a `case` in a switch is
+a place to write a half-solution, whereas `createRovingFocus(root, { columns })` is not.
 
-- **One-shot** (edge-triggered): fired once when the effect appears in the
-  list. Effects present in the very first apply are baseline and are NOT
-  fired — a component that mounts already-loading does not announce
-  "Loading" to a screen reader that can already see it.
-- **Ongoing** (level-triggered): started whenever present — including the
-  first apply (a dialog that mounts open IS trapped) — and stopped when the
-  effect leaves the list or the runner stops. Executors return the cleanup.
+The mandate here ("a component that needs an effect the vocabulary cannot express is a
+change request against THIS spec") is exactly what caused the accretion: it told every port
+to ADD an arm rather than reach for — or extend — a primitive.
 
-## Vocabulary v2
+## The rule now
 
-| Spec | Kind | Executor primitive |
-| --- | --- | --- |
-| `announce { message, politeness }` | one-shot | sr-announcer |
-| `focus-trap { part }` | ongoing | focus-trap/createFocusTrap; stop restores focus |
-| `scroll-lock` | ongoing | focus-trap/preventBodyScroll |
-| `dismiss-on-outside { part, action, exceptParts? }` | ongoing | outside-click/onPointerDownOutside |
+A behavior **composes primitives directly**. Impure work lives in a composition function in
+the behavior file; each framework boundary calls it and nothing more:
 
-`dismiss-on-outside` dispatches `action` through the host on pointerdown
-outside `part`. Events landing inside any `exceptParts` are ignored: a
-layer's own trigger must not dismiss the layer and re-activate it on the
-same gesture (live defect in the dialog oracle).
+- The composition (start the primitives, hold their cleanups) lives in `x.behavior.ts` — a
+  plain function (e.g. `startDialogModalEffects({ content, getTrigger, onDismiss })`) when
+  it composes more than one primitive, or an inline call when it is one.
+- **WC / Astro**: `bindX` calls it on the relevant transition, holds the cleanup, tears down.
+- **React**: a `useEffect` calls the SAME function, returns its cleanup.
 
-Vocabulary v3 additions (ruled 2026-07-08):
+There is no `EffectSpec`, no `effects()` member, no `createEffectRunner`, no `EffectHost`,
+no `use-behavior-effects`. Need a capability → compose the primitive from the primitives
+matrix. Need a capability no primitive has → **extend or add a PRIMITIVE**, never a local
+executor. See `05-authoring.md`; references: `radio-group` (one primitive, direct call) and
+`dialog` (multi-primitive composition function).
 
-| Spec | Kind | Executor primitive |
-| --- | --- | --- |
-| `presence { part }` | ongoing | Presence adapter (wave 0-B): keeps the part mounted through its exit animation, then releases. Astro: no-op (CSS-only, no exit animation) |
+## Carried forward — still true
 
-Non-modal ruling (2026-07-08): a non-modal overlay declares NO focus-trap,
-NO scroll-lock. Pointer events pass through; dismiss-on-outside still fires.
-Modality selects the effect list; it never changes an effect's meaning.
+**Temporal kinds** (the composition function owns this lifecycle, not a runner):
+- **One-shot / edge-triggered** (e.g. a screen-reader announce): fire once on the state
+  TRANSITION, not on baseline mount — a component that mounts already-loading must not
+  announce "Loading". The composition tracks the previous value and fires only on the edge.
+- **Ongoing / level-triggered** (focus-trap, scroll-lock, dismiss, roving): start when the
+  condition becomes true (including a component that mounts already-open — a dialog that
+  mounts open IS trapped), and tear down when it becomes false or on unmount. The primitive
+  returns the cleanup.
 
-## The host
+**Which primitive each old effect composed** (use this as the composition map):
 
-Executors reach the DOM only through an `EffectHost` supplied by the
-framework binding:
+| old effect | compose this primitive |
+| --- | --- |
+| announce | `sr-announcer` (`announceToScreenReader` / `createPoliteAnnouncer`) |
+| focus-trap | `focus-trap` (`createFocusTrap`) — cleanup restores focus |
+| scroll-lock | `focus-trap` (`preventBodyScroll`) |
+| dismiss-on-outside | `outside-click` (`onPointerDownOutside`) — spare `exceptParts`; a layer's own trigger must not dismiss then re-activate on one gesture |
+| roving-focus | `roving-focus` (`createRovingFocus`) |
+| grid-roving | `roving-focus` extended to 2D (`{ columns }`) — do NOT reimplement it |
+| hover-intent | `hover-delay` (`createHoverIntent` / `createControlledHoverDelay`) — do NOT reimplement it |
+| typeahead | `typeahead` (`createTypeahead`) |
 
-```ts
-interface EffectHost {
-  getPart(part: string): HTMLElement | null; // resolve declared part -> element
-  dispatch(action: string): void; // the binding's accepted-dispatch + callback protocol
-}
-```
-
-The behavior stays element-free; the binding owns part registration (refs in
-React, shadow-DOM queries in WC). Effects started in an earlier apply keep
-their start-time host; `apply(effects, host)` takes the current host so new
-effects capture fresh state.
-
-## The runner
-
-`createEffectRunner()` returns `{ apply(effects, host), stop() }` — a pure
-diff over `effectKey` identity. Framework adapters own the lifecycle:
-
-- React: `hooks/use-behavior-effects.ts` applies after every commit and
-  stops on unmount.
-- WC: apply after each patch, stop on disconnect. (Not yet written.)
-- Astro: no client runtime, no effects; static tiers only.
+**Non-modal ruling (2026-07-08, still holds):** a non-modal overlay composes NO focus-trap
+and NO scroll-lock; pointer events pass through; outside-dismiss still applies. Modality
+selects which primitives the behavior composes; it never changes a primitive's meaning.

--- a/packages/ui/docs/spec/05-authoring.md
+++ b/packages/ui/docs/spec/05-authoring.md
@@ -10,9 +10,12 @@ and `dialog` (overlay) are the richest; `container`/`card` are the simplest.
 Per component, three kinds of file and nothing else:
 
 - **`x.behavior.ts` = the model.** The pure score -- reducers, aria/keymap
-  projections, effects-as-data -- AND `bindX(root)`, the DOM-native client.
-  The score never *performs*; it describes. It is a total function from state
-  to attributes, so it survives contact with any framework.
+  projections -- AND `bindX(root)`, the DOM-native client, plus (when the
+  component does impure work) a small composition function. The score's
+  projections never *perform*; they describe -- a total function from state to
+  attributes, so they survive contact with any framework. Impure work (focus
+  trap, dismiss, roving, announce) is COMPOSED from primitives in a function in
+  this file that each framework boundary calls -- see `bindX` below.
 - **`x.classes.ts` = the view.** Class strings. No logic.
 - **`x.tsx` / `x.element.ts` / `x.astro` = decorators over the behavior.**
   Each is a thin wrapper that adds exactly two things around the invariant
@@ -44,29 +47,50 @@ shared "binder". The substrate the score composes is in `lib/` and
 before writing any primitive** -- `aria-manager`, `focus-trap`, `roving-focus`,
 `memory` etc. already exist.
 
+**Never put a wrapper between a behavior and a primitive.** No effect vocabulary,
+no `EffectSpec` union, no runner, no executor slot, no registry. A behavior that
+needs a capability COMPOSES the primitive directly; a behavior that needs a
+capability no primitive has EXTENDS or ADDS a primitive -- never a local
+half-solution. A shared executor slot is a honeypot: it is exactly what once let
+`grid-roving` and `hover-intent` reimplement `roving-focus`/`hover-delay` instead
+of composing them. (The retired effects-as-data layer -- Spec 03 -- was removed
+for precisely this reason.)
+
 ## The substrate you compose (never rewrite)
 
 - `lib/contract.ts` -- `createBehavior(spec, config)` -> `{ memory, dispatch }`.
-- `lib/effects.ts` -- `createEffectRunner()`; effects are a closed data union
-  run by the existing primitives (focus-trap, roving, hover, dismiss).
+- `primitives/*` -- the behavior primitives you compose directly: `sr-announcer`,
+  `focus-trap`, `roving-focus`, `outside-click`/`dismissable-layer`, `hover-delay`,
+  `typeahead`, `disclosure`, `selection-group`, `collision-detector`, ... Check the
+  primitives matrix; every impure capability is one of these.
 - `primitives/aria-manager.ts` -- `updateAriaAttribute(el, name, value, { validate: false })`
   applies a resolved projection to an element.
 - `hooks/use-memory.ts` -- `useMemory` (the one surviving React hook,
-  `useSyncExternalStore`); `hooks/use-behavior-effects.ts` runs the runner in a
-  React effect.
+  `useSyncExternalStore`). React runs a behavior's composed primitives in a plain
+  `useEffect` that calls the same composition function `bindX` does.
 - `primitives/rafters-element.ts` -- the shadow-DOM WC base (for pure statics).
 
 ## `bindX` -- the DOM-native client (WC + Astro share it)
 
-Lives in the behavior file. Shape (see `bindNavigationMenu`, `bindDialog`):
+Lives in the behavior file. Shape (see `bindDialog`, `bindRadioGroup`). Two
+composition shapes: a **direct call** when it is one primitive (`radio-group`:
+`createRovingFocus` inline in both `bindRadioGroup` and the React `useEffect`),
+and a **colocated composition function** when more than one (`dialog`'s
+`startDialogModalEffects({ content, getTrigger, onDismiss })`, called by both the
+bind and the React `useEffect`):
 
 1. Read config from the root's `data-*`/attributes.
 2. `getPart` -- `root.querySelector('[data-part="x"]')` (or `getElementById`
    when a part portals out, as dialog's content does).
-3. `createBehavior` + `createEffectRunner`; an `EffectHost` of `{ getPart, dispatch }`.
+3. `createBehavior` -> `{ memory, dispatch }`.
 4. Read part ids from the server markup -- never generate them.
-5. `render()` = apply the aria projection with `aria-manager` (`validate: false`),
-   toggle `hidden` on presence parts, `runner.apply(spec.effects(...))`.
+5. `render()` = apply the aria projection with `aria-manager` (`validate: false`)
+   and toggle `hidden` on presence parts. For impure work, call the behavior's
+   composition function on the relevant state transition and hold its cleanup:
+   ongoing primitives (focus-trap, dismiss, roving) start when their condition
+   becomes true (including a component that mounts already-open) and tear down on
+   the reverse transition/unbind; one-shot ones (announce) fire only on the edge,
+   never on baseline mount.
 6. `memory.subscribe(render)` (fires immediately: first paint).
 7. Wire events (`click` -> dispatch; `keydown` -> `spec.keymap` -> dispatch),
    return a teardown.
@@ -76,11 +100,11 @@ Lives in the behavior file. Shape (see `bindNavigationMenu`, `bindDialog`):
 | archetype | reference | shape |
 |---|---|---|
 | pure static | `container`, `card` | no `bindX`, no `useBehavior`/`useMemory`; the decorators are markup + classes + slots only. WC = `RaftersElement` shadow + `<slot>`. |
-| simple-interactive | `button` | `bindButton`; native `<button>` fulfils Enter/Space, so wire `click` only. One-shot `announce` effect is edge-triggered. |
-| static + effect | `grid` | static except a conditional effect (grid-roving when `role=grid`). |
+| simple-interactive | `button` | `bindButton`; native `<button>` fulfils Enter/Space, so wire `click` only. Composes `sr-announcer` on the loading edge (one-shot). |
+| static + composed | `grid` | static except it composes `roving-focus` (2D, `{ columns }`) when `role=grid`. |
 | text-input | `input` | primary state is a **value**; `setValue` gated by disabled/readonly; native input owns caret/IME/selection -- do not re-implement. |
-| overlay + presence | `dialog` | presence (content mounts/unmounts in React, `hidden`-toggles in the bind) + the ongoing effects runner (focus-trap, scroll-lock, dismiss). Effect-observed parts stay light DOM. |
-| compound | `navigation-menu` | many-part instances (trigger/content per value), roving + hover-intent + dismiss effects. |
+| overlay + presence | `dialog` | presence (content mounts/unmounts in React, `hidden`-toggles in the bind) + a composition function that starts `focus-trap` + `scroll-lock` (`preventBodyScroll`) + `outside-click` on open and tears them down on close. Composed parts stay light DOM. |
+| compound | `navigation-menu` | many-part instances (trigger/content per value); composes `roving-focus` + `hover-delay` + `outside-click`. |
 
 ## The three gotchas (encode all three)
 
@@ -96,13 +120,13 @@ Lives in the behavior file. Shape (see `bindNavigationMenu`, `bindDialog`):
 
 - **React compound decorators carry real hook weight.** A static (button,
   badge) is a couple lines; a compound controlled component is ~40-50 lines of
-  genuine wiring (instance, ids, the dispatch protocol, effect host). That is
-  retained-mode's floor, not fat.
+  genuine wiring (instance, ids, the dispatch protocol, the composed primitives
+  in a `useEffect`). That is retained-mode's floor, not fat.
 - **Portaled overlays need presence tracking** -- but only for the *unguarded*
   cross-ref sources (`aria-labelledby`/`describedby`, which lack the `open`
   guard `aria-controls` has). Everything else keeps a stable id.
 - **Two WC shapes.** Behavior-carrying components are **light-DOM enhancers**
-  (the bind reads real document DOM for effects). Pure statics are **shadow +
+  (the bind reads real document DOM for the primitives it composes). Pure statics are **shadow +
   slots** (`RaftersElement`) -- simpler, but they render every region, so
   unfilled slots become empty padded space. Accepted cost of a no-bind static.
 - `card`/`alert` render raw heading/`<p>` via `createElement` because Typography

--- a/packages/ui/docs/spec/components/dialog.md
+++ b/packages/ui/docs/spec/components/dialog.md
@@ -1,7 +1,15 @@
 # Component Spec — Dialog
 
-Status: DRAFT. Second test article. Validates composition (Spec 02) and
-effects (Spec 03).
+Status: DRAFT. Second test article. Validates composition (Spec 02).
+
+> **Effects-as-data is retired (Spec 03 retired 2026-07-19).** Where this doc
+> below describes dialog emitting `focus-trap`/`scroll-lock`/`dismiss` effects
+> through a runner, the current implementation composes those primitives
+> DIRECTLY: a `startDialogModalEffects({ content, getTrigger, onDismiss })`
+> function in `dialog.behavior.ts` starts `createFocusTrap` + `preventBodyScroll`
+> + `onPointerDownOutside` on open and tears them down on close, called by both
+> `bindDialog` (WC/Astro) and a React `useEffect`. dialog is the OVERLAY reference
+> for this pattern -- see `05-authoring.md`. Do not reintroduce an effect list.
 
 Files (`src/components/dialog/`):
 

--- a/packages/ui/docs/spec/components/navigation-menu.md
+++ b/packages/ui/docs/spec/components/navigation-menu.md
@@ -1,8 +1,16 @@
 # Component Spec — Navigation Menu
 
-Status: DRAFT. Third test article: many-instance parts, effect-owned focus,
+Status: DRAFT. Third test article: many-instance parts, roving focus,
 time-based interaction (hover intent), and the component whose oracle
 controller was the exact pattern the behavior layer exists to replace.
+
+> **Effects-as-data is retired (Spec 03 retired 2026-07-19).** Where this doc
+> describes `roving`/`hover-intent`/`dismiss` effects, the target implementation
+> (issue #1864) composes the primitives DIRECTLY: `createRovingFocus` +
+> `hover-delay` (`createHoverIntent`) + `onPointerDownOutside`, in a composition
+> function called by both `bindNavigationMenu` and a React `useEffect`. The old
+> `hover-intent` executor REIMPLEMENTED `hover-delay` -- compose the primitive,
+> never copy it. See `05-authoring.md`.
 
 Files (`src/components/navigation-menu/`):
 


### PR DESCRIPTION
## Summary

Retire the effects-as-data layer at the RULES level so no future port re-adds it. Doc-only;
the matching code removal is the teardown issue #1867.

## Acceptance criteria mapping

### Spec 03 (effects-as-data) is retired and replaced with the direct-composition rule
`03-effects.md` now carries a RETIRED banner and states the new rule -- behaviors compose
primitives directly, no vocabulary/runner/executor -- while preserving the still-true
temporal-kinds and non-modal rulings and a per-effect primitive-map table.
Evidence: packages/ui/docs/spec/03-effects.md:1.

### The authoring guide teaches direct primitive composition, not effects-as-data
`05-authoring.md`'s score bullet, substrate list, bindX shape, and archetype table were rewritten
to drop `createEffectRunner`/`EffectHost`/`effects()`/`use-behavior-effects` and describe composing
primitives in a function each framework boundary calls; an explicit anti-pattern rule was added.
Evidence: packages/ui/docs/spec/05-authoring.md:46.

### The contract chain (01/02) no longer mandates an effects member for new behaviors
The `effects` member in `01-behavior-contract.md` and `02-composer.md` is annotated RETIRED and made
optional, pointing at Spec 03 and the teardown so no new behavior declares it.
Evidence: packages/ui/docs/spec/01-behavior-contract.md:116.

### The archetype reference docs stop teaching the effects pattern
`dialog.md` and `navigation-menu.md` carry banners describing the direct-composition reality and
pointing at the authoring guide, so ports imitating them inherit the correct pattern.
Evidence: packages/ui/docs/spec/components/dialog.md:3.

### Verification: doc-only and preflight green
`pnpm preflight` exits 0 and `git status` shows only `docs/spec/*` changed (6 files), confirming no
code path is touched by this PR.
Evidence: packages/ui/docs/spec/02-composer.md:28.

## Not done

- The CODE removal is deliberately OUT of scope: deleting `lib/effects.ts`, the `effects` member in
  `lib/contract.ts`, the `.effects` synthesis in `lib/compose.ts`, and `hooks/use-behavior-effects.ts`
  is the teardown issue #1867, which lands only after the 8 component un-reinvention fixes stop
  importing effects.ts. This PR is the rules-of-record change alone, so the specs deliberately mark
  the member "retired/optional" rather than remove it while the code still references it.
- Per-component reference docs beyond `dialog` and `navigation-menu` are updated with their own
  component PRs (radio-group/button/toggle/grid/popover/select), not here.

Closes #1871
