### PR TITLE
fix(ui): popover composes the outside-click primitive directly (#1863)

### DIFF
--- a/packages/ui/src/components/popover/popover.behavior.ts
+++ b/packages/ui/src/components/popover/popover.behavior.ts
@@ -5,7 +5,6 @@ import {
   type BehaviorSpec,
   type PartIds,
 } from '../../lib/contract';
-import { createEffectRunner, type EffectHost } from '../../lib/effects';
 import {
   disclosable,
   isOpen,
@@ -16,6 +15,7 @@ import {
 } from '../../lib/disclosable';
 import { updateAriaAttribute } from '../../primitives/aria-manager';
 import { computePosition } from '../../primitives/collision-detector';
+import { onPointerDownOutside } from '../../primitives/outside-click';
 import type { Align, Side } from '../../primitives/types';
 
 /**
@@ -67,9 +67,10 @@ const popoverSurface: Slice<
   initialState: () => ({}),
 };
 
-/** The popover glue: the dialog-role identity, the Escape contract, and the
- *  non-modal dismiss effect. No focus-trap and no scroll-lock -- popover is
- *  deliberately non-modal. */
+/** The popover glue: the dialog-role identity and the Escape contract. No
+ *  focus-trap and no scroll-lock -- popover is deliberately non-modal. The
+ *  light-dismiss (outside-pointerdown) is composed directly by the bindings,
+ *  not declared here. */
 const popoverGlue: GlueSlice<PopoverConfig, PopoverState, { close: undefined }, PopoverPart> = {
   kind: 'glue',
   name: 'popover',
@@ -79,19 +80,6 @@ const popoverGlue: GlueSlice<PopoverConfig, PopoverState, { close: undefined }, 
     content: { role: 'dialog' },
   }),
   keymap: (event, _state, part) => (part === 'content' && event.key === 'Escape' ? 'close' : null),
-  effects: (state, config) => {
-    if (!isOpen(state, config)) return [];
-    return [
-      {
-        type: 'dismiss-on-outside',
-        part: 'content',
-        action: 'close',
-        // Spare BOTH the trigger (so a toggle gesture does not dismiss then
-        // re-open) and the anchor (which can be a distinct element).
-        exceptParts: ['trigger', 'anchor'],
-      },
-    ];
-  },
 };
 
 export const popover: BehaviorSpec<PopoverConfig, PopoverState, PopoverActions, PopoverPart> =
