### PR TITLE
fix(ui): dismissable-layer stacked-Escape + pin direct dismissal path (#1883)

### DIFF
--- a/packages/ui/docs/spec/05-authoring.md
+++ b/packages/ui/docs/spec/05-authoring.md
@@ -56,6 +56,16 @@ half-solution. A shared executor slot is a honeypot: it is exactly what once let
 of composing them. (The retired effects-as-data layer -- Spec 03 -- was removed
 for precisely this reason.)
 
+**Canonical dismissal path (the port wave).** An overlay composes its dismissal
+DIRECTLY: `outside-click` for pointerdown-outside, and Escape via the score's
+keymap (as `dialog` does) or the `escape-keydown` primitive -- the shape `dialog`
+proves in `startDialogModalEffects` (dismiss on pointerdown outside `content`,
+sparing the trigger). The overlay ports -- alert-dialog, drawer, sheet, hover-card,
+dropdown-menu, command, context-menu, combobox -- reach for those primitives, NOT
+for `dismissable-layer`'s module-global `layerStack`. The standalone stack stays
+for existing consumers, but a port never reaches for it: one dismissal path, not a
+three-way "which mechanism?" fork.
+
 ## The substrate you compose (never rewrite)
 
 - `lib/contract.ts` -- `createBehavior(spec, config)` -> `{ memory, dispatch }`.

--- a/packages/ui/src/primitives/dismissable-layer.ts
+++ b/packages/ui/src/primitives/dismissable-layer.ts
@@ -308,27 +308,35 @@ export function createDismissableLayerStack(
   // Add to stack
   layerStack.push(layer);
 
-  // Create base dismissable layer with modified escape handling
+  const isTopmost = () => layerStack[layerStack.length - 1] === layer;
+
+  // The base createDismissableLayer fires onInteractOutside and onDismiss
+  // unconditionally after the trigger-specific handler. Passing the raw
+  // options.onDismiss straight through would dismiss EVERY stacked layer on a
+  // single Escape (or a single outside click). Gate all consumer callbacks --
+  // including onInteractOutside and onDismiss -- on this layer being topmost,
+  // so one Escape pops exactly one layer, top-down.
   const baseCleanup = createDismissableLayer(layer, {
     ...options,
     onEscapeKeyDown: (event) => {
-      // Only handle escape for topmost layer
-      if (layerStack[layerStack.length - 1] !== layer) return;
-
+      if (!isTopmost()) return;
       options.onEscapeKeyDown?.(event);
-      // Let the original onDismiss handle through the base implementation
     },
     onPointerDownOutside: (event) => {
-      // Only handle pointer down for topmost layer
-      if (layerStack[layerStack.length - 1] !== layer) return;
-
+      if (!isTopmost()) return;
       options.onPointerDownOutside?.(event);
     },
     onFocusOutside: (event) => {
-      // Only handle focus for topmost layer
-      if (layerStack[layerStack.length - 1] !== layer) return;
-
+      if (!isTopmost()) return;
       options.onFocusOutside?.(event);
+    },
+    onInteractOutside: (event) => {
+      if (!isTopmost()) return;
+      options.onInteractOutside?.(event);
+    },
+    onDismiss: () => {
+      if (!isTopmost()) return;
+      options.onDismiss?.();
     },
   });
 

--- a/packages/ui/test/primitives/dismissable-layer.test.ts
+++ b/packages/ui/test/primitives/dismissable-layer.test.ts
@@ -243,21 +243,26 @@ describe('createDismissableLayerStack', () => {
     expect(getDismissableLayerStack()).toHaveLength(0);
   });
 
-  it('only handles escape for topmost layer', () => {
+  it('dismisses only the topmost layer on Escape', () => {
     const onDismiss1 = vi.fn();
     const onDismiss2 = vi.fn();
 
     const cleanup1 = createDismissableLayerStack(layer1, { onDismiss: onDismiss1 });
     const cleanup2 = createDismissableLayerStack(layer2, { onDismiss: onDismiss2 });
 
-    // Escape should only affect topmost layer
+    // A single Escape dismisses ONLY the topmost layer (layer2), never the one
+    // beneath it. onDismiss1 firing here is the regression this test guards.
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(onDismiss2).toHaveBeenCalledTimes(1);
+    expect(onDismiss1).not.toHaveBeenCalled();
 
-    // Note: Due to how events work, both may receive the event but only topmost should process
-    // The implementation filters by checking if layer is topmost
+    // Once the top layer unmounts, the next Escape falls through to the layer
+    // beneath it -- one Escape pops one layer, top-down.
+    cleanup2();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(onDismiss1).toHaveBeenCalledTimes(1);
 
     cleanup1();
-    cleanup2();
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the dismissable-layer stacked-Escape bug and pins the canonical dismissal path for the overlay port wave.

`createDismissableLayerStack` wrapped only the three trigger-specific handlers (`onEscapeKeyDown`, `onPointerDownOutside`, `onFocusOutside`) with a topmost guard, but passed the raw `options.onDismiss` and `options.onInteractOutside` straight through the `...options` spread. The base `createDismissableLayer` fires both unconditionally after the trigger handler, so a single Escape dismissed EVERY stacked layer instead of only the topmost one.

The fix gates `onDismiss` and `onInteractOutside` on the layer being topmost as well, via a shared `isTopmost()` helper, so one Escape (or one outside click) pops exactly one layer, top-down. The base primitive is untouched -- single-layer consumers still dismiss exactly once.

## Acceptance criteria mapping

### 1. The stacked-Escape bug is fixed -- only the topmost layer dismisses on a single Escape
`createDismissableLayerStack` previously wrapped only `onEscapeKeyDown`/`onPointerDownOutside`/`onFocusOutside` with a topmost guard, while the raw `options.onDismiss` and `options.onInteractOutside` rode the `...options` spread into the base, which fires them unconditionally -- so every stacked layer dismissed on one Escape. The fix hoists the predicate into `isTopmost()` and gates all five consumer callbacks, so the base's unconditional `onDismiss?.()` reaches the real consumer callback only for the topmost layer; one Escape pops exactly one layer, top-down.
Evidence: dismissable-layer.ts:311 (`isTopmost` helper), dismissable-layer.ts:337 (`onDismiss` guard), dismissable-layer.ts:331 (`onInteractOutside` guard).

### 2. A test proves only the top layer dismisses on Escape
The formerly assertion-free stack test is replaced with a real regression test: two stacked layers, a single Escape asserts `onDismiss2` fired once and `onDismiss1` never fired (the discriminating assertion that goes red against unfixed code), then it proves the next Escape falls through to the lower layer after the top one unmounts via `cleanup2()`.
Evidence: dismissable-layer.test.ts:246-265, specifically the `expect(onDismiss1).not.toHaveBeenCalled()` assertion at dismissable-layer.test.ts:256.

### 3. The standalone stack remains for existing consumers; the base primitive is untouched
Only the stack wrapper changed; the base `createDismissableLayer` and its single-fire behavior are unmodified, so single-layer consumers still dismiss exactly once. The one non-test importer, `navigation-menu.controller.ts`, uses the base `createDismissableLayer`, not the stack, so no live consumer behavior changes.
Evidence: the diff touches only `createDismissableLayerStack` (dismissable-layer.ts:299-344); `createDismissableLayer` (dismissable-layer.ts:165) is unchanged.

### 4. 05-authoring.md pins direct composition as the canonical dismissal path for the port wave
A new note states overlays compose `outside-click` + Escape (via the score's keymap, as `dialog` does, or the `escape-keydown` primitive) DIRECTLY -- the shape `dialog` proves in `startDialogModalEffects` -- NOT the module-global `layerStack`. It names the eight overlay ports and states the standalone stack stays for existing consumers while ports do not reach for it, removing the three-way "which mechanism?" fork.
Evidence: 05-authoring.md:59-67 (the "Canonical dismissal path (the port wave)" note).

## Not done

- **The base `createDismissableLayer` unconditional-fire shape is left as-is.** Firing `onDismiss` exactly once per outside interaction is correct for single-layer consumers; the stack-awareness belongs in the stack wrapper, which owns the `layerStack`. Moving the guard into the base would be wrong.
- **No migration of overlays onto the pinned path.** This PR documents the canonical path; the eight overlay ports (alert-dialog, drawer, sheet, hover-card, dropdown-menu, command, context-menu, combobox) are not implemented here -- that is the port wave's work.
- **`onInteractOutside` gating is included beyond the literal Escape-only ask** for parallelism with the three guards that already existed (the wrapper's whole intent is "only the topmost layer reacts"); it also fixes the same leak on the outside-click path. This is correct overlay-stack behavior and touches no live consumer, since the stack is currently used only in tests.

## Verification

- `pnpm --filter @rafters/ui test:unit`: 169 passed (32 files). The `DOMException ... JavaScript file loading is disabled` lines are the expected happy-dom SSR-script behavior documented in 05-authoring.md, not failures.
- `pnpm preflight`: exit 0 (unit-tests, lint, format, typecheck all green).

Closes #1883

🤖 Generated with [Claude Code](https://claude.com/claude-code)