### PR TITLE
feat(#1795): port slider to the behavior layer

### DIFF
--- a/packages/ui/docs/spec/components/slider.md
+++ b/packages/ui/docs/spec/components/slider.md
@@ -1,0 +1,133 @@
+# Component Spec — Slider
+
+Status: DRAFT. Archetype `simple-interactive` (value axis), imitates `switch`
+for the score/decorator shape and `radio-group` for the many-part projection.
+
+Files (`src/components/slider/`):
+
+```
+slider.classes.ts    slider.behavior.ts    slider.tsx
+slider.element.ts     slider.astro
+```
+
+Tests mirror into `test/components/slider/` (behavior, classes, and React / WC /
+Astro conformance on the shared harness).
+
+## Composition
+
+The score is pure and multi-thumb; the impure surface is COMPOSED from three
+primitives directly (Spec 05, no effects layer):
+
+```
+interactive        the mouse/touch drag surface -> normalized {left, top}
+keyboard-handler   arrow / Page / Home / End keydown on the focused thumb
+form-value         the hidden mirrored inputs a <form> submits under `name`
+```
+
+`composeSliderInteractions({ root, getConfig, getValues, getFocusedIndex,
+request, setDragging })` folds `createInteractive` + `createKeyboardHandler` into
+one teardown, shared verbatim by `bindSlider` (WC + Astro) and the React
+controller's effect. The value math that turns interactive's raw point (or a key)
+into a stepped, clamped value is COMPONENT-INTERNAL pure state — the exported
+`valueFromPoint` / `stepForKey` / `clampToStep` / `nearestThumbIndex` helpers,
+never a reducer (a reducer receives no config, and the math needs min/max/step).
+
+`interactive` stamps `role="slider"` + `tabindex` on its surface (it assumes it
+IS the widget). Here the surface is the container and the THUMBS are the sliders,
+so `neutralizeInteractiveAria` strips that stamp immediately after every
+create/update (`applyAria` runs only there, never on a pointer event).
+
+Controlled/uncontrolled per the ownership-of-truth boundary: `config.value`
+shadows `state.values`; projections and the callback read `effectiveValues`.
+
+## Config, state, actions
+
+```ts
+interface SliderConfig {
+  variant; size;                 // rafters extensions (classes only)
+  min; max; step;                // the range and its grid
+  orientation;                   // 'horizontal' | 'vertical'
+  value?: number[];              // controlled
+  defaultValue?: number[];       // uncontrolled seed
+  disabled?: boolean;
+  name?: string;                 // form-value axis
+}
+interface SliderState { values: number[] } // intrinsic only; always ascending
+type SliderActions = { setThumb: { index: number; value: number } };
+```
+
+One action: `setThumb` receives an ALREADY-clamped value (the pure helpers own
+the math) and re-sorts a range so thumbs never cross. Which thumb is dragging
+(`active`) and the `data-dragging` flag are EPHEMERAL — bind-local closure and a
+DOM attribute, like radio-group's roving focus — not score state.
+
+## Parts and ARIA
+
+| Part | Presence | ARIA |
+| --- | --- | --- |
+| root | always | `data-orientation`, `data-disabled` (only when disabled); no role (not the widget); the `interactive` pointer surface |
+| track | always | `aria-hidden="true"`, `data-orientation` |
+| range | always | `aria-hidden="true"` (decorative fill) |
+| thumb | one per value | `role="slider"`, `aria-valuemin/valuemax/valuenow`, `aria-orientation`, `aria-disabled` (only when disabled); consumer supplies the accessible name |
+
+The thumb is a `many` part, so its projection lives in `sliderThumbAria(value,
+state, config)`, first-classed onto `sliderBehavior.instanceAria` so the harness's
+generic `assertInstanceAriaFulfillment` drives it (each instance keyed by
+`data-value`). `aria-valuenow` equals the thumb's own value string, so the
+data-value-keyed driver and the projection agree by construction. Every thumb is
+a tab stop (`tabindex=0`, `-1` while disabled); the container is never a tab stop.
+
+## Keyboard
+
+`keymap` is the pure claim record (Spec 01): the eight slider keys on a `thumb`
+claim `setThumb`. The bind resolves WHICH thumb (the focused one, via
+`focusedThumbIndex`) and the target value via `stepForKey`, then dispatches.
+
+| Key | Effect |
+| --- | --- |
+| ArrowRight / ArrowUp | + step |
+| ArrowLeft / ArrowDown | − step |
+| PageUp / PageDown | ± ten steps |
+| Home / End | jump to min / max |
+
+Orientation does NOT remap the keys (oracle rule: Right/Up always increase,
+Left/Down always decrease). `data-dragging` is toggled on the root during a
+pointer gesture for the CSS to read; it is not projected (ephemeral).
+
+## Motion
+
+`thumb-travel`: the thumb transitions on the x/bottom axis. Intent only —
+`transition-all duration-150 motion-reduce:transition-none`; durations/easing
+come from tokens.
+
+## Oracle dispositions (src/old/ui/slider.{tsx,element.ts,classes.ts})
+
+| Oracle feature | Disposition |
+| --- | --- |
+| controlled/uncontrolled `value`/`defaultValue` + `onValueChange` | contract |
+| multi-thumb range (`defaultValue={[25,75]}`), values kept sorted | contract |
+| drag a thumb / press the track to move the nearest thumb | contract (via `interactive` + `nearestThumbIndex`) |
+| Arrow / Page / Home / End keymap, step + 10×step, orientation-invariant keys | contract |
+| `aria-valuemin/max/now`, `aria-orientation` per thumb; `role="slider"` | contract |
+| horizontal + vertical orientation | contract |
+| `variant` / `size` (rafters extensions) | contract (classes only; `default`=`primary`) |
+| `disabled` gate (native path + programmatic) | contract (score `canDispatch` + thumb `tabindex=-1`) |
+| form submission | contract (form-value primitive: one hidden input per thumb under `name`); the oracle had no form association — an ADD, not a port |
+| per-thumb `aria-valuemin/max` clamped to the neighbour thumb | dropped — the oracle used the GLOBAL min/max for every thumb; preserved faithfully. A future enhancement, not a port. |
+| `aria-valuetext` | dropped — the oracle never set it; a consumer-supplied label is the escape until a formatter axis lands |
+| separate `onValueCommit` (release vs. move) | dropped — the oracle had none; `onValueChange` fires per committed move, and the bind emits a bubbling `input` event |
+| pointer capture on the thumb (`setPointerCapture`) | framework-affordance — `interactive` tracks the drag at the document level instead, so capture is unnecessary |
+
+## WCAG 2.1 AA obligations
+
+- 1.3.1 / 4.1.2: `role="slider"` with `aria-valuemin/max/now` and
+  `aria-orientation` per thumb, asserted against real DOM by the harness across
+  React / WC / Astro.
+- 2.1.1 Keyboard: every thumb is operable by Arrow / Page / Home / End; disabled
+  removes the thumbs from the tab order and gates all movement.
+- 2.4.7 Focus Visible: token focus ring on the thumb
+  (`focus-visible:ring-2 ring-<variant>-ring`).
+- 2.5.3 / naming: the control has no intrinsic text, so a consumer MUST supply an
+  accessible name (`aria-label` / `aria-labelledby`) on the thumbs; the
+  conformance suite supplies one per scenario and axe verifies it.
+- 1.4.13 / motion: thumb travel honours `motion-reduce:transition-none`.

--- a/packages/ui/src/components/slider/slider.astro
+++ b/packages/ui/src/components/slider/slider.astro
@@ -1,0 +1,150 @@
+---
+/**
+ * Astro performance (controller) for slider.
+ *
+ * Server-renders the full LIGHT-DOM container -- track, range, and one
+ * role=slider thumb per value -- with classes, the score's initial projection
+ * (data-orientation / aria-valuemin/max/now / aria-orientation), and the thumb
+ * geometry already applied, so the control is correct and accessible before any
+ * JS. The <script> then hands each server-rendered root to bindSlider -- the
+ * SAME DOM-native controller the Web Component uses. One score, three
+ * performances, zero drift.
+ *
+ * The slider has no intrinsic text, so the consumer MUST supply an accessible
+ * name (aria-label / aria-labelledby), applied to every thumb.
+ */
+import {
+  effectiveValues,
+  percentFor,
+  sliderBehavior,
+  sliderFormValue,
+  sliderThumbAria,
+  type SliderConfig,
+  type SliderOrientation,
+  type SliderPart,
+  type SliderSize,
+  type SliderVariant,
+} from './slider.behavior';
+import { sliderClasses } from './slider.classes';
+import type { PartIds } from '../../lib/contract';
+
+interface Props {
+  id: string;
+  variant?: SliderVariant;
+  size?: SliderSize;
+  min?: number;
+  max?: number;
+  step?: number;
+  orientation?: SliderOrientation;
+  defaultValue?: number[];
+  disabled?: boolean;
+  name?: string;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+}
+
+const {
+  id,
+  variant = 'default',
+  size = 'default',
+  min = 0,
+  max = 100,
+  step = 1,
+  orientation = 'horizontal',
+  defaultValue = [min],
+  disabled = false,
+  name,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledby,
+} = Astro.props;
+
+const config: SliderConfig = {
+  variant,
+  size,
+  min,
+  max,
+  step,
+  orientation,
+  defaultValue,
+  disabled,
+  name,
+};
+const state = sliderBehavior.initialState(config);
+const classes = sliderClasses(config, state);
+
+const ids = {} as PartIds<SliderPart>;
+for (const part of Object.keys(sliderBehavior.parts) as SliderPart[]) {
+  ids[part] = `${id}-${part}`;
+}
+const aria = sliderBehavior.aria(state, config, ids);
+
+const values = effectiveValues(state, config);
+const isHorizontal = orientation === 'horizontal';
+const low = Math.min(...values);
+const high = Math.max(...values);
+const rangeStart = values.length > 1 ? percentFor(low, config) : 0;
+const rangeEnd = percentFor(high, config);
+const rangeStyle = isHorizontal
+  ? `left:${rangeStart}%;right:${100 - rangeEnd}%;top:0;bottom:0`
+  : `bottom:${rangeStart}%;top:${100 - rangeEnd}%;left:0;right:0`;
+
+// The class rides a spread attrs object (never a literal class= on a span), the
+// same escape switch.astro uses -- these carry no typography role.
+const trackAttrs = { 'data-part': 'track', id: ids.track, class: classes.track, ...aria.track };
+const rangeAttrs = { 'data-part': 'range', class: classes.range, style: rangeStyle, ...aria.range };
+
+const thumbs = values.map((value, index) => {
+  const pct = percentFor(value, config);
+  const style = isHorizontal
+    ? `left:${pct}%;top:50%;transform:translate(-50%,-50%)`
+    : `bottom:${pct}%;left:50%;transform:translate(-50%,50%)`;
+  return {
+    role: 'slider',
+    'data-part': 'thumb',
+    'data-index': index,
+    'data-value': value,
+    tabindex: disabled ? -1 : 0,
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledby,
+    class: classes.thumb,
+    style,
+    ...sliderThumbAria(String(value), state, config),
+  };
+});
+
+const hiddenInputs = sliderFormValue(state, config);
+---
+
+<div
+  data-part="root"
+  id={ids.root}
+  data-step={step}
+  data-name={name}
+  class={classes.root}
+  {...aria.root}
+>
+  <span {...trackAttrs}>
+    <span {...rangeAttrs}></span>
+  </span>
+
+  {thumbs.map((thumb) => <span {...thumb}></span>)}
+
+  {
+    hiddenInputs.map((input, index) => (
+      <input type="hidden" data-slider-input data-index={index} name={input.name} value={input.value} />
+    ))
+  }
+</div>
+
+<script>
+  import { bindSlider } from './slider.behavior';
+
+  // The <script> is bundled and runs once per page; bind every instance's
+  // server-rendered root. Same controller as the Web Component.
+  const roots = document.querySelectorAll<HTMLElement>('div[data-part="root"][data-step]');
+  for (const root of roots) {
+    if (root.dataset['bound'] === 'true') continue;
+    root.dataset['bound'] = 'true';
+    bindSlider(root);
+  }
+</script>

--- a/packages/ui/src/components/slider/slider.behavior.ts
+++ b/packages/ui/src/components/slider/slider.behavior.ts
@@ -1,0 +1,496 @@
+import { compose, type Slice } from '../../lib/compose';
+import {
+  createBehavior,
+  type AriaAttrs,
+  type BehaviorSpec,
+  type PartIds,
+} from '../../lib/contract';
+import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { createInteractive } from '../../primitives/interactive';
+import { createKeyboardHandler } from '../../primitives/keyboard-handler';
+import { formValueAttrs, type FormValueAttrs } from '../../primitives/form-value';
+import type { InteractiveMode, NormalizedPoint } from '../../primitives/types';
+
+/**
+ * Slider: a continuous/stepped value control. One or more thumbs (role=slider)
+ * set value(s) in a [min, max] range by drag or arrow keys. The shadcn/Radix
+ * base surface is array-valued (`defaultValue={[25, 75]}` is a range slider), so
+ * the score is multi-thumb from the ground up; a single-thumb slider is just the
+ * one-element array.
+ *
+ * Composition (Spec 05, "compose the primitive, never reimplement it"):
+ * - pointer drag rides the `interactive` primitive -- it owns the mouse/touch
+ *   surface and the document-level drag tracking, and hands back a normalized
+ *   {left, top} (both 0-1). The value math that turns that point (or a key) into
+ *   a stepped, clamped value is COMPONENT-INTERNAL pure state -- the exported
+ *   `valueFromPoint`/`stepForKey`/`clampToStep` helpers below, never inside a
+ *   reducer (a reducer gets no config, and the math needs min/max/step).
+ * - keyboard nav rides `keyboard-handler` (`createKeyboardHandler`); the keymap
+ *   projection is the pure claim record (Spec 01), the bind computes the payload.
+ * - the form-value axis (`name` -> submitted values) is the pure
+ *   `sliderFormValue` projection built on the `form-value` primitive; the three
+ *   decorators render its hidden inputs and the bind keeps them in sync.
+ *
+ * Ephemeral, not score state: which thumb is being dragged (bind-local closure,
+ * like radio-group tracks focus in the DOM) and the `data-dragging` flag the CSS
+ * reads. The only score state is `values`; controlled/uncontrolled follows the
+ * ownership-of-truth boundary (config.value shadows state.values).
+ */
+export type SliderVariant =
+  | 'default'
+  | 'primary'
+  | 'secondary'
+  | 'destructive'
+  | 'success'
+  | 'warning'
+  | 'info'
+  | 'accent';
+
+export type SliderSize = 'sm' | 'default' | 'lg';
+
+export type SliderOrientation = 'horizontal' | 'vertical';
+
+export interface SliderConfig {
+  variant: SliderVariant;
+  size: SliderSize;
+  /** Range floor. */
+  min: number;
+  /** Range ceiling. */
+  max: number;
+  /** Increment the value snaps to. */
+  step: number;
+  /** Axis the thumbs travel along. */
+  orientation: SliderOrientation;
+  /** Controlled values: shadow the intrinsic state when present. */
+  value?: number[] | undefined;
+  /** Uncontrolled seed for the intrinsic values. */
+  defaultValue?: number[] | undefined;
+  /** No drag or key movement while disabled (gates the programmatic path too). */
+  disabled?: boolean | undefined;
+  /** Form-value axis: the field name each thumb's value submits under. */
+  name?: string | undefined;
+}
+
+export interface SliderState {
+  /** Intrinsic values -- ignored while a controlled value is present. Always
+   *  ascending for a range (the reducer re-sorts on every move). */
+  values: number[];
+}
+
+export type SliderActions = {
+  /** Move one thumb to an already-clamped value; re-sorts a range. */
+  setThumb: { index: number; value: number };
+};
+
+export type SliderPart = 'root' | 'track' | 'range' | 'thumb';
+
+/** The effective values: a controlled `config.value` shadows intrinsic state. */
+export function effectiveValues(state: SliderState, config: SliderConfig): number[] {
+  return config.value ?? state.values;
+}
+
+/** Snap a raw value to the step grid and clamp it into [min, max]. */
+export function clampToStep(value: number, config: SliderConfig): number {
+  const { min, max, step } = config;
+  const stepped = step > 0 ? min + Math.round((value - min) / step) * step : value;
+  return Math.min(Math.max(stepped, min), max);
+}
+
+/** Percentage (0-100) of a value along the range -- the thumb/range geometry. */
+export function percentFor(value: number, config: SliderConfig): number {
+  const { min, max } = config;
+  if (max === min) return 0;
+  return ((value - min) / (max - min)) * 100;
+}
+
+/**
+ * Turn a normalized pointer point (interactive's raw output, both axes 0-1) into
+ * a stepped, clamped value. Vertical inverts: the track top is the max end.
+ */
+export function valueFromPoint(point: NormalizedPoint, config: SliderConfig): number {
+  const pct = config.orientation === 'vertical' ? 1 - point.top : point.left;
+  return clampToStep(config.min + pct * (config.max - config.min), config);
+}
+
+/** Index of the thumb nearest a value -- the one a track press grabs. */
+export function nearestThumbIndex(values: number[], value: number): number {
+  let closest = 0;
+  let best = Infinity;
+  for (let i = 0; i < values.length; i++) {
+    const current = values[i];
+    if (current === undefined) continue;
+    const distance = Math.abs(current - value);
+    if (distance < best) {
+      best = distance;
+      closest = i;
+    }
+  }
+  return closest;
+}
+
+/**
+ * The value a key targets from a thumb's current value, or `null` when the key
+ * is not a slider key. Arrows step by `step`, Page keys by ten steps, Home/End
+ * jump to the ends. Orientation does not remap the keys (the oracle's rule:
+ * Right/Up always increase, Left/Down always decrease).
+ */
+export function stepForKey(key: string, current: number, config: SliderConfig): number | null {
+  const large = config.step * 10;
+  switch (key) {
+    case 'ArrowRight':
+    case 'ArrowUp':
+      return clampToStep(current + config.step, config);
+    case 'ArrowLeft':
+    case 'ArrowDown':
+      return clampToStep(current - config.step, config);
+    case 'PageUp':
+      return clampToStep(current + large, config);
+    case 'PageDown':
+      return clampToStep(current - large, config);
+    case 'Home':
+      return config.min;
+    case 'End':
+      return config.max;
+    default:
+      return null;
+  }
+}
+
+/**
+ * The form-value projection: one hidden-input descriptor per thumb (Radix
+ * mirrors a range's every value under the same name). Pure data -- the three
+ * decorators render it and the bind syncs the live values. Empty without a name.
+ */
+export function sliderFormValue(state: SliderState, config: SliderConfig): FormValueAttrs[] {
+  if (!config.name) return [];
+  return effectiveValues(state, config)
+    .map((value) => formValueAttrs({ name: config.name, value: String(value) }))
+    .filter((attrs): attrs is FormValueAttrs => attrs !== null);
+}
+
+const SLIDER_KEYS = [
+  'ArrowRight',
+  'ArrowLeft',
+  'ArrowUp',
+  'ArrowDown',
+  'Home',
+  'End',
+  'PageUp',
+  'PageDown',
+] as const;
+
+const slider: Slice<SliderConfig, SliderState, SliderActions, SliderPart> = {
+  name: 'slider',
+  parts: {
+    // The container carries no role (it is not the widget); the thumbs are the
+    // role=slider widgets. track + range are decorative geometry.
+    root: {},
+    track: {},
+    range: {},
+    thumb: { role: 'slider', many: true },
+  },
+  initialState: (config) => ({
+    values: [...(config.value ?? config.defaultValue ?? [config.min])],
+  }),
+  actions: {
+    // The value arrives already clamped/stepped (the pure helpers own the math,
+    // since a reducer gets no config). A range stays sorted ascending so the
+    // thumbs never cross and the neighbours' geometry stays monotonic.
+    setThumb: (state, { index, value }) => {
+      const values = [...state.values];
+      if (index < 0 || index >= values.length) return state;
+      values[index] = value;
+      if (values.length > 1) values.sort((a, b) => a - b);
+      return { values };
+    },
+  },
+  // The gate: a disabled slider rejects every move, so a controlled consumer's
+  // callback never fires for a change it would refuse.
+  canDispatch: (_state, action, config) => (action === 'setThumb' ? !config.disabled : true),
+  aria: (_state, config) => ({
+    root: {
+      'data-orientation': config.orientation,
+      'data-disabled': config.disabled ? 'true' : undefined,
+    },
+    track: { 'aria-hidden': 'true', 'data-orientation': config.orientation },
+    range: { 'aria-hidden': 'true' },
+  }),
+  // The pure claim record (Spec 01): these keys move a thumb. The bind computes
+  // WHICH thumb (the focused one) and the target value via stepForKey.
+  keymap: (event, _state, part) =>
+    part === 'thumb' && (SLIDER_KEYS as ReadonlyArray<string>).includes(event.key)
+      ? 'setThumb'
+      : null,
+};
+
+/**
+ * Per-instance projection for the `thumb` many-part. `aria()` projects one
+ * AriaAttrs per part NAME; thumbs occur once per value, so their projection
+ * takes the instance value (mirroring radio-group's radioItemAria). The oracle
+ * used the GLOBAL min/max for every thumb (no neighbour-clamping); that is
+ * preserved faithfully -- see the dispositions in slider.md. `aria-valuenow`
+ * equals the thumb's own value string (its data-value), so the harness's
+ * data-value-keyed driver and the projection agree by construction.
+ */
+export function sliderThumbAria(
+  value: string,
+  _state: SliderState,
+  config: SliderConfig,
+): AriaAttrs {
+  return {
+    'aria-valuemin': String(config.min),
+    'aria-valuemax': String(config.max),
+    'aria-valuenow': value,
+    'aria-orientation': config.orientation,
+    'aria-disabled': config.disabled ? 'true' : undefined,
+  };
+}
+
+// First-class the thumb's per-instance projection on the spec (Spec 05's open
+// gap): the harness's generic `assertInstanceAriaFulfillment` reads
+// `spec.instanceAria`, and `compose` does not carry it, so it is attached here.
+export const sliderBehavior: BehaviorSpec<SliderConfig, SliderState, SliderActions, SliderPart> = {
+  ...compose('slider', slider),
+  instanceAria: (part, value, state, config) =>
+    part === 'thumb' ? sliderThumbAria(value, state, config) : {},
+};
+
+/** The interactive mode for a slider orientation (1D, single axis). */
+function interactiveMode(config: SliderConfig): InteractiveMode {
+  return config.orientation === 'vertical' ? '1d-vertical' : '1d-horizontal';
+}
+
+/**
+ * Strip the ARIA the `interactive` primitive stamps on its surface. Interactive
+ * assumes it IS the slider (role=slider + tabindex=0); here the surface is the
+ * container and the THUMBS are the sliders, so the stamp is removed right after
+ * every create/update. `applyAria` only runs inside create/update (never on a
+ * pointer event -- confirmed in interactive.ts), so one wipe per call suffices.
+ */
+function neutralizeInteractiveAria(surface: HTMLElement): void {
+  surface.removeAttribute('role');
+  surface.removeAttribute('tabindex');
+  surface.removeAttribute('aria-disabled');
+}
+
+export interface SliderInteractionOptions {
+  /** The interactive surface AND the keyboard host -- the container root. */
+  root: HTMLElement;
+  getConfig: () => SliderConfig;
+  /** Effective (controlled-aware) values at call time. */
+  getValues: () => number[];
+  /** Focused thumb index, from the DOM -- the keyboard target. */
+  getFocusedIndex: () => number | null;
+  /** Commit a thumb move; returns the thumb's index AFTER the range re-sort. */
+  request: (index: number, value: number) => number;
+  /** Toggle the ephemeral `data-dragging` flag the CSS reads. */
+  setDragging: (on: boolean) => void;
+}
+
+/**
+ * Compose the impure pointer + keyboard surface. Shared verbatim by `bindSlider`
+ * (WC + Astro) and the React controller's effect -- one composition, three
+ * performances, so the drag/keyboard rules can never drift.
+ */
+export function composeSliderInteractions(options: SliderInteractionOptions): () => void {
+  const { root, getConfig, getValues, getFocusedIndex, request, setDragging } = options;
+
+  let active: number | null = null;
+  // A press flags "pick the nearest thumb on the NEXT normalized move" -- so the
+  // pick reuses interactive's own point math instead of duplicating rect reads.
+  let pickPending = false;
+
+  const onPointerDown = (): void => {
+    if (getConfig().disabled) return;
+    pickPending = true;
+    setDragging(true);
+  };
+  root.addEventListener('pointerdown', onPointerDown);
+
+  const cleanupInteractive = createInteractive(root, {
+    mode: interactiveMode(getConfig()),
+    disabled: getConfig().disabled ?? false,
+    onMove: (point) => {
+      if (getConfig().disabled) return;
+      const value = valueFromPoint(point, getConfig());
+      if (pickPending) {
+        active = nearestThumbIndex(getValues(), value);
+        pickPending = false;
+      }
+      if (active === null) return;
+      active = request(active, value);
+    },
+  });
+  neutralizeInteractiveAria(root);
+
+  const endDrag = (): void => {
+    active = null;
+    pickPending = false;
+    setDragging(false);
+  };
+  window.addEventListener('pointerup', endDrag);
+  window.addEventListener('pointercancel', endDrag);
+
+  // Keyboard rides the keyboard-handler primitive. Registered on the root so a
+  // focused thumb's keydown bubbles up; the handler resolves the focused thumb
+  // from the DOM (like radio-group) and computes the target via stepForKey.
+  const cleanupKeyboard = createKeyboardHandler(root, {
+    key: ['ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown', 'Home', 'End', 'PageUp', 'PageDown'],
+    preventDefault: true,
+    handler: (event) => {
+      const config = getConfig();
+      if (config.disabled) return;
+      const index = getFocusedIndex();
+      if (index === null) return;
+      const current = getValues()[index];
+      if (current === undefined) return;
+      const target = stepForKey(event.key, current, config);
+      if (target === null || target === current) return;
+      request(index, target);
+    },
+  });
+
+  return () => {
+    root.removeEventListener('pointerdown', onPointerDown);
+    window.removeEventListener('pointerup', endDrag);
+    window.removeEventListener('pointercancel', endDrag);
+    cleanupInteractive();
+    cleanupKeyboard();
+  };
+}
+
+/** The focused thumb's index from the DOM, or null. Shared by bind and React. */
+export function focusedThumbIndex(root: HTMLElement): number | null {
+  const activeEl = (root.getRootNode() as Document | ShadowRoot)
+    .activeElement as HTMLElement | null;
+  const thumb = activeEl?.closest<HTMLElement>('[data-part="thumb"]') ?? null;
+  if (!thumb || !root.contains(thumb)) return null;
+  const index = Number(thumb.dataset['index']);
+  return Number.isInteger(index) ? index : null;
+}
+
+const THUMB_SELECTOR = '[data-part="thumb"]';
+
+/**
+ * The DOM-native binding of the slider score -- the client the Web Component and
+ * the Astro <script> both import. React (retained-mode) reads the projections
+ * declaratively instead, but composes the SAME `composeSliderInteractions`.
+ *
+ * Uncontrolled: WC/Astro have no reactive prop, so `config.value` is undefined
+ * and the effective values are the intrinsic state, seeded from the
+ * server-rendered thumbs.
+ */
+export function bindSlider(root: HTMLElement): () => void {
+  const thumbEls = Array.from(root.querySelectorAll<HTMLElement>(THUMB_SELECTOR));
+  const seeded = thumbEls
+    .map((el) => Number(el.getAttribute('aria-valuenow')))
+    .filter((n) => Number.isFinite(n));
+
+  const config: SliderConfig = {
+    variant: 'default',
+    size: 'default',
+    min: Number(thumbEls[0]?.getAttribute('aria-valuemin') ?? 0),
+    max: Number(thumbEls[0]?.getAttribute('aria-valuemax') ?? 100),
+    step: Number(root.getAttribute('data-step') ?? 1),
+    orientation: root.getAttribute('data-orientation') === 'vertical' ? 'vertical' : 'horizontal',
+    disabled: root.getAttribute('data-disabled') === 'true',
+    name: root.getAttribute('data-name') ?? undefined,
+    defaultValue:
+      seeded.length > 0 ? seeded : [Number(thumbEls[0]?.getAttribute('aria-valuemin') ?? 0)],
+  };
+
+  const getPart = (part: string): HTMLElement | null =>
+    part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
+
+  const { memory, dispatch } = createBehavior(sliderBehavior, config);
+
+  const ids = {} as PartIds<SliderPart>;
+  for (const part of Object.keys(sliderBehavior.parts) as SliderPart[]) {
+    ids[part] = getPart(part)?.id ?? '';
+  }
+
+  const applyProjection = (el: HTMLElement, attrs: AriaAttrs) => {
+    for (const [name, value] of Object.entries(attrs)) {
+      updateAriaAttribute(el, name as never, value as never, { validate: false });
+    }
+  };
+
+  const isHorizontal = config.orientation === 'horizontal';
+
+  const paintThumb = (el: HTMLElement, index: number, value: number): void => {
+    el.dataset['index'] = String(index);
+    el.dataset['value'] = String(value);
+    applyProjection(el, sliderThumbAria(String(value), memory.get(), config));
+    const pct = percentFor(value, config);
+    if (isHorizontal) {
+      el.style.left = `${pct}%`;
+    } else {
+      el.style.bottom = `${pct}%`;
+    }
+  };
+
+  const render = () => {
+    const state = memory.get();
+    const values = effectiveValues(state, config);
+    const projection = sliderBehavior.aria(state, config, ids);
+    for (const part of ['root', 'track', 'range'] as const) {
+      const attrs = projection[part];
+      const el = getPart(part);
+      if (el && attrs) applyProjection(el, attrs);
+    }
+
+    const thumbs = Array.from(root.querySelectorAll<HTMLElement>(THUMB_SELECTOR));
+    for (const [index, el] of thumbs.entries()) {
+      const value = values[index];
+      if (value !== undefined) paintThumb(el, index, value);
+    }
+
+    // The range fill spans the thumbs (single thumb: min end -> value).
+    const range = getPart('range');
+    if (range) {
+      const low = percentFor(Math.min(...values), config);
+      const high = percentFor(Math.max(...values), config);
+      const start = values.length > 1 ? low : 0;
+      if (isHorizontal) {
+        range.style.left = `${start}%`;
+        range.style.right = `${100 - high}%`;
+      } else {
+        range.style.bottom = `${start}%`;
+        range.style.top = `${100 - high}%`;
+      }
+    }
+
+    // Keep the hidden form inputs in sync with the live values.
+    const inputs = Array.from(root.querySelectorAll<HTMLInputElement>('input[data-slider-input]'));
+    for (const [index, input] of inputs.entries()) {
+      const value = values[index];
+      if (value !== undefined) input.value = String(value);
+    }
+  };
+  const unsubscribe = memory.subscribe(render); // fires immediately: first paint
+
+  const request = (index: number, value: number): number => {
+    if (!dispatch('setThumb', config, { index, value })) return index;
+    const values = memory.get().values;
+    root.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+    const landed = values.indexOf(value);
+    return landed === -1 ? index : landed;
+  };
+
+  const stopInteractions = composeSliderInteractions({
+    root,
+    getConfig: () => config,
+    getValues: () => effectiveValues(memory.get(), config),
+    getFocusedIndex: () => focusedThumbIndex(root),
+    request,
+    setDragging: (on) => {
+      if (on) root.setAttribute('data-dragging', 'true');
+      else root.removeAttribute('data-dragging');
+    },
+  });
+
+  return () => {
+    unsubscribe();
+    stopInteractions();
+  };
+}

--- a/packages/ui/src/components/slider/slider.classes.ts
+++ b/packages/ui/src/components/slider/slider.classes.ts
@@ -1,0 +1,99 @@
+import type {
+  SliderConfig,
+  SliderOrientation,
+  SliderSize,
+  SliderState,
+  SliderVariant,
+} from './slider.behavior';
+
+export interface SliderClassSet {
+  root: string;
+  track: string;
+  range: string;
+  thumb: string;
+}
+
+// The disabled presentation rides the projected `data-disabled` on the root, not
+// a swapped string: one class set covers both ends and the score's flag is what
+// the CSS reads -- so light-DOM markup, the WC, and React all dim identically.
+const baseRootClasses =
+  'relative flex touch-none select-none items-center ' +
+  'data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+
+const rootOrientationClasses: Record<SliderOrientation, string> = {
+  horizontal: 'w-full',
+  vertical: 'h-full flex-col',
+};
+
+const baseTrackClasses = 'relative grow overflow-hidden rounded-full bg-muted';
+
+const trackSizeClasses: Record<SliderSize, string> = {
+  sm: 'data-[orientation=horizontal]:h-1 data-[orientation=vertical]:w-1',
+  default: 'data-[orientation=horizontal]:h-2 data-[orientation=vertical]:w-2',
+  lg: 'data-[orientation=horizontal]:h-3 data-[orientation=vertical]:w-3',
+};
+
+const trackOrientationClasses: Record<SliderOrientation, string> = {
+  horizontal: 'w-full',
+  vertical: 'h-full',
+};
+
+const baseRangeClasses = 'absolute';
+
+const rangeOrientationClasses: Record<SliderOrientation, string> = {
+  horizontal: 'h-full',
+  vertical: 'w-full',
+};
+
+const rangeFillClasses: Record<SliderVariant, string> = {
+  default: 'bg-primary',
+  primary: 'bg-primary',
+  secondary: 'bg-secondary',
+  destructive: 'bg-destructive',
+  success: 'bg-success',
+  warning: 'bg-warning',
+  info: 'bg-info',
+  accent: 'bg-accent',
+};
+
+const baseThumbClasses =
+  'absolute block rounded-full border-2 bg-background ' +
+  'ring-offset-background transition-all duration-150 motion-reduce:transition-none ' +
+  'hover:scale-110 active:scale-105 ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ' +
+  'disabled:cursor-not-allowed';
+
+const thumbSizeClasses: Record<SliderSize, string> = {
+  sm: 'h-4 w-4',
+  default: 'h-5 w-5',
+  lg: 'h-6 w-6',
+};
+
+const thumbVariantClasses: Record<SliderVariant, string> = {
+  default: 'border-primary focus-visible:ring-primary-ring',
+  primary: 'border-primary focus-visible:ring-primary-ring',
+  secondary: 'border-secondary focus-visible:ring-secondary-ring',
+  destructive: 'border-destructive focus-visible:ring-destructive-ring',
+  success: 'border-success focus-visible:ring-success-ring',
+  warning: 'border-warning focus-visible:ring-warning-ring',
+  info: 'border-info focus-visible:ring-info-ring',
+  accent: 'border-accent focus-visible:ring-accent-ring',
+};
+
+export function sliderClasses(config: SliderConfig, _state?: SliderState): SliderClassSet {
+  const { variant, size, orientation } = config;
+  return {
+    root: `${baseRootClasses} ${rootOrientationClasses[orientation]}`,
+    track: `${baseTrackClasses} ${trackSizeClasses[size]} ${trackOrientationClasses[orientation]}`,
+    range: `${baseRangeClasses} ${rangeOrientationClasses[orientation]} ${rangeFillClasses[variant]}`,
+    thumb: `${baseThumbClasses} ${thumbSizeClasses[size]} ${thumbVariantClasses[variant]}`,
+  };
+}
+
+export function sliderVariants(
+  options: { variant?: SliderVariant; size?: SliderSize } = {},
+): string {
+  const variant = options.variant ?? 'default';
+  const size = options.size ?? 'default';
+  return `${baseThumbClasses} ${thumbSizeClasses[size]} ${thumbVariantClasses[variant]}`;
+}

--- a/packages/ui/src/components/slider/slider.element.ts
+++ b/packages/ui/src/components/slider/slider.element.ts
@@ -1,0 +1,34 @@
+/**
+ * WC performance for slider: the thinnest wrapper. The score AND the DOM-native
+ * binding (bindSlider) live in slider.behavior.ts, shared with the Astro
+ * performance. This file only adapts that binding to the custom-element
+ * lifecycle.
+ *
+ * A light-DOM enhancer: the author (or Astro) provides the real container with
+ * its track/range/thumb children so the pointer surface and the role=slider
+ * thumbs exist before any JS -- the WC never renders a shadow tree of its own.
+ * The bind is deferred one microtask because connectedCallback can fire before
+ * the light-DOM children are parsed (upgrade order).
+ */
+import { bindSlider } from './slider.behavior';
+
+export class RaftersSlider extends HTMLElement {
+  private teardown: (() => void) | null = null;
+
+  connectedCallback(): void {
+    queueMicrotask(() => {
+      if (!this.isConnected || this.teardown) return;
+      const root = this.querySelector<HTMLElement>('[data-part="root"]');
+      if (root) this.teardown = bindSlider(root);
+    });
+  }
+
+  disconnectedCallback(): void {
+    this.teardown?.();
+    this.teardown = null;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-slider')) {
+  customElements.define('rafters-slider', RaftersSlider);
+}

--- a/packages/ui/src/components/slider/slider.tsx
+++ b/packages/ui/src/components/slider/slider.tsx
@@ -1,0 +1,245 @@
+import * as React from 'react';
+import { createBehavior, type PartIds } from '../../lib/contract';
+import { useMemory } from '../../hooks/use-memory';
+import classy from '../../primitives/classy';
+import {
+  composeSliderInteractions,
+  effectiveValues,
+  focusedThumbIndex,
+  percentFor,
+  sliderBehavior,
+  sliderFormValue,
+  sliderThumbAria,
+  type SliderConfig,
+  type SliderOrientation,
+  type SliderPart,
+  type SliderSize,
+  type SliderVariant,
+} from './slider.behavior';
+import { sliderClasses } from './slider.classes';
+
+export { sliderVariants } from './slider.classes';
+export type { SliderSize, SliderVariant, SliderOrientation };
+
+/**
+ * Slider -- the React performance of the slider score. The shadcn Slider
+ * surface: an array-valued `value`/`defaultValue` (a two-element array is a
+ * range with two thumbs), `onValueChange`, `min`/`max`/`step`, `orientation`,
+ * plus the rafters `variant`/`size` extensions.
+ *
+ * Thin by construction: the score owns the value math and projections, so the
+ * controller wires memory + classes and composes the ONE pointer/keyboard
+ * surface (`composeSliderInteractions`) in an effect -- the same composition the
+ * WC/Astro bind runs. The value/name props ride the form-value axis into the
+ * hidden inputs the score projects.
+ *
+ * @cognitive-load 3/10 - decision 1, information 1, interaction 1, disruption 0,
+ * learning 0. One continuous choice along a visible range; the thumb position
+ * and any printed value are the only information to read. A universally learned
+ * drag/arrow affordance, no workflow disruption, nothing to learn.
+ * @attention-economics The track makes the whole range visible at a glance, so
+ * the control communicates both the current value and its bounds without
+ * competing for attention. Best for approximate selection within a bounded
+ * range; pair with a printed value when precision matters.
+ * @trust-building Immediate, reversible feedback -- the thumb tracks the pointer
+ * and every arrow key in real time, and the disabled gate keeps an unavailable
+ * control from moving while staying discoverable. Steps snap predictably so the
+ * user is never left between valid values.
+ * @accessibility Each thumb is a role="slider" with aria-valuemin/max/now and
+ * aria-orientation, wired to real DOM by the harness. Arrow keys step, Page keys
+ * jump by ten steps, Home/End reach the ends; every thumb is a tab stop. The
+ * control has no intrinsic text, so consumers MUST supply an accessible name
+ * (aria-label / aria-labelledby). Disabled removes the thumbs from the tab order
+ * and gates all movement.
+ */
+export interface SliderProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'onChange' | 'defaultValue'
+> {
+  /** Controlled values (one element per thumb). */
+  value?: number[];
+  /** Uncontrolled seed for the values. */
+  defaultValue?: number[];
+  /** Fires on every committed move with the values the consumer should adopt. */
+  onValueChange?: (value: number[]) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+  orientation?: SliderOrientation;
+  disabled?: boolean;
+  variant?: SliderVariant;
+  size?: SliderSize;
+  /** Form-value axis: the field name each thumb's value submits under. */
+  name?: string;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+}
+
+export const Slider = React.forwardRef<HTMLDivElement, SliderProps>((props, ref) => {
+  const {
+    className,
+    value,
+    defaultValue = [0],
+    onValueChange,
+    min = 0,
+    max = 100,
+    step = 1,
+    orientation = 'horizontal',
+    disabled = false,
+    variant = 'default',
+    size = 'default',
+    name,
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledby,
+    ...rest
+  } = props;
+
+  const config: SliderConfig = {
+    variant,
+    size,
+    min,
+    max,
+    step,
+    orientation,
+    value,
+    defaultValue,
+    disabled,
+    name,
+  };
+
+  const { memory, dispatch } = React.useMemo(() => createBehavior(sliderBehavior, config), []);
+  const state = useMemory(memory);
+
+  const rootRef = React.useRef<HTMLDivElement | null>(null);
+  const setRef = React.useCallback(
+    (element: HTMLDivElement | null) => {
+      rootRef.current = element;
+      if (typeof ref === 'function') ref(element);
+      else if (ref) ref.current = element;
+    },
+    [ref],
+  );
+
+  // Gotcha #1: report the value the consumer should adopt, computed from the
+  // EFFECTIVE values before (a controlled slider's effective value never moves)
+  // with the moved thumb applied and the range re-sorted -- never intrinsic.
+  const latest = React.useRef({ config, onValueChange });
+  latest.current = { config, onValueChange };
+  const request = React.useCallback(
+    (index: number, next: number): number => {
+      const { config: cfg, onValueChange: cb } = latest.current;
+      const current = effectiveValues(memory.get(), cfg);
+      const proposed = [...current];
+      proposed[index] = next;
+      if (proposed.length > 1) proposed.sort((a, b) => a - b);
+      if (!dispatch('setThumb', cfg, { index, value: next })) return index;
+      cb?.(proposed);
+      const landed = proposed.indexOf(next);
+      return landed === -1 ? index : landed;
+    },
+    [memory, dispatch],
+  );
+
+  // Compose the ONE pointer/keyboard surface -- the same composition the bind
+  // runs. Re-created only when orientation/disabled change (interactive fixes
+  // its mode at create; min/max/step are read live via getConfig).
+  React.useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    return composeSliderInteractions({
+      root,
+      getConfig: () => latest.current.config,
+      getValues: () => effectiveValues(memory.get(), latest.current.config),
+      getFocusedIndex: () => focusedThumbIndex(root),
+      request,
+      setDragging: (on) => {
+        if (on) root.setAttribute('data-dragging', 'true');
+        else root.removeAttribute('data-dragging');
+      },
+    });
+  }, [orientation, disabled, request, memory]);
+
+  const uid = React.useId();
+  const ids = {} as PartIds<SliderPart>;
+  for (const part of Object.keys(sliderBehavior.parts) as SliderPart[])
+    ids[part] = `${uid}-${part}`;
+  const aria = sliderBehavior.aria(state, config, ids);
+  const classes = sliderClasses(config, state);
+
+  const values = effectiveValues(state, config);
+  const isHorizontal = orientation === 'horizontal';
+  const low = Math.min(...values);
+  const high = Math.max(...values);
+  const rangeStart = values.length > 1 ? percentFor(low, config) : 0;
+  const rangeEnd = percentFor(high, config);
+  const rangeStyle: React.CSSProperties = isHorizontal
+    ? { left: `${rangeStart}%`, right: `${100 - rangeEnd}%`, top: 0, bottom: 0 }
+    : { bottom: `${rangeStart}%`, top: `${100 - rangeEnd}%`, left: 0, right: 0 };
+
+  // Decorative structure (track/range) and the thumbs are built with
+  // createElement so the class strings stay plain composition, the same escape
+  // switch uses for its thumb -- these carry no typography role.
+  const range = React.createElement('span', {
+    'data-part': 'range',
+    className: classes.range,
+    style: rangeStyle,
+    ...aria.range,
+  });
+  const track = React.createElement(
+    'span',
+    { 'data-part': 'track', id: ids.track, className: classes.track, ...aria.track },
+    range,
+  );
+
+  const thumbs = values.map((thumbValue, index) => {
+    const pct = percentFor(thumbValue, config);
+    const thumbStyle: React.CSSProperties = isHorizontal
+      ? { left: `${pct}%`, top: '50%', transform: 'translate(-50%, -50%)' }
+      : { bottom: `${pct}%`, left: '50%', transform: 'translate(-50%, 50%)' };
+    return React.createElement('span', {
+      key: index,
+      role: 'slider',
+      'data-part': 'thumb',
+      'data-index': index,
+      'data-value': thumbValue,
+      tabIndex: disabled ? -1 : 0,
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabelledby,
+      className: classes.thumb,
+      style: thumbStyle,
+      ...sliderThumbAria(String(thumbValue), state, config),
+    });
+  });
+
+  const inputs = sliderFormValue(state, config).map((input, index) =>
+    React.createElement('input', {
+      key: index,
+      type: 'hidden',
+      'data-slider-input': '',
+      'data-index': index,
+      name: input.name,
+      value: input.value,
+      readOnly: true,
+    }),
+  );
+
+  return (
+    <div
+      ref={setRef}
+      data-part="root"
+      id={ids.root}
+      data-step={step}
+      data-name={name}
+      className={classy(classes.root, className)}
+      {...aria.root}
+      {...rest}
+    >
+      {track}
+      {thumbs}
+      {inputs}
+    </div>
+  );
+});
+
+Slider.displayName = 'Slider';
+export default Slider;

