### PR TITLE
fix(#1862): grid composes roving-focus directly at both boundaries

### DIFF
--- a/packages/ui/src/components/grid/grid.behavior.ts
+++ b/packages/ui/src/components/grid/grid.behavior.ts
@@ -1,12 +1,12 @@
 import { createBehavior, type AriaAttrs, type BehaviorSpec } from '../../lib/contract';
-import { createEffectRunner, type EffectHost, type EffectSpec } from '../../lib/effects';
 import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { createRovingFocus } from '../../primitives/roving-focus';
 
 /**
  * Grid: named attention structures over a 12-column vocabulary. A static
  * score -- no state, no actions, no keymap -- but the structure contract
- * (roles, per-instance priority projection, the grid-roving keyboard
- * effect) is behavior, and the harness audits it here.
+ * (roles, per-instance priority projection, the 2D roving keyboard
+ * navigation) is behavior, and the harness audits it here.
  *
  * Ruled 2026-07-03:
  * - columns are whatever the agent wants, 1-12 (the literal class ceiling
@@ -79,11 +79,11 @@ export const grid: BehaviorSpec<GridConfig, GridState, GridActions, GridPart> = 
     },
   }),
   keymap: () => null,
-  effects: (_state, config): EffectSpec[] => {
-    const columns = fixedColumns(config);
-    if (config.role !== 'grid' || columns === null) return [];
-    return [{ type: 'grid-roving', part: 'root', columns }];
-  },
+  // Static score, like container: the ARIA grid keyboard contract is not
+  // effects-as-data. The bindings compose the roving-focus primitive directly
+  // (createRovingFocus with its 2D columns option), gated on an honest
+  // role="grid" with a fixed column count -- see bindGrid below and grid.tsx.
+  effects: () => [],
 };
 
 /** Per-instance projection for grid items: the item DECLARES its priority;
@@ -109,8 +109,8 @@ function parseColumns(raw: string | null): ResponsiveColumns | undefined {
  * and the Astro <script> both import THIS; only React (retained-mode) reads
  * the projection declaratively. Grid is a STATIC score, so the binding is the
  * thinnest of the family: no click/keydown wiring (grid has no keymap and no
- * actions), just the one-shot projection apply and the conditional
- * grid-roving effect that engages only under an honest role="grid".
+ * actions), just the one-shot projection apply and the roving-focus primitive,
+ * composed directly and engaged only under an honest role="grid".
  *
  * Three-gotcha ledger for this archetype:
  *   1. Controlled-callback before/after: N/A. Grid has no controlled value
@@ -139,13 +139,17 @@ export function bindGrid(root: HTMLElement): () => void {
     ariaLabel: attr('aria-label'),
   };
 
-  const getPart = (part: string): HTMLElement | null =>
-    part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
-
   const { memory } = createBehavior(grid, config);
-  const runner = createEffectRunner();
-  // Grid has no actions; the effect host never dispatches.
-  const host: EffectHost = { getPart, dispatch: () => {} };
+
+  // role="grid" with a fixed column count engages the ARIA grid keyboard
+  // contract: 2D roving across the [data-roving-item] cells. Composed
+  // directly -- createRovingFocus owns the roving tabindex and arrow/Home/End
+  // movement (Left/Right by 1, Up/Down by a row). Presentation grids and
+  // fluid-column grids stay inert: the honesty gate is the same predicate the
+  // score's aria projection uses (fixed columns only).
+  const columns = fixedColumns(config);
+  const stopRoving =
+    config.role === 'grid' && columns !== null ? createRovingFocus(root, { columns }) : undefined;
 
   // The projection is already resolved (final strings, undefined = absent),
   // so apply it raw: validate:false skips aria-manager's author-input
@@ -160,12 +164,11 @@ export function bindGrid(root: HTMLElement): () => void {
     const state = memory.get();
     const projection = grid.aria(state, config, { root: root.id ?? '', row: '', cell: '' });
     if (projection.root) applyProjection(root, projection.root);
-    runner.apply(grid.effects(state, config), host);
   };
   const unsubscribe = memory.subscribe(render); // fires immediately: first paint
 
   return () => {
     unsubscribe();
-    runner.stop();
+    stopRoving?.();
   };
 }

--- a/packages/ui/src/components/grid/grid.tsx
+++ b/packages/ui/src/components/grid/grid.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { createBehavior, type PartIds } from '../../lib/contract';
-import { useBehaviorEffects } from '../../hooks/use-behavior-effects';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
+import { createRovingFocus } from '../../primitives/roving-focus';
 import {
   grid,
   gridItemAttrs,
@@ -81,26 +81,27 @@ function GridRoot(props: GridProps) {
   const config: GridConfig = { preset, pattern, columns, gap, padding, role, ariaLabel };
 
   // The controller composes the score with the substrate -- no useBehavior.
-  // Grid is a static score: createBehavior is a formality (state never
-  // moves), useMemory subscribes React to it, and useBehaviorEffects runs the
-  // one conditional effect (grid-roving, present only under role="grid").
-  // There are no actions, so the effect host never dispatches.
+  // Grid is a static score: createBehavior is a formality (state never moves),
+  // useMemory subscribes React to it, and a useEffect below composes the
+  // roving-focus primitive directly (present only under an honest role="grid").
   const { memory } = React.useMemo(() => createBehavior(grid, config), []);
   const state = useMemory(memory);
   const classes = gridClasses(config, state);
   const interactive = role === 'grid' && typeof columns === 'number';
 
-  // getPart resolves a part to its element by querying under the root: the
-  // DOM is the registry, so there is no ref bookkeeping to keep.
   const rootRef = React.useRef<HTMLDivElement>(null);
-  const getPart = React.useCallback(
-    (part: string): HTMLElement | null =>
-      part === 'root'
-        ? rootRef.current
-        : (rootRef.current?.querySelector<HTMLElement>(`[data-part="${part}"]`) ?? null),
-    [],
-  );
-  useBehaviorEffects(grid.effects(state, config), { getPart, dispatch: () => {} });
+
+  // role="grid" with a fixed column count engages the ARIA grid keyboard
+  // contract: compose the roving-focus primitive directly with its 2D columns
+  // option (Left/Right by 1, Up/Down by a row, Home/End to the ends). It owns
+  // the roving tabindex across the [data-roving-item] cells. Presentation and
+  // fluid-column grids stay inert -- the effect only runs when interactive.
+  React.useEffect(() => {
+    if (!interactive) return;
+    const root = rootRef.current;
+    if (!root) return;
+    return createRovingFocus(root, { columns: columns as number });
+  }, [interactive, columns]);
 
   // grid.aria ignores ids (the root carries no id refs); pass empties.
   const aria = grid.aria(state, config, { root: '', row: '', cell: '' } as PartIds<GridPart>);

--- a/packages/ui/src/primitives/roving-focus.ts
+++ b/packages/ui/src/primitives/roving-focus.ts
@@ -31,6 +31,17 @@ export interface RovingFocusOptions {
   orientation?: Orientation;
 
   /**
+   * Two-dimensional grid navigation. When set, arrow keys rove a fixed-column
+   * grid instead of a 1D list: ArrowLeft/Right move by 1, ArrowUp/Down move by
+   * a full row (`columns`), Home/End jump to the first/last item. Movement
+   * clamps at the edges (no wrap). Reuses the same [data-roving-item] tabstop,
+   * focus tracking, and disabled filtering as the 1D path; the `orientation`,
+   * `loop`, and `dir` options do not apply in this mode. This is the ARIA grid
+   * pattern's keyboard contract (role="grid" with a fixed column count).
+   */
+  columns?: number;
+
+  /**
    * Whether to wrap navigation at ends
    * @default true
    */
@@ -170,6 +181,26 @@ function shouldNavigate(
 }
 
 /**
+ * Grid navigation delta for a key in 2D mode: ArrowLeft/Right step one column,
+ * ArrowUp/Down step a full row (`columns`). Returns null for keys that do not
+ * rove the grid, so the caller leaves them to Home/End or the browser.
+ */
+function gridDelta(key: string, columns: number): number | null {
+  switch (key) {
+    case 'ArrowRight':
+      return 1;
+    case 'ArrowLeft':
+      return -1;
+    case 'ArrowDown':
+      return columns;
+    case 'ArrowUp':
+      return -columns;
+    default:
+      return null;
+  }
+}
+
+/**
  * Create roving focus behavior for a container
  * Returns cleanup function to remove event listeners
  *
@@ -201,6 +232,7 @@ export function createRovingFocus(
     orientation = 'horizontal',
     loop = true,
     dir = 'ltr',
+    columns,
     currentIndex: initialIndex = 0,
     onNavigate,
     preventDefault = true,
@@ -239,6 +271,23 @@ export function createRovingFocus(
     if (key === 'End') {
       if (preventDefault) event.preventDefault();
       currentIndex = items.length - 1;
+      const item = items[currentIndex];
+      if (item) {
+        updateTabindex(items, currentIndex);
+        item.focus();
+        onNavigate?.(item, currentIndex);
+      }
+      return;
+    }
+
+    // Two-dimensional grid navigation: ArrowLeft/Right move by one column,
+    // ArrowUp/Down by a full row, clamped at the edges (no wrap). Reuses the
+    // tabstop/focus machinery below; Home/End were already handled above.
+    if (columns !== undefined) {
+      const delta = gridDelta(key, columns);
+      if (delta === null) return;
+      if (preventDefault) event.preventDefault();
+      currentIndex = Math.max(0, Math.min(currentIndex + delta, items.length - 1));
       const item = items[currentIndex];
       if (item) {
         updateTabindex(items, currentIndex);

--- a/packages/ui/test/components/grid/grid.astro.conformance.test.ts
+++ b/packages/ui/test/components/grid/grid.astro.conformance.test.ts
@@ -1,7 +1,7 @@
 /**
  * Astro performance of the Grid score. Grid is a STATIC score -- no state, no
  * actions, no keymap -- but the STRUCTURE contract (role disposition, the
- * conditional grid-roving effect) is behavior, so this test drives both
+ * conditional 2D roving-focus composition) is behavior, so this test drives both
  * archetypes end to end. AstroContainer renders the SSR markup but does NOT
  * run the <script>, so the test calls bindGrid directly -- that IS the
  * script's job. A presentation grid stays inert; an honest role="grid"
@@ -39,7 +39,7 @@ describe('grid conformance [astro]', () => {
     );
     expect(root.hasAttribute('role')).toBe(false);
     expect(root.getAttribute('data-preset')).toBe('bento');
-    // The grid-roving effect never engaged: nothing claimed a 0 tab stop.
+    // Roving-focus never engaged: nothing claimed a 0 tab stop.
     expect(document.body.querySelector('[tabindex="0"]')).toBeNull();
     expect(root.textContent).toContain('Metric');
   });

--- a/packages/ui/test/components/grid/grid.behavior.test.ts
+++ b/packages/ui/test/components/grid/grid.behavior.test.ts
@@ -28,22 +28,13 @@ describe('grid aria projection', () => {
   });
 });
 
-describe('grid effects', () => {
-  it('presentation grids have no effects', () => {
-    expect(grid.effects(state, { columns: 3 })).toEqual([]);
-    expect(grid.effects(state, { columns: { base: 2, md: 4 } })).toEqual([]);
-  });
-
-  it('role=grid with fixed columns wires 2D roving', () => {
-    expect(grid.effects(state, { role: 'grid', columns: 4, ariaLabel: 'x' })).toEqual([
-      { type: 'grid-roving', part: 'root', columns: 4 },
-    ]);
-  });
-
-  it('role=grid without fixed columns wires NOTHING (honesty gate)', () => {
-    expect(grid.effects(state, { role: 'grid', columns: 'auto', ariaLabel: 'x' })).toEqual([]);
-  });
-});
+// The 2D grid keyboard contract is no longer a declarative effect on the score
+// -- the WC/Astro bind and the React controller each compose the roving-focus
+// primitive directly (createRovingFocus with its 2D columns option), gated on
+// an honest role="grid" with a fixed column count. That behavior (Left/Right
+// move by one column, Up/Down by a full row, Home/End to the ends, clamped at
+// the edges, presentation/fluid grids stay inert) is asserted end to end in the
+// react/wc/astro conformance suites, which drive the real DOM it operates on.
 
 describe('grid item projection', () => {
   it('items declare their priority through data-priority', () => {

--- a/packages/ui/test/components/grid/grid.element.conformance.test.ts
+++ b/packages/ui/test/components/grid/grid.element.conformance.test.ts
@@ -2,7 +2,7 @@
  * WC performance of the grid score, driven end to end against light-DOM
  * markup. Same score as the React conformance test -- proves the static
  * projection (role disposition, data-preset/data-columns) and the conditional
- * grid-roving effect drive through the DOM binding.
+ * 2D roving-focus composition drive through the DOM binding.
  *
  * The two archetype cases the issue names:
  *  - role="grid" (opted in via grid-role) engages the 2D keyboard contract;
@@ -92,7 +92,7 @@ describe('grid conformance [wc]', () => {
     const root = await mountPresentation();
     expect(root.hasAttribute('role')).toBe(false);
     expect(root.getAttribute('data-preset')).toBe('bento');
-    // The grid-roving effect never engaged: nothing claimed a 0 tab stop.
+    // Roving-focus never engaged: nothing claimed a 0 tab stop.
     expect(document.body.querySelector('[tabindex="0"]')).toBeNull();
     const declared = Array.from(document.body.querySelectorAll('[data-priority]'));
     expect(declared).toHaveLength(3);

--- a/packages/ui/test/primitives/roving-focus.test.ts
+++ b/packages/ui/test/primitives/roving-focus.test.ts
@@ -263,6 +263,87 @@ describe('createRovingFocus', () => {
   });
 });
 
+describe('createRovingFocus 2D (columns)', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  // A 2x2 grid of roving cells, matching the ARIA grid conformance fixtures.
+  function createGrid(count: number): HTMLButtonElement[] {
+    const items: HTMLButtonElement[] = [];
+    for (let i = 0; i < count; i++) {
+      const item = document.createElement('button');
+      item.setAttribute('data-roving-item', '');
+      container.appendChild(item);
+      items.push(item);
+    }
+    return items;
+  }
+
+  it('roves in two dimensions: Left/Right by 1, Up/Down by a row', () => {
+    const items = createGrid(4);
+    const cleanup = createRovingFocus(container, { columns: 2 });
+
+    expect(items[0]?.getAttribute('tabindex')).toBe('0');
+    expect(items[1]?.getAttribute('tabindex')).toBe('-1');
+
+    items[0]?.focus();
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(document.activeElement).toBe(items[1]);
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    expect(document.activeElement).toBe(items[3]);
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    expect(document.activeElement).toBe(items[2]);
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    expect(document.activeElement).toBe(items[0]);
+
+    cleanup();
+  });
+
+  it('Home/End jump to the first/last cell', () => {
+    const items = createGrid(4);
+    const cleanup = createRovingFocus(container, { columns: 2 });
+
+    items[0]?.focus();
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    expect(document.activeElement).toBe(items[3]);
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+    expect(document.activeElement).toBe(items[0]);
+
+    cleanup();
+  });
+
+  it('clamps at the edges (no wrap)', () => {
+    const items = createGrid(4);
+    const cleanup = createRovingFocus(container, { columns: 2 });
+
+    // Top-left: Up and Left stay put.
+    items[0]?.focus();
+    container.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    expect(document.activeElement).toBe(items[0]);
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    expect(document.activeElement).toBe(items[0]);
+
+    // Bottom-right: Down and Right stay put.
+    items[3]?.focus();
+    container.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    expect(document.activeElement).toBe(items[3]);
+    container.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(document.activeElement).toBe(items[3]);
+
+    cleanup();
+  });
+});
+
 describe('focusItem', () => {
   let container: HTMLDivElement;
 


### PR DESCRIPTION
## Summary

grid's `grid-roving` effect executor reimplemented the `roving-focus` primitive from scratch (same
`[data-roving-item]` query, disabled-filtering, tabstop management, focusin sync) with 2D column
math bolted on. This retires grid's dependence on the effects-as-data layer by extending the
primitive to 2D and composing it directly at BOTH framework boundaries -- the WC/Astro `bindGrid`
and the React `grid.tsx` -- so the roving core lives in one place. The 1D `{orientation}` path is
untouched, so radio-group/select/nav-menu are unaffected.

Closes #1862.

## Acceptance criteria mapping

### 1. grid.behavior.ts no longer imports from `lib/effects`; no grid-roving executor remains as grid's concern
The `createEffectRunner`/`EffectHost`/`EffectSpec` import is deleted from the top of grid.behavior.ts;
the score's effect builder is now the static-score form `effects: () => []` (grid.behavior.ts:86),
and the bind composes the primitive rather than driving an executor through a runner. grid emits no
effects and holds no roving logic. The now-dead `grid-roving` arm in `lib/effects.ts` is left for the
#1867 teardown per the issue's merge-queue scope correction (see Not done) -- this PR stops importing
effects, it does not edit effects.ts.
Evidence: grid.behavior.ts:1-3 (import removed), grid.behavior.ts:86 (`effects: () => []`), and the
green `pnpm --filter @rafters/ui test:unit` run.

### 2. 2D roving nav is unchanged across React, WC, Astro: Arrow +/-1 and +/-columns, Home/End, disabled-skip, shadow-safe focus
The identical primitive `createRovingFocus(root, {columns})` drives all three boundaries, so behavior
cannot diverge between them. Each conformance suite drives the real DOM through the same sequence on a
2x2 grid: start cell0 -> ArrowRight=1 -> ArrowDown=+cols=3 -> ArrowLeft=2 -> ArrowUp=0 -> End=3 ->
Home=0. The primitive tracks the tabstop via its own focusin listener (getFocusableItems), which is
shadow-safe because the listener sits inside the same tree as the cells, replacing the executor's
`getRootNode().activeElement` read with an equivalent-or-better mechanism; disabled-skip is inherited
from the shared getFocusableItems filter.
Evidence: grid.conformance.test.tsx / grid.element.conformance.test.ts / grid.astro.conformance.test.ts
each "arrow keys rove in two dimensions"; disabled-skip and edge-clamp asserted at
roving-focus.test.ts:266 (`createRovingFocus 2D (columns)`).

### 3. The roving core lives in ONE place (the primitive), not duplicated in an executor
The 2D math is added to the primitive as `gridDelta` (roving-focus.ts:188) plus a branch in the
existing `handleKeyDown` (roving-focus.ts:286) that reuses `updateTabindex` and `getFocusableItems`.
No primitive body is copied into grid: both `bindGrid` and `grid.tsx` only call
`createRovingFocus(root, {columns})`. The extension is additive -- the 1D `{orientation}` branch is
unchanged, so existing consumers keep their behavior.
Evidence: roving-focus.ts:188 (`gridDelta`), roving-focus.ts:286 (2D branch reusing shared machinery),
grid.behavior.ts:152 and grid.tsx:103 (the only two composition call sites).

### 4. conformance + preflight green
`pnpm --filter @rafters/ui test:unit` passes: default suite 366 files / 5977 tests (6 pre-existing
skips, untouched), astro suite 32 files / 169 tests. `pnpm preflight` exits 0 across lint, format,
typecheck, and build.
Evidence: the test:unit and preflight runs recorded in this branch's build; the lefthook pre-commit
gates (unit-tests, lint, format, typecheck) passed on commit.

## Not done

- Did NOT edit `lib/effects.ts`. The `GridRovingEffect` type and its executor are now dead but left in
  place; the effects.ts teardown (#1867) deletes them wholesale after all 8 component fixes land.
  Editing effects.ts here would collide with the other parallel effect-removal PRs in the merge queue.
  This is the scope correction posted on the issue overriding its original "delete from effects.ts" line.
- Did NOT touch `hooks/use-behavior-effects.ts` or `lib/contract.ts` -- #1867 owns the wholesale removal
  of the effects member and the hook.
- Did NOT convert grid to `compose()`. grid stays a plain static-score literal with `effects: () => []`,
  matching its sibling container (the house pattern for static scores until #1867 drops the required
  `effects` member).
- Did NOT change select/nav-menu despite their roving arms; they are separate issues and stay on the 1D
  `{orientation}` path this PR left untouched.