### PR TITLE
refactor(#1865): select composes primitives directly, retiring effects.ts

### DIFF
--- a/packages/ui/src/components/select/select.behavior.ts
+++ b/packages/ui/src/components/select/select.behavior.ts
@@ -5,9 +5,11 @@ import {
   type BehaviorSpec,
   type PartIds,
 } from '../../lib/contract';
-import { createEffectRunner, type EffectHost, type EffectSpec } from '../../lib/effects';
 import { updateAriaAttribute } from '../../primitives/aria-manager';
 import { formValueAttrs } from '../../primitives/form-value';
+import { onPointerDownOutside } from '../../primitives/outside-click';
+import { createRovingFocus } from '../../primitives/roving-focus';
+import { createTypeahead } from '../../primitives/typeahead';
 
 /**
  * Select: a listbox picker. The trigger (a combobox button) discloses a
@@ -158,22 +160,65 @@ const selectSlice: Slice<SelectConfig, SelectState, SelectActions, SelectPart> =
     }
     return null;
   },
-  effects: (state, config): EffectSpec[] => {
-    if (!isOpen(state, config)) return [];
-    return [
-      { type: 'roving-focus', part: 'content', orientation: 'vertical' },
-      { type: 'typeahead', part: 'content' },
-      // Outside pointerdown closes; the trigger toggles instead of
-      // close-then-open on the same gesture.
-      { type: 'dismiss-on-outside', part: 'content', action: 'close', exceptParts: ['trigger'] },
-    ];
-  },
 };
 
 export const select: BehaviorSpec<SelectConfig, SelectState, SelectActions, SelectPart> = compose(
   'select',
   selectSlice,
 );
+
+/** The parts and dispatch the open-listbox trio composes against. */
+export interface SelectOpenPorts {
+  /** The listbox: focus roves inside it, typeahead jumps within it, and a
+   *  pointerdown landing outside it dismisses. */
+  content: HTMLElement;
+  /** Resolves the trigger so the opening gesture's pointerdown is spared --
+   *  otherwise it would both dismiss the listbox and re-open it. */
+  getTrigger: () => HTMLElement | null;
+  /** Outside-pointerdown handler, already spared of the trigger. Receives the
+   *  native event so a boundary could offer a consumer veto before closing. */
+  onDismiss: (event: Event) => void;
+}
+
+/** The [role="option"] descendants of the listbox that are not disabled --
+ *  the item set roving and typeahead operate over (shared so both agree). */
+function enabledOptions(content: HTMLElement): HTMLElement[] {
+  return Array.from(content.querySelectorAll<HTMLElement>('[role="option"]')).filter(
+    (item) => !item.hasAttribute('data-disabled') && item.getAttribute('aria-disabled') !== 'true',
+  );
+}
+
+/**
+ * The open-listbox effect trio, composed directly (replacing the effects
+ * runner): rove arrow/Home/End focus across the options, type-to-jump to the
+ * best matching option, and dismiss on a pointerdown outside `content` --
+ * sparing the trigger. Both matches move DOM focus to an option; the binding's
+ * own focus listener mirrors that into the highlight (roving/typeahead stay
+ * select-agnostic). Level-triggered: BOTH bindSelect and the React Select start
+ * this on the open transition (after content is un-hidden so the option set is
+ * focusable) and call the returned cleanup on close/unmount.
+ */
+export function startSelectOpenEffects({
+  content,
+  getTrigger,
+  onDismiss,
+}: SelectOpenPorts): () => void {
+  const stopRoving = createRovingFocus(content, { orientation: 'vertical' });
+  const stopTypeahead = createTypeahead(content, {
+    getItems: () => enabledOptions(content),
+    onMatch: (item) => item.focus(),
+  });
+  const stopDismiss = onPointerDownOutside(content, (event) => {
+    const target = event.target as Node;
+    if (getTrigger()?.contains(target)) return;
+    onDismiss(event);
+  });
+  return () => {
+    stopDismiss();
+    stopTypeahead();
+    stopRoving();
+  };
+}
 
 /**
  * Per-instance projection for the many-instance `item` part. Spec 01's aria()
@@ -240,16 +285,13 @@ export function bindSelect(root: HTMLElement): () => void {
     part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
 
   const { memory, dispatch } = createBehavior(select, config);
-  const runner = createEffectRunner();
 
   const request = (action: keyof SelectActions, payload?: string): boolean =>
     dispatch(action, config, ...((payload === undefined ? [] : [payload]) as [string]));
 
-  const host: EffectHost = {
-    getPart,
-    dispatch: (action, payload) =>
-      void request(action as keyof SelectActions, payload as string | undefined),
-  };
+  // The open-listbox effect trio is level-triggered: present only while open.
+  // render() starts it on the transition and this cleanup stops it on close.
+  let openEffectsCleanup: (() => void) | null = null;
 
   // ids READ from the server/author markup, never generated.
   const ids = {} as PartIds<SelectPart>;
@@ -297,7 +339,24 @@ export function bindSelect(root: HTMLElement): () => void {
     const input = root.querySelector<HTMLInputElement>('input[data-part="hidden-input"]');
     if (input) input.value = value;
 
-    runner.apply(select.effects(state, config), host);
+    // Compose the open-listbox effect trio directly, level-triggered: start it
+    // once on the open transition (content is now un-hidden above so roving and
+    // typeahead see focusable options), tear it down when the listbox closes.
+    if (open && !openEffectsCleanup) {
+      const content = getPart('content');
+      if (content) {
+        openEffectsCleanup = startSelectOpenEffects({
+          content,
+          getTrigger: () => getPart('trigger'),
+          onDismiss: () => {
+            request('close');
+          },
+        });
+      }
+    } else if (!open && openEffectsCleanup) {
+      openEffectsCleanup();
+      openEffectsCleanup = null;
+    }
 
     // Open-focus: land on the selected (or first) option when the listbox
     // opens and focus is not already inside it. Once focus is in, subsequent
@@ -393,7 +452,8 @@ export function bindSelect(root: HTMLElement): () => void {
 
   return () => {
     unsubscribe();
-    runner.stop();
+    openEffectsCleanup?.();
+    openEffectsCleanup = null;
     root.removeEventListener('click', onClick);
     root.removeEventListener('keydown', onKeydown);
     root.removeEventListener('focusin', onFocusIn);

--- a/packages/ui/src/components/select/select.tsx
+++ b/packages/ui/src/components/select/select.tsx
@@ -12,9 +12,10 @@
  *   association via a mirrored hidden input.
  *
  * The React performance is a DECORATOR over select.behavior.ts: it adds only
- * the view (select.classes.ts) and React wiring (useMemory + useBehaviorEffects
- * + the dispatch protocol). Every decision -- reducers, aria, keymap, effects --
- * lives in the score. The shadcn drop-in surface (Trigger, Value, Content,
+ * the view (select.classes.ts) and React wiring (useMemory + a useEffect that
+ * composes startSelectOpenEffects + the dispatch protocol). Every decision --
+ * reducers, aria, keymap, and the open-listbox effect trio -- lives in the
+ * score. The shadcn drop-in surface (Trigger, Value, Content,
  * Item, Group, Label, Separator, Portal, Viewport, ScrollUp/DownButton, Icon)
  * plus the `Select.*` namespace is preserved; each extra is a thin view wrapper.
  *
@@ -37,7 +38,6 @@
 import * as React from 'react';
 import { createBehavior, type AriaAttrs, type PartIds, type PayloadArgs } from '../../lib/contract';
 import { keyInputOf } from '../../hooks/key-input';
-import { useBehaviorEffects } from '../../hooks/use-behavior-effects';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
 import { mergeProps } from '../../primitives/slot';
@@ -49,6 +49,7 @@ import {
   selectItemAria,
   selectedLabel,
   selectedValue,
+  startSelectOpenEffects,
   type SelectActions,
   type SelectConfig,
   type SelectPart,
@@ -171,14 +172,24 @@ export function Select({
     [memory, dispatch],
   );
 
-  useBehaviorEffects(select.effects(state, config), {
-    getPart,
-    dispatch: (action, payload) =>
-      request(
-        action as keyof SelectActions,
-        ...([payload] as PayloadArgs<SelectActions[keyof SelectActions]>),
-      ),
-  });
+  // The open-listbox effect trio, composed directly on the open transition
+  // (replacing the effects runner): roving focus, typeahead, and outside
+  // dismissal sparing the trigger. Level-triggered via the dependency array;
+  // declared ABOVE the open-focus effect so roving sets the roving tabindex
+  // before focusSelectedOption lands focus. getPart/request are stable, so the
+  // listeners are torn down and rebuilt only on the open transition.
+  React.useEffect(() => {
+    if (!effectiveOpen) return;
+    const content = getPart('content');
+    if (!content) return;
+    return startSelectOpenEffects({
+      content,
+      getTrigger: () => getPart('trigger'),
+      onDismiss: () => {
+        request('close');
+      },
+    });
+  }, [effectiveOpen, getPart, request]);
 
   // Open-focus: land on the selected (or first) option when the listbox opens
   // and focus is not already inside it -- the same rule bindSelect runs.

--- a/packages/ui/test/components/select/select.behavior.test.ts
+++ b/packages/ui/test/components/select/select.behavior.test.ts
@@ -181,23 +181,9 @@ describe('select keymap', () => {
   });
 });
 
-describe('select effects', () => {
-  it('closed: no effects', () => {
-    expect(select.effects(select.initialState(closed), closed)).toEqual([]);
-  });
-
-  it('open: roving focus, typeahead, and outside dismissal sparing the trigger', () => {
-    expect(select.effects(select.initialState(openSeed), openSeed)).toEqual([
-      { type: 'roving-focus', part: 'content', orientation: 'vertical' },
-      { type: 'typeahead', part: 'content' },
-      { type: 'dismiss-on-outside', part: 'content', action: 'close', exceptParts: ['trigger'] },
-    ]);
-  });
-
-  it('controlled open drives effects without touching intrinsic state', () => {
-    const config: SelectConfig = { open: true };
-    expect(select.effects({ open: false, value: '', highlighted: undefined }, config)).toHaveLength(
-      3,
-    );
-  });
-});
+// The open-listbox effect trio (roving focus, typeahead, trigger-spared outside
+// dismissal) is no longer a declarative effect-spec on the score; the bindings
+// compose the primitives directly via startSelectOpenEffects. The BEHAVIOR is
+// asserted end to end in the conformance suites (select.conformance.test.tsx /
+// .astro. / .element.): arrows rove the options, a keystroke jumps focus to the
+// matching option, and a pointerdown outside the listbox closes it.


### PR DESCRIPTION
## Summary

Retire select's dependence on the soon-to-be-deleted `lib/effects.ts` layer by composing its
open-listbox effect trio -- roving-focus, typeahead, and trigger-spared outside dismissal --
directly at BOTH framework boundaries, following the multi-primitive pattern dialog (#1869)
established and radio-group (#1870) proved. The three primitives are wired once in a colocated
composition function, `startSelectOpenEffects(SelectOpenPorts)`, in `select.behavior.ts`, called
by both `bindSelect` (WC/Astro) and the React `Select` controller. The score's `effects()` method
and the `lib/effects` import are removed; the runner and the React `useBehaviorEffects` hook are
replaced by level-triggered composition on the open transition.

## Acceptance criteria mapping

### 1. select.behavior.ts no longer imports from `lib/effects`

The `import { createEffectRunner, type EffectHost, type EffectSpec } from '../../lib/effects'`
line is deleted and replaced by direct imports of the three primitives it wrapped
(`createRovingFocus`, `createTypeahead`, `onPointerDownOutside`). The score's `effects()` method
that emitted the three `EffectSpec` objects is removed, and `bindSelect` no longer constructs a
`createEffectRunner`/`EffectHost` -- it composes the primitives itself via the new
`startSelectOpenEffects`. React's `select.tsx` correspondingly drops `useBehaviorEffects`.
Evidence: `select.behavior.ts` imports now list `primitives/outside-click`, `primitives/roving-focus`,
`primitives/typeahead` and no `lib/effects`; preflight typecheck passes (no dangling reference);
grep of the three touched files for `lib/effects`/`useBehaviorEffects`/`createEffectRunner`/
`EffectSpec` returns clean.

### 2. Vertical roving, type-to-search (focus->highlight mirroring), and outside-dismiss (sparing trigger) behave identically across React/WC/Astro; open/close starts/stops all three; conformance + preflight green

`startSelectOpenEffects` composes `createRovingFocus(content, { orientation: 'vertical' })`,
`createTypeahead(content, { getItems: enabledOptions, onMatch: item => item.focus() })`, and
`onPointerDownOutside(content, ...)` that returns early when the trigger contains the target --
the exact wiring the retired runner performed, factored to ONE function so all three performances
share it. Both matches move DOM focus to an option; the binding's existing focusin listener still
mirrors that into the highlight (unchanged). It is level-triggered at both boundaries: `bindSelect`'s
`render()` starts the trio on the open transition (after `contentEl.hidden = !open`, so
roving/typeahead see focusable options) and the bind's returned cleanup stops it on close/unbind;
the React `useEffect` keys on `effectiveOpen` and returns the same cleanup, declared above the
open-focus effect so roving sets the tabindex before `focusSelectedOption` runs.
Evidence: `select.conformance.test.tsx`, `select.astro.conformance.test.ts`, and
`select.element.conformance.test.ts` each assert "arrows rove the options", "typeahead jumps focus
to the first matching option", "Escape closes and returns focus to the trigger", and "pointerdown
outside closes" -- all green. `pnpm --filter @rafters/ui test:unit`: 366 files / 5974 passed (6
pre-existing skips) plus astro config 32 files / 169 passed. `pnpm preflight`: green
(unit-tests, lint, format, typecheck, full workspace build). The behavior-unit
`describe('select effects')` block that asserted `effects()` data is removed, since that data no
longer exists on the score and the behavior is covered by the conformance suites above.

## Not done

- Did NOT touch `lib/effects.ts` or `hooks/use-behavior-effects.ts` -- teardown #1867 deletes them
  wholesale; other components still consume them until then.
- Did NOT touch any other component's files. This PR is scoped to `select.behavior.ts`,
  `select.tsx`, and `select.behavior.test.ts`, keeping it disjoint and queue-parallel-safe with
  the sibling effects-migration PRs.
- Did NOT edit the select conformance suites -- none referenced `select.effects()` statically;
  they already assert BEHAVIOR, so no change was required beyond removing the effects-as-data
  block from the behavior unit test.
- Did NOT extend any primitive -- select needed no capability the primitives lacked (unlike grid's
  additive `columns` option on roving-focus).
- Did NOT invent a consumer veto: select.tsx has no dismiss-veto ref (unlike dialog), so
  `onDismiss` is simply `request('close')`.
- Did NOT address the pre-existing `exhaustive-deps` lint warning on the `createBehavior` useMemo
  (`select.tsx` line 130) -- it is outside this change's hunks and reflects the intentional
  once-only construction.

Closes #1865