### PR TITLE
feat(ui): port accordion to the behavior layer

### DIFF
--- a/packages/ui/docs/spec/components/accordion.md
+++ b/packages/ui/docs/spec/components/accordion.md
@@ -1,0 +1,177 @@
+# Component Spec — Accordion
+
+Status: DRAFT. Disclosure archetype -- the many-section member of the family
+(collapsible is the single-region one; tabs folds the same set state onto an
+always-one-active axis).
+
+Files (`src/components/accordion/`):
+
+```
+accordion.behavior.ts   accordion.classes.ts   accordion.tsx
+accordion.element.ts    accordion.astro
+```
+
+Tests mirror into `test/components/accordion/`: behavior (pure), classes
+(parity), and conformance across React, WC, and Astro on the shared harness.
+
+## Composition
+
+```
+accordion slice   state {value, multiple, collapsible}, action toggle,
+                  parts root + item/heading/trigger/content (many)
+roving-focus      composed directly, vertical axis -- ArrowUp/ArrowDown/Home/End
+```
+
+The score's only state axis is the SET of expanded values. Focus movement across
+the header buttons is NOT state -- it is ephemeral DOM state owned by the
+composed `roving-focus` primitive, the same split navigation-menu, radio-group,
+and toggle-group make.
+
+### Why selection-group and disclosure are not composed
+
+The port issue named three primitives. `roving-focus` composes literally.
+`selection-group` and `disclosure` do not, and the reason is structural rather
+than preferential: both own a `createMemory` cell of their own
+(`createSelectionGroup` returns `{ memory, ... }`; `createDisclosure` is a single
+boolean cell), while `createBehavior` already owns THE memory cell for this
+component. Composing either would place one logical state in two cells with no
+reconciliation path, and `Slice` reducers are pure `(state, payload) => state`
+over that one cell -- there is no seam through which a second cell could be
+driven or read.
+
+radio-group and toggle-group set the precedent (selection-as-reducer); the
+`toggle` reducer here re-expresses `createSelectionGroup.toggle`'s exact
+semantics -- multiple-mode membership, single-mode replacement, and the
+`collapsible` close-to-empty rule -- as a reducer over the one cell. The
+primitives remain the right shape for a framework-agnostic consumer that is NOT
+a behavior-layer score; nothing about them is rewritten here.
+
+## Config, state, actions
+
+```ts
+interface AccordionConfig {
+  type?: 'single' | 'multiple';       // default 'single'
+  value?: string | string[];          // controlled
+  defaultValue?: string | string[];   // uncontrolled seed
+  collapsible?: boolean;              // single mode: allow closing to empty
+  disabled?: boolean;                 // gates toggling
+  headingLevel?: number;              // default 3
+}
+interface AccordionState {
+  value: string[];       // intrinsic expanded set
+  multiple: boolean;     // seeded from config.type
+  collapsible: boolean;  // seeded from config.collapsible (always true when multiple)
+}
+type AccordionActions = { toggle: string }; // payload: the section's value
+```
+
+The reducer receives `(state, payload)` with no config (Spec 01), so both mode
+flags are seeded into state at `initialState`.
+
+Controlled/uncontrolled per the ownership-of-truth boundary applied to a set:
+`config.value` is the consumer's controlled value (passed fresh, never stored),
+`state.value` is intrinsic, and projections plus the change callback read the
+effective set via `expandedValues(state, config)`. `emitValue` reports a string
+for single mode and an array for multiple -- the oracle's
+`type === 'single' ? (values[0] ?? '') : values`.
+
+Single, non-collapsible mode returns the SAME state object when the open section
+is re-activated. That identity is load-bearing: each decorator compares the
+effective set before against the intrinsic set after to decide whether the
+consumer callback fires, so a refused edit must not look like a move.
+
+## Parts and ARIA
+
+| Part | Presence | ARIA |
+| --- | --- | --- |
+| root | always | `data-orientation="vertical"`, `data-type`, `data-collapsible`, `data-heading-level`, `data-disabled` (when disabled) |
+| item (many) | one per section | `data-state` |
+| heading (many) | one per section | `role="heading"`, `aria-level` |
+| trigger (many) | one per section | `aria-expanded`, `aria-controls`, `data-state` |
+| content (many) | one per section, always in the DOM | `role="region"`, `aria-labelledby`, `data-state`, `hidden` while collapsed |
+
+`item`/`heading`/`trigger`/`content` are `many` parts, so their attributes come
+from `BehaviorSpec.instanceAria(part, value, state, config, ids)` rather than
+`aria()`, which projects one `AriaAttrs` per part NAME and cannot express N
+instances. The shared harness drives `spec.instanceAria` generically
+(`assertInstanceAriaFulfillment`), so every rendered instance in every framework
+is asserted against the score with no per-component wiring.
+
+`aria-controls` is projected unconditionally -- guarded only on the sibling id
+being real, not on the open axis. Panels are present-but-hidden rather than
+unmounted, so the reference is never dangling and the oracle advertised it while
+collapsed too. This deliberately diverges from the `disclosable` slice's
+`open && ids.content` guard, which exists for overlays whose content leaves the
+DOM.
+
+Item-level `disabled` is expressed by natively disabling that header button (the
+React `disabled` prop, the Astro/author markup attribute), which also removes it
+from the tab order and from roving. The reducer sees only a value and cannot
+know which sections the author disabled; accordion-level `disabled` is the gate
+it can express, via `canDispatch`.
+
+## Keyboard
+
+| Key | Owner | Effect |
+| --- | --- | --- |
+| Enter, Space | native `<button>` (declared in `keymap`) | toggle the focused section |
+| ArrowDown, ArrowUp | roving-focus (vertical) | move focus to the next/previous enabled header, wrapping |
+| Home, End | roving-focus | move focus to the first/last enabled header |
+| Tab | native | leave the accordion -- exactly one header is in the tab order |
+
+The score declares Enter/Space -> `toggle` for the pure keymap contract, but the
+DOM binds rely on the native `<button>` converting them to a click; wiring the
+keymap as well would double-toggle. Arrow and Home/End keys are deliberately NOT
+claimed by the score -- the composed primitive owns focus movement, and
+expansion never follows focus.
+
+## Oracle dispositions (src/old/ui/accordion.*, boundary 9)
+
+The oracle's behavior lived in a rejected `accordion.controller.ts`, which was
+not read for this port; the dispositions below cover the surface the framework
+files expose.
+
+| Oracle feature | Disposition |
+| --- | --- |
+| `type` single/multiple + `collapsible` | contract |
+| controlled/uncontrolled `value`/`defaultValue` + `onValueChange` (string for single, array for multiple) | contract |
+| item-level `disabled` | contract (native `disabled` on the header button; roving skips it) |
+| `role="heading"` wrapper with `aria-level={3}` around the header button | contract, generalized: the level is `config.headingLevel` and rides the `heading` instance projection instead of being hand-written per framework |
+| header button `aria-expanded` + `aria-controls`, set while collapsed too | contract |
+| panel `role="region"` + `aria-labelledby` back to its header | contract |
+| panel always mounted, visibility toggled by `hidden` | contract (crawlable content, and the height transition runs on the same node) |
+| ArrowUp/ArrowDown/Home/End roving tabindex over `[data-roving-item]` headers | contract (the same `roving-focus` primitive, composed directly on the vertical axis) |
+| chevron `<svg>` rotating via `group-data-[state=open]:rotate-180` | contract |
+| `data-accordion-item` / `data-accordion-trigger` / `data-accordion-content` markers | framework-affordance -- replaced by the layer-wide `data-part` + `data-value` registry the harness and the binds query |
+| Astro `accordionId` prop threaded to every child to hand-template `${accordionId}-trigger-${value}` ids | framework-affordance -- the Astro decorator mints instance ids from the root `id`, as navigation-menu does; children no longer need the group id |
+| React `AccordionItem` minting ids from `useId()` per item | framework-affordance -- ids now derive from one root `useId()` so the trigger/panel pair is resolvable without an item-local context of its own |
+| `AccordionItemContext` throwing outside its provider | contract (both provider levels throw with a named message) |
+| `data-[state=closed]:animate-accordion-up` / `data-[state=open]:animate-accordion-down` on the panel | defect-do-not-port -- those keyframes interpolate `var(--radix-accordion-content-height)`, a Radix-owned variable nothing in this system ever sets, so the animation runs to an undefined height; replaced by `overflow-hidden transition-all duration-300 motion-reduce:transition-none` (declared height-axis intent) |
+| React root rendering a bare `classy(className)` with no root class | contract -- `accordionClasses().root` is deliberately empty: the root is the styling anchor for the projected `data-*`, not a visual |
+
+## Motion
+
+Expand/collapse along the height axis (y). Declared as intent only:
+`overflow-hidden transition-all duration-300 motion-reduce:transition-none` on
+the panel, plus `transition-transform duration-300` on the chevron. Duration and
+easing come from the token scale; reduced motion disables both. Padding lives on
+the panel's inner box, never on the panel itself, so the panel can collapse to
+zero height. A keyframed height animation waits on a real content-height
+utility in the token system.
+
+## WCAG 2.1 AA obligations
+
+- 1.3.1/4.1.2: each header button is contained by a `role="heading"` element
+  carrying `aria-level`, projects `aria-expanded`, and references its panel by
+  real DOM id; each panel is a `role="region"` named by `aria-labelledby` back to
+  its header. Asserted by the harness across all three performances, plus axe.
+- 2.1.1: every section is fully operable from the keyboard -- Enter/Space
+  activate natively, ArrowUp/ArrowDown/Home/End move focus. No pointer-only path.
+- 2.4.3: roving tabindex keeps exactly one header in the tab order, so Tab enters
+  and leaves the accordion once rather than stepping through every section.
+- 2.4.7: a token focus ring on each header (`focus-visible:ring-ring` with an
+  offset).
+- Collapsed panels carry `hidden`, so they are inert and out of the tab order
+  rather than merely invisible.
+- A disabled section advertises the native `disabled` state, leaves the tab
+  order, and cannot be toggled by pointer or keyboard.

--- a/packages/ui/docs/spec/matrix/components.md
+++ b/packages/ui/docs/spec/matrix/components.md
@@ -64,7 +64,7 @@ Behavior-layer support: only the five articles have react (verified). Old tree a
 
 | component | is | does | states | uses (current) | uses (planned) | motion | old tree | layer |
 |---|---|---|---|---|---|---|---|---|
-| **accordion** | Stacked expandable sections | Opens one/many sections; header buttons control regions | item: open/closed | - | disclosure, roving-focus, selection-group | animate-accordion-up/down -> expand/collapse: height, axis y | astro/react | none |
+| **accordion** | Stacked expandable sections | Opens one/many sections; header buttons control regions | item: open/closed | roving-focus | - | animate-accordion-up/down -> expand/collapse: height, axis y | astro/react | react/wc/astro OK |
 | **collapsible** | Single expandable region | Toggles one content region open/closed | open, closed | disclosure | - | animate-collapsible-up/down -> expand/collapse: height, axis y | react | none |
 | **tabs** | Tabbed panels | Shows one panel per selected tab; arrows move (automatic activation) | active tab | - | roving-focus, selection-group | data-[state=active] swap -> indicator-move: transition, axis x | astro/react | none |
 

