### PR TITLE
feat(#1804): port typography to the behavior layer -- the static text set

### DIFF
--- a/packages/ui/docs/spec/components/typography.md
+++ b/packages/ui/docs/spec/components/typography.md
@@ -1,0 +1,109 @@
+# Component Spec — Typography
+
+Status: DRAFT. A STATIC score in the grain of Container: no state, no actions,
+no keymap, no effects. The semantic text set (H1–H6, P, Code, Small,
+Blockquote, List, and the presentational variants) proves the static grain
+scales to a *set* of elements — one score decides structure (variant → tag),
+the classes file carries the whole view, and each performance is pure
+decoration application (no `useMemory`, no controller, no composed primitives).
+
+Files (`src/components/typography/`):
+
+```
+typography.behavior.ts   typography.classes.ts   typography.tsx
+typography.element.ts     typography.astro
+```
+
+## Purpose
+
+The one text set. Agents never hand-roll `<h1 class="text-4xl font-bold …">`;
+they reach for `H1`, `P`, `Code`, `Blockquote`, `Ul`/`Li`, and token props tune
+individual dimensions. There is no raw class surface — every utility comes from
+the resolver.
+
+## Composition
+
+- **React**: named components — `H1`–`H6`, `P`, `Lead`, `Large`, `Muted`,
+  `Small`, `Code`, `CodeBlock`, `Blockquote`, `Mark`, `Abbr`, `Ul`/`Ol`/`Li`
+  (`List` aliases `Ul` for shadcn parity), plus a generic `Typography` with
+  `as`/`variant`. A factory builds each named component (DRY construction, not a
+  decision surface).
+- **Web Component**: `<rafters-typography variant="…">` renders the variant's
+  tag inside a shadow root (RaftersElement), carrying the shared composed
+  classes. Unknown `variant` falls back to `p` — never throws.
+- **Astro**: `<Typography as="…" variant="…">` renders the element through
+  Astro's dynamic-tag support (one tag, not the oracle's branch-per-element).
+
+## Config / state / actions
+
+- **Config**: `variant` (or, on the generic wrapper, `as` which derives the
+  variant) plus the eight token-prop dimensions —
+  `size` `weight` `color` `line` `tracking` `family` `align` `transform`.
+- **State**: none. `initialState()` returns `{}`.
+- **Actions**: none. `canDispatch()` is `true` (there is nothing to gate).
+
+## Structure contract
+
+- The **variant chooses the semantic element** (`variantToTag`): headings are
+  real `h1`–`h6`, `blockquote` is a real quotation, lists are real lists,
+  `code`/`mark`/`abbr` carry native semantics. `codeblock` renders `pre` and
+  nests a `code`.
+- The **element IS the accessibility contract** — which is why the score's ARIA
+  projection is empty and the conformance suite asserts the *element*, not a
+  projected role.
+- **Token props replace, never append.** Defaults are stored dimensionally so an
+  override swaps the matching dimension (`size="2xl"` on `H1` replaces
+  `text-4xl`, and suppresses the CQ `@lg:text-5xl` on that same dimension). A
+  non-size override leaves the CQ default surviving. This dodges the Tailwind
+  alphabetical-cascade trap (`text-accent` would otherwise lose to
+  `text-foreground`).
+- **`color` is a fill signature** (#1637), not a raw utility: a plain word emits
+  `text-{word}`; an invalid signature emits nothing. Same contract as
+  Container/Card.
+- **h5/h6 borrow h4.** The variant scale stops at h4; `H5`/`H6` (and `as="h5"`
+  /`"h6"`) render their own tag with h4's classes. `span` reads as body (`p`).
+
+## Parts + ARIA
+
+| Part | Element | Role | ARIA |
+| --- | --- | --- | --- |
+| `root` | the variant's semantic tag | native | none projected — the element carries the meaning |
+
+## Keyboard + effects
+
+None. A static text set has no interaction tier and no impure work: no keymap,
+and (Spec 03 is gone) no effects. The score composes no primitives.
+
+## Oracle dispositions (src/old/ui/typography.{tsx,classes.ts,element.ts,astro})
+
+| Oracle feature | Disposition |
+| --- | --- |
+| variant vocabulary (h1–h4, p, lead, large, small, muted, code, codeblock, blockquote, mark, abbr, ul, ol, li) | contract — ported verbatim in `typography.classes.ts` |
+| dimensional token props (size/weight/color/line/tracking/family/align/transform) | contract |
+| `color` as a fill signature (#1637) | contract |
+| variant → tag map + `p` fallback (`resolveVariant`) | contract — moved onto the score |
+| `as`-element → variant derivation (span→p, h5/h6→h4) | contract — moved onto the score as `variantForElement` |
+| h5/h6 as tags (no own variant scale) | ported as-is — h5/h6 render their tag with h4 classes |
+| generic `<Typography as … variant …>` | contract |
+| named per-tag components (H1…, P, Code, …) | contract — React factory; Astro's per-tag `.astro` files collapse into one dynamic tag |
+| editable / contenteditable / `onChange` / `onEnter` / `onBackspaceAtStart` / placeholder | **stripped** — block-editor concern, belongs in a studio-layer wrapper (matches Container's editable strip). `Fill, not background. No editor props.` |
+| `InlineToolbar` / `SlashMenu` / `SelectionInfo` / inline-mark rich text | **stripped** — editor surface, not the text set |
+| `CodeBlock` `language` / `showLineNumbers` | dropped — syntax highlighting + gutter are a studio/highlighter concern; `CodeBlock` renders `pre > code` only |
+| `Lead`/`Large`/`Muted`/`Mark`/`Abbr` presentational variants | contract — exposed as React named components; present in every framework's class vocabulary |
+
+## WCAG obligations (author-owned)
+
+- Follow heading order — H1 once per page, never skip a level. The component
+  renders the tag it is told; hierarchy discipline is the author's.
+- Do not use headings for styling only — use `P` with token props (`lead`,
+  `muted`, `large`) for visual weight without structural meaning.
+- Token-driven color must meet contrast; `color` resolves design tokens, but the
+  author owns the pairing.
+
+## Open
+
+- The article-flow utilities Container bakes for `as="article"` still point at
+  raw sizes, not the Typography role tokens; repointing both at shared display/
+  title/body role tokens is a designer pass (flagged on Container, not done
+  here).
+- `CodeBlock` line numbers / syntax highlighting await a highlighter primitive.

--- a/packages/ui/src/components/typography/typography.astro
+++ b/packages/ui/src/components/typography/typography.astro
@@ -1,0 +1,71 @@
+---
+/**
+ * Typography -- the Astro performance of the static score
+ * (typography.behavior.ts). A static has nothing to subscribe to: this is pure
+ * decoration application, zero client JavaScript. `as` chooses the semantic
+ * element and derives the variant (via the score's `variantForElement`: h5/h6
+ * borrow h4's scale, span reads as body); an explicit `variant` overrides that.
+ * Token props override individual typography dimensions.
+ *
+ * The element is rendered through Astro's dynamic-tag support (a capitalized
+ * variable bound to a native element name), so element selection is one tag,
+ * not the branch-per-element the oracle (src/old/ui/typography.astro) paid for
+ * by hand.
+ *
+ * @cognitive-load 1/10
+ */
+import type { HTMLAttributes } from 'astro/types';
+import classy from '../../primitives/classy';
+import {
+  resolveVariant,
+  variantForElement,
+  type TypographyElement,
+  type TypographyVariant,
+} from './typography.behavior';
+import { resolveTypography } from './typography.classes';
+
+interface Props extends HTMLAttributes<'div'> {
+  as?: TypographyElement;
+  variant?: TypographyVariant;
+  size?: string;
+  weight?: string;
+  color?: string;
+  line?: string;
+  tracking?: string;
+  family?: string;
+  align?: string;
+  transform?: string;
+}
+
+const {
+  as: Tag = 'p',
+  variant,
+  size,
+  weight,
+  color,
+  line,
+  tracking,
+  family,
+  align,
+  transform,
+  class: className,
+  ...attrs
+} = Astro.props;
+
+const resolvedVariant = variant ? resolveVariant(variant) : variantForElement(Tag);
+const classes = classy(
+  resolveTypography(resolvedVariant, {
+    size,
+    weight,
+    color,
+    line,
+    tracking,
+    family,
+    align,
+    transform,
+  }),
+  className,
+);
+---
+
+<Tag data-part="root" class={classes} {...attrs}><slot /></Tag>

--- a/packages/ui/src/components/typography/typography.behavior.ts
+++ b/packages/ui/src/components/typography/typography.behavior.ts
@@ -1,0 +1,148 @@
+import type { BehaviorSpec } from '../../lib/contract';
+
+/**
+ * Typography: a STATIC score, in the grain of container. The semantic text
+ * set (H1-H6, P, Code, Small, Blockquote, List, and the presentational
+ * variants) has no state, no actions, no keymap, and no effects -- its whole
+ * contract is structural: a variant chooses a native text element (the score's
+ * `variantToTag`) and the classes file dresses it with token-prop utilities.
+ * The element IS the accessibility contract (a heading is a heading, a
+ * blockquote is a quotation), which is why the aria projection is empty and
+ * the harness asserts the ELEMENT, not a projected role.
+ *
+ * The score owns two pure structural decisions so they survive with no DOM:
+ * - `variantToTag` / `resolveVariant`: variant -> semantic tag, unknown -> `p`.
+ * - `variantForElement`: the generic `as`-element -> variant defaulting the
+ *   Astro/React wrappers use (h5/h6 borrow h4's scale; span reads as body).
+ */
+
+export type TypographyVariant =
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'p'
+  | 'lead'
+  | 'large'
+  | 'small'
+  | 'muted'
+  | 'code'
+  | 'codeblock'
+  | 'blockquote'
+  | 'mark'
+  | 'abbr'
+  | 'ul'
+  | 'ol'
+  | 'li';
+
+/**
+ * The native element a consumer may hand the generic wrapper via `as`. A
+ * superset of the tags variants render (adds h5/h6/span), because the generic
+ * component lets the element drive and derives the variant from it.
+ */
+export type TypographyElement =
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6'
+  | 'p'
+  | 'blockquote'
+  | 'code'
+  | 'small'
+  | 'span'
+  | 'mark';
+
+/**
+ * Per-dimension token-prop overrides. Each replaces the matching dimension of
+ * the variant's defaults at emit time (see typography.classes.ts). `undefined`
+ * is explicit for exactOptionalPropertyTypes.
+ */
+export interface TypographyTokenProps {
+  size?: string | undefined;
+  weight?: string | undefined;
+  color?: string | undefined;
+  line?: string | undefined;
+  tracking?: string | undefined;
+  family?: string | undefined;
+  align?: string | undefined;
+  transform?: string | undefined;
+}
+
+export interface TypographyConfig extends TypographyTokenProps {
+  variant?: TypographyVariant | undefined;
+}
+
+export type TypographyState = Record<never, never>;
+export type TypographyActions = Record<never, never>;
+export type TypographyPart = 'root';
+
+/**
+ * Variant -> semantic HTML tag (the element the wrappers render). Unknown
+ * variants fall back to `p` via `resolveVariant` -- this map NEVER throws.
+ * `codeblock` renders `pre` (its wrapper nests a `code` inside).
+ */
+export const variantToTag: Record<TypographyVariant, string> = {
+  h1: 'h1',
+  h2: 'h2',
+  h3: 'h3',
+  h4: 'h4',
+  p: 'p',
+  lead: 'p',
+  large: 'p',
+  small: 'small',
+  muted: 'p',
+  code: 'code',
+  codeblock: 'pre',
+  blockquote: 'blockquote',
+  mark: 'mark',
+  abbr: 'abbr',
+  ul: 'ul',
+  ol: 'ol',
+  li: 'li',
+};
+
+/**
+ * Coerce an arbitrary value to a known variant. Unknown or empty values fall
+ * back to `p`. NEVER throws -- the WC reads an untrusted attribute through this.
+ */
+export function resolveVariant(value: unknown): TypographyVariant {
+  if (typeof value !== 'string' || value.length === 0) return 'p';
+  if (value in variantToTag) return value as TypographyVariant;
+  return 'p';
+}
+
+/**
+ * The generic wrapper's element -> variant defaulting. `span` reads as body
+ * text (`p`); h5/h6 have no variant scale of their own and borrow h4's; any
+ * other element that is itself a variant maps to that variant. Faithful to the
+ * oracle's Astro resolution -- the variant vocabulary stops at h4, the tags do
+ * not.
+ */
+export function variantForElement(element: TypographyElement): TypographyVariant {
+  if (element === 'span') return 'p';
+  if (element === 'h5' || element === 'h6') return 'h4';
+  return resolveVariant(element);
+}
+
+/**
+ * The static score. Empty everywhere an interactive score is not: no state to
+ * hold, no actions to dispatch, no keys to bind, and (Spec 03 is gone) no
+ * effects to run. The one part is the rendered text element; its ARIA is the
+ * empty projection because the semantic tag carries the meaning natively.
+ */
+export const typography: BehaviorSpec<
+  TypographyConfig,
+  TypographyState,
+  TypographyActions,
+  TypographyPart
+> = {
+  name: 'typography',
+  parts: { root: {} },
+  initialState: () => ({}),
+  actions: {},
+  canDispatch: () => true,
+  aria: () => ({ root: {} }),
+  keymap: () => null,
+};

--- a/packages/ui/src/components/typography/typography.classes.ts
+++ b/packages/ui/src/components/typography/typography.classes.ts
@@ -1,0 +1,162 @@
+/**
+ * Class resolution for Typography -- the view over the static score.
+ *
+ * Variant defaults are stored dimensionally (size, weight, color, line,
+ * tracking, family, align, transform) rather than as flat utility strings.
+ * Token-prop overrides replace the matching dimension at emit time, so defaults
+ * never fight overrides in the Tailwind cascade (which orders utilities
+ * alphabetically and thus cannot be trusted for overrides: `text-accent` would
+ * lose to `text-foreground` on 'a' < 'f').
+ *
+ * Ported from the oracle (src/old/ui/typography.classes.ts) verbatim; the
+ * TypographyVariant / TypographyTokenProps types now live on the score
+ * (typography.behavior.ts) so the pure behavior test imports them with no DOM.
+ */
+
+import { resolveFillName } from '../../primitives/fill-resolver';
+import type { TypographyTokenProps, TypographyVariant } from './typography.behavior';
+
+interface CqOverrides {
+  size?: string;
+  weight?: string;
+  line?: string;
+  tracking?: string;
+}
+
+interface VariantDefaults extends TypographyTokenProps {
+  layout?: string;
+  cq?: Record<string, CqOverrides>;
+}
+
+const VARIANTS: Record<TypographyVariant, VariantDefaults> = {
+  h1: {
+    size: '4xl',
+    weight: 'bold',
+    tracking: 'tight',
+    color: 'foreground',
+    layout: 'scroll-m-20',
+    cq: { lg: { size: '5xl' } },
+  },
+  h2: {
+    size: '3xl',
+    weight: 'semibold',
+    tracking: 'tight',
+    color: 'foreground',
+    layout: 'scroll-m-20',
+  },
+  h3: {
+    size: '2xl',
+    weight: 'semibold',
+    tracking: 'tight',
+    color: 'foreground',
+    layout: 'scroll-m-20',
+  },
+  h4: {
+    size: 'xl',
+    weight: 'semibold',
+    tracking: 'tight',
+    color: 'foreground',
+    layout: 'scroll-m-20',
+  },
+  p: { line: '7', color: 'foreground' },
+  lead: { size: 'xl', color: 'muted-foreground' },
+  large: { size: 'lg', weight: 'semibold', color: 'foreground' },
+  small: { size: 'sm', weight: 'medium', line: 'none', color: 'foreground' },
+  muted: { size: 'sm', color: 'muted-foreground' },
+  code: {
+    size: 'sm',
+    family: 'mono',
+    color: 'foreground',
+    layout: 'rounded bg-muted px-1 py-0.5',
+  },
+  codeblock: {
+    size: 'sm',
+    family: 'mono',
+    color: 'foreground',
+    layout: 'relative rounded-lg bg-muted p-4 overflow-x-auto [&_code]:bg-transparent [&_code]:p-0',
+  },
+  blockquote: { color: 'foreground', layout: 'mt-6 border-l-2 border-border pl-6 italic' },
+  mark: { color: 'accent-foreground', layout: 'bg-accent px-1 rounded' },
+  abbr: { layout: 'cursor-help underline decoration-dotted underline-offset-4' },
+  ul: { color: 'foreground', layout: 'my-6 ml-6 list-disc [&>li]:mt-2' },
+  ol: { color: 'foreground', layout: 'my-6 ml-6 list-decimal [&>li]:mt-2' },
+  li: { line: '7' },
+};
+
+const DIM_TO_UTIL: Record<keyof TypographyTokenProps, (v: string) => string> = {
+  size: (v) => `text-${v}`,
+  weight: (v) => `font-${v}`,
+  line: (v) => `leading-${v}`,
+  tracking: (v) => `tracking-${v}`,
+  family: (v) => `font-${v}`,
+  align: (v) => `text-${v}`,
+  transform: (v) => v,
+  // Fill signature in text context: plain words emit text-{word}; a
+  // word-to-word signature emits gradient text via bg-clip-text. Invalid
+  // signatures emit nothing -- same contract as Container/Card (#1637).
+  color: (v) => resolveFillName(v, 'text'),
+};
+
+const DIM_KEYS = Object.keys(DIM_TO_UTIL) as (keyof TypographyTokenProps)[];
+
+function emitDim(dim: keyof TypographyTokenProps, value: string, prefix = ''): string {
+  const util = DIM_TO_UTIL[dim](value);
+  if (!util || !prefix) return util;
+  return util
+    .split(/\s+/)
+    .map((u) => `${prefix}${u}`)
+    .join(' ');
+}
+
+function emitProps(props: TypographyTokenProps, prefix = ''): string {
+  const classes: string[] = [];
+  for (const key of DIM_KEYS) {
+    const value = props[key];
+    if (value == null) continue;
+    const util = emitDim(key, value, prefix);
+    if (util) classes.push(util);
+  }
+  return classes.join(' ');
+}
+
+export function resolveTypography(
+  variant: TypographyVariant,
+  overrides: TypographyTokenProps = {},
+): string {
+  const defaults = VARIANTS[variant];
+  const merged: TypographyTokenProps = {};
+  for (const key of DIM_KEYS) merged[key] = overrides[key] ?? defaults[key];
+
+  const parts: string[] = [];
+  if (defaults.layout) parts.push(defaults.layout);
+  parts.push(emitProps(merged));
+
+  // CQ defaults survive only where the prop didn't override the same dimension.
+  if (defaults.cq) {
+    for (const [breakpoint, cqDefaults] of Object.entries(defaults.cq)) {
+      const surviving: TypographyTokenProps = {};
+      for (const key of Object.keys(cqDefaults) as (keyof CqOverrides)[]) {
+        if (overrides[key] == null) surviving[key] = cqDefaults[key];
+      }
+      parts.push(emitProps(surviving, `@${breakpoint}:`));
+    }
+  }
+
+  return parts.filter(Boolean).join(' ');
+}
+
+/**
+ * Emit token-prop classes without any variant defaults. Exposed for tests that
+ * exercise the prop-to-utility emit path in isolation.
+ */
+export function tokenPropsToClasses(props: TypographyTokenProps): string {
+  return emitProps(props);
+}
+
+/**
+ * Flat-string map of variant defaults with no overrides. Kept for consumers
+ * that need the baseline class string (e.g. List's li, CodeBlock wrapper).
+ */
+export const typographyClasses = Object.fromEntries(
+  (Object.keys(VARIANTS) as TypographyVariant[]).map((v) => [v, resolveTypography(v)]),
+) as Record<TypographyVariant, string>;

--- a/packages/ui/src/components/typography/typography.element.ts
+++ b/packages/ui/src/components/typography/typography.element.ts
@@ -1,0 +1,112 @@
+/**
+ * <rafters-typography> -- the Web Component performance of the static score.
+ *
+ * Like container/card, Typography is a PURE STATIC: empty ARIA projection, no
+ * state, no effects, so there is nothing to bind -- no `bindTypography` exists.
+ * The element renders once inside its shadow root from the shared class
+ * resolver (resolveTypography), so the WC carries the EXACT composition the
+ * React and Astro performances do. Presentation resolves from the compiled
+ * utility sheet adopted by RaftersElement plus the token custom properties
+ * inherited from the host :root.
+ *
+ * The `variant` attribute drives both the rendered tag (via the score's
+ * `variantToTag`) and the composed class string. TypographyTokenProps
+ * attributes (size/weight/color/line/tracking/family/align/transform) override
+ * the variant defaults at compose time. Unknown variants fall back to `p` --
+ * NEVER throws. DOM is built via createElement/appendChild; no innerHTML.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import {
+  resolveVariant,
+  variantToTag,
+  type TypographyTokenProps,
+  type TypographyVariant,
+} from './typography.behavior';
+import { resolveTypography } from './typography.classes';
+
+export type { TypographyTokenProps, TypographyVariant } from './typography.behavior';
+
+/** Attribute names that map to TypographyTokenProps keys. */
+const OVERRIDE_ATTRIBUTES = [
+  'size',
+  'weight',
+  'color',
+  'line',
+  'tracking',
+  'family',
+  'align',
+  'transform',
+] as const;
+
+type OverrideAttribute = (typeof OVERRIDE_ATTRIBUTES)[number];
+
+/** All attributes the element observes. Variant is first; overrides follow. */
+const OBSERVED_ATTRIBUTES = ['variant', ...OVERRIDE_ATTRIBUTES] as const;
+
+/**
+ * Compose the inner element's class string from the shared resolver. Exported
+ * so tests assert the WC renders the exact same composition the Astro/React
+ * targets do -- the parity guarantee.
+ */
+export function composeTypographyClasses(
+  variant: TypographyVariant,
+  overrides: TypographyTokenProps = {},
+): string {
+  return resolveTypography(variant, overrides);
+}
+
+export class RaftersTypography extends RaftersElement {
+  static override styles = ':host { display: block; }';
+
+  static readonly observedAttributes: readonly string[] = OBSERVED_ATTRIBUTES;
+
+  /**
+   * Read all TypographyTokenProps attributes off the element, omitting absent
+   * entries so the resolver skips them cleanly.
+   */
+  private readOverrides(): TypographyTokenProps {
+    const out: TypographyTokenProps = {};
+    for (const attr of OVERRIDE_ATTRIBUTES) {
+      const value = this.getAttribute(attr);
+      if (value !== null && value.length > 0) {
+        out[attr satisfies OverrideAttribute] = value;
+      }
+    }
+    return out;
+  }
+
+  /** Resolve the current variant from the `variant` attribute. */
+  private currentVariant(): TypographyVariant {
+    return resolveVariant(this.getAttribute('variant'));
+  }
+
+  /**
+   * Build the semantic tag tree for the current variant, carrying the composed
+   * utility class string and data-part="root" (the harness contract).
+   * codeblock -> pre > code > slot; all other variants -> tag > slot.
+   */
+  override render(): Node {
+    const variant = this.currentVariant();
+    const tag = variantToTag[variant];
+    const className = composeTypographyClasses(variant, this.readOverrides());
+    const root = document.createElement(tag);
+    root.setAttribute('data-part', 'root');
+    if (className) root.className = className;
+
+    if (variant === 'codeblock') {
+      const code = document.createElement('code');
+      code.appendChild(document.createElement('slot'));
+      root.appendChild(code);
+      return root;
+    }
+
+    root.appendChild(document.createElement('slot'));
+    return root;
+  }
+}
+
+const TAG_NAME = 'rafters-typography';
+if (typeof customElements !== 'undefined' && !customElements.get(TAG_NAME)) {
+  customElements.define(TAG_NAME, RaftersTypography);
+}

--- a/packages/ui/src/components/typography/typography.tsx
+++ b/packages/ui/src/components/typography/typography.tsx
@@ -1,0 +1,149 @@
+import * as React from 'react';
+import classy from '../../primitives/classy';
+import {
+  resolveVariant,
+  variantForElement,
+  variantToTag,
+  type TypographyElement,
+  type TypographyTokenProps,
+  type TypographyVariant,
+} from './typography.behavior';
+import { resolveTypography } from './typography.classes';
+
+/**
+ * The React performances of the static Typography score. A static has nothing
+ * to subscribe to -- no useMemory, no controller, no composed primitives: token
+ * props in, resolved classes out, the semantic tag chosen by the variant. Each
+ * named component is a thin wrapper the factory builds; the only two things
+ * added around the score are the view (typography.classes.ts) and the tag.
+ */
+
+export type {
+  TypographyElement,
+  TypographyTokenProps,
+  TypographyVariant,
+} from './typography.behavior';
+
+export interface TypographyComponentProps
+  extends React.HTMLAttributes<HTMLElement>, TypographyTokenProps {}
+
+interface FactoryOptions {
+  /** codeblock nests its children in a <code> inside the <pre> root. */
+  nestCode?: boolean;
+}
+
+function splitTokenProps(props: TypographyComponentProps): {
+  tokens: TypographyTokenProps;
+  rest: Omit<TypographyComponentProps, keyof TypographyTokenProps>;
+} {
+  const { size, weight, color, line, tracking, family, align, transform, ...rest } = props;
+  return { tokens: { size, weight, color, line, tracking, family, align, transform }, rest };
+}
+
+/**
+ * Build a named typography component for a fixed variant + tag. This is DRY
+ * construction, not a decision surface -- every variant runs the same
+ * resolveTypography path, so the wrapper stays thin.
+ */
+function makeTypography(
+  variant: TypographyVariant,
+  tag: string,
+  displayName: string,
+  options: FactoryOptions = {},
+): React.ForwardRefExoticComponent<TypographyComponentProps & React.RefAttributes<HTMLElement>> {
+  const Component = React.forwardRef<HTMLElement, TypographyComponentProps>((props, ref) => {
+    const { tokens, rest } = splitTokenProps(props);
+    const { className, children, ...attrs } = rest;
+    const classes = classy(resolveTypography(variant, tokens), className);
+    const content = options.nestCode ? React.createElement('code', null, children) : children;
+    return React.createElement(
+      tag,
+      { ref, 'data-part': 'root', className: classes || undefined, ...attrs },
+      content,
+    );
+  });
+  Component.displayName = displayName;
+  return Component;
+}
+
+// Headings. h5/h6 render their own tags but borrow h4's scale -- the variant
+// vocabulary stops at h4, faithful to the oracle.
+export const H1 = makeTypography('h1', 'h1', 'H1');
+export const H2 = makeTypography('h2', 'h2', 'H2');
+export const H3 = makeTypography('h3', 'h3', 'H3');
+export const H4 = makeTypography('h4', 'h4', 'H4');
+export const H5 = makeTypography('h4', 'h5', 'H5');
+export const H6 = makeTypography('h4', 'h6', 'H6');
+
+// Body and its presentational variants (all render <p>).
+export const P = makeTypography('p', 'p', 'P');
+export const Lead = makeTypography('lead', 'p', 'Lead');
+export const Large = makeTypography('large', 'p', 'Large');
+export const Muted = makeTypography('muted', 'p', 'Muted');
+
+// Inline + block text.
+export const Small = makeTypography('small', 'small', 'Small');
+export const Code = makeTypography('code', 'code', 'Code');
+export const CodeBlock = makeTypography('codeblock', 'pre', 'CodeBlock', { nestCode: true });
+export const Blockquote = makeTypography('blockquote', 'blockquote', 'Blockquote');
+export const Mark = makeTypography('mark', 'mark', 'Mark');
+export const Abbr = makeTypography('abbr', 'abbr', 'Abbr');
+
+// Lists.
+export const Ul = makeTypography('ul', 'ul', 'Ul');
+export const Ol = makeTypography('ol', 'ol', 'Ol');
+export const Li = makeTypography('li', 'li', 'Li');
+/** shadcn parity alias: the default list is an unordered list. */
+export const List = Ul;
+
+export interface TypographyProps extends TypographyComponentProps {
+  /** Native element to render. Drives the variant when `variant` is absent. */
+  as?: TypographyElement;
+  /** Preset. Overrides the element-derived variant. */
+  variant?: TypographyVariant;
+}
+
+/**
+ * The generic wrapper: an escape hatch for dynamic element selection. `as`
+ * chooses the tag and derives the variant (h5/h6 borrow h4; span reads as
+ * body); an explicit `variant` overrides that derivation.
+ *
+ * @cognitive-load 1/10 - decision 0, information 1, interaction 0, disruption
+ * 0, learning 0. Reading text is not a decision and not an interaction; the
+ * only load is parsing the words themselves. Consistent hierarchy makes even
+ * that information cost lower, not higher. A static, universally learned
+ * surface with zero workflow disruption.
+ * @attention-economics Hierarchy IS the attention budget: one H1 names the
+ * page, H2/H3 rank the sections, body text recedes, muted/small step further
+ * back. The scale spends contrast where attention should land and withholds it
+ * everywhere else, so a scan resolves structure before a single word is read.
+ * @trust-building Consistent type across every element and framework reads as
+ * professional and considered; a stable heading hierarchy makes long content
+ * feel navigable and honest rather than arbitrary. Nothing shifts, nothing
+ * surprises -- the text set is furniture the reader stops noticing.
+ * @accessibility The semantic element IS the contract: headings are real
+ * h1-h6 (screen-reader document outline, never headings-for-styling),
+ * blockquote is a real quotation, lists are real lists, code/mark/abbr carry
+ * native semantics. No ARIA is projected because none is needed; authors own
+ * heading order (never skip a level) and sufficient token-driven contrast.
+ */
+export const Typography = React.forwardRef<HTMLElement, TypographyProps>((props, ref) => {
+  const { as: element = 'p', variant, ...componentProps } = props;
+  const { tokens, rest } = splitTokenProps(componentProps);
+  const { className, children, ...attrs } = rest;
+  const resolvedVariant = variant ? resolveVariant(variant) : variantForElement(element);
+  const classes = classy(resolveTypography(resolvedVariant, tokens), className);
+  return React.createElement(
+    element,
+    { ref, 'data-part': 'root', className: classes || undefined, ...attrs },
+    children,
+  );
+});
+
+Typography.displayName = 'Typography';
+
+// Re-exported for callers that build the class string directly (parity guard).
+export { resolveTypography, typographyClasses } from './typography.classes';
+export { variantToTag };
+
+export default Typography;

--- a/packages/ui/test/components/typography/typography.astro.conformance.test.ts
+++ b/packages/ui/test/components/typography/typography.astro.conformance.test.ts
@@ -1,0 +1,65 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { afterEach, describe, expect, it } from 'vitest';
+import { assertAxeClean, partElement } from '../../harness/conformance';
+import Typography from '../../../src/components/typography/typography.astro';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+async function render(props: Record<string, unknown>, slot = 'content'): Promise<HTMLElement> {
+  const astroContainer = await AstroContainer.create();
+  const html = await astroContainer.renderToString(Typography, {
+    props,
+    slots: { default: slot },
+  });
+  // Wrap in a landmark so bare text is not flagged by the axe region rule.
+  document.body.innerHTML = `<main>${html}</main>`;
+  return document.body;
+}
+
+describe('typography conformance [astro]', () => {
+  it('as chooses the element and derives the variant; data-part root is present', async () => {
+    const body = await render({ as: 'h1' }, 'Title');
+    const root = partElement(body, 'root');
+    expect(root?.tagName.toLowerCase()).toBe('h1');
+    expect(root?.className).toContain('text-4xl');
+    expect(root?.className).toContain('@lg:text-5xl');
+    await assertAxeClean(body);
+  });
+
+  it('h5 renders its own tag but borrows h4 scale', async () => {
+    const body = await render({ as: 'h5' }, 'Sub');
+    const root = partElement(body, 'root') as HTMLElement;
+    expect(root.tagName.toLowerCase()).toBe('h5');
+    expect(root.className).toContain('text-xl');
+  });
+
+  it('span reads as body text', async () => {
+    const body = await render({ as: 'span' }, 'inline');
+    const root = partElement(body, 'root') as HTMLElement;
+    expect(root.tagName.toLowerCase()).toBe('span');
+    expect(root.className).toContain('leading-7');
+  });
+
+  it('an explicit variant overrides the element-derived one', async () => {
+    const body = await render({ as: 'p', variant: 'lead' }, 'intro');
+    const root = partElement(body, 'root') as HTMLElement;
+    expect(root.tagName.toLowerCase()).toBe('p');
+    expect(root.className).toContain('text-xl');
+  });
+
+  it('token props override the variant default', async () => {
+    const body = await render({ as: 'h1', size: '2xl' }, 'Title');
+    const root = partElement(body, 'root') as HTMLElement;
+    expect(root.className).toContain('text-2xl');
+    expect(root.className).not.toContain('text-4xl');
+  });
+
+  it('consumer class merges via classy', async () => {
+    const body = await render({ as: 'p', class: 'max-w-prose' }, 'x');
+    const root = partElement(body, 'root') as HTMLElement;
+    expect(root.className).toContain('leading-7');
+    expect(root.className).toContain('max-w-prose');
+  });
+});

--- a/packages/ui/test/components/typography/typography.behavior.test.ts
+++ b/packages/ui/test/components/typography/typography.behavior.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveVariant,
+  typography,
+  variantForElement,
+  variantToTag,
+  type TypographyVariant,
+} from '../../../src/components/typography/typography.behavior';
+
+describe('typography score', () => {
+  it('is a static: one part, empty aria, no keymap, no state', () => {
+    expect(Object.keys(typography.parts)).toEqual(['root']);
+    expect(typography.parts.root).toEqual({});
+    expect(typography.initialState({})).toEqual({});
+    expect(typography.aria({}, {}, { root: 'r' })).toEqual({ root: {} });
+    expect(typography.keymap({ key: 'Enter' }, {}, 'root', {})).toBeNull();
+    expect(typography.canDispatch({}, 'noop' as never, {})).toBe(true);
+  });
+});
+
+describe('variantToTag', () => {
+  it('maps each variant to its semantic element', () => {
+    expect(variantToTag.h1).toBe('h1');
+    expect(variantToTag.h4).toBe('h4');
+    expect(variantToTag.p).toBe('p');
+    // Presentational variants render <p>.
+    expect(variantToTag.lead).toBe('p');
+    expect(variantToTag.large).toBe('p');
+    expect(variantToTag.muted).toBe('p');
+    expect(variantToTag.small).toBe('small');
+    expect(variantToTag.code).toBe('code');
+    expect(variantToTag.codeblock).toBe('pre');
+    expect(variantToTag.blockquote).toBe('blockquote');
+    expect(variantToTag.mark).toBe('mark');
+    expect(variantToTag.abbr).toBe('abbr');
+    expect(variantToTag.ul).toBe('ul');
+    expect(variantToTag.ol).toBe('ol');
+    expect(variantToTag.li).toBe('li');
+  });
+
+  it('covers every variant in the vocabulary', () => {
+    const variants: TypographyVariant[] = [
+      'h1',
+      'h2',
+      'h3',
+      'h4',
+      'p',
+      'lead',
+      'large',
+      'small',
+      'muted',
+      'code',
+      'codeblock',
+      'blockquote',
+      'mark',
+      'abbr',
+      'ul',
+      'ol',
+      'li',
+    ];
+    for (const variant of variants) {
+      expect(variantToTag[variant]).toBeTruthy();
+    }
+  });
+});
+
+describe('resolveVariant', () => {
+  it('passes known variants through', () => {
+    expect(resolveVariant('h2')).toBe('h2');
+    expect(resolveVariant('blockquote')).toBe('blockquote');
+  });
+
+  it('falls back to p for unknown, empty, or non-string values -- never throws', () => {
+    expect(resolveVariant('display')).toBe('p');
+    expect(resolveVariant('')).toBe('p');
+    expect(resolveVariant(null)).toBe('p');
+    expect(resolveVariant(undefined)).toBe('p');
+    expect(resolveVariant(42)).toBe('p');
+  });
+});
+
+describe('variantForElement', () => {
+  it('derives the variant from the native element', () => {
+    expect(variantForElement('h1')).toBe('h1');
+    expect(variantForElement('blockquote')).toBe('blockquote');
+    expect(variantForElement('code')).toBe('code');
+  });
+
+  it('span reads as body text', () => {
+    expect(variantForElement('span')).toBe('p');
+  });
+
+  it('h5 and h6 have no scale of their own and borrow h4', () => {
+    expect(variantForElement('h5')).toBe('h4');
+    expect(variantForElement('h6')).toBe('h4');
+  });
+});

--- a/packages/ui/test/components/typography/typography.classes.test.ts
+++ b/packages/ui/test/components/typography/typography.classes.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveTypography,
+  tokenPropsToClasses,
+  typographyClasses,
+} from '../../../src/components/typography/typography.classes';
+
+describe('resolveTypography variant defaults', () => {
+  it('h1 carries its dimensional defaults and the CQ upscale', () => {
+    const h1 = resolveTypography('h1');
+    expect(h1).toContain('text-4xl');
+    expect(h1).toContain('font-bold');
+    expect(h1).toContain('tracking-tight');
+    expect(h1).toContain('text-foreground');
+    expect(h1).toContain('scroll-m-20');
+    expect(h1).toContain('@lg:text-5xl');
+  });
+
+  it('p is body flow, small tightens its leading', () => {
+    expect(resolveTypography('p')).toContain('leading-7');
+    expect(resolveTypography('small')).toContain('text-sm');
+    expect(resolveTypography('small')).toContain('leading-none');
+  });
+
+  it('code and codeblock are monospace surfaces', () => {
+    const code = resolveTypography('code');
+    expect(code).toContain('font-mono');
+    expect(code).toContain('bg-muted');
+    expect(resolveTypography('codeblock')).toContain('overflow-x-auto');
+  });
+
+  it('lists carry their marker layout', () => {
+    expect(resolveTypography('ul')).toContain('list-disc');
+    expect(resolveTypography('ol')).toContain('list-decimal');
+  });
+});
+
+describe('token-prop overrides', () => {
+  it('replace the matching dimension, not append to it', () => {
+    const h1 = resolveTypography('h1', { size: '2xl' });
+    expect(h1).toContain('text-2xl');
+    expect(h1).not.toContain('text-4xl');
+  });
+
+  it('a size override suppresses the CQ default on the same dimension', () => {
+    const h1 = resolveTypography('h1', { size: '2xl' });
+    expect(h1).not.toContain('@lg:text-5xl');
+  });
+
+  it('a non-size override leaves the CQ default surviving', () => {
+    const h1 = resolveTypography('h1', { weight: 'black' });
+    expect(h1).toContain('font-black');
+    expect(h1).not.toContain('font-bold');
+    expect(h1).toContain('@lg:text-5xl');
+  });
+});
+
+describe('color is a fill signature', () => {
+  it('a plain word emits text-{word}', () => {
+    expect(resolveTypography('p', { color: 'accent' })).toContain('text-accent');
+  });
+
+  it('an invalid signature emits nothing for the color dimension', () => {
+    // Empty override string is skipped; the variant default still lands.
+    expect(resolveTypography('p', { color: 'foreground' })).toContain('text-foreground');
+  });
+});
+
+describe('emit path in isolation', () => {
+  it('tokenPropsToClasses emits only the given dimensions, no defaults', () => {
+    expect(tokenPropsToClasses({ size: 'lg', weight: 'bold' })).toBe('text-lg font-bold');
+    expect(tokenPropsToClasses({})).toBe('');
+  });
+
+  it('typographyClasses is the baseline map with no overrides', () => {
+    expect(typographyClasses.p).toBe(resolveTypography('p'));
+    expect(typographyClasses.h1).toContain('text-4xl');
+  });
+});

--- a/packages/ui/test/components/typography/typography.conformance.test.tsx
+++ b/packages/ui/test/components/typography/typography.conformance.test.tsx
@@ -1,0 +1,137 @@
+import * as React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  Blockquote,
+  Code,
+  CodeBlock,
+  H1,
+  H5,
+  Li,
+  Small,
+  Typography,
+  Ul,
+  P,
+} from '../../../src/components/typography/typography';
+import { assertAxeClean } from '../../harness/conformance';
+
+const body = () => document.body;
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('typography conformance [react]', () => {
+  it('the semantic element IS the contract: each variant renders its tag with data-part root', () => {
+    render(
+      <main>
+        <H1>Title</H1>
+        <P>Body prose.</P>
+        <Blockquote>Quoted.</Blockquote>
+        <P>
+          Inline <Code>useState</Code> and <Small>small print</Small>.
+        </P>
+        <Ul>
+          <Li>one</Li>
+          <Li>two</Li>
+        </Ul>
+      </main>,
+    );
+    const h1 = body().querySelector('h1');
+    expect(h1).not.toBeNull();
+    expect(h1?.getAttribute('data-part')).toBe('root');
+    expect(h1?.className).toContain('text-4xl');
+    expect(body().querySelector('blockquote')).not.toBeNull();
+    expect(body().querySelector('code')?.className).toContain('font-mono');
+    expect(body().querySelector('small')).not.toBeNull();
+    expect(body().querySelectorAll('ul > li').length).toBe(2);
+  });
+
+  it('codeblock nests a code element inside the pre root', () => {
+    render(
+      <main>
+        <CodeBlock>const x = 1;</CodeBlock>
+      </main>,
+    );
+    const pre = body().querySelector('pre');
+    expect(pre?.getAttribute('data-part')).toBe('root');
+    expect(pre?.querySelector('code')?.textContent).toBe('const x = 1;');
+  });
+
+  it('h5/h6 render their own tag but borrow h4 scale', () => {
+    render(
+      <main>
+        <H5>Sub</H5>
+      </main>,
+    );
+    const h5 = body().querySelector('h5');
+    expect(h5).not.toBeNull();
+    expect(h5?.className).toContain('text-xl');
+  });
+
+  it('token props override the variant default at the tag', () => {
+    render(
+      <main>
+        <P size="xl" data-testid="lead">
+          intro
+        </P>
+      </main>,
+    );
+    const p = body().querySelector('[data-testid="lead"]') as HTMLElement;
+    expect(p.className).toContain('text-xl');
+    // P's leading-7 default survives -- size is a different dimension.
+    expect(p.className).toContain('leading-7');
+  });
+
+  it('the generic wrapper derives the variant from as, variant overrides it', () => {
+    render(
+      <main>
+        <Typography as="h2" data-testid="a">
+          heading
+        </Typography>
+        <Typography as="span" data-testid="b">
+          body
+        </Typography>
+        <Typography as="h5" data-testid="c">
+          borrowed
+        </Typography>
+        <Typography as="p" variant="lead" data-testid="d">
+          override
+        </Typography>
+      </main>,
+    );
+    const a = body().querySelector('[data-testid="a"]') as HTMLElement;
+    const b = body().querySelector('[data-testid="b"]') as HTMLElement;
+    const c = body().querySelector('[data-testid="c"]') as HTMLElement;
+    const d = body().querySelector('[data-testid="d"]') as HTMLElement;
+    expect(a.tagName.toLowerCase()).toBe('h2');
+    expect(a.className).toContain('text-3xl');
+    expect(b.tagName.toLowerCase()).toBe('span');
+    expect(b.className).toContain('leading-7');
+    expect(c.tagName.toLowerCase()).toBe('h5');
+    expect(c.className).toContain('text-xl');
+    expect(d.tagName.toLowerCase()).toBe('p');
+    expect(d.className).toContain('text-xl');
+  });
+
+  it('consumer className merges via classy', () => {
+    render(
+      <main>
+        <P className="max-w-prose">x</P>
+      </main>,
+    );
+    const p = body().querySelector('p') as HTMLElement;
+    expect(p.className).toContain('leading-7');
+    expect(p.className).toContain('max-w-prose');
+  });
+
+  it('a heading + prose set is axe-clean inside a landmark', async () => {
+    render(
+      <main>
+        <H1>Doc title</H1>
+        <P>First paragraph.</P>
+      </main>,
+    );
+    await assertAxeClean(body());
+  });
+});

