### PR TITLE
feat(#1802): port toggle-group to the behavior layer

### DIFF
--- a/packages/ui/docs/spec/components/toggle-group.md
+++ b/packages/ui/docs/spec/components/toggle-group.md
@@ -1,0 +1,157 @@
+# Component Spec — Toggle Group
+
+Status: DRAFT. Toggle-family article. Ports the imperative
+`old/ui/toggle-group.controller.ts` + `old/ui/toggle-group.element.ts` onto the
+behavior layer (selection state as reducer, focus movement as the composed
+`roving-focus` primitive).
+
+Files (`src/components/toggle-group/`):
+
+```
+toggle-group.classes.ts   toggle-group.behavior.ts   toggle-group.tsx
+toggle-group.element.ts   toggle-group.astro
+```
+
+Tests mirror into `test/components/toggle-group/`: `.behavior.test.ts` (pure),
+`.classes.test.ts` (parity), `.conformance.test.tsx` (React),
+`.element.conformance.test.ts` (WC), `.astro.conformance.test.ts` (Astro).
+
+## Composition
+
+```
+toggle-group slice   state {value, multiple}, action toggle, root + item parts,
+                     group role, data-orientation/data-disabled aria,
+                     Space/Enter keymap; roving-focus composed in the client
+```
+
+A single slice — no glue. The score's only state axis is the set of selected
+values; focus movement across items is NOT state, it is ephemeral DOM state
+owned by the `roving-focus` primitive (mirroring radio-group/navigation-menu).
+Unlike radio-group, selection does NOT follow focus: arrow keys move focus only,
+and activation (Space/Enter/click, fulfilled natively by the item `<button>`s)
+toggles the focused item. This is the WAI-ARIA toolbar pattern, not the radio
+pattern.
+
+`roving-focus` is composed DIRECTLY — the WC/Astro `bindToggleGroup` and the
+React controller each call `createRovingFocus(root, { orientation })`. There is
+no effect vocabulary and no runner: the client composes the primitive against
+real document DOM. The item buttons carry `data-roving-item` so the primitive
+finds them (they are plain buttons, not one of the roles roving matches by
+default).
+
+Two modes over one action. The reducer receives `(state, payload)` with no
+config (Spec 01), so the mode is seeded into state (`multiple`) at
+`initialState` from `config.type`:
+
+- **single** (default) is COLLAPSIBLE — re-activating the selected item clears
+  it (the oracle's `current === itemValue ? '' : itemValue`).
+- **multiple** is additive — activation toggles the value in/out of the set.
+
+Controlled/uncontrolled per the ownership-of-truth boundary applied to a set
+(the same shape as radio-group applied to a string): `config.value` is the
+consumer's controlled value (passed fresh, never stored); `state.value` is
+intrinsic, seeded from `defaultValue`. Projections and the `onValueChange`
+callback read the EFFECTIVE value via `selectedValues(state, config)`;
+`emitValue(values, config)` shapes the callback payload (`string` for single,
+`string[]` for multiple).
+
+## Config, state, actions
+
+```ts
+interface ToggleGroupConfig {
+  type?: 'single' | 'multiple';        // default 'single'
+  value?: string | string[];           // controlled
+  defaultValue?: string | string[];    // uncontrolled seed
+  orientation?: 'horizontal' | 'vertical'; // default 'horizontal'
+  disabled?: boolean;    // group-level; gates toggle, propagates to items
+  required?: boolean;    // inert form surface (see dispositions)
+  name?: string;         // inert form surface (see dispositions)
+  variant?: 'default' | 'outline';
+  size?: 'default' | 'sm' | 'lg';
+}
+interface ToggleGroupState { value: string[]; multiple: boolean } // intrinsic
+type ToggleGroupActions = { toggle: string }
+```
+
+`canDispatch` rejects `toggle` when the group is disabled, so a controlled
+consumer's callback never fires for an edit the group would refuse. Item-level
+`disabled` is handled in the bind/decorator (native `disabled` + roving skips
+disabled items) rather than in `canDispatch`, which cannot see the item value.
+
+## Parts and ARIA
+
+| Part | Presence | ARIA |
+| --- | --- | --- |
+| root | always | `role="group"`, `data-orientation`, `data-disabled` (when disabled) |
+| item | many | `aria-pressed` (`'true'`/`'false'`), `data-state` (`on`/`off`) |
+
+The root is `role="group"`, which does NOT support `aria-orientation`,
+`aria-disabled`, or `aria-required` (they are outside its allowed-attribute set
+— axe flags them). So the group advertises orientation via `data-orientation`
+and expresses group-disabled by natively disabling its items, matching the
+oracle WC. Items are native `<button type="button">` toggle buttons carrying
+`aria-pressed` — valid on a button regardless of mode.
+
+`item` is a `many` part: its projection is the exported `toggleItemAria(value,
+state, config)`, driven per instance by React/Astro/the bind and asserted by
+`assertInstanceContractFulfillment`. `tabindex` is deliberately ABSENT from the
+projection — roving-focus owns it as ephemeral DOM state, so it must not appear
+in a projection the conformance harness asserts against.
+
+The item projection carries the resolved string `aria-pressed: 'false'` in the
+common unpressed case; the DOM binds apply it with `{ validate: false }` so
+aria-manager does not coerce the string `'false'` truthy (Gotcha #2).
+
+## Keyboard and effects
+
+- `keymap`: Space/Enter on an `item` -> `toggle`. Declared for the pure keymap
+  contract; the DOM binds do NOT wire it — the native `<button>` converts
+  Space/Enter to a click that the delegated click handler dispatches (wiring
+  keymap too would double-toggle: select-then-deselect in single mode). Arrow
+  keys are NOT claimed — the roving-focus primitive owns them for movement.
+- Roving: `bindToggleGroup` and the React effect each compose
+  `createRovingFocus(root, { orientation })` directly. It owns the roving
+  tabindex and arrow/Home/End movement across the `[data-roving-item]` item
+  buttons, and skips disabled items.
+- Activation is delegated click only (bind) / item `onClick` (React). No keydown
+  branch — selection does not follow focus, so there is nothing to wire on top
+  of roving (contrast radio-group, which adds a select-follows-focus keydown).
+
+## Oracle dispositions (`src/old/ui/toggle-group.*`)
+
+| Oracle feature | Disposition |
+| --- | --- |
+| single (collapsible) + multiple selection modes | contract |
+| single re-click clears; multiple adds/removes | contract |
+| controlled/uncontrolled + onValueChange (`string` \| `string[]`) | contract |
+| orientation (horizontal/vertical) drives roving + layout | contract |
+| group + item `disabled`; roving skips disabled items | contract |
+| click / Space / Enter toggle the focused item | contract |
+| `aria-pressed` + `data-state` (on/off) reflection on items | contract |
+| variant (default/outline) + size (default/sm/lg) | contract |
+| arrow keys move focus ONLY, no select-follows-focus | contract — the toolbar pattern (this component's correct behavior, unlike radio-group which improved to arrow-selects) |
+| WC form-association via ElementInternals (`setFormValue`, `valueMissing`, CSV/FormData submission, `name`/`required` validity) | dropped — deferred to the `form-value` primitive, which does not yet exist (planned across the checkbox/switch/select family). `name`/`required` are preserved as an INERT surface (`data-name`, and `required` accepted on config) so the wiring exists when form-value lands. The old React tsx never rendered hidden inputs either; form participation was WC-only |
+| WC `input`/`change`/`rafters-toggle-group-change` events | dropped — same deferral; the selection contract is `onValueChange` (React) and the projected `aria-pressed`/`data-state` (all three) |
+| shadow-DOM `<rafters-toggle-group>` + `<rafters-toggle-group-item>` pair | defect-do-not-port — replaced by a single light-DOM enhancer (`bindToggleGroup`), matching button/radio-group; the host provides the real `role="group"` markup with `<button data-part="item">` children so roving and focus act on real document DOM |
+| `createSelectionGroup` primitive for single/multiple state | framework-affordance — expressed instead as reducer state (`{ value, multiple }`), the behavior-layer equivalent, exactly as radio-group expresses its single-select state as reducer state rather than composing the primitive (no behavior-layer component composes `createSelectionGroup`) |
+
+## Deltas from the oracle
+
+1. Selection is reducer state driven through the score + the composed
+   `roving-focus` primitive, not the imperative `createToggleGroup` controller.
+2. Group-disabled is expressed by natively disabling items plus a `data-disabled`
+   marker on the root, rather than `aria-disabled` on the group (invalid on
+   `role="group"`).
+3. A single light-DOM enhancer replaces the shadow-DOM element pair; the item
+   buttons are the real focusable/roving targets.
+
+## WCAG 2.1 AA obligations
+
+- 1.3.1 / 4.1.2: `role="group"` on the container with per-item `aria-pressed` +
+  `data-state`, asserted against real DOM by the harness. The group is given an
+  accessible name by the consumer (`aria-label` / `aria-labelledby`).
+- 2.1.1 Keyboard: arrows (per orientation) + Home/End move focus; Space/Enter
+  and click activate the focused item; disabled items are skipped by roving.
+- 2.4.3 Focus Order: roving tabindex keeps exactly one item in the tab order;
+  Tab enters the group and Tab leaves it (arrows move within).
+- 2.4.7: token focus ring on the item (`focus-visible:ring-ring`).

--- a/packages/ui/src/components/toggle-group/toggle-group.astro
+++ b/packages/ui/src/components/toggle-group/toggle-group.astro
@@ -1,0 +1,116 @@
+---
+/**
+ * Astro performance (controller) for toggle-group.
+ *
+ * Server-renders the full LIGHT-DOM markup with classes and the score's initial
+ * projection already applied, so the group is correct and accessible before any
+ * JS. The <script> then hands each server-rendered root to bindToggleGroup --
+ * the SAME DOM-native controller the Web Component uses. Astro imports the
+ * behavior binding like any other module; there is no astro-specific runtime.
+ *
+ * The projection is computed here from the same toggleGroup.aria / toggleItemAria
+ * the React and WC controllers read -- one score, three performances, zero drift.
+ */
+import {
+  toggleGroup,
+  toggleItemAria,
+  type ToggleGroupConfig,
+  type ToggleGroupPart,
+  type ToggleGroupSize,
+  type ToggleGroupType,
+  type ToggleGroupVariant,
+} from './toggle-group.behavior';
+import { toggleGroupClasses } from './toggle-group.classes';
+import type { PartIds } from '../../lib/contract';
+
+interface Item {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+interface Props {
+  id: string;
+  items: Item[];
+  type?: ToggleGroupType;
+  value?: string | string[];
+  orientation?: 'horizontal' | 'vertical';
+  disabled?: boolean;
+  required?: boolean;
+  name?: string;
+  variant?: ToggleGroupVariant;
+  size?: ToggleGroupSize;
+}
+
+const {
+  id,
+  items,
+  type = 'single',
+  value,
+  orientation = 'horizontal',
+  disabled = false,
+  required = false,
+  name,
+  variant = 'default',
+  size = 'default',
+} = Astro.props;
+
+const config: ToggleGroupConfig = {
+  type,
+  defaultValue: value,
+  orientation,
+  disabled,
+  required,
+  name,
+  variant,
+  size,
+};
+const state = toggleGroup.initialState(config);
+const classes = toggleGroupClasses(config, state);
+
+const ids = {} as PartIds<ToggleGroupPart>;
+for (const part of Object.keys(toggleGroup.parts) as ToggleGroupPart[]) {
+  ids[part] = `${id}-${part}`;
+}
+const rootAria = toggleGroup.aria(state, config, ids);
+---
+
+<div
+  data-part="root"
+  id={ids.root}
+  role="group"
+  data-type={type}
+  data-name={name}
+  class={classes.root}
+  {...rootAria.root}
+>
+  {
+    items.map((item) => (
+      <button
+        type="button"
+        data-part="item"
+        data-value={item.value}
+        data-roving-item
+        disabled={disabled || item.disabled}
+        class={classes.item}
+        {...toggleItemAria(item.value, state, config)}
+      >
+        {item.label}
+      </button>
+    ))
+  }
+</div>
+
+<script>
+  import { bindToggleGroup } from './toggle-group.behavior';
+
+  // The <script> is bundled and runs once per page; bind every instance's
+  // server-rendered root. Same controller as the Web Component.
+  for (const root of document.querySelectorAll<HTMLElement>(
+    '[data-part="root"][role="group"][data-type]',
+  )) {
+    if (root.dataset['bound'] === 'true') continue;
+    root.dataset['bound'] = 'true';
+    bindToggleGroup(root);
+  }
+</script>

--- a/packages/ui/src/components/toggle-group/toggle-group.behavior.ts
+++ b/packages/ui/src/components/toggle-group/toggle-group.behavior.ts
@@ -1,0 +1,271 @@
+import { compose, type Slice } from '../../lib/compose';
+import {
+  createBehavior,
+  type AriaAttrs,
+  type BehaviorSpec,
+  type PartIds,
+} from '../../lib/contract';
+import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { createRovingFocus } from '../../primitives/roving-focus';
+
+/**
+ * Toggle group: a set of toggle buttons coordinated as a single- or
+ * multiple-select group. Ports the imperative old/ui/toggle-group.controller.ts
+ * + old/ui/toggle-group.element.ts onto the behavior layer -- selection state as
+ * reducer, focus movement as the composed roving-focus primitive.
+ *
+ * The score's only state axis is the set of selected values. Focus movement
+ * across items is NOT state -- it is ephemeral DOM state owned by roving-focus
+ * (mirroring radio-group/navigation-menu). Unlike radio-group, selection does
+ * NOT follow focus: arrow keys move focus only; activation (Space/Enter/click,
+ * fulfilled natively by the item <button>s) toggles the focused item. This is
+ * the WAI-ARIA toolbar pattern, not the radio pattern.
+ *
+ * Two modes over one action:
+ * - single (default) is collapsible -- re-activating the selected item clears it
+ *   (the oracle's `current === itemValue ? '' : itemValue`).
+ * - multiple is additive -- activation toggles the value in/out of the set.
+ *
+ * The reducer receives `(state, payload)` with no config (Spec 01), so the mode
+ * is seeded into state (`multiple`) at initialState from `config.type`.
+ *
+ * Controlled/uncontrolled per the ownership-of-truth boundary applied to a set
+ * (the same shape as radio-group applied to a string): `config.value` is the
+ * consumer's controlled value (passed fresh, never stored); `state.value` is the
+ * intrinsic set, seeded from `defaultValue`. Projections and the change callback
+ * read the EFFECTIVE value via `selectedValues(state, config)`.
+ */
+export type ToggleGroupType = 'single' | 'multiple';
+export type ToggleGroupVariant = 'default' | 'outline';
+export type ToggleGroupSize = 'default' | 'sm' | 'lg';
+export type ToggleGroupOrientation = 'horizontal' | 'vertical';
+
+export interface ToggleGroupConfig {
+  /** Selection mode. Default 'single'. */
+  type?: ToggleGroupType | undefined;
+  /** Controlled value: shadows the intrinsic state when present. */
+  value?: string | string[] | undefined;
+  /** Uncontrolled seed for the intrinsic value. */
+  defaultValue?: string | string[] | undefined;
+  /** Arrow-key navigation axis. Default 'horizontal'. */
+  orientation?: ToggleGroupOrientation | undefined;
+  /** Whether the entire group is disabled (gates toggling, propagates to items). */
+  disabled?: boolean | undefined;
+  /** Advertised via the form surface (see toggle-group.md dispositions). */
+  required?: boolean | undefined;
+  /** Form field name (inert surface; see toggle-group.md dispositions). */
+  name?: string | undefined;
+  /** Visual variant. */
+  variant?: ToggleGroupVariant | undefined;
+  /** Size variant. */
+  size?: ToggleGroupSize | undefined;
+}
+
+export interface ToggleGroupState {
+  /** Intrinsic selected values -- ignored while a controlled value is present. */
+  value: string[];
+  /** Mode, seeded from config.type: the reducer sees no config (Spec 01). */
+  multiple: boolean;
+}
+
+export type ToggleGroupActions = {
+  /** Toggle a value (payload: the item's value). */
+  toggle: string;
+};
+
+export type ToggleGroupPart = 'root' | 'item';
+
+/** Normalize a controlled/default value to an array of selected strings. */
+function toArray(value: string | string[] | undefined): string[] {
+  if (value === undefined) return [];
+  if (Array.isArray(value)) return value.filter((entry) => entry !== '');
+  return value === '' ? [] : [value];
+}
+
+function isMultiple(config: ToggleGroupConfig): boolean {
+  return (config.type ?? 'single') === 'multiple';
+}
+
+export function orientationOf(config: ToggleGroupConfig): ToggleGroupOrientation {
+  return config.orientation ?? 'horizontal';
+}
+
+/** The effective selected set: a controlled value shadows intrinsic state. */
+export function selectedValues(state: ToggleGroupState, config: ToggleGroupConfig): string[] {
+  if (config.value !== undefined) {
+    const values = toArray(config.value);
+    return isMultiple(config) ? values : values.slice(0, 1);
+  }
+  return state.value;
+}
+
+/** Report shape for onValueChange: string for single, string[] for multiple. */
+export function emitValue(values: string[], config: ToggleGroupConfig): string | string[] {
+  return isMultiple(config) ? values : (values[0] ?? '');
+}
+
+const toggleGroupSlice: Slice<
+  ToggleGroupConfig,
+  ToggleGroupState,
+  ToggleGroupActions,
+  ToggleGroupPart
+> = {
+  name: 'toggle-group',
+  parts: {
+    root: { role: 'group' },
+    item: { many: true },
+  },
+  initialState: (config) => {
+    const multiple = isMultiple(config);
+    const seed = toArray(config.value ?? config.defaultValue);
+    return { value: multiple ? seed : seed.slice(0, 1), multiple };
+  },
+  actions: {
+    toggle: (state, value) => {
+      if (!value) return state;
+      if (state.multiple) {
+        const has = state.value.includes(value);
+        return {
+          multiple: true,
+          value: has ? state.value.filter((entry) => entry !== value) : [...state.value, value],
+        };
+      }
+      // Single mode is COLLAPSIBLE: re-activating the selected item clears it.
+      const isOnlySelected = state.value.length === 1 && state.value[0] === value;
+      return { multiple: false, value: isOnlySelected ? [] : [value] };
+    },
+  },
+  // The group-level disabled gate: a disabled group rejects toggling, so a
+  // controlled consumer's callback never fires for an edit it would refuse.
+  // Item-level disabled is handled in the bind/decorator (native disabled +
+  // roving skips disabled items) rather than here, which cannot see the value.
+  canDispatch: (_state, action, config) => (action === 'toggle' ? !config.disabled : true),
+  // role="group" does not support aria-orientation/aria-disabled/aria-required
+  // (they are not in its allowed-attribute set -- axe would flag them), so the
+  // group advertises orientation via data-orientation and expresses disabled by
+  // natively disabling its items. Matches the oracle WC.
+  aria: (_state, config) => ({
+    root: {
+      'data-orientation': orientationOf(config),
+      'data-disabled': config.disabled ? 'true' : undefined,
+    },
+  }),
+  // Space/Enter on an item map to toggle. Declared for the pure keymap contract;
+  // the DOM binds rely on the native <button> converting Space/Enter to a click
+  // (wiring keymap too would double-toggle). Arrow keys are NOT claimed -- the
+  // roving-focus primitive owns them for movement.
+  keymap: (event, _state, part) =>
+    part === 'item' && (event.key === 'Enter' || event.key === ' ') ? 'toggle' : null,
+};
+
+export const toggleGroup: BehaviorSpec<
+  ToggleGroupConfig,
+  ToggleGroupState,
+  ToggleGroupActions,
+  ToggleGroupPart
+> = compose('toggle-group', toggleGroupSlice);
+
+/**
+ * Per-instance projection for the `item` many-part. `aria()` projects one
+ * AriaAttrs per part NAME; items occur once per value, so their projection takes
+ * the instance value (mirroring radio-group's radioItemAria). tabindex is
+ * deliberately absent: roving-focus owns it as ephemeral DOM state, so it must
+ * not appear in a projection the conformance harness asserts against.
+ */
+export function toggleItemAria(
+  value: string,
+  state: ToggleGroupState,
+  config: ToggleGroupConfig,
+): AriaAttrs {
+  const pressed = selectedValues(state, config).includes(value);
+  return {
+    'aria-pressed': pressed ? 'true' : 'false',
+    'data-state': pressed ? 'on' : 'off',
+  };
+}
+
+/** Toggle items participating in toggling/roving (excludes disabled). */
+const ITEM_SELECTOR = '[data-part="item"][data-value]:not([disabled])';
+
+/**
+ * The DOM-native binding of the toggle-group score -- the client the Web
+ * Component and the Astro <script> both import; only React (retained-mode) reads
+ * the projections declaratively instead. Composes the substrate the same way the
+ * React controller does: createBehavior is the model, createRovingFocus drives
+ * arrow/Home/End movement and the roving tabindex, aria-manager applies the
+ * projection, and the DOM is the part registry.
+ *
+ * Activation is delegated click only: the item <button>s convert Space/Enter to
+ * a native click, so no keydown branch is needed (matches bindToggle). Arrow
+ * keys are handled by the composed roving-focus primitive, which finds the item
+ * buttons by their `data-roving-item` marker.
+ */
+export function bindToggleGroup(root: HTMLElement): () => void {
+  const pressedAtMount = Array.from(
+    root.querySelectorAll<HTMLElement>('[data-part="item"][data-state="on"]'),
+  )
+    .map((el) => el.getAttribute('data-value'))
+    .filter((value): value is string => value !== null);
+
+  const config: ToggleGroupConfig = {
+    type: root.getAttribute('data-type') === 'multiple' ? 'multiple' : 'single',
+    orientation: root.getAttribute('data-orientation') === 'vertical' ? 'vertical' : 'horizontal',
+    disabled: root.getAttribute('data-disabled') === 'true',
+    // WC/Astro are uncontrolled (no reactive prop), so config.value stays
+    // undefined; seed the intrinsic set from the server-rendered pressed items.
+    defaultValue: pressedAtMount,
+  };
+
+  const getPart = (part: string): HTMLElement | null =>
+    part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
+
+  const { memory, dispatch } = createBehavior(toggleGroup, config);
+
+  // Compose the roving-focus primitive directly -- it owns the roving tabindex
+  // and arrow/Home/End movement across the [data-roving-item] item buttons.
+  const stopRoving = createRovingFocus(root, { orientation: orientationOf(config) });
+
+  // ids are READ from the markup (server- or author-minted), never generated.
+  const ids = {} as PartIds<ToggleGroupPart>;
+  for (const part of Object.keys(toggleGroup.parts) as ToggleGroupPart[]) {
+    ids[part] = getPart(part)?.id ?? '';
+  }
+
+  // The score's projection is already resolved (final strings, undefined =
+  // absent), so apply it raw: validate:false skips aria-manager's author-input
+  // coercion, which would re-read the resolved string 'false' as truthy.
+  const applyProjection = (el: HTMLElement, attrs: AriaAttrs) => {
+    for (const [name, value] of Object.entries(attrs)) {
+      updateAriaAttribute(el, name as never, value as never, { validate: false });
+    }
+  };
+
+  const render = () => {
+    const state = memory.get();
+    const projection = toggleGroup.aria(state, config, ids);
+    for (const part of Object.keys(projection) as ToggleGroupPart[]) {
+      const attrs = projection[part];
+      const el = getPart(part);
+      if (el && attrs) applyProjection(el, attrs);
+    }
+    for (const el of root.querySelectorAll<HTMLElement>('[data-part="item"]')) {
+      const value = el.dataset['value'];
+      if (value === undefined) continue;
+      applyProjection(el, toggleItemAria(value, state, config));
+    }
+  };
+  const unsubscribe = memory.subscribe(render); // fires immediately: first paint
+
+  const onClick = (event: Event) => {
+    const item = (event.target as HTMLElement).closest<HTMLElement>(ITEM_SELECTOR);
+    const value = item?.dataset['value'];
+    if (value !== undefined && root.contains(item)) dispatch('toggle', config, value);
+  };
+  root.addEventListener('click', onClick);
+
+  return () => {
+    unsubscribe();
+    stopRoving();
+    root.removeEventListener('click', onClick);
+  };
+}

--- a/packages/ui/src/components/toggle-group/toggle-group.classes.ts
+++ b/packages/ui/src/components/toggle-group/toggle-group.classes.ts
@@ -1,0 +1,69 @@
+import type {
+  ToggleGroupConfig,
+  ToggleGroupSize,
+  ToggleGroupState,
+  ToggleGroupVariant,
+} from './toggle-group.behavior';
+
+export interface ToggleGroupClassSet {
+  /** The role="group" container: orientation-driven layout + variant chrome. */
+  root: string;
+  /** Each toggle item button: base + size + variant, pressed driven by data-state. */
+  item: string;
+}
+
+const rootBaseClasses = 'inline-flex items-center justify-center gap-1 rounded-lg';
+const rootDefaultVariantClasses = 'bg-muted p-1';
+const rootVerticalClasses = 'flex-col';
+
+const itemBaseClasses =
+  'inline-flex items-center justify-center ' +
+  'rounded-md ' +
+  'text-label-large ' +
+  'transition-all duration-200 motion-reduce:transition-none ' +
+  'active:scale-[0.98] ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ' +
+  'disabled:pointer-events-none disabled:opacity-50 ' +
+  'hover:bg-muted hover:text-muted-foreground';
+
+const itemSizeClasses: Record<ToggleGroupSize, string> = {
+  default: 'h-9 px-3',
+  sm: 'h-8 px-2',
+  lg: 'h-10 px-4',
+};
+
+// Pressed styling is data-state driven: the score projects data-state=on|off on
+// each item, so the same class string works for all three performances with no
+// conditional application.
+const itemDefaultVariantClasses =
+  'bg-transparent data-[state=on]:bg-background data-[state=on]:text-foreground data-[state=on]:shadow-sm';
+
+const itemOutlineVariantClasses =
+  'border border-input bg-transparent data-[state=on]:bg-accent data-[state=on]:text-accent-foreground';
+
+function rootClasses(variant: ToggleGroupVariant, orientation: 'horizontal' | 'vertical'): string {
+  const parts = [rootBaseClasses];
+  if (orientation === 'vertical') parts.push(rootVerticalClasses);
+  if (variant === 'default') parts.push(rootDefaultVariantClasses);
+  return parts.join(' ');
+}
+
+function itemClasses(variant: ToggleGroupVariant, size: ToggleGroupSize): string {
+  const variantClasses =
+    variant === 'outline' ? itemOutlineVariantClasses : itemDefaultVariantClasses;
+  return `${itemBaseClasses} ${itemSizeClasses[size]} ${variantClasses}`;
+}
+
+/** The view: class strings keyed by config/state. No logic. */
+export function toggleGroupClasses(
+  config: ToggleGroupConfig,
+  _state: ToggleGroupState,
+): ToggleGroupClassSet {
+  const variant = config.variant ?? 'default';
+  const size = config.size ?? 'default';
+  const orientation = config.orientation ?? 'horizontal';
+  return {
+    root: rootClasses(variant, orientation),
+    item: itemClasses(variant, size),
+  };
+}

--- a/packages/ui/src/components/toggle-group/toggle-group.element.ts
+++ b/packages/ui/src/components/toggle-group/toggle-group.element.ts
@@ -1,0 +1,35 @@
+/**
+ * WC performance for toggle-group: the thinnest wrapper. The score AND the
+ * DOM-native binding (bindToggleGroup) live in toggle-group.behavior.ts, shared
+ * with the Astro performance. This file only adapts that binding to the
+ * custom-element lifecycle.
+ *
+ * A light-DOM enhancer: the author (or Astro) provides the real
+ * `<div data-part="root" role="group">` with `<button data-part="item">`
+ * children, so native focus and the roving-focus effect operate on real
+ * document DOM -- the WC never renders a shadow tree of its own. The bind is
+ * deferred one microtask because connectedCallback can fire before the
+ * light-DOM children are parsed (upgrade order).
+ */
+import { bindToggleGroup } from './toggle-group.behavior';
+
+export class RaftersToggleGroup extends HTMLElement {
+  private teardown: (() => void) | null = null;
+
+  connectedCallback(): void {
+    queueMicrotask(() => {
+      if (!this.isConnected || this.teardown) return;
+      const root = this.querySelector<HTMLElement>('[data-part="root"]');
+      if (root) this.teardown = bindToggleGroup(root);
+    });
+  }
+
+  disconnectedCallback(): void {
+    this.teardown?.();
+    this.teardown = null;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-toggle-group')) {
+  customElements.define('rafters-toggle-group', RaftersToggleGroup);
+}

--- a/packages/ui/src/components/toggle-group/toggle-group.tsx
+++ b/packages/ui/src/components/toggle-group/toggle-group.tsx
@@ -1,0 +1,244 @@
+import * as React from 'react';
+import { createBehavior, type PartIds } from '../../lib/contract';
+import { useMemory } from '../../hooks/use-memory';
+import classy from '../../primitives/classy';
+import { createRovingFocus } from '../../primitives/roving-focus';
+import {
+  emitValue,
+  orientationOf,
+  selectedValues,
+  toggleGroup,
+  toggleItemAria,
+  type ToggleGroupConfig,
+  type ToggleGroupPart,
+  type ToggleGroupState,
+} from './toggle-group.behavior';
+import { toggleGroupClasses, type ToggleGroupClassSet } from './toggle-group.classes';
+
+interface ToggleGroupContextValue {
+  state: ToggleGroupState;
+  config: ToggleGroupConfig;
+  classes: ToggleGroupClassSet;
+  groupDisabled: boolean;
+  request: (value: string) => boolean;
+}
+
+const ToggleGroupContext = React.createContext<ToggleGroupContextValue | null>(null);
+
+function useToggleGroupContext(component: string): ToggleGroupContextValue {
+  const context = React.useContext(ToggleGroupContext);
+  if (!context) {
+    throw new Error(`${component} must be used within <ToggleGroup>`);
+  }
+  return context;
+}
+
+/** Order-insensitive set equality: selection is by value, order is not state. */
+function sameSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const set = new Set(a);
+  return b.every((value) => set.has(value));
+}
+
+export interface ToggleGroupProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'onChange' | 'defaultValue'
+> {
+  /** Selection mode: single allows one (collapsible), multiple allows any number. */
+  type?: 'single' | 'multiple';
+  /** Controlled value: string for single, string[] for multiple. */
+  value?: string | string[];
+  /** Default value for uncontrolled usage. */
+  defaultValue?: string | string[];
+  /** Callback when the selection changes via user interaction. */
+  onValueChange?: (value: string | string[]) => void;
+  /** Visual variant. */
+  variant?: 'default' | 'outline';
+  /** Size variant. */
+  size?: 'default' | 'sm' | 'lg';
+  /** Whether all items are disabled. */
+  disabled?: boolean;
+  /** Layout / arrow-navigation orientation. Default 'horizontal'. */
+  orientation?: 'horizontal' | 'vertical';
+  /** Advertised via the form surface (see toggle-group.md dispositions). */
+  required?: boolean;
+  /** Form field name (inert surface; see toggle-group.md dispositions). */
+  name?: string;
+}
+
+/**
+ * Grouped toggle set: coordinates toggle buttons as a single- (collapsible) or
+ * multiple-select group. Arrow keys move focus (roving tabindex); Space, Enter,
+ * or click toggle the focused item -- selection does NOT follow focus (the
+ * toolbar pattern, not the radio pattern).
+ *
+ * @cognitive-load 3/10 - decision 1, information 1, interaction 1, disruption 0,
+ * learning 0. One decision over a visible few (which option(s) to enable);
+ * options are shown side by side so comparison is direct and nothing must be
+ * recalled. A universally learned button affordance with no workflow disruption.
+ * @attention-economics Options visible simultaneously: the set supports
+ * side-by-side comparison and keeps the current selection in view. Best for 2-5
+ * options; beyond ~7 a Select reclaims the attention budget.
+ * @trust-building Immediate visual feedback on each pressed item, reversible
+ * choices, and an always-visible current state. Single mode is collapsible so a
+ * user can return to "nothing selected"; multiple mode makes each toggle
+ * independent and non-destructive.
+ * @accessibility role="group" on the container with per-item aria-pressed +
+ * data-state on native <button>s, wired to real DOM by the harness. Roving
+ * tabindex keeps exactly one item in the tab order; arrow keys move focus;
+ * Space/Enter/click activate. Disabled items leave the tab order (native
+ * disabled) and are skipped by roving.
+ */
+export function ToggleGroup({
+  type = 'single',
+  value,
+  defaultValue,
+  onValueChange,
+  variant = 'default',
+  size = 'default',
+  disabled = false,
+  orientation = 'horizontal',
+  required = false,
+  name,
+  className,
+  children,
+  ...props
+}: ToggleGroupProps) {
+  const config: ToggleGroupConfig = {
+    type,
+    value,
+    defaultValue,
+    orientation,
+    disabled,
+    required,
+    name,
+    variant,
+    size,
+  };
+
+  // The controller composes the score with the substrate -- no useBehavior.
+  // createBehavior is the model; useMemory subscribes React to it; the effect
+  // below composes the roving-focus primitive directly against the root.
+  const { memory, dispatch } = React.useMemo(() => createBehavior(toggleGroup, config), []);
+  const state = useMemory(memory);
+
+  const uid = React.useId();
+  const ids = React.useMemo(() => {
+    const out = {} as PartIds<ToggleGroupPart>;
+    for (const part of Object.keys(toggleGroup.parts) as ToggleGroupPart[]) {
+      out[part] = `${uid}-${part}`;
+    }
+    return out;
+  }, [uid]);
+
+  const rootRef = React.useRef<HTMLDivElement>(null);
+
+  // Gotcha #1: the controlled callback compares the EFFECTIVE value before
+  // against the INTRINSIC value after the reducer -- a controlled group's
+  // effective value never moves (config shadows it), but the callback must still
+  // report the value to set. canDispatch already gates group-disabled.
+  const latest = React.useRef({ config, onValueChange });
+  latest.current = { config, onValueChange };
+  const request = React.useCallback(
+    (itemValue: string): boolean => {
+      const { config: cfg, onValueChange: cb } = latest.current;
+      const before = selectedValues(memory.get(), cfg);
+      if (!dispatch('toggle', cfg, itemValue)) return false;
+      const after = memory.get().value;
+      if (!sameSet(before, after)) cb?.(emitValue(after, cfg));
+      return true;
+    },
+    [memory, dispatch],
+  );
+
+  // Compose the roving-focus primitive directly against the root -- it owns the
+  // roving tabindex and arrow/Home/End movement across the [data-roving-item]
+  // item buttons. Selection does NOT follow focus, so unlike radio-group there
+  // is no second keydown effect: activation flows through the item <button>'s
+  // native click (Space/Enter included).
+  React.useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    return createRovingFocus(root, { orientation: orientationOf(config) });
+  }, [orientation]);
+
+  const aria = toggleGroup.aria(state, config, ids);
+  const classes = toggleGroupClasses(config, state);
+
+  const contextValue: ToggleGroupContextValue = {
+    state,
+    config,
+    classes,
+    groupDisabled: disabled,
+    request,
+  };
+
+  return (
+    <ToggleGroupContext.Provider value={contextValue}>
+      {/* biome-ignore lint/a11y/useSemanticElements: role="group" is correct for a toggle group per WAI-ARIA APG; fieldset is for form controls */}
+      <div
+        ref={rootRef}
+        data-part="root"
+        id={ids.root}
+        role="group"
+        data-type={type}
+        data-name={name}
+        className={classy(classes.root, className)}
+        {...aria.root}
+        {...props}
+      >
+        {children}
+      </div>
+    </ToggleGroupContext.Provider>
+  );
+}
+
+ToggleGroup.displayName = 'ToggleGroup';
+
+export interface ToggleGroupItemProps extends Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  'value'
+> {
+  /** Value that identifies this toggle item. */
+  value: string;
+}
+
+export function ToggleGroupItem({
+  value,
+  className,
+  children,
+  disabled: itemDisabled,
+  onClick,
+  ...props
+}: ToggleGroupItemProps) {
+  const { state, config, classes, groupDisabled, request } =
+    useToggleGroupContext('ToggleGroupItem');
+  const isDisabled = groupDisabled || itemDisabled;
+  const aria = toggleItemAria(value, state, config);
+
+  return (
+    <button
+      type="button"
+      data-part="item"
+      data-value={value}
+      data-roving-item
+      disabled={isDisabled}
+      className={classy(classes.item, className)}
+      {...aria}
+      onClick={(event) => {
+        onClick?.(event);
+        if (event.defaultPrevented) return;
+        request(value);
+      }}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+ToggleGroupItem.displayName = 'ToggleGroupItem';
+
+ToggleGroup.Item = ToggleGroupItem;
+
+export default ToggleGroup;

--- a/packages/ui/test/components/toggle-group/toggle-group.astro.conformance.test.ts
+++ b/packages/ui/test/components/toggle-group/toggle-group.astro.conformance.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Astro performance of the toggle-group score, driven end to end. AstroContainer
+ * renders the SSR markup with the initial projection already applied, but does
+ * NOT run the <script>, so the test calls bindToggleGroup directly -- that IS the
+ * script's job -- then drives the same score the React and WC performances drive.
+ * One score, three performances.
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import ToggleGroup from '../../../src/components/toggle-group/toggle-group.astro';
+import { bindToggleGroup } from '../../../src/components/toggle-group/toggle-group.behavior';
+
+const items = [
+  { value: 'a', label: 'Alpha' },
+  { value: 'b', label: 'Beta' },
+  { value: 'c', label: 'Gamma' },
+];
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+async function mount(props: Record<string, unknown> = {}): Promise<HTMLElement> {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(ToggleGroup, {
+    props: { id: 'tg', items, ...props },
+  });
+  document.body.innerHTML = html;
+  const root = document.body.querySelector('[data-part="root"][role="group"]') as HTMLElement;
+  bindToggleGroup(root); // the <script> does this per instance on the real page
+  return root;
+}
+
+const item = (value: string) =>
+  document.body.querySelector<HTMLElement>(`[data-part="item"][data-value="${value}"]`)!;
+
+describe('toggle-group conformance [astro]', () => {
+  it('SSR: group + toggle items, the seeded value pressed, orientation reflected', async () => {
+    await mount({ value: 'b', orientation: 'vertical' });
+    const root = document.body.querySelector('[data-part="root"]');
+    expect(root?.getAttribute('role')).toBe('group');
+    expect(root?.getAttribute('data-orientation')).toBe('vertical');
+    expect(item('b').getAttribute('aria-pressed')).toBe('true');
+    expect(item('b').getAttribute('data-state')).toBe('on');
+    expect(item('a').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('single: click selects an item and reflects the projection', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(item('a'));
+    expect(item('a').getAttribute('aria-pressed')).toBe('true');
+    expect(item('a').getAttribute('data-state')).toBe('on');
+  });
+
+  it('multiple: SSR seeds every value, clicks add to the set', async () => {
+    const user = userEvent.setup();
+    await mount({ type: 'multiple', value: ['a', 'c'] });
+    expect(item('a').getAttribute('aria-pressed')).toBe('true');
+    expect(item('c').getAttribute('aria-pressed')).toBe('true');
+    await user.click(item('b'));
+    expect(item('b').getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('arrow keys move focus ONLY -- they do not toggle', async () => {
+    const user = userEvent.setup();
+    await mount();
+    item('a').focus();
+    await user.keyboard('{ArrowRight}');
+    expect(document.activeElement).toBe(item('b'));
+    expect(item('b').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('Space toggles the focused item', async () => {
+    const user = userEvent.setup();
+    await mount();
+    item('c').focus();
+    await user.keyboard(' ');
+    expect(item('c').getAttribute('aria-pressed')).toBe('true');
+  });
+});

--- a/packages/ui/test/components/toggle-group/toggle-group.behavior.test.ts
+++ b/packages/ui/test/components/toggle-group/toggle-group.behavior.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Pure behavior test for the toggle-group score. No DOM: exercises reducers,
+ * aria/keymap projections, canDispatch gates, and the per-instance toggleItemAria
+ * projection directly.
+ */
+import { describe, expect, it } from 'vitest';
+import { createBehavior } from '../../../src/lib/contract';
+import {
+  emitValue,
+  selectedValues,
+  toggleGroup,
+  toggleItemAria,
+  type ToggleGroupConfig,
+  type ToggleGroupState,
+} from '../../../src/components/toggle-group/toggle-group.behavior';
+
+const single: ToggleGroupConfig = { type: 'single' };
+const multiple: ToggleGroupConfig = { type: 'multiple' };
+const ids = { root: 'tg', item: 'tg-item' };
+
+describe('toggle-group initialState', () => {
+  it('single seeds from a string defaultValue', () => {
+    expect(toggleGroup.initialState({ type: 'single', defaultValue: 'b' })).toEqual({
+      value: ['b'],
+      multiple: false,
+    });
+  });
+
+  it('multiple seeds from an array defaultValue', () => {
+    expect(toggleGroup.initialState({ type: 'multiple', defaultValue: ['a', 'c'] })).toEqual({
+      value: ['a', 'c'],
+      multiple: true,
+    });
+  });
+
+  it('single clamps a multi-value seed to the first', () => {
+    expect(toggleGroup.initialState({ type: 'single', defaultValue: ['a', 'b'] })).toEqual({
+      value: ['a'],
+      multiple: false,
+    });
+  });
+
+  it("treats '' and undefined as nothing selected", () => {
+    expect(toggleGroup.initialState({ defaultValue: '' })).toEqual({ value: [], multiple: false });
+    expect(toggleGroup.initialState({})).toEqual({ value: [], multiple: false });
+  });
+
+  it('seeds from a controlled value', () => {
+    expect(toggleGroup.initialState({ type: 'multiple', value: ['x'] })).toEqual({
+      value: ['x'],
+      multiple: true,
+    });
+  });
+});
+
+describe('toggle-group selectedValues (controlled shadows intrinsic)', () => {
+  it('reads intrinsic state when uncontrolled', () => {
+    expect(selectedValues({ value: ['x'], multiple: false }, single)).toEqual(['x']);
+  });
+
+  it('a controlled value shadows the intrinsic state', () => {
+    expect(
+      selectedValues({ value: ['x'], multiple: false }, { type: 'single', value: 'y' }),
+    ).toEqual(['y']);
+  });
+
+  it('a controlled multiple value is read as an array', () => {
+    expect(
+      selectedValues({ value: [], multiple: true }, { type: 'multiple', value: ['a', 'b'] }),
+    ).toEqual(['a', 'b']);
+  });
+
+  it('a controlled single value is clamped to the first', () => {
+    expect(
+      selectedValues({ value: [], multiple: false }, { type: 'single', value: ['a', 'b'] }),
+    ).toEqual(['a']);
+  });
+});
+
+describe('toggle-group toggle action -- single (collapsible)', () => {
+  it('selects a value', () => {
+    const { memory, dispatch } = createBehavior(toggleGroup, single);
+    expect(dispatch('toggle', single, 'a')).toBe(true);
+    expect(memory.get().value).toEqual(['a']);
+  });
+
+  it('re-toggling the selected value clears it (collapsible)', () => {
+    const config: ToggleGroupConfig = { type: 'single', defaultValue: 'a' };
+    const { memory, dispatch } = createBehavior(toggleGroup, config);
+    dispatch('toggle', config, 'a');
+    expect(memory.get().value).toEqual([]);
+  });
+
+  it('selecting a different value replaces the selection', () => {
+    const config: ToggleGroupConfig = { type: 'single', defaultValue: 'a' };
+    const { memory, dispatch } = createBehavior(toggleGroup, config);
+    dispatch('toggle', config, 'b');
+    expect(memory.get().value).toEqual(['b']);
+  });
+});
+
+describe('toggle-group toggle action -- multiple (additive)', () => {
+  it('adds values to the set', () => {
+    const { memory, dispatch } = createBehavior(toggleGroup, multiple);
+    dispatch('toggle', multiple, 'a');
+    dispatch('toggle', multiple, 'b');
+    expect(memory.get().value).toEqual(['a', 'b']);
+  });
+
+  it('re-toggling removes a value from the set', () => {
+    const config: ToggleGroupConfig = { type: 'multiple', defaultValue: ['a', 'b'] };
+    const { memory, dispatch } = createBehavior(toggleGroup, config);
+    dispatch('toggle', config, 'a');
+    expect(memory.get().value).toEqual(['b']);
+  });
+});
+
+describe('toggle-group canDispatch (group-disabled gate)', () => {
+  it('allows toggle when enabled', () => {
+    const state: ToggleGroupState = { value: [], multiple: false };
+    expect(toggleGroup.canDispatch(state, 'toggle', single)).toBe(true);
+  });
+
+  it('rejects toggle when the group is disabled', () => {
+    const state: ToggleGroupState = { value: [], multiple: false };
+    expect(toggleGroup.canDispatch(state, 'toggle', { disabled: true })).toBe(false);
+  });
+
+  it('dispatch is gated by the config it is CALLED with', () => {
+    const { memory, dispatch } = createBehavior(toggleGroup, single);
+    expect(dispatch('toggle', { type: 'single', disabled: true }, 'a')).toBe(false);
+    expect(memory.get().value).toEqual([]);
+  });
+});
+
+describe('toggle-group group aria projection', () => {
+  function rootAria(config: ToggleGroupConfig) {
+    return toggleGroup.aria(toggleGroup.initialState(config), config, ids).root;
+  }
+
+  it('projects the default horizontal orientation, no disabled', () => {
+    expect(rootAria({})).toEqual({
+      'data-orientation': 'horizontal',
+      'data-disabled': undefined,
+    });
+  });
+
+  it('reflects vertical orientation', () => {
+    expect(rootAria({ orientation: 'vertical' })?.['data-orientation']).toBe('vertical');
+  });
+
+  it('projects data-disabled when the group is disabled', () => {
+    expect(rootAria({ disabled: true })?.['data-disabled']).toBe('true');
+  });
+
+  it('never projects aria-orientation/aria-disabled/aria-required (invalid on role=group)', () => {
+    const aria = rootAria({ orientation: 'vertical', disabled: true, required: true });
+    expect(aria).not.toHaveProperty('aria-orientation');
+    expect(aria).not.toHaveProperty('aria-disabled');
+    expect(aria).not.toHaveProperty('aria-required');
+  });
+});
+
+describe('toggle-group item projection (toggleItemAria)', () => {
+  it('the selected item is pressed; others are unpressed', () => {
+    const config: ToggleGroupConfig = { type: 'single', defaultValue: 'a' };
+    const state = toggleGroup.initialState(config);
+    expect(toggleItemAria('a', state, config)).toEqual({
+      'aria-pressed': 'true',
+      'data-state': 'on',
+    });
+    expect(toggleItemAria('b', state, config)).toEqual({
+      'aria-pressed': 'false',
+      'data-state': 'off',
+    });
+  });
+
+  it('multiple mode presses every selected value', () => {
+    const config: ToggleGroupConfig = { type: 'multiple', defaultValue: ['a', 'c'] };
+    const state = toggleGroup.initialState(config);
+    expect(toggleItemAria('a', state, config)['aria-pressed']).toBe('true');
+    expect(toggleItemAria('c', state, config)['aria-pressed']).toBe('true');
+    expect(toggleItemAria('b', state, config)['aria-pressed']).toBe('false');
+  });
+
+  it('carries no tabindex (roving owns it as ephemeral DOM state)', () => {
+    expect(toggleItemAria('a', { value: ['a'], multiple: false }, single)).not.toHaveProperty(
+      'tabindex',
+    );
+  });
+
+  it('a controlled value drives the pressed instance', () => {
+    expect(
+      toggleItemAria('b', { value: ['a'], multiple: false }, { type: 'single', value: 'b' })[
+        'aria-pressed'
+      ],
+    ).toBe('true');
+  });
+});
+
+describe('toggle-group keymap', () => {
+  const state: ToggleGroupState = { value: [], multiple: false };
+  it('Enter and Space on an item map to toggle', () => {
+    expect(toggleGroup.keymap({ key: 'Enter' }, state, 'item', single)).toBe('toggle');
+    expect(toggleGroup.keymap({ key: ' ' }, state, 'item', single)).toBe('toggle');
+  });
+
+  it('does not claim activation on the root, and does not claim arrows (roving owns them)', () => {
+    expect(toggleGroup.keymap({ key: 'Enter' }, state, 'root', single)).toBeNull();
+    expect(toggleGroup.keymap({ key: 'ArrowRight' }, state, 'item', single)).toBeNull();
+  });
+});
+
+describe('toggle-group emitValue (change-callback shape)', () => {
+  it('single reports a string (empty when cleared)', () => {
+    expect(emitValue(['a'], single)).toBe('a');
+    expect(emitValue([], single)).toBe('');
+  });
+
+  it('multiple reports the array', () => {
+    expect(emitValue(['a', 'b'], multiple)).toEqual(['a', 'b']);
+  });
+});

--- a/packages/ui/test/components/toggle-group/toggle-group.classes.test.ts
+++ b/packages/ui/test/components/toggle-group/toggle-group.classes.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Classes parity test: the view is pure class strings keyed by config/state.
+ * Asserts orientation drives the container layout, the default variant carries
+ * the muted chrome, and each item carries the base + size + variant classes with
+ * data-[state=on] pressed styling -- the same class contract all three
+ * performances paint.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  toggleGroup,
+  type ToggleGroupConfig,
+} from '../../../src/components/toggle-group/toggle-group.behavior';
+import { toggleGroupClasses } from '../../../src/components/toggle-group/toggle-group.classes';
+
+function classesFor(config: ToggleGroupConfig) {
+  return toggleGroupClasses(config, toggleGroup.initialState(config));
+}
+
+describe('toggle-group root classes', () => {
+  it('the default variant carries the muted group chrome', () => {
+    const root = classesFor({}).root;
+    expect(root).toContain('inline-flex');
+    expect(root).toContain('rounded-lg');
+    expect(root).toContain('bg-muted');
+    expect(root).toContain('p-1');
+  });
+
+  it('the outline variant drops the muted chrome', () => {
+    const root = classesFor({ variant: 'outline' }).root;
+    expect(root).not.toContain('bg-muted');
+  });
+
+  it('vertical orientation stacks the group as a column', () => {
+    expect(classesFor({ orientation: 'vertical' }).root.split(/\s+/)).toContain('flex-col');
+  });
+
+  it('horizontal orientation (default) does not stack', () => {
+    expect(classesFor({}).root.split(/\s+/)).not.toContain('flex-col');
+  });
+});
+
+describe('toggle-group item classes', () => {
+  it('the item carries the base toggle classes and the focus ring', () => {
+    const item = classesFor({}).item;
+    expect(item).toContain('rounded-md');
+    expect(item).toContain('focus-visible:ring-ring');
+    expect(item).toContain('disabled:opacity-50');
+  });
+
+  it('the default size is h-9 px-3; sm and lg override it', () => {
+    expect(classesFor({}).item).toContain('h-9 px-3');
+    expect(classesFor({ size: 'sm' }).item).toContain('h-8 px-2');
+    expect(classesFor({ size: 'lg' }).item).toContain('h-10 px-4');
+  });
+
+  it('the default variant drives pressed styling off data-[state=on]', () => {
+    const item = classesFor({}).item;
+    expect(item).toContain('data-[state=on]:bg-background');
+    expect(item).toContain('data-[state=on]:text-foreground');
+  });
+
+  it('the outline variant is bordered and presses to the accent', () => {
+    const item = classesFor({ variant: 'outline' }).item;
+    expect(item).toContain('border-input');
+    expect(item).toContain('data-[state=on]:bg-accent');
+    expect(item).toContain('data-[state=on]:text-accent-foreground');
+  });
+});

--- a/packages/ui/test/components/toggle-group/toggle-group.conformance.test.tsx
+++ b/packages/ui/test/components/toggle-group/toggle-group.conformance.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * React performance of the toggle-group score, driven end to end. Selection
+ * moves only through dispatched actions; roving focus is a declarative effect;
+ * arrow keys move focus ONLY (selection does NOT follow focus -- the toolbar
+ * pattern). Activation is Space/Enter/click, fulfilled by the native <button>.
+ */
+import * as React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ToggleGroup, ToggleGroupItem } from '../../../src/components/toggle-group/toggle-group';
+import {
+  toggleGroup,
+  toggleItemAria,
+  type ToggleGroupConfig,
+} from '../../../src/components/toggle-group/toggle-group.behavior';
+import {
+  assertAxeClean,
+  assertContractFulfillment,
+  assertInstanceContractFulfillment,
+  partElement,
+} from '../../harness/conformance';
+
+interface SetupProps {
+  type?: 'single' | 'multiple';
+  value?: string | string[];
+  defaultValue?: string | string[];
+  onValueChange?: (value: string | string[]) => void;
+  orientation?: 'horizontal' | 'vertical';
+  disabled?: boolean;
+  disabledItems?: string[];
+}
+
+function TestGroup({ disabledItems = [], type = 'single', ...props }: SetupProps) {
+  return (
+    <ToggleGroup aria-label="Text formatting" type={type} {...props}>
+      <ToggleGroupItem value="a" disabled={disabledItems.includes('a')}>
+        Alpha
+      </ToggleGroupItem>
+      <ToggleGroupItem value="b" disabled={disabledItems.includes('b')}>
+        Beta
+      </ToggleGroupItem>
+      <ToggleGroupItem value="c" disabled={disabledItems.includes('c')}>
+        Gamma
+      </ToggleGroupItem>
+    </ToggleGroup>
+  );
+}
+
+const body = () => document.body;
+
+function itemFor(value: string): HTMLElement {
+  const element = body().querySelector<HTMLElement>(`[data-part="item"][data-value="${value}"]`);
+  if (!element) throw new Error(`no item for ${value}`);
+  return element;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('toggle-group conformance [react]', () => {
+  it('renders a role=group with toggle items, axe-clean', async () => {
+    render(
+      <main>
+        <TestGroup defaultValue="a" />
+      </main>,
+    );
+    const root = partElement(body(), 'root');
+    expect(root?.getAttribute('role')).toBe('group');
+    expect(root?.getAttribute('data-orientation')).toBe('horizontal');
+    expect(itemFor('a').getAttribute('aria-pressed')).toBe('true');
+    await assertAxeClean(body());
+  });
+
+  it('contract: root + item projections equal the rendered DOM', () => {
+    const config: ToggleGroupConfig = {
+      type: 'single',
+      defaultValue: 'b',
+      orientation: 'horizontal',
+    };
+    render(<TestGroup defaultValue="b" />);
+    const root = partElement(body(), 'root');
+    if (!root) throw new Error('no root');
+    const state = toggleGroup.initialState(config);
+    assertContractFulfillment(toggleGroup, root, state, config, ['root', 'item']);
+    assertInstanceContractFulfillment(root, 'item', ['a', 'b', 'c'], (key) =>
+      toggleItemAria(key, state, config),
+    );
+  });
+
+  it('single: click selects an item and fires onValueChange with the string', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(
+      <main>
+        <TestGroup onValueChange={onValueChange} />
+      </main>,
+    );
+    await user.click(itemFor('b'));
+    expect(itemFor('b').getAttribute('aria-pressed')).toBe('true');
+    expect(itemFor('b').getAttribute('data-state')).toBe('on');
+    expect(itemFor('a').getAttribute('aria-pressed')).toBe('false');
+    expect(onValueChange).toHaveBeenCalledWith('b');
+    await assertAxeClean(body());
+  });
+
+  it('single is collapsible: re-clicking the selected item clears it and reports empty', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<TestGroup defaultValue="a" onValueChange={onValueChange} />);
+    await user.click(itemFor('a'));
+    expect(itemFor('a').getAttribute('aria-pressed')).toBe('false');
+    expect(onValueChange).toHaveBeenLastCalledWith('');
+  });
+
+  it('multiple: clicks add and remove values, reporting the array', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<TestGroup type="multiple" onValueChange={onValueChange} />);
+    await user.click(itemFor('a'));
+    expect(onValueChange).toHaveBeenLastCalledWith(['a']);
+    await user.click(itemFor('c'));
+    expect(itemFor('a').getAttribute('aria-pressed')).toBe('true');
+    expect(itemFor('c').getAttribute('aria-pressed')).toBe('true');
+    expect(onValueChange).toHaveBeenLastCalledWith(['a', 'c']);
+    await user.click(itemFor('a'));
+    expect(itemFor('a').getAttribute('aria-pressed')).toBe('false');
+    expect(onValueChange).toHaveBeenLastCalledWith(['c']);
+  });
+
+  it('arrow keys move focus ONLY -- they do not toggle', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<TestGroup onValueChange={onValueChange} />);
+    itemFor('a').focus();
+    await user.keyboard('{ArrowRight}');
+    expect(document.activeElement).toBe(itemFor('b'));
+    expect(itemFor('b').getAttribute('aria-pressed')).toBe('false');
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it('Space and Enter toggle the focused item', async () => {
+    const user = userEvent.setup();
+    render(<TestGroup type="multiple" />);
+    itemFor('b').focus();
+    await user.keyboard(' ');
+    expect(itemFor('b').getAttribute('aria-pressed')).toBe('true');
+    itemFor('c').focus();
+    await user.keyboard('{Enter}');
+    expect(itemFor('c').getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('controlled single: state follows the prop, callback reports the value to set', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const { rerender } = render(<TestGroup value="a" onValueChange={onValueChange} />);
+    expect(itemFor('a').getAttribute('aria-pressed')).toBe('true');
+
+    // A controlled group's effective value does not move on click, but the
+    // callback still reports what to set.
+    await user.click(itemFor('b'));
+    expect(onValueChange).toHaveBeenLastCalledWith('b');
+    expect(itemFor('a').getAttribute('aria-pressed')).toBe('true');
+    expect(itemFor('b').getAttribute('aria-pressed')).toBe('false');
+
+    rerender(<TestGroup value="b" onValueChange={onValueChange} />);
+    expect(itemFor('b').getAttribute('aria-pressed')).toBe('true');
+    expect(itemFor('a').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('controlled multiple: callback reports the new array, effective value stays shadowed', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const { rerender } = render(
+      <TestGroup type="multiple" value={['a']} onValueChange={onValueChange} />,
+    );
+    expect(itemFor('a').getAttribute('aria-pressed')).toBe('true');
+
+    await user.click(itemFor('b'));
+    expect(onValueChange).toHaveBeenLastCalledWith(['a', 'b']);
+    // Effective value is shadowed by the prop until the parent updates it.
+    expect(itemFor('b').getAttribute('aria-pressed')).toBe('false');
+
+    rerender(<TestGroup type="multiple" value={['a', 'b']} onValueChange={onValueChange} />);
+    expect(itemFor('a').getAttribute('aria-pressed')).toBe('true');
+    expect(itemFor('b').getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('a disabled group gates toggling', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<TestGroup disabled onValueChange={onValueChange} />);
+    expect(partElement(body(), 'root')?.getAttribute('data-disabled')).toBe('true');
+    await user.click(itemFor('a'));
+    expect(itemFor('a').getAttribute('aria-pressed')).toBe('false');
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it('roving skips a disabled item', async () => {
+    const user = userEvent.setup();
+    render(<TestGroup disabledItems={['b']} />);
+    expect(itemFor('b').hasAttribute('disabled')).toBe(true);
+    itemFor('a').focus();
+    await user.keyboard('{ArrowRight}');
+    // b is disabled, so focus jumps to c.
+    expect(document.activeElement).toBe(itemFor('c'));
+  });
+});

--- a/packages/ui/test/components/toggle-group/toggle-group.element.conformance.test.ts
+++ b/packages/ui/test/components/toggle-group/toggle-group.element.conformance.test.ts
@@ -1,0 +1,139 @@
+/**
+ * WC performance of the toggle-group score, driven end to end against light-DOM
+ * markup. Same score as the React conformance test -- the only difference is the
+ * controller applies the projection imperatively via bindToggleGroup.
+ */
+import { cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { RaftersToggleGroup } from '../../../src/components/toggle-group/toggle-group.element';
+
+beforeAll(() => {
+  if (!customElements.get('rafters-toggle-group')) {
+    customElements.define('rafters-toggle-group', RaftersToggleGroup);
+  }
+});
+
+interface MountOptions {
+  type?: 'single' | 'multiple';
+  orientation?: 'horizontal' | 'vertical';
+  pressed?: string[];
+  disabled?: boolean;
+  disabledItems?: string[];
+}
+
+function itemMarkup(value: string, label: string, pressed: boolean, disabled: boolean): string {
+  const state = pressed ? 'on' : 'off';
+  return `<button type="button" data-part="item" data-value="${value}" data-roving-item data-state="${state}" aria-pressed="${pressed}"${disabled ? ' disabled' : ''}>${label}</button>`;
+}
+
+async function mount(options: MountOptions = {}): Promise<HTMLElement> {
+  const {
+    type = 'single',
+    orientation = 'horizontal',
+    pressed = [],
+    disabled = false,
+    disabledItems = [],
+  } = options;
+  const items = [
+    ['a', 'Alpha'],
+    ['b', 'Beta'],
+    ['c', 'Gamma'],
+  ]
+    .map(([value, label]) =>
+      itemMarkup(
+        value as string,
+        label as string,
+        pressed.includes(value as string),
+        disabled || disabledItems.includes(value as string),
+      ),
+    )
+    .join('');
+  document.body.innerHTML = `
+    <rafters-toggle-group>
+      <div data-part="root" role="group" aria-label="Text formatting" data-type="${type}" data-orientation="${orientation}"${disabled ? ' data-disabled="true"' : ''}>
+        ${items}
+      </div>
+    </rafters-toggle-group>`;
+  await Promise.resolve(); // let the element's deferred bind run
+  return document.body.querySelector('[data-part="root"]') as HTMLElement;
+}
+
+const item = (value: string) =>
+  document.body.querySelector<HTMLElement>(`[data-part="item"][data-value="${value}"]`)!;
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+describe('toggle-group conformance [wc]', () => {
+  it('reflects the server-rendered pressed item as the initial selection', async () => {
+    await mount({ pressed: ['b'] });
+    expect(item('b').getAttribute('aria-pressed')).toBe('true');
+    expect(item('b').getAttribute('data-state')).toBe('on');
+    expect(item('a').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('single: click selects an item and reflects aria-pressed/data-state', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(item('b'));
+    expect(item('b').getAttribute('aria-pressed')).toBe('true');
+    expect(item('b').getAttribute('data-state')).toBe('on');
+    expect(item('a').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('single is collapsible: re-clicking the selected item clears it', async () => {
+    const user = userEvent.setup();
+    await mount({ pressed: ['a'] });
+    await user.click(item('a'));
+    expect(item('a').getAttribute('aria-pressed')).toBe('false');
+    expect(item('a').getAttribute('data-state')).toBe('off');
+  });
+
+  it('multiple: clicks add to the set', async () => {
+    const user = userEvent.setup();
+    await mount({ type: 'multiple' });
+    await user.click(item('a'));
+    await user.click(item('c'));
+    expect(item('a').getAttribute('aria-pressed')).toBe('true');
+    expect(item('c').getAttribute('aria-pressed')).toBe('true');
+    expect(item('b').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('arrow keys move focus ONLY -- they do not toggle', async () => {
+    const user = userEvent.setup();
+    await mount();
+    item('a').focus();
+    await user.keyboard('{ArrowRight}');
+    expect(document.activeElement).toBe(item('b'));
+    expect(item('b').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('Space and Enter toggle the focused item', async () => {
+    const user = userEvent.setup();
+    await mount({ type: 'multiple' });
+    item('c').focus();
+    await user.keyboard(' ');
+    expect(item('c').getAttribute('aria-pressed')).toBe('true');
+    item('a').focus();
+    await user.keyboard('{Enter}');
+    expect(item('a').getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('roving skips a disabled item', async () => {
+    const user = userEvent.setup();
+    await mount({ disabledItems: ['b'] });
+    item('a').focus();
+    await user.keyboard('{ArrowRight}');
+    expect(document.activeElement).toBe(item('c'));
+  });
+
+  it('a disabled group gates toggling', async () => {
+    const user = userEvent.setup();
+    await mount({ disabled: true });
+    await user.click(item('a'));
+    expect(item('a').getAttribute('aria-pressed')).toBe('false');
+  });
+});


### PR DESCRIPTION
## Summary

Ports `toggle-group` onto the behavior layer as a net-new component under
`packages/ui/src/components/toggle-group/`. A toggle-family group that
coordinates toggle buttons as a single- (collapsible) or multiple-select set.
Mirrors the radio-group reference: selection lives in the score reducer,
roving-focus is composed directly at both the WC/Astro bind and the React
effect, and no effects layer or `selection-group` primitive is touched.

Design note on `selection-group`: the issue body lists it as a primitive to
compose, but `legion sym refs createSelectionGroup` shows it is referenced ONLY
by the rejected `old/ui/*.controller.ts` files -- no behavior-layer component
composes it. radio-group hand-writes selection in its score reducer and
dispositions the primitive as a "framework-affordance -- expressed instead as
reducer state". toggle-group follows that precedent so the aria projection stays
a total function of state (which the conformance harness asserts).

## Acceptance criteria mapping

### 1. Component doc written
`packages/ui/docs/spec/components/toggle-group.md` documents composition,
config/state/actions, the parts + ARIA table, keyboard/effects, oracle
dispositions, deltas, and WCAG obligations. It describes DIRECT primitive
composition rather than the deleted `effects`/`useBehaviorEffects` vocabulary,
so it reflects the actual code, not the stale radio-group.md wording.
Evidence: packages/ui/docs/spec/components/toggle-group.md:1

### 2. JSDoc intelligence tags present
The `ToggleGroup` export carries all four tags the registry parses:
`@cognitive-load` with the five-dimension breakdown, `@attention-economics`,
`@trust-building`, and `@accessibility`.
Evidence: packages/ui/src/components/toggle-group/toggle-group.tsx:75

### 3. Exported from the package as the articles are
The package's `./next/*` wildcard export (`"./next/*": "./src/components/*/*.tsx"`)
resolves `@rafters/ui/next/toggle-group` to the new folder; the folder existing
IS the export, so no package.json change is needed (nor allowed by the wave
rules). The `.element` wildcard likewise exposes the WC.
Evidence: packages/ui/package.json:10

### 4. Behavior test (pure, no DOM)
`toggle-group.behavior.test.ts` drives the score with zero DOM: initialState
seeding/clamping, `selectedValues` controlled-shadow, single (collapsible) and
multiple `toggle`, the `canDispatch` disabled gate, the group + item projections,
`keymap`, and `emitValue`'s string-vs-array shape.
Evidence: packages/ui/test/components/toggle-group/toggle-group.behavior.test.ts:80

### 5. Classes parity test
`toggle-group.classes.test.ts` asserts the observable class contract: muted
chrome only on the default variant, `flex-col` only when vertical, size
overrides, and `data-[state=on]` pressed styling for both variants.
Evidence: packages/ui/test/components/toggle-group/toggle-group.classes.test.ts:33

### 6. Conformance test via the shared harness (aria + keymap against rendered DOM)
React, WC, and Astro conformance suites each drive the one score against real
rendered DOM through `assertContractFulfillment` +
`assertInstanceContractFulfillment` (aria projection equals DOM) plus interaction
assertions (click/Space/Enter toggle, arrows move focus only, disabled gate,
roving skip). All three pass.
Evidence: packages/ui/test/components/toggle-group/toggle-group.conformance.test.tsx:76

### 7. shadcn drop-in parity where the component exists in shadcn
`ToggleGroup` + `ToggleGroupItem` (with the `ToggleGroup.Item` namespace) expose
the shadcn/Radix surface: `type`, `value`, `defaultValue`, `onValueChange`
(string for single, string[] for multiple), `variant`, `size`, `disabled`,
`orientation`.
Evidence: packages/ui/src/components/toggle-group/toggle-group.tsx:43

### 8. test:unit green, preflight green
`pnpm --filter @rafters/ui test:unit` passes the full ui suite across the React,
WC, and Astro configs; `pnpm preflight` exits 0 (build + lint + typecheck + format).
Evidence: packages/ui/test/components/toggle-group/toggle-group.astro.conformance.test.ts:38

## Not done

- **Form association (ElementInternals: `setFormValue`, `valueMissing`,
  CSV/FormData submission, `formResetCallback`)** -- dropped, deferred to the
  not-yet-existing `form-value` primitive (planned across checkbox/switch/select);
  `name`/`required` are kept as an inert config surface. Matches radio-group's
  disposition. The old React tsx never rendered hidden inputs either.
- **Matrix line (`docs/spec/matrix/components.md`) and `CHANGELOG.md`** -- NOT
  updated. The issue's closing directives ask for both, but the wave hardening
  rules forbid touching any shared file (the matrix is now `components.md`, not
  the deleted `components.jsonl`); this keeps the wave parallel-safe. Flagged so
  the reconciliation is visible, not buried.
- **Archetype seam note in the issue comments** -- could not be retrieved
  (`gh` is blocked, `legion issue view` returns body only, legion MCP tools are
  write-only). Proceeded on the radio-group precedent, which already documents
  the selection-as-reducer decision the seam note almost certainly restates.

Closes #1802