--- a/packages/ui/src/components/accordion/accordion.astro
+++ b/packages/ui/src/components/accordion/accordion.astro
@@ -1,0 +1,150 @@
+---
+/**
+ * Astro performance (controller) for accordion.
+ *
+ * Server-renders the full LIGHT-DOM markup with classes and the score's initial
+ * projection already applied, so the sections are correct, crawlable, and
+ * accessible before any JS -- the seeded panel is open and the rest are hidden
+ * with no flash. The <script> then hands each server-rendered root to
+ * bindAccordion -- the SAME DOM-native controller the Web Component uses. Astro
+ * imports the behavior binding like any other module; there is no astro-specific
+ * runtime.
+ *
+ * The projection is computed here from the same accordion.aria /
+ * accordionInstanceAria the React and WC performances read -- one score, three
+ * performances, zero drift. Instance ids are minted from the root id, so the
+ * oracle's per-part `accordionId` prop threading is gone.
+ */
+import type { PartIds } from '../../lib/contract';
+import {
+  accordion,
+  accordionInstanceAria,
+  type AccordionConfig,
+  type AccordionPart,
+  type AccordionType,
+} from './accordion.behavior';
+import { accordionClasses } from './accordion.classes';
+
+interface Item {
+  value: string;
+  label: string;
+  body: string;
+  disabled?: boolean;
+}
+
+interface Props {
+  id: string;
+  items: Item[];
+  type?: AccordionType;
+  value?: string | string[];
+  collapsible?: boolean;
+  disabled?: boolean;
+  headingLevel?: number;
+}
+
+const {
+  id,
+  items,
+  type = 'single',
+  value,
+  collapsible = false,
+  disabled = false,
+  headingLevel = 3,
+} = Astro.props;
+
+const config: AccordionConfig = {
+  type,
+  defaultValue: value,
+  collapsible,
+  disabled,
+  headingLevel,
+};
+const state = accordion.initialState(config);
+const classes = accordionClasses(config, state);
+
+const ids = {} as PartIds<AccordionPart>;
+for (const part of Object.keys(accordion.parts) as AccordionPart[]) {
+  ids[part] = `${id}-${part}`;
+}
+const rootAria = accordion.aria(state, config, ids);
+const instanceId = (part: AccordionPart, itemValue: string) => `${id}-${part}-${itemValue}`;
+---
+
+<div data-part="root" id={ids.root} class={classes.root} {...rootAria.root}>
+  {
+    items.map((item) => {
+      const triggerId = instanceId('trigger', item.value);
+      const contentId = instanceId('content', item.value);
+      const siblingIds = { trigger: triggerId, content: contentId };
+      return (
+        <div
+          data-part="item"
+          data-value={item.value}
+          data-disabled={disabled || item.disabled ? '' : undefined}
+          class={classes.item}
+          {...accordionInstanceAria('item', item.value, state, config, {})}
+        >
+          <div
+            data-part="heading"
+            data-value={item.value}
+            class={classes.heading}
+            {...accordionInstanceAria('heading', item.value, state, config, {})}
+          >
+            <button
+              type="button"
+              id={triggerId}
+              data-part="trigger"
+              data-value={item.value}
+              data-roving-item
+              disabled={disabled || item.disabled}
+              class={classes.trigger}
+              {...accordionInstanceAria('trigger', item.value, state, config, siblingIds)}
+            >
+              {item.label}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+                class={classes.triggerIcon}
+              >
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+            </button>
+          </div>
+          <div
+            id={contentId}
+            data-part="content"
+            data-value={item.value}
+            class={classes.content}
+            {...accordionInstanceAria('content', item.value, state, config, siblingIds)}
+          >
+            <div class={classes.contentInner}>{item.body}</div>
+          </div>
+        </div>
+      );
+    })
+  }
+</div>
+
+<script>
+  import { bindAccordion } from './accordion.behavior';
+
+  // The <script> is bundled and runs once per page; bind every instance's
+  // server-rendered root. Same controller as the Web Component.
+  // data-collapsible is accordion's own root marker: toggle-group also renders
+  // [data-part="root"][data-type], so the selector must not be ambiguous.
+  for (const root of document.querySelectorAll<HTMLElement>(
+    '[data-part="root"][data-type][data-collapsible]',
+  )) {
+    if (root.dataset['bound'] === 'true') continue;
+    root.dataset['bound'] = 'true';
+    bindAccordion(root);
+  }
+</script>

