### PR TITLE
feat(ui): collision-detector accepts a point/DOMRect anchor (#1882)

### DIFF
--- a/packages/ui/src/primitives/collision-detector.test.ts
+++ b/packages/ui/src/primitives/collision-detector.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { computePosition } from './collision-detector';
+
+/**
+ * A floating element whose measured size is fixed, so base-position math is
+ * deterministic regardless of the happy-dom layout (which reports zeros).
+ */
+function makeFloating(width: number, height: number): HTMLElement {
+  const el = document.createElement('div');
+  el.getBoundingClientRect = () => new DOMRect(0, 0, width, height);
+  return el;
+}
+
+describe('computePosition anchor kinds', () => {
+  it('accepts a point anchor as a zero-size rect', () => {
+    const floating = makeFloating(50, 20);
+
+    const result = computePosition({ x: 100, y: 100 }, floating, {
+      side: 'bottom',
+      align: 'center',
+      avoidCollisions: false,
+    });
+
+    // bottom of a zero-height point is its y; center aligns 100 - 50/2.
+    expect(result.x).toBe(75);
+    expect(result.y).toBe(100);
+  });
+
+  it('accepts a DOMRect anchor directly (size is honored, not zeroed)', () => {
+    const floating = makeFloating(50, 20);
+
+    const result = computePosition(new DOMRect(200, 50, 40, 30), floating, {
+      side: 'bottom',
+      align: 'center',
+      avoidCollisions: false,
+    });
+
+    // bottom = 50 + 30; center = 200 + 40/2 - 50/2.
+    expect(result.x).toBe(195);
+    expect(result.y).toBe(80);
+  });
+
+  it('resolves an HTMLElement identically to its matching DOMRect (backward compatible)', () => {
+    const floating = makeFloating(50, 20);
+    const rect = new DOMRect(200, 50, 40, 30);
+    const anchorEl = document.createElement('div');
+    anchorEl.getBoundingClientRect = () => rect;
+
+    const fromElement = computePosition(anchorEl, floating, {
+      side: 'bottom',
+      align: 'center',
+      avoidCollisions: false,
+    });
+    const fromRect = computePosition(rect, floating, {
+      side: 'bottom',
+      align: 'center',
+      avoidCollisions: false,
+    });
+
+    expect(fromRect.x).toBe(fromElement.x);
+    expect(fromRect.y).toBe(fromElement.y);
+  });
+});

--- a/packages/ui/src/primitives/collision-detector.ts
+++ b/packages/ui/src/primitives/collision-detector.ts
@@ -144,6 +144,27 @@ function getViewportRect(): DOMRect {
 }
 
 /**
+ * Anchor accepted by {@link computePosition}.
+ * - `HTMLElement`: measured via `getBoundingClientRect()`
+ * - `DOMRect`: used directly
+ * - `{ x, y }` point: treated as a zero-size rect at the given coordinates
+ */
+export type Anchor = HTMLElement | DOMRect | { x: number; y: number };
+
+/**
+ * Resolve any accepted anchor into the DOMRect the positioning math runs on.
+ */
+function resolveAnchorRect(anchor: Anchor): DOMRect {
+  if ('getBoundingClientRect' in anchor) {
+    return anchor.getBoundingClientRect();
+  }
+  if ('width' in anchor) {
+    return anchor;
+  }
+  return new DOMRect(anchor.x, anchor.y, 0, 0);
+}
+
+/**
  * Calculate position for given side and alignment
  */
 function calculateBasePosition(
@@ -260,6 +281,10 @@ function calculateArrowPosition(
 /**
  * Compute optimal position for floating element
  *
+ * The anchor may be an `HTMLElement` (measured via `getBoundingClientRect()`),
+ * a `DOMRect` (used directly), or a `{ x, y }` point (treated as a zero-size
+ * rect at that coordinate -- useful for context menus at a cursor position).
+ *
  * @example
  * ```typescript
  * const result = computePosition(anchor, floating, {
@@ -275,7 +300,7 @@ function calculateArrowPosition(
  * ```
  */
 export function computePosition(
-  anchor: HTMLElement,
+  anchor: Anchor,
   floating: HTMLElement,
   options: CollisionOptions = {},
 ): CollisionResult {
@@ -304,7 +329,7 @@ export function computePosition(
   } = options;
 
   // Get rects
-  const anchorRect = anchor.getBoundingClientRect();
+  const anchorRect = resolveAnchorRect(anchor);
   const floatingRect = floating.getBoundingClientRect();
   const boundaryRect = collisionBoundary
     ? collisionBoundary.getBoundingClientRect()


### PR DESCRIPTION
Extends `collision-detector`'s `computePosition` to accept a point or `DOMRect`
anchor in addition to an `HTMLElement`, so `context-menu` can position at
pointer coordinates without the zero-size-dummy-anchor hack the composition
rule forbids. The positioning math already ran entirely off a `DOMRect`, so
this is a purely additive widening at the single measurement seam.

## Acceptance criteria mapping

### computePosition accepts HTMLElement | DOMRect | { x: number; y: number }

The `anchor` parameter is now typed `Anchor`, an exported union of exactly
those three shapes, applied to the signature. Callers positioning at a cursor
can name the type.
Evidence: packages/ui/src/primitives/collision-detector.ts:152
Evidence: packages/ui/src/primitives/collision-detector.ts:303

### A point becomes a zero-size DOMRect at (x, y)

New `resolveAnchorRect` helper discriminates structurally: `getBoundingClientRect`
in anchor -> element (measured as before); else `width` in anchor -> `DOMRect`
(used directly); else a `{ x, y }` point becomes `new DOMRect(x, y, 0, 0)`. The
`width`-before-point order is load-bearing -- a real `DOMRect` also carries
`x`/`y`, so testing `width` first prevents a `DOMRect` from being collapsed to a
point.
Evidence: packages/ui/src/primitives/collision-detector.ts:157

### Additive and backward-compatible; existing HTMLElement callers unchanged

`computePosition` swapped one line -- `anchor.getBoundingClientRect()` became
`resolveAnchorRect(anchor)`; all downstream math is untouched. The parameter
type only widened (a superset), so the existing callers -- popover, tooltip,
float, and the legacy `old/ui` menus (select, dropdown-menu, combobox,
date-picker, hover-card) -- compile and behave identically. None appear in this
diff, and the workspace typecheck in preflight passed across all of them.
Evidence: packages/ui/src/primitives/collision-detector.ts:332

### Test for the point + DOMRect cases

New colocated `collision-detector.test.ts` (happy-dom): the point case asserts a
`{ x, y }` anchor resolves to a zero-size rect (x=75, y=100); the `DOMRect` case
asserts size is honored (x=195, not the x=175 a mis-collapsed point would
produce), guarding the discrimination order; and an equivalence case pins
backward-compat by proving an `HTMLElement` and its matching `DOMRect` produce
identical output. All three pass; `test:unit` and `preflight` are green.
Evidence: packages/ui/src/primitives/collision-detector.test.ts:15
Evidence: packages/ui/src/primitives/collision-detector.test.ts:29
Evidence: packages/ui/src/primitives/collision-detector.test.ts:43

### Files: collision-detector.ts + its test only

The issue scopes the change to the primitive and its test, and the diff honors
that exactly: one modified source file (`collision-detector.ts`, a type
widening plus one helper) and one new colocated test file
(`collision-detector.test.ts`). No component, registry, doc, or config file was
touched -- `git diff --stat` against `origin/main` reports precisely these two
paths, 90 insertions and 2 deletions, which is why the workspace typecheck
could confirm every existing caller unchanged without any of them appearing in
the diff.
Evidence: packages/ui/src/primitives/collision-detector.test.ts:1

## Not done

- Sibling helpers left `HTMLElement`-only. `applyPosition`, `autoPosition`, and
  `getAvailableSpace` were not widened -- out of scope for this issue and it
  would add untested surface. `context-menu` needs only `computePosition`.
- No CHANGELOG entry. The repo's CHANGELOG rule is scoped to CLI behavior
  changes; this is a UI primitive type widening, and the issue restricts the
  change to two files.
- No `context-menu` consumer wiring. This issue only gates that work by making
  the anchor polymorphic; the consuming component is a separate change.

Closes #1882
