### PR TITLE
feat(#1765): port collapsible to the behavior layer

### DIFF
--- a/packages/ui/docs/spec/components/collapsible.md
+++ b/packages/ui/docs/spec/components/collapsible.md
@@ -1,0 +1,108 @@
+# Component Spec — Collapsible
+
+Status: DRAFT. Disclosure archetype -- the simplest member of the disclosable
+family (dialog, popover, sheet fold the same axis).
+
+Files (`src/components/collapsible/`):
+
+```
+collapsible.behavior.ts   collapsible.classes.ts   collapsible.tsx
+collapsible.element.ts     collapsible.astro
+```
+
+Tests mirror into `test/components/collapsible/`: behavior (pure), classes
+(parity), and conformance across React, WC, and Astro on the shared harness.
+
+## Composition
+
+```
+disclosable (lib)      state {open}, actions open/close, trigger/content parts
+collapsible-surface    part only: root
+collapsible glue       disabled gate, data-state/data-disabled styling hooks
+```
+
+`disclosable` is the reusable open/closed axis. Controlled/uncontrolled per
+boundary 4: `config.open` is the consumer's controlled value, `state.open` is
+intrinsic, projections and gates read `isOpen(state, config)`. The idempotence
+gate (open only when effectively closed, close only when effectively open) makes
+consumer callbacks fire once per real transition. The collapsible glue adds one
+gate of its own -- a disabled region rejects both actions.
+
+There is no impure work: no overlay, no focus trap, no scroll lock, no
+light-dismiss, no announcement. So the score composes no primitive beyond the
+disclosable slice, and neither `bindCollapsible` nor the React root runs an
+effect. The trigger is a native `<button>`, so Enter and Space arrive as click
+and the score declares no keymap.
+
+## Config, state, actions
+
+```ts
+interface CollapsibleConfig {
+  open?: boolean;        // controlled
+  defaultOpen?: boolean; // uncontrolled seed
+  disabled?: boolean;    // gates the toggle
+}
+interface CollapsibleState { open: boolean } // intrinsic only
+type CollapsibleActions = { open: undefined; close: undefined };
+```
+
+No `toggle` action: the trigger dispatches `open` or `close` computed from the
+effective value, so intrinsic state can never drift from a controlled consumer.
+
+## Parts and ARIA
+
+| Part | Presence | ARIA |
+| --- | --- | --- |
+| root | always | `data-state`, `data-disabled` (when disabled) |
+| trigger | always | `aria-expanded`, `aria-controls` (only while content is in the DOM), `data-state`, `data-disabled` (when disabled) |
+| content | while open (or forceMount) | `data-state`, `data-disabled` (when disabled) |
+
+The trigger's `aria-expanded` + `aria-controls` is the complete WAI-ARIA
+disclosure wiring; `aria-controls` follows the empty-id convention (ratified
+2026-07-08) -- projected only when the content id is real and the region is open,
+so an initially-closed collapsible never leaks a dangling reference. Native
+`disabled` on the trigger is set structurally by each performance (the React
+`disabled` prop, the Astro/author markup attribute); the score reads it into
+`config.disabled` for the gate.
+
+## Keyboard and effects
+
+- `keymap`: none. The native `<button>` fulfils Enter/Space as click; a disabled
+  button suppresses both, and `canDispatch` is the belt-and-suspenders.
+- Effects: none. Presence is a pure DOM concern -- the content is
+  present-but-hidden in the WC/Astro bind (toggled on the open axis) and mounts
+  on open in React (`forceMount` keeps it mounted, hidden, while closed).
+
+## Oracle dispositions (src/old/ui/collapsible.tsx, boundary 9)
+
+| Oracle feature | Disposition |
+| --- | --- |
+| controlled/uncontrolled + onOpenChange | contract |
+| disabled prop (gates onOpenChange) | contract (moved from an imperative `if (disabled) return` to the score's `canDispatch` gate) |
+| Trigger / Content surface | contract |
+| asChild on Trigger and Content | framework affordance (React) |
+| forceMount | contract, with a divergence: a force-mounted closed region carries `hidden` (it must stay inert and out of the tab order) |
+| root `data-state` / `data-disabled` | contract (projected via the root part) |
+| content `aria-labelledby={triggerId}` | defect-do-not-port -- name-from-author is prohibited on a role-less div (axe `aria-prohibited-attr`); the trigger's aria-expanded + aria-controls is the complete disclosure wiring, and Radix omits it too |
+| `animate-collapsible-up/down` on content | defect-do-not-port -- those utilities were never defined in the token system, so porting them is dead classes; replaced by `overflow-hidden transition-all duration-200 motion-reduce:transition-none` (declared height-axis intent) |
+| exported-but-unwired `collapsibleTriggerClasses` / `collapsibleDisabledClasses` | dropped -- the oracle exported them without applying them; the behavior-layer `collapsibleClasses` returns one coherent set |
+
+## Motion
+
+Expand/collapse along the height axis (y). Declared as intent only:
+`overflow-hidden transition-all duration-200 motion-reduce:transition-none`.
+Duration and easing come from the token scale; reduced-motion disables the
+transition. A keyframed height animation waits on a real
+`--collapsible-content-height` utility in the token system.
+
+## WCAG 2.1 AA obligations
+
+- 1.3.1/4.1.2: the trigger's `aria-expanded` and (while open) `aria-controls`
+  are wired to the content's real DOM id, asserted by the harness across all
+  three performances.
+- 2.1.1: the region is fully operable from the keyboard via the native button
+  (Enter/Space); no pointer-only path.
+- 2.4.7: a token focus ring on the trigger (`focus-visible:ring-ring` with a
+  `ring-offset-background` offset).
+- A disabled collapsible advertises the native `disabled` state and cannot be
+  toggled by pointer or keyboard.

--- a/packages/ui/src/components/collapsible/collapsible.astro
+++ b/packages/ui/src/components/collapsible/collapsible.astro
@@ -1,0 +1,68 @@
+---
+/**
+ * Astro performance for collapsible. Server-renders the full light-DOM
+ * structure with the initial-state projection already applied (correct and
+ * inert before JS), then the <script> hands each instance to bindCollapsible --
+ * the SAME DOM-native client the Web Component uses. One score, three
+ * performances, zero drift.
+ *
+ * The content stays in light DOM (present-but-hidden) so the expand/collapse
+ * transition runs on the same node without an unmount to defer.
+ */
+import {
+  collapsible,
+  type CollapsibleConfig,
+  type CollapsiblePart,
+} from './collapsible.behavior';
+import { collapsibleClasses } from './collapsible.classes';
+import type { PartIds } from '../../lib/contract';
+
+interface Props {
+  id: string;
+  defaultOpen?: boolean;
+  disabled?: boolean;
+  label?: string;
+}
+
+const { id, defaultOpen = false, disabled = false, label = 'Toggle' } = Astro.props;
+
+const config: CollapsibleConfig = { defaultOpen, disabled };
+const state = collapsible.initialState(config);
+const classes = collapsibleClasses(config, state);
+
+// Only trigger/content carry ids (aria-controls targets content); root has none.
+const ids = {} as PartIds<CollapsiblePart>;
+for (const part of Object.keys(collapsible.parts) as CollapsiblePart[]) {
+  ids[part] = part === 'root' ? '' : `${id}-${part}`;
+}
+const aria = collapsible.aria(state, config, ids);
+const open = state.open;
+---
+
+<rafters-collapsible data-part="root" default-open={String(defaultOpen)} class={classes.root} {...aria.root}>
+  <button
+    type="button"
+    id={ids.trigger}
+    data-part="trigger"
+    disabled={disabled}
+    class={classes.trigger}
+    {...aria.trigger}
+  >
+    <slot name="trigger">{label}</slot>
+  </button>
+
+  <div id={ids.content} data-part="content" class={classes.content} hidden={!open} {...aria.content}>
+    <slot />
+  </div>
+</rafters-collapsible>
+
+<script>
+  import { bindCollapsible } from './collapsible.behavior';
+
+  for (const root of document.querySelectorAll('rafters-collapsible[data-part="root"]')) {
+    const el = root as HTMLElement;
+    if (el.dataset['bound'] === 'true') continue;
+    el.dataset['bound'] = 'true';
+    bindCollapsible(el);
+  }
+</script>

--- a/packages/ui/src/components/collapsible/collapsible.behavior.ts
+++ b/packages/ui/src/components/collapsible/collapsible.behavior.ts
@@ -1,0 +1,173 @@
+import { compose, type GlueSlice, type Slice } from '../../lib/compose';
+import {
+  createBehavior,
+  type AriaAttrs,
+  type BehaviorSpec,
+  type PartIds,
+} from '../../lib/contract';
+import {
+  disclosable,
+  isOpen,
+  type DisclosableActions,
+  type DisclosableConfig,
+  type DisclosablePart,
+  type DisclosableState,
+} from '../../lib/disclosable';
+import { updateAriaAttribute } from '../../primitives/aria-manager';
+
+/**
+ * Collapsible: a single expandable region. It shares the disclosable open/close
+ * axis with dialog and popover, but it is the SIMPLEST member of the family --
+ * a plain disclosure with no overlay, no focus trap, no scroll lock, and no
+ * light-dismiss. A native `<button>` trigger toggles one content region; Enter
+ * and Space are fulfilled by the button element itself, so the score declares no
+ * keymap. The only concern beyond the disclosable axis is `disabled`, which
+ * gates the toggle so a disabled region can never open or close.
+ */
+export interface CollapsibleConfig extends DisclosableConfig {
+  /** A disabled collapsible refuses to toggle (gates open/close). */
+  disabled?: boolean | undefined;
+}
+
+export type CollapsibleState = DisclosableState;
+export type CollapsibleActions = DisclosableActions;
+
+/** The wrapper part, beyond the disclosable trigger/content pair. It carries
+ *  the open/disabled data-state for styling the region as a whole. */
+export type CollapsibleSurfacePart = 'root';
+export type CollapsiblePart = DisclosablePart | CollapsibleSurfacePart;
+
+export { isOpen };
+
+function isDisabled(config: CollapsibleConfig): boolean {
+  return config.disabled === true;
+}
+
+/** Structure-only slice: the wrapper root part. Contributes no state and no
+ *  actions -- its ARIA is written by the glue over the merged state. */
+const collapsibleSurface: Slice<
+  CollapsibleConfig,
+  Record<never, never>,
+  Record<never, never>,
+  CollapsibleSurfacePart
+> = {
+  name: 'collapsible-surface',
+  parts: {
+    root: {},
+  },
+  initialState: () => ({}),
+};
+
+/** The collapsible glue: the disabled gate and the data-state styling hooks.
+ *  No aria-labelledby on content -- name-from-author is prohibited on a
+ *  role-less region, and the trigger's aria-expanded + aria-controls is the
+ *  complete WAI-ARIA disclosure wiring (see collapsible.md dispositions). */
+const collapsibleGlue: GlueSlice<
+  CollapsibleConfig,
+  CollapsibleState,
+  CollapsibleActions,
+  CollapsiblePart
+> = {
+  kind: 'glue',
+  name: 'collapsible',
+  // A disabled collapsible rejects both open and close, so a controlled
+  // consumer's callback never fires for an edit it would refuse (oracle:
+  // `if (disabled) return` before onOpenChange). ANDs with the disclosable
+  // idempotence gate.
+  canDispatch: (_state, _action, config) => !isDisabled(config),
+  aria: (state, config) => {
+    const open = isOpen(state, config);
+    const disabled = isDisabled(config);
+    const disabledAttr = disabled ? '' : undefined;
+    return {
+      root: {
+        'data-state': open ? 'open' : 'closed',
+        'data-disabled': disabledAttr,
+      },
+      trigger: {
+        'data-disabled': disabledAttr,
+      },
+      content: {
+        'data-disabled': disabledAttr,
+      },
+    };
+  },
+};
+
+export const collapsible: BehaviorSpec<
+  CollapsibleConfig,
+  CollapsibleState,
+  CollapsibleActions,
+  CollapsiblePart
+> = compose('collapsible', disclosable<CollapsibleConfig>(), collapsibleSurface, collapsibleGlue);
+
+/**
+ * The DOM-native binding of the collapsible score -- the client the Web
+ * Component and the Astro <script> both import. Only React reads the
+ * projections declaratively. There is no impure work to compose: no primitive
+ * (no trap, no dismiss, no announce) -- just the aria projection, the content
+ * presence toggle, and the native-button click. The trigger is a real
+ * `<button>`, so Enter/Space arrive as click; a disabled button suppresses both
+ * natively and the canDispatch gate is the belt-and-suspenders.
+ */
+export function bindCollapsible(root: HTMLElement): () => void {
+  const trigger = root.querySelector<HTMLElement>('[data-part="trigger"]');
+  const contentAtMount = root.querySelector<HTMLElement>('[data-part="content"]');
+  const config: CollapsibleConfig = {
+    disabled: trigger?.hasAttribute('disabled') ?? false,
+    // Seed the intrinsic open from the server-rendered markup. WC/Astro are
+    // uncontrolled (no reactive prop), so config.open stays undefined.
+    defaultOpen:
+      root.getAttribute('default-open') === 'true' || contentAtMount?.dataset['state'] === 'open',
+  };
+
+  const getPart = (part: string): HTMLElement | null =>
+    part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
+
+  const { memory, dispatch } = createBehavior(collapsible, config);
+
+  const request = (action: keyof CollapsibleActions): boolean => dispatch(action, config);
+
+  // ids READ from the server/author markup, never generated.
+  const ids = {} as PartIds<CollapsiblePart>;
+  for (const part of Object.keys(collapsible.parts) as CollapsiblePart[]) {
+    ids[part] = getPart(part)?.id ?? '';
+  }
+
+  // The projection is already resolved, so apply it raw: validate:false skips
+  // aria-manager's author-input coercion that flips the resolved string 'false'.
+  const applyProjection = (el: HTMLElement, attrs: AriaAttrs) => {
+    for (const [name, value] of Object.entries(attrs)) {
+      updateAriaAttribute(el, name as never, value as never, { validate: false });
+    }
+  };
+
+  const render = () => {
+    const state = memory.get();
+    const open = isOpen(state, config);
+    const projection = collapsible.aria(state, config, ids);
+    for (const part of Object.keys(projection) as CollapsiblePart[]) {
+      const attrs = projection[part];
+      const el = getPart(part);
+      if (el && attrs) applyProjection(el, attrs);
+    }
+    // Presence: the content is present-but-hidden, toggled on the open axis. It
+    // stays in light DOM so the exit transition runs on the same node.
+    const content = getPart('content');
+    if (content) content.hidden = !open;
+  };
+  const unsubscribe = memory.subscribe(render); // fires immediately: first paint
+
+  const onClick = (event: Event) => {
+    const target = event.target as HTMLElement;
+    if (target.closest('[data-part="trigger"]')) {
+      request(isOpen(memory.get(), config) ? 'close' : 'open');
+    }
+  };
+  root.addEventListener('click', onClick);
+
+  return () => {
+    unsubscribe();
+    root.removeEventListener('click', onClick);
+  };
+}

--- a/packages/ui/src/components/collapsible/collapsible.classes.ts
+++ b/packages/ui/src/components/collapsible/collapsible.classes.ts
@@ -1,0 +1,40 @@
+import type { CollapsibleConfig, CollapsibleState } from './collapsible.behavior';
+
+export interface CollapsibleClassSet {
+  /** The wrapper region. Layout is the consumer's; the wrapper is structural. */
+  root: string;
+  /** The disclosure trigger button: hover feedback, focus ring, disabled dim. */
+  trigger: string;
+  /** The revealed region: clips its content and animates the height axis. */
+  content: string;
+}
+
+// The wrapper owns no visual of its own -- it is the styling anchor for the
+// data-state/data-disabled the score projects, which consumers key off.
+const rootClasses = '';
+
+const triggerClasses =
+  'inline-flex items-center hover:bg-muted ' +
+  'transition-colors duration-150 motion-reduce:transition-none ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ' +
+  'ring-offset-background focus-visible:ring-offset-2 ' +
+  'disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none';
+
+// Motion intent (declared, not keyframed): expand/collapse along the height
+// axis. overflow-hidden clips the region while it grows/shrinks; the transition
+// carries the token-scale duration and yields to reduced-motion. The oracle's
+// `animate-collapsible-up/down` utilities were never defined in the token
+// system, so porting them would be dead classes (see collapsible.md).
+const contentClasses = 'overflow-hidden transition-all duration-200 motion-reduce:transition-none';
+
+/** The view: class strings keyed by config/state. No logic. */
+export function collapsibleClasses(
+  _config: CollapsibleConfig,
+  _state: CollapsibleState,
+): CollapsibleClassSet {
+  return {
+    root: rootClasses,
+    trigger: triggerClasses,
+    content: contentClasses,
+  };
+}

--- a/packages/ui/src/components/collapsible/collapsible.element.ts
+++ b/packages/ui/src/components/collapsible/collapsible.element.ts
@@ -1,0 +1,32 @@
+/**
+ * WC performance for collapsible: the thinnest wrapper. The score AND the
+ * DOM-native binding (bindCollapsible) live in collapsible.behavior.ts, shared
+ * with the Astro performance. This file only adapts that binding to the
+ * custom-element lifecycle -- deferring the bind one microtask because
+ * connectedCallback can fire before the light-DOM parts are parsed.
+ *
+ * A light-DOM enhancer: the author (or Astro) provides the real
+ * `<rafters-collapsible data-part="root">` with a `<button data-part="trigger">`
+ * and a `<div data-part="content">`, so native focus and click operate on real
+ * document DOM -- the WC never renders a shadow tree of its own.
+ */
+import { bindCollapsible } from './collapsible.behavior';
+
+export class RaftersCollapsible extends HTMLElement {
+  private teardown: (() => void) | null = null;
+
+  connectedCallback(): void {
+    queueMicrotask(() => {
+      if (this.isConnected && !this.teardown) this.teardown = bindCollapsible(this);
+    });
+  }
+
+  disconnectedCallback(): void {
+    this.teardown?.();
+    this.teardown = null;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-collapsible')) {
+  customElements.define('rafters-collapsible', RaftersCollapsible);
+}

--- a/packages/ui/src/components/collapsible/collapsible.tsx
+++ b/packages/ui/src/components/collapsible/collapsible.tsx
@@ -1,0 +1,227 @@
+import * as React from 'react';
+import { createBehavior, type AriaAttrs, type PartIds } from '../../lib/contract';
+import { useMemory } from '../../hooks/use-memory';
+import classy from '../../primitives/classy';
+import { mergeProps } from '../../primitives/slot';
+import {
+  collapsible,
+  isOpen,
+  type CollapsibleActions,
+  type CollapsibleConfig,
+  type CollapsiblePart,
+  type CollapsibleState,
+} from './collapsible.behavior';
+import { collapsibleClasses, type CollapsibleClassSet } from './collapsible.classes';
+
+interface CollapsibleContextValue {
+  state: CollapsibleState;
+  config: CollapsibleConfig;
+  ids: PartIds<CollapsiblePart>;
+  aria: Partial<Record<CollapsiblePart, AriaAttrs>>;
+  classes: CollapsibleClassSet;
+  effectiveOpen: boolean;
+  disabled: boolean;
+  request: (action: keyof CollapsibleActions) => boolean;
+}
+
+const CollapsibleContext = React.createContext<CollapsibleContextValue | null>(null);
+
+function useCollapsibleContext(component: string): CollapsibleContextValue {
+  const context = React.useContext(CollapsibleContext);
+  if (!context) {
+    throw new Error(`${component} must be used within <Collapsible>`);
+  }
+  return context;
+}
+
+export interface CollapsibleProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Controlled open state. */
+  open?: boolean;
+  /** Default open state for uncontrolled usage. */
+  defaultOpen?: boolean;
+  /** Callback when the open state changes via user interaction. */
+  onOpenChange?: (open: boolean) => void;
+  /** Whether the collapsible is disabled (gates the toggle). */
+  disabled?: boolean;
+}
+
+/**
+ * A single expandable region. The trigger toggles one content region open and
+ * closed; a native `<button>` fulfils Enter/Space, so there is no custom keymap.
+ *
+ * @cognitive-load 2/10 - decision 0, information 1, interaction 1, disruption 0,
+ * learning 0. No decision (the reveal is reversible and consequence-free); one
+ * unit of information behind one universally-learned expand/collapse affordance,
+ * with no workflow disruption.
+ * @attention-economics Progressive disclosure: the hidden content does not
+ * compete for attention until the user chooses to expand it, so the collapsed
+ * state keeps the initial scan cheap. Best for a single optional or secondary
+ * region; multiple related regions belong in an Accordion.
+ * @trust-building Immediate visual feedback on the trigger's expanded state, a
+ * fully reversible action, and an always-clear open/closed indicator. The region
+ * never collapses on its own, so the user is never surprised by vanishing content.
+ * @accessibility The trigger is a native button carrying aria-expanded and, while
+ * open, aria-controls wired to the content's real DOM id -- the complete WAI-ARIA
+ * disclosure pattern, asserted against rendered DOM by the harness. A disabled
+ * collapsible sets the native disabled attribute and refuses to toggle.
+ */
+export function Collapsible({
+  open,
+  defaultOpen = false,
+  onOpenChange,
+  disabled = false,
+  className,
+  children,
+  ...props
+}: CollapsibleProps) {
+  const config: CollapsibleConfig = { open, defaultOpen, disabled };
+
+  // The controller composes the score with the substrate -- no useBehavior.
+  // createBehavior is the model; useMemory subscribes React to it. There is no
+  // impure primitive to compose, so no useEffect: a plain disclosure.
+  const { memory, dispatch } = React.useMemo(() => createBehavior(collapsible, config), []);
+  const state = useMemory(memory);
+  const effectiveOpen = isOpen(state, config);
+
+  const uid = React.useId();
+  const ids = React.useMemo(() => {
+    const out = {} as PartIds<CollapsiblePart>;
+    for (const part of Object.keys(collapsible.parts) as CollapsiblePart[]) {
+      // Only trigger/content need ids (aria-controls targets content); root
+      // carries none, matching the oracle wrapper.
+      out[part] = part === 'root' ? '' : `${uid}-${part}`;
+    }
+    return out;
+  }, [uid]);
+
+  // Gotcha #1: report the value to set even when a controlled group's effective
+  // value cannot move. canDispatch already gates disabled + idempotence, so the
+  // callback fires once per real transition and never while disabled.
+  const latest = React.useRef({ config, onOpenChange });
+  latest.current = { config, onOpenChange };
+  const request = React.useCallback(
+    (action: keyof CollapsibleActions): boolean => {
+      const { config: cfg, onOpenChange: cb } = latest.current;
+      if (!dispatch(action, cfg)) return false;
+      cb?.(action === 'open');
+      return true;
+    },
+    [dispatch],
+  );
+
+  const aria = collapsible.aria(state, config, ids);
+  const classes = collapsibleClasses(config, state);
+
+  const contextValue: CollapsibleContextValue = {
+    state,
+    config,
+    ids,
+    aria,
+    classes,
+    effectiveOpen,
+    disabled,
+    request,
+  };
+
+  return (
+    <CollapsibleContext.Provider value={contextValue}>
+      <div data-part="root" className={classy(classes.root, className)} {...aria.root} {...props}>
+        {children}
+      </div>
+    </CollapsibleContext.Provider>
+  );
+}
+
+Collapsible.displayName = 'Collapsible';
+
+export interface CollapsibleTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Render as the child element (polymorphic). */
+  asChild?: boolean;
+}
+
+export function CollapsibleTrigger({
+  asChild,
+  onClick,
+  className,
+  disabled: disabledProp,
+  children,
+  ...props
+}: CollapsibleTriggerProps) {
+  const { effectiveOpen, ids, aria, classes, disabled, request } =
+    useCollapsibleContext('CollapsibleTrigger');
+  const isTriggerDisabled = disabledProp ?? disabled;
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    if (event.defaultPrevented) return;
+    request(effectiveOpen ? 'close' : 'open');
+  };
+
+  const partProps = {
+    'data-part': 'trigger',
+    id: ids.trigger,
+    disabled: isTriggerDisabled,
+    className: classy(classes.trigger, className),
+    ...aria.trigger,
+    onClick: handleClick,
+  };
+
+  if (asChild && React.isValidElement(children)) {
+    const childProps = children.props as Record<string, unknown>;
+    return React.cloneElement(children, mergeProps(partProps, childProps) as React.Attributes);
+  }
+
+  return (
+    <button type="button" {...partProps} {...props}>
+      {children}
+    </button>
+  );
+}
+
+CollapsibleTrigger.displayName = 'CollapsibleTrigger';
+
+export interface CollapsibleContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Keep the content mounted while closed (hidden + data-state=closed). */
+  forceMount?: boolean;
+  /** Render as the child element (polymorphic). */
+  asChild?: boolean;
+}
+
+export function CollapsibleContent({
+  forceMount,
+  asChild,
+  className,
+  children,
+  ...props
+}: CollapsibleContentProps) {
+  const { effectiveOpen, ids, aria, classes } = useCollapsibleContext('CollapsibleContent');
+
+  if (!(forceMount || effectiveOpen)) return null;
+
+  const partProps = {
+    'data-part': 'content',
+    id: ids.content || undefined,
+    // A force-mounted closed region must stay inert and out of the tab order.
+    hidden: effectiveOpen ? undefined : true,
+    className: classy(classes.content, className),
+    ...aria.content,
+  };
+
+  if (asChild && React.isValidElement(children)) {
+    const childProps = children.props as Record<string, unknown>;
+    return React.cloneElement(children, mergeProps(partProps, childProps) as React.Attributes);
+  }
+
+  return (
+    <div {...partProps} {...props}>
+      {children}
+    </div>
+  );
+}
+
+CollapsibleContent.displayName = 'CollapsibleContent';
+
+Collapsible.Trigger = CollapsibleTrigger;
+Collapsible.Content = CollapsibleContent;
+
+export default Collapsible;