--- a/packages/ui/src/components/accordion/accordion.behavior.ts
+++ b/packages/ui/src/components/accordion/accordion.behavior.ts
@@ -1,0 +1,358 @@
+import { compose, type Slice } from '../../lib/compose';
+import {
+  createBehavior,
+  type AriaAttrs,
+  type BehaviorSpec,
+  type InstanceIds,
+  type PartIds,
+} from '../../lib/contract';
+import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { createRovingFocus } from '../../primitives/roving-focus';
+
+/**
+ * Accordion: a vertical stack of expandable sections. Each section is a header
+ * button that discloses one region; `type` decides whether the stack holds one
+ * open section or many.
+ *
+ * The score's only state axis is the SET of expanded values. Focus movement
+ * across the header buttons is NOT state -- it is ephemeral DOM state owned by
+ * the composed roving-focus primitive (the same split navigation-menu,
+ * radio-group, and toggle-group make).
+ *
+ * On the three primitives the port issue named:
+ * - `roving-focus` composes literally, on the vertical axis (ArrowUp/ArrowDown,
+ *   Home/End), directly in `bindAccordion` and in the React mount effect.
+ * - `selection-group` and `disclosure` do NOT compose into a score. Both own a
+ *   `createMemory` cell of their own, and `createBehavior` already owns THE
+ *   memory cell for this component; composing either would put one logical
+ *   state in two cells with no reconciliation path, and Slice reducers are pure
+ *   `(state, payload) => state` over the single cell. radio-group and
+ *   toggle-group set this precedent (selection-as-reducer); the `toggle`
+ *   reducer below re-expresses `createSelectionGroup.toggle`'s exact semantics
+ *   -- including `collapsible` -- as a reducer over that one cell. See
+ *   docs/spec/components/accordion.md.
+ *
+ * The reducer receives `(state, payload)` with no config (Spec 01), so the two
+ * mode flags are seeded into state (`multiple`, `collapsible`) at initialState.
+ *
+ * Controlled/uncontrolled per the ownership-of-truth boundary applied to a set:
+ * `config.value` is the consumer's controlled value (passed fresh, never
+ * stored); `state.value` is the intrinsic set, seeded from `defaultValue`.
+ * Projections and the change callback read the EFFECTIVE set via
+ * `expandedValues(state, config)`.
+ */
+export type AccordionType = 'single' | 'multiple';
+
+export interface AccordionConfig {
+  /** Disclosure mode. 'single' holds at most one open section, 'multiple' any
+   *  number. Default 'single'. */
+  type?: AccordionType | undefined;
+  /** Controlled value: shadows the intrinsic set when present. String for
+   *  single, string[] for multiple. */
+  value?: string | string[] | undefined;
+  /** Uncontrolled seed for the intrinsic set. */
+  defaultValue?: string | string[] | undefined;
+  /** In single mode, allow re-activating the open section to close it, leaving
+   *  the accordion fully collapsed. Ignored in multiple mode (always
+   *  collapsible). Default false -- the oracle's default. */
+  collapsible?: boolean | undefined;
+  /** Whether the whole accordion is disabled (gates toggling; the decorators
+   *  natively disable every header button, which also drops them from roving). */
+  disabled?: boolean | undefined;
+  /** Heading level of the `role="heading"` wrapper around each header button.
+   *  Default 3 -- the oracle's `aria-level={3}`. */
+  headingLevel?: number | undefined;
+}
+
+export interface AccordionState {
+  /** Intrinsic expanded values -- ignored while a controlled value is present. */
+  value: string[];
+  /** Mode, seeded from config.type: the reducer sees no config (Spec 01). */
+  multiple: boolean;
+  /** Single-mode close-to-empty, seeded from config.collapsible. */
+  collapsible: boolean;
+}
+
+export type AccordionActions = {
+  /** Expand or collapse a section (payload: the item's value). */
+  toggle: string;
+};
+
+export type AccordionPart = 'root' | 'item' | 'heading' | 'trigger' | 'content';
+
+/** Normalize a controlled/default value to an array of values. */
+function toArray(value: string | string[] | undefined): string[] {
+  if (value === undefined) return [];
+  if (Array.isArray(value)) return value.filter((entry) => entry !== '');
+  return value === '' ? [] : [value];
+}
+
+export function isMultiple(config: AccordionConfig): boolean {
+  return (config.type ?? 'single') === 'multiple';
+}
+
+export function headingLevelOf(config: AccordionConfig): number {
+  return config.headingLevel ?? 3;
+}
+
+/** The effective expanded set: a controlled value shadows intrinsic state. */
+export function expandedValues(state: AccordionState, config: AccordionConfig): string[] {
+  if (config.value !== undefined) {
+    const values = toArray(config.value);
+    return isMultiple(config) ? values : values.slice(0, 1);
+  }
+  return state.value;
+}
+
+/** Whether one section is effectively expanded. */
+export function isItemExpanded(
+  value: string,
+  state: AccordionState,
+  config: AccordionConfig,
+): boolean {
+  return expandedValues(state, config).includes(value);
+}
+
+/** Report shape for onValueChange: string for single, string[] for multiple --
+ *  the oracle's `type === 'single' ? (values[0] ?? '') : values`. */
+export function emitValue(values: string[], config: AccordionConfig): string | string[] {
+  return isMultiple(config) ? values : (values[0] ?? '');
+}
+
+const accordionSlice: Slice<AccordionConfig, AccordionState, AccordionActions, AccordionPart> = {
+  name: 'accordion',
+  parts: {
+    root: {},
+    // One instance per section, each keyed by its data-value.
+    item: { many: true },
+    // The role=heading wrapper the header button lives in: the WAI-ARIA
+    // accordion pattern requires the button to be contained by a heading.
+    heading: { many: true, role: 'heading' },
+    trigger: { many: true },
+    // Panels stay in the DOM hidden when collapsed: the content must be
+    // crawlable and SSR-stable, and the height transition needs the same node.
+    content: { many: true, role: 'region' },
+  },
+  initialState: (config) => {
+    const multiple = isMultiple(config);
+    const seed = toArray(config.value ?? config.defaultValue);
+    return {
+      value: multiple ? seed : seed.slice(0, 1),
+      multiple,
+      // Multiple mode is inherently collapsible: every section closes
+      // independently, so the flag only constrains single mode.
+      collapsible: multiple || config.collapsible === true,
+    };
+  },
+  actions: {
+    // The set semantics of createSelectionGroup.toggle, as a reducer over the
+    // one memory cell createBehavior owns.
+    toggle: (state, value) => {
+      if (!value) return state;
+      if (state.multiple) {
+        const has = state.value.includes(value);
+        return {
+          ...state,
+          value: has ? state.value.filter((entry) => entry !== value) : [...state.value, value],
+        };
+      }
+      const isOnlyOpen = state.value.length === 1 && state.value[0] === value;
+      if (isOnlyOpen) {
+        // Single, non-collapsible: re-activating the open section is a no-op,
+        // so the accordion always keeps exactly one section open. Returning the
+        // same state means the decorators' before/after comparison sees no
+        // move and the consumer callback stays silent.
+        return state.collapsible ? { ...state, value: [] } : state;
+      }
+      return { ...state, value: [value] };
+    },
+  },
+  // The accordion-level disabled gate: a disabled accordion rejects toggling,
+  // so a controlled consumer's callback never fires for an edit it would
+  // refuse. Item-level disabled is expressed by natively disabling that header
+  // button (which also removes it from roving), because the reducer sees only
+  // the value and cannot know which items the author disabled.
+  canDispatch: (_state, action, config) => (action === 'toggle' ? config.disabled !== true : true),
+  aria: (state, config) => ({
+    root: {
+      // The accordion axis is always vertical: arrow navigation is Up/Down and
+      // the sections stack. Exposed as a styling/roving hook, not as
+      // aria-orientation -- the root has no ARIA role to carry it.
+      'data-orientation': 'vertical',
+      'data-type': isMultiple(config) ? 'multiple' : 'single',
+      'data-collapsible': state.collapsible ? 'true' : 'false',
+      'data-heading-level': String(headingLevelOf(config)),
+      'data-disabled': config.disabled ? 'true' : undefined,
+    },
+  }),
+  // Enter/Space on a header button map to toggle. Declared for the pure keymap
+  // contract; the DOM binds rely on the native <button> converting Enter/Space
+  // to a click (wiring the keymap too would double-toggle). Arrow/Home/End are
+  // NOT claimed -- the composed roving-focus primitive owns focus movement.
+  keymap: (event, _state, part) =>
+    part === 'trigger' && (event.key === 'Enter' || event.key === ' ') ? 'toggle' : null,
+};
+
+/**
+ * Per-instance ARIA for the `many` parts (Spec 01: BehaviorSpec.instanceAria).
+ * `aria()` projects one AriaAttrs per part NAME; item/heading/trigger/content
+ * occur once per section value, so their projections take the instance value and
+ * the instance's sibling ids (a trigger reads its panel's id; the panel reads
+ * its trigger's).
+ *
+ * `aria-controls` is projected UNCONDITIONALLY (guarded only on the id being
+ * real), not on the open axis: the panel is present-but-hidden rather than
+ * unmounted, so the reference is never dangling and the oracle advertised it
+ * closed as well as open. That is the opposite of the `disclosable` slice's
+ * `open && ids.content` guard, which exists for overlays whose content leaves
+ * the DOM.
+ */
+export function accordionInstanceAria(
+  part: AccordionPart,
+  value: string,
+  state: AccordionState,
+  config: AccordionConfig,
+  ids: InstanceIds<AccordionPart>,
+): AriaAttrs {
+  const expanded = isItemExpanded(value, state, config);
+  const stateAttr = expanded ? 'open' : 'closed';
+  if (part === 'item') {
+    return { 'data-state': stateAttr };
+  }
+  if (part === 'heading') {
+    // role + aria-level ride the projection rather than being hand-written per
+    // decorator: role="heading" without aria-level is an incomplete heading.
+    return { role: 'heading', 'aria-level': String(headingLevelOf(config)) };
+  }
+  if (part === 'trigger') {
+    return {
+      'aria-expanded': expanded ? 'true' : 'false',
+      'aria-controls': ids.content || undefined,
+      'data-state': stateAttr,
+    };
+  }
+  if (part === 'content') {
+    return {
+      role: 'region',
+      'aria-labelledby': ids.trigger || undefined,
+      'data-state': stateAttr,
+      hidden: expanded ? undefined : true,
+    };
+  }
+  return {};
+}
+
+export const accordion: BehaviorSpec<
+  AccordionConfig,
+  AccordionState,
+  AccordionActions,
+  AccordionPart
+> = { ...compose('accordion', accordionSlice), instanceAria: accordionInstanceAria };
+
+/** Header buttons participating in toggling (excludes disabled ones, which the
+ *  roving-focus primitive also skips). */
+const TRIGGER_SELECTOR = '[data-part="trigger"][data-value]:not([disabled])';
+
+/**
+ * The DOM-native binding of the accordion score -- the client the Web Component
+ * and the Astro <script> both import; only React (retained-mode) reads the
+ * projections declaratively instead. Composes the substrate the same way the
+ * React decorator does: createBehavior is the model, createRovingFocus drives
+ * ArrowUp/ArrowDown/Home/End movement and the roving tabindex across the header
+ * buttons, aria-manager applies the projection, and the DOM is the part
+ * registry.
+ *
+ * Activation is delegated click only: the header <button>s convert Enter/Space
+ * to a native click, so no keydown branch is needed. Panels are
+ * present-but-hidden -- `hidden` rides the instance projection, so the exit
+ * transition runs on the same node.
+ */
+export function bindAccordion(root: HTMLElement): () => void {
+  const expandedAtMount = Array.from(
+    root.querySelectorAll<HTMLElement>('[data-part="trigger"][data-state="open"]'),
+  )
+    .map((el) => el.getAttribute('data-value'))
+    .filter((value): value is string => value !== null);
+
+  const config: AccordionConfig = {
+    type: root.getAttribute('data-type') === 'multiple' ? 'multiple' : 'single',
+    collapsible: root.getAttribute('data-collapsible') === 'true',
+    disabled: root.getAttribute('data-disabled') === 'true',
+    headingLevel: Number.parseInt(root.getAttribute('data-heading-level') ?? '', 10) || undefined,
+    // WC/Astro are uncontrolled (no reactive prop), so config.value stays
+    // undefined; seed the intrinsic set from the server-rendered open sections.
+    defaultValue: expandedAtMount,
+  };
+
+  const getPart = (part: string): HTMLElement | null =>
+    part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
+
+  const { memory, dispatch } = createBehavior(accordion, config);
+
+  // Compose the roving-focus primitive directly -- it owns the roving tabindex
+  // and ArrowUp/ArrowDown/Home/End movement across the [data-roving-item]
+  // header buttons. The accordion axis is vertical.
+  const stopRoving = createRovingFocus(root, { orientation: 'vertical' });
+
+  // ids are READ from the markup (server- or author-minted), never generated.
+  const ids = {} as PartIds<AccordionPart>;
+  for (const part of Object.keys(accordion.parts) as AccordionPart[]) {
+    ids[part] = getPart(part)?.id ?? '';
+  }
+
+  // The score's projection is already resolved (final strings, undefined =
+  // absent), so apply it raw: validate:false skips aria-manager's author-input
+  // coercion, which would re-read the resolved string 'false' as truthy.
+  const applyProjection = (el: HTMLElement, attrs: AriaAttrs) => {
+    for (const [name, value] of Object.entries(attrs)) {
+      updateAriaAttribute(el, name as never, value as never, { validate: false });
+    }
+  };
+
+  // The `many` parts, resolved from the score's own declaration -- no hardcoded
+  // list, so the loop stays honest if a part is added.
+  const manyParts = (Object.keys(accordion.parts) as AccordionPart[]).filter(
+    (part) => accordion.parts[part].many,
+  );
+
+  const projectInstances = (state: AccordionState) => {
+    for (const part of manyParts) {
+      for (const el of root.querySelectorAll<HTMLElement>(`[data-part="${part}"]`)) {
+        const value = el.dataset['value'];
+        if (value === undefined) continue;
+        const instanceIds: InstanceIds<AccordionPart> = {};
+        for (const sibling of manyParts) {
+          instanceIds[sibling] =
+            root.querySelector<HTMLElement>(`[data-part="${sibling}"][data-value="${value}"]`)
+              ?.id ?? '';
+        }
+        applyProjection(el, accordionInstanceAria(part, value, state, config, instanceIds));
+      }
+    }
+  };
+
+  const render = () => {
+    const state = memory.get();
+    const projection = accordion.aria(state, config, ids);
+    for (const part of Object.keys(projection) as AccordionPart[]) {
+      const attrs = projection[part];
+      const el = getPart(part);
+      if (el && attrs) applyProjection(el, attrs);
+    }
+    projectInstances(state);
+  };
+  const unsubscribe = memory.subscribe(render); // fires immediately: first paint
+
+  const onClick = (event: Event) => {
+    const trigger = (event.target as HTMLElement).closest<HTMLElement>(TRIGGER_SELECTOR);
+    const value = trigger?.dataset['value'];
+    if (value !== undefined && root.contains(trigger)) dispatch('toggle', config, value);
+  };
+  root.addEventListener('click', onClick);
+
+  return () => {
+    unsubscribe();
+    stopRoving();
+    root.removeEventListener('click', onClick);
+  };
+}

--- a/packages/ui/src/components/accordion/accordion.classes.ts
+++ b/packages/ui/src/components/accordion/accordion.classes.ts
@@ -1,0 +1,69 @@
+import type { AccordionConfig, AccordionState } from './accordion.behavior';
+
+export interface AccordionClassSet {
+  /** The stack container. Layout is the consumer's; the root is structural. */
+  root: string;
+  /** One section wrapper: the rule that separates stacked sections. */
+  item: string;
+  /** The role=heading wrapper the header button lives in. */
+  heading: string;
+  /** The header button: full-width row, hover feedback, focus ring, disabled dim. */
+  trigger: string;
+  /** The chevron, rotated off the trigger's data-state via the group variant. */
+  triggerIcon: string;
+  /** The panel: clips its content and carries the height-axis motion intent. */
+  content: string;
+  /** The panel's inner padding box (the panel itself must stay unpadded so it
+   *  can collapse to zero height). */
+  contentInner: string;
+}
+
+// The root owns no visual of its own -- it is the styling anchor for the
+// data-orientation/data-type/data-disabled the score projects.
+const rootClasses = '';
+
+const itemClasses = 'border-b';
+
+const headingClasses = 'flex';
+
+const triggerClasses =
+  'group flex flex-1 items-center justify-between py-4 text-title-small ' +
+  'transition-all duration-300 motion-reduce:transition-none ' +
+  'hover:underline ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ' +
+  'disabled:pointer-events-none disabled:opacity-50';
+
+// The icon rotates off the trigger's data-state (projected by the score) via
+// the group variant, so the projection writes one attribute per trigger and the
+// chevron follows for free.
+const triggerIconClasses =
+  'h-4 w-4 shrink-0 transition-transform duration-300 motion-reduce:transition-none ' +
+  'group-data-[state=open]:rotate-180';
+
+// Motion intent (declared, not keyframed): expand/collapse along the height
+// axis. overflow-hidden clips the panel while it grows/shrinks; the transition
+// carries the token-scale duration and yields to reduced motion. The oracle's
+// `data-[state=*]:animate-accordion-up/down` utilities are NOT ported: their
+// keyframes interpolate `var(--radix-accordion-content-height)`, a Radix-owned
+// variable nothing in this system ever sets, so they animate to an undefined
+// height (see accordion.md dispositions).
+const contentClasses =
+  'overflow-hidden text-body-small transition-all duration-300 motion-reduce:transition-none';
+
+const contentInnerClasses = 'pb-4 pt-0';
+
+/** The view: class strings keyed by config/state. No logic. */
+export function accordionClasses(
+  _config: AccordionConfig,
+  _state: AccordionState,
+): AccordionClassSet {
+  return {
+    root: rootClasses,
+    item: itemClasses,
+    heading: headingClasses,
+    trigger: triggerClasses,
+    triggerIcon: triggerIconClasses,
+    content: contentClasses,
+    contentInner: contentInnerClasses,
+  };
+}

