### PR TITLE
fix(ui): remove dead effect-runner scaffolding from bindToggle

### DIFF
--- a/packages/ui/src/components/toggle/toggle.behavior.ts
+++ b/packages/ui/src/components/toggle/toggle.behavior.ts
@@ -5,7 +5,6 @@ import {
   type BehaviorSpec,
   type PartIds,
 } from '../../lib/contract';
-import { createEffectRunner, type EffectHost } from '../../lib/effects';
 import { updateAriaAttribute } from '../../primitives/aria-manager';
 import {
   pressable,
@@ -94,13 +93,8 @@ export function bindToggle(root: HTMLElement): () => void {
     part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
 
   const { memory, dispatch } = createBehavior(toggle, config);
-  const runner = createEffectRunner();
 
   const request = (action: keyof ToggleActions): boolean => dispatch(action, config);
-  const host: EffectHost = {
-    getPart,
-    dispatch: (action) => void request(action as keyof ToggleActions),
-  };
 
   // ids are READ from the markup; toggle carries no id-ref aria, but the
   // projection contract still takes them.
@@ -124,7 +118,6 @@ export function bindToggle(root: HTMLElement): () => void {
       const el = getPart(part);
       if (el && attrs) applyProjection(el, attrs);
     }
-    runner.apply(toggle.effects(state, config), host);
   };
   const unsubscribe = memory.subscribe(render); // fires immediately: first paint
 
@@ -141,7 +134,6 @@ export function bindToggle(root: HTMLElement): () => void {
 
   return () => {
     unsubscribe();
-    runner.stop();
     root.removeEventListener('click', onClick);
   };
 }

--- a/packages/ui/test/components/toggle/toggle.behavior.test.ts
+++ b/packages/ui/test/components/toggle/toggle.behavior.test.ts
@@ -93,11 +93,7 @@ describe('toggle keymap', () => {
   });
 });
 
-describe('toggle effects', () => {
-  it('a toggle has no effects -- it is an instant state swap, never loading', () => {
-    expect(toggle.effects(toggle.initialState(base), base)).toEqual([]);
-    expect(toggle.effects(toggle.initialState({ ...base, defaultPressed: true }), base)).toEqual(
-      [],
-    );
-  });
-});
+// A toggle is an instant state swap, never loading -- it composes no effect
+// primitive at either boundary. The WC/Astro bind and the React controller both
+// wire click -> press only; there is no runner and nothing to drive. So there is
+// no effects data to assert here.


### PR DESCRIPTION
## Summary

Remove the dead effect-runner scaffolding from `bindToggle`, so `toggle.behavior.ts`
stops importing from `lib/effects.ts`. toggle composes the `pressable` slice but sets no
`loading` config, so `toggle.effects()` has been `[]` since the toggle port. `bindToggle`
nonetheless carried `createEffectRunner`, an `EffectHost`, `runner.apply(toggle.effects(...),
host)` in `render`, and `runner.stop()` in cleanup -- all copied verbatim from `bindButton`,
driving an empty effect list forever. This is the trivial case in the effects retirement:
no primitive to compose, pure dead-code removal, so `lib/effects` loses an importer ahead of
teardown #1867.

## Acceptance criteria mapping

### 1. `toggle.behavior.ts` no longer imports from `lib/effects`

The `import { createEffectRunner, type EffectHost } from '../../lib/effects'` line is deleted
(was toggle.behavior.ts:8). Inside `bindToggle`, `const runner = createEffectRunner()` and the
`host: EffectHost` construction are gone, `render` (toggle.behavior.ts:113) drops the
`runner.apply(toggle.effects(state, config), host)` call and keeps only the aria projection
loop, and the cleanup (toggle.behavior.ts:135) drops `runner.stop()`. The file's only remaining
substrate imports are `compose`, `contract`, `aria-manager`, and `pressable` -- nothing
references the EffectSpec/EffectHost vocabulary.

Both boundaries stop touching effects.ts, not just the bind. The React controller `toggle.tsx`
needed no change because it never consumed `effects()`: it has no `useBehaviorEffects` import
or call, as its own comment at toggle.tsx:74-76 states ("Toggle has no effects ... so no effect
runner is wired"). This is NOT a half-fix -- the WC bind is fixed by removal, React was already
clean by prior absence.

Evidence: `pnpm preflight` typecheck passes, proving no dangling `EffectHost`/`createEffectRunner`
reference remains; `getPart` (toggle.behavior.ts:92) and `request` (toggle.behavior.ts:97) are
still referenced by the ids loop and `onClick`, so no orphaned local is left behind.

### 2. No functional/aria change; conformance suite + preflight green

`render` still reads `state` (toggle.behavior.ts:114) and applies the identical aria projection;
`onClick` still gates activation via `request('press')`. The removed runner only ever drove an
empty effect list, so nothing observable changed.

Evidence: `pnpm --filter @rafters/ui test:unit` passes (32 files, 169 tests). The toggle
conformance suite runs one score across React, WC, and Astro and asserts contract fulfillment,
aria-pressed/data-state, axe cleanliness, the Enter/Space flip through the keymap, and
disabled-suppression (test/components/toggle/conformance-suite.ts) -- all unchanged and green.
`pnpm preflight` exits 0 (lint, format, typecheck, build all clean).

### 3. Part of the effects.ts teardown -- toggle stops importing effects.ts (trivial, no effect)

toggle is one of the behaviors that must stop importing `lib/effects.ts` before #1867 can
delete it wholesale. It is the trivial case: no primitive to compose, just dead scaffolding.
The only test asserting `effects()` data -- the `describe('toggle effects')` block asserting
`toggle.effects()` returns `[]` -- is removed and replaced with an explanatory comment
(toggle.behavior.test.ts:96-99), following the radio-group #1870 precedent. The conformance
suite never asserted effects() data, so no conformance file changed.

Evidence: `toggle.effects()` still resolves via `compose` (toggle does not define `effects`
locally), so the assertion was genuinely vestigial with no behavior to migrate it to; the
remaining behavior-test blocks (aria, suppression, actions, keymap) are untouched and pass.

## Not done

- Did not touch `lib/effects.ts` or `hooks/use-behavior-effects.ts` -- the wholesale teardown
  #1867 deletes them; this PR only stops toggle importing the runner.
- Did not remove the `effects()` method from `BehaviorSpec`/`compose`. `toggle.effects()` still
  resolves via `compose` and returns `[]`; toggle defines no local `effects`, so there is
  nothing component-local to strip. Removing the method from the contract is #1867 scope.
- Did not modify `toggle.tsx` -- the React boundary was already clean (see criterion 1).
- Did not touch any other component; the diff is confined to toggle's `behavior.ts` and its
  behavior test, keeping this queue-parallel-safe with the sibling effects-retirement PRs.

Closes #1860