--- a/packages/ui/test/components/collapsible/collapsible.astro.conformance.test.ts
+++ b/packages/ui/test/components/collapsible/collapsible.astro.conformance.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Astro performance of the collapsible score, driven end to end. AstroContainer
+ * renders the SSR markup but does NOT run the <script>, so the test binds
+ * bindCollapsible directly -- that IS the script's job -- then drives the same
+ * score the React and WC performances drive. One score, three performances.
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import Collapsible from '../../../src/components/collapsible/collapsible.astro';
+import { bindCollapsible } from '../../../src/components/collapsible/collapsible.behavior';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+async function mount(
+  props: Record<string, unknown> = {},
+  slots: Record<string, string> = {},
+): Promise<HTMLElement> {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Collapsible, { props: { id: 'c', ...props }, slots });
+  document.body.innerHTML = html;
+  const root = document.body.querySelector('rafters-collapsible') as HTMLElement;
+  bindCollapsible(root); // the <script> does this per instance on the real page
+  return root;
+}
+
+const trigger = () => document.body.querySelector<HTMLElement>('[data-part="trigger"]')!;
+const content = () => document.body.querySelector<HTMLElement>('[data-part="content"]')!;
+
+describe('collapsible conformance [astro]', () => {
+  it('SSR closed: content hidden and crawlable, trigger collapsed', async () => {
+    await mount();
+    expect(content().hidden).toBe(true);
+    expect(trigger().getAttribute('aria-expanded')).toBe('false');
+    expect(trigger().hasAttribute('aria-controls')).toBe(false);
+  });
+
+  it('bind: trigger opens, aria wires to content, toggles closed again', async () => {
+    const user = userEvent.setup();
+    await mount({}, { default: '<p>Revealed content</p>' });
+    await user.click(trigger());
+    expect(content().hidden).toBe(false);
+    expect(trigger().getAttribute('aria-expanded')).toBe('true');
+    expect(trigger().getAttribute('aria-controls')).toBe('c-content');
+    await user.click(trigger());
+    expect(content().hidden).toBe(true);
+    expect(trigger().getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('SSR defaultOpen renders open and wired', async () => {
+    await mount({ defaultOpen: true }, { default: '<p>Revealed content</p>' });
+    expect(content().hidden).toBe(false);
+    expect(trigger().getAttribute('aria-expanded')).toBe('true');
+    expect(trigger().getAttribute('aria-controls')).toBe('c-content');
+  });
+});

--- a/packages/ui/test/components/collapsible/collapsible.behavior.test.ts
+++ b/packages/ui/test/components/collapsible/collapsible.behavior.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { createBehavior, type PartIds } from '../../../src/lib/contract';
+import {
+  collapsible,
+  isOpen,
+  type CollapsibleConfig,
+  type CollapsiblePart,
+} from '../../../src/components/collapsible/collapsible.behavior';
+
+const ids: PartIds<CollapsiblePart> = {
+  root: 'r',
+  trigger: 't',
+  content: 'c',
+};
+
+const closed: CollapsibleConfig = {};
+const openUncontrolled: CollapsibleConfig = { defaultOpen: true };
+
+function ariaAt(config: CollapsibleConfig, partIds: PartIds<CollapsiblePart> = ids) {
+  return collapsible.aria(collapsible.initialState(config), config, partIds);
+}
+
+describe('collapsible parts', () => {
+  it('declares the wrapper, trigger and content', () => {
+    expect(Object.keys(collapsible.parts).sort()).toEqual(['content', 'root', 'trigger']);
+    expect(collapsible.parts.content.optional).toBe(true);
+    expect(collapsible.parts.trigger.optional).toBeUndefined();
+    expect(collapsible.parts.root.optional).toBeUndefined();
+  });
+});
+
+describe('collapsible state: controlled vs intrinsic', () => {
+  it('seeds intrinsic open from defaultOpen', () => {
+    expect(collapsible.initialState({ defaultOpen: true }).open).toBe(true);
+    expect(collapsible.initialState({}).open).toBe(false);
+  });
+
+  it('controlled config shadows intrinsic state', () => {
+    const state = collapsible.initialState({});
+    expect(isOpen(state, { open: true })).toBe(true);
+    expect(isOpen({ open: true }, { open: false })).toBe(false);
+    expect(isOpen({ open: true }, {})).toBe(true);
+  });
+});
+
+describe('collapsible canDispatch', () => {
+  it('idempotence gate: open only when closed, close only when open', () => {
+    const state = collapsible.initialState(closed);
+    expect(collapsible.canDispatch(state, 'open', closed)).toBe(true);
+    expect(collapsible.canDispatch(state, 'close', closed)).toBe(false);
+
+    const openState = { open: true };
+    expect(collapsible.canDispatch(openState, 'open', closed)).toBe(false);
+    expect(collapsible.canDispatch(openState, 'close', closed)).toBe(true);
+  });
+
+  it('disabled gate: rejects both open and close', () => {
+    const disabled: CollapsibleConfig = { disabled: true };
+    expect(collapsible.canDispatch({ open: false }, 'open', disabled)).toBe(false);
+    expect(collapsible.canDispatch({ open: true }, 'close', disabled)).toBe(false);
+  });
+
+  it('gates on the CONTROLLED value when present', () => {
+    const drifted = { open: false };
+    expect(collapsible.canDispatch(drifted, 'close', { open: true })).toBe(true);
+    expect(collapsible.canDispatch(drifted, 'open', { open: true })).toBe(false);
+  });
+});
+
+describe('collapsible actions', () => {
+  it('open and close move intrinsic state through dispatch', () => {
+    const { memory, dispatch } = createBehavior(collapsible, closed);
+    expect(dispatch('open', closed)).toBe(true);
+    expect(memory.get().open).toBe(true);
+    expect(dispatch('open', closed)).toBe(false);
+    expect(dispatch('close', closed)).toBe(true);
+    expect(memory.get().open).toBe(false);
+  });
+
+  it('a disabled collapsible never moves', () => {
+    const disabled: CollapsibleConfig = { disabled: true };
+    const { memory, dispatch } = createBehavior(collapsible, disabled);
+    expect(dispatch('open', disabled)).toBe(false);
+    expect(memory.get().open).toBe(false);
+  });
+});
+
+describe('collapsible aria projection', () => {
+  it('closed: trigger collapsed, no dangling aria-controls', () => {
+    const aria = ariaAt(closed);
+    expect(aria.trigger).toEqual({
+      'aria-expanded': 'false',
+      'aria-controls': undefined,
+      'data-state': 'closed',
+      'data-disabled': undefined,
+    });
+  });
+
+  it('open: trigger expanded and wired to content', () => {
+    const aria = ariaAt(openUncontrolled);
+    expect(aria.trigger?.['aria-expanded']).toBe('true');
+    expect(aria.trigger?.['aria-controls']).toBe('c');
+    expect(aria.trigger?.['data-state']).toBe('open');
+  });
+
+  it('root and content mirror the open axis', () => {
+    expect(ariaAt(closed).root).toEqual({ 'data-state': 'closed', 'data-disabled': undefined });
+    expect(ariaAt(openUncontrolled).root?.['data-state']).toBe('open');
+    expect(ariaAt(closed).content?.['data-state']).toBe('closed');
+    expect(ariaAt(openUncontrolled).content?.['data-state']).toBe('open');
+  });
+
+  it('disabled: data-disabled on root, trigger and content', () => {
+    const aria = ariaAt({ disabled: true });
+    expect(aria.root?.['data-disabled']).toBe('');
+    expect(aria.trigger?.['data-disabled']).toBe('');
+    expect(aria.content?.['data-disabled']).toBe('');
+  });
+
+  it('content carries no name-from-author (no aria-labelledby)', () => {
+    const aria = ariaAt(openUncontrolled);
+    expect(aria.content?.['aria-labelledby']).toBeUndefined();
+    expect(aria.content?.role).toBeUndefined();
+  });
+});
+
+describe('collapsible keymap', () => {
+  it('claims nothing -- the native button fulfils Enter/Space', () => {
+    const state = { open: false };
+    expect(collapsible.keymap({ key: 'Enter' }, state, 'trigger', closed)).toBeNull();
+    expect(collapsible.keymap({ key: ' ' }, state, 'trigger', closed)).toBeNull();
+    expect(collapsible.keymap({ key: 'Escape' }, state, 'content', closed)).toBeNull();
+  });
+});

--- a/packages/ui/test/components/collapsible/collapsible.classes.test.ts
+++ b/packages/ui/test/components/collapsible/collapsible.classes.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { collapsible } from '../../../src/components/collapsible/collapsible.behavior';
+import { collapsibleClasses } from '../../../src/components/collapsible/collapsible.classes';
+
+const config = {};
+const classes = collapsibleClasses(config, collapsible.initialState(config));
+
+describe('collapsible classes', () => {
+  it('the trigger has hover feedback and a token focus ring', () => {
+    expect(classes.trigger).toContain('hover:bg-muted');
+    expect(classes.trigger).toContain('focus-visible:ring-ring');
+    expect(classes.trigger).toContain('ring-offset-background');
+  });
+
+  it('the trigger dims and blocks interaction while disabled', () => {
+    expect(classes.trigger).toContain('disabled:opacity-50');
+    expect(classes.trigger).toContain('disabled:cursor-not-allowed');
+    expect(classes.trigger).toContain('disabled:pointer-events-none');
+  });
+
+  it('the content clips its region and declares the height-axis motion intent', () => {
+    expect(classes.content).toContain('overflow-hidden');
+    expect(classes.content).toContain('transition-all');
+    expect(classes.content).toContain('duration-200');
+  });
+
+  it('motion respects reduced-motion on both the trigger and the content', () => {
+    expect(classes.trigger).toContain('motion-reduce:transition-none');
+    expect(classes.content).toContain('motion-reduce:transition-none');
+  });
+
+  it('carries no raw color, spacing or z-index utilities', () => {
+    for (const value of Object.values(classes)) {
+      expect(value).not.toMatch(/\bz-\d/);
+      expect(value).not.toMatch(/\bbg-\[/);
+      expect(value).not.toMatch(/\btext-\[/);
+    }
+  });
+});

--- a/packages/ui/test/components/collapsible/collapsible.conformance.test.tsx
+++ b/packages/ui/test/components/collapsible/collapsible.conformance.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * React performance of the collapsible score, driven end to end. The content
+ * renders inline inside the root, so part queries run against the RTL container.
+ */
+import * as React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '../../../src/components/collapsible/collapsible';
+import { collapsible } from '../../../src/components/collapsible/collapsible.behavior';
+import {
+  assertAxeClean,
+  assertContractFulfillment,
+  domPartIds,
+  partElement,
+} from '../../harness/conformance';
+
+interface SetupProps {
+  open?: boolean;
+  defaultOpen?: boolean;
+  disabled?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+function TestCollapsible(props: SetupProps) {
+  return (
+    <Collapsible {...props}>
+      <CollapsibleTrigger>Toggle section</CollapsibleTrigger>
+      <CollapsibleContent>
+        <p>Revealed content</p>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('collapsible conformance [react]', () => {
+  it('closed: trigger renders collapsed, content absent, axe-clean', async () => {
+    const { container } = render(<TestCollapsible />);
+    const trigger = partElement(container, 'trigger');
+    expect(trigger).not.toBeNull();
+    expect(partElement(container, 'content')).toBeNull();
+    expect(trigger?.getAttribute('aria-expanded')).toBe('false');
+    expect(trigger?.hasAttribute('aria-controls')).toBe(false);
+    expect(partElement(container, 'root')?.getAttribute('data-state')).toBe('closed');
+    await assertAxeClean(container);
+  });
+
+  it('open: every part renders and ARIA equals the projection', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<TestCollapsible />);
+    await user.click(partElement(container, 'trigger') as HTMLElement);
+
+    const config = { defaultOpen: false, disabled: false };
+    const state = { open: true };
+    assertContractFulfillment(collapsible, container, state, config, [
+      'root',
+      'trigger',
+      'content',
+    ]);
+    await assertAxeClean(container);
+  });
+
+  it('trigger and content are wired by real DOM ids', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<TestCollapsible />);
+    await user.click(partElement(container, 'trigger') as HTMLElement);
+    const ids = domPartIds(container, ['trigger', 'content'] as const);
+    expect(partElement(container, 'trigger')?.getAttribute('aria-controls')).toBe(ids.content);
+    expect(ids.content).toBeTruthy();
+  });
+
+  it('Enter and Space on the native button toggle the region', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<TestCollapsible />);
+    const trigger = partElement(container, 'trigger') as HTMLElement;
+    trigger.focus();
+    await user.keyboard('{Enter}');
+    expect(partElement(container, 'content')).not.toBeNull();
+    await user.keyboard(' ');
+    expect(partElement(container, 'content')).toBeNull();
+  });
+
+  it('click toggles open then closed', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<TestCollapsible />);
+    const trigger = partElement(container, 'trigger') as HTMLElement;
+    await user.click(trigger);
+    expect(partElement(container, 'content')).not.toBeNull();
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    await user.click(trigger);
+    expect(partElement(container, 'content')).toBeNull();
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('disabled: the trigger is inert and never opens', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const { container } = render(<TestCollapsible disabled onOpenChange={onOpenChange} />);
+    const trigger = partElement(container, 'trigger') as HTMLButtonElement;
+    expect(trigger.disabled).toBe(true);
+    expect(trigger.hasAttribute('data-disabled')).toBe(true);
+    await user.click(trigger);
+    expect(partElement(container, 'content')).toBeNull();
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('defaultOpen mounts open', async () => {
+    const { container } = render(<TestCollapsible defaultOpen />);
+    expect(partElement(container, 'content')).not.toBeNull();
+    expect(partElement(container, 'trigger')?.getAttribute('aria-expanded')).toBe('true');
+    await assertAxeClean(container);
+  });
+
+  it('forceMount keeps the content in the DOM, hidden, while closed', () => {
+    const { container } = render(
+      <Collapsible>
+        <CollapsibleTrigger>Toggle</CollapsibleTrigger>
+        <CollapsibleContent forceMount>
+          <p>Always mounted</p>
+        </CollapsibleContent>
+      </Collapsible>,
+    );
+    const content = partElement(container, 'content');
+    expect(content).not.toBeNull();
+    expect(content?.getAttribute('data-state')).toBe('closed');
+    expect(content?.hasAttribute('hidden')).toBe(true);
+  });
+
+  it('uncontrolled callback fires once per real transition', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const { container } = render(<TestCollapsible onOpenChange={onOpenChange} />);
+    const trigger = partElement(container, 'trigger') as HTMLElement;
+    await user.click(trigger);
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    await user.click(trigger);
+    expect(onOpenChange).toHaveBeenCalledTimes(2);
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('controlled: callbacks fire, state follows the prop, never the gesture', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const { container, rerender } = render(
+      <TestCollapsible open={false} onOpenChange={onOpenChange} />,
+    );
+    await user.click(partElement(container, 'trigger') as HTMLElement);
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    expect(partElement(container, 'content')).toBeNull();
+
+    rerender(<TestCollapsible open onOpenChange={onOpenChange} />);
+    expect(partElement(container, 'content')).not.toBeNull();
+  });
+});

--- a/packages/ui/test/components/collapsible/collapsible.element.conformance.test.ts
+++ b/packages/ui/test/components/collapsible/collapsible.element.conformance.test.ts
@@ -1,0 +1,84 @@
+/**
+ * WC performance of the collapsible score, driven end to end against light-DOM
+ * markup. Same score as the React conformance test -- proves presence (content
+ * hidden off the open axis) and the native-button toggle drive through the DOM
+ * binding.
+ */
+import { cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { RaftersCollapsible } from '../../../src/components/collapsible/collapsible.element';
+
+beforeAll(() => {
+  if (!customElements.get('rafters-collapsible')) {
+    customElements.define('rafters-collapsible', RaftersCollapsible);
+  }
+});
+
+async function mount(disabled = false): Promise<HTMLElement> {
+  document.body.innerHTML = `
+    <rafters-collapsible data-part="root" data-state="closed">
+      <button type="button" data-part="trigger" id="c-trigger" aria-expanded="false" data-state="closed"${
+        disabled ? ' disabled' : ''
+      }>Toggle</button>
+      <div data-part="content" id="c-content" data-state="closed" hidden>
+        <p>Revealed content</p>
+      </div>
+    </rafters-collapsible>`;
+  await Promise.resolve();
+  return document.body.querySelector('rafters-collapsible') as HTMLElement;
+}
+
+const trigger = () => document.body.querySelector<HTMLElement>('[data-part="trigger"]')!;
+const content = () => document.body.querySelector<HTMLElement>('[data-part="content"]')!;
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+describe('collapsible conformance [wc]', () => {
+  it('closed: content hidden, trigger collapsed', async () => {
+    await mount();
+    expect(content().hidden).toBe(true);
+    expect(trigger().getAttribute('aria-expanded')).toBe('false');
+    expect(trigger().hasAttribute('aria-controls')).toBe(false);
+  });
+
+  it('trigger opens: content shows, aria wired to content', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger());
+    expect(content().hidden).toBe(false);
+    expect(trigger().getAttribute('aria-expanded')).toBe('true');
+    expect(trigger().getAttribute('aria-controls')).toBe('c-content');
+  });
+
+  it('trigger toggles closed again', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger());
+    await user.click(trigger());
+    expect(content().hidden).toBe(true);
+    expect(trigger().getAttribute('aria-expanded')).toBe('false');
+    expect(trigger().hasAttribute('aria-controls')).toBe(false);
+  });
+
+  it('Enter and Space on the native button toggle the region', async () => {
+    const user = userEvent.setup();
+    await mount();
+    trigger().focus();
+    await user.keyboard('{Enter}');
+    expect(content().hidden).toBe(false);
+    await user.keyboard(' ');
+    expect(content().hidden).toBe(true);
+  });
+
+  it('disabled: the native button suppresses the toggle', async () => {
+    const user = userEvent.setup();
+    await mount(true);
+    await user.click(trigger());
+    expect(content().hidden).toBe(true);
+    expect(trigger().getAttribute('aria-expanded')).toBe('false');
+  });
+});