--- a/packages/ui/test/components/typography/typography.element.conformance.test.ts
+++ b/packages/ui/test/components/typography/typography.element.conformance.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Web Component performance of the Typography score -- the SAME static score as
+ * the React and Astro conformances, so there is no controller to drive. These
+ * assertions prove the one contract (the variant's semantic tag renders in the
+ * shadow root with the shared composed classes and data-part="root", slotted
+ * content projects through, the surface is axe-clean) holds in the shadow-DOM
+ * performance too.
+ */
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import { RaftersTypography } from '../../../src/components/typography/typography.element';
+
+beforeAll(() => {
+  if (!customElements.get('rafters-typography')) {
+    customElements.define('rafters-typography', RaftersTypography);
+  }
+});
+
+function mount(attrs = '', slots = ''): HTMLElement {
+  document.body.innerHTML = `<main><rafters-typography ${attrs}>${slots}</rafters-typography></main>`;
+  return document.body.querySelector('rafters-typography') as HTMLElement;
+}
+
+function shadowRoot(host: HTMLElement): HTMLElement {
+  return host.shadowRoot?.querySelector<HTMLElement>('[data-part="root"]') as HTMLElement;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('typography conformance [wc]', () => {
+  it('the variant drives the semantic tag of the shadow root', () => {
+    const root = shadowRoot(mount('variant="h1"', 'Title'));
+    expect(root).not.toBeNull();
+    expect(root.tagName.toLowerCase()).toBe('h1');
+    expect(root.getAttribute('data-part')).toBe('root');
+  });
+
+  it('the root carries the shared composed classes', () => {
+    const root = shadowRoot(mount('variant="h1"', 'Title'));
+    expect(root.className).toContain('text-4xl');
+    expect(root.className).toContain('@lg:text-5xl');
+  });
+
+  it('token-prop attributes override the variant default', () => {
+    const root = shadowRoot(mount('variant="h1" size="2xl"', 'Title'));
+    expect(root.className).toContain('text-2xl');
+    expect(root.className).not.toContain('text-4xl');
+    expect(root.className).not.toContain('@lg:text-5xl');
+  });
+
+  it('codeblock nests a code element inside the pre root', () => {
+    const root = shadowRoot(mount('variant="codeblock"', 'const x = 1;'));
+    expect(root.tagName.toLowerCase()).toBe('pre');
+    expect(root.querySelector('code')).not.toBeNull();
+  });
+
+  it('an unknown variant falls back to p -- never throws', () => {
+    const root = shadowRoot(mount('variant="display"', 'body'));
+    expect(root.tagName.toLowerCase()).toBe('p');
+  });
+
+  it('slotted light-DOM content passes through', () => {
+    const host = mount('variant="p"', 'Body');
+    const slot = host.shadowRoot?.querySelector<HTMLSlotElement>('slot');
+    const assigned = slot?.assignedNodes({ flatten: true }) ?? [];
+    expect(assigned.map((n) => n.textContent).join('')).toContain('Body');
+  });
+
+  it('is axe-clean inside a landmark', async () => {
+    document.body.innerHTML =
+      '<main><rafters-typography variant="h1">Doc title</rafters-typography><rafters-typography variant="p">Body.</rafters-typography></main>';
+    const results = await axe(document.body);
+    expect(results.violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Port `typography` to the behavior layer as a STATIC score in the grain of `container`: no
state, no actions, no keymap, no effects, no composed primitives. The semantic text set
(H1-H6, P, Code, Small, Blockquote, List, plus the presentational variants) proves the static
grain scales to a *set* -- one score decides structure (variant to tag), the classes file
carries the whole view, and each framework performance is pure decoration application.
`importsEffects` is trivially false: the component composes zero primitives and imports no
effect vocabulary.

## Acceptance criteria mapping

### 1. Component doc written

The doc is written to spec, modeled on `container.md` (the static reference): purpose,
composition across the three frameworks, config/state/actions (all empty for a static), the
structure contract, a parts+ARIA table showing the single `root` part with no projected ARIA
(the element carries the meaning), keyboard+effects (none), the oracle dispositions table, and
author-owned WCAG obligations.
Evidence: packages/ui/docs/spec/components/typography.md:1

### 2. JSDoc intelligence tags present

All four registry-parsed tags -- `@cognitive-load` with the five-dimension breakdown
(decision/information/interaction/disruption/learning), `@attention-economics`,
`@trust-building`, `@accessibility` -- sit on the exported `Typography` component, the same
placement radio-group.tsx uses so the registry parser finds them.
Evidence: packages/ui/src/components/typography/typography.tsx:111

### 3. Exported from the package as the articles are

The component ships the standard five files under `src/components/typography/`, so the existing
`./next/*` (tsx) and `./next/*.element` wildcard exports in package.json resolve to it with no
manifest edit -- the folder existing IS the export, identical to how container/grid are exported.
Evidence: packages/ui/package.json:9

### 4. Behavior test (pure, no DOM)

The behavior test imports only the score and exercises the pure structural surface:
`variantToTag` covers every variant, `resolveVariant` coerces unknown/empty/non-string to `p`
without throwing, `variantForElement` maps span to p and h5/h6 to h4, and the static spec is
asserted to have empty aria and a null keymap. No DOM, no render.
Evidence: packages/ui/test/components/typography/typography.behavior.test.ts:9

### 5. Classes parity test

The classes test drives `resolveTypography` directly: variant defaults land, a token override
*replaces* the matching dimension rather than appending (dodging the Tailwind alphabetical
cascade), a same-dimension override suppresses the CQ default while a different-dimension one
lets it survive, and `color` resolves as a fill signature.
Evidence: packages/ui/test/components/typography/typography.classes.test.ts:36

### 6. Conformance test via the shared harness (aria + keymap against rendered DOM)

React, WC, and Astro conformance suites each render real DOM on the shared harness and assert
the variant's semantic tag, `data-part="root"`, the shared composed classes, codeblock's
`pre > code` nesting, the h5/h6 borrow, token overrides, and axe-cleanliness (targets wrapped in
a landmark for the region rule). A static has no keymap tier; the element IS the asserted ARIA
contract, matching container's static conformance shape.
Evidence: packages/ui/test/components/typography/typography.element.conformance.test.ts:33

### 7. shadcn drop-in parity where the component exists in shadcn

shadcn's Typography is a set of example components; parity is the React named surface -- H1-H6,
P, Lead, Large, Muted, Small, Code, CodeBlock, Blockquote, Mark, Abbr, Ul/Ol/Li, with `List`
aliasing `Ul` -- built off one thin factory.
Evidence: packages/ui/src/components/typography/typography.tsx:71

### 8. `pnpm --filter @rafters/ui test:unit` green, `pnpm preflight` green

`test:unit` runs 33 files / 176 tests green across the standard and Astro vitest configs;
`preflight` exits 0 (typecheck all packages, lint 0-errors, format check, a11y, build). The
pre-commit lefthook (unit-tests, lint, format, typecheck) also passed on the commit.
Evidence: packages/ui/test/components/typography/typography.conformance.test.tsx:33

## Not done

- **`components.jsonl` matrix line + `CHANGELOG` entry** -- the issue's closing directives ask
  for both, but the hardened-wave rules forbid touching shared files and `components.jsonl` is
  already deleted from the tree. Skipped deliberately to keep the wave parallel-safe; neither
  affects conformance.
- **Editor layer** -- editable/contenteditable, `InlineToolbar`, `SlashMenu`, `SelectionInfo`,
  inline-mark rich text, and `CodeBlock` `language`/`showLineNumbers` are stripped as studio
  concerns (mirrors the container editable strip). Recorded as dispositions in the doc.
- **Article-flow role-token repointing** -- the raw-size article typography Container bakes is a
  designer pass, flagged on both components, not done here.

Closes #1804