--- a/packages/ui/test/components/slider/conformance-suite.ts
+++ b/packages/ui/test/components/slider/conformance-suite.ts
@@ -1,0 +1,170 @@
+/**
+ * Slider conformance suite -- one suite, run per render adapter. The React and
+ * WC conformance tests are each their adapter plus a call into
+ * runSliderConformance. Astro drives the same score from its own file.
+ */
+import { describe, expect, it } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { sliderBehavior, type SliderConfig } from '../../../src/components/slider/slider.behavior';
+import {
+  assertAxeClean,
+  assertContractFulfillment,
+  assertInstanceAriaFulfillment,
+  partElement,
+  partElements,
+  type RenderResult,
+} from '../../harness/conformance';
+
+export interface SliderScenarioProps {
+  variant?: SliderConfig['variant'];
+  size?: SliderConfig['size'];
+  value?: number[];
+  min?: number;
+  max?: number;
+  step?: number;
+  orientation?: SliderConfig['orientation'];
+  disabled?: boolean;
+}
+
+export interface SliderAdapter {
+  name: string;
+  /** Every scenario carries an accessible name: a slider has no intrinsic text,
+   *  so the adapter always applies `label` as each thumb's accessible name. */
+  render(props: SliderScenarioProps, label: string): RenderResult | Promise<RenderResult>;
+}
+
+interface Scenario {
+  name: string;
+  props: SliderScenarioProps;
+}
+
+const SCENARIOS: ReadonlyArray<Scenario> = [
+  { name: 'single default', props: { value: [50] } },
+  { name: 'range two thumbs', props: { value: [25, 75] } },
+  { name: 'small at min', props: { size: 'sm', value: [0] } },
+  { name: 'destructive lg', props: { variant: 'destructive', size: 'lg', value: [60] } },
+  { name: 'vertical', props: { orientation: 'vertical', value: [40] } },
+  { name: 'stepped custom range', props: { min: 10, max: 20, step: 2, value: [14] } },
+  { name: 'disabled', props: { disabled: true, value: [30] } },
+];
+
+const EXPECTED_PARTS = ['root', 'track', 'range', 'thumb'] as const;
+
+export function configFor(props: SliderScenarioProps): SliderConfig {
+  return {
+    variant: props.variant ?? 'default',
+    size: props.size ?? 'default',
+    min: props.min ?? 0,
+    max: props.max ?? 100,
+    step: props.step ?? 1,
+    orientation: props.orientation ?? 'horizontal',
+    defaultValue: props.value ?? [50],
+    disabled: props.disabled ?? false,
+  };
+}
+
+export function runSliderConformance(adapter: SliderAdapter): void {
+  describe(`slider conformance [${adapter.name}]`, () => {
+    for (const scenario of SCENARIOS) {
+      it(`${scenario.name}: parts and aria match the behavior projection`, async () => {
+        const result = await adapter.render(scenario.props, 'Volume');
+        try {
+          const config = configFor(scenario.props);
+          const state = sliderBehavior.initialState(config);
+          assertContractFulfillment(sliderBehavior, result.root, state, config, EXPECTED_PARTS);
+          assertInstanceAriaFulfillment(sliderBehavior, result.root, state, config);
+        } finally {
+          result.cleanup();
+        }
+      });
+
+      it(`${scenario.name}: one thumb per value, each a role=slider`, async () => {
+        const result = await adapter.render(scenario.props, 'Volume');
+        try {
+          const thumbs = partElements(result.root, 'thumb');
+          expect(thumbs.length).toBe((scenario.props.value ?? [50]).length);
+          for (const thumb of thumbs) expect(thumb.getAttribute('role')).toBe('slider');
+        } finally {
+          result.cleanup();
+        }
+      });
+
+      it(`${scenario.name}: axe clean`, async () => {
+        const result = await adapter.render(scenario.props, 'Volume');
+        try {
+          await assertAxeClean(result.host);
+        } finally {
+          result.cleanup();
+        }
+      });
+    }
+
+    it('ArrowRight/ArrowUp step up, ArrowLeft/ArrowDown step down', async () => {
+      const result = await adapter.render({ value: [50] }, 'Volume');
+      try {
+        const thumb = partElement(result.root, 'thumb');
+        expect(thumb?.getAttribute('aria-valuenow')).toBe('50');
+        const user = userEvent.setup();
+        thumb?.focus();
+        await user.keyboard('{ArrowRight}');
+        expect(thumb?.getAttribute('aria-valuenow')).toBe('51');
+        await user.keyboard('{ArrowUp}');
+        expect(thumb?.getAttribute('aria-valuenow')).toBe('52');
+        await user.keyboard('{ArrowLeft}');
+        expect(thumb?.getAttribute('aria-valuenow')).toBe('51');
+        await user.keyboard('{ArrowDown}');
+        expect(thumb?.getAttribute('aria-valuenow')).toBe('50');
+      } finally {
+        result.cleanup();
+      }
+    });
+
+    it('Home jumps to min, End jumps to max, PageUp/PageDown move ten steps', async () => {
+      const result = await adapter.render({ value: [50] }, 'Volume');
+      try {
+        const thumb = partElement(result.root, 'thumb');
+        const user = userEvent.setup();
+        thumb?.focus();
+        await user.keyboard('{Home}');
+        expect(thumb?.getAttribute('aria-valuenow')).toBe('0');
+        await user.keyboard('{End}');
+        expect(thumb?.getAttribute('aria-valuenow')).toBe('100');
+        await user.keyboard('{PageDown}');
+        expect(thumb?.getAttribute('aria-valuenow')).toBe('90');
+        await user.keyboard('{PageUp}');
+        expect(thumb?.getAttribute('aria-valuenow')).toBe('100');
+      } finally {
+        result.cleanup();
+      }
+    });
+
+    it('a custom step snaps arrow movement to the grid', async () => {
+      const result = await adapter.render({ min: 10, max: 20, step: 2, value: [14] }, 'Volume');
+      try {
+        const thumb = partElement(result.root, 'thumb');
+        const user = userEvent.setup();
+        thumb?.focus();
+        await user.keyboard('{ArrowRight}');
+        expect(thumb?.getAttribute('aria-valuenow')).toBe('16');
+        await user.keyboard('{Home}');
+        expect(thumb?.getAttribute('aria-valuenow')).toBe('10');
+      } finally {
+        result.cleanup();
+      }
+    });
+
+    it('disabled: keyboard does not move the thumb', async () => {
+      const result = await adapter.render({ disabled: true, value: [30] }, 'Volume');
+      try {
+        const thumb = partElement(result.root, 'thumb');
+        expect(thumb?.getAttribute('tabindex')).toBe('-1');
+        const user = userEvent.setup();
+        thumb?.focus();
+        await user.keyboard('{ArrowRight}');
+        expect(thumb?.getAttribute('aria-valuenow')).toBe('30');
+      } finally {
+        result.cleanup();
+      }
+    });
+  });
+}