### PR DESCRIPTION
## Summary

Ports `collapsible` to the behavior layer as the simplest member of the disclosable family.
The score is `disclosable()` + a structure-only `root` surface slice + a `disabled`-gate glue,
composed into one `BehaviorSpec`. There is no overlay, no focus trap, no scroll lock, no
light-dismiss, and no keymap: a native `<button>` trigger fulfils Enter/Space as click, and the
content is present-but-hidden on the open axis. `bindCollapsible` drives the WC and Astro
performances; React reads the projections declaratively via `useMemory` with no impure effect to
compose. The retired effects layer is not imported.

## Acceptance criteria mapping

### 1. Component doc written
`packages/ui/docs/spec/components/collapsible.md` follows dialog.md: composition tree,
config/state/actions, a parts+ARIA table that matches the score's projection, keyboard/effects,
the oracle-disposition table, motion intent, and WCAG obligations.
Evidence: packages/ui/docs/spec/components/collapsible.md

### 2. JSDoc intelligence tags present
The registry-parsed tags sit on the `Collapsible` root export: `@cognitive-load 2/10` with a
five-dimension breakdown (decision 0, information 1, interaction 1, disruption 0, learning 0)
summing to the matrix score, plus `@attention-economics`, `@trust-building`, `@accessibility`.
Evidence: packages/ui/src/components/collapsible/collapsible.tsx:52

