### PR TITLE
chore(ui): remove the rejected ./next/ export namespace

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,8 +7,6 @@
     ".": "./src/index.ts",
     "./primitives/*": "./src/primitives/*.ts",
     "./components/*": "./src/old/*.tsx",
-    "./next/*.element": "./src/components/*/*.element.ts",
-    "./next/*": "./src/components/*/*.tsx",
     "./hooks/*": "./src/hooks/*.ts",
     "./dialog": "./src/old/ui/dialog.tsx",
     "./dialog.vue": "./src/old/ui/dialog.vue.ts",


### PR DESCRIPTION
## Summary

Removes the rejected `./next/` export namespace from `packages/ui/package.json` -- two
wildcard entries deleted, nothing else changed. This is a removal of live surface, not a
cleanup of stale lines: `ca34b99e` landed on main via the port-wave branches and replaced the
original eleven explicit `./next/<component>` entries with `./next/*` and `./next/*.element`,
which makes every one of the 34 folders in `src/components` addressable under the rejected
prefix. The namespace resolves nothing anyone asks for regardless -- `packages/ui` is a
code-only workspace package, never built and never published, and consumers receive source
through the registry via `rafters add`.

## Acceptance criteria mapping

### 1. Both `./next/*` wildcard entries removed from packages/ui/package.json

The single hunk deletes the two consecutive keys that sat between `./components/*` and
`./hooks/*`: `./next/*.element` mapping to `./src/components/*/*.element.ts`, and `./next/*`
mapping to `./src/components/*/*.tsx`. The surrounding keys keep their positions and values,
so `src/components` is no longer reachable from the manifest by any specifier.
Evidence: `git diff origin/main...HEAD` reports `1 file changed, 2 deletions(-)` with zero
insertions.

### 2. No replacement entry introduced in any form

Nothing was substituted -- not explicit per-component entries, not a narrower pattern, not a
renamed prefix. This is the point of the change rather than an omission: the branch originally
deleted eleven explicit entries, and `ca34b99e` compressing those into two wildcards is
precisely how the surface widened while looking tidier. A wildcard is the right compression
for a namespace worth keeping (`./primitives/*` on line 8 is exactly that), and the wrong tool
when the namespace itself is rejected.
Evidence: diff has zero insertions; no key matching `next` and no path containing
`src/components` exists in `packages/ui/package.json` after the change.

### 3. No reference to the namespace remains in the repo

Searched repo-wide before deleting so removal could not orphan a caller. Every hit for
`next/` is unrelated: `prev/next` prose in `primitives/keyboard-handler.ts:260` and the
pagination docs, `next/font` in the design-tokens font importer and a CLI changelog entry, and
an `@next/next/no-img-element` eslint directive at `src/old/ui/image.tsx:308`.
Evidence: `legion sym etc find-content 'next/' --repo rafters` returns no export-path usage;
`@rafters/ui/next` returns zero results.

### 4. `./components/*` still resolves to `./src/old/*.tsx`

Left untouched at its original position. This is the one entry resolving real imports --
apps/demo imports `@rafters/ui/components/ui/<name>` across its demo components and those land
in `src/old/ui` through this pattern. An earlier revision of this branch split it into
`./components/ui/*` plus new-tree patterns; that was reverted, so the line is byte-identical
to main.
Evidence: `packages/ui/package.json:9` reads `"./components/*": "./src/old/*.tsx"` and is
absent from the diff; `pnpm typecheck` passes for apps/demo.

### 5. No export entry added for `src/components`

None added, and the two removed wildcards were the only entries that pointed there. An entry
for the new tree would be indirection bought for nobody, since nothing consumes this package
by specifier. Making the registry read `src/components` instead of `src/old/ui` is the change
that actually matters for distribution, and it is filed as #1896 and deliberately parked until
more of the port wave lands.
Evidence: no path containing `src/components` appears anywhere in
`packages/ui/package.json`.

### 6. typecheck and preflight green

Both re-run on the rebased HEAD, not inherited from the pre-rebase commit. Typecheck covers
all twelve workspace projects (studio is skipped by its own script, pending re-architecture).
Evidence: `pnpm typecheck` -- all projects "Done", no errors; `pnpm preflight` -- `EXIT=0`.

## Not done

- **The `ca34b99e` deletion of `components.jsonl` is not revisited.** That commit also removed
  the matrix tracker, its schema and its canary test, and it is now on main. Separate concern;
  this PR touches only the export namespace. It does leave the 17 open port issues carrying a
  directive to update a file that no longer exists -- worth a follow-up sweep.
- **The registry still serves `src/old/ui`.** `componentService.ts:54` is unchanged, so
  `rafters add` continues to fetch old-tree components. Filed as #1896, parked, because the
  cutover drops every unported component from the registry.
- **apps/demo still imports workspace packages.** It should consume the registry like a real
  consumer, which would retire `./components/*` too. Blocked on #1896.
- **`src/old` untouched.** It is deleted when the port wave completes; no migration attempted.

Closes #1897
