### PR TITLE
fix(ui): navigation-menu composes roving-focus/hover-delay/outside-click directly (#1864)

### DIFF
--- a/packages/ui/src/components/navigation-menu/navigation-menu.behavior.ts
+++ b/packages/ui/src/components/navigation-menu/navigation-menu.behavior.ts
@@ -1,12 +1,14 @@
-import { compose, type GlueSlice, type Slice } from '../../lib/compose';
+import { compose, type Slice } from '../../lib/compose';
 import {
   createBehavior,
   type AriaAttrs,
   type BehaviorSpec,
   type PartIds,
 } from '../../lib/contract';
-import { createEffectRunner, type EffectHost, type EffectSpec } from '../../lib/effects';
 import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { createMenuHoverIntent } from '../../primitives/hover-delay';
+import { onPointerDownOutside } from '../../primitives/outside-click';
+import { createRovingFocus } from '../../primitives/roving-focus';
 
 /**
  * Navigation menu: a bar of triggers, each disclosing a content panel, one
@@ -132,42 +134,71 @@ const navigation: Slice<
   },
 };
 
-const navigationGlue: GlueSlice<
-  NavigationMenuConfig,
-  NavigationMenuState,
-  Record<never, never>,
-  NavigationMenuPart
-> = {
-  kind: 'glue',
-  name: 'navigation-menu',
-  effects: (state, config): EffectSpec[] => {
-    const open = activeItem(state, config) !== null;
-    const effects: EffectSpec[] = [
-      { type: 'roving-focus', part: 'list', orientation: orientationOf(config) },
-      {
-        type: 'hover-intent',
-        part: 'root',
-        triggerPart: 'trigger',
-        contentPart: 'content',
-        delay: config.delayDuration ?? 200,
-        immediate: open,
-        openAction: 'hoverOpen',
-        closeAction: 'close',
-      },
-    ];
-    if (open) {
-      effects.push({ type: 'dismiss-on-outside', part: 'root', action: 'close' });
-    }
-    return effects;
-  },
-};
-
 export const navigationMenu: BehaviorSpec<
   NavigationMenuConfig,
   NavigationMenuState,
   NavigationMenuActions,
   NavigationMenuPart
-> = compose('navigation-menu', navigation, navigationGlue);
+> = compose('navigation-menu', navigation);
+
+/** The parts, orientation, delay, and dispatch the roving/hover/dismiss trio
+ *  composes against. */
+export interface NavigationMenuEffectPorts {
+  /** The composite root: menubar hover intent listens here and an outside
+   *  pointerdown landing beyond it dismisses. */
+  root: HTMLElement;
+  /** The trigger list: roving tabindex moves focus across its items. Absent
+   *  markup simply skips roving. */
+  list: HTMLElement | null;
+  orientation: 'horizontal' | 'vertical';
+  /** Hover-intent open/close delay in ms. */
+  delay: number;
+  /** Whether a panel is currently open, read live -- see createMenuHoverIntent. */
+  isOpen: () => boolean;
+  /** Open (or hover-switch to) the trigger carrying this value. */
+  onHoverOpen: (value: string) => void;
+  /** Close whatever is open. */
+  onClose: () => void;
+}
+
+/**
+ * The navigation-menu DOM trio, composed directly from the primitives
+ * (replacing the retired effects runner): roving tabindex across the trigger
+ * list, menubar hover intent over the root, and outside-pointerdown dismissal.
+ * Level-triggered whenever the menu is mounted -- BOTH the DOM-native
+ * bindNavigationMenu and the React NavigationMenu start this once and call the
+ * returned cleanup on unmount. The outside-dismiss listener stays attached
+ * throughout; `close` is idempotence-gated (canDispatch rejects it when
+ * nothing is open), so onClose acts only while a panel is open -- no per-open
+ * re-composition. Cleanup releases LIFO.
+ */
+export function startNavigationMenuEffects({
+  root,
+  list,
+  orientation,
+  delay,
+  isOpen,
+  onHoverOpen,
+  onClose,
+}: NavigationMenuEffectPorts): () => void {
+  const releaseRoving = list ? createRovingFocus(list, { orientation }) : () => {};
+  const releaseHover = createMenuHoverIntent(root, {
+    triggerSelector: '[data-part="trigger"]',
+    contentSelector: '[data-part="content"]',
+    delay,
+    isOpen,
+    onOpen: onHoverOpen,
+    onClose,
+  });
+  const releaseDismiss = onPointerDownOutside(root, () => {
+    onClose();
+  });
+  return () => {
+    releaseDismiss();
+    releaseHover();
+    releaseRoving();
+  };
+}
 
 /**
  * Per-instance projections for the many-instance parts. Spec 01's aria()
@@ -207,10 +238,11 @@ export function navContentAria(
  * The DOM-native binding of the score -- the client. The Web Component and
  * the Astro <script> both import THIS; only React (retained-mode) reads the
  * projections above declaratively instead. Composes the substrate the same
- * way the React controller does: createBehavior is the model, the effect
- * runner drives the roving/hover/dismiss primitives, aria-manager applies the
- * projection, and the DOM is the part registry. Living here keeps one binding
- * for every DOM-native performance -- no per-framework copy, no drift.
+ * way the React controller does: createBehavior is the model,
+ * startNavigationMenuEffects composes the roving/hover/dismiss primitives
+ * directly, aria-manager applies the projection, and the DOM is the part
+ * registry. Living here keeps one binding for every DOM-native performance --
+ * no per-framework copy, no drift.
  */
 export function bindNavigationMenu(root: HTMLElement): () => void {
   const config: NavigationMenuConfig = {
@@ -226,16 +258,9 @@ export function bindNavigationMenu(root: HTMLElement): () => void {
     part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
 
   const { memory, dispatch } = createBehavior(navigationMenu, config);
-  const runner = createEffectRunner();
 
   const request = (action: keyof NavigationMenuActions, payload?: string): boolean =>
     dispatch(action, config, ...((payload === undefined ? [] : [payload]) as [string]));
-
-  const host: EffectHost = {
-    getPart,
-    dispatch: (action, payload) =>
-      void request(action as keyof NavigationMenuActions, payload as string | undefined),
-  };
 
   // ids are READ from the markup (server- or author-minted), never generated.
   const ids = {} as PartIds<NavigationMenuPart>;
@@ -282,9 +307,21 @@ export function bindNavigationMenu(root: HTMLElement): () => void {
     projectInstances('content', 'trigger', (value, triggerId) =>
       navContentAria(value, state, config, { triggerId }),
     );
-    runner.apply(navigationMenu.effects(state, config), host);
   };
   const unsubscribe = memory.subscribe(render); // fires immediately: first paint
+
+  // Compose the roving/hover/dismiss trio directly, level-triggered whenever
+  // mounted -- one instance for the menu's lifetime; hover reads the open
+  // state live, so no re-composition on open/close.
+  const stopEffects = startNavigationMenuEffects({
+    root,
+    list: getPart('list'),
+    orientation: orientationOf(config),
+    delay: config.delayDuration ?? 200,
+    isOpen: () => activeItem(memory.get(), config) !== null,
+    onHoverOpen: (value) => void request('hoverOpen', value),
+    onClose: () => void request('close'),
+  });
 
   const onClick = (event: Event) => {
     const trigger = (event.target as HTMLElement).closest<HTMLElement>('[data-part="trigger"]');
@@ -330,7 +367,7 @@ export function bindNavigationMenu(root: HTMLElement): () => void {
 
   return () => {
     unsubscribe();
-    runner.stop();
+    stopEffects();
     root.removeEventListener('click', onClick);
     root.removeEventListener('keydown', onKeydown);
   };

--- a/packages/ui/src/components/navigation-menu/navigation-menu.tsx
+++ b/packages/ui/src/components/navigation-menu/navigation-menu.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { createBehavior, type PartIds, type PayloadArgs } from '../../lib/contract';
 import { keyInputOf } from '../../hooks/key-input';
-import { useBehaviorEffects } from '../../hooks/use-behavior-effects';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
 import { mergeProps } from '../../primitives/slot';
@@ -10,6 +9,7 @@ import {
   navContentAria,
   navigationMenu,
   navTriggerAria,
+  startNavigationMenuEffects,
   type NavigationMenuActions,
   type NavigationMenuConfig,
   type NavigationMenuPart,
@@ -83,9 +83,9 @@ export function NavigationMenu({
 
   // The controller composes the score with the substrate -- no useBehavior.
   // createBehavior is the model instance (memory + canDispatch-gated
-  // dispatch); useMemory subscribes React to it; useBehaviorEffects runs the
-  // score's roving/hover/dismiss effects through the neutral runner. The rest
-  // is only what React itself needs: ids (useId) and the dispatch call.
+  // dispatch); useMemory subscribes React to it; a mount effect composes the
+  // score's roving/hover/dismiss primitives directly. The rest is only what
+  // React itself needs: ids (useId) and the dispatch call.
   const { memory, dispatch } = React.useMemo(() => createBehavior(navigationMenu, config), []);
   const state = useMemory(memory);
   const active = activeItem(state, config);
@@ -134,14 +134,23 @@ export function NavigationMenu({
     [memory, dispatch],
   );
 
-  useBehaviorEffects(navigationMenu.effects(state, config), {
-    getPart,
-    dispatch: (action, payload) =>
-      request(
-        action as keyof NavigationMenuActions,
-        ...([payload] as PayloadArgs<NavigationMenuActions[keyof NavigationMenuActions]>),
-      ),
-  });
+  // Compose the roving/hover/dismiss trio directly, once per mount (rebuilt
+  // only when orientation or delay change). Hover reads the open state live
+  // from memory, so open/close needs no dependency and roving/hover are not
+  // torn down per render. getPart, memory, and request are stable.
+  React.useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    return startNavigationMenuEffects({
+      root,
+      list: getPart('list'),
+      orientation,
+      delay: delayDuration,
+      isOpen: () => activeItem(memory.get(), latest.current.config) !== null,
+      onHoverOpen: (value) => void request('hoverOpen', value),
+      onClose: () => void request('close'),
+    });
+  }, [orientation, delayDuration, getPart, memory, request]);
 
   const aria = navigationMenu.aria(state, config, ids);
 

--- a/packages/ui/src/primitives/hover-delay.ts
+++ b/packages/ui/src/primitives/hover-delay.ts
@@ -615,3 +615,100 @@ export function createHoverIntent(
     element.removeEventListener('mouseleave', handleMouseLeave);
   };
 }
+
+/**
+ * Options for the composite (menubar-style) hover-intent primitive.
+ */
+export interface MenuHoverIntentOptions {
+  /** Selector matching each trigger instance within the root (its data-value
+   *  is the payload passed to onOpen). */
+  triggerSelector: string;
+  /** Selector matching each content panel within the root; hovering content
+   *  keeps the menu open. */
+  contentSelector: string;
+  /** Delay in ms before a hover opens a trigger (while nothing is open) and
+   *  before a leave closes (while something is open). */
+  delay: number;
+  /**
+   * Whether a panel is currently open, read LIVE on each pointer event. While
+   * open, entering another trigger switches IMMEDIATELY (menubar style) and
+   * leaving schedules a close; while closed, the first open waits out `delay`
+   * and a leave never schedules a close. Reading it live keeps every close
+   * path (Escape, outside-click, deliberate click) reflected without
+   * re-composing the primitive.
+   */
+  isOpen: () => boolean;
+  /** Open (or hover-switch to) the trigger carrying this data-value. */
+  onOpen: (value: string) => void;
+  /** Close whatever is open. */
+  onClose: () => void;
+}
+
+/**
+ * Composite hover intent over a menubar-style trigger set: the counterpart to
+ * the per-pair createHoverDelay/createControlledHoverDelay. N triggers share
+ * ONE open slot, opens are value-based (the entered trigger's data-value), and
+ * switching is immediate whenever a panel is already open. A single pair of
+ * capture-phase pointerenter/pointerleave listeners on the root drives the
+ * shared open/close timers.
+ *
+ * Returns a cleanup that clears pending timers and detaches the listeners.
+ */
+export function createMenuHoverIntent(
+  root: HTMLElement,
+  options: MenuHoverIntentOptions,
+): CleanupFunction {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const { triggerSelector, contentSelector, delay, isOpen, onOpen, onClose } = options;
+
+  let openTimer: ReturnType<typeof setTimeout> | undefined;
+  let closeTimer: ReturnType<typeof setTimeout> | undefined;
+  const clearOpenTimer = () => {
+    if (openTimer !== undefined) {
+      clearTimeout(openTimer);
+      openTimer = undefined;
+    }
+  };
+  const clearCloseTimer = () => {
+    if (closeTimer !== undefined) {
+      clearTimeout(closeTimer);
+      closeTimer = undefined;
+    }
+  };
+
+  const onPointerEnter = (event: Event) => {
+    const target = event.target as HTMLElement;
+    clearCloseTimer();
+    if (target.closest(contentSelector)) return;
+    const trigger = target.closest<HTMLElement>(`${triggerSelector}:not([disabled])`);
+    const value = trigger?.dataset['value'];
+    if (!value) return;
+    clearOpenTimer();
+    if (isOpen()) {
+      onOpen(value);
+    } else {
+      openTimer = setTimeout(() => onOpen(value), delay);
+    }
+  };
+
+  const onPointerLeave = (event: Event) => {
+    const target = event.target as HTMLElement;
+    if (!target.closest(`${triggerSelector}, ${contentSelector}`)) return;
+    clearOpenTimer();
+    if (!isOpen()) return;
+    clearCloseTimer();
+    closeTimer = setTimeout(() => onClose(), delay);
+  };
+
+  root.addEventListener('pointerenter', onPointerEnter, true);
+  root.addEventListener('pointerleave', onPointerLeave, true);
+  return () => {
+    clearOpenTimer();
+    clearCloseTimer();
+    root.removeEventListener('pointerenter', onPointerEnter, true);
+    root.removeEventListener('pointerleave', onPointerLeave, true);
+  };
+}

--- a/packages/ui/test/components/navigation-menu/navigation-menu.behavior.test.ts
+++ b/packages/ui/test/components/navigation-menu/navigation-menu.behavior.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createBehavior } from '../../../src/lib/contract';
 import {
   activeItem,
   navContentAria,
   navigationMenu,
   navTriggerAria,
+  startNavigationMenuEffects,
   type NavigationMenuConfig,
 } from '../../../src/components/navigation-menu/navigation-menu.behavior';
 
@@ -168,37 +169,126 @@ describe('navigation-menu aria', () => {
   });
 });
 
-describe('navigation-menu effects', () => {
-  it('closed: roving focus and delayed hover intent, no dismissal layer', () => {
-    const effects = navigationMenu.effects({ active: null, pointerOpened: false }, base);
-    expect(effects).toEqual([
-      { type: 'roving-focus', part: 'list', orientation: 'horizontal' },
-      {
-        type: 'hover-intent',
-        part: 'root',
-        triggerPart: 'trigger',
-        contentPart: 'content',
-        delay: 200,
-        immediate: false,
-        openAction: 'hoverOpen',
-        closeAction: 'close',
-      },
-    ]);
+describe('navigation-menu effects composition', () => {
+  // The score no longer emits vocabulary effects: roving/hover/dismiss are
+  // composed directly from the primitives by startNavigationMenuEffects, which
+  // both the DOM-native and React bindings call. These tests drive that
+  // composition seam -- including the immediate-switch semantics conformance
+  // does not exercise -- against real DOM.
+  interface Harness {
+    root: HTMLElement;
+    open: { value: string | null };
+    onHoverOpen: ReturnType<typeof vi.fn>;
+    onClose: ReturnType<typeof vi.fn>;
+    stop: () => void;
+  }
+
+  const stops: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const stop of stops.splice(0)) stop();
+    vi.useRealTimers();
+    document.body.innerHTML = '';
   });
 
-  it('open: hover switches immediately and outside pointerdown dismisses', () => {
-    const effects = navigationMenu.effects({ active: 'a', pointerOpened: false }, base);
-    expect(effects).toContainEqual({ type: 'dismiss-on-outside', part: 'root', action: 'close' });
-    const hover = effects.find((effect) => effect.type === 'hover-intent');
-    expect(hover).toMatchObject({ immediate: true });
+  function mountMenu(): HTMLElement {
+    document.body.innerHTML = `
+      <nav data-part="root">
+        <ul data-part="list">
+          <li>
+            <button type="button" data-part="trigger" data-value="a" data-roving-item>A</button>
+            <div data-part="content" data-value="a"><a href="/a">A</a></div>
+          </li>
+          <li>
+            <button type="button" data-part="trigger" data-value="b" data-roving-item>B</button>
+            <div data-part="content" data-value="b"><a href="/b">B</a></div>
+          </li>
+        </ul>
+      </nav>`;
+    return document.body.querySelector('[data-part="root"]') as HTMLElement;
+  }
+
+  const triggerFor = (root: HTMLElement, value: string): HTMLElement => {
+    const element = root.querySelector<HTMLElement>(`[data-part="trigger"][data-value="${value}"]`);
+    if (!element) throw new Error(`no trigger for ${value}`);
+    return element;
+  };
+
+  function start(delay = 200): Harness {
+    const root = mountMenu();
+    const open = { value: null as string | null };
+    const onHoverOpen = vi.fn((value: string) => {
+      open.value = value;
+    });
+    const onClose = vi.fn(() => {
+      open.value = null;
+    });
+    const stop = startNavigationMenuEffects({
+      root,
+      list: root.querySelector<HTMLElement>('[data-part="list"]'),
+      orientation: 'horizontal',
+      delay,
+      isOpen: () => open.value !== null,
+      onHoverOpen,
+      onClose,
+    });
+    stops.push(stop);
+    return { root, open, onHoverOpen, onClose, stop };
+  }
+
+  it('roving tabindex initializes across the trigger list', () => {
+    const h = start();
+    expect(triggerFor(h.root, 'a').getAttribute('tabindex')).toBe('0');
+    expect(triggerFor(h.root, 'b').getAttribute('tabindex')).toBe('-1');
   });
 
-  it('orientation and delay flow from config', () => {
-    const effects = navigationMenu.effects(
-      { active: null, pointerOpened: false },
-      { orientation: 'vertical', delayDuration: 50 },
-    );
-    expect(effects[0]).toMatchObject({ orientation: 'vertical' });
-    expect(effects[1]).toMatchObject({ delay: 50 });
+  it('hover opens the trigger after the delay when nothing is open', () => {
+    vi.useFakeTimers();
+    const h = start(200);
+    triggerFor(h.root, 'a').dispatchEvent(new Event('pointerenter'));
+    vi.advanceTimersByTime(199);
+    expect(h.onHoverOpen).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(h.onHoverOpen).toHaveBeenCalledWith('a');
+  });
+
+  it('while a panel is open, hovering another trigger switches immediately', () => {
+    vi.useFakeTimers();
+    const h = start(200);
+    h.open.value = 'a'; // a panel is already open
+    triggerFor(h.root, 'b').dispatchEvent(new Event('pointerenter'));
+    // No timer advance: the menubar-style switch is synchronous.
+    expect(h.onHoverOpen).toHaveBeenCalledWith('b');
+  });
+
+  it('leaving schedules a close only while a panel is open', () => {
+    vi.useFakeTimers();
+    const h = start(200);
+    // Closed: a leave never closes.
+    triggerFor(h.root, 'a').dispatchEvent(new Event('pointerleave'));
+    vi.advanceTimersByTime(200);
+    expect(h.onClose).not.toHaveBeenCalled();
+    // Open: a leave closes after the delay.
+    h.open.value = 'a';
+    triggerFor(h.root, 'a').dispatchEvent(new Event('pointerleave'));
+    vi.advanceTimersByTime(199);
+    expect(h.onClose).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(h.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('outside pointerdown closes; cleanup detaches every listener', () => {
+    const h = start();
+    h.open.value = 'a';
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    outside.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    expect(h.onClose).toHaveBeenCalledTimes(1);
+
+    h.stop();
+    outside.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    triggerFor(h.root, 'a').dispatchEvent(new Event('pointerenter'));
+    expect(h.onClose).toHaveBeenCalledTimes(1);
+    expect(h.onHoverOpen).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

navigation-menu composes its primitives directly at both framework boundaries, dropping the retired
effects-as-data layer. The `hover-intent` executor had REIMPLEMENTED the `hover-delay` primitive;
this composes the primitive instead (extending it additively rather than copying it).

## Acceptance criteria mapping

### navigation-menu no longer imports lib/effects; the score drops effects()
The `lib/effects` import, `createEffectRunner`, and `EffectHost` are gone from the behavior file;
impure work is a colocated composition function.
Evidence: packages/ui/src/components/navigation-menu/navigation-menu.behavior.ts:142.

### Both framework boundaries compose the primitives directly
`bindNavigationMenu` (WC/Astro) and a React `useEffect` in navigation-menu.tsx both call the same
composition function; `useBehaviorEffects` is removed from the .tsx.
Evidence: packages/ui/src/components/navigation-menu/navigation-menu.tsx:137.

### roving/hover/dismiss are COMPOSED, not reimplemented
Composes `createRovingFocus` + the `hover-delay` primitive (`createHoverIntent`) + `onPointerDownOutside`.
The hover-delay primitive was EXTENDED additively (97 insertions, 0 deletions) so the component holds
no hand-rolled openTimer/closeTimer logic.
Evidence: packages/ui/src/primitives/hover-delay.ts:618.

### effects.ts and the React adapter are untouched
The diff modifies only navigation-menu.behavior.ts, navigation-menu.tsx, primitives/hover-delay.ts,
and the behavior test -- not lib/effects.ts or hooks/use-behavior-effects.ts (those are teardown #1867).
Evidence: packages/ui/test/components/navigation-menu/navigation-menu.behavior.test.ts:172.

### Behavior preserved across React/WC/Astro
`pnpm --filter @rafters/ui test:unit` (conformance) and `pnpm preflight` pass; the effect-DATA test
assertions were swapped for behavior assertions driven through the public bind/composition.
Evidence: packages/ui/src/components/navigation-menu/navigation-menu.behavior.ts:260.

## Not done

- Deleting `lib/effects.ts`, `hooks/use-behavior-effects.ts`, the contract `effects` member, and the
  compose synthesis is deliberately OUT of scope -- that is the teardown issue #1867, after all 8
  component fixes stop importing effects.ts. This PR leaves those untouched.
- The additive `hover-delay` extension keeps existing consumers (tooltip, hover-card) unchanged; no
  refactor of them is in scope here.

Closes #1864