### 3. Exported from the package as the articles are
The package's `./next/*` export maps to the wildcard `./src/components/*/*.tsx`, so the new
`collapsible/` folder existing IS the export -- no index or package.json edit is needed, matching
how dialog and radio-group are exposed.
Evidence: packages/ui/src/components/collapsible/collapsible.tsx:264

### 4. Behavior test (pure, no DOM)
`collapsible.behavior.test.ts` exercises the score with no DOM: parts declaration, controlled-vs-
intrinsic state, the idempotence + disabled `canDispatch` gates, open/close actions through
dispatch, the aria projection (including the deliberately absent name-from-author), and the empty
keymap.
Evidence: packages/ui/test/components/collapsible/collapsible.behavior.test.ts

### 5. Classes parity test
`collapsible.classes.test.ts` asserts the trigger's hover/focus-ring/disabled tokens, the content's
`overflow-hidden` + height-axis transition intent, reduced-motion on both, and that no raw color,
spacing, or z-index utilities leak in.
Evidence: packages/ui/test/components/collapsible/collapsible.classes.test.ts

### 6. Conformance test via the shared harness (aria + keymap against rendered DOM)
React, WC, and Astro each drive the one score through the shared harness: `assertContractFulfillment`
compares the DOM's ARIA to the projection against real ids, axe runs clean, and the native-button
Enter/Space + click toggles are driven with userEvent. One score, three performances.
Evidence: packages/ui/test/components/collapsible/collapsible.conformance.test.tsx:56