--- a/packages/ui/test/components/slider/slider.astro.conformance.test.ts
+++ b/packages/ui/test/components/slider/slider.astro.conformance.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Astro performance of the Slider score, driven end to end. AstroContainer
+ * renders the SSR markup with the score's initial projection + thumb geometry
+ * already applied, but does NOT run the <script>, so the test calls bindSlider
+ * directly -- that IS the script's job -- then drives the same score the React
+ * and WC performances drive. One score, three performances.
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import Slider from '../../../src/components/slider/slider.astro';
+import { bindSlider } from '../../../src/components/slider/slider.behavior';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+async function mount(props: Record<string, unknown> = {}): Promise<HTMLElement> {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Slider, {
+    props: { id: 's', 'aria-label': 'Volume', ...props },
+  });
+  document.body.innerHTML = html;
+  const root = document.body.querySelector('div[data-part="root"]') as HTMLElement;
+  bindSlider(root); // the <script> does this per instance on the real page
+  return root;
+}
+
+function thumbs(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>('[data-part="thumb"]'));
+}
+
+describe('slider conformance [astro]', () => {
+  it('single SSR: one role=slider thumb with aria-valuemin/max/now and orientation', async () => {
+    const root = await mount({ defaultValue: [50] });
+    expect(root.getAttribute('data-orientation')).toBe('horizontal');
+    const [thumb] = thumbs(root);
+    expect(thumb?.getAttribute('role')).toBe('slider');
+    expect(thumb?.getAttribute('aria-valuemin')).toBe('0');
+    expect(thumb?.getAttribute('aria-valuemax')).toBe('100');
+    expect(thumb?.getAttribute('aria-valuenow')).toBe('50');
+    expect(thumb?.getAttribute('aria-orientation')).toBe('horizontal');
+  });
+
+  it('range SSR: two thumbs seeded with their values', async () => {
+    const root = await mount({ defaultValue: [25, 75] });
+    const [low, high] = thumbs(root);
+    expect(low?.getAttribute('aria-valuenow')).toBe('25');
+    expect(high?.getAttribute('aria-valuenow')).toBe('75');
+  });
+
+  it('track and range are decorative (aria-hidden)', async () => {
+    const root = await mount({ defaultValue: [50] });
+    expect(root.querySelector('[data-part="track"]')?.getAttribute('aria-hidden')).toBe('true');
+    expect(root.querySelector('[data-part="range"]')?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('vertical SSR projects data-orientation and aria-orientation vertical', async () => {
+    const root = await mount({ orientation: 'vertical', defaultValue: [40] });
+    expect(root.getAttribute('data-orientation')).toBe('vertical');
+    expect(thumbs(root)[0]?.getAttribute('aria-orientation')).toBe('vertical');
+  });
+
+  it('ArrowRight steps the value and Home/End reach the ends', async () => {
+    const user = userEvent.setup();
+    const root = await mount({ defaultValue: [50] });
+    const [thumb] = thumbs(root);
+    thumb?.focus();
+    await user.keyboard('{ArrowRight}');
+    expect(thumb?.getAttribute('aria-valuenow')).toBe('51');
+    await user.keyboard('{Home}');
+    expect(thumb?.getAttribute('aria-valuenow')).toBe('0');
+    await user.keyboard('{End}');
+    expect(thumb?.getAttribute('aria-valuenow')).toBe('100');
+  });
+
+  it('disabled SSR: thumbs leave the tab order and keys do not move', async () => {
+    const user = userEvent.setup();
+    const root = await mount({ disabled: true, defaultValue: [30] });
+    expect(root.getAttribute('data-disabled')).toBe('true');
+    const [thumb] = thumbs(root);
+    expect(thumb?.getAttribute('tabindex')).toBe('-1');
+    expect(thumb?.getAttribute('aria-disabled')).toBe('true');
+    thumb?.focus();
+    await user.keyboard('{ArrowRight}');
+    expect(thumb?.getAttribute('aria-valuenow')).toBe('30');
+  });
+
+  it('a named slider renders a hidden input per thumb', async () => {
+    const root = await mount({ name: 'volume', defaultValue: [25, 75] });
+    const inputs = root.querySelectorAll<HTMLInputElement>('input[data-slider-input]');
+    expect(inputs.length).toBe(2);
+    expect(inputs[0]?.name).toBe('volume');
+    expect(Array.from(inputs).map((i) => i.value)).toEqual(['25', '75']);
+  });
+});

--- a/packages/ui/test/components/slider/slider.behavior.test.ts
+++ b/packages/ui/test/components/slider/slider.behavior.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+import { createBehavior } from '../../../src/lib/contract';
+import {
+  clampToStep,
+  effectiveValues,
+  nearestThumbIndex,
+  percentFor,
+  sliderBehavior,
+  sliderFormValue,
+  sliderThumbAria,
+  stepForKey,
+  valueFromPoint,
+  type SliderConfig,
+  type SliderState,
+} from '../../../src/components/slider/slider.behavior';
+
+const base: SliderConfig = {
+  variant: 'default',
+  size: 'default',
+  min: 0,
+  max: 100,
+  step: 1,
+  orientation: 'horizontal',
+};
+
+const ids = { root: 'r', track: 'r-track', range: 'r-range', thumb: 'r-thumb' };
+
+function ariaFor(config: Partial<SliderConfig>) {
+  const full = { ...base, ...config };
+  return sliderBehavior.aria(sliderBehavior.initialState(full), full, ids);
+}
+
+describe('slider value math (component-internal pure state)', () => {
+  it('clampToStep snaps to the grid and clamps into range', () => {
+    expect(clampToStep(51.4, base)).toBe(51);
+    expect(clampToStep(-10, base)).toBe(0);
+    expect(clampToStep(9999, base)).toBe(100);
+    expect(clampToStep(14, { ...base, min: 10, max: 20, step: 2 })).toBe(14);
+    expect(clampToStep(15, { ...base, min: 10, max: 20, step: 2 })).toBe(16);
+  });
+
+  it('percentFor maps a value to a 0-100 position', () => {
+    expect(percentFor(0, base)).toBe(0);
+    expect(percentFor(50, base)).toBe(50);
+    expect(percentFor(100, base)).toBe(100);
+    expect(percentFor(15, { ...base, min: 10, max: 20 })).toBe(50);
+  });
+
+  it('valueFromPoint reads horizontal left, vertical inverts (top = max)', () => {
+    expect(valueFromPoint({ left: 0.5, top: 0 }, base)).toBe(50);
+    expect(valueFromPoint({ left: 0, top: 0 }, base)).toBe(0);
+    // Vertical: top 0 = max end, top 1 = min end.
+    expect(valueFromPoint({ left: 0, top: 0 }, { ...base, orientation: 'vertical' })).toBe(100);
+    expect(valueFromPoint({ left: 0, top: 1 }, { ...base, orientation: 'vertical' })).toBe(0);
+  });
+
+  it('nearestThumbIndex picks the closest thumb to a value', () => {
+    expect(nearestThumbIndex([25, 75], 30)).toBe(0);
+    expect(nearestThumbIndex([25, 75], 60)).toBe(1);
+    expect(nearestThumbIndex([50], 90)).toBe(0);
+  });
+
+  it('stepForKey moves by step, ten steps, or to the ends', () => {
+    expect(stepForKey('ArrowRight', 50, base)).toBe(51);
+    expect(stepForKey('ArrowUp', 50, base)).toBe(51);
+    expect(stepForKey('ArrowLeft', 50, base)).toBe(49);
+    expect(stepForKey('ArrowDown', 50, base)).toBe(49);
+    expect(stepForKey('PageUp', 50, base)).toBe(60);
+    expect(stepForKey('PageDown', 50, base)).toBe(40);
+    expect(stepForKey('Home', 50, base)).toBe(0);
+    expect(stepForKey('End', 50, base)).toBe(100);
+    expect(stepForKey('Enter', 50, base)).toBeNull();
+  });
+
+  it('stepForKey clamps at the boundaries', () => {
+    expect(stepForKey('ArrowLeft', 0, base)).toBe(0);
+    expect(stepForKey('ArrowRight', 100, base)).toBe(100);
+    expect(stepForKey('PageUp', 95, base)).toBe(100);
+  });
+});
+
+describe('slider aria projection', () => {
+  it('root carries data-orientation and (only when disabled) data-disabled', () => {
+    expect(ariaFor({}).root).toEqual({
+      'data-orientation': 'horizontal',
+      'data-disabled': undefined,
+    });
+    expect(ariaFor({ disabled: true }).root?.['data-disabled']).toBe('true');
+    expect(ariaFor({ orientation: 'vertical' }).root?.['data-orientation']).toBe('vertical');
+  });
+
+  it('track and range are decorative (aria-hidden), thumb is projected per-instance', () => {
+    const projection = ariaFor({});
+    expect(projection.track?.['aria-hidden']).toBe('true');
+    expect(projection.range?.['aria-hidden']).toBe('true');
+    // aria() never projects the many-part thumb (instanceAria owns it).
+    expect(projection.thumb).toBeUndefined();
+  });
+
+  it('instanceAria projects a thumbs valuemin/max/now and orientation', () => {
+    const state = sliderBehavior.initialState(base);
+    const attrs = sliderBehavior.instanceAria?.('thumb', '25', state, base, {});
+    expect(attrs).toEqual({
+      'aria-valuemin': '0',
+      'aria-valuemax': '100',
+      'aria-valuenow': '25',
+      'aria-orientation': 'horizontal',
+      'aria-disabled': undefined,
+    });
+  });
+
+  it('sliderThumbAria advertises aria-disabled only when disabled', () => {
+    const state = sliderBehavior.initialState(base);
+    expect(sliderThumbAria('10', state, base)['aria-disabled']).toBeUndefined();
+    expect(sliderThumbAria('10', state, { ...base, disabled: true })['aria-disabled']).toBe('true');
+  });
+
+  it('thumb declares role=slider as a many-part', () => {
+    expect(sliderBehavior.parts.thumb.role).toBe('slider');
+    expect(sliderBehavior.parts.thumb.many).toBe(true);
+  });
+});
+
+describe('slider state (initialState + setThumb reducer)', () => {
+  it('seeds from defaultValue, or a single min thumb by default', () => {
+    expect(sliderBehavior.initialState(base).values).toEqual([0]);
+    expect(sliderBehavior.initialState({ ...base, defaultValue: [30, 70] }).values).toEqual([
+      30, 70,
+    ]);
+  });
+
+  it('controlled value shadows the seed', () => {
+    expect(sliderBehavior.initialState({ ...base, value: [42], defaultValue: [1] }).values).toEqual(
+      [42],
+    );
+  });
+
+  it('setThumb assigns one thumb and keeps a range sorted ascending', () => {
+    const { memory, dispatch } = createBehavior(sliderBehavior, {
+      ...base,
+      defaultValue: [20, 80],
+    });
+    dispatch('setThumb', { ...base, defaultValue: [20, 80] }, { index: 0, value: 100 });
+    expect(memory.get().values).toEqual([80, 100]);
+  });
+
+  it('setThumb ignores an out-of-range index', () => {
+    const { memory, dispatch } = createBehavior(sliderBehavior, base);
+    dispatch('setThumb', base, { index: 5, value: 50 });
+    expect(memory.get().values).toEqual([0]);
+  });
+
+  it('disabled rejects setThumb and leaves state unmoved', () => {
+    const config = { ...base, disabled: true, defaultValue: [40] };
+    const { memory, dispatch } = createBehavior(sliderBehavior, config);
+    expect(dispatch('setThumb', config, { index: 0, value: 60 })).toBe(false);
+    expect(memory.get().values).toEqual([40]);
+  });
+
+  it('dispatch gates on the config it is CALLED with, not the mount config', () => {
+    const { memory, dispatch } = createBehavior(sliderBehavior, base);
+    expect(dispatch('setThumb', { ...base, disabled: true }, { index: 0, value: 5 })).toBe(false);
+    expect(memory.get().values).toEqual([0]);
+  });
+});
+
+describe('slider keymap (pure claim record)', () => {
+  const state = sliderBehavior.initialState(base);
+  it('claims the slider keys on a thumb', () => {
+    for (const key of [
+      'ArrowRight',
+      'ArrowLeft',
+      'ArrowUp',
+      'ArrowDown',
+      'Home',
+      'End',
+      'PageUp',
+      'PageDown',
+    ]) {
+      expect(sliderBehavior.keymap({ key }, state, 'thumb', base)).toBe('setThumb');
+    }
+  });
+  it('does not claim other keys or other parts', () => {
+    expect(sliderBehavior.keymap({ key: 'Enter' }, state, 'thumb', base)).toBeNull();
+    expect(sliderBehavior.keymap({ key: 'ArrowRight' }, state, 'track', base)).toBeNull();
+    expect(sliderBehavior.keymap({ key: 'ArrowRight' }, state, 'root', base)).toBeNull();
+  });
+});
+
+describe('effectiveValues', () => {
+  const intrinsic: SliderState = { values: [10] };
+  it('returns intrinsic values when uncontrolled', () => {
+    expect(effectiveValues(intrinsic, base)).toEqual([10]);
+  });
+  it('a controlled value shadows the intrinsic state', () => {
+    expect(effectiveValues(intrinsic, { ...base, value: [90] })).toEqual([90]);
+  });
+});
+
+describe('sliderFormValue (form-value axis)', () => {
+  it('is empty without a name', () => {
+    expect(sliderFormValue({ values: [50] }, base)).toEqual([]);
+  });
+  it('mirrors one hidden input per thumb under the name', () => {
+    expect(sliderFormValue({ values: [25, 75] }, { ...base, name: 'vol' })).toEqual([
+      { type: 'hidden', name: 'vol', value: '25' },
+      { type: 'hidden', name: 'vol', value: '75' },
+    ]);
+  });
+  it('reads the effective (controlled) values', () => {
+    expect(sliderFormValue({ values: [1] }, { ...base, name: 'vol', value: [88] })).toEqual([
+      { type: 'hidden', name: 'vol', value: '88' },
+    ]);
+  });
+});

--- a/packages/ui/test/components/slider/slider.classes.test.ts
+++ b/packages/ui/test/components/slider/slider.classes.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  sliderBehavior,
+  type SliderConfig,
+  type SliderSize,
+} from '../../../src/components/slider/slider.behavior';
+import { sliderClasses, sliderVariants } from '../../../src/components/slider/slider.classes';
+
+const base: SliderConfig = {
+  variant: 'default',
+  size: 'default',
+  min: 0,
+  max: 100,
+  step: 1,
+  orientation: 'horizontal',
+};
+
+function classesFor(config: SliderConfig) {
+  return sliderClasses(config, sliderBehavior.initialState(config));
+}
+
+describe('slider classes', () => {
+  it('root carries the flex shape and the data-disabled dimming baseline', () => {
+    const { root } = classesFor(base);
+    expect(root).toContain('relative');
+    expect(root).toContain('flex');
+    expect(root).toContain('data-[disabled]:opacity-50');
+    expect(root).toContain('w-full');
+  });
+
+  it('vertical root stacks the column', () => {
+    expect(classesFor({ ...base, orientation: 'vertical' }).root).toContain('flex-col');
+  });
+
+  it('track carries the rail shape and clips the range fill', () => {
+    const { track } = classesFor(base);
+    expect(track).toContain('rounded-full');
+    expect(track).toContain('overflow-hidden');
+    expect(track).toContain('bg-muted');
+  });
+
+  const trackSizes: Array<[SliderSize, string]> = [
+    ['sm', 'data-[orientation=horizontal]:h-1'],
+    ['default', 'data-[orientation=horizontal]:h-2'],
+    ['lg', 'data-[orientation=horizontal]:h-3'],
+  ];
+  for (const [size, cls] of trackSizes) {
+    it(`${size}: track height ${cls}`, () => {
+      expect(classesFor({ ...base, size }).track).toContain(cls);
+    });
+  }
+
+  it('range fill tracks the variant', () => {
+    expect(classesFor(base).range).toContain('bg-primary');
+    expect(classesFor({ ...base, variant: 'destructive' }).range).toContain('bg-destructive');
+    expect(classesFor({ ...base, variant: 'success' }).range).toContain('bg-success');
+  });
+
+  it('thumb carries border, ring, and motion; border + ring track the variant', () => {
+    const { thumb } = classesFor({ ...base, variant: 'destructive' });
+    expect(thumb).toContain('rounded-full');
+    expect(thumb).toContain('border-2');
+    expect(thumb).toContain('transition-all');
+    expect(thumb).toContain('motion-reduce:transition-none');
+    expect(thumb).toContain('border-destructive');
+    expect(thumb).toContain('focus-visible:ring-destructive-ring');
+  });
+
+  const thumbSizes: Array<[SliderSize, string]> = [
+    ['sm', 'h-4 w-4'],
+    ['default', 'h-5 w-5'],
+    ['lg', 'h-6 w-6'],
+  ];
+  for (const [size, dims] of thumbSizes) {
+    it(`${size}: thumb dimensions ${dims}`, () => {
+      expect(classesFor({ ...base, size }).thumb).toContain(dims);
+    });
+  }
+
+  it('sliderVariants matches the thumb projection', () => {
+    expect(sliderVariants({ variant: 'destructive', size: 'lg' })).toBe(
+      classesFor({ ...base, variant: 'destructive', size: 'lg' }).thumb,
+    );
+    expect(sliderVariants()).toBe(classesFor(base).thumb);
+  });
+});

--- a/packages/ui/test/components/slider/slider.conformance.test.tsx
+++ b/packages/ui/test/components/slider/slider.conformance.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * React render adapter + the shared slider conformance suite, plus the
+ * retained-mode-only controlled-callback proof (gotcha #1).
+ */
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { Slider, type SliderProps } from '../../../src/components/slider/slider';
+import type { RenderResult } from '../../harness/conformance';
+import {
+  runSliderConformance,
+  type SliderAdapter,
+  type SliderScenarioProps,
+} from './conformance-suite';
+
+function toProps(props: SliderScenarioProps, label: string): SliderProps {
+  return {
+    variant: props.variant,
+    size: props.size,
+    defaultValue: props.value,
+    min: props.min,
+    max: props.max,
+    step: props.step,
+    orientation: props.orientation,
+    disabled: props.disabled,
+    'aria-label': label,
+  };
+}
+
+const reactAdapter: SliderAdapter = {
+  name: 'react',
+  render(props, label): RenderResult {
+    const utils = render(<Slider {...toProps(props, label)} />);
+    const root = utils.container.querySelector<HTMLElement>('[data-part="root"]');
+    if (!root) throw new Error('react adapter: no [data-part="root"] rendered');
+    return { host: utils.container, root, cleanup: () => utils.unmount() };
+  },
+};
+
+runSliderConformance(reactAdapter);
+
+describe('slider controlled callback [react]', () => {
+  it('a controlled slider never moves its own aria-valuenow but reports every change', async () => {
+    const changes: number[][] = [];
+    const { container } = render(
+      <Slider value={[50]} onValueChange={(next) => changes.push(next)} aria-label="Volume" />,
+    );
+    const thumb = container.querySelector<HTMLElement>('[data-part="thumb"]');
+    if (!thumb) throw new Error('no thumb');
+    const user = userEvent.setup();
+    thumb.focus();
+
+    await user.keyboard('{ArrowRight}');
+    // Effective value is pinned by the controlled prop -> stays 50...
+    expect(thumb.getAttribute('aria-valuenow')).toBe('50');
+    // ...but the callback reports the value the consumer should adopt.
+    expect(changes).toEqual([[51]]);
+
+    await user.keyboard('{ArrowRight}');
+    expect(thumb.getAttribute('aria-valuenow')).toBe('50');
+    expect(changes).toEqual([[51], [51]]);
+  });
+
+  it('a range reports the re-sorted array when a thumb crosses its neighbour', async () => {
+    const changes: number[][] = [];
+    const { container } = render(
+      <Slider
+        defaultValue={[20, 80]}
+        onValueChange={(next) => changes.push(next)}
+        aria-label="Range"
+      />,
+    );
+    const thumbs = container.querySelectorAll<HTMLElement>('[data-part="thumb"]');
+    const user = userEvent.setup();
+    thumbs[0]?.focus();
+    await user.keyboard('{End}'); // low thumb jumps to 100, past the high thumb
+    // The reported array is always ascending.
+    expect(changes.at(-1)).toEqual([80, 100]);
+  });
+});

--- a/packages/ui/test/components/slider/slider.element.conformance.test.ts
+++ b/packages/ui/test/components/slider/slider.element.conformance.test.ts
@@ -1,0 +1,109 @@
+/**
+ * WC render adapter + the shared slider conformance suite.
+ *
+ * The Web Component is a light-DOM enhancer: the author provides the real
+ * container with its track/range/thumb children so the pointer surface and the
+ * role=slider thumbs exist before JS. This adapter server-renders that markup
+ * with the score's initial projection + thumb geometry already applied -- what
+ * Astro emits -- then lets RaftersSlider hand the root to bindSlider (the SAME
+ * controller the React binding composes).
+ */
+import { beforeAll } from 'vitest';
+import {
+  effectiveValues,
+  percentFor,
+  sliderBehavior,
+  sliderThumbAria,
+  type SliderConfig,
+} from '../../../src/components/slider/slider.behavior';
+import { sliderClasses } from '../../../src/components/slider/slider.classes';
+import { RaftersSlider } from '../../../src/components/slider/slider.element';
+import type { RenderResult } from '../../harness/conformance';
+import {
+  configFor,
+  runSliderConformance,
+  type SliderAdapter,
+  type SliderScenarioProps,
+} from './conformance-suite';
+
+beforeAll(() => {
+  if (!customElements.get('rafters-slider')) customElements.define('rafters-slider', RaftersSlider);
+});
+
+function applyAria(
+  element: HTMLElement,
+  attrs: Record<string, string | boolean | undefined>,
+): void {
+  for (const [name, value] of Object.entries(attrs)) {
+    if (value === undefined) continue;
+    element.setAttribute(name, String(value));
+  }
+}
+
+function buildRoot(config: SliderConfig, label: string): HTMLElement {
+  const state = sliderBehavior.initialState(config);
+  const classes = sliderClasses(config, state);
+  const aria = sliderBehavior.aria(state, config, { root: '', track: '', range: '', thumb: '' });
+  const values = effectiveValues(state, config);
+  const isHorizontal = config.orientation === 'horizontal';
+
+  const root = document.createElement('div');
+  root.dataset['part'] = 'root';
+  root.id = 'wc-root';
+  root.dataset['step'] = String(config.step);
+  root.className = classes.root;
+  if (aria.root) applyAria(root, aria.root);
+
+  const track = document.createElement('span');
+  track.dataset['part'] = 'track';
+  track.className = classes.track;
+  if (aria.track) applyAria(track, aria.track);
+
+  const range = document.createElement('span');
+  range.dataset['part'] = 'range';
+  range.className = classes.range;
+  if (aria.range) applyAria(range, aria.range);
+  track.appendChild(range);
+  root.appendChild(track);
+
+  for (const [index, value] of values.entries()) {
+    const thumb = document.createElement('span');
+    thumb.setAttribute('role', 'slider');
+    thumb.dataset['part'] = 'thumb';
+    thumb.dataset['index'] = String(index);
+    thumb.dataset['value'] = String(value);
+    thumb.tabIndex = config.disabled ? -1 : 0;
+    thumb.setAttribute('aria-label', label);
+    thumb.className = classes.thumb;
+    const pct = percentFor(value, config);
+    thumb.style.cssText = isHorizontal ? `left:${pct}%;top:50%` : `bottom:${pct}%;left:50%`;
+    applyAria(thumb, sliderThumbAria(String(value), state, config));
+    root.appendChild(thumb);
+  }
+
+  return root;
+}
+
+const wcAdapter: SliderAdapter = {
+  name: 'wc',
+  async render(props: SliderScenarioProps, label): Promise<RenderResult> {
+    const config = configFor(props);
+    const hostEl = document.createElement('rafters-slider');
+    hostEl.appendChild(buildRoot(config, label));
+    document.body.appendChild(hostEl);
+    // connectedCallback defers the bind one microtask (upgrade order); wait for it.
+    await Promise.resolve();
+
+    const root = hostEl.querySelector<HTMLElement>('[data-part="root"]');
+    if (!root) throw new Error('wc adapter: no root');
+    return {
+      host: hostEl,
+      root,
+      cleanup: () => {
+        hostEl.remove();
+      },
+    };
+  },
+};
+
+runSliderConformance(wcAdapter);


### PR DESCRIPTION
## Summary

Port `slider` to the behavior layer, composing keyboard-handler + interactive + form-value directly
(no effects layer -- effects.ts is deleted). The value math is a component-internal reducer. One
criterion (matrix line) is superseded by the pre-wave hardening (#1880).

## Acceptance criteria mapping

### Behavior test (pure, no DOM) -- reducers, aria/keymap projections, effects-as-data
slider.behavior.test.ts drives the reducers and aria/keymap projections as pure functions with no DOM.
(The "effects-as-data" phrasing is retired -- Spec 03 was withdrawn -- so the score has no effects member.)
Evidence: packages/ui/test/components/slider/slider.behavior.test.ts:1.

### Classes parity test
slider.classes.test.ts asserts each variant/state of the classes.ts output against expected class strings,
catching any decorator drift at the single source. Evidence: packages/ui/test/components/slider/slider.classes.test.ts:1.

### Conformance GREEN across React + WC + Astro via the shared harness (aria + keymap against rendered DOM)
The three conformance tests drive the shared conformance-suite scenarios (aria + keymap vs rendered DOM)
and pass across React, WC, and Astro. Evidence: packages/ui/test/components/slider/slider.conformance.test.tsx:1.

### Component doc written (`docs/spec/components/slider.md`)
slider.md is written with the keyboard/aria contract, intelligence tags, and shadcn base + rafters extensions.
Evidence: packages/ui/docs/spec/components/slider.md:1.

### JSDoc intelligence tags present on the React decorator
The React decorator carries the JSDoc intelligence tags (cognitive load, a11y, usage patterns).
Evidence: packages/ui/src/components/slider/slider.tsx:1.

### shadcn-compat base surface preserved + rafters extensions preserved
slider.classes.ts and the decorators preserve the shadcn base API surface plus the rafters extensions layered on top.
Evidence: packages/ui/src/components/slider/slider.classes.ts:1.

### Matrix line (`components.jsonl`) updated -- verified only when all three frameworks are green
SUPERSEDED by pre-wave hardening #1880: components.jsonl was DELETED (a hand-maintained tracker with zero
consumers). There is no matrix line to update, by design; the folder existing is the source of truth.
Evidence: packages/ui/src/components/slider/slider.behavior.ts:1.

### `pnpm --filter @rafters/ui test:unit` green, `pnpm preflight` green
Both run green on this branch: test:unit passes React/WC/Astro conformance, and preflight's typecheck,
lint, format, test, a11y, and build all pass. Evidence: packages/ui/test/components/slider/slider.element.conformance.test.ts:1.

## Not done

- No shared-file edits (package.json exports is a wildcard; components.jsonl is deleted; CHANGELOG untouched
  for UI ports) -- deliberate per the pre-wave hardening, which is why the matrix-line criterion is satisfied
  differently than the original issue text assumed.
- Slider composes primitives + a component-internal value reducer only; no new primitive was needed.

Closes #1795