--- a/packages/ui/src/components/accordion/accordion.element.ts
+++ b/packages/ui/src/components/accordion/accordion.element.ts
@@ -1,0 +1,35 @@
+/**
+ * WC performance for accordion: the thinnest wrapper. The score AND the
+ * DOM-native binding (bindAccordion) live in accordion.behavior.ts, shared with
+ * the Astro performance. This file only adapts that binding to the
+ * custom-element lifecycle.
+ *
+ * A light-DOM enhancer: the author (or Astro) provides the real
+ * `<div data-part="root">` with its section markup, so native focus and the
+ * composed roving-focus primitive operate on real document DOM -- the WC never
+ * renders a shadow tree of its own. The bind is deferred one microtask because
+ * connectedCallback can fire before the light-DOM children are parsed (upgrade
+ * order).
+ */
+import { bindAccordion } from './accordion.behavior';
+
+export class RaftersAccordion extends HTMLElement {
+  private teardown: (() => void) | null = null;
+
+  connectedCallback(): void {
+    queueMicrotask(() => {
+      if (!this.isConnected || this.teardown) return;
+      const root = this.querySelector<HTMLElement>('[data-part="root"]');
+      if (root) this.teardown = bindAccordion(root);
+    });
+  }
+
+  disconnectedCallback(): void {
+    this.teardown?.();
+    this.teardown = null;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-accordion')) {
+  customElements.define('rafters-accordion', RaftersAccordion);
+}

--- a/packages/ui/src/components/accordion/accordion.tsx
+++ b/packages/ui/src/components/accordion/accordion.tsx
@@ -1,0 +1,353 @@
+import * as React from 'react';
+import { useMemory } from '../../hooks/use-memory';
+import { createBehavior, type PartIds } from '../../lib/contract';
+import classy from '../../primitives/classy';
+import { createRovingFocus } from '../../primitives/roving-focus';
+import {
+  accordion,
+  accordionInstanceAria,
+  emitValue,
+  expandedValues,
+  type AccordionConfig,
+  type AccordionPart,
+  type AccordionState,
+} from './accordion.behavior';
+import { accordionClasses, type AccordionClassSet } from './accordion.classes';
+
+interface AccordionContextValue {
+  state: AccordionState;
+  config: AccordionConfig;
+  classes: AccordionClassSet;
+  groupDisabled: boolean;
+  instanceId: (part: AccordionPart, value: string) => string;
+  request: (value: string) => boolean;
+}
+
+const AccordionContext = React.createContext<AccordionContextValue | null>(null);
+
+function useAccordionContext(component: string): AccordionContextValue {
+  const context = React.useContext(AccordionContext);
+  if (!context) {
+    throw new Error(`${component} must be used within <Accordion>`);
+  }
+  return context;
+}
+
+interface AccordionItemContextValue {
+  value: string;
+  triggerId: string;
+  contentId: string;
+  disabled: boolean;
+}
+
+const AccordionItemContext = React.createContext<AccordionItemContextValue | null>(null);
+
+function useAccordionItemContext(component: string): AccordionItemContextValue {
+  const context = React.useContext(AccordionItemContext);
+  if (!context) {
+    throw new Error(`${component} must be used within <AccordionItem>`);
+  }
+  return context;
+}
+
+/** Order-insensitive set equality: expansion is by value, order is not state. */
+function sameSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const set = new Set(a);
+  return b.every((value) => set.has(value));
+}
+
+export interface AccordionProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'onChange' | 'defaultValue'
+> {
+  /** Disclosure mode: single holds at most one open section, multiple any number. */
+  type?: 'single' | 'multiple';
+  /** Controlled value: string for single, string[] for multiple. */
+  value?: string | string[];
+  /** Default value for uncontrolled usage. */
+  defaultValue?: string | string[];
+  /** Callback when the expanded set changes via user interaction. */
+  onValueChange?: (value: string | string[]) => void;
+  /** In single mode, allow closing the open section (default false). */
+  collapsible?: boolean;
+  /** Whether every section is disabled. */
+  disabled?: boolean;
+  /** Heading level of the wrapper around each header button (default 3). */
+  headingLevel?: number;
+}
+
+/**
+ * Stacked expandable sections: header buttons that disclose regions, one open
+ * at a time (`single`) or any number (`multiple`). ArrowUp/ArrowDown and
+ * Home/End move focus across the headers via a roving tabindex; Enter, Space, or
+ * click toggles the focused section. Panels stay in the DOM hidden when
+ * collapsed, so their content is crawlable and the height transition runs on the
+ * same node.
+ *
+ * @cognitive-load 3/10 - decision 1, information 1, interaction 1, disruption 0,
+ * learning 0. One decision at a time (which section to open) over a visible list
+ * of labelled headers; collapsed panels hold information out of view until it is
+ * asked for, so nothing must be held in memory. The expand/collapse affordance
+ * is universally learned and the page never moves under the reader.
+ * @attention-economics Progressive disclosure spends attention only where it is
+ * requested: headers are the scannable index, the open panel is the single
+ * focus. Single mode enforces one demand at a time; multiple mode trades that
+ * focus for comparison across sections. Beyond roughly ten sections the header
+ * list itself becomes the scanning cost and a Tabs or navigation surface is the
+ * cheaper structure.
+ * @trust-building Reversible and predictable: every section reopens exactly as
+ * it was, nothing is destroyed by collapsing, and the chevron plus data-state
+ * keep the current shape visible at a glance. Content is never removed from the
+ * document, so find-in-page and assistive tooling can still reach it.
+ * @accessibility Each header button is contained by a role="heading" wrapper
+ * carrying aria-level (the WAI-ARIA accordion pattern), and projects
+ * aria-expanded plus aria-controls pointing at its panel; each panel is a
+ * role="region" named by aria-labelledby back to its header. Roving tabindex
+ * keeps exactly one header in the tab order; ArrowUp/ArrowDown/Home/End move
+ * focus; Enter/Space activate natively. Disabled sections leave the tab order
+ * (native disabled) and are skipped by roving.
+ */
+export function Accordion({
+  type = 'single',
+  value,
+  defaultValue,
+  onValueChange,
+  collapsible = false,
+  disabled = false,
+  headingLevel = 3,
+  className,
+  children,
+  ...props
+}: AccordionProps) {
+  const config: AccordionConfig = {
+    type,
+    value,
+    defaultValue,
+    collapsible,
+    disabled,
+    headingLevel,
+  };
+
+  // The decorator composes the score with the substrate -- no useBehavior.
+  // createBehavior is the model; useMemory subscribes React to it; the effect
+  // below composes the roving-focus primitive directly against the root.
+  const { memory, dispatch } = React.useMemo(() => createBehavior(accordion, config), []);
+  const state = useMemory(memory);
+
+  const uid = React.useId();
+  const ids = React.useMemo(() => {
+    const out = {} as PartIds<AccordionPart>;
+    for (const part of Object.keys(accordion.parts) as AccordionPart[]) {
+      out[part] = `${uid}-${part}`;
+    }
+    return out;
+  }, [uid]);
+  // Instance ids derived from the root uid -- never hand-templated per call site.
+  const instanceId = React.useCallback(
+    (part: AccordionPart, itemValue: string) => `${uid}-${part}-${itemValue}`,
+    [uid],
+  );
+
+  const rootRef = React.useRef<HTMLDivElement>(null);
+
+  // Gotcha #1: the controlled callback compares the EFFECTIVE set before
+  // against the INTRINSIC set after the reducer -- a controlled accordion's
+  // effective set never moves (config shadows it), but the callback must still
+  // report the set to apply. canDispatch already gates accordion-disabled, and
+  // single non-collapsible returns identical state on a re-activation, so the
+  // set comparison also absorbs that no-op.
+  const latest = React.useRef({ config, onValueChange });
+  latest.current = { config, onValueChange };
+  const request = React.useCallback(
+    (itemValue: string): boolean => {
+      const { config: cfg, onValueChange: cb } = latest.current;
+      const before = expandedValues(memory.get(), cfg);
+      if (!dispatch('toggle', cfg, itemValue)) return false;
+      const after = memory.get().value;
+      if (!sameSet(before, after)) cb?.(emitValue(after, cfg));
+      return true;
+    },
+    [memory, dispatch],
+  );
+
+  // Compose the roving-focus primitive directly against the root -- it owns the
+  // roving tabindex and ArrowUp/ArrowDown/Home/End movement across the
+  // [data-roving-item] header buttons. Expansion does NOT follow focus, so
+  // there is no second keydown effect: activation flows through the header
+  // <button>'s native click (Enter/Space included).
+  React.useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    return createRovingFocus(root, { orientation: 'vertical' });
+  }, []);
+
+  const aria = accordion.aria(state, config, ids);
+  const classes = accordionClasses(config, state);
+
+  const contextValue: AccordionContextValue = {
+    state,
+    config,
+    classes,
+    groupDisabled: disabled,
+    instanceId,
+    request,
+  };
+
+  return (
+    <AccordionContext.Provider value={contextValue}>
+      <div
+        ref={rootRef}
+        data-part="root"
+        id={ids.root}
+        className={classy(classes.root, className)}
+        {...aria.root}
+        {...props}
+      >
+        {children}
+      </div>
+    </AccordionContext.Provider>
+  );
+}
+
+Accordion.displayName = 'Accordion';
+
+export interface AccordionItemProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Value that identifies this section. */
+  value: string;
+  /** Whether this section is disabled. */
+  disabled?: boolean;
+}
+
+export function AccordionItem({
+  value,
+  disabled = false,
+  className,
+  children,
+  ...props
+}: AccordionItemProps) {
+  const { state, config, classes, groupDisabled, instanceId } =
+    useAccordionContext('AccordionItem');
+  const itemContext: AccordionItemContextValue = {
+    value,
+    triggerId: instanceId('trigger', value),
+    contentId: instanceId('content', value),
+    disabled: groupDisabled || disabled,
+  };
+  const aria = accordionInstanceAria('item', value, state, config, {});
+
+  return (
+    <AccordionItemContext.Provider value={itemContext}>
+      <div
+        data-part="item"
+        data-value={value}
+        data-disabled={itemContext.disabled ? '' : undefined}
+        className={classy(classes.item, className)}
+        {...aria}
+        {...props}
+      >
+        {children}
+      </div>
+    </AccordionItemContext.Provider>
+  );
+}
+
+AccordionItem.displayName = 'AccordionItem';
+
+export type AccordionTriggerProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export function AccordionTrigger({
+  className,
+  children,
+  disabled: propDisabled,
+  onClick,
+  ...props
+}: AccordionTriggerProps) {
+  const { state, config, classes, request } = useAccordionContext('AccordionTrigger');
+  const {
+    value,
+    triggerId,
+    contentId,
+    disabled: itemDisabled,
+  } = useAccordionItemContext('AccordionTrigger');
+  const disabled = propDisabled ?? itemDisabled;
+  const headingAria = accordionInstanceAria('heading', value, state, config, {});
+  const aria = accordionInstanceAria('trigger', value, state, config, {
+    trigger: triggerId,
+    content: contentId,
+  });
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: role=heading is the projected part; a raw <h3 className> is disallowed by the typography rule, and the level is config-driven
+    <div data-part="heading" data-value={value} className={classes.heading} {...headingAria}>
+      <button
+        type="button"
+        id={triggerId}
+        data-part="trigger"
+        data-value={value}
+        data-roving-item
+        disabled={disabled}
+        className={classy(classes.trigger, className)}
+        {...aria}
+        onClick={(event) => {
+          onClick?.(event);
+          if (event.defaultPrevented) return;
+          request(value);
+        }}
+        {...props}
+      >
+        {children}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+          className={classes.triggerIcon}
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+AccordionTrigger.displayName = 'AccordionTrigger';
+
+export type AccordionContentProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function AccordionContent({ className, children, ...props }: AccordionContentProps) {
+  const { state, config, classes } = useAccordionContext('AccordionContent');
+  const { value, triggerId, contentId } = useAccordionItemContext('AccordionContent');
+  const aria = accordionInstanceAria('content', value, state, config, {
+    trigger: triggerId,
+    content: contentId,
+  });
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: role=region is the projected part -- the WAI-ARIA accordion panel; <section> would hard-code the role the score owns
+    <div
+      id={contentId}
+      data-part="content"
+      data-value={value}
+      className={classy(classes.content, className)}
+      {...aria}
+      {...props}
+    >
+      <div className={classes.contentInner}>{children}</div>
+    </div>
+  );
+}
+
+AccordionContent.displayName = 'AccordionContent';
+
+Accordion.Item = AccordionItem;
+Accordion.Trigger = AccordionTrigger;
+Accordion.Content = AccordionContent;
+
+export default Accordion;

