### PR TITLE
feat(ui): port tabs to the behavior layer

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`tabs` ported to the behavior layer (#1799).** The imperative
+  `old/ui/tabs.controller.ts` and its four-file Astro surface are replaced by a
+  single score (`tabs.behavior.ts`): the active tab is reducer state
+  (`{ value }`), focus movement is the composed `roving-focus` primitive bound
+  to the tablist, and the `trigger`/`panel` many-parts cross-reference each
+  other through the score's `instanceAria` member. `bindTabs` is the DOM-native
+  client the WC and Astro performances share; React reads the projections
+  declaratively. Automatic activation (an arrow key moves focus AND activates)
+  and the roving cursor seeded to the active tab both carry over from the
+  oracle. `orientation` is new: the rail projects `aria-orientation` and roving
+  moves on the matching axis, defaulting to horizontal (see
+  `docs/spec/components/tabs.md` dispositions).
 - **`radio-group` ported to the behavior layer (#1787).** The imperative
   `old/ui/radio-group.controller.ts` + form-associated WC pair are replaced by a
   single score (`radio-group.behavior.ts`): selection is reducer state

--- a/packages/ui/docs/spec/components/tabs.md
+++ b/packages/ui/docs/spec/components/tabs.md
@@ -1,0 +1,165 @@
+# Component Spec — Tabs
+
+Status: DRAFT. Disclosure article. Ports the imperative
+`old/ui/tabs.controller.ts` onto the behavior layer: active-tab selection as
+reducer state, focus movement as the composed `roving-focus` primitive.
+
+Files (`src/components/tabs/`):
+
+```
+tabs.classes.ts   tabs.behavior.ts   tabs.tsx
+tabs.element.ts   tabs.astro
+```
+
+Tests mirror into `test/components/tabs/`: `.behavior.test.ts` (pure),
+`.classes.test.ts` (parity), `.conformance.test.tsx` (React),
+`.element.conformance.test.ts` (WC), `.astro.conformance.test.ts` (Astro).
+
+## Composition
+
+```
+tabs slice    state {value}, action activate, root + list + trigger + panel
+              parts, tablist/tab/tabpanel roles, orientation aria,
+              Enter/Space keymap, instanceAria for the two many parts
+```
+
+A single slice — no glue. The score's only state axis is which tab is active;
+focus movement across triggers is NOT state, it is ephemeral DOM state owned by
+the `roving-focus` primitive (mirroring radio-group and navigation-menu).
+
+Tabs use **automatic activation**: `startTabsRoving` passes roving-focus an
+`onNavigate` callback that activates whatever tab focus just landed on, so an
+arrow key moves and activates in one gesture. This is the oracle controller's
+behavior and the WAI-ARIA APG default for tab sets whose panels already live in
+the DOM. It is safe to fire on every move because `activate` is idempotent:
+re-activating the active tab returns the SAME state ref, so memory does not
+notify and a controlled consumer's callback does not re-fire.
+
+Controlled/uncontrolled per the ownership-of-truth boundary applied to a string
+(the same shape as radio-group/navigation-menu): `config.value` is the
+consumer's controlled value (passed fresh, never stored); `state.value` is
+intrinsic, seeded from `defaultValue`. Projections and the `onValueChange`
+callback read the EFFECTIVE value via `activeTab(state, config)`.
+
+## Config, state, actions
+
+```ts
+interface TabsConfig {
+  value?: string;        // controlled ('' = none active)
+  defaultValue?: string; // uncontrolled seed
+  orientation?: 'horizontal' | 'vertical'; // default 'horizontal'
+}
+interface TabsState { value: string | null }  // intrinsic only
+type TabsActions = { activate: string }       // tabs never deactivate
+```
+
+There is no `canDispatch` gate: unlike radio-group there is no group-level
+`disabled`, because a tab set with no reachable panel is not a meaningful
+state. Per-trigger `disabled` is handled in the bind/decorator (native
+`disabled` on the button, and roving-focus skips disabled items).
+
+## Parts and ARIA
+
+| Part | Presence | ARIA |
+| --- | --- | --- |
+| root | always | `data-orientation` |
+| list | always | `role="tablist"`, `aria-orientation` |
+| trigger | many | `role="tab"`, `aria-selected` (`'true'`/`'false'`), `aria-controls` (its panel's id), `data-state` (`active`/`inactive`) |
+| panel | many | `role="tabpanel"`, `aria-labelledby` (its trigger's id), `data-state`, `hidden` (absent while active) |
+
+`trigger` and `panel` are `many` parts that cross-reference each other by id, so
+they project through the score's `instanceAria(part, value, state, config, ids)`
+member (Spec 01) rather than bespoke sibling functions — the generic harness
+driver `assertInstanceAriaFulfillment` resolves each instance's sibling ids from
+the DOM and asserts the projection with no per-component wiring.
+
+`tabindex` is deliberately ABSENT from the trigger projection: roving-focus owns
+it as ephemeral DOM state, so it must not appear in a projection the conformance
+harness asserts against. The panel's `hidden` IS projected, as a boolean the
+harness asserts by presence — React writes `hidden=""` where the DOM-native
+binding writes `hidden="true"`.
+
+The trigger projection carries the resolved string `aria-selected: 'false'` in
+the common inactive case; the DOM binds apply it with `{ validate: false }` so
+aria-manager does not coerce the string `'false'` truthy (Gotcha #2).
+
+Ids are shared across the three performances through `tabsIds(baseId, value)`
+(`<base>-tab-<value>` / `<base>-panel-<value>`). React seeds `baseId` from
+`useId`, Astro from the author's `id` prop, and the DOM-native bind reads the
+resulting ids back off the markup rather than minting its own.
+
+## Keyboard
+
+- `keymap`: Enter/Space on a `trigger` -> `activate`. Declared for the pure
+  keymap contract; no performance wires a keydown for it, because the native
+  `<button data-part="trigger">` converts Enter/Space to a click (Spec 01
+  rule 5) and a second listener would race roving-focus and double-fire.
+- Arrow keys (per orientation) and Home/End are NOT claimed by the keymap —
+  roving-focus owns them for movement, and automatic activation rides its
+  `onNavigate`.
+- Roving binds to the `[role="tablist"]` element, never the root. Panels live
+  inside the root, so a root-level keydown listener would move tabs while focus
+  sits in panel content (asserted in the WC conformance suite).
+- Roving's `currentIndex` is seeded to the active tab's position, so Tab enters
+  the set at the tab whose panel is showing rather than always at the first.
+  Astro additionally renders that roving tabindex server-side, so keyboard order
+  is correct before any JS.
+- Panels carry `tabIndex={0}`: after choosing a tab, Tab moves from the trigger
+  into the panel, which is how a keyboard user reaches panel content.
+
+## Oracle dispositions (`src/old/ui/tabs.*`)
+
+| Oracle feature | Disposition |
+| --- | --- |
+| single-select, NOT collapsible (re-click keeps the tab active) | contract |
+| automatic activation: arrows move focus AND activate | contract |
+| roving bound to the tablist, not the root | contract |
+| roving `currentIndex` seeded to the active tab (`startIndex`) | contract — preserved here, unlike radio-group which dropped it |
+| click activates and focuses the clicked trigger | contract |
+| `aria-selected` / `data-state` reflection on triggers | contract |
+| panel `hidden` + `data-state` reflection; panels stay in the DOM | contract |
+| `aria-controls` / `aria-labelledby` trigger-panel cross-reference | contract |
+| focusable panels (`tabIndex=0`) | contract |
+| disabled triggers excluded from activation and skipped by roving | contract |
+| controlled/uncontrolled + `onValueChange` (React) | contract |
+| shadcn namespaced surface (`Tabs.List`/`Trigger`/`Content`) plus the named exports | contract |
+| Astro SSR roving tabindex (`tabindex={defaultChecked ? 0 : -1}`) | contract |
+| `createSelectionGroup` primitive for single-select state | framework-affordance — expressed instead as reducer state (`{ value }`), the behavior-layer equivalent, exactly as radio-group and navigation-menu express their selection. The score's projections are asserted against `createBehavior`'s memory, and `createSelectionGroup` owns a separate `createMemory` cell with no seam to inject as the score's store; composing it would create a second, invisible source of truth |
+| React context carrying only `baseId`, with the controller mounted through a callback ref | framework-affordance — replaced by the retained-mode controller (`createBehavior` + `useMemory`), so React reads the projections declaratively instead of letting an imperative controller write attributes React does not know about |
+| Astro multi-file surface (`tabs-list.astro` / `tabs-trigger.astro` / `tabs-content.astro`) with `<slot />` panel bodies | framework-affordance — collapsed into one props-driven `tabs.astro`, matching every merged Astro performance (radio-group, navigation-menu). Astro requires static slot names, so a per-value panel slot is not expressible; rich panel bodies belong to the React and WC performances |
+| Astro config attributes `data-rafters-tabs` / `data-tabs-id` / `data-default-value` | dropped — the bind reads its config from the part markup itself (`[data-part="list"]`'s `aria-orientation`, and the server-rendered `[data-state="active"]` trigger), so there is no parallel config channel to drift |
+| `TabsController.setValue(value)` and the exposed `controller.group` cell | dropped — the imperative escape hatch is replaced by the controlled `value` prop in React; the WC and Astro performances are uncontrolled by design, as with radio-group and toggle-group |
+| horizontal-only navigation | improved — `orientation` is a rafters extension over the oracle, projecting `aria-orientation` on the rail and switching roving to the vertical axis. The oracle hardcoded `'horizontal'` |
+| root classes applied in Astro only (`tabsRootClasses`), React root left unstyled | defect-do-not-port — `tabsClasses().root` is now painted by all three performances, so the layout does not depend on which framework rendered it |
+
+## Deltas from the oracle
+
+1. `orientation` is new: the rail projects `aria-orientation` and roving moves on
+   the matching axis. Default `'horizontal'` preserves oracle behavior exactly.
+2. The React root now paints the root classes the oracle applied only in Astro.
+3. Selection is reducer state read through `instanceAria`, not an imperative
+   `createTabs` controller writing attributes behind React's back.
+
+## WCAG 2.1 AA obligations
+
+- 1.3.1 / 4.1.2: `role="tablist"` with `aria-orientation`, per-trigger
+  `role="tab"` + `aria-selected` + `aria-controls`, and per-panel
+  `role="tabpanel"` + `aria-labelledby`, asserted against real DOM by the
+  harness in all three performances.
+- 2.1.1 Keyboard: arrows (per orientation) and Home/End move and activate;
+  Enter/Space activate the focused tab; disabled triggers are skipped.
+- 2.4.3 Focus Order: roving tabindex keeps exactly one trigger in the tab order,
+  seeded to the active tab; Tab then moves into the focusable panel.
+- 2.4.7 Focus Visible: token focus ring on both the trigger and the panel
+  (`focus-visible:ring-ring`).
+- 2.3.3 Animation from Interactions: the indicator-move transition is opted out
+  by `motion-reduce:transition-none`.
+- Inactive panels are `hidden`, so AT never reaches the content of a tab the
+  user did not choose.
+
+## Motion
+
+`indicator-move: transition, axis x` — the active pill travels along the rail's
+main axis as `data-state` swaps. Declared as intent only; duration and easing
+come from tokens (`transition-all duration-200`), and `motion-reduce` removes
+the transition entirely.

--- a/packages/ui/src/components/tabs/tabs.astro
+++ b/packages/ui/src/components/tabs/tabs.astro
@@ -1,0 +1,121 @@
+---
+/**
+ * Astro performance (controller) for tabs.
+ *
+ * Server-renders the full LIGHT-DOM markup with classes and the score's initial
+ * projection already applied, so the correct panel is showing and the set is
+ * accessible before any JS. The <script> then hands each server-rendered root
+ * to bindTabs -- the SAME DOM-native controller the Web Component uses. Astro
+ * imports the behavior binding like any other module; there is no astro-specific
+ * runtime.
+ *
+ * The projection is computed here from the same tabs.aria / tabsInstanceAria the
+ * React and WC controllers read -- one score, three performances, zero drift.
+ */
+import {
+  tabs,
+  tabsIds,
+  tabsInstanceAria,
+  type TabsConfig,
+  type TabsOrientation,
+  type TabsPart,
+} from './tabs.behavior';
+import { tabsClasses } from './tabs.classes';
+import type { PartIds } from '../../lib/contract';
+
+interface Tab {
+  value: string;
+  label: string;
+  /** Panel body. Props-driven, matching every merged Astro performance: Astro
+   *  requires static slot names, so a per-value slot is not expressible. */
+  content?: string;
+  disabled?: boolean;
+}
+
+interface Props {
+  id: string;
+  tabs: Tab[];
+  /** Which tab is active on first paint. */
+  value?: string;
+  orientation?: TabsOrientation;
+}
+
+const { id, tabs: items, value = '', orientation = 'horizontal' } = Astro.props;
+
+const config: TabsConfig = { defaultValue: value, orientation };
+const state = tabs.initialState(config);
+const classes = tabsClasses(config, state);
+
+const ids = {} as PartIds<TabsPart>;
+for (const part of Object.keys(tabs.parts) as TabsPart[]) {
+  ids[part] = `${id}-${part}`;
+}
+const rootAria = tabs.aria(state, config, ids);
+
+// The roving tabindex before JS: the active trigger is the single tab stop, so
+// keyboard order is already correct on the server-rendered page.
+const firstEnabled = items.find((item) => !item.disabled)?.value;
+const tabStop = items.some((item) => item.value === state.value) ? state.value : firstEnabled;
+---
+
+<div data-part="root" id={ids.root} class={classes.root} {...rootAria.root}>
+  <div data-part="list" id={ids.list} role="tablist" class={classes.list} {...rootAria.list}>
+    {
+      items.map((item) => {
+        const { triggerId, panelId } = tabsIds(id, item.value);
+        return (
+          <button
+            type="button"
+            role="tab"
+            id={triggerId}
+            data-part="trigger"
+            data-value={item.value}
+            disabled={item.disabled}
+            tabindex={item.value === tabStop ? 0 : -1}
+            class={classes.trigger}
+            {...tabsInstanceAria('trigger', item.value, state, config, {
+              trigger: triggerId,
+              panel: panelId,
+            })}
+          >
+            {item.label}
+          </button>
+        );
+      })
+    }
+  </div>
+  {
+    items.map((item) => {
+      const { triggerId, panelId } = tabsIds(id, item.value);
+      return (
+        <div
+          role="tabpanel"
+          id={panelId}
+          data-part="panel"
+          data-value={item.value}
+          tabindex="0"
+          class={classes.panel}
+          {...tabsInstanceAria('panel', item.value, state, config, {
+            trigger: triggerId,
+            panel: panelId,
+          })}
+        >
+          {item.content}
+        </div>
+      );
+    })
+  }
+</div>
+
+<script>
+  import { bindTabs } from './tabs.behavior';
+
+  // The <script> is bundled and runs once per page; bind every instance's
+  // server-rendered root. Same controller as the Web Component.
+  for (const root of document.querySelectorAll<HTMLElement>('[data-part="root"]')) {
+    if (!root.querySelector('[data-part="list"][role="tablist"]')) continue;
+    if (root.dataset['bound'] === 'true') continue;
+    root.dataset['bound'] = 'true';
+    bindTabs(root);
+  }
+</script>

--- a/packages/ui/src/components/tabs/tabs.behavior.ts
+++ b/packages/ui/src/components/tabs/tabs.behavior.ts
@@ -1,0 +1,297 @@
+import { compose, type Slice } from '../../lib/compose';
+import {
+  createBehavior,
+  type AriaAttrs,
+  type BehaviorSpec,
+  type InstanceIds,
+  type PartIds,
+} from '../../lib/contract';
+import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { createRovingFocus } from '../../primitives/roving-focus';
+
+/**
+ * Tabs: a list of triggers, exactly one active, each disclosing its panel.
+ * Ports the imperative old/ui/tabs.controller.ts wholesale.
+ *
+ * The score's only state axis is which tab is active. Focus movement across
+ * triggers is NOT state -- it is ephemeral DOM state owned by the roving-focus
+ * primitive (mirroring radio-group/navigation-menu). Tabs use AUTOMATIC
+ * activation: roving moves focus and the newly focused tab becomes active in
+ * the same gesture. That is the oracle controller's behavior and the WAI-ARIA
+ * APG default for tab sets whose panels are already in the DOM.
+ *
+ * Controlled/uncontrolled per the ownership-of-truth boundary applied to a
+ * string, the same shape as radio-group/navigation-menu: `config.value` is the
+ * consumer's controlled value (passed fresh, never stored); `state.value` is the
+ * intrinsic value seeded from `defaultValue`. Projections and the change
+ * callback read the EFFECTIVE value via `activeTab(state, config)`.
+ */
+export type TabsOrientation = 'horizontal' | 'vertical';
+
+export interface TabsConfig {
+  /** Controlled active tab: shadows the intrinsic state when present. '' = none. */
+  value?: string | undefined;
+  /** Uncontrolled seed for the intrinsic active tab. */
+  defaultValue?: string | undefined;
+  /** Arrow-key navigation axis. Default 'horizontal'. */
+  orientation?: TabsOrientation | undefined;
+}
+
+export interface TabsState {
+  /** Intrinsic active tab -- ignored while a controlled value is present. */
+  value: string | null;
+}
+
+export type TabsActions = {
+  /** Make a tab active (payload: the trigger's value). Tabs never deactivate. */
+  activate: string;
+};
+
+export type TabsPart = 'root' | 'list' | 'trigger' | 'panel';
+
+/** The effective active tab: a controlled value shadows intrinsic state. */
+export function activeTab(state: TabsState, config: TabsConfig): string | null {
+  if (config.value !== undefined) return config.value === '' ? null : config.value;
+  return state.value;
+}
+
+/** Whether a given tab value is the effective active one. */
+export function isTabActive(value: string, state: TabsState, config: TabsConfig): boolean {
+  return activeTab(state, config) === value;
+}
+
+export function orientationOf(config: TabsConfig): TabsOrientation {
+  return config.orientation ?? 'horizontal';
+}
+
+/**
+ * The id naming the three performances share, so a trigger's `aria-controls`
+ * and its panel's `aria-labelledby` always resolve to each other. React seeds
+ * `baseId` from `useId` and Astro from the author's `id` prop; the DOM-native
+ * bind reads the resulting ids back off the markup rather than minting its own
+ * (Spec 01: behaviors never generate ids). Sharing the naming here is what
+ * keeps the cross-reference identical across all three.
+ */
+export function tabsIds(baseId: string, value: string): { triggerId: string; panelId: string } {
+  return { triggerId: `${baseId}-tab-${value}`, panelId: `${baseId}-panel-${value}` };
+}
+
+const tabsSlice: Slice<TabsConfig, TabsState, TabsActions, TabsPart> = {
+  name: 'tabs',
+  parts: {
+    root: {},
+    list: { role: 'tablist' },
+    trigger: { role: 'tab', many: true },
+    // Panels stay in the DOM and toggle `hidden`: panel content must be
+    // SSR-stable and present before JS. Presence is constant; visibility is
+    // state, projected as the boolean `hidden` on the instance.
+    panel: { role: 'tabpanel', many: true },
+  },
+  initialState: (config) => {
+    const seed = config.value ?? config.defaultValue ?? '';
+    return { value: seed === '' ? null : seed };
+  },
+  actions: {
+    // Single mode, NOT collapsible: re-activating the active tab keeps it
+    // active. Returning the SAME state ref when unchanged means memory does not
+    // notify and a controlled consumer's callback does not re-fire -- the same
+    // idempotence radio-group's `select` earns, and what makes automatic
+    // activation safe to fire on every roving move.
+    activate: (state, value) => (state.value === value ? state : { value }),
+  },
+  aria: (_state, config) => ({
+    // The root is an unlabelled wrapper; orientation rides data-* so the view
+    // can key off it without the root claiming a role it does not have.
+    root: { 'data-orientation': orientationOf(config) },
+    list: { 'aria-orientation': orientationOf(config) },
+  }),
+  // Enter/Space on a trigger activate it. Declared for the pure keymap
+  // contract; the DOM binds rely on the native <button> converting Enter/Space
+  // to a click (wiring a keydown too would race roving-focus and double-fire).
+  // Arrow/Home/End are NOT claimed -- roving-focus owns them for movement, and
+  // automatic activation rides its onNavigate callback.
+  keymap: (event, _state, part) =>
+    part === 'trigger' && (event.key === 'Enter' || event.key === ' ') ? 'activate' : null,
+};
+
+/**
+ * Per-instance ARIA for the `many` parts (Spec 01: BehaviorSpec.instanceAria).
+ * `aria()` projects one AriaAttrs per part NAME; trigger/panel occur once per
+ * tab value, so their projections take the instance value and the instance's
+ * sibling ids (a trigger reads its panel's id; a panel reads its trigger's).
+ *
+ * `tabindex` is deliberately absent from the trigger projection: roving-focus
+ * owns it as ephemeral DOM state, so it must not appear in a projection the
+ * conformance harness asserts against. The panel's `hidden` IS projected, as a
+ * boolean the harness asserts by presence -- React writes `hidden=""` where the
+ * DOM-native bind writes `hidden="true"`.
+ */
+export function tabsInstanceAria(
+  part: TabsPart,
+  value: string,
+  state: TabsState,
+  config: TabsConfig,
+  ids: InstanceIds<TabsPart>,
+): AriaAttrs {
+  const active = isTabActive(value, state, config);
+  if (part === 'trigger') {
+    return {
+      'aria-selected': active ? 'true' : 'false',
+      'aria-controls': ids.panel ?? '',
+      'data-state': active ? 'active' : 'inactive',
+    };
+  }
+  if (part === 'panel') {
+    return {
+      'aria-labelledby': ids.trigger ?? '',
+      'data-state': active ? 'active' : 'inactive',
+      hidden: active ? undefined : true,
+    };
+  }
+  return {};
+}
+
+export const tabs: BehaviorSpec<TabsConfig, TabsState, TabsActions, TabsPart> = {
+  ...compose('tabs', tabsSlice),
+  instanceAria: tabsInstanceAria,
+};
+
+/** Triggers eligible for focus and activation (excludes disabled ones). */
+const TRIGGER_SELECTOR = '[data-part="trigger"][data-value]:not([disabled])';
+
+/**
+ * Compose the roving-focus primitive for a tab list. Both the DOM-native bind
+ * and the React performance call THIS, so automatic activation is written once.
+ *
+ * Two details are load-bearing, carried over from the oracle controller:
+ *   - roving binds to the `[role="tablist"]` element, never the root. Panels
+ *     live inside the root, so a root-level keydown listener would move tabs
+ *     while focus sits in panel content.
+ *   - `currentIndex` is seeded to the active tab's position, so Tab enters the
+ *     set at the tab whose panel is showing rather than always at the first.
+ */
+export function startTabsRoving(
+  list: HTMLElement | null,
+  orientation: TabsOrientation,
+  currentValue: string | null,
+  onActivate: (value: string) => void,
+): () => void {
+  if (!list) return () => {};
+  const triggers = Array.from(list.querySelectorAll<HTMLElement>(TRIGGER_SELECTOR));
+  const currentIndex = Math.max(
+    0,
+    triggers.findIndex((trigger) => trigger.dataset['value'] === currentValue),
+  );
+  return createRovingFocus(list, {
+    orientation,
+    currentIndex,
+    // Automatic activation: moving focus activates the newly focused tab.
+    onNavigate: (element) => {
+      const value = element.dataset['value'];
+      if (value !== undefined) onActivate(value);
+    },
+  });
+}
+
+/**
+ * The DOM-native binding of the tabs score -- the client. The Web Component and
+ * the Astro <script> both import THIS; only React (retained-mode) reads the
+ * projections above declaratively instead. Composes the substrate the same way
+ * the React controller does: createBehavior is the model, startTabsRoving
+ * composes roving-focus, aria-manager applies the projection, and the DOM is
+ * the part registry.
+ */
+export function bindTabs(root: HTMLElement): () => void {
+  const getPart = (part: string): HTMLElement | null =>
+    part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
+
+  const list = getPart('list');
+  const config: TabsConfig = {
+    orientation: list?.getAttribute('aria-orientation') === 'vertical' ? 'vertical' : 'horizontal',
+    // Seed the intrinsic value from the server-rendered active trigger. WC and
+    // Astro are uncontrolled (no reactive prop), so config.value stays undefined.
+    defaultValue:
+      root.querySelector<HTMLElement>('[data-part="trigger"][data-state="active"]')?.dataset[
+        'value'
+      ] ?? '',
+  };
+
+  const { memory, dispatch } = createBehavior(tabs, config);
+  const request = (value: string): boolean => dispatch('activate', config, value);
+
+  // ids are READ from the markup (server- or author-minted), never generated.
+  const ids = {} as PartIds<TabsPart>;
+  for (const part of Object.keys(tabs.parts) as TabsPart[]) {
+    ids[part] = getPart(part)?.id ?? '';
+  }
+
+  // The score's projection is already resolved (final strings, undefined =
+  // absent), so apply it raw: validate:false skips aria-manager's author-input
+  // coercion, which would re-read the resolved string 'false' as truthy.
+  const applyProjection = (el: HTMLElement, attrs: AriaAttrs) => {
+    for (const [name, value] of Object.entries(attrs)) {
+      updateAriaAttribute(el, name as never, value as never, { validate: false });
+    }
+  };
+
+  // The `many` parts, resolved from the score's own declaration -- no hardcoded
+  // trigger/panel list, so this loop matches the generic harness driver.
+  const manyParts = (Object.keys(tabs.parts) as TabsPart[]).filter((part) => tabs.parts[part].many);
+
+  const projectInstances = (state: TabsState) => {
+    for (const part of manyParts) {
+      for (const el of root.querySelectorAll<HTMLElement>(`[data-part="${part}"]`)) {
+        const value = el.dataset['value'];
+        if (value === undefined) continue;
+        const instanceIds: InstanceIds<TabsPart> = {};
+        for (const sibling of manyParts) {
+          instanceIds[sibling] =
+            root.querySelector<HTMLElement>(`[data-part="${sibling}"][data-value="${value}"]`)
+              ?.id ?? '';
+        }
+        applyProjection(el, tabsInstanceAria(part, value, state, config, instanceIds));
+      }
+    }
+  };
+
+  const render = () => {
+    const state = memory.get();
+    const projection = tabs.aria(state, config, ids);
+    for (const part of Object.keys(projection) as TabsPart[]) {
+      const attrs = projection[part];
+      const el = getPart(part);
+      if (el && attrs) applyProjection(el, attrs);
+    }
+    projectInstances(state);
+  };
+  const unsubscribe = memory.subscribe(render); // fires immediately: first paint
+
+  const stopRoving = startTabsRoving(
+    list,
+    orientationOf(config),
+    activeTab(memory.get(), config),
+    (value) => {
+      request(value);
+    },
+  );
+
+  // Click activation. Native <button> triggers turn Enter/Space into a click,
+  // which is how the score's Enter/Space keymap is fulfilled without a second
+  // keydown listener racing roving-focus. Focusing the clicked trigger keeps
+  // the roving tabstop on the tab the user just chose (oracle parity).
+  const onClick = (event: Event) => {
+    const trigger = (event.target as HTMLElement).closest<HTMLElement>(TRIGGER_SELECTOR);
+    if (!trigger || !root.contains(trigger)) return;
+    const value = trigger.dataset['value'];
+    if (value === undefined) return;
+    request(value);
+    trigger.focus();
+  };
+  root.addEventListener('click', onClick);
+
+  return () => {
+    unsubscribe();
+    stopRoving();
+    root.removeEventListener('click', onClick);
+  };
+}

--- a/packages/ui/src/components/tabs/tabs.classes.ts
+++ b/packages/ui/src/components/tabs/tabs.classes.ts
@@ -1,0 +1,53 @@
+import type { TabsConfig, TabsState } from './tabs.behavior';
+
+export interface TabsClassSet {
+  /** The wrapper: stacks the list above its panels (or beside, when vertical). */
+  root: string;
+  /** The [role="tablist"] rail. */
+  list: string;
+  /** Each [role="tab"] trigger, including its data-state styling. */
+  trigger: string;
+  /** Each [role="tabpanel"]: focusable, so it carries a focus ring. */
+  panel: string;
+}
+
+const rootHorizontalClasses = 'flex flex-col gap-2';
+const rootVerticalClasses = 'flex flex-row gap-2';
+
+const listBaseClasses =
+  'inline-flex items-center justify-center rounded-md bg-muted p-1 text-muted-foreground';
+const listHorizontalClasses = 'h-10';
+const listVerticalClasses = 'h-auto flex-col';
+
+const triggerBaseClasses = [
+  'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5',
+  'text-label-medium ring-offset-background cursor-pointer',
+  // Motion intent indicator-move: the active pill travels along the rail's main
+  // axis. Duration and easing come from tokens; motion-reduce opts out entirely.
+  'transition-all duration-200 motion-reduce:transition-none',
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+  'disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none',
+].join(' ');
+
+// State-driven styling: the score projects data-state onto every trigger, so
+// one class string serves all three performances with no conditional applying.
+const triggerStateClasses = [
+  'data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+  'data-[state=inactive]:text-muted-foreground hover:bg-muted hover:text-foreground',
+].join(' ');
+
+const panelClasses = [
+  'ring-offset-background',
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+].join(' ');
+
+/** The view: class strings keyed by config/state. No logic. */
+export function tabsClasses(config: TabsConfig, _state: TabsState): TabsClassSet {
+  const vertical = config.orientation === 'vertical';
+  return {
+    root: vertical ? rootVerticalClasses : rootHorizontalClasses,
+    list: `${listBaseClasses} ${vertical ? listVerticalClasses : listHorizontalClasses}`,
+    trigger: `${triggerBaseClasses} ${triggerStateClasses}`,
+    panel: panelClasses,
+  };
+}

--- a/packages/ui/src/components/tabs/tabs.element.ts
+++ b/packages/ui/src/components/tabs/tabs.element.ts
@@ -1,0 +1,36 @@
+/**
+ * WC performance for tabs: the thinnest wrapper. The score AND the DOM-native
+ * binding (bindTabs) live in tabs.behavior.ts, shared with the Astro
+ * performance. This file only adapts that binding to the custom-element
+ * lifecycle.
+ *
+ * A light-DOM enhancer: the author (or Astro) provides the real
+ * `<div data-part="root">` with a `[data-part="list"][role="tablist"]` of
+ * `<button data-part="trigger">`s and `[data-part="panel"]` panels, so native
+ * focus and the roving-focus primitive operate on real document DOM -- the WC
+ * never renders a shadow tree of its own. The bind is deferred one microtask
+ * because connectedCallback can fire before the light-DOM children are parsed
+ * (upgrade order).
+ */
+import { bindTabs } from './tabs.behavior';
+
+export class RaftersTabs extends HTMLElement {
+  private teardown: (() => void) | null = null;
+
+  connectedCallback(): void {
+    queueMicrotask(() => {
+      if (!this.isConnected || this.teardown) return;
+      const root = this.querySelector<HTMLElement>('[data-part="root"]');
+      if (root) this.teardown = bindTabs(root);
+    });
+  }
+
+  disconnectedCallback(): void {
+    this.teardown?.();
+    this.teardown = null;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-tabs')) {
+  customElements.define('rafters-tabs', RaftersTabs);
+}

--- a/packages/ui/src/components/tabs/tabs.tsx
+++ b/packages/ui/src/components/tabs/tabs.tsx
@@ -1,0 +1,265 @@
+import * as React from 'react';
+import { useMemory } from '../../hooks/use-memory';
+import { createBehavior, type AriaAttrs, type PartIds } from '../../lib/contract';
+import classy from '../../primitives/classy';
+import {
+  activeTab,
+  startTabsRoving,
+  tabs,
+  tabsIds,
+  tabsInstanceAria,
+  type TabsConfig,
+  type TabsOrientation,
+  type TabsPart,
+  type TabsState,
+} from './tabs.behavior';
+import { tabsClasses, type TabsClassSet } from './tabs.classes';
+
+interface TabsContextValue {
+  state: TabsState;
+  config: TabsConfig;
+  classes: TabsClassSet;
+  /** The root's part projection, computed once so children never re-project. */
+  aria: Partial<Record<TabsPart, AriaAttrs>>;
+  baseId: string;
+  request: (value: string) => boolean;
+}
+
+const TabsContext = React.createContext<TabsContextValue | null>(null);
+
+function useTabsContext(component: string): TabsContextValue {
+  const context = React.useContext(TabsContext);
+  if (!context) {
+    throw new Error(`${component} must be used within <Tabs>`);
+  }
+  return context;
+}
+
+export interface TabsProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Controlled active tab. */
+  value?: string;
+  /** Default active tab for uncontrolled usage. */
+  defaultValue?: string;
+  /** Callback when the active tab changes via user interaction. */
+  onValueChange?: (value: string) => void;
+  /** Layout / arrow-navigation axis. Default 'horizontal'. */
+  orientation?: TabsOrientation;
+}
+
+/**
+ * Tabbed panels. One panel shows at a time; arrow keys move focus across the
+ * triggers and activate as they go (automatic activation), Home/End jump to the
+ * ends, and Tab enters the set at the tab whose panel is showing.
+ *
+ * @cognitive-load 4/10 - decision 1, information 1, interaction 1, disruption 1,
+ * learning 0. One decision (which view to see) over a small visible set, but the
+ * non-selected content is hidden, so the user must remember what lives behind
+ * each label -- the recall cost a radio group does not charge. A universally
+ * learned affordance; switching costs one click and is fully reversible.
+ * @attention-economics Content organization: the visible panel is the current
+ * context, the other labels advertise available contexts, and the active pill
+ * marks where the user is. Tabs buy screen real estate by hiding siblings, so
+ * the labels must carry the whole scent of what they conceal; past roughly
+ * seven tabs the labels stop being scannable and the budget is overdrawn.
+ * @trust-building The active tab is always unambiguous (aria-selected plus the
+ * data-state pill), selection persists while the user works inside a panel, and
+ * navigation is predictable: arrows never skip, never wrap unexpectedly, and
+ * never lose the panel the user was reading without showing them the new one.
+ * @accessibility role="tablist" with aria-orientation on the rail, role="tab"
+ * with aria-selected and aria-controls on every trigger, and role="tabpanel"
+ * with aria-labelledby on every panel, all wired to real DOM by the harness.
+ * Roving tabindex keeps exactly one trigger in the tab order; inactive panels
+ * are `hidden` so AT never reaches stale content; panels are focusable so
+ * keyboard users reach panel content directly after choosing a tab.
+ */
+export function Tabs({
+  value,
+  defaultValue = '',
+  onValueChange,
+  orientation = 'horizontal',
+  className,
+  children,
+  ...props
+}: TabsProps) {
+  const config: TabsConfig = { value, defaultValue, orientation };
+
+  // The controller composes the score with the substrate -- no useBehavior.
+  // createBehavior is the model; useMemory subscribes React to it; a useEffect
+  // below composes the roving-focus primitive directly against the tab list.
+  const { memory, dispatch } = React.useMemo(() => createBehavior(tabs, config), []);
+  const state = useMemory(memory);
+
+  const uid = React.useId();
+  const ids = React.useMemo(() => {
+    const out = {} as PartIds<TabsPart>;
+    for (const part of Object.keys(tabs.parts) as TabsPart[]) {
+      out[part] = `${uid}-${part}`;
+    }
+    return out;
+  }, [uid]);
+
+  const rootRef = React.useRef<HTMLDivElement>(null);
+
+  // Gotcha #1: the controlled callback compares the EFFECTIVE value before
+  // against the INTRINSIC value after the reducer -- a controlled set's
+  // effective value never moves (config shadows it), but the callback must
+  // still report the value to set. `activate` is idempotent, so the repeated
+  // dispatches automatic activation produces never re-fire the callback.
+  const latest = React.useRef({ config, onValueChange });
+  latest.current = { config, onValueChange };
+  const request = React.useCallback(
+    (nextValue: string): boolean => {
+      const { config: cfg, onValueChange: cb } = latest.current;
+      const before = activeTab(memory.get(), cfg) ?? '';
+      if (!dispatch('activate', cfg, nextValue)) return false;
+      const after = memory.get().value ?? '';
+      if (after !== before) cb?.(after);
+      return true;
+    },
+    [memory, dispatch],
+  );
+
+  // Compose roving-focus against the TAB LIST, not the root: panels live inside
+  // the root, so a root-level listener would move tabs while focus sits in
+  // panel content. startTabsRoving is the same composition bindTabs calls, so
+  // automatic activation cannot drift between the retained and DOM-native
+  // performances. Deliberately not re-run on state change -- that would reset
+  // the roving cursor mid-navigation.
+  React.useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    return startTabsRoving(
+      root.querySelector<HTMLElement>('[data-part="list"]'),
+      orientation,
+      activeTab(memory.get(), latest.current.config),
+      request,
+    );
+  }, [orientation, memory, request]);
+
+  const aria = tabs.aria(state, config, ids);
+  const classes = tabsClasses(config, state);
+
+  const contextValue: TabsContextValue = { state, config, classes, aria, baseId: uid, request };
+
+  return (
+    <TabsContext.Provider value={contextValue}>
+      <div
+        ref={rootRef}
+        data-part="root"
+        id={ids.root}
+        className={classy(classes.root, className)}
+        {...aria.root}
+        {...props}
+      >
+        {children}
+      </div>
+    </TabsContext.Provider>
+  );
+}
+
+Tabs.displayName = 'Tabs';
+
+export type TabsListProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function TabsList({ className, children, ...props }: TabsListProps) {
+  // Keyboard navigation is owned by the composed roving-focus primitive; this
+  // part is the rail it acts on, so the decorator contributes markup only.
+  const { classes, aria } = useTabsContext('TabsList');
+
+  return (
+    <div
+      data-part="list"
+      role="tablist"
+      className={classy(classes.list, className)}
+      {...aria.list}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+TabsList.displayName = 'TabsList';
+
+export interface TabsTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Value that identifies this tab. */
+  value: string;
+}
+
+export function TabsTrigger({
+  value,
+  className,
+  children,
+  disabled,
+  onClick,
+  ...props
+}: TabsTriggerProps) {
+  const { state, config, classes, baseId, request } = useTabsContext('TabsTrigger');
+  const { triggerId, panelId } = tabsIds(baseId, value);
+  const aria = tabsInstanceAria('trigger', value, state, config, {
+    trigger: triggerId,
+    panel: panelId,
+  });
+
+  return (
+    <button
+      type="button"
+      role="tab"
+      data-part="trigger"
+      data-value={value}
+      id={triggerId}
+      disabled={disabled}
+      className={classy(classes.trigger, className)}
+      {...aria}
+      onClick={(event) => {
+        onClick?.(event);
+        if (event.defaultPrevented) return;
+        request(value);
+      }}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+TabsTrigger.displayName = 'TabsTrigger';
+
+export interface TabsContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Value that identifies the tab this panel belongs to. */
+  value: string;
+}
+
+export function TabsContent({ value, className, children, ...props }: TabsContentProps) {
+  const { state, config, classes, baseId } = useTabsContext('TabsContent');
+  const { triggerId, panelId } = tabsIds(baseId, value);
+  const aria = tabsInstanceAria('panel', value, state, config, {
+    trigger: triggerId,
+    panel: panelId,
+  });
+
+  return (
+    <div
+      role="tabpanel"
+      data-part="panel"
+      data-value={value}
+      id={panelId}
+      // biome-ignore lint/a11y/noNoninteractiveTabindex: tabpanels are focusable per the WAI-ARIA authoring practices
+      tabIndex={0}
+      className={classy(classes.panel, className)}
+      {...aria}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+TabsContent.displayName = 'TabsContent';
+
+// shadcn-compatible namespaced surface, preserved from the oracle.
+Tabs.List = TabsList;
+Tabs.Trigger = TabsTrigger;
+Tabs.Content = TabsContent;
+
+export default Tabs;

--- a/packages/ui/test/components/tabs/tabs.astro.conformance.test.ts
+++ b/packages/ui/test/components/tabs/tabs.astro.conformance.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Astro performance of the tabs score, driven end to end. AstroContainer renders
+ * the SSR markup with the initial projection already applied, but does NOT run
+ * the <script>, so the test calls bindTabs directly -- that IS the script's job
+ * -- then drives the same score the React and WC performances drive. One score,
+ * three performances.
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import Tabs from '../../../src/components/tabs/tabs.astro';
+import { bindTabs } from '../../../src/components/tabs/tabs.behavior';
+
+const items = [
+  { value: 'overview', label: 'Overview', content: 'Overview panel' },
+  { value: 'details', label: 'Details', content: 'Details panel' },
+  { value: 'history', label: 'History', content: 'History panel' },
+];
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+async function mount(props: Record<string, unknown> = {}): Promise<HTMLElement> {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Tabs, {
+    props: { id: 'demo', tabs: items, value: 'overview', ...props },
+  });
+  document.body.innerHTML = html;
+  const root = document.body.querySelector('[data-part="root"]') as HTMLElement;
+  bindTabs(root); // the <script> does this per instance on the real page
+  return root;
+}
+
+const trigger = (value: string) =>
+  document.body.querySelector<HTMLElement>(`[data-part="trigger"][data-value="${value}"]`)!;
+const panel = (value: string) =>
+  document.body.querySelector<HTMLElement>(`[data-part="panel"][data-value="${value}"]`)!;
+
+describe('tabs conformance [astro]', () => {
+  it('SSR: tablist + tabs + tabpanels with the seeded tab active', async () => {
+    await mount({ value: 'details' });
+    const list = document.body.querySelector('[data-part="list"]');
+    expect(list?.getAttribute('role')).toBe('tablist');
+    expect(list?.getAttribute('aria-orientation')).toBe('horizontal');
+    expect(trigger('details').getAttribute('role')).toBe('tab');
+    expect(trigger('details').getAttribute('aria-selected')).toBe('true');
+    expect(trigger('details').getAttribute('data-state')).toBe('active');
+    expect(panel('details').getAttribute('role')).toBe('tabpanel');
+    expect(panel('details').hasAttribute('hidden')).toBe(false);
+    expect(panel('overview').hasAttribute('hidden')).toBe(true);
+  });
+
+  it('SSR: the trigger and its panel cross-reference each other by id', async () => {
+    await mount();
+    expect(trigger('overview').getAttribute('aria-controls')).toBe('demo-panel-overview');
+    expect(panel('overview').getAttribute('aria-labelledby')).toBe('demo-tab-overview');
+    expect(panel('overview').id).toBe('demo-panel-overview');
+  });
+
+  it('SSR: the active tab is the single tab stop before any JS runs', async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(Tabs, {
+      props: { id: 'demo', tabs: items, value: 'history' },
+    });
+    document.body.innerHTML = html;
+    expect(trigger('history').getAttribute('tabindex')).toBe('0');
+    expect(trigger('overview').getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('click activates a tab and swaps the visible panel', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger('history'));
+    expect(trigger('history').getAttribute('aria-selected')).toBe('true');
+    expect(trigger('history').getAttribute('data-state')).toBe('active');
+    expect(panel('history').hasAttribute('hidden')).toBe(false);
+    expect(panel('overview').hasAttribute('hidden')).toBe(true);
+  });
+
+  it('arrow keys move focus AND activate the newly focused tab', async () => {
+    const user = userEvent.setup();
+    await mount();
+    trigger('overview').focus();
+    await user.keyboard('{ArrowRight}');
+    expect(document.activeElement).toBe(trigger('details'));
+    expect(trigger('details').getAttribute('aria-selected')).toBe('true');
+    expect(panel('details').hasAttribute('hidden')).toBe(false);
+  });
+
+  it('Space activates the focused tab via the native button', async () => {
+    const user = userEvent.setup();
+    await mount();
+    trigger('history').focus();
+    await user.keyboard(' ');
+    expect(trigger('history').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('a vertical axis reflects aria-orientation and moves with up/down arrows', async () => {
+    const user = userEvent.setup();
+    await mount({ orientation: 'vertical' });
+    expect(
+      document.body.querySelector('[data-part="list"]')?.getAttribute('aria-orientation'),
+    ).toBe('vertical');
+    trigger('overview').focus();
+    await user.keyboard('{ArrowDown}');
+    expect(trigger('details').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('a disabled tab is skipped by roving', async () => {
+    const user = userEvent.setup();
+    await mount({
+      tabs: [items[0], { ...items[1], disabled: true }, items[2]],
+    });
+    expect(trigger('details').hasAttribute('disabled')).toBe(true);
+    trigger('overview').focus();
+    await user.keyboard('{ArrowRight}');
+    expect(trigger('history').getAttribute('aria-selected')).toBe('true');
+  });
+});

--- a/packages/ui/test/components/tabs/tabs.behavior.test.ts
+++ b/packages/ui/test/components/tabs/tabs.behavior.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Pure behavior test for the tabs score. No DOM: exercises reducers, the
+ * aria/keymap projections, and the per-instance tabsInstanceAria projection
+ * directly. Roving-focus behavior (arrow/Home/End movement and the automatic
+ * activation that rides its onNavigate) is asserted end to end in the three
+ * conformance suites, which drive the real DOM the primitive operates on.
+ */
+import { describe, expect, it } from 'vitest';
+import { createBehavior } from '../../../src/lib/contract';
+import {
+  activeTab,
+  isTabActive,
+  orientationOf,
+  tabs,
+  tabsIds,
+  tabsInstanceAria,
+  type TabsConfig,
+  type TabsState,
+} from '../../../src/components/tabs/tabs.behavior';
+
+const base: TabsConfig = {};
+const ids = { root: 'r', list: 'r-list', trigger: 'r-trigger', panel: 'r-panel' };
+
+describe('tabs initialState', () => {
+  it('seeds from defaultValue', () => {
+    expect(tabs.initialState({ defaultValue: 'details' })).toEqual({ value: 'details' });
+  });
+
+  it('seeds from a controlled value', () => {
+    expect(tabs.initialState({ value: 'overview' })).toEqual({ value: 'overview' });
+  });
+
+  it("treats '' and absence as no active tab", () => {
+    expect(tabs.initialState({ defaultValue: '' })).toEqual({ value: null });
+    expect(tabs.initialState({})).toEqual({ value: null });
+  });
+});
+
+describe('tabs activeTab (controlled shadows intrinsic)', () => {
+  it('reads intrinsic state when uncontrolled', () => {
+    expect(activeTab({ value: 'a' }, {})).toBe('a');
+  });
+
+  it('a controlled value shadows the intrinsic state', () => {
+    expect(activeTab({ value: 'a' }, { value: 'b' })).toBe('b');
+  });
+
+  it("a controlled '' reads as no active tab", () => {
+    expect(activeTab({ value: 'a' }, { value: '' })).toBeNull();
+  });
+
+  it('isTabActive reports the effective value, not the intrinsic one', () => {
+    expect(isTabActive('b', { value: 'a' }, { value: 'b' })).toBe(true);
+    expect(isTabActive('a', { value: 'a' }, { value: 'b' })).toBe(false);
+  });
+});
+
+describe('tabs orientation', () => {
+  it('defaults to horizontal', () => {
+    expect(orientationOf({})).toBe('horizontal');
+  });
+
+  it('honors an explicit vertical axis', () => {
+    expect(orientationOf({ orientation: 'vertical' })).toBe('vertical');
+  });
+});
+
+describe('tabs activate action', () => {
+  it('activate switches the active tab', () => {
+    const { memory, dispatch } = createBehavior(tabs, base);
+    expect(dispatch('activate', base, 'details')).toBe(true);
+    expect(memory.get().value).toBe('details');
+  });
+
+  it('re-activating the active tab keeps the same state ref (no notify, no re-fire)', () => {
+    const config: TabsConfig = { defaultValue: 'overview' };
+    const { memory, dispatch } = createBehavior(tabs, config);
+    const before = memory.get();
+    dispatch('activate', config, 'overview');
+    // Same reference -> memory does not notify. This is what makes automatic
+    // activation safe: roving fires onNavigate on every move, including moves
+    // that land back on the already-active tab.
+    expect(memory.get()).toBe(before);
+    expect(memory.get().value).toBe('overview');
+  });
+
+  it('tabs never deactivate: there is no action that clears the value', () => {
+    expect(Object.keys(tabs.actions)).toEqual(['activate']);
+  });
+});
+
+describe('tabs aria projection', () => {
+  it('projects the default horizontal axis onto the root and the list', () => {
+    const state = tabs.initialState(base);
+    const projection = tabs.aria(state, base, ids);
+    expect(projection.root).toEqual({ 'data-orientation': 'horizontal' });
+    expect(projection.list).toEqual({ 'aria-orientation': 'horizontal' });
+  });
+
+  it('reflects a vertical axis', () => {
+    const config: TabsConfig = { orientation: 'vertical' };
+    const projection = tabs.aria(tabs.initialState(config), config, ids);
+    expect(projection.root?.['data-orientation']).toBe('vertical');
+    expect(projection.list?.['aria-orientation']).toBe('vertical');
+  });
+
+  it('declares tablist/tab/tabpanel roles and the two many parts', () => {
+    expect(tabs.parts.list.role).toBe('tablist');
+    expect(tabs.parts.trigger).toEqual({ role: 'tab', many: true });
+    expect(tabs.parts.panel).toEqual({ role: 'tabpanel', many: true });
+  });
+});
+
+describe('tabs instance projection (tabsInstanceAria)', () => {
+  const config: TabsConfig = { defaultValue: 'overview' };
+  const state = tabs.initialState(config);
+  const instanceIds = { trigger: 't', panel: 'p' };
+
+  it('the active trigger is selected and controls its panel', () => {
+    expect(tabsInstanceAria('trigger', 'overview', state, config, instanceIds)).toEqual({
+      'aria-selected': 'true',
+      'aria-controls': 'p',
+      'data-state': 'active',
+    });
+  });
+
+  it('an inactive trigger still advertises the panel it controls', () => {
+    expect(tabsInstanceAria('trigger', 'details', state, config, instanceIds)).toEqual({
+      'aria-selected': 'false',
+      'aria-controls': 'p',
+      'data-state': 'inactive',
+    });
+  });
+
+  it('the active panel is labelled by its tab and NOT hidden', () => {
+    expect(tabsInstanceAria('panel', 'overview', state, config, instanceIds)).toEqual({
+      'aria-labelledby': 't',
+      'data-state': 'active',
+      hidden: undefined,
+    });
+  });
+
+  it('an inactive panel is hidden', () => {
+    expect(tabsInstanceAria('panel', 'details', state, config, instanceIds).hidden).toBe(true);
+  });
+
+  it('carries no tabindex on the trigger (roving owns it as ephemeral DOM state)', () => {
+    expect(tabsInstanceAria('trigger', 'overview', state, config, instanceIds)).not.toHaveProperty(
+      'tabindex',
+    );
+  });
+
+  it('a controlled value drives which instance is active', () => {
+    const controlled: TabsConfig = { value: 'details' };
+    expect(
+      tabsInstanceAria('trigger', 'details', { value: 'overview' }, controlled, instanceIds)[
+        'aria-selected'
+      ],
+    ).toBe('true');
+  });
+
+  it('projects nothing for the single parts', () => {
+    expect(tabsInstanceAria('root', 'overview', state, config, instanceIds)).toEqual({});
+    expect(tabsInstanceAria('list', 'overview', state, config, instanceIds)).toEqual({});
+  });
+
+  it('is wired onto the spec so the generic harness driver finds it', () => {
+    expect(tabs.instanceAria).toBe(tabsInstanceAria);
+  });
+});
+
+describe('tabs id naming (shared by all three performances)', () => {
+  it('derives a trigger/panel pair that cross-reference each other', () => {
+    expect(tabsIds('demo', 'overview')).toEqual({
+      triggerId: 'demo-tab-overview',
+      panelId: 'demo-panel-overview',
+    });
+  });
+});
+
+describe('tabs keymap', () => {
+  const state: TabsState = { value: null };
+
+  it('Enter and Space on a trigger map to activate', () => {
+    expect(tabs.keymap({ key: 'Enter' }, state, 'trigger', base)).toBe('activate');
+    expect(tabs.keymap({ key: ' ' }, state, 'trigger', base)).toBe('activate');
+  });
+
+  it('does not claim arrows or Home/End: roving-focus owns movement', () => {
+    for (const key of ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End']) {
+      expect(tabs.keymap({ key }, state, 'trigger', base)).toBeNull();
+    }
+  });
+
+  it('does not claim activation on the list, panel, or root', () => {
+    expect(tabs.keymap({ key: 'Enter' }, state, 'list', base)).toBeNull();
+    expect(tabs.keymap({ key: 'Enter' }, state, 'panel', base)).toBeNull();
+    expect(tabs.keymap({ key: 'Enter' }, state, 'root', base)).toBeNull();
+  });
+});

--- a/packages/ui/test/components/tabs/tabs.classes.test.ts
+++ b/packages/ui/test/components/tabs/tabs.classes.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Classes parity test: the view is pure class strings keyed by config/state.
+ * Asserts orientation drives the root and rail layout, the trigger carries the
+ * data-state contract both the pill styling and the motion intent hang off, and
+ * the panel carries a focus ring because it is focusable -- the same class
+ * contract all three performances paint.
+ */
+import { describe, expect, it } from 'vitest';
+import { tabs, type TabsConfig } from '../../../src/components/tabs/tabs.behavior';
+import { tabsClasses } from '../../../src/components/tabs/tabs.classes';
+
+function classesFor(config: TabsConfig) {
+  return tabsClasses(config, tabs.initialState(config));
+}
+
+describe('tabs classes', () => {
+  it('the default (no orientation) stacks the rail above the panels', () => {
+    expect(classesFor({}).root).toBe('flex flex-col gap-2');
+  });
+
+  it('horizontal orientation stacks the rail above the panels', () => {
+    expect(classesFor({ orientation: 'horizontal' }).root).toBe('flex flex-col gap-2');
+  });
+
+  it('vertical orientation puts the rail beside the panels', () => {
+    expect(classesFor({ orientation: 'vertical' }).root).toBe('flex flex-row gap-2');
+  });
+
+  it('the rail is a fixed-height row when horizontal and a column when vertical', () => {
+    expect(classesFor({}).list).toContain('h-10');
+    expect(classesFor({}).list).not.toContain('flex-col');
+    expect(classesFor({ orientation: 'vertical' }).list).toContain('flex-col');
+  });
+
+  it('the rail carries the muted trough the active pill sits in', () => {
+    const list = classesFor({}).list;
+    expect(list).toContain('bg-muted');
+    expect(list).toContain('rounded-md');
+  });
+
+  it('the trigger styles both data-state branches off one string', () => {
+    const trigger = classesFor({}).trigger;
+    expect(trigger).toContain('data-[state=active]:bg-background');
+    expect(trigger).toContain('data-[state=active]:text-foreground');
+    expect(trigger).toContain('data-[state=inactive]:text-muted-foreground');
+  });
+
+  it('the trigger declares the indicator-move motion intent and honors reduced motion', () => {
+    const trigger = classesFor({}).trigger;
+    expect(trigger).toContain('transition-all');
+    expect(trigger).toContain('motion-reduce:transition-none');
+  });
+
+  it('the trigger carries the focus ring and the disabled treatment', () => {
+    const trigger = classesFor({}).trigger;
+    expect(trigger).toContain('focus-visible:ring-ring');
+    expect(trigger).toContain('disabled:opacity-50');
+    expect(trigger).toContain('disabled:cursor-not-allowed');
+  });
+
+  it('the panel carries a focus ring because tabpanels are focusable', () => {
+    const panel = classesFor({}).panel;
+    expect(panel).toContain('focus-visible:ring-ring');
+    expect(panel).toContain('ring-offset-background');
+  });
+});

--- a/packages/ui/test/components/tabs/tabs.conformance.test.tsx
+++ b/packages/ui/test/components/tabs/tabs.conformance.test.tsx
@@ -1,0 +1,219 @@
+/**
+ * React performance of the tabs score, driven end to end. Activation moves only
+ * through dispatched actions; roving focus is composed from the primitive; arrow
+ * keys move focus AND activate the newly focused tab (automatic activation).
+ */
+import * as React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../../src/components/tabs/tabs';
+import { tabs, type TabsConfig } from '../../../src/components/tabs/tabs.behavior';
+import {
+  assertAxeClean,
+  assertContractFulfillment,
+  assertInstanceAriaFulfillment,
+  partElement,
+} from '../../harness/conformance';
+
+interface SetupProps {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  orientation?: 'horizontal' | 'vertical';
+  disabledTabs?: string[];
+}
+
+function TestTabs({ disabledTabs = [], ...props }: SetupProps) {
+  return (
+    <Tabs {...props}>
+      <TabsList aria-label="Account views">
+        <TabsTrigger value="overview" disabled={disabledTabs.includes('overview')}>
+          Overview
+        </TabsTrigger>
+        <TabsTrigger value="details" disabled={disabledTabs.includes('details')}>
+          Details
+        </TabsTrigger>
+        <TabsTrigger value="history" disabled={disabledTabs.includes('history')}>
+          History
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="overview">Overview panel</TabsContent>
+      <TabsContent value="details">Details panel</TabsContent>
+      <TabsContent value="history">History panel</TabsContent>
+    </Tabs>
+  );
+}
+
+const body = () => document.body;
+
+function triggerFor(value: string): HTMLElement {
+  const element = body().querySelector<HTMLElement>(`[data-part="trigger"][data-value="${value}"]`);
+  if (!element) throw new Error(`no trigger for ${value}`);
+  return element;
+}
+
+function panelFor(value: string): HTMLElement {
+  const element = body().querySelector<HTMLElement>(`[data-part="panel"][data-value="${value}"]`);
+  if (!element) throw new Error(`no panel for ${value}`);
+  return element;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('tabs conformance [react]', () => {
+  it('renders a tablist with tabs and tabpanels, axe-clean', async () => {
+    // Wrapped in a landmark: a tablist is not itself a landmark, and axe's
+    // best-practice `region` rule flags page content outside one.
+    render(
+      <main>
+        <TestTabs defaultValue="overview" />
+      </main>,
+    );
+    expect(partElement(body(), 'list')?.getAttribute('role')).toBe('tablist');
+    expect(partElement(body(), 'list')?.getAttribute('aria-orientation')).toBe('horizontal');
+    expect(triggerFor('overview').getAttribute('role')).toBe('tab');
+    expect(panelFor('overview').getAttribute('role')).toBe('tabpanel');
+    await assertAxeClean(body());
+  });
+
+  it('contract: the part and instance projections equal the rendered DOM', () => {
+    const config: TabsConfig = {
+      value: undefined,
+      defaultValue: 'details',
+      orientation: 'horizontal',
+    };
+    render(<TestTabs defaultValue="details" />);
+    const root = partElement(body(), 'root');
+    if (!root) throw new Error('no root');
+    const state = tabs.initialState(config);
+    assertContractFulfillment(tabs, root, state, config, ['root', 'list', 'trigger', 'panel']);
+    assertInstanceAriaFulfillment(tabs, root, state, config);
+  });
+
+  it('the trigger and its panel cross-reference each other by id', () => {
+    render(<TestTabs defaultValue="overview" />);
+    expect(triggerFor('overview').getAttribute('aria-controls')).toBe(panelFor('overview').id);
+    expect(panelFor('overview').getAttribute('aria-labelledby')).toBe(triggerFor('overview').id);
+  });
+
+  it('shows only the active panel and hides the rest', () => {
+    render(<TestTabs defaultValue="details" />);
+    expect(panelFor('details').hasAttribute('hidden')).toBe(false);
+    expect(panelFor('overview').hasAttribute('hidden')).toBe(true);
+    expect(panelFor('history').hasAttribute('hidden')).toBe(true);
+  });
+
+  it('click activates a tab, swaps the panel, and fires onValueChange', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(
+      <main>
+        <TestTabs defaultValue="overview" onValueChange={onValueChange} />
+      </main>,
+    );
+    await user.click(triggerFor('details'));
+    expect(triggerFor('details').getAttribute('aria-selected')).toBe('true');
+    expect(triggerFor('details').getAttribute('data-state')).toBe('active');
+    expect(triggerFor('overview').getAttribute('aria-selected')).toBe('false');
+    expect(panelFor('details').hasAttribute('hidden')).toBe(false);
+    expect(panelFor('overview').hasAttribute('hidden')).toBe(true);
+    expect(onValueChange).toHaveBeenCalledWith('details');
+    await assertAxeClean(body());
+  });
+
+  it('re-clicking the active tab does NOT deactivate it or re-fire the callback', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<TestTabs defaultValue="overview" onValueChange={onValueChange} />);
+    await user.click(triggerFor('overview'));
+    expect(triggerFor('overview').getAttribute('aria-selected')).toBe('true');
+    expect(panelFor('overview').hasAttribute('hidden')).toBe(false);
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it('arrow keys move focus AND activate the newly focused tab', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<TestTabs defaultValue="overview" onValueChange={onValueChange} />);
+    triggerFor('overview').focus();
+    await user.keyboard('{ArrowRight}');
+    expect(document.activeElement).toBe(triggerFor('details'));
+    expect(triggerFor('details').getAttribute('aria-selected')).toBe('true');
+    expect(panelFor('details').hasAttribute('hidden')).toBe(false);
+    expect(onValueChange).toHaveBeenLastCalledWith('details');
+    await user.keyboard('{ArrowLeft}');
+    expect(document.activeElement).toBe(triggerFor('overview'));
+    expect(triggerFor('overview').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('Home and End jump to the first and last tab and activate them', async () => {
+    const user = userEvent.setup();
+    render(<TestTabs defaultValue="details" />);
+    triggerFor('details').focus();
+    await user.keyboard('{End}');
+    expect(triggerFor('history').getAttribute('aria-selected')).toBe('true');
+    await user.keyboard('{Home}');
+    expect(triggerFor('overview').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('a vertical axis moves with up/down arrows and reflects aria-orientation', async () => {
+    const user = userEvent.setup();
+    render(<TestTabs defaultValue="overview" orientation="vertical" />);
+    expect(partElement(body(), 'list')?.getAttribute('aria-orientation')).toBe('vertical');
+    triggerFor('overview').focus();
+    await user.keyboard('{ArrowDown}');
+    expect(triggerFor('details').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('Space and Enter activate the focused tab via the native button', async () => {
+    const user = userEvent.setup();
+    render(<TestTabs defaultValue="overview" />);
+    triggerFor('details').focus();
+    await user.keyboard(' ');
+    expect(triggerFor('details').getAttribute('aria-selected')).toBe('true');
+    triggerFor('history').focus();
+    await user.keyboard('{Enter}');
+    expect(triggerFor('history').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('controlled: state follows the prop, callback reports the value to set', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const { rerender } = render(<TestTabs value="overview" onValueChange={onValueChange} />);
+    expect(triggerFor('overview').getAttribute('aria-selected')).toBe('true');
+
+    // A controlled set's effective value does not move on click, but the
+    // callback still reports what to set.
+    await user.click(triggerFor('details'));
+    expect(onValueChange).toHaveBeenLastCalledWith('details');
+    expect(triggerFor('overview').getAttribute('aria-selected')).toBe('true');
+    expect(triggerFor('details').getAttribute('aria-selected')).toBe('false');
+
+    rerender(<TestTabs value="details" onValueChange={onValueChange} />);
+    expect(triggerFor('details').getAttribute('aria-selected')).toBe('true');
+    expect(panelFor('details').hasAttribute('hidden')).toBe(false);
+  });
+
+  it('roving skips a disabled tab', async () => {
+    const user = userEvent.setup();
+    render(<TestTabs defaultValue="overview" disabledTabs={['details']} />);
+    expect(triggerFor('details').hasAttribute('disabled')).toBe(true);
+    triggerFor('overview').focus();
+    await user.keyboard('{ArrowRight}');
+    // details is disabled, so focus and activation jump to history.
+    expect(document.activeElement).toBe(triggerFor('history'));
+    expect(triggerFor('history').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('keeps exactly one trigger in the tab order (roving tabindex)', () => {
+    render(<TestTabs defaultValue="details" />);
+    const tabbable = ['overview', 'details', 'history'].filter(
+      (value) => triggerFor(value).getAttribute('tabindex') === '0',
+    );
+    // Tab enters the set at the tab whose panel is showing, not at the first.
+    expect(tabbable).toEqual(['details']);
+  });
+});

--- a/packages/ui/test/components/tabs/tabs.element.conformance.test.ts
+++ b/packages/ui/test/components/tabs/tabs.element.conformance.test.ts
@@ -1,0 +1,145 @@
+/**
+ * WC performance of the tabs score, driven end to end against light-DOM markup.
+ * Same score as the React conformance test -- the only difference is the
+ * controller applies the projection imperatively via bindTabs.
+ */
+import { cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { RaftersTabs } from '../../../src/components/tabs/tabs.element';
+
+beforeAll(() => {
+  if (!customElements.get('rafters-tabs')) {
+    customElements.define('rafters-tabs', RaftersTabs);
+  }
+});
+
+const VALUES = ['overview', 'details', 'history'] as const;
+
+interface MountOptions {
+  active?: string;
+  orientation?: 'horizontal' | 'vertical';
+  disabledTabs?: string[];
+}
+
+async function mount(options: MountOptions = {}): Promise<HTMLElement> {
+  const { active = 'overview', orientation = 'horizontal', disabledTabs = [] } = options;
+  const triggers = VALUES.map((value) => {
+    const on = value === active;
+    const disabled = disabledTabs.includes(value) ? ' disabled' : '';
+    return `<button type="button" role="tab" data-part="trigger" data-value="${value}" id="t-tab-${value}" aria-controls="t-panel-${value}" aria-selected="${on}" data-state="${on ? 'active' : 'inactive'}"${disabled}>${value}</button>`;
+  }).join('');
+  const panels = VALUES.map((value) => {
+    const on = value === active;
+    return `<div role="tabpanel" data-part="panel" data-value="${value}" id="t-panel-${value}" aria-labelledby="t-tab-${value}" tabindex="0" data-state="${on ? 'active' : 'inactive'}"${on ? '' : ' hidden'}>${value} panel</div>`;
+  }).join('');
+  document.body.innerHTML = `
+    <rafters-tabs>
+      <div data-part="root">
+        <div data-part="list" role="tablist" aria-orientation="${orientation}">${triggers}</div>
+        ${panels}
+      </div>
+    </rafters-tabs>`;
+  await Promise.resolve(); // let the element's deferred bind run
+  return document.body.querySelector('[data-part="root"]') as HTMLElement;
+}
+
+const trigger = (value: string) =>
+  document.body.querySelector<HTMLElement>(`[data-part="trigger"][data-value="${value}"]`)!;
+const panel = (value: string) =>
+  document.body.querySelector<HTMLElement>(`[data-part="panel"][data-value="${value}"]`)!;
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+describe('tabs conformance [wc]', () => {
+  it('reflects the server-rendered active trigger as the initial selection', async () => {
+    await mount({ active: 'details' });
+    expect(trigger('details').getAttribute('aria-selected')).toBe('true');
+    expect(trigger('details').getAttribute('data-state')).toBe('active');
+    expect(trigger('overview').getAttribute('aria-selected')).toBe('false');
+    expect(panel('details').hasAttribute('hidden')).toBe(false);
+    expect(panel('overview').hasAttribute('hidden')).toBe(true);
+  });
+
+  it('click activates a tab and swaps the visible panel', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger('history'));
+    expect(trigger('history').getAttribute('aria-selected')).toBe('true');
+    expect(trigger('history').getAttribute('data-state')).toBe('active');
+    expect(panel('history').hasAttribute('hidden')).toBe(false);
+    expect(panel('overview').hasAttribute('hidden')).toBe(true);
+  });
+
+  it('arrow keys move focus AND activate the newly focused tab', async () => {
+    const user = userEvent.setup();
+    await mount();
+    trigger('overview').focus();
+    await user.keyboard('{ArrowRight}');
+    expect(document.activeElement).toBe(trigger('details'));
+    expect(trigger('details').getAttribute('aria-selected')).toBe('true');
+    expect(panel('details').hasAttribute('hidden')).toBe(false);
+    await user.keyboard('{ArrowLeft}');
+    expect(document.activeElement).toBe(trigger('overview'));
+    expect(trigger('overview').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('Home and End jump to the first and last tab and activate them', async () => {
+    const user = userEvent.setup();
+    await mount({ active: 'details' });
+    trigger('details').focus();
+    await user.keyboard('{End}');
+    expect(trigger('history').getAttribute('aria-selected')).toBe('true');
+    await user.keyboard('{Home}');
+    expect(trigger('overview').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('a vertical axis moves with up/down arrows', async () => {
+    const user = userEvent.setup();
+    await mount({ orientation: 'vertical' });
+    trigger('overview').focus();
+    await user.keyboard('{ArrowDown}');
+    expect(trigger('details').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('Space and Enter activate the focused tab via the native button', async () => {
+    const user = userEvent.setup();
+    await mount();
+    trigger('details').focus();
+    await user.keyboard(' ');
+    expect(trigger('details').getAttribute('aria-selected')).toBe('true');
+    trigger('history').focus();
+    await user.keyboard('{Enter}');
+    expect(trigger('history').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('roving skips a disabled tab', async () => {
+    const user = userEvent.setup();
+    await mount({ disabledTabs: ['details'] });
+    trigger('overview').focus();
+    await user.keyboard('{ArrowRight}');
+    expect(document.activeElement).toBe(trigger('history'));
+    expect(trigger('history').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('arrow keys pressed inside a panel do NOT move the tabs', async () => {
+    const user = userEvent.setup();
+    await mount();
+    panel('overview').focus();
+    await user.keyboard('{ArrowRight}');
+    // Roving binds to the tablist, not the root, so panel content keeps its
+    // own arrow keys (text navigation, nested widgets).
+    expect(trigger('overview').getAttribute('aria-selected')).toBe('true');
+    expect(trigger('details').getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('Tab enters the set at the active tab, not the first (seeded roving index)', async () => {
+    await mount({ active: 'history' });
+    expect(trigger('history').getAttribute('tabindex')).toBe('0');
+    expect(trigger('overview').getAttribute('tabindex')).toBe('-1');
+    expect(trigger('details').getAttribute('tabindex')).toBe('-1');
+  });
+});


### PR DESCRIPTION
## Summary

Ports `tabs` to the behavior layer. The imperative `old/ui/tabs.controller.ts`
and its four-file Astro surface (`tabs.astro` + `tabs-list` / `tabs-trigger` /
`tabs-content`) are replaced by one score and three thin decorators.

The active tab is reducer state (`{ value }`) with the controlled-shadows
-intrinsic boundary radio-group and navigation-menu already use. Focus movement
is the composed `roving-focus` primitive, bound to the `[role="tablist"]`
element rather than the root so panel content keeps its own arrow keys.
Automatic activation rides roving's `onNavigate`, which is safe because
`activate` is idempotent: re-activating the active tab returns the SAME state
ref, so memory does not notify and a controlled consumer's callback does not
re-fire on the repeated dispatches arrow navigation produces.

`trigger` and `panel` are `many` parts that cross-reference each other by id
(`aria-controls` / `aria-labelledby`), so they project through the score's
`instanceAria` member (landed on main in #1884) rather than bespoke sibling
functions -- the generic `assertInstanceAriaFulfillment` harness driver resolves
each instance's sibling ids from the DOM and asserts the projection with no
per-component wiring. Tabs is the two-many-part cross-referencing case that
member was built for.

Carried over from the oracle: automatic activation, the roving cursor seeded to
the active tab (so Tab enters at the tab whose panel is showing), click
-activates-and-focuses, the shadcn namespaced surface, and the Astro
server-rendered roving tabindex. New: `orientation`, which projects
`aria-orientation` on the rail and switches roving to the vertical axis,
defaulting to horizontal so oracle behavior is unchanged.

No shared file is restructured -- the diff is the tabs component folder, its
test folder, its doc, and one CHANGELOG entry.

## Acceptance criteria mapping

### Behavior test (pure, no DOM)

`tabs.behavior.test.ts` runs against the score alone, with no renderer and no
document. It pins the decisions rather than the rendering: that a controlled
value shadows intrinsic state, that `activate` returns an identical state
reference when the value is unchanged (the property automatic activation depends
on), that the instance projections omit `tabindex` because roving owns it as
ephemeral DOM state, and that the keymap declines to claim arrows or Home/End.
It also asserts `tabs.instanceAria` is the same function reference the
decorators call, which is what guarantees the harness and the performances
cannot diverge.
Evidence: packages/ui/test/components/tabs/tabs.behavior.test.ts:168

### Classes parity test

`tabs.classes.test.ts` exercises `tabsClasses(config, state)` directly, checking
the contract the three performances must share rather than the visual result: the
orientation branch on the root and the rail, both `data-[state=...]` selectors on
the trigger (which is what lets one class string serve React, WC, and Astro with
no conditional application anywhere), the `motion-reduce` opt-out the WCAG
obligation depends on, and the panel focus ring that a focusable tabpanel
requires.
Evidence: packages/ui/test/components/tabs/tabs.classes.test.ts:44

### Conformance GREEN across React + WC + Astro via the shared harness (aria + keymap against rendered DOM)

Three suites drive the one score through the shared harness against real
rendered DOM. React runs `assertContractFulfillment` over all four parts plus
`assertInstanceAriaFulfillment` over both many-parts, and adds `assertAxeClean`.
WC drives `bindTabs` through the custom element against hand-written light-DOM
markup, including the assertion that arrow keys inside a panel do NOT move the
tabs -- the observable consequence of binding roving to the tablist. Astro
renders through `AstroContainer` and calls `bindTabs` directly (the container
does not execute the `<script>`, and that call is the script's job), covering
SSR facts no other suite reaches. All three assert the same keyboard map:
arrows per orientation, Home/End, and Enter/Space via the native button.
Evidence: packages/ui/test/components/tabs/tabs.element.conformance.test.ts:139

### shadcn-compat base preserved + rafters extensions preserved

The shadcn base survives intact as both named exports (`Tabs`, `TabsList`,
`TabsTrigger`, `TabsContent`) and the namespaced surface (`Tabs.List`,
`Tabs.Trigger`, `Tabs.Content`), with the same prop names the oracle exposed:
`value`, `defaultValue`, `onValueChange`, and per-trigger `disabled`. The
rafters extensions on top are preserved too -- the framework-agnostic client is
still one shared function (now `bindTabs` rather than `createTabs`), panels stay
in the DOM and toggle `hidden` rather than unmounting, and Astro still ships the
pre-JS roving tabindex. `orientation` is added on top of that surface without
displacing any of it.
Evidence: packages/ui/src/components/tabs/tabs.tsx:261

### Component doc written (`docs/spec/components/tabs.md`)

Written on the radio-group/dialog article model: composition, config/state/
actions, the parts-and-ARIA table, keyboard, WCAG obligations, and the motion
intent. The substance is the disposition table, which classifies every oracle
feature so a later reader can distinguish a deliberate drop from an oversight --
including the four that did not survive as-is (the multi-file Astro slot
surface, the `data-rafters-tabs` config channel, the imperative `setValue`, and
the exposed selection-group cell) and the one defect that was fixed rather than
ported (root classes applied in Astro only).
Evidence: packages/ui/docs/spec/components/tabs.md:118

### JSDoc intelligence tags present

The four tags the registry parses sit on the `Tabs` React component, and each is
written for tabs specifically rather than filled in generically.
`@cognitive-load` carries the five-dimension breakdown and explains the recall
cost that distinguishes tabs from a radio group (siblings are hidden, so labels
must carry the scent of what they conceal). `@attention-economics`,
`@trust-building`, and `@accessibility` follow, the last enumerating the roles,
the roving tab order, and why inactive panels are `hidden`.
Evidence: packages/ui/src/components/tabs/tabs.tsx:54

### Exported from the package as the articles are

No export edit was needed, and that is the correct outcome rather than an
omission: commit ca34b99e wildcarded the `./next/*` entries specifically so a
port PR never has to touch `package.json`. `./next/*` maps to
`./src/components/*/*.tsx` and `./next/*.element` to
`./src/components/*/*.element.ts`, so placing the files at
`src/components/tabs/` makes `@rafters/ui/next/tabs` and
`@rafters/ui/next/tabs.element` resolve exactly as radio-group, navigation-menu,
and toggle-group do. Verified by `pnpm preflight`, whose build step resolves the
package exports.
Evidence: packages/ui/src/components/tabs/tabs.element.ts:17

### `pnpm --filter @rafters/ui test:unit` green, `pnpm preflight` green

Both run clean from the worktree. `test:unit` runs the two configs in sequence:
the main suite reports 393 files and 6218 passing (6 pre-existing skips,
untouched by this change), and the Astro config reports 39 files and 207
passing. `pnpm preflight` then chains typecheck, lint, format:check, test:unit,
test:a11y, and build, exiting 0. No test was skipped, weakened, or commented out
to get there. The `DOMException` noise in the Astro run is happy-dom declining to
auto-execute the SSR script, documented as expected in the authoring guide.
Evidence: packages/ui/test/components/tabs/tabs.astro.conformance.test.ts:31

## Not done

- **Vue performance.** Out of scope, as with every ported component; the port
  mandate is React, WC, and Astro, and vue stays absent across the wave.
- **Manual activation mode.** Radix exposes `activationMode="manual"` (arrows
  move focus without activating). The oracle had no such option and the issue
  specifies automatic activation, so it is not implemented; adding it later means
  gating the `onNavigate` in `startTabsRoving`, with no change to the score.
- **Rich panel bodies in the Astro performance.** `tabs.astro` is props-driven,
  so panel content is a string. Astro rejects a computed `slot[name]`, so a
  per-value panel slot is not expressible; this matches every merged Astro
  performance and is recorded as a `framework-affordance` disposition rather
  than silently dropped.
- **A dedicated indicator element.** The `indicator-move` motion intent is
  carried by the active pill's `transition-all` on the trigger, as the oracle
  did. No separate indicator part was invented, since the score has no state
  that would drive one.
- **`legion-review`.** The issue's workflow lists `/legion-review` after PR
  creation; that is the operator's step, not this branch's.

Closes #1799
