### PR TITLE
fix(ui): button composes sr-announcer directly, dropping effects.ts

### DIFF
--- a/packages/ui/src/components/button/button.behavior.ts
+++ b/packages/ui/src/components/button/button.behavior.ts
@@ -5,8 +5,8 @@ import {
   type BehaviorSpec,
   type PartIds,
 } from '../../lib/contract';
-import { createEffectRunner, type EffectHost } from '../../lib/effects';
 import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { announceToScreenReader } from '../../primitives/sr-announcer';
 import {
   pressable,
   type PressableActions,
@@ -57,8 +57,8 @@ export const button: BehaviorSpec<ButtonConfig, ButtonState, ButtonActions, Butt
  * The DOM-native binding of the button score -- the client. The Web Component
  * and the Astro <script> both import THIS; only React (retained-mode) reads the
  * projections declaratively instead. Same shape as bindDialog / bindNavigationMenu:
- * createBehavior is the model, the effect runner drives the announce primitive,
- * aria-manager applies the projection, and the DOM is the part registry.
+ * createBehavior is the model, the render composes the sr-announcer primitive
+ * directly, aria-manager applies the projection, and the DOM is the part registry.
  *
  * Archetype notes (simple-interactive):
  * - The `root` is a native <button>, so Enter/Space are fulfilled by the
@@ -66,11 +66,12 @@ export const button: BehaviorSpec<ButtonConfig, ButtonState, ButtonActions, Butt
  *   there is no keydown branch. A suppressed press (disabled/loading/soft-
  *   disabled, gated by canDispatch) also prevents the click's default so a
  *   form is not submitted and a double activation cannot land.
- * - The announce effect is edge-triggered (one-shot). The runner's first
- *   apply() is baseline: a button whose markup mounts already-loading projects
- *   aria-busy but does NOT announce. The runtime loading transition is the
- *   retained-mode (React) surface -- the DOM-native bind reads config once from
- *   the server/author markup, exactly like bindDialog reads default-open.
+ * - The loading announcement is edge-triggered: it fires once on the loading
+ *   false->true transition, never on a baseline mount (a button whose markup
+ *   mounts already-loading projects aria-busy but stays silent). The bind reads
+ *   config once from the server/author markup, so loading never transitions
+ *   here -- the edge tracking below is the same shape the React controller
+ *   uses, and the runtime transition is the retained-mode (React) surface.
  */
 export function bindButton(root: HTMLElement): () => void {
   // Config is READ from the projected markup (server- or author-minted), never
@@ -91,12 +92,20 @@ export function bindButton(root: HTMLElement): () => void {
     part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
 
   const { memory, dispatch } = createBehavior(button, config);
-  const runner = createEffectRunner();
 
   const request = (action: keyof ButtonActions): boolean => dispatch(action, config);
-  const host: EffectHost = {
-    getPart,
-    dispatch: (action) => void request(action as keyof ButtonActions),
+
+  // Edge-triggered loading announcement, composing sr-announcer directly. Seed
+  // the previous-loading tracker to the baseline config so a mount that is
+  // already loading is NOT announced; only a false->true transition fires. The
+  // DOM-native bind reads config once, so this never transitions in practice --
+  // it holds the same contract the React controller drives at runtime.
+  let prevLoading = config.loading ?? false;
+  const announceLoadingEdge = (loading: boolean) => {
+    if (loading && !prevLoading) {
+      announceToScreenReader(config.loadingAnnouncement ?? 'Loading', 'polite');
+    }
+    prevLoading = loading;
   };
 
   // ids are READ from the markup; button carries no id-ref aria, but the
@@ -121,7 +130,7 @@ export function bindButton(root: HTMLElement): () => void {
       const el = getPart(part);
       if (el && attrs) applyProjection(el, attrs);
     }
-    runner.apply(button.effects(state, config), host);
+    announceLoadingEdge(config.loading ?? false);
   };
   const unsubscribe = memory.subscribe(render); // fires immediately: first paint (baseline)
 
@@ -138,7 +147,6 @@ export function bindButton(root: HTMLElement): () => void {
 
   return () => {
     unsubscribe();
-    runner.stop();
     root.removeEventListener('click', onClick);
   };
 }

--- a/packages/ui/src/components/button/button.tsx
+++ b/packages/ui/src/components/button/button.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { createBehavior, type PartIds } from '../../lib/contract';
-import { useBehaviorEffects } from '../../hooks/use-behavior-effects';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
+import { announceToScreenReader } from '../../primitives/sr-announcer';
 import {
   button,
   type ButtonActions,
@@ -90,29 +90,11 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props, r
   };
 
   // The controller composes the score with the substrate directly -- no
-  // useBehavior. createBehavior is the model, useMemory subscribes, and
-  // useBehaviorEffects reconciles the announce effect after every commit
-  // (the runner persists across commits, so loading false->true fires while a
-  // mount-already-loading button stays baseline-suppressed).
+  // useBehavior. createBehavior is the model, useMemory subscribes, and the
+  // effect below composes the sr-announcer primitive directly on the loading
+  // false->true edge (a mount-already-loading button stays baseline-suppressed).
   const { memory, dispatch } = React.useMemo(() => createBehavior(button, config), []);
   const state = useMemory(memory);
-
-  const rootRef = React.useRef<HTMLButtonElement | null>(null);
-  const setRef = React.useCallback(
-    (element: HTMLButtonElement | null) => {
-      rootRef.current = element;
-      if (typeof ref === 'function') ref(element);
-      else if (ref) ref.current = element;
-    },
-    [ref],
-  );
-  const getPart = React.useCallback(
-    (part: string): HTMLElement | null =>
-      part === 'root'
-        ? rootRef.current
-        : (rootRef.current?.querySelector<HTMLElement>(`[data-part="${part}"]`) ?? null),
-    [],
-  );
 
   // Gotcha #1: the controlled callback compares the EFFECTIVE value before
   // (the `pressed` prop when controlled) against the INTRINSIC value after the
@@ -131,11 +113,19 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props, r
     [dispatch, memory],
   );
 
-  const host = React.useMemo(
-    () => ({ getPart, dispatch: (action: string) => void request(action as keyof ButtonActions) }),
-    [getPart, request],
-  );
-  useBehaviorEffects(button.effects(state, config), host);
+  // Compose the sr-announcer primitive directly, edge-triggered: announce the
+  // loading message once on the loading false->true transition, never on a
+  // baseline mount. prevLoading seeds to the current loading so the first commit
+  // is baseline; announceToScreenReader is called only inside the edge branch so
+  // no live region is constructed for a button that never transitions.
+  const prevLoading = React.useRef(loading);
+  React.useEffect(() => {
+    const wasLoading = prevLoading.current;
+    prevLoading.current = loading;
+    if (loading && !wasLoading) {
+      announceToScreenReader(loadingAnnouncement ?? 'Loading', 'polite');
+    }
+  }, [loading, loadingAnnouncement]);
 
   const uid = React.useId();
   const ids = {} as PartIds<ButtonPart>;
@@ -145,7 +135,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props, r
 
   return (
     <button
-      ref={setRef}
+      ref={ref}
       type={type ?? 'button'}
       disabled={disabled}
       data-part="root"

--- a/packages/ui/test/components/button/button.behavior.test.ts
+++ b/packages/ui/test/components/button/button.behavior.test.ts
@@ -106,22 +106,11 @@ describe('button keymap', () => {
   });
 });
 
-describe('button effects', () => {
-  it('loading config requests a polite announcement', () => {
-    const config = { ...base, loading: true, loadingAnnouncement: 'Saving' };
-    expect(button.effects(button.initialState(config), config)).toEqual([
-      { type: 'announce', message: 'Saving', politeness: 'polite' },
-    ]);
-  });
-
-  it('defaults the loading message', () => {
-    const config = { ...base, loading: true };
-    expect(button.effects(button.initialState(config), config)).toEqual([
-      { type: 'announce', message: 'Loading', politeness: 'polite' },
-    ]);
-  });
-
-  it('no effects when not loading', () => {
-    expect(button.effects(button.initialState(base), base)).toEqual([]);
-  });
-});
+// The loading announcement is no longer a declarative effect on the score --
+// the WC/Astro bind and the React controller each compose the sr-announcer
+// primitive directly, edge-triggered. Its behavior (a mount that is already
+// loading projects aria-busy but stays silent; a loading false->true transition
+// announces the loading message once) is asserted end to end: baseline
+// suppression in the shared conformance suite ('loading at mount ... announce
+// suppressed') and the runtime transition in the React-only edge-triggered
+// suite ('announces when loading transitions false -> true').


### PR DESCRIPTION
## Summary

button composes the `sr-announcer` primitive directly at BOTH framework boundaries -- the
DOM-native `bindButton` (WC + Astro) and the React `Button` controller -- dropping the redundant
`AnnounceEffect` and the `createEffectRunner`/`EffectHost` indirection. The announce arm was a 1:1
wrapper over `announceToScreenReader`; the runner bought nothing but its baseline-diff edge trick,
which is a few lines of prev-loading tracking in each boundary. button is the touchstone for this
arc, so it follows radio-group #1870 (direct call) and dialog #1869 (both boundaries), specialized
to the one-shot, edge-triggered announce.

## Acceptance criteria mapping

### 1. `button.behavior.ts` no longer imports from `lib/effects`

The `import { createEffectRunner, type EffectHost } from '../../lib/effects'` line is deleted; the
only added import is `announceToScreenReader` from `../../primitives/sr-announcer` (button.behavior.ts:9).
`bindButton` drops the `runner`, the `host`, the `runner.apply(button.effects(...), host)` call in
`render`, and the `runner.stop()` in teardown. Removed at BOTH consumers, not just the bind:
`button.tsx` also drops `useBehaviorEffects` and composes the primitive in a `useEffect`, so
`button.effects()` has no remaining caller on either side.
Evidence: preflight typecheck passes (exit 0), proving no dangling `EffectRunner`/`EffectHost`
reference remains after the import removal.

### 2. Loading announcement fires once on the transition, NOT on baseline mount, identically across React, WC, and Astro

`bindButton` tracks `prevLoading` seeded from the baseline config (button.behavior.ts:103) and its
`announceLoadingEdge` (line 104) fires `announceToScreenReader` only on `loading && !prevLoading`,
invoked from `render()` (line 133) -- the DOM-native bind reads config once, so a mount-already-loading
button stays baseline-silent. React `Button` seeds a prev-loading ref to the initial `loading`
(button.tsx:121) and its `useEffect` keyed on `[loading, loadingAnnouncement]` (lines 122-127)
announces only inside the `loading && !wasLoading` branch, so no live region is constructed unless
the false->true edge actually fires.
Evidence: the shared conformance suite (`conformance-suite.ts`, "loading at mount: aria-busy
projected, announce suppressed") runs across all three adapters and asserts `getAnnouncerCount()`
stays 0 at baseline; the React edge suite (`button.conformance.test.tsx`, "announces when loading
transitions false -> true") asserts the live-region text equals the message on the transition.
`test:unit` green (169 tests, 32 files).

### 3. No change to screen-reader output or timing vs. today

Both boundaries call the identical primitive the old executor called -- `announceToScreenReader(msg,
'polite')` with `msg = loadingAnnouncement ?? 'Loading'` (button.behavior.ts:106, button.tsx:126) --
so the live region, politeness, message, and dedup are byte-for-byte the same as the previous
`AnnounceEffect` path; only the trigger moved from the runner's baseline-diff to explicit prev-loading
tracking, preserving the one-shot edge timing.
Evidence: `button.conformance.test.tsx` still asserts the region text is exactly `Saving changes`
on transition and `getAnnouncerCount()` is 1; the baseline-suppression assertion is unchanged.

### 4. `button.effects()` is no longer consumed (effects hook removed); `pressable` + aria projection unchanged

Per the issue's both-boundaries scope correction, the effects hook is removed from BOTH consumers
rather than editing `button.effects()` to return `[]`: the `pressable` slice (which supplies the
composed `effects()`) is left untouched so teardown #1867 owns its dead announce arm. Nothing in
button reads `effects()` anymore. The `aria-manager` projection, the loading/`aria-busy` state, and
the double-submit / soft-disabled gating are unchanged.
Evidence: `button.behavior.test.ts` aria/keymap/actions/suppression describes (lines 13, 49, 66, 97)
pass unchanged; the `describe('button effects')` data-assertion block is replaced with a note
(lines 109-116) pointing to the conformance suites, mirroring radio-group #1870.

### 5. Full `pnpm --filter @rafters/ui test:unit` + preflight green

The change is confined to button's three files and introduces no new dependency, type, or dangling
reference, so both the scoped conformance run and the workspace-wide preflight complete without
regression. The pre-commit hook additionally re-ran unit-tests, lint, format, and typecheck on the
staged diff and passed before the commit landed.
Evidence: `pnpm --filter @rafters/ui test:unit` passes (32 files, 169 tests, 0 failures). `pnpm
preflight` exits 0 with unit-tests, lint, format, typecheck, and the registry build all clean.

## Not done

- Did not touch `lib/effects.ts` or `hooks/use-behavior-effects.ts` -- teardown #1867 removes them
  wholesale once every consumer is migrated; this PR only stops button importing `lib/effects`.
- Did not edit the `pressable` slice -- its now-dead `announce` arm in `effects()` is left for #1867
  per the issue's scope correction; button just stops consuming it.
- Did not touch `loadedAnnouncement` -- pre-existing public API that pressable's effect never
  consumed; adding loaded-announce behavior is out of scope and removing the prop would break API.
- No consumer-veto to preserve -- the old button.tsx host merely dispatched, with no announce veto.
- Did not re-implement any primitive -- `announceToScreenReader` is called as-is from sr-announcer.

Closes #1859