--- a/packages/ui/test/components/accordion/accordion.astro.conformance.test.ts
+++ b/packages/ui/test/components/accordion/accordion.astro.conformance.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Astro performance of the accordion score, driven end to end. AstroContainer
+ * renders the SSR markup with the initial projection already applied, but does
+ * NOT run the <script>, so the test calls bindAccordion directly -- that IS the
+ * script's job -- then drives the same score the React and WC performances
+ * drive. One score, three performances.
+ */
+import userEvent from '@testing-library/user-event';
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { afterEach, describe, expect, it } from 'vitest';
+import Accordion from '../../../src/components/accordion/accordion.astro';
+import { bindAccordion } from '../../../src/components/accordion/accordion.behavior';
+
+const items = [
+  { value: 'a', label: 'Alpha', body: 'Body alpha' },
+  { value: 'b', label: 'Beta', body: 'Body beta' },
+  { value: 'c', label: 'Gamma', body: 'Body gamma' },
+];
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+async function mount(props: Record<string, unknown> = {}): Promise<HTMLElement> {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Accordion, {
+    props: { id: 'faq', items, ...props },
+  });
+  document.body.innerHTML = html;
+  const root = document.body.querySelector('[data-part="root"]') as HTMLElement;
+  bindAccordion(root); // the <script> does this per instance on the real page
+  return root;
+}
+
+const trigger = (value: string) =>
+  document.body.querySelector<HTMLElement>(`[data-part="trigger"][data-value="${value}"]`)!;
+const content = (value: string) =>
+  document.body.querySelector<HTMLElement>(`[data-part="content"][data-value="${value}"]`)!;
+
+describe('accordion conformance [astro]', () => {
+  it('SSR: the seeded section is open and the rest are hidden before any JS', async () => {
+    const root = await mount({ value: 'b' });
+    expect(root.getAttribute('data-orientation')).toBe('vertical');
+    expect(root.getAttribute('data-type')).toBe('single');
+    expect(trigger('b').getAttribute('aria-expanded')).toBe('true');
+    expect(content('b').hasAttribute('hidden')).toBe(false);
+    expect(content('a').hasAttribute('hidden')).toBe(true);
+  });
+
+  it('SSR: panel bodies are in the markup even while collapsed -- crawlable', async () => {
+    await mount();
+    expect(content('a').textContent).toContain('Body alpha');
+    expect(content('a').hasAttribute('hidden')).toBe(true);
+  });
+
+  it('SSR: ids are minted from the root id and cross-referenced both ways', async () => {
+    await mount();
+    expect(trigger('a').id).toBe('faq-trigger-a');
+    expect(content('a').id).toBe('faq-content-a');
+    expect(trigger('a').getAttribute('aria-controls')).toBe('faq-content-a');
+    expect(content('a').getAttribute('aria-labelledby')).toBe('faq-trigger-a');
+  });
+
+  it('SSR: each header sits in a role=heading wrapper at the configured level', async () => {
+    await mount({ headingLevel: 2 });
+    const heading = trigger('a').parentElement as HTMLElement;
+    expect(heading.getAttribute('role')).toBe('heading');
+    expect(heading.getAttribute('aria-level')).toBe('2');
+  });
+
+  it('SSR: panels are regions named by their header', async () => {
+    await mount();
+    expect(content('a').getAttribute('role')).toBe('region');
+  });
+
+  it('single: clicking a header opens it and closes the previous one', async () => {
+    const user = userEvent.setup();
+    await mount({ value: 'a' });
+    await user.click(trigger('b'));
+    expect(content('b').hasAttribute('hidden')).toBe(false);
+    expect(content('a').hasAttribute('hidden')).toBe(true);
+  });
+
+  it('single collapsible: re-clicking the open header collapses everything', async () => {
+    const user = userEvent.setup();
+    await mount({ value: 'a', collapsible: true });
+    await user.click(trigger('a'));
+    expect(content('a').hasAttribute('hidden')).toBe(true);
+  });
+
+  it('multiple: SSR seeds every value and clicks accumulate', async () => {
+    const user = userEvent.setup();
+    await mount({ type: 'multiple', value: ['a', 'c'] });
+    expect(content('a').hasAttribute('hidden')).toBe(false);
+    expect(content('c').hasAttribute('hidden')).toBe(false);
+    await user.click(trigger('b'));
+    expect(content('b').hasAttribute('hidden')).toBe(false);
+    expect(content('a').hasAttribute('hidden')).toBe(false);
+  });
+
+  it('ArrowDown/ArrowUp rove focus across the headers', async () => {
+    const user = userEvent.setup();
+    await mount();
+    trigger('a').focus();
+    await user.keyboard('{ArrowDown}');
+    expect(document.activeElement).toBe(trigger('b'));
+    await user.keyboard('{ArrowUp}');
+    expect(document.activeElement).toBe(trigger('a'));
+  });
+
+  it('Space toggles the focused header', async () => {
+    const user = userEvent.setup();
+    await mount();
+    trigger('c').focus();
+    await user.keyboard(' ');
+    expect(content('c').hasAttribute('hidden')).toBe(false);
+  });
+
+  it('a disabled section is natively disabled and refuses activation', async () => {
+    const user = userEvent.setup();
+    await mount({
+      items: [
+        { value: 'a', label: 'Alpha', body: 'Body alpha' },
+        { value: 'b', label: 'Beta', body: 'Body beta', disabled: true },
+      ],
+    });
+    expect(trigger('b').hasAttribute('disabled')).toBe(true);
+    await user.click(trigger('b'));
+    expect(content('b').hasAttribute('hidden')).toBe(true);
+  });
+});

