### PR TITLE
feat(ui): first-class BehaviorSpec.instanceAria for many-part components (#1884)

### DIFF
--- a/packages/ui/src/components/navigation-menu/navigation-menu.astro
+++ b/packages/ui/src/components/navigation-menu/navigation-menu.astro
@@ -10,13 +10,12 @@
  * no astro-specific runtime.
  *
  * The projection is computed here from the same navigationMenu.aria /
- * navTriggerAria / navContentAria the React and WC controllers read -- one
- * score, three performances, zero drift.
+ * navInstanceAria the React and WC controllers read -- one score, three
+ * performances, zero drift.
  */
 import {
   navigationMenu,
-  navTriggerAria,
-  navContentAria,
+  navInstanceAria,
   type NavigationMenuConfig,
   type NavigationMenuPart,
 } from './navigation-menu.behavior';
@@ -72,7 +71,7 @@ const instanceId = (part: NavigationMenuPart, value: string) => `${id}-${part}-$
               data-value={item.value}
               data-roving-item
               class={classes.trigger}
-              {...navTriggerAria(item.value, state, config, { contentId })}
+              {...navInstanceAria('trigger', item.value, state, config, { trigger: triggerId, content: contentId })}
             >
               {item.label}
             </button>
@@ -81,7 +80,7 @@ const instanceId = (part: NavigationMenuPart, value: string) => `${id}-${part}-$
               data-part="content"
               data-value={item.value}
               class={classes.content}
-              {...navContentAria(item.value, state, config, { triggerId })}
+              {...navInstanceAria('content', item.value, state, config, { trigger: triggerId, content: contentId })}
             >
               {item.links.map((link) => (
                 <a href={link.href} class={classes.link}>

--- a/packages/ui/src/components/navigation-menu/navigation-menu.behavior.ts
+++ b/packages/ui/src/components/navigation-menu/navigation-menu.behavior.ts
@@ -3,6 +3,7 @@ import {
   createBehavior,
   type AriaAttrs,
   type BehaviorSpec,
+  type InstanceIds,
   type PartIds,
 } from '../../lib/contract';
 import { updateAriaAttribute } from '../../primitives/aria-manager';
@@ -134,12 +135,46 @@ const navigation: Slice<
   },
 };
 
+/**
+ * Per-instance ARIA for the `many` parts (Spec 01: BehaviorSpec.instanceAria).
+ * `aria()` projects one AriaAttrs per part NAME; trigger/content occur once per
+ * item value, so their projections take the instance value and the instance's
+ * sibling ids (a trigger reads its content's id; content reads its trigger's).
+ * The generic contract member `navigationMenu.instanceAria` points at this
+ * exact function, so the conformance harness drives it without bespoke wiring
+ * while the component's own decorators call the concrete function directly.
+ */
+export function navInstanceAria(
+  part: NavigationMenuPart,
+  value: string,
+  state: NavigationMenuState,
+  config: NavigationMenuConfig,
+  ids: InstanceIds<NavigationMenuPart>,
+): AriaAttrs {
+  const open = activeItem(state, config) === value;
+  if (part === 'trigger') {
+    return {
+      'aria-expanded': open ? 'true' : 'false',
+      'aria-controls': ids.content ?? '',
+      'data-state': open ? 'open' : 'closed',
+    };
+  }
+  if (part === 'content') {
+    return {
+      'aria-labelledby': ids.trigger ?? '',
+      'data-state': open ? 'open' : 'closed',
+      hidden: open ? undefined : true,
+    };
+  }
+  return {};
+}
+
 export const navigationMenu: BehaviorSpec<
   NavigationMenuConfig,
   NavigationMenuState,
   NavigationMenuActions,
   NavigationMenuPart
-> = compose('navigation-menu', navigation);
+> = { ...compose('navigation-menu', navigation), instanceAria: navInstanceAria };
 
 /** The parts, orientation, delay, and dispatch the roving/hover/dismiss trio
  *  composes against. */
@@ -201,40 +236,6 @@ export function startNavigationMenuEffects({
 }
 
 /**
- * Per-instance projections for the many-instance parts. Spec 01's aria()
- * projects one AriaAttrs per part NAME; trigger/content occur once per item
- * value, so their projections take the instance value. (Contract amendment
- * candidate: instance projection for `many` parts.)
- */
-export function navTriggerAria(
-  value: string,
-  state: NavigationMenuState,
-  config: NavigationMenuConfig,
-  ids: { contentId: string },
-): AriaAttrs {
-  const open = activeItem(state, config) === value;
-  return {
-    'aria-expanded': open ? 'true' : 'false',
-    'aria-controls': ids.contentId,
-    'data-state': open ? 'open' : 'closed',
-  };
-}
-
-export function navContentAria(
-  value: string,
-  state: NavigationMenuState,
-  config: NavigationMenuConfig,
-  ids: { triggerId: string },
-): AriaAttrs {
-  const open = activeItem(state, config) === value;
-  return {
-    'aria-labelledby': ids.triggerId,
-    'data-state': open ? 'open' : 'closed',
-    hidden: open ? undefined : true,
-  };
-}
-
-/**
  * The DOM-native binding of the score -- the client. The Web Component and
  * the Astro <script> both import THIS; only React (retained-mode) reads the
  * projections above declaratively instead. Composes the substrate the same
@@ -277,19 +278,27 @@ export function bindNavigationMenu(root: HTMLElement): () => void {
     }
   };
 
-  // Project every instance of a `many` part, resolving its sibling's id.
-  const projectInstances = (
-    part: 'trigger' | 'content',
-    sibling: 'trigger' | 'content',
-    project: (value: string, siblingId: string) => AriaAttrs,
-  ) => {
-    for (const el of root.querySelectorAll<HTMLElement>(`[data-part="${part}"]`)) {
-      const value = el.dataset['value'];
-      if (value === undefined) continue;
-      const siblingId =
-        root.querySelector<HTMLElement>(`[data-part="${sibling}"][data-value="${value}"]`)?.id ??
-        '';
-      applyProjection(el, project(value, siblingId));
+  // The `many` parts, resolved once from the score's own declaration -- no
+  // hardcoded trigger/content list, so any many-part score binds identically.
+  const manyParts = (Object.keys(navigationMenu.parts) as NavigationMenuPart[]).filter(
+    (part) => navigationMenu.parts[part].many,
+  );
+
+  // Project every rendered instance of every `many` part, resolving each
+  // instance's sibling ids (the elements of the many parts sharing its value).
+  const projectInstances = (state: NavigationMenuState) => {
+    for (const part of manyParts) {
+      for (const el of root.querySelectorAll<HTMLElement>(`[data-part="${part}"]`)) {
+        const value = el.dataset['value'];
+        if (value === undefined) continue;
+        const instanceIds: InstanceIds<NavigationMenuPart> = {};
+        for (const sibling of manyParts) {
+          instanceIds[sibling] =
+            root.querySelector<HTMLElement>(`[data-part="${sibling}"][data-value="${value}"]`)
+              ?.id ?? '';
+        }
+        applyProjection(el, navInstanceAria(part, value, state, config, instanceIds));
+      }
     }
   };
 
@@ -301,12 +310,7 @@ export function bindNavigationMenu(root: HTMLElement): () => void {
       const el = getPart(part);
       if (el && attrs) applyProjection(el, attrs);
     }
-    projectInstances('trigger', 'content', (value, contentId) =>
-      navTriggerAria(value, state, config, { contentId }),
-    );
-    projectInstances('content', 'trigger', (value, triggerId) =>
-      navContentAria(value, state, config, { triggerId }),
-    );
+    projectInstances(state);
   };
   const unsubscribe = memory.subscribe(render); // fires immediately: first paint
 

--- a/packages/ui/src/components/navigation-menu/navigation-menu.tsx
+++ b/packages/ui/src/components/navigation-menu/navigation-menu.tsx
@@ -6,9 +6,8 @@ import classy from '../../primitives/classy';
 import { mergeProps } from '../../primitives/slot';
 import {
   activeItem,
-  navContentAria,
+  navInstanceAria,
   navigationMenu,
-  navTriggerAria,
   startNavigationMenuEffects,
   type NavigationMenuActions,
   type NavigationMenuConfig,
@@ -255,7 +254,10 @@ export function NavigationMenuTrigger({
 }: NavigationMenuTriggerProps) {
   const { config, state, classes, request } = useNavigationMenuContext('NavigationMenuTrigger');
   const { value, triggerId, contentId } = useItemContext('NavigationMenuTrigger');
-  const aria = navTriggerAria(value, state, config, { contentId });
+  const aria = navInstanceAria('trigger', value, state, config, {
+    trigger: triggerId,
+    content: contentId,
+  });
 
   return (
     <button
@@ -296,7 +298,10 @@ export type NavigationMenuContentProps = React.HTMLAttributes<HTMLDivElement>;
 export function NavigationMenuContent({ className, ...props }: NavigationMenuContentProps) {
   const { config, state, classes } = useNavigationMenuContext('NavigationMenuContent');
   const { value, triggerId, contentId } = useItemContext('NavigationMenuContent');
-  const aria = navContentAria(value, state, config, { triggerId });
+  const aria = navInstanceAria('content', value, state, config, {
+    trigger: triggerId,
+    content: contentId,
+  });
 
   return (
     <div

--- a/packages/ui/src/lib/contract.ts
+++ b/packages/ui/src/lib/contract.ts
@@ -21,6 +21,14 @@ export type PartIds<Part extends string> = Record<Part, string>;
 export type ActionPayloads = Record<string, unknown>;
 export type PayloadArgs<P> = P extends undefined ? [] : [payload: P];
 
+/**
+ * The ids of a single many-part INSTANCE, keyed by part name -- the sibling
+ * ids `instanceAria` wires against (e.g. a trigger reads its content's id and
+ * vice versa). Partial because `many` is a runtime PartDecl field, not narrowed
+ * at the type level: only the instance's own many parts carry a key.
+ */
+export type InstanceIds<Part extends string> = Partial<Record<Part, string>>;
+
 export interface BehaviorSpec<Config, State, Actions extends ActionPayloads, Part extends string> {
   name: string;
   parts: Record<Part, PartDecl>;
@@ -33,6 +41,23 @@ export interface BehaviorSpec<Config, State, Actions extends ActionPayloads, Par
   canDispatch: (state: State, action: keyof Actions, config: Config) => boolean;
 
   aria: (state: State, config: Config, ids: PartIds<Part>) => Partial<Record<Part, AriaAttrs>>;
+
+  /**
+   * Per-instance ARIA for `many` parts. `aria()` projects one AriaAttrs per
+   * part NAME; a `many` part occurs once per instance value (trigger/content
+   * per menu item), which one AriaAttrs cannot express. `instanceAria` projects
+   * the attrs for ONE instance of ONE part, given its value and its sibling
+   * ids. OPTIONAL: statics and uniform-item components (radio-group's N-uniform
+   * roving needs no per-instance ARIA -- #1870) omit it, so it never cascades
+   * to the ~30 static specs.
+   */
+  instanceAria?: (
+    part: Part,
+    value: string,
+    state: State,
+    config: Config,
+    ids: InstanceIds<Part>,
+  ) => AriaAttrs;
 
   keymap: (event: KeyInput, state: State, part: Part, config: Config) => keyof Actions | null;
 }

--- a/packages/ui/test/components/navigation-menu/navigation-menu.astro.conformance.test.ts
+++ b/packages/ui/test/components/navigation-menu/navigation-menu.astro.conformance.test.ts
@@ -10,7 +10,11 @@ import { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it } from 'vitest';
 import NavigationMenu from '../../../src/components/navigation-menu/navigation-menu.astro';
-import { bindNavigationMenu } from '../../../src/components/navigation-menu/navigation-menu.behavior';
+import {
+  bindNavigationMenu,
+  navigationMenu,
+} from '../../../src/components/navigation-menu/navigation-menu.behavior';
+import { assertInstanceAriaFulfillment } from '../../harness/conformance';
 
 const items = [
   {
@@ -54,6 +58,20 @@ describe('navigation-menu conformance [astro]', () => {
     // Links are in the DOM even while closed -- SSR-stable and crawlable.
     expect(content('products').querySelector('a[href="/a"]')).not.toBeNull();
     expect(trigger('products').getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('per-instance ARIA equals the score projection, closed (SSR) and open', async () => {
+    const user = userEvent.setup();
+    const root = await mount();
+    // SSR-rendered markup already carries the closed projection.
+    assertInstanceAriaFulfillment(navigationMenu, root, { active: null, pointerOpened: false }, {});
+    await user.click(trigger('products'));
+    assertInstanceAriaFulfillment(
+      navigationMenu,
+      root,
+      { active: 'products', pointerOpened: false },
+      {},
+    );
   });
 
   it('click opens a panel: content shown, trigger expanded', async () => {

--- a/packages/ui/test/components/navigation-menu/navigation-menu.behavior.test.ts
+++ b/packages/ui/test/components/navigation-menu/navigation-menu.behavior.test.ts
@@ -2,9 +2,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createBehavior } from '../../../src/lib/contract';
 import {
   activeItem,
-  navContentAria,
+  navInstanceAria,
   navigationMenu,
-  navTriggerAria,
   startNavigationMenuEffects,
   type NavigationMenuConfig,
 } from '../../../src/components/navigation-menu/navigation-menu.behavior';
@@ -123,38 +122,39 @@ describe('navigation-menu aria', () => {
   });
 
   it('trigger instances: expanded tracks the active value, controls is never dangling', () => {
-    const open = navTriggerAria('a', { active: 'a', pointerOpened: false }, base, {
-      contentId: 'c-a',
+    const open = navInstanceAria('trigger', 'a', { active: 'a', pointerOpened: false }, base, {
+      content: 'c-a',
     });
     expect(open).toEqual({
       'aria-expanded': 'true',
       'aria-controls': 'c-a',
       'data-state': 'open',
     });
-    const closed = navTriggerAria('b', { active: 'a', pointerOpened: false }, base, {
-      contentId: 'c-b',
+    const closed = navInstanceAria('trigger', 'b', { active: 'a', pointerOpened: false }, base, {
+      content: 'c-b',
     });
     expect(closed['aria-expanded']).toBe('false');
     expect(closed['data-state']).toBe('closed');
   });
 
   it('content instances: labelled by their trigger, hidden when closed', () => {
-    const open = navContentAria('a', { active: 'a', pointerOpened: false }, base, {
-      triggerId: 't-a',
+    const open = navInstanceAria('content', 'a', { active: 'a', pointerOpened: false }, base, {
+      trigger: 't-a',
     });
     expect(open).toEqual({ 'aria-labelledby': 't-a', 'data-state': 'open', hidden: undefined });
-    const closed = navContentAria('a', { active: null, pointerOpened: false }, base, {
-      triggerId: 't-a',
+    const closed = navInstanceAria('content', 'a', { active: null, pointerOpened: false }, base, {
+      trigger: 't-a',
     });
     expect(closed['hidden']).toBe(true);
   });
 
   it('instance projections read the CONTROLLED value', () => {
-    const aria = navTriggerAria(
+    const aria = navInstanceAria(
+      'trigger',
       'a',
       { active: null, pointerOpened: false },
       { value: 'a' },
-      { contentId: 'c' },
+      { content: 'c' },
     );
     expect(aria['aria-expanded']).toBe('true');
   });

--- a/packages/ui/test/components/navigation-menu/navigation-menu.conformance.test.tsx
+++ b/packages/ui/test/components/navigation-menu/navigation-menu.conformance.test.tsx
@@ -19,8 +19,13 @@ import {
   NavigationMenuViewport,
   navigationMenuTriggerStyle,
 } from '../../../src/components/navigation-menu/navigation-menu';
+import { navigationMenu } from '../../../src/components/navigation-menu/navigation-menu.behavior';
 import { navigationMenuClasses } from '../../../src/components/navigation-menu/navigation-menu.classes';
-import { assertAxeClean, partElement } from '../../harness/conformance';
+import {
+  assertAxeClean,
+  assertInstanceAriaFulfillment,
+  partElement,
+} from '../../harness/conformance';
 
 interface SetupProps {
   value?: string;
@@ -86,6 +91,21 @@ describe('navigation-menu conformance [react]', () => {
     const content = contentFor('products');
     expect(trigger.getAttribute('aria-controls')).toBe(content.id);
     expect(content.getAttribute('aria-labelledby')).toBe(trigger.id);
+  });
+
+  it('per-instance ARIA equals the score projection, closed and open', async () => {
+    const user = userEvent.setup();
+    render(<TestMenu />);
+    const root = partElement(body(), 'root') as HTMLElement;
+    // The generic harness reads spec.instanceAria and every rendered instance.
+    assertInstanceAriaFulfillment(navigationMenu, root, { active: null, pointerOpened: false }, {});
+    await user.click(triggerFor('products'));
+    assertInstanceAriaFulfillment(
+      navigationMenu,
+      root,
+      { active: 'products', pointerOpened: false },
+      {},
+    );
   });
 
   it('click opens, click again closes, clicking another switches', async () => {

--- a/packages/ui/test/components/navigation-menu/navigation-menu.element.conformance.test.ts
+++ b/packages/ui/test/components/navigation-menu/navigation-menu.element.conformance.test.ts
@@ -6,7 +6,9 @@
 import { cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { navigationMenu } from '../../../src/components/navigation-menu/navigation-menu.behavior';
 import { RaftersNavigationMenu } from '../../../src/components/navigation-menu/navigation-menu.element';
+import { assertInstanceAriaFulfillment } from '../../harness/conformance';
 
 beforeAll(() => {
   if (!customElements.get('rafters-navigation-menu')) {
@@ -50,6 +52,21 @@ describe('navigation-menu conformance [wc]', () => {
     expect(trigger('products').getAttribute('aria-expanded')).toBe('false');
     expect(trigger('products').getAttribute('aria-controls')).toBe('c-products');
     expect(content('products').getAttribute('aria-labelledby')).toBe('t-products');
+  });
+
+  it('per-instance ARIA equals the score projection, closed and open', async () => {
+    const user = userEvent.setup();
+    const root = await mount();
+    // The DOM-native binding writes hidden="true"; the harness asserts by
+    // presence, so the same driver holds across React/WC/Astro.
+    assertInstanceAriaFulfillment(navigationMenu, root, { active: null, pointerOpened: false }, {});
+    await user.click(trigger('products'));
+    assertInstanceAriaFulfillment(
+      navigationMenu,
+      root,
+      { active: 'products', pointerOpened: false },
+      {},
+    );
   });
 
   it('click opens, click again closes, clicking another switches', async () => {

--- a/packages/ui/test/harness/conformance.ts
+++ b/packages/ui/test/harness/conformance.ts
@@ -117,10 +117,12 @@ export function assertContractFulfillment<
 }
 
 /**
- * Tier 2 for many parts (Spec 01, ruled 2026-07-08): a part declared
- * `many: true` projects per instance via its sibling `<part>Aria` function.
- * The suite supplies the instance keys in DOM order; every rendered instance
- * is asserted against its own projection -- including absence.
+ * Tier 2 for `many` parts, BESPOKE variant: the suite supplies an
+ * `instanceAria(key)` closure and the DOM-order instance keys. Used by
+ * uniform-item components (radio-group, table) whose per-instance projection
+ * takes only the key -- no sibling ids -- so it lives beside the component, not
+ * on the spec. Spec-driven many parts (nav-menu) use
+ * `assertInstanceAriaFulfillment` below instead.
  */
 export function assertInstanceContractFulfillment<Part extends string>(
   root: HTMLElement,
@@ -147,6 +149,68 @@ export function assertInstanceContractFulfillment<Part extends string>(
         expect(element.getAttribute(attr), `instance "${key}" of "${part}" ${attr}`).toBe(
           String(value),
         );
+      }
+    }
+  }
+}
+
+/**
+ * Tier 2 for `many` parts (Spec 01, BehaviorSpec.instanceAria): the score's own
+ * `instanceAria(part, value, state, config, ids)` projects each instance, and
+ * this driver asserts every rendered instance against it -- generically, with
+ * NO per-component wiring. It reads which parts are `many` from the spec, finds
+ * each instance by its `data-value`, resolves the instance's sibling ids from
+ * the DOM (behaviors never generate ids -- Spec 01), and compares.
+ *
+ * A spec that omits `instanceAria` (statics, uniform-item components) has no
+ * per-instance ARIA to assert, so this is a no-op for them.
+ */
+export function assertInstanceAriaFulfillment<
+  Config,
+  State,
+  Actions extends ActionPayloads,
+  Part extends string,
+>(
+  spec: BehaviorSpec<Config, State, Actions, Part>,
+  root: HTMLElement,
+  state: State,
+  config: Config,
+): void {
+  const project = spec.instanceAria;
+  if (!project) return;
+
+  const manyParts = (Object.keys(spec.parts) as Part[]).filter((part) => spec.parts[part].many);
+  for (const part of manyParts) {
+    for (const element of partElements(root, part)) {
+      const value = element.dataset['value'];
+      if (value === undefined) continue;
+      const ids: Partial<Record<Part, string>> = {};
+      for (const sibling of manyParts) {
+        ids[sibling] =
+          root.querySelector<HTMLElement>(`[data-part="${sibling}"][data-value="${value}"]`)?.id ??
+          '';
+      }
+      for (const [attr, projected] of Object.entries(project(part, value, state, config, ids))) {
+        if (projected === undefined) {
+          expect(
+            element.hasAttribute(attr),
+            `instance "${value}" of "${part}" must NOT render ${attr}`,
+          ).toBe(false);
+        } else if (typeof projected === 'boolean') {
+          // A boolean projection asserts PRESENCE, not a serialized value:
+          // React writes hidden={true} as `hidden=""` while the DOM-native
+          // binding writes `hidden="true"`. hasAttribute is the only check that
+          // holds across all three frameworks. (Only `true`/undefined occur on
+          // nav-menu's `hidden`; a boolean `false` would diverge, but no score
+          // emits one -- absence is expressed as undefined.)
+          expect(element.hasAttribute(attr), `instance "${value}" of "${part}" ${attr}`).toBe(
+            projected,
+          );
+        } else {
+          expect(element.getAttribute(attr), `instance "${value}" of "${part}" ${attr}`).toBe(
+            projected,
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

`BehaviorSpec.aria` projects one `AriaAttrs` per part NAME, which cannot express N instances of a `many` part (navigation-menu has a trigger and a content panel per menu item). navigation-menu papered over this with bespoke `navTriggerAria`/`navContentAria` functions its decorators called by name -- a fallback every future many-part port (tabs/accordion/menubar/combobox) would have had to clone.

This adds a first-class, **optional** `instanceAria(part, value, state, config, ids)` to the contract, migrates navigation-menu onto it, and teaches the conformance harness to drive it generically -- so per-instance ARIA is asserted across React/WC/Astro with no bespoke wiring.

## Acceptance criteria mapping

### 1. Add optional `instanceAria?(part, value, state, config, ids): AriaAttrs` to the BehaviorSpec contract
The field is added to the `BehaviorSpec` interface, typed with a new `InstanceIds<Part> = Partial<Record<Part,string>>` alias. It is optional (`?`) so it does not become a required member and never cascades to the ~30 static specs or to uniform-item components -- radio-group's N-uniform roving (#1870) projects every item identically from just the key and continues to omit it. `Partial` is deliberate: `many` is a runtime `PartDecl` field, so the type cannot narrow to only-many keys -- only the instance's own many parts carry a key.
Evidence: packages/ui/src/lib/contract.ts:54 (optional instanceAria member), packages/ui/src/lib/contract.ts:30 (InstanceIds alias).

### 2. Migrate navigation-menu onto instanceAria, and update the .tsx/.astro decorators to call the generic instanceAria
A single `navInstanceAria` part-switches on `'trigger'`/`'content'`, merging the two former near-identical `navTriggerAria`/`navContentAria` bodies, and is attached to the spec via `{ ...compose('navigation-menu', navigation), instanceAria: navInstanceAria }` -- staying off the compose synthesis as the issue requires. Both access paths point at the SAME concrete function: the generic `navigationMenu.instanceAria` member is what the harness reaches, while the component's own typed decorators call the exported `navInstanceAria` directly (mirroring the existing `startNavigationMenuEffects` pattern and sidestepping the optional-member undefined narrowing -- one implementation, two access paths, zero drift). `bindNavigationMenu`'s instance loop derives the many-part set from `navigationMenu.parts[part].many` instead of a hardcoded trigger/content pair.
Evidence: packages/ui/src/components/navigation-menu/navigation-menu.behavior.ts:147 (navInstanceAria + spread-attach), navigation-menu.tsx:257 and navigation-menu.astro:74 (decorators call the generic fn), navigation-menu.behavior.ts:283 (many-parts derived from the spec).

### 3. Make the conformance harness drive instanceAria generically across React/WC/Astro
`assertInstanceAriaFulfillment(spec, root, state, config)` reads `spec.instanceAria` (no-op when absent), filters the spec's `many` parts, finds each instance by `data-value`, resolves the instance's sibling ids from the real DOM (behaviors never generate ids), and asserts the projection including absence. Its boolean branch asserts by `hasAttribute` rather than `String(value)` because React serializes `hidden={true}` to `hidden=""` while the DOM-native binding writes `hidden="true"` -- presence is the only framework-neutral check. All three nav-menu conformance suites call it in a closed + open scenario, so per-instance ARIA is asserted with no bespoke wiring.
Evidence: packages/ui/test/harness/conformance.ts:168 (generic driver), conformance.ts:199 (boolean hasAttribute branch), navigation-menu.conformance.test.tsx:101 / navigation-menu.element.conformance.test.ts:62 / navigation-menu.astro.conformance.test.ts:67 (React/WC/Astro call sites).

### 4. Conformance stays green and per-instance ARIA behavior is identical after the migration
`pnpm --filter @rafters/ui test:unit` passes (364 files / 5879 tests React+WC; 32 files / 170 tests Astro) and `pnpm preflight` passes. The behavior unit tests keep every `toEqual({...})` expected-attrs object byte-identical -- only the ids key names (`contentId`->`content`, `triggerId`->`trigger`) and the added part argument changed, which is the proof the projection output did not move.
Evidence: packages/ui/test/components/navigation-menu/navigation-menu.behavior.test.ts:125 and :141 (unchanged expected attrs), green test:unit + preflight runs.

## Not done

- **radio-group and table are NOT migrated to `instanceAria`.** They are uniform-item `many` components whose per-instance projection takes only the key (no sibling ids), so they keep the bespoke `assertInstanceContractFulfillment` harness variant and their own `radioItemAria`/`tableRowAttrs` functions. The issue explicitly cites radio-group (#1870) as proof N-uniform roving needs no `instanceAria`; migrating them is out of scope and would add indirection without payoff.
- **No new many-part components (tabs/accordion/menubar/combobox) are ported.** This PR only unblocks them by giving the contract + harness the seam; each port is its own issue.
- **effects.ts and the compose synthesis are untouched**, per the issue constraints -- `instanceAria` is attached to the composed spec object, not folded through `compose`.

Closes #1884