@@ -147,8 +135,11 @@ function numberAttribute(root: HTMLElement, name: string): number | undefined {
  * declaratively. Two overlay concerns beyond the pure score: PRESENCE (content
  * is present-but-hidden, toggled on the open axis) and the framework
  * affordances (positioning + focus-first, edge-triggered on open; reposition
- * on scroll/resize while open). Non-modal, so the ongoing effect set is just
- * dismiss-on-outside. Enter-only; exit animation waits on Presence.
+ * on scroll/resize while open). Non-modal, so the only composed primitive is
+ * the outside-pointerdown light-dismiss (onPointerDownOutside), started on the
+ * open edge and torn down on close/unbind -- sparing the trigger and anchor so
+ * a toggle gesture does not dismiss then re-open. Enter-only; exit animation
+ * waits on Presence.
  */
 export function bindPopover(root: HTMLElement): () => void {
   const contentEl = root.querySelector<HTMLElement>('[data-part="content"]');
@@ -167,13 +158,12 @@ export function bindPopover(root: HTMLElement): () => void {
     part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
 
   const { memory, dispatch } = createBehavior(popover, config);
-  const runner = createEffectRunner();
 
   const request = (action: keyof PopoverActions): boolean => dispatch(action, config);
-  const host: EffectHost = {
-    getPart,
-    dispatch: (action) => void request(action as keyof PopoverActions),
-  };
+
+  // The light-dismiss is level-triggered: present only while open. render()
+  // starts it on the open edge and this cleanup stops it on close.
+  let dismissCleanup: (() => void) | null = null;
 
   // ids READ from the server/author markup, never generated.
   const ids = {} as PartIds<PopoverPart>;
@@ -217,17 +207,29 @@ export function bindPopover(root: HTMLElement): () => void {
       if (el && attrs) applyProjection(el, attrs);
     }
     // Presence: content hides off the open axis, staying in light DOM so the
-    // dismiss effect can read it via document .contains.
+    // dismiss listener can read it via document .contains.
     const content = getPart('content');
     if (content) content.hidden = !open;
-    runner.apply(popover.effects(state, config), host);
-    // Edge-triggered affordances: position + focus on the closed->open edge,
-    // stop repositioning on the open->closed edge.
+    // Edge-triggered affordances: on the closed->open edge position + focus and
+    // start the outside-pointerdown light-dismiss; on the open->closed edge stop
+    // repositioning and tear the dismiss listener down.
     if (open && !wasOpen) {
       startPositioning();
       focusFirst(content);
+      if (content) {
+        dismissCleanup = onPointerDownOutside(content, (event) => {
+          const target = event.target as Node;
+          // Spare BOTH the trigger (so a toggle gesture does not dismiss then
+          // re-open) and the anchor (which can be a distinct element).
+          if (getPart('trigger')?.contains(target)) return;
+          if (getPart('anchor')?.contains(target)) return;
+          request('close');
+        });
+      }
     } else if (!open && wasOpen) {
       stopPositioning();
+      dismissCleanup?.();
+      dismissCleanup = null;
     }
     wasOpen = open;
   };
@@ -269,7 +271,8 @@ export function bindPopover(root: HTMLElement): () => void {
 
   return () => {
     unsubscribe();
-    runner.stop();
+    dismissCleanup?.();
+    dismissCleanup = null;
     stopPositioning();
     root.removeEventListener('click', onClick);
     root.removeEventListener('keydown', onKeydown);

--- a/packages/ui/src/components/popover/popover.tsx
+++ b/packages/ui/src/components/popover/popover.tsx
@@ -35,10 +35,10 @@ import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { createBehavior, type AriaAttrs, type PartIds } from '../../lib/contract';
 import { keyInputOf } from '../../hooks/key-input';
-import { useBehaviorEffects } from '../../hooks/use-behavior-effects';
 import { useMemory } from '../../hooks/use-memory';
 import { usePresence } from '../../hooks/use-presence';
 import classy from '../../primitives/classy';
+import { onPointerDownOutside } from '../../primitives/outside-click';
 import { mergeProps } from '../../primitives/slot';
 import type { Align, Side } from '../../primitives/types';
 import {
@@ -131,26 +131,30 @@ export function Popover({ children, open, defaultOpen = false, onOpenChange }: P
     [dispatch],
   );
 
-  const host = React.useMemo(
-    () => ({
-      getPart,
+  // The light-dismiss, composed directly on the open edge (replacing the
+  // effects runner): dismiss on a pointerdown outside the content, sparing the
+  // trigger and anchor. Level-triggered via the dependency array; the cleanup
+  // tears the listener down on close/unmount. Runs at the parent level after
+  // PopoverContent has mounted its portaled content, so getPart resolves it.
+  React.useEffect(() => {
+    if (!effectiveOpen) return;
+    const content = getPart('content');
+    if (!content) return;
+    return onPointerDownOutside(content, (event) => {
+      const target = event.target as Node;
+      if (getPart('trigger')?.contains(target)) return;
+      if (getPart('anchor')?.contains(target)) return;
       // Outside-pointerdown dismissals offer the consumer veto first (oracle
-      // protocol: callback runs, close proceeds unless defaultPrevented).
-      dispatch: (action: string, _payload?: unknown, nativeEvent?: Event) => {
-        if (action === 'close' && nativeEvent) {
-          const veto = dismissVetoRef.current;
-          if (veto) {
-            veto.onPointerDownOutside?.(nativeEvent);
-            veto.onInteractOutside?.(nativeEvent);
-            if (nativeEvent.defaultPrevented) return;
-          }
-        }
-        request(action as keyof PopoverActions);
-      },
-    }),
-    [getPart, request],
-  );
-  useBehaviorEffects(popover.effects(state, config), host);
+      // protocol: callbacks run, close proceeds unless defaultPrevented).
+      const veto = dismissVetoRef.current;
+      if (veto) {
+        veto.onPointerDownOutside?.(event);
+        veto.onInteractOutside?.(event);
+        if (event.defaultPrevented) return;
+      }
+      request('close');
+    });
+  }, [effectiveOpen, getPart, request]);
 
   const aria = popover.aria(state, config, ids);
 

--- a/packages/ui/test/components/popover/popover.behavior.test.ts
+++ b/packages/ui/test/components/popover/popover.behavior.test.ts
@@ -115,24 +115,10 @@ describe('popover keymap', () => {
   });
 });
 
-describe('popover effects (non-modal)', () => {
-  it('closed: no effects', () => {
-    expect(popover.effects(popover.initialState(closed), closed)).toEqual([]);
-  });
-
-  it('open: only outside-dismissal, sparing trigger AND anchor -- no trap, no scroll lock', () => {
-    expect(popover.effects(popover.initialState(openUncontrolled), openUncontrolled)).toEqual([
-      {
-        type: 'dismiss-on-outside',
-        part: 'content',
-        action: 'close',
-        exceptParts: ['trigger', 'anchor'],
-      },
-    ]);
-  });
-
-  it('controlled open drives the dismiss effect without touching intrinsic state', () => {
-    const config: PopoverConfig = { open: true };
-    expect(popover.effects({ open: false }, config)).toHaveLength(1);
-  });
-});
+// The outside-pointerdown light-dismiss is no longer a declarative effect on
+// the score -- the WC/Astro bind and the React controller each compose the
+// onPointerDownOutside primitive directly. Its behavior (a pointerdown outside
+// the content closes the popover, sparing the trigger and anchor; present only
+// while open; non-modal, so no focus-trap or scroll-lock) is asserted end to
+// end in the react/wc/astro conformance suites, which drive the real DOM the
+// primitive operates on.


### PR DESCRIPTION
## Summary

popover's only `EffectSpec` was `dismiss-on-outside` -- a thin wrap of the
`onPointerDownOutside` primitive. This PR drops the effect and composes the
primitive directly at BOTH framework boundaries, removing popover's dependence
on the retired `lib/effects` layer. `bindPopover` (WC/Astro) drops
`createEffectRunner`/`EffectHost` and owns the light-dismiss lifecycle inline;
`popover.tsx` (React) replaces `useBehaviorEffects` with a `useEffect` composing
the same primitive, preserving the consumer veto; the score loses `effects()`
and the `lib/effects` import. `lib/effects.ts` itself is untouched.

## Acceptance criteria mapping

### 1. popover.behavior.ts no longer imports from `lib/effects`

The `import { createEffectRunner, type EffectHost } from '../../lib/effects'`
line is deleted, and the glue's `effects()` member is removed. In its place
`bindPopover` composes the primitive directly: `onPointerDownOutside(content,
handler)` is started on the closed->open edge (in the existing `if (open &&
!wasOpen)` render block) and its cleanup is called on the open->closed edge and
in the unbind return. The handler carries today's logic verbatim -- ignore
pointerdowns inside `trigger` or `anchor`, else `request('close')`.
Evidence: `popover.behavior.ts` imports `onPointerDownOutside` from
`primitives/outside-click` and no longer references `lib/effects`; `pnpm
typecheck` and `pnpm lint` pass in the pre-commit gate.

### 2. Outside-pointerdown dismissal (sparing trigger + anchor) behaves identically across React/WC/Astro; open/close starts/stops the listener; conformance + preflight green

The spare-trigger/anchor containment check and the `close` dispatch are carried
into both boundaries unchanged, so behavior is identical: WC/Astro start the
listener on the open edge and tear it down on the close edge and unbind; React
early-returns when `!effectiveOpen` and its effect cleanup runs on close/unmount
(deps `[effectiveOpen, getPart, request]`), matching the old runner's
present-while-open semantics. The React consumer veto
(`onPointerDownOutside`/`onInteractOutside`, `defaultPrevented` keeps it open) is
preserved from the former `host.dispatch`.
Evidence: `popover.conformance.test.tsx:107` (outside dismisses; trigger toggles,
not close-then-open) and `:228` (veto keeps it open; without a veto it closes);
`popover.element.conformance.test.ts:346` (WC outside-dismiss; Astro shares
`bindPopover`). `pnpm --filter @rafters/ui test:unit` -> 169 passed; `pnpm
preflight` -> exit 0.

## Not done

- `lib/effects.ts` and `hooks/use-behavior-effects.ts` are untouched -- the
  wholesale teardown (#1867) removes them; this PR only removes popover as a
  consumer. `touchedEffectsTs` is false.
- No colocated composition helper was factored (unlike dialog #1869): popover
  composes a single primitive, so per the radio-group #1870 precedent the
  ~3-line containment check is inlined at each boundary rather than wrapped in an
  exported function with a diverging veto port.
- No other component or primitive touched -- scope is popover only, queue-safe.
- The astro conformance suite has no dedicated outside-dismiss case; it shares
  `bindPopover` with the WC suite, which does cover it. Left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1863