--- a/packages/ui/test/components/accordion/accordion.behavior.test.ts
+++ b/packages/ui/test/components/accordion/accordion.behavior.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Pure behavior test for the accordion score: reducers, gates, and the
+ * aria/instanceAria/keymap projections. No DOM, no framework -- this is the
+ * score alone, the same one all three performances drive.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  accordion,
+  accordionInstanceAria,
+  emitValue,
+  expandedValues,
+  isItemExpanded,
+  isMultiple,
+  headingLevelOf,
+  type AccordionConfig,
+  type AccordionState,
+} from '../../../src/components/accordion/accordion.behavior';
+
+const base: AccordionConfig = {};
+
+function stateFor(config: AccordionConfig): AccordionState {
+  return accordion.initialState(config);
+}
+
+function toggle(state: AccordionState, value: string): AccordionState {
+  return accordion.actions.toggle(state, value);
+}
+
+describe('accordion initial state', () => {
+  it('single mode seeds at most one value and is non-collapsible by default', () => {
+    const state = stateFor({ defaultValue: ['a', 'b'] });
+    expect(state.value).toEqual(['a']);
+    expect(state.multiple).toBe(false);
+    expect(state.collapsible).toBe(false);
+  });
+
+  it('multiple mode seeds the whole set and is inherently collapsible', () => {
+    const state = stateFor({ type: 'multiple', defaultValue: ['a', 'b'] });
+    expect(state.value).toEqual(['a', 'b']);
+    expect(state.multiple).toBe(true);
+    expect(state.collapsible).toBe(true);
+  });
+
+  it('a controlled value seeds the intrinsic set too, so first paint matches', () => {
+    expect(stateFor({ value: 'b' }).value).toEqual(['b']);
+  });
+
+  it('an empty string is absence, not a value', () => {
+    expect(stateFor({ defaultValue: '' }).value).toEqual([]);
+    expect(stateFor({ type: 'multiple', defaultValue: ['a', ''] }).value).toEqual(['a']);
+  });
+});
+
+describe('accordion toggle reducer', () => {
+  it('single: opening a section replaces the open one', () => {
+    const opened = toggle(stateFor({ defaultValue: 'a' }), 'b');
+    expect(opened.value).toEqual(['b']);
+  });
+
+  it('single non-collapsible: re-activating the open section is a no-op', () => {
+    const state = stateFor({ defaultValue: 'a' });
+    const next = toggle(state, 'a');
+    expect(next.value).toEqual(['a']);
+    // Identity matters: the decorators compare before/after to decide whether
+    // the consumer callback fires, so a refused edit must not look like a move.
+    expect(next).toBe(state);
+  });
+
+  it('single collapsible: re-activating the open section closes everything', () => {
+    const state = stateFor({ defaultValue: 'a', collapsible: true });
+    expect(toggle(state, 'a').value).toEqual([]);
+  });
+
+  it('multiple: sections accumulate and toggle out independently', () => {
+    let state = stateFor({ type: 'multiple' });
+    state = toggle(state, 'a');
+    state = toggle(state, 'b');
+    expect(state.value).toEqual(['a', 'b']);
+    state = toggle(state, 'a');
+    expect(state.value).toEqual(['b']);
+  });
+
+  it('an empty payload never moves state', () => {
+    const state = stateFor({ type: 'multiple', defaultValue: 'a' });
+    expect(toggle(state, '')).toBe(state);
+  });
+});
+
+describe('accordion gates', () => {
+  it('a disabled accordion rejects toggling', () => {
+    const state = stateFor({ disabled: true });
+    expect(accordion.canDispatch(state, 'toggle', { disabled: true })).toBe(false);
+    expect(accordion.canDispatch(state, 'toggle', {})).toBe(true);
+  });
+});
+
+describe('accordion effective value', () => {
+  it('a controlled value shadows the intrinsic set', () => {
+    const state: AccordionState = { value: ['a'], multiple: false, collapsible: false };
+    expect(expandedValues(state, { value: 'b' })).toEqual(['b']);
+    expect(expandedValues(state, {})).toEqual(['a']);
+  });
+
+  it('a controlled single value is clamped to one entry', () => {
+    const state = stateFor(base);
+    expect(expandedValues(state, { value: ['a', 'b'] })).toEqual(['a']);
+    expect(expandedValues(state, { type: 'multiple', value: ['a', 'b'] })).toEqual(['a', 'b']);
+  });
+
+  it('isItemExpanded reads the effective set', () => {
+    const state = stateFor({ defaultValue: 'a' });
+    expect(isItemExpanded('a', state, base)).toBe(true);
+    expect(isItemExpanded('a', state, { value: 'b' })).toBe(false);
+  });
+
+  it('emitValue reports a string for single and an array for multiple', () => {
+    expect(emitValue(['a'], base)).toBe('a');
+    expect(emitValue([], base)).toBe('');
+    expect(emitValue(['a', 'b'], { type: 'multiple' })).toEqual(['a', 'b']);
+  });
+
+  it('isMultiple and headingLevelOf read the config defaults', () => {
+    expect(isMultiple(base)).toBe(false);
+    expect(isMultiple({ type: 'multiple' })).toBe(true);
+    expect(headingLevelOf(base)).toBe(3);
+    expect(headingLevelOf({ headingLevel: 2 })).toBe(2);
+  });
+});
+
+describe('accordion root projection', () => {
+  it('advertises the vertical axis, the mode, and the heading level', () => {
+    const config: AccordionConfig = { type: 'multiple', headingLevel: 2 };
+    const root = accordion.aria(stateFor(config), config, {
+      root: '',
+      item: '',
+      heading: '',
+      trigger: '',
+      content: '',
+    }).root;
+    expect(root?.['data-orientation']).toBe('vertical');
+    expect(root?.['data-type']).toBe('multiple');
+    expect(root?.['data-collapsible']).toBe('true');
+    expect(root?.['data-heading-level']).toBe('2');
+    expect(root?.['data-disabled']).toBeUndefined();
+  });
+
+  it('projects data-disabled only when the accordion is disabled', () => {
+    const config: AccordionConfig = { disabled: true };
+    const ids = { root: '', item: '', heading: '', trigger: '', content: '' };
+    expect(accordion.aria(stateFor(config), config, ids).root?.['data-disabled']).toBe('true');
+  });
+});
+
+describe('accordion instance projection', () => {
+  const config: AccordionConfig = {};
+  const state = stateFor({ defaultValue: 'a' });
+  const ids = { trigger: 't-a', content: 'c-a' };
+
+  it('the trigger carries aria-expanded, aria-controls, and data-state', () => {
+    const open = accordionInstanceAria('trigger', 'a', state, config, ids);
+    expect(open['aria-expanded']).toBe('true');
+    expect(open['aria-controls']).toBe('c-a');
+    expect(open['data-state']).toBe('open');
+
+    const closed = accordionInstanceAria('trigger', 'b', state, config, {
+      trigger: 't-b',
+      content: 'c-b',
+    });
+    expect(closed['aria-expanded']).toBe('false');
+    expect(closed['data-state']).toBe('closed');
+  });
+
+  it('aria-controls is projected while collapsed too -- the panel never unmounts', () => {
+    const closed = accordionInstanceAria('trigger', 'b', state, config, {
+      trigger: 't-b',
+      content: 'c-b',
+    });
+    expect(closed['aria-controls']).toBe('c-b');
+  });
+
+  it('an unresolved sibling id projects absence rather than an empty reference', () => {
+    const orphan = accordionInstanceAria('trigger', 'b', state, config, {});
+    expect(orphan['aria-controls']).toBeUndefined();
+  });
+
+  it('the panel is a region named by its trigger, hidden while collapsed', () => {
+    const open = accordionInstanceAria('content', 'a', state, config, ids);
+    expect(open['role']).toBe('region');
+    expect(open['aria-labelledby']).toBe('t-a');
+    expect(open['hidden']).toBeUndefined();
+
+    const closed = accordionInstanceAria('content', 'b', state, config, {
+      trigger: 't-b',
+      content: 'c-b',
+    });
+    expect(closed['hidden']).toBe(true);
+  });
+
+  it('the heading wrapper carries role and the configured level', () => {
+    expect(accordionInstanceAria('heading', 'a', state, config, {})).toEqual({
+      role: 'heading',
+      'aria-level': '3',
+    });
+    expect(
+      accordionInstanceAria('heading', 'a', state, { headingLevel: 2 }, {})['aria-level'],
+    ).toBe('2');
+  });
+
+  it('the item wrapper mirrors data-state for styling', () => {
+    expect(accordionInstanceAria('item', 'a', state, config, {})['data-state']).toBe('open');
+    expect(accordionInstanceAria('item', 'b', state, config, {})['data-state']).toBe('closed');
+  });
+
+  it('the root has no per-instance projection', () => {
+    expect(accordionInstanceAria('root', 'a', state, config, {})).toEqual({});
+  });
+});
+
+describe('accordion keymap', () => {
+  const state = stateFor(base);
+
+  it('Enter and Space on a trigger map to toggle', () => {
+    expect(accordion.keymap({ key: 'Enter' }, state, 'trigger', base)).toBe('toggle');
+    expect(accordion.keymap({ key: ' ' }, state, 'trigger', base)).toBe('toggle');
+  });
+
+  it('arrow and Home/End keys are NOT claimed -- roving-focus owns movement', () => {
+    for (const key of ['ArrowDown', 'ArrowUp', 'Home', 'End']) {
+      expect(accordion.keymap({ key }, state, 'trigger', base)).toBeNull();
+    }
+  });
+
+  it('activation keys on other parts are not claimed', () => {
+    expect(accordion.keymap({ key: 'Enter' }, state, 'content', base)).toBeNull();
+    expect(accordion.keymap({ key: 'Enter' }, state, 'root', base)).toBeNull();
+  });
+});
+
+describe('accordion parts', () => {
+  it('declares the section parts as many, with the pattern roles', () => {
+    expect(accordion.parts.root.many).toBeUndefined();
+    for (const part of ['item', 'heading', 'trigger', 'content'] as const) {
+      expect(accordion.parts[part].many, `${part} is a many part`).toBe(true);
+    }
+    expect(accordion.parts.heading.role).toBe('heading');
+    expect(accordion.parts.content.role).toBe('region');
+  });
+});

--- a/packages/ui/test/components/accordion/accordion.classes.test.ts
+++ b/packages/ui/test/components/accordion/accordion.classes.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Classes parity test: the view is pure class strings keyed by config/state.
+ * Asserts each part carries the class contract all three performances paint --
+ * the section rule, the header row, the data-state-driven chevron rotation, and
+ * the clipped panel with its declared height-axis motion intent.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  accordion,
+  type AccordionConfig,
+} from '../../../src/components/accordion/accordion.behavior';
+import { accordionClasses } from '../../../src/components/accordion/accordion.classes';
+
+function classesFor(config: AccordionConfig) {
+  return accordionClasses(config, accordion.initialState(config));
+}
+
+describe('accordion structural classes', () => {
+  it('the root is a styling anchor with no visual of its own', () => {
+    expect(classesFor({}).root).toBe('');
+  });
+
+  it('each section is separated by a bottom rule', () => {
+    expect(classesFor({}).item.split(/\s+/)).toContain('border-b');
+  });
+
+  it('the heading wrapper lays the header button out as a row', () => {
+    expect(classesFor({}).heading.split(/\s+/)).toContain('flex');
+  });
+});
+
+describe('accordion trigger classes', () => {
+  it('the header fills its row and carries the focus ring and disabled dim', () => {
+    const trigger = classesFor({}).trigger;
+    expect(trigger).toContain('flex-1');
+    expect(trigger).toContain('items-center');
+    expect(trigger).toContain('justify-between');
+    expect(trigger).toContain('focus-visible:ring-ring');
+    expect(trigger).toContain('disabled:opacity-50');
+  });
+
+  it('the header is a group so the chevron can key off its data-state', () => {
+    expect(classesFor({}).trigger.split(/\s+/)).toContain('group');
+    expect(classesFor({}).triggerIcon).toContain('group-data-[state=open]:rotate-180');
+  });
+
+  it('the chevron rotation yields to reduced motion', () => {
+    expect(classesFor({}).triggerIcon).toContain('motion-reduce:transition-none');
+  });
+});
+
+describe('accordion content classes', () => {
+  it('the panel clips its content so it can collapse to zero height', () => {
+    expect(classesFor({}).content.split(/\s+/)).toContain('overflow-hidden');
+  });
+
+  it('the panel declares height-axis motion intent that yields to reduced motion', () => {
+    const content = classesFor({}).content;
+    expect(content).toContain('transition-all');
+    expect(content).toContain('motion-reduce:transition-none');
+  });
+
+  it('the oracle radix-variable keyframes are not ported', () => {
+    const content = classesFor({}).content;
+    expect(content).not.toContain('animate-accordion-down');
+    expect(content).not.toContain('animate-accordion-up');
+  });
+
+  it('padding lives on the inner box, never on the collapsing panel', () => {
+    expect(classesFor({}).content).not.toContain('pb-4');
+    expect(classesFor({}).contentInner).toContain('pb-4');
+  });
+});