### 7. shadcn drop-in parity where the component exists in shadcn
`Collapsible` exposes the namespaced `Collapsible.Trigger` / `Collapsible.Content`, `asChild` on
both, `open`/`defaultOpen`/`onOpenChange`/`disabled`, and `forceMount` -- the shadcn/Radix
collapsible surface, so it is a drop-in replacement.
Evidence: packages/ui/src/components/collapsible/collapsible.tsx:261

### 8. test:unit green, preflight green
`pnpm --filter @rafters/ui test:unit` passes across both the default and astro vitest configs, and
`pnpm preflight` (typecheck + lint + format:check + tests + build) exits 0. The 37 collapsible
tests are green across all three frameworks.
Evidence: pnpm preflight exit code 0; test:unit 173 tests passing

## Not done

- **Matrix `components.jsonl` update** -- the file is deleted on `main`; the wave hardening scopes
  each port to only its own component folder + test + doc, so no matrix or CHANGELOG edit is made
  (the issue's closing directives predate that deletion).
- **Keyframed height animation** -- the collapse is declared as transition intent only; a true
  height keyframe waits on a real `--collapsible-content-height` utility in the token system. The
  oracle's `animate-collapsible-up/down` were never defined, so porting them would be dead classes.
- **Content `aria-labelledby`** -- dropped as a defect (name-from-author is prohibited on a
  role-less div; axe `aria-prohibited-attr`). The trigger's `aria-expanded` + `aria-controls` is the
  complete disclosure wiring.
- **Vue performance** -- out of scope for this wave (React/WC/Astro only), same as the other ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1765
