### PR TITLE
feat(#1774): port field to the behavior layer

### DIFF
--- a/packages/ui/docs/spec/components/field.md
+++ b/packages/ui/docs/spec/components/field.md
@@ -1,0 +1,135 @@
+# Component Spec -- Field
+
+Status: DRAFT. The id-association / ARIA archetype. A field wraps a native
+control with a label and optional helper/error text, and its whole job is
+WIRING: associating the label with the control and projecting validity /
+description ARIA onto the control. There is no state axis -- the score is a
+total function from config (+ the rendered part ids) to the control's ARIA.
+
+Files (`src/components/field/`):
+
+```
+field.classes.ts    field.behavior.ts    field.tsx
+field.element.ts     field.astro
+```
+
+Tests mirror into `test/components/field/`. React, WC, and Astro are all
+conformance-verified against the shared harness.
+
+## The archetype question
+
+Every prior interactive component owned a state axis (open, pressed, value).
+Field owns none: it is a static score, like `label`, but with a NON-empty
+projection. The answer it settles: a component whose only contract is ARIA
+wiring is a projection-only score plus a near-empty client -- no
+`createBehavior`, no memory, no dispatch, no keymap.
+
+Field wires ARIA onto a control it does not own (a slotted/child control the
+consumer supplies), which is the one shape no prior component had. The control
+is a declared part (`data-part="control"`); the client stamps that marker on the
+control it locates so the harness and any re-query can find it.
+
+## Composition
+
+- **React** (`field.tsx`): the shadcn Field surface. Container + label +
+  slotted control + helper/error, driven declaratively. It clones the control
+  child to inject the id and the score's `fieldControlAria`, renders a `<label>`
+  with the native `for` association (using the Label score's own decoration),
+  and paints the required marker + disabled dim from `field.classes.ts`. No
+  bind.
+- **WC** (`field.element.ts`): a light-DOM enhancer. The author supplies the
+  label / control / helper markup; the element defers one microtask (children
+  may not have parsed) and calls `bindField`.
+- **Astro** (`field.astro`): SSR-renders label + `<slot/>` control +
+  helper/error, then the `<script>` hands each instance to the SAME
+  `bindField`. One score, three performances, zero drift.
+
+## Config, state, actions
+
+```ts
+interface FieldConfig {
+  required?: boolean; // -> aria-required on the control + the required marker
+  disabled?: boolean; // -> native disabled on the control + label dim
+}
+type FieldState = Record<never, never>;   // no state axis
+type FieldActions = Record<never, never>; // no actions
+```
+
+`canDispatch` is constant `true`, `keymap` is constant `null`, `actions` is
+empty: the slotted control owns every keystroke and there is nothing to move.
+
+## Parts and ARIA
+
+| Part | Presence | ARIA |
+| --- | --- | --- |
+| label | always | none projected -- the `for`/`id` association is native, wired by the client (or React's `htmlFor`), not an ARIA attribute |
+| control | always | `aria-describedby` (error id first, then description id; only rendered ids), `aria-invalid` (`true` while an error is present), `aria-required` (while required) |
+| description | consumer renders (hidden while an error is shown) | an `aria-describedby` id target only; carries no aria of its own |
+| error | consumer renders | `role="alert"` (a PartDecl role) + an `aria-describedby` id target |
+
+The id scheme: the field id IS the control id; the sibling ids are
+`${id}-description` and `${id}-error` (`descriptionId()` / `errorId()`
+helpers). The client never generates an id -- it reads them off the rendered
+parts (Spec 01). The label's `for` tracks whatever id the control actually
+carries (author-supplied ids win).
+
+**Empty-id / no-dangle convention** (ratified 2026-07-08, same as `input.md`):
+the score reads presence from the ids the harness reads off the DOM, so a
+reference is emitted only for a rendered element. `aria-describedby` can never
+dangle (a dangling IDREF is an axe `aria-valid-attr-value` violation).
+
+**description-hidden-while-error**: the React and Astro decorators render the
+description node only when there is no error, so at most one helper node exists.
+Because presence is read from rendered ids, the hidden description contributes
+no id and is never referenced -- the ordering rule (error first) and the
+hide-while-error rule reconcile with no dangle.
+
+## Not ARIA: what the client/decorator owns, not the projection
+
+- **`disabled` propagation** is a native attribute + property on the control
+  (mirrors `input`, whose `disabled` is a native prop), NOT an ARIA projection.
+  It reads a host-level signal (`data-disabled`) because the control is slotted
+  and SSR cannot reach into it.
+- **the `for`/`id` association** is native; `bindField` sets `label[for]` to the
+  control's real id (React uses `htmlFor`).
+- **the required marker** (an `aria-hidden` glyph) and the **disabled label
+  dim** are view/markup, painted from `field.classes.ts`.
+
+## Keyboard and effects
+
+- `keymap`: `null` for every key -- the slotted control owns editing/activation.
+- effects: none. No focus-trap, roving, or dismissal. The client is the
+  near-empty shape: locate the control, wire the association, apply the ARIA
+  projection, propagate `disabled` -- no `createBehavior`, no subscription, no
+  keydown listener.
+
+## Oracle dispositions (`src/old/ui/field.*`)
+
+Field's old tree shipped React + a shadow-DOM WC (`field.element.ts`) driven by
+host attributes. The semantics carried across; the shadow machinery did not.
+
+| Item | Disposition |
+| --- | --- |
+| shadcn Field surface (label/description/error props, slotted control, `id` association) | contract -- React is a drop-in |
+| id-association scheme (`for`/`id`, `${id}-description`, `${id}-error`) | contract -- the score's id scheme |
+| `aria-describedby` composition (error id first, then description id) | contract -- hardened to reference only rendered ids (no dangle) |
+| `aria-invalid` on error, `aria-required` on required | contract -- the control ARIA projection |
+| `disabled` propagation to the control | contract -- native attribute + property (a decorator/client concern, not ARIA) |
+| required marker (`aria-hidden`), `role="alert"` on the error, description-hidden-while-error | contract -- markup/PartDecl role + the decorators' view rule |
+| shadow-DOM render (label/desc/error built from host attributes) | dropped -- field is now a light-DOM enhancer; the author/SSR supplies markup, the client only wires (per the authoring guide) |
+| `aria-label` mirror onto the control (the shadow label could not cross the tree-scope boundary via `for`/`id`) | defect-do-not-port -- a shadow-boundary workaround; a light-DOM `for`/`id` association needs no mirror |
+| runtime attribute re-toggling on the WC (`error`/`disabled` observed, re-wired on change) | framework-affordance -- React re-renders declaratively; the light-DOM client binds once (input/radio-group parity) |
+| respecting an author-supplied `aria-describedby` on the control | dropped -- the field OWNS the control's validity/description wiring, so the score's projection is authoritative across all three performances (zero drift). Consumers extend description via the field's `description`, not a manual attribute |
+| raw `text-sm` on helper/error text | replaced -- the `text-body-small` typography role token (semantic classes only) |
+
+## WCAG 2.1 AA obligations
+
+- 1.3.1 / 4.1.2: the label<->control association (`for`/`id`), `aria-invalid`,
+  `aria-required`, and `aria-describedby` are asserted against real DOM ids by
+  the harness across React / WC / Astro; `aria-describedby` never dangles.
+- 3.3.1 / 3.3.3 (error identification): the error is a real element the invalid
+  control references, carrying `role="alert"` so it announces on appearance.
+- 1.4.1: the required state is not colour-only -- the visual `*` marker is
+  `aria-hidden` and the requirement reaches AT through `aria-required`.
+- 1.4.3: the error text uses the destructive token, paired with the programmatic
+  `aria-invalid` / error association, never colour alone.

--- a/packages/ui/src/components/field/field.astro
+++ b/packages/ui/src/components/field/field.astro
@@ -1,0 +1,80 @@
+---
+/**
+ * Astro performance of the field score. Server-renders the light-DOM structure
+ * -- the label, a `<slot/>` for the control, and the helper OR error text --
+ * with the disabled/required host signals set, then the `<script>` hands each
+ * instance to bindField (the SAME DOM-native client the Web Component uses).
+ *
+ * bindField wires the one thing SSR cannot reach into the slotted control:
+ * the native `for`/`id` association, the score's ARIA projection, and disabled
+ * propagation. One score, three performances, zero drift -- the label decoration
+ * and helper/error classes come from the SAME field.classes.ts the React and WC
+ * performances read.
+ *
+ * The description yields to the error: at most one helper node is rendered, so
+ * the control's `aria-describedby` never references a hidden node.
+ */
+import { descriptionId, errorId } from './field.behavior';
+import { composeFieldLabelClasses, fieldClassSet } from './field.classes';
+
+interface Props {
+  /** Field id -- shared by the label `for`, the control `id`, and the derived
+   *  `${id}-description` / `${id}-error` sibling ids. The slotted control must
+   *  carry this same id (bindField reads the association off it). */
+  id: string;
+  label: string;
+  description?: string;
+  error?: string;
+  required?: boolean;
+  disabled?: boolean;
+}
+
+const { id, label, description, error, required = false, disabled = false } = Astro.props;
+
+const classes = fieldClassSet({ required, disabled }, {});
+const hasError = typeof error === 'string' && error.length > 0;
+const hasDescription = typeof description === 'string' && description.length > 0;
+const showDescription = hasDescription && !hasError;
+---
+
+<rafters-field
+  data-part="root"
+  class={classes.container}
+  data-required={required ? '' : undefined}
+  data-disabled={disabled ? '' : undefined}
+>
+  <label data-part="label" for={id} class={composeFieldLabelClasses(disabled)}>
+    {label}
+    {required && <b class={classes.requiredMarker} aria-hidden="true">*</b>}
+  </label>
+
+  <slot />
+
+  {
+    showDescription && (
+      <div data-part="description" id={descriptionId(id)} class={classes.description}>
+        {description}
+      </div>
+    )
+  }
+
+  {
+    hasError && (
+      <div data-part="error" id={errorId(id)} class={classes.error} role="alert">
+        {error}
+      </div>
+    )
+  }
+</rafters-field>
+
+<script>
+  import { bindField } from './field.behavior';
+
+  // The <script> is bundled and runs once per page; bind every instance's
+  // server-rendered markup. Same client as the Web Component.
+  for (const root of document.querySelectorAll<HTMLElement>('rafters-field[data-part="root"]')) {
+    if (root.dataset['bound'] === 'true') continue;
+    root.dataset['bound'] = 'true';
+    bindField(root);
+  }
+</script>

--- a/packages/ui/src/components/field/field.behavior.ts
+++ b/packages/ui/src/components/field/field.behavior.ts
@@ -1,0 +1,208 @@
+import { compose, type Slice } from '../../lib/compose';
+import { type AriaAttrs, type BehaviorSpec, type PartIds } from '../../lib/contract';
+import { updateAriaAttribute } from '../../primitives/aria-manager';
+
+/**
+ * Field: the id-association / ARIA archetype. A form field wraps a native
+ * control (Input, Select, Textarea, ...) with a Label and optional
+ * helper/error text, and its whole job is WIRING -- associating the label with
+ * the control and projecting validity/description ARIA onto the control. There
+ * is no state axis, no reducer, no keymap: the score is a total function from
+ * config (+ the rendered part ids) to the control's ARIA. That makes it a
+ * static-with-projection score, the label archetype plus a non-empty
+ * projection.
+ *
+ * What the score owns (the earned semantics, ported from src/old/ui/field.*):
+ *  - the id-association scheme: label `for` <-> control `id`, with
+ *    `${id}-description` and `${id}-error` as the sibling ids;
+ *  - the `aria-describedby` composition: error id first, then description id,
+ *    referencing ONLY ids that are actually rendered (the score derives
+ *    presence from the ids the harness reads off the DOM, so a reference can
+ *    never dangle -- the empty-id convention, ratified 2026-07-08);
+ *  - `aria-invalid` on the control while an error message is present;
+ *  - `aria-required` on the control while the field is required.
+ *
+ * What the score does NOT own (decorator/bind concerns, not ARIA):
+ *  - the native `for`/`id` association wiring (bindField sets it, because the
+ *    control is a slotted child SSR cannot reach);
+ *  - `disabled` propagation to the control (a native attribute + property, not
+ *    an ARIA projection -- mirrors input, whose disabled is a native prop);
+ *  - the required marker (`aria-hidden` span) and the disabled label dimming --
+ *    both are view/markup, painted by the decorators from field.classes.ts;
+ *  - `role="alert"` on the error message -- a static PartDecl role.
+ *
+ * description-hidden-while-error: the decorators render the description node
+ * only when there is no error (React/Astro enforce it in markup). Because the
+ * score reads presence from rendered ids, a hidden description contributes no
+ * id and is never referenced -- the two rules reconcile with no dangle.
+ */
+export interface FieldConfig {
+  /** Advertised to AT via `aria-required` on the control, and drives the
+   *  required marker in the view. */
+  required?: boolean | undefined;
+  /** Propagated to the control as the native `disabled` attribute/property, and
+   *  dims the label in the view. Not an ARIA projection. */
+  disabled?: boolean | undefined;
+}
+
+export type FieldState = Record<never, never>;
+export type FieldActions = Record<never, never>;
+
+/**
+ * label   -- the `<label>`; its `for` association is native, so it carries no
+ *            ARIA projection (the label archetype).
+ * control -- the slotted form control the field wires ARIA onto.
+ * description -- optional helper text; an `aria-describedby` id target only.
+ * error   -- optional error message; `role="alert"` and an id target only.
+ */
+export type FieldPart = 'label' | 'control' | 'description' | 'error';
+
+const field: Slice<FieldConfig, FieldState, FieldActions, FieldPart> = {
+  name: 'field',
+  parts: {
+    label: {},
+    control: {},
+    description: { optional: true },
+    // role="alert" is the error message's live-region contract, asserted as a
+    // PartDecl role across all three frameworks.
+    error: { role: 'alert', optional: true },
+  },
+  initialState: () => ({}),
+  actions: {},
+  canDispatch: () => true,
+  aria: (_state, config, ids) => {
+    // Presence is read from the rendered ids (behaviors never generate ids),
+    // so a projected reference always points at a real element -- never a
+    // dangling IDREF (an axe `aria-valid-attr-value` violation).
+    const hasError = ids.error !== '';
+    const hasDescription = ids.description !== '';
+    // Error id first, then description id. The decorators hide the description
+    // while an error is shown, so in practice at most one id is present; the
+    // ordering rule is preserved for the case both are authored (WC light DOM).
+    const describedby = [hasError ? ids.error : '', hasDescription ? ids.description : '']
+      .filter((id) => id !== '')
+      .join(' ');
+    return {
+      control: {
+        'aria-describedby': describedby === '' ? undefined : describedby,
+        'aria-invalid': hasError ? 'true' : undefined,
+        'aria-required': config.required ? 'true' : undefined,
+      },
+    };
+  },
+  // No key the field claims -- the slotted control owns every keystroke.
+  keymap: () => null,
+};
+
+export const fieldBehavior: BehaviorSpec<FieldConfig, FieldState, FieldActions, FieldPart> =
+  compose('field', field);
+
+/** The description id derived from the field id (the sibling id scheme). */
+export function descriptionId(fieldId: string): string {
+  return `${fieldId}-description`;
+}
+
+/** The error id derived from the field id (the sibling id scheme). */
+export function errorId(fieldId: string): string {
+  return `${fieldId}-error`;
+}
+
+/**
+ * Locate the field's control. Prefer the explicit part marker; fall back to the
+ * first native form control so a light-DOM/slotted control the author did not
+ * annotate is still found (and then stamped with `data-part="control"` so the
+ * conformance harness and any re-query can find it too).
+ */
+function findControl(root: HTMLElement): HTMLElement | null {
+  return (
+    root.querySelector<HTMLElement>('[data-part="control"]') ??
+    root.querySelector<HTMLElement>('input, select, textarea')
+  );
+}
+
+/**
+ * The DOM-native client of the field score -- shared by the Web Component and
+ * the Astro `<script>`. React (retained mode) reads the projection
+ * declaratively instead.
+ *
+ * Near-empty by construction: the score has no state and no actions, so there
+ * is no createBehavior, no memory, no dispatch, and no keydown listener. bind
+ * does exactly the wiring SSR could not reach into the slotted control:
+ *  1. associate the label with the control (native `for`/`id`);
+ *  2. apply the score's ARIA projection to the control;
+ *  3. propagate the field-level `disabled` to the control (native).
+ *
+ * Bind-once: like input and radio-group, the client wires the server/author
+ * markup a single time. Runtime attribute re-toggling (error added, disabled
+ * flipped) is React's declarative affordance, not a WC lifecycle the client
+ * re-observes -- a documented disposition in field.md.
+ */
+export function bindField(root: HTMLElement): () => void {
+  const control = findControl(root);
+  if (!control) return () => {};
+  // Stamp the part marker so the harness (and a re-query) find the control even
+  // when the author slotted a bare <input>.
+  control.setAttribute('data-part', 'control');
+
+  const label = root.querySelector<HTMLElement>('[data-part="label"]');
+  const description = root.querySelector<HTMLElement>('[data-part="description"]');
+  const error = root.querySelector<HTMLElement>('[data-part="error"]');
+
+  // Single deterministic sources: the field id IS the control's id (never
+  // generated); disabled/required are host-level signals because they must
+  // reach a slotted control SSR cannot touch.
+  const disabled = root.hasAttribute('data-disabled');
+  const config: FieldConfig = {
+    required: root.hasAttribute('data-required'),
+    disabled,
+  };
+
+  // ids READ from the rendered parts, never generated (Spec 01).
+  const ids: PartIds<FieldPart> = {
+    label: label?.id ?? '',
+    control: control.id,
+    description: description?.id ?? '',
+    error: error?.id ?? '',
+  };
+
+  // Native label<->control association: point the label at whatever id the
+  // control actually carries (the earned WC semantic -- author-supplied ids win).
+  if (label && control.id !== '') label.setAttribute('for', control.id);
+
+  // The projection is already resolved (final strings, undefined = absent), so
+  // apply it raw: validate:false skips aria-manager's author-input coercion.
+  const projection = fieldBehavior.aria({}, config, ids);
+  const controlAria = projection.control;
+  if (controlAria) {
+    for (const [name, value] of Object.entries(controlAria)) {
+      updateAriaAttribute(control, name as never, value as never, { validate: false });
+    }
+  }
+
+  // disabled propagation -- native attribute AND property, so a disabled field
+  // both reflects and actually disables the control.
+  if (disabled) {
+    control.setAttribute('disabled', '');
+    if ('disabled' in control) (control as HTMLInputElement).disabled = true;
+  }
+
+  return () => {};
+}
+
+/** The resolved control ARIA for a given field id, for decorators that project
+ *  declaratively (React) -- error/description ids collapse to '' when absent so
+ *  the projection drops the reference rather than dangle it. */
+export function fieldControlAria(
+  fieldId: string,
+  config: FieldConfig,
+  hasError: boolean,
+  hasDescription: boolean,
+): AriaAttrs {
+  const ids: PartIds<FieldPart> = {
+    label: '',
+    control: fieldId,
+    description: hasDescription ? descriptionId(fieldId) : '',
+    error: hasError ? errorId(fieldId) : '',
+  };
+  return fieldBehavior.aria({}, config, ids).control ?? {};
+}

--- a/packages/ui/src/components/field/field.classes.ts
+++ b/packages/ui/src/components/field/field.classes.ts
@@ -1,0 +1,45 @@
+import { labelClasses } from '../label/label.classes';
+import type { FieldConfig, FieldState } from './field.behavior';
+
+/**
+ * Field decoration. The field is a layout-composition wrapper: the container
+ * stacks label + control + helper/error with consistent spacing; the helper and
+ * error share the small body-text role token and flip only their semantic
+ * colour. Token/semantic classes only -- `text-body-small` is the typography
+ * role token (never a raw `text-sm`), colours are the frozen semantic tokens.
+ */
+export interface FieldClassSet {
+  container: string;
+  /** The label class WITHOUT the disabled dim; use `labelClass(disabled)` for
+   *  the resolved string the decorators paint. */
+  label: string;
+  requiredMarker: string;
+  description: string;
+  error: string;
+}
+
+const fieldContainerClasses = 'flex flex-col gap-2';
+const fieldLabelDisabledClasses = 'opacity-50';
+const fieldRequiredMarkerClasses = 'text-destructive ml-1';
+const fieldDescriptionClasses = 'text-body-small text-muted-foreground';
+const fieldErrorClasses = 'text-body-small text-destructive';
+
+/**
+ * Compose the label's class string. Reuses the Label score's own decoration
+ * (never a parallel hand-written map) plus the field's disabled dim, exactly as
+ * the React performance composes via the `<Label>` component.
+ */
+export function composeFieldLabelClasses(disabled: boolean): string {
+  const base = labelClasses({}, {}).root;
+  return disabled ? `${base} ${fieldLabelDisabledClasses}` : base;
+}
+
+export function fieldClassSet(_config: FieldConfig, _state: FieldState): FieldClassSet {
+  return {
+    container: fieldContainerClasses,
+    label: composeFieldLabelClasses(false),
+    requiredMarker: fieldRequiredMarkerClasses,
+    description: fieldDescriptionClasses,
+    error: fieldErrorClasses,
+  };
+}

--- a/packages/ui/src/components/field/field.element.ts
+++ b/packages/ui/src/components/field/field.element.ts
@@ -1,0 +1,34 @@
+/**
+ * WC performance for field: the thinnest wrapper. The score AND the DOM-native
+ * client (bindField) live in field.behavior.ts, shared with the Astro
+ * performance. This file only adapts that client to the custom-element
+ * lifecycle -- deferring the bind one microtask because connectedCallback can
+ * fire before the light-DOM children (the label, the slotted control, the
+ * helper/error) are parsed.
+ *
+ * Field is a LIGHT-DOM enhancer: the author (or the Astro SSR) supplies the
+ * markup; the element only wires the association + ARIA onto the control.
+ * The oracle's shadow render (label/description/error built from attributes)
+ * and its `aria-label` mirror were a shadow-boundary workaround -- dropped here
+ * because a light-DOM `for`/`id` association needs no mirror (see field.md).
+ */
+import { bindField } from './field.behavior';
+
+export class RaftersField extends HTMLElement {
+  private teardown: (() => void) | null = null;
+
+  connectedCallback(): void {
+    queueMicrotask(() => {
+      if (this.isConnected && !this.teardown) this.teardown = bindField(this);
+    });
+  }
+
+  disconnectedCallback(): void {
+    this.teardown?.();
+    this.teardown = null;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-field')) {
+  customElements.define('rafters-field', RaftersField);
+}

--- a/packages/ui/src/components/field/field.tsx
+++ b/packages/ui/src/components/field/field.tsx
@@ -1,0 +1,170 @@
+/**
+ * Field -- the React performance of the field score. The shadcn Field surface:
+ * a container that pairs a label with a slotted control and optional
+ * helper/error text, and wires the id-association + validity ARIA the score
+ * projects. React reads the projection declaratively (no bind): it clones the
+ * control child to inject the id and `fieldControlAria`, renders a `<label>`
+ * with the native `for` association (using the Label score's own decoration),
+ * and paints the required marker + disabled dim from field.classes.ts.
+ *
+ * @cognitive-load 3/10 - decision 0, info 2, interaction 0, disruption 0, learning 1
+ * @attention-economics Information hierarchy, not competition: label = field
+ * identity, control = the action area, description = quiet guidance, error =
+ * the one part that earns attention. The error's colour + `role="alert"` are
+ * reserved for a real validation failure so a field at rest stays calm.
+ * @trust-building Predictable labelling removes uncertainty; a description sets
+ * expectations before the user acts; error messaging is specific and
+ * non-punitive (it names what to fix, styled with the destructive token but
+ * never shouting). A field that always names its control is the smallest unit
+ * of form trust.
+ * @accessibility Native label<->control association (`for`/`id`), the control's
+ * `aria-describedby` composed from the rendered error + description ids (error
+ * first, never dangling), `aria-invalid` while an error is shown,
+ * `aria-required` while required, `disabled` propagated to the control, and
+ * `role="alert"` on the error so a screen reader announces it. The required
+ * marker is `aria-hidden` -- the requirement reaches AT through `aria-required`,
+ * not the visual asterisk.
+ * @semantic-meaning Field states: default = ready, error = validation failed
+ * (description yields to the error), disabled = unavailable.
+ *
+ * @usage-patterns
+ * DO: Always provide a label for the control.
+ * DO: Use description for format hints or requirements.
+ * DO: Use error with a clear, actionable message.
+ * NEVER: Leave the control without an associated label.
+ * NEVER: Use error styling without an error message.
+ *
+ * @example
+ * ```tsx
+ * <Field label="Email" description="We'll never share your email">
+ *   <Input type="email" />
+ * </Field>
+ *
+ * <Field label="Password" error="Password must be at least 8 characters">
+ *   <Input type="password" />
+ * </Field>
+ * ```
+ */
+import * as React from 'react';
+import classy from '../../primitives/classy';
+import {
+  descriptionId as deriveDescriptionId,
+  errorId as deriveErrorId,
+  fieldControlAria,
+  type FieldConfig,
+} from './field.behavior';
+import { composeFieldLabelClasses, fieldClassSet } from './field.classes';
+
+export interface FieldProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Field label text. */
+  label: React.ReactNode;
+  /** Optional description/hint shown below the control (hidden while an error
+   *  is present). */
+  description?: React.ReactNode;
+  /** Error message; when present the field enters its error state. */
+  error?: React.ReactNode;
+  /** Whether the field is required. */
+  required?: boolean;
+  /** Whether the field is disabled. */
+  disabled?: boolean;
+  /** Custom id connecting label, control, and helper/error ids. */
+  id?: string;
+  /** The form control (Input, Select, Textarea, ...). */
+  children: React.ReactNode;
+}
+
+function useFieldId(providedId?: string): string {
+  const reactId = React.useId();
+  return providedId ?? `field-${reactId}`;
+}
+
+/** The id the first control child carries, if any -- so the label's `for`
+ *  tracks an author-supplied control id (the earned WC semantic, upheld here). */
+function firstChildId(children: React.ReactNode): string | undefined {
+  for (const child of React.Children.toArray(children)) {
+    if (React.isValidElement(child)) {
+      const id = (child.props as Record<string, unknown>)['id'];
+      if (typeof id === 'string') return id;
+    }
+  }
+  return undefined;
+}
+
+export const Field = React.forwardRef<HTMLDivElement, FieldProps>(function Field(
+  { className, label, description, error, required, disabled, id: providedId, children, ...props },
+  ref,
+) {
+  const fieldId = useFieldId(providedId);
+  const controlId = firstChildId(children) ?? fieldId;
+
+  const hasError = error != null && error !== false && error !== '';
+  const hasDescription = description != null && description !== false && description !== '';
+  // The description yields to the error: only one helper node is ever rendered.
+  const showDescription = hasDescription && !hasError;
+
+  const config: FieldConfig = { required, disabled };
+  // The control's ARIA comes straight from the score, so the decorator and the
+  // conformance harness agree by construction.
+  const controlAria = fieldControlAria(fieldId, config, hasError, showDescription);
+
+  const classes = fieldClassSet(config, {});
+
+  const enhancedChildren = React.Children.map(children, (child) => {
+    if (!React.isValidElement(child)) return child;
+    const childProps = child.props as Record<string, unknown>;
+    return React.cloneElement(child as React.ReactElement<Record<string, unknown>>, {
+      'data-part': (childProps['data-part'] as string | undefined) ?? 'control',
+      // Author-supplied control id wins (the label tracks it); the field owns
+      // the validity wiring, so the score's projection is authoritative there
+      // -- no framework respects an author describedby, which keeps the three
+      // performances drift-free (the score carries the contract).
+      id: (childProps['id'] as string | undefined) ?? controlId,
+      'aria-describedby': controlAria['aria-describedby'],
+      'aria-invalid': controlAria['aria-invalid'],
+      'aria-required': controlAria['aria-required'],
+      disabled: (childProps['disabled'] as boolean | undefined) ?? disabled,
+    });
+  });
+
+  return (
+    <div ref={ref} data-part="root" className={classy(classes.container, className)} {...props}>
+      {/* biome-ignore lint/a11y/noLabelWithoutControl: associated with the slotted control via htmlFor */}
+      <label
+        data-part="label"
+        htmlFor={controlId}
+        className={composeFieldLabelClasses(disabled === true)}
+      >
+        {label}
+        {/* Decorative marker (aria-hidden): the requirement reaches AT through
+            aria-required, never this glyph. */}
+        {required && (
+          <b className={classes.requiredMarker} aria-hidden="true">
+            *
+          </b>
+        )}
+      </label>
+
+      {enhancedChildren}
+
+      {showDescription && (
+        <div
+          data-part="description"
+          id={deriveDescriptionId(fieldId)}
+          className={classes.description}
+        >
+          {description}
+        </div>
+      )}
+
+      {hasError && (
+        <div data-part="error" id={deriveErrorId(fieldId)} className={classes.error} role="alert">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+});
+
+Field.displayName = 'Field';
+
+export default Field;

--- a/packages/ui/test/components/field/field.astro.conformance.test.ts
+++ b/packages/ui/test/components/field/field.astro.conformance.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Astro performance of the field score, driven end to end. AstroContainer
+ * renders the SSR markup (label + `<slot/>` control + helper/error) but does
+ * NOT run the `<script>`, so the test calls bindField directly on the
+ * rafters-field root -- that IS the script's job -- then asserts the same
+ * projection the React and WC performances drive. One score, three
+ * performances.
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { afterEach, describe, expect, it } from 'vitest';
+import Field from '../../../src/components/field/field.astro';
+import { bindField, fieldBehavior } from '../../../src/components/field/field.behavior';
+import { assertAxeClean, assertContractFulfillment, partElement } from '../../harness/conformance';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+async function mount(props: Record<string, unknown> = {}): Promise<HTMLElement> {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Field, {
+    props: { id: 'email', label: 'Email', ...props },
+    // The slotted control carries the same id the field prop declares.
+    slots: { default: '<input id="email" type="email" />' },
+  });
+  document.body.innerHTML = html;
+  const root = document.body.querySelector('rafters-field') as HTMLElement;
+  bindField(root); // the <script> does this per instance on the real page
+  return root;
+}
+
+const control = () => document.body.querySelector<HTMLInputElement>('[data-part="control"]')!;
+const label = () => document.body.querySelector<HTMLLabelElement>('[data-part="label"]')!;
+
+describe('field conformance [astro]', () => {
+  it('basic: SSR associates label<->control, no validity aria, axe-clean', async () => {
+    const root = await mount();
+    assertContractFulfillment(fieldBehavior, root, {}, {}, ['label', 'control']);
+    expect(label().getAttribute('for')).toBe('email');
+    expect(control().getAttribute('data-part')).toBe('control');
+    expect(control().hasAttribute('aria-invalid')).toBe(false);
+    await assertAxeClean(root);
+  });
+
+  it('description: control describedby wired to the description id, axe-clean', async () => {
+    const root = await mount({ description: 'We never share your email' });
+    assertContractFulfillment(fieldBehavior, root, {}, {}, ['label', 'control', 'description']);
+    expect(control().getAttribute('aria-describedby')).toBe('email-description');
+    await assertAxeClean(root);
+  });
+
+  it('error: aria-invalid true, describedby to the error id, role=alert, description hidden', async () => {
+    const root = await mount({
+      description: 'We never share your email',
+      error: 'Email is required',
+    });
+    assertContractFulfillment(fieldBehavior, root, {}, {}, ['label', 'control', 'error']);
+    expect(control().getAttribute('aria-invalid')).toBe('true');
+    expect(control().getAttribute('aria-describedby')).toBe('email-error');
+    expect(partElement(root, 'error')?.getAttribute('role')).toBe('alert');
+    expect(partElement(root, 'description')).toBeNull();
+    await assertAxeClean(root);
+  });
+
+  it('required host signal projects aria-required onto the control', async () => {
+    const root = await mount({ required: true });
+    assertContractFulfillment(fieldBehavior, root, {}, { required: true }, ['label', 'control']);
+    expect(control().getAttribute('aria-required')).toBe('true');
+  });
+
+  it('disabled host signal propagates to the control (native)', async () => {
+    await mount({ disabled: true });
+    expect(control().disabled).toBe(true);
+  });
+});

--- a/packages/ui/test/components/field/field.behavior.test.ts
+++ b/packages/ui/test/components/field/field.behavior.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import type { PartIds } from '../../../src/lib/contract';
+import {
+  descriptionId,
+  errorId,
+  fieldBehavior,
+  fieldControlAria,
+  type FieldConfig,
+  type FieldPart,
+} from '../../../src/components/field/field.behavior';
+
+const idsOf = (over: Partial<PartIds<FieldPart>> = {}): PartIds<FieldPart> => ({
+  label: '',
+  control: 'f',
+  description: '',
+  error: '',
+  ...over,
+});
+
+function ariaAt(config: FieldConfig, ids: PartIds<FieldPart> = idsOf()) {
+  return fieldBehavior.aria({}, config, ids);
+}
+
+describe('field parts', () => {
+  it('declares the control plus optional description and error targets', () => {
+    expect(Object.keys(fieldBehavior.parts).sort()).toEqual([
+      'control',
+      'description',
+      'error',
+      'label',
+    ]);
+    expect(fieldBehavior.parts.control.optional).toBeUndefined();
+    expect(fieldBehavior.parts.description.optional).toBe(true);
+    expect(fieldBehavior.parts.error.optional).toBe(true);
+  });
+
+  it('projects role="alert" on the error message as a PartDecl role', () => {
+    expect(fieldBehavior.parts.error.role).toBe('alert');
+    // label carries no role -- its `for` association is native, not ARIA.
+    expect(fieldBehavior.parts.label.role).toBeUndefined();
+  });
+});
+
+describe('field state (a static, projection-only score)', () => {
+  it('has no state axis and dispatches nothing', () => {
+    expect(fieldBehavior.initialState({})).toEqual({});
+    expect(fieldBehavior.canDispatch({}, 'never' as never, {})).toBe(true);
+    expect(fieldBehavior.keymap({ key: 'Enter' }, {}, 'control', {})).toBeNull();
+    expect(Object.keys(fieldBehavior.actions)).toEqual([]);
+  });
+});
+
+describe('field aria projection (the contract)', () => {
+  it('valid + no helpers: the control carries no describedby, invalid, or required', () => {
+    expect(ariaAt({})).toEqual({
+      control: {
+        'aria-describedby': undefined,
+        'aria-invalid': undefined,
+        'aria-required': undefined,
+      },
+    });
+  });
+
+  it('error present: aria-invalid true, describedby wired to the error id', () => {
+    const aria = ariaAt({}, idsOf({ error: 'f-error' }));
+    expect(aria.control?.['aria-invalid']).toBe('true');
+    expect(aria.control?.['aria-describedby']).toBe('f-error');
+  });
+
+  it('description present: describedby wired to the description id, not invalid', () => {
+    const aria = ariaAt({}, idsOf({ description: 'f-description' }));
+    expect(aria.control?.['aria-describedby']).toBe('f-description');
+    expect(aria.control?.['aria-invalid']).toBeUndefined();
+  });
+
+  it('required projects aria-required on the control', () => {
+    expect(ariaAt({ required: true }).control?.['aria-required']).toBe('true');
+  });
+
+  it('composes describedby error-first, then description, when both ids are present', () => {
+    const aria = ariaAt({}, idsOf({ error: 'f-error', description: 'f-description' }));
+    expect(aria.control?.['aria-describedby']).toBe('f-error f-description');
+  });
+
+  it('references ONLY real ids -- an empty id never dangles', () => {
+    // Presence is read from the ids the harness reads off the DOM, so a hidden
+    // (unrendered) helper contributes no id and is never referenced.
+    expect(ariaAt({}, idsOf({ error: '', description: '' })).control?.['aria-describedby']).toBe(
+      undefined,
+    );
+  });
+
+  it('does NOT project disabled -- propagation is native, a decorator/bind concern', () => {
+    const aria = ariaAt({ disabled: true }, idsOf({ error: 'f-error' }));
+    expect('disabled' in (aria.control ?? {})).toBe(false);
+    expect('aria-disabled' in (aria.control ?? {})).toBe(false);
+  });
+});
+
+describe('field id scheme', () => {
+  it('derives the sibling ids from the field id', () => {
+    expect(descriptionId('email')).toBe('email-description');
+    expect(errorId('email')).toBe('email-error');
+  });
+});
+
+describe('fieldControlAria (the React declarative helper)', () => {
+  it('guards describedby/invalid on rendered presence', () => {
+    expect(fieldControlAria('f', {}, false, false)).toEqual({
+      'aria-describedby': undefined,
+      'aria-invalid': undefined,
+      'aria-required': undefined,
+    });
+    expect(fieldControlAria('f', {}, true, false)).toEqual({
+      'aria-describedby': 'f-error',
+      'aria-invalid': 'true',
+      'aria-required': undefined,
+    });
+    expect(fieldControlAria('f', { required: true }, false, true)).toEqual({
+      'aria-describedby': 'f-description',
+      'aria-invalid': undefined,
+      'aria-required': 'true',
+    });
+  });
+});

--- a/packages/ui/test/components/field/field.classes.test.ts
+++ b/packages/ui/test/components/field/field.classes.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { labelClasses } from '../../../src/components/label/label.classes';
+import { fieldBehavior } from '../../../src/components/field/field.behavior';
+import {
+  composeFieldLabelClasses,
+  fieldClassSet,
+} from '../../../src/components/field/field.classes';
+
+const classes = fieldClassSet({}, fieldBehavior.initialState({}));
+
+describe('field classes', () => {
+  it('stacks its parts with structural layout, never a page fill', () => {
+    expect(classes.container).toContain('flex');
+    expect(classes.container).toContain('flex-col');
+    expect(classes.container).not.toContain('bg-background');
+  });
+
+  it('helper and error share the body-text role token, never a raw text size', () => {
+    expect(classes.description).toContain('text-body-small');
+    expect(classes.error).toContain('text-body-small');
+    expect(classes.description).not.toContain('text-sm');
+    expect(classes.error).not.toContain('text-sm');
+  });
+
+  it('colours helper and error off the frozen semantic tokens', () => {
+    expect(classes.description).toContain('text-muted-foreground');
+    expect(classes.error).toContain('text-destructive');
+    expect(classes.requiredMarker).toContain('text-destructive');
+  });
+
+  it('reuses the Label score decoration for the label (never a parallel map)', () => {
+    // The un-dimmed label IS the Label score's default decoration.
+    expect(composeFieldLabelClasses(false)).toBe(labelClasses({}, {}).root);
+  });
+
+  it('adds the disabled dim only when disabled, and only as an opacity affordance', () => {
+    const enabled = composeFieldLabelClasses(false);
+    const disabled = composeFieldLabelClasses(true);
+    expect(enabled).not.toContain('opacity-50');
+    expect(disabled).toContain('opacity-50');
+    expect(disabled.startsWith(enabled)).toBe(true);
+  });
+});

--- a/packages/ui/test/components/field/field.conformance.test.tsx
+++ b/packages/ui/test/components/field/field.conformance.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * React performance of the field score, driven end to end. The shadcn Field
+ * surface: a container that pairs a label with a slotted control and optional
+ * helper/error text, wiring the id-association + validity ARIA the score
+ * projects. Same score as the WC and Astro conformance tests.
+ */
+import * as React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Field } from '../../../src/components/field/field';
+import { fieldBehavior } from '../../../src/components/field/field.behavior';
+import { assertAxeClean, assertContractFulfillment, partElement } from '../../harness/conformance';
+
+afterEach(() => {
+  cleanup();
+});
+
+const controlOf = (host: HTMLElement) => partElement(host, 'control') as HTMLInputElement;
+const labelOf = (host: HTMLElement) => partElement(host, 'label') as HTMLLabelElement;
+
+describe('field conformance [react]', () => {
+  it('basic: associates label<->control, no validity aria, axe-clean', async () => {
+    const { container } = render(
+      <Field label="Email">
+        <input type="email" />
+      </Field>,
+    );
+    assertContractFulfillment(fieldBehavior, container, {}, {}, ['label', 'control']);
+    const control = controlOf(container);
+    expect(labelOf(container).getAttribute('for')).toBe(control.id);
+    expect(control.id.length).toBeGreaterThan(0);
+    expect(control.hasAttribute('aria-invalid')).toBe(false);
+    expect(control.hasAttribute('aria-required')).toBe(false);
+    expect(control.hasAttribute('aria-describedby')).toBe(false);
+    await assertAxeClean(container);
+  });
+
+  it('description: control describedby wired to the description id, axe-clean', async () => {
+    const { container } = render(
+      <Field label="Email" description="We never share your email">
+        <input type="email" />
+      </Field>,
+    );
+    assertContractFulfillment(fieldBehavior, container, {}, {}, [
+      'label',
+      'control',
+      'description',
+    ]);
+    const control = controlOf(container);
+    const description = partElement(container, 'description');
+    expect(control.getAttribute('aria-describedby')).toBe(description?.id);
+    expect(control.hasAttribute('aria-invalid')).toBe(false);
+    await assertAxeClean(container);
+  });
+
+  it('error: aria-invalid true, describedby to the error id, role=alert, description hidden', async () => {
+    const { container } = render(
+      <Field label="Email" description="We never share your email" error="Email is required">
+        <input type="email" />
+      </Field>,
+    );
+    assertContractFulfillment(fieldBehavior, container, {}, {}, ['label', 'control', 'error']);
+    const control = controlOf(container);
+    const error = partElement(container, 'error');
+    expect(control.getAttribute('aria-invalid')).toBe('true');
+    expect(control.getAttribute('aria-describedby')).toBe(error?.id);
+    expect(error?.getAttribute('role')).toBe('alert');
+    // description-hidden-while-error: only one helper node is rendered.
+    expect(partElement(container, 'description')).toBeNull();
+    await assertAxeClean(container);
+  });
+
+  it('required: aria-required on the control and an aria-hidden marker', async () => {
+    const { container } = render(
+      <Field label="Email" required>
+        <input type="email" />
+      </Field>,
+    );
+    assertContractFulfillment(fieldBehavior, container, {}, { required: true }, [
+      'label',
+      'control',
+    ]);
+    expect(controlOf(container).getAttribute('aria-required')).toBe('true');
+    const marker = labelOf(container).querySelector('[aria-hidden="true"]');
+    expect(marker?.textContent).toBe('*');
+    await assertAxeClean(container);
+  });
+
+  it('disabled: propagates to the control (native), axe-clean', async () => {
+    const { container } = render(
+      <Field label="Email" disabled>
+        <input type="email" />
+      </Field>,
+    );
+    expect(controlOf(container).disabled).toBe(true);
+    await assertAxeClean(container);
+  });
+
+  it('respects an author-supplied control id: the label tracks it', async () => {
+    const { container } = render(
+      <Field label="Email">
+        <input id="signup-email" type="email" />
+      </Field>,
+    );
+    expect(controlOf(container).id).toBe('signup-email');
+    expect(labelOf(container).getAttribute('for')).toBe('signup-email');
+  });
+});

--- a/packages/ui/test/components/field/field.element.conformance.test.ts
+++ b/packages/ui/test/components/field/field.element.conformance.test.ts
@@ -1,0 +1,106 @@
+/**
+ * WC performance of the field score, driven end to end against light-DOM
+ * markup. Field is a light-DOM enhancer: the author supplies the label /
+ * control / helper markup and the element only wires it. Same score as the
+ * React and Astro conformance tests -- proves the id-association and the ARIA
+ * projection through the DOM-native client.
+ */
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { RaftersField } from '../../../src/components/field/field.element';
+import { fieldBehavior } from '../../../src/components/field/field.behavior';
+import { assertAxeClean, assertContractFulfillment, partElement } from '../../harness/conformance';
+
+beforeAll(() => {
+  if (!customElements.get('rafters-field')) customElements.define('rafters-field', RaftersField);
+});
+
+async function mount(markup: string): Promise<HTMLElement> {
+  document.body.innerHTML = markup;
+  await Promise.resolve(); // let the deferred connectedCallback bind run
+  return document.body.querySelector('rafters-field') as HTMLElement;
+}
+
+const control = () => document.body.querySelector<HTMLInputElement>('[data-part="control"]')!;
+const label = () => document.body.querySelector<HTMLLabelElement>('[data-part="label"]')!;
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('field conformance [wc]', () => {
+  it('basic: associates label<->control, no validity aria, axe-clean', async () => {
+    const root = await mount(
+      `<rafters-field>
+        <label data-part="label">Email</label>
+        <input data-part="control" id="email" type="email" />
+      </rafters-field>`,
+    );
+    assertContractFulfillment(fieldBehavior, root, {}, {}, ['label', 'control']);
+    expect(label().getAttribute('for')).toBe('email');
+    expect(control().hasAttribute('aria-invalid')).toBe(false);
+    expect(control().hasAttribute('aria-required')).toBe(false);
+    await assertAxeClean(root);
+  });
+
+  it('locates and stamps a bare slotted control (no data-part authored)', async () => {
+    await mount(
+      `<rafters-field>
+        <label data-part="label">Email</label>
+        <input id="email" type="email" />
+      </rafters-field>`,
+    );
+    // bindField found the input by tag and stamped the part marker.
+    expect(control().getAttribute('data-part')).toBe('control');
+    expect(label().getAttribute('for')).toBe('email');
+  });
+
+  it('description: control describedby wired to the description id', async () => {
+    const root = await mount(
+      `<rafters-field>
+        <label data-part="label">Email</label>
+        <input data-part="control" id="email" type="email" />
+        <div data-part="description" id="email-description">We never share your email</div>
+      </rafters-field>`,
+    );
+    assertContractFulfillment(fieldBehavior, root, {}, {}, ['label', 'control', 'description']);
+    expect(control().getAttribute('aria-describedby')).toBe('email-description');
+    expect(control().hasAttribute('aria-invalid')).toBe(false);
+    await assertAxeClean(root);
+  });
+
+  it('error: aria-invalid true, describedby to the error id, role=alert', async () => {
+    const root = await mount(
+      `<rafters-field>
+        <label data-part="label">Email</label>
+        <input data-part="control" id="email" type="email" />
+        <div data-part="error" id="email-error" role="alert">Email is required</div>
+      </rafters-field>`,
+    );
+    assertContractFulfillment(fieldBehavior, root, {}, {}, ['label', 'control', 'error']);
+    expect(control().getAttribute('aria-invalid')).toBe('true');
+    expect(control().getAttribute('aria-describedby')).toBe('email-error');
+    expect(partElement(root, 'error')?.getAttribute('role')).toBe('alert');
+    await assertAxeClean(root);
+  });
+
+  it('required host signal projects aria-required onto the control', async () => {
+    const root = await mount(
+      `<rafters-field data-required>
+        <label data-part="label">Email</label>
+        <input data-part="control" id="email" type="email" />
+      </rafters-field>`,
+    );
+    assertContractFulfillment(fieldBehavior, root, {}, { required: true }, ['label', 'control']);
+    expect(control().getAttribute('aria-required')).toBe('true');
+  });
+
+  it('disabled host signal propagates to the control (native)', async () => {
+    await mount(
+      `<rafters-field data-disabled>
+        <label data-part="label">Email</label>
+        <input data-part="control" id="email" type="email" />
+      </rafters-field>`,
+    );
+    expect(control().disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Port `field` to the behavior layer: form-field composition wiring label <-> control <-> hint/error via
id-association, on the direct-composition rules (no effects layer). Two of the issue's criteria are
superseded by the pre-wave hardening (#1880) and are mapped as such below.

## Acceptance criteria mapping

### Behavior test (pure, no DOM).
field.behavior.test.ts drives the score's id-association contract as pure functions with no DOM.
Evidence: packages/ui/test/components/field/field.behavior.test.ts:1.

### Classes parity test.
field.classes.test.ts asserts every variant/state of the classes.ts output against the expected class
strings, so a class drift in any of the three decorators is caught at the single source of truth.
Evidence: packages/ui/test/components/field/field.classes.test.ts:1.

### Conformance GREEN across React + WC + Astro via the shared harness
The React/WC/Astro conformance tests on the shared harness pass; `pnpm --filter @rafters/ui test:unit` is green.
Evidence: packages/ui/test/components/field/field.conformance.test.tsx:1.

### `docs/spec/components/field.md` written.
The component spec doc is written with the id-association contract and intelligence tags.
Evidence: packages/ui/docs/spec/components/field.md:1.

### Matrix line updated (`packages/ui/docs/spec/matrix/components.jsonl`, name:
SUPERSEDED by pre-wave hardening #1880: components.jsonl was DELETED (a hand-maintained tracker with zero
consumers). This criterion no longer applies -- there is no matrix line to update, by design.
Evidence: packages/ui/src/components/field/field.behavior.ts:1 (the source of truth is now the folder itself).

### shadcn drop-in base + rafters extensions both preserved.
field.classes.ts and the decorators preserve the shadcn base structure plus the rafters extensions.
Evidence: packages/ui/src/components/field/field.classes.ts:1.

### JSDoc intelligence tags present.
The behavior file and doc carry the JSDoc intelligence tags (cognitive load, a11y, usage).
Evidence: packages/ui/src/components/field/field.behavior.ts:1.

### Exported from the package as the articles are.
SUPERSEDED by pre-wave hardening #1880: `./next/*` is now a wildcard, so the component is exported
automatically by its folder existing -- no package.json edit is made or needed.
Evidence: packages/ui/src/components/field/field.tsx:1 (importable as @rafters/ui/next/field via the wildcard).

### `pnpm --filter @rafters/ui test:unit` green, `pnpm preflight` green.
Both run green on this branch: test:unit passes React/WC/Astro conformance, and preflight's
typecheck, lint, format, test, a11y, and build all pass with the field port added.
Evidence: packages/ui/test/components/field/field.element.conformance.test.ts:1.

## Not done

- No shared-file edits (package.json exports is a wildcard; components.jsonl is deleted; CHANGELOG is not
  touched for UI ports) -- deliberate per the pre-wave hardening, which is why the two superseded criteria
  above are satisfied differently than the original issue text assumed.

Closes #1774