--- a/packages/ui/test/components/accordion/accordion.conformance.test.tsx
+++ b/packages/ui/test/components/accordion/accordion.conformance.test.tsx
@@ -1,0 +1,253 @@
+/**
+ * React performance of the accordion score, driven end to end. Replaces the
+ * oracle's imperative createAccordion controller: expansion moves only through
+ * dispatched actions, and focus movement is the composed roving-focus primitive.
+ */
+import { cleanup, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '../../../src/components/accordion/accordion';
+import { accordion } from '../../../src/components/accordion/accordion.behavior';
+import {
+  assertAxeClean,
+  assertInstanceAriaFulfillment,
+  partElement,
+  partElements,
+} from '../../harness/conformance';
+
+interface SetupProps {
+  type?: 'single' | 'multiple';
+  value?: string | string[];
+  defaultValue?: string | string[];
+  onValueChange?: (value: string | string[]) => void;
+  collapsible?: boolean;
+  disabled?: boolean;
+  headingLevel?: number;
+  disabledItem?: string;
+}
+
+function TestAccordion({ disabledItem, ...props }: SetupProps) {
+  return (
+    <Accordion {...props}>
+      {['a', 'b', 'c'].map((value) => (
+        <AccordionItem key={value} value={value} disabled={disabledItem === value}>
+          <AccordionTrigger>Section {value}</AccordionTrigger>
+          <AccordionContent>Body {value}</AccordionContent>
+        </AccordionItem>
+      ))}
+    </Accordion>
+  );
+}
+
+const body = () => document.body;
+
+function triggerFor(value: string): HTMLElement {
+  const element = body().querySelector<HTMLElement>(`[data-part="trigger"][data-value="${value}"]`);
+  if (!element) throw new Error(`no trigger for ${value}`);
+  return element;
+}
+
+function contentFor(value: string): HTMLElement {
+  const element = body().querySelector<HTMLElement>(`[data-part="content"][data-value="${value}"]`);
+  if (!element) throw new Error(`no content for ${value}`);
+  return element;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('accordion conformance [react]', () => {
+  it('collapsed: panels stay in the DOM, hidden -- the body is crawlable', async () => {
+    render(<TestAccordion />);
+    expect(partElements(body(), 'content')).toHaveLength(3);
+    expect(contentFor('a').hidden).toBe(true);
+    expect(contentFor('a').getAttribute('data-state')).toBe('closed');
+    expect(triggerFor('a').getAttribute('aria-expanded')).toBe('false');
+    await assertAxeClean(body());
+  });
+
+  it('each header button sits inside a role=heading wrapper at the configured level', async () => {
+    render(<TestAccordion headingLevel={2} defaultValue="a" />);
+    const heading = triggerFor('a').parentElement as HTMLElement;
+    expect(heading.getAttribute('role')).toBe('heading');
+    expect(heading.getAttribute('aria-level')).toBe('2');
+    expect(partElement(body(), 'root')?.getAttribute('data-heading-level')).toBe('2');
+    await assertAxeClean(body());
+  });
+
+  it('trigger and panel are wired by real ids, collapsed as well as expanded', () => {
+    render(<TestAccordion defaultValue="a" />);
+    for (const value of ['a', 'b']) {
+      expect(triggerFor(value).getAttribute('aria-controls')).toBe(contentFor(value).id);
+      expect(contentFor(value).getAttribute('aria-labelledby')).toBe(triggerFor(value).id);
+    }
+    expect(contentFor('b').hidden).toBe(true);
+  });
+
+  it('per-instance ARIA equals the score projection, collapsed and expanded', async () => {
+    const user = userEvent.setup();
+    render(<TestAccordion />);
+    const root = partElement(body(), 'root') as HTMLElement;
+    assertInstanceAriaFulfillment(
+      accordion,
+      root,
+      { value: [], multiple: false, collapsible: false },
+      {},
+    );
+    await user.click(triggerFor('b'));
+    assertInstanceAriaFulfillment(
+      accordion,
+      root,
+      { value: ['b'], multiple: false, collapsible: false },
+      {},
+    );
+  });
+
+  it('single: opening a section closes the previously open one', async () => {
+    const user = userEvent.setup();
+    render(<TestAccordion defaultValue="a" />);
+    await user.click(triggerFor('b'));
+    expect(contentFor('b').hidden).toBe(false);
+    expect(contentFor('a').hidden).toBe(true);
+    await assertAxeClean(body());
+  });
+
+  it('single non-collapsible: clicking the open header keeps it open', async () => {
+    const user = userEvent.setup();
+    render(<TestAccordion defaultValue="a" />);
+    await user.click(triggerFor('a'));
+    expect(contentFor('a').hidden).toBe(false);
+  });
+
+  it('single collapsible: clicking the open header closes everything', async () => {
+    const user = userEvent.setup();
+    render(<TestAccordion defaultValue="a" collapsible />);
+    await user.click(triggerFor('a'));
+    expect(contentFor('a').hidden).toBe(true);
+  });
+
+  it('multiple: sections expand independently and accumulate', async () => {
+    const user = userEvent.setup();
+    render(<TestAccordion type="multiple" />);
+    await user.click(triggerFor('a'));
+    await user.click(triggerFor('c'));
+    expect(contentFor('a').hidden).toBe(false);
+    expect(contentFor('c').hidden).toBe(false);
+    await assertAxeClean(body());
+    await user.click(triggerFor('a'));
+    expect(contentFor('a').hidden).toBe(true);
+    expect(contentFor('c').hidden).toBe(false);
+  });
+
+  it('ArrowDown/ArrowUp rove focus across headers with wrap; Home/End jump', async () => {
+    const user = userEvent.setup();
+    render(<TestAccordion />);
+    triggerFor('a').focus();
+    await user.keyboard('{ArrowDown}');
+    expect(document.activeElement).toBe(triggerFor('b'));
+    await user.keyboard('{ArrowUp}');
+    expect(document.activeElement).toBe(triggerFor('a'));
+    await user.keyboard('{End}');
+    expect(document.activeElement).toBe(triggerFor('c'));
+    await user.keyboard('{Home}');
+    expect(document.activeElement).toBe(triggerFor('a'));
+  });
+
+  it('arrow keys move focus ONLY -- expansion does not follow focus', async () => {
+    const user = userEvent.setup();
+    render(<TestAccordion />);
+    triggerFor('a').focus();
+    await user.keyboard('{ArrowDown}');
+    expect(contentFor('b').hidden).toBe(true);
+  });
+
+  it('Enter and Space on the focused header toggle it', async () => {
+    const user = userEvent.setup();
+    render(<TestAccordion type="multiple" />);
+    triggerFor('a').focus();
+    await user.keyboard('{Enter}');
+    expect(contentFor('a').hidden).toBe(false);
+    triggerFor('b').focus();
+    await user.keyboard(' ');
+    expect(contentFor('b').hidden).toBe(false);
+  });
+
+  it('a disabled section cannot be opened and is skipped by roving', async () => {
+    const user = userEvent.setup();
+    render(<TestAccordion disabledItem="b" />);
+    await user.click(triggerFor('b'));
+    expect(contentFor('b').hidden).toBe(true);
+    triggerFor('a').focus();
+    await user.keyboard('{ArrowDown}');
+    expect(document.activeElement).toBe(triggerFor('c'));
+  });
+
+  it('a disabled accordion refuses every section', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<TestAccordion disabled onValueChange={onValueChange} />);
+    await user.click(triggerFor('a'));
+    expect(contentFor('a').hidden).toBe(true);
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(partElement(body(), 'root')?.getAttribute('data-disabled')).toBe('true');
+  });
+
+  it('controlled: the callback reports, state follows the prop', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const { rerender } = render(<TestAccordion value="" onValueChange={onValueChange} />);
+
+    await user.click(triggerFor('a'));
+    expect(onValueChange).toHaveBeenLastCalledWith('a');
+    expect(contentFor('a').hidden).toBe(true);
+
+    rerender(<TestAccordion value="a" onValueChange={onValueChange} />);
+    expect(contentFor('a').hidden).toBe(false);
+    expect(triggerFor('a').getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('controlled multiple: the callback reports the whole set as an array', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<TestAccordion type="multiple" value={['a']} onValueChange={onValueChange} />);
+    await user.click(triggerFor('b'));
+    expect(onValueChange).toHaveBeenLastCalledWith(['a', 'b']);
+  });
+
+  it('uncontrolled callback fires once per real transition, never for a refused one', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<TestAccordion defaultValue="a" onValueChange={onValueChange} />);
+    await user.click(triggerFor('b'));
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange).toHaveBeenLastCalledWith('b');
+    // Single non-collapsible: re-activating the open section moves nothing.
+    await user.click(triggerFor('b'));
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('a part used outside its provider fails loudly', () => {
+    expect(() => render(<AccordionItem value="a">x</AccordionItem>)).toThrow(
+      /must be used within <Accordion>/,
+    );
+  });
+
+  it('the shadcn namespaced surface renders the same parts', () => {
+    render(
+      <Accordion defaultValue="a">
+        <Accordion.Item value="a">
+          <Accordion.Trigger>Section a</Accordion.Trigger>
+          <Accordion.Content>Body a</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>,
+    );
+    expect(contentFor('a').hidden).toBe(false);
+    expect(triggerFor('a').getAttribute('aria-expanded')).toBe('true');
+  });
+});

--- a/packages/ui/test/components/accordion/accordion.element.conformance.test.ts
+++ b/packages/ui/test/components/accordion/accordion.element.conformance.test.ts
@@ -1,0 +1,206 @@
+/**
+ * WC performance of the accordion score, driven end to end against light-DOM
+ * markup. Same score as the React conformance test -- the only difference is
+ * that the controller applies the projection imperatively via bindAccordion,
+ * seeding the intrinsic set from the server-rendered open sections.
+ */
+import { cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { RaftersAccordion } from '../../../src/components/accordion/accordion.element';
+import { assertAxeClean } from '../../harness/conformance';
+
+beforeAll(() => {
+  if (!customElements.get('rafters-accordion')) {
+    customElements.define('rafters-accordion', RaftersAccordion);
+  }
+});
+
+interface MountOptions {
+  type?: 'single' | 'multiple';
+  collapsible?: boolean;
+  open?: string[];
+  disabled?: boolean;
+  disabledItems?: string[];
+  headingLevel?: number;
+}
+
+const SECTIONS: ReadonlyArray<[string, string]> = [
+  ['a', 'Alpha'],
+  ['b', 'Beta'],
+  ['c', 'Gamma'],
+];
+
+function sectionMarkup(
+  value: string,
+  label: string,
+  expanded: boolean,
+  disabled: boolean,
+  level: number,
+): string {
+  const state = expanded ? 'open' : 'closed';
+  return `
+    <div data-part="item" data-value="${value}" data-state="${state}">
+      <div data-part="heading" data-value="${value}" role="heading" aria-level="${level}">
+        <button type="button" id="acc-trigger-${value}" data-part="trigger" data-value="${value}"
+                data-roving-item data-state="${state}" aria-expanded="${expanded}"
+                aria-controls="acc-content-${value}"${disabled ? ' disabled' : ''}>${label}</button>
+      </div>
+      <div id="acc-content-${value}" data-part="content" data-value="${value}" role="region"
+           aria-labelledby="acc-trigger-${value}" data-state="${state}"${expanded ? '' : ' hidden'}>
+        Body ${label}
+      </div>
+    </div>`;
+}
+
+async function mount(options: MountOptions = {}): Promise<HTMLElement> {
+  const {
+    type = 'single',
+    collapsible = false,
+    open = [],
+    disabled = false,
+    disabledItems = [],
+    headingLevel = 3,
+  } = options;
+  const sections = SECTIONS.map(([value, label]) =>
+    sectionMarkup(
+      value,
+      label,
+      open.includes(value),
+      disabled || disabledItems.includes(value),
+      headingLevel,
+    ),
+  ).join('');
+  document.body.innerHTML = `
+    <rafters-accordion>
+      <div data-part="root" data-orientation="vertical" data-type="${type}" data-collapsible="${collapsible}" data-heading-level="${headingLevel}"${disabled ? ' data-disabled="true"' : ''}>
+        ${sections}
+      </div>
+    </rafters-accordion>`;
+  await Promise.resolve(); // let the element's deferred bind run
+  return document.body.querySelector('[data-part="root"]') as HTMLElement;
+}
+
+const trigger = (value: string) =>
+  document.body.querySelector<HTMLElement>(`[data-part="trigger"][data-value="${value}"]`)!;
+const content = (value: string) =>
+  document.body.querySelector<HTMLElement>(`[data-part="content"][data-value="${value}"]`)!;
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+describe('accordion conformance [wc]', () => {
+  it('seeds the intrinsic set from the server-rendered open section', async () => {
+    await mount({ open: ['b'] });
+    expect(trigger('b').getAttribute('aria-expanded')).toBe('true');
+    expect(content('b').hasAttribute('hidden')).toBe(false);
+    expect(trigger('a').getAttribute('aria-expanded')).toBe('false');
+    expect(content('a').hasAttribute('hidden')).toBe(true);
+    await assertAxeClean(document.body);
+  });
+
+  it('the panel is named by its header and referenced back, collapsed included', async () => {
+    await mount();
+    expect(trigger('a').getAttribute('aria-controls')).toBe(content('a').id);
+    expect(content('a').getAttribute('aria-labelledby')).toBe(trigger('a').id);
+  });
+
+  it('single: clicking a header opens it and closes the previous one', async () => {
+    const user = userEvent.setup();
+    await mount({ open: ['a'] });
+    await user.click(trigger('b'));
+    expect(content('b').hasAttribute('hidden')).toBe(false);
+    expect(content('a').hasAttribute('hidden')).toBe(true);
+    expect(trigger('a').getAttribute('data-state')).toBe('closed');
+  });
+
+  it('single non-collapsible: re-clicking the open header keeps it open', async () => {
+    const user = userEvent.setup();
+    await mount({ open: ['a'] });
+    await user.click(trigger('a'));
+    expect(content('a').hasAttribute('hidden')).toBe(false);
+  });
+
+  it('single collapsible: re-clicking the open header collapses everything', async () => {
+    const user = userEvent.setup();
+    await mount({ open: ['a'], collapsible: true });
+    await user.click(trigger('a'));
+    expect(content('a').hasAttribute('hidden')).toBe(true);
+  });
+
+  it('multiple: sections accumulate and collapse independently', async () => {
+    const user = userEvent.setup();
+    await mount({ type: 'multiple' });
+    await user.click(trigger('a'));
+    await user.click(trigger('c'));
+    expect(content('a').hasAttribute('hidden')).toBe(false);
+    expect(content('c').hasAttribute('hidden')).toBe(false);
+    await user.click(trigger('a'));
+    expect(content('a').hasAttribute('hidden')).toBe(true);
+    expect(content('c').hasAttribute('hidden')).toBe(false);
+  });
+
+  it('ArrowDown/ArrowUp rove focus with wrap; Home/End jump to the ends', async () => {
+    const user = userEvent.setup();
+    await mount();
+    trigger('a').focus();
+    await user.keyboard('{ArrowDown}');
+    expect(document.activeElement).toBe(trigger('b'));
+    await user.keyboard('{ArrowUp}');
+    expect(document.activeElement).toBe(trigger('a'));
+    await user.keyboard('{End}');
+    expect(document.activeElement).toBe(trigger('c'));
+    await user.keyboard('{Home}');
+    expect(document.activeElement).toBe(trigger('a'));
+  });
+
+  it('arrow keys move focus ONLY -- expansion does not follow focus', async () => {
+    const user = userEvent.setup();
+    await mount();
+    trigger('a').focus();
+    await user.keyboard('{ArrowDown}');
+    expect(content('b').hasAttribute('hidden')).toBe(true);
+  });
+
+  it('Enter and Space on the focused header toggle it', async () => {
+    const user = userEvent.setup();
+    await mount({ type: 'multiple' });
+    trigger('a').focus();
+    await user.keyboard('{Enter}');
+    expect(content('a').hasAttribute('hidden')).toBe(false);
+    trigger('b').focus();
+    await user.keyboard(' ');
+    expect(content('b').hasAttribute('hidden')).toBe(false);
+  });
+
+  it('roving skips a disabled section and the click is refused', async () => {
+    const user = userEvent.setup();
+    await mount({ disabledItems: ['b'] });
+    await user.click(trigger('b'));
+    expect(content('b').hasAttribute('hidden')).toBe(true);
+    trigger('a').focus();
+    await user.keyboard('{ArrowDown}');
+    expect(document.activeElement).toBe(trigger('c'));
+  });
+
+  it('a disabled accordion gates every section', async () => {
+    const user = userEvent.setup();
+    await mount({ disabled: true });
+    await user.click(trigger('a'));
+    expect(content('a').hasAttribute('hidden')).toBe(true);
+  });
+
+  it('disconnecting the element tears the binding down', async () => {
+    const user = userEvent.setup();
+    await mount();
+    const host = document.body.querySelector('rafters-accordion') as HTMLElement;
+    const headerA = trigger('a');
+    const panelA = content('a');
+    host.remove();
+    document.body.append(panelA, headerA);
+    await user.click(headerA);
+    expect(panelA.hasAttribute('hidden')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Ports `accordion` to the behavior layer as one score plus three decorators:
`accordion.behavior.ts` (score + `bindAccordion`), `accordion.classes.ts` (view),
and `accordion.tsx` / `accordion.element.ts` / `accordion.astro` (React, Web
Component, Astro), with behavior, classes, and three-framework conformance tests
plus `docs/spec/components/accordion.md`.

The score's only state axis is the SET of expanded values, held as reducer state
(`{ value, multiple, collapsible }`) over the single memory cell `createBehavior`
owns. Focus movement is not state: `createRovingFocus` is composed directly on
the vertical axis (ArrowUp/ArrowDown/Home/End) in both `bindAccordion` and the
React mount effect. `item`/`heading`/`trigger`/`content` are `many` parts
projected through `BehaviorSpec.instanceAria`, so the shared harness asserts
every rendered instance against the score generically.

**Two decisions worth reviewer attention.**

1. **selection-group and disclosure are not composed** (the issue named them).
   Both own a `createMemory` cell of their own -- `createSelectionGroup` returns
   `{ memory, ... }`, `createDisclosure` is a single boolean cell -- while
   `createBehavior` already owns THE memory cell for this component. Composing
   either would put one logical state in two cells with no reconciliation path,
   and `Slice` reducers are pure `(state, payload) => state` over that one cell.
   radio-group and toggle-group set the selection-as-reducer precedent
   (toggle-group's own commit records the same rejection); the `toggle` reducer
   here re-expresses `createSelectionGroup.toggle`'s exact semantics, the
   `collapsible` close-to-empty rule included. Reasoned out in full in
   `accordion.md` so nobody "fixes" it later by wiring in a second cell. Neither
   primitive is modified.

2. **Three decorators, not just `.tsx`.** The issue's deliverable line names only
   `accordion.tsx`, but Spec 05 mandates one behavior and three decorators, and
   every merged wave-3 port proves the mandate overrides the matrix "old tree"
   column: slider (matrix `react/wc`) shipped `.astro` anyway, collapsible
   (`react`) and toggle-group (`react/wc`) both shipped all three. Read as
   terseness, not a React-only carve-out.

`aria-controls` is projected while collapsed too -- panels are present-but-hidden
rather than unmounted, so the reference is never dangling and panel bodies stay
crawlable. That deliberately diverges from the `disclosable` slice's
`open && ids.content` guard, which exists for overlays whose content leaves the
DOM.

`pnpm --filter @rafters/ui test:unit` and `pnpm preflight` both exit 0.

Closes #1753

## Acceptance criteria mapping

### Component doc written

`docs/spec/components/accordion.md` follows the collapsible/dialog article shape:
composition (including why two named primitives are not composed), the
config/state/actions block, a parts-and-ARIA table covering all five parts, the
keyboard table with the score/primitive ownership split made explicit, the oracle
disposition table, motion intent, and the WCAG 2.1 AA obligations. It records the
reasoning for every divergence so a future reader does not have to reconstruct it
from the diff.

Evidence: packages/ui/docs/spec/components/accordion.md:39

### JSDoc intelligence tags present

The React decorator's `Accordion` doc block carries all four tags the registry
parses. `@cognitive-load` gives the five-dimension breakdown (decision 1,
information 1, interaction 1, disruption 0, learning 0) rather than a bare score;
`@attention-economics` names when the pattern stops paying (past roughly ten
sections the header list is itself the scanning cost); `@trust-building` covers
reversibility and content never leaving the document; `@accessibility` states the
heading/region wiring and the roving tab-order contract.

Evidence: packages/ui/src/components/accordion/accordion.tsx:88

### Exported from the package as the articles are

Accordion is reachable exactly as the merged articles are -- deep path imports
from `src/components/accordion/`, with the React surface exporting the named
components plus the shadcn-compatible namespaced `Accordion.Item` /
`Accordion.Trigger` / `Accordion.Content` and a default export. `src/index.ts`
carries no component re-exports for any ported component (dialog, navigation-menu,
toggle-group included), so adding one here would have broken the established
pattern rather than followed it. The namespaced surface is exercised by a
conformance test.

Evidence: packages/ui/src/components/accordion/accordion.tsx:344

### Behavior test (pure, no DOM)

`accordion.behavior.test.ts` drives the score with no DOM and no framework,
covering the seeding rules, all three `toggle` branches, the disabled gate, the
controlled-shadowing helpers, and both projections. It specifically pins the
REFERENCE IDENTITY of the refused single non-collapsible edit, because that
identity is what lets every decorator suppress the consumer callback with a plain
set comparison instead of a per-framework special case. It also asserts the
negative that arrow keys are not claimed by the keymap, which is the boundary
between the score and the composed primitive.

Evidence: packages/ui/test/components/accordion/accordion.behavior.test.ts:71

### Classes parity test

`accordion.classes.test.ts` asserts the class contract every performance paints
rather than restating the strings: the section rule, the header carrying `group`
so the chevron can key off the projected `data-state`, the panel clipping so it
can collapse to zero height, and padding living on the inner box. It also asserts
a negative -- that the dead radix-variable keyframes are absent -- so the
subtraction cannot silently regress back in.

Evidence: packages/ui/test/components/accordion/accordion.classes.test.ts:57

### Conformance test via the shared harness (aria + keymap against rendered DOM)

All three frameworks run the shared harness against real rendered DOM. React and
WC drive `assertAxeClean` plus the interaction paths; React additionally drives
`assertInstanceAriaFulfillment`, which reads `spec.instanceAria` and compares
every rendered instance to the score generically, so per-section ARIA cannot
drift from hand-written expectations. Astro renders through `AstroContainer` and
calls `bindAccordion` directly (the container does not run the `<script>`),
proving the SSR markup is correct before hydration. Keymap coverage is real DOM
too: Enter/Space toggle, arrows rove without expanding, disabled sections are
skipped.

Evidence: packages/ui/test/components/accordion/accordion.conformance.test.tsx:100

### shadcn drop-in parity where the component exists in shadcn

The React prop surface matches shadcn/Radix Accordion: `type`, `value`,
`defaultValue`, `onValueChange`, `collapsible`, `disabled`, plus per-item `value`
and `disabled`, with `onValueChange` reporting a string in single mode and an
array in multiple mode -- the oracle's exact emit shape. Both the flat named
exports and the namespaced `Accordion.Item` form are available, so existing call
sites move without edits. The rafters extension beyond that surface is
`headingLevel`, which generalizes the oracle's hard-coded `aria-level={3}`.

Evidence: packages/ui/src/components/accordion/accordion.behavior.ts:118

### `pnpm --filter @rafters/ui test:unit` green, `pnpm preflight` green

Both were run from the worktree before commit and exit 0. `test:unit` covers both
vitest configs: 393 files under the main config and 39 under the Astro config,
with the twelve accordion suites among them and no test skipped or weakened to
get there. Preflight runs lint, format, typecheck, and the workspace build; the
two formatting deviations oxfmt reported on first run were fixed by running the
formatter, not by relaxing a rule.

Evidence: packages/ui/package.json:8

## Not done

- **Vue** stays missing, as it does for every ported component -- there is no Vue
  decorator or render adapter in the repo yet.
- **No lab page.** Merged wave-3 ports (slider, collapsible, toggle-group) did not
  add one; `apps/lab` remains untouched here for the same reason.
- **`components.jsonl` and `test/matrix/component-line.test.ts` were not touched**
  because neither exists in this tree; the live matrix is
  `docs/spec/matrix/components.md`, and the accordion row there was updated per
  the issue's closing directive. No merged port has touched a matrix file at all,
  so this row update is ahead of, not behind, current practice.
- **No CHANGELOG entry.** The repo's rule ties CHANGELOG entries to CLI behavior
  changes, and no merged component port has added one.
- **Keyframed height animation** is not shipped. Motion is declared intent only
  (`overflow-hidden` plus a token-duration transition that yields to reduced
  motion); a real keyframed collapse waits on a content-height utility in the
  token system, exactly as collapsible left it.
- **Item-level `disabled` is not in the score.** The reducer sees only a value and
  cannot know which sections the author disabled, so it is expressed structurally
  by natively disabling that header button, which also drops it from the tab order
  and from roving. Only accordion-level `disabled` is a `canDispatch` gate.