### PR TITLE
feat(ui): port input-group to the behavior layer

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`input-group` ported to the behavior layer (#1778).** The oracle's
+  shadow-DOM element pair (`<rafters-input-group>` +
+  `<rafters-input-group-addon>`) collapses into one light-DOM enhancer over a
+  single score (`input-group.behavior.ts`). The group is a WRAPPER, not a value
+  owner: the contained native control keeps its value, caret, IME, and form
+  participation, so the score has no state axis, no actions, and no keymap --
+  the `field` shape, applied to the text-input family. It projects validity onto
+  the control (`aria-invalid`, omitted when valid so a contained `Input` stays
+  the single authority) plus `data-state` on the root, which is what draws the
+  border. Affix position becomes two declared parts (`addonStart`/`addonEnd`),
+  so the harness asserts `data-position` identically in React, the Web
+  Component, and Astro. One behavioral correction: the oracle propagated
+  `disabled` unconditionally and silently re-enabled an individually disabled
+  control, so propagation is now an OR (`isControlDisabled`) and reaches every
+  disableable descendant, affix buttons included. `form-value` and
+  `input-events` are dispositioned not-ported (see
+  `docs/spec/components/input-group.md`).
+
 - **`radio-group` ported to the behavior layer (#1787).** The imperative
   `old/ui/radio-group.controller.ts` + form-associated WC pair are replaced by a
   single score (`radio-group.behavior.ts`): selection is reducer state

--- a/packages/ui/docs/spec/components/input-group.md
+++ b/packages/ui/docs/spec/components/input-group.md
@@ -1,0 +1,177 @@
+# Component Spec -- InputGroup
+
+Status: DRAFT. The wrapper archetype applied to the text-input family. Answers
+whether a component that LOOKS like a control -- one border, one focus ring, one
+apparent field -- must therefore OWN a control's state. It must not.
+
+Files (`src/components/input-group/`):
+
+```
+input-group.classes.ts   input-group.behavior.ts   input-group.tsx
+input-group.element.ts   input-group.astro
+```
+
+Tests mirror into `test/components/input-group/`. React, Web Component, and
+Astro are all conformance-verified against the shared harness.
+
+## The archetype question
+
+The issue lists `value` and `invalid` as the group's states, and the group is
+drawn as a single control. The tempting reading is that InputGroup owns a value
+the way `input` does -- a `setValue` reducer over a controlled/uncontrolled
+cell.
+
+It does not, and the oracle says so first. `src/old/ui/input-group.tsx` ships an
+`InputGroupInput` that is a bare styled `<input>` with no value handling and no
+validity wiring; `src/old/ui/input-group.element.ts` propagates `disabled` and
+draws a focus-within ring and nothing else. Neither surface ever held a value.
+
+Two further constraints close it:
+
+- `createBehavior` owns THE single memory cell. A group-level value cell placed
+  over a control that already has one gives the assembly two cells for one
+  string, and they diverge the moment a consumer nests the ported `<Input>`
+  (whose own score owns the value) inside a group.
+- The value is not the group's to hold. Caret, IME composition, selection, and
+  form participation all belong to the native `<input>`, which is exactly the
+  boundary `input.md` already drew.
+
+So `value` is satisfied by COMPOSITION -- the contained control holds it -- and
+`invalid` is a config the group PROJECTS onto that control. The group is a
+wrapper, and `field.behavior.ts` is its template: a static, projection-only
+score plus a bind that reaches into a slotted control SSR cannot touch.
+
+## Config, state, actions
+
+```ts
+interface InputGroupConfig {
+  size?: 'sm' | 'default' | 'lg';
+  disabled?: boolean;
+  invalid?: boolean;
+}
+type InputGroupState = Record<never, never>;   // no state axis
+type InputGroupActions = Record<never, never>; // nothing dispatchable
+```
+
+There is no reducer, no `canDispatch` gate, and no keymap. The score is a total
+function from config (plus the rendered part ids) to the assembly's projection.
+
+## Parts and ARIA
+
+| Part | Presence | ARIA |
+| --- | --- | --- |
+| root | always | `data-state` (`invalid`/`default`). No role, no `aria-invalid` |
+| control | always | `aria-invalid` (only when invalid), `data-state` (`invalid`/`default`) |
+| addonStart | optional | `data-position="start"` |
+| addonEnd | optional | `data-position="end"` |
+
+**No role on the root.** `field` sets the precedent. A `role="group"` with no
+accessible name adds a nameless node to the AT tree without adding meaning, and
+the group has no name to give -- the label belongs to the control. The contained
+control carries the semantics; the wrapper carries the chrome.
+
+**`aria-invalid` is omitted when valid**, which is `field`'s convention rather
+than `input`'s always-present `'true'`/`'false'`. The group is a wrapper, so an
+absent attribute leaves a contained control that projects its OWN validity -- the
+ported `Input` -- as the single authority, instead of overwriting it with a
+literal `'false'`. As a side effect this sidesteps `aria-manager`'s truthy
+coercion of the string `'false'` entirely; the bind still applies with
+`{ validate: false }`, but no projected value depends on it.
+
+**`data-state` is reflected on the root as well as the control** because the
+root draws the border. The contained control renders no border of its own to
+turn destructive, so the destructive treatment has to land on the box.
+
+**`data-position` is projected, not hand-written.** Each affix's side comes out
+of the score, so React, the Web Component, and Astro are asserted against one
+source rather than three markup conventions.
+
+## The disabled rule
+
+```ts
+isControlDisabled(config, ownDisabled) = config.disabled === true || ownDisabled
+```
+
+Stated once and read by every performance: `bindInputGroup` for the DOM-native
+path, `InputGroupInput` and `input-group.astro` for the retained/SSR paths.
+
+A disabled group disables every disableable descendant, not just the control --
+an affix's "Apply" button must not stay live inside a dead group. That is the
+oracle's earned rule and it is kept.
+
+The OR is the correction. See the disposition table.
+
+## Host signals vs projection output
+
+`bindInputGroup` recovers its config from the root's attributes, so the two
+kinds of attribute are kept separate:
+
+- **Host signals** (author/SSR input, read by the client): `disabled` /
+  `data-disabled`, `data-invalid`, `data-size`.
+- **Projection output** (the score's own writing): `data-state`,
+  `aria-invalid`, `data-position`.
+
+Without the split the client would read back its own output on a second bind and
+could not tell config from consequence.
+
+## Keyboard
+
+None claimed. Every keystroke belongs to the contained control, and an affix
+holds ordinary focusable content that keeps its native behavior. `keymap`
+returns `null` for every key on every part.
+
+Focus is visible wherever it lands inside the box: the ring is a
+`focus-within` ring on the root, not a `focus-visible` ring on the control.
+
+## Motion
+
+Intent only: the focus ring transitions its shadow on focus change
+(`transition-shadow duration-100`), and honours `motion-reduce:transition-none`.
+Durations and easing come from tokens; the score declares no motion.
+
+## Oracle dispositions (`src/old/ui/input-group.*`, react + wc)
+
+| Item | Disposition |
+| --- | --- |
+| `InputGroup` / `InputGroupAddon` / `InputGroupInput` React surface | contract -- same names, same props (`size`, `disabled`, `position`, `variant`), same composition order; a drop-in |
+| `size` vocabulary (`sm`/`default`/`lg`) and unknown-value fallback | contract -- carried into the score, with `parseInputGroupSize` for the attribute path |
+| addon `position` (`start`/`end`) and its divider side | contract -- promoted from a class-only concern to two declared parts, so the harness asserts it in all three frameworks |
+| addon `variant` (`default`/`filled`) | contract -- decoration only, so it stays in `input-group.classes.ts` and never reaches the score |
+| focus-within ring around the whole assembly | contract -- an ordinary class on the light-DOM root instead of a `:host(:focus-within)` rule |
+| `disabled` propagation to contained controls | contract, CORRECTED -- see below |
+| unconditional `child.disabled = disabled` | defect-do-not-port -- the oracle assigned `false` as readily as `true`, so an ENABLED group silently re-enabled a control the author had disabled individually. `isControlDisabled` makes propagation an OR |
+| `<rafters-input-group-addon>` custom element | dropped -- it existed so an affix could own a shadow root. In the light-DOM model an affix is a `<div data-part="addonStart">`; a second element with a lifecycle buys nothing |
+| shadow DOM, `::slotted()` normalisation, `:host` display shims, the rebuilt inner `.group` wrapper | dropped -- all were shadow-boundary workarounds. A light-DOM enhancer needs none of them (the same trade `field` made) |
+| `bg-background` on the group | replaced -- `bg-transparent`, so the control inherits the surface it sits on (fill-never-background) |
+| `text-sm` on the small size | replaced -- `text-body-small`, the typography role token |
+| `form-value` primitive (issue: "add") | not ported -- it builds a hidden mirror input for controls that are NOT native form fields. The contained `<input>` is form-associated already, so a mirror would submit the field twice |
+| `input-events` primitive (issue: "add") | not ported -- it is the contenteditable/IME handler for the editor subsystem. The group runs no editing path at all; the native control owns `beforeinput` and composition (the same disposition `input.md` reached) |
+| `required`, error message, `aria-describedby` | not ported -- `field` owns them and composes AROUND a group. Duplicating them here would put two authorities on one control's `aria-describedby` |
+
+## Deltas from the oracle
+
+1. **Light DOM, not shadow DOM.** The Web Component enhances author markup
+   rather than rendering a wrapper into a shadow root. This is what lets the
+   affixes be plain elements and the ring be a plain class.
+2. **Fill is `bg-transparent`.** The group inherits the surface it sits on.
+3. **The propagation OR** (above) -- the one behavioral correction.
+4. **Bind-once.** Like input/field/radio-group, the client wires server/author
+   markup a single time. Re-toggling `disabled` or `data-invalid` at runtime is
+   React's declarative affordance, not a lifecycle this client re-observes.
+
+## WCAG 2.1 AA obligations
+
+- 1.3.1/4.1.2: `aria-invalid` is projected onto the CONTROL, where assistive
+  tech expects validity, never onto the decorative wrapper. Asserted against
+  real DOM in all three conformance suites.
+- 2.4.7 (focus visible): the ring is `focus-within` on the root, so focus is
+  visible wherever it lands inside the box -- including on an affix button,
+  which a control-only ring would leave unringed.
+- 2.1.1 (keyboard): the group claims no key, so the control and any affix
+  button keep their full native keyboard behavior. A disabled group removes its
+  descendants from the tab order natively, leaving no reachable dead tab stop.
+- 1.4.3 (contrast): validity uses the destructive token pair on the border and
+  ring, not a subtle background.
+- 4.1.2 (name): the affixes are decoration, NOT an accessible name. An icon
+  affix must be `aria-hidden`, and the control still needs a real label (Field,
+  `<Label>`, or `aria-label`) -- exercised in the conformance tests.

--- a/packages/ui/docs/spec/components/input-group.md
+++ b/packages/ui/docs/spec/components/input-group.md
@@ -153,6 +153,17 @@ Durations and easing come from tokens; the score declares no motion.
 1. **Light DOM, not shadow DOM.** The Web Component enhances author markup
    rather than rendering a wrapper into a shadow root. This is what lets the
    affixes be plain elements and the ring be a plain class.
+
+   The cost, stated plainly because it is the likeliest reviewer question: the
+   bind applies the ARIA/state projection and the disabled propagation, but it
+   does NOT paint classes. A hand-authored `<rafters-input-group>` is
+   behaviorally correct and visually unstyled unless the author also copies the
+   class strings (which is what `input-group.astro` server-renders, and what
+   the React performance paints). The oracle's shadow element DID apply its own
+   classes, so this is a real trade, not a wash: it buys the light-DOM
+   affixes, the plain `focus-within` ring, and one element instead of two. It
+   is the same trade `input` and `field` made -- decoration is the
+   performance's job, not the client's -- so the family stays consistent.
 2. **Fill is `bg-transparent`.** The group inherits the surface it sits on.
 3. **The propagation OR** (above) -- the one behavioral correction.
 4. **Bind-once.** Like input/field/radio-group, the client wires server/author

--- a/packages/ui/docs/spec/matrix/components.md
+++ b/packages/ui/docs/spec/matrix/components.md
@@ -56,7 +56,7 @@ Behavior-layer support: only the five articles have react (verified). Old tree a
 |---|---|---|---|---|---|---|---|---|
 | **field** | Label+control+message wrapper | Wires label, description, and validation message ids to a control | invalid | - | - | none | react/wc | none |
 | **input** | Single-line text field | Edits text; reflects validity; form-associated | value, invalid, disabled | - | form-value, input-events | transition-shadow focus | astro/react/wc | none |
-| **input-group** | Input with addons | Composes input with leading/trailing addons as one control | value, invalid | - | form-value, input-events | none | react/wc | none |
+| **input-group** | Input with addons | Composes input with leading/trailing addons as one control | value, invalid | - | - | none | react/wc | react/wc/astro OK |
 | **input-otp** | Segmented one-time-code input | One char per slot; auto-advance; paste splits | slots filled, active slot | - | form-value, input-events, keyboard-handler | animate-pulse caret -> caret-blink: feedback-loop | react/wc | none |
 | **textarea** | Multi-line text field | Edits multiline text; autosize optional | value, invalid, disabled | - | form-value, input-events | transition-shadow focus | react/wc | none |
 

--- a/packages/ui/src/components/input-group/input-group.astro
+++ b/packages/ui/src/components/input-group/input-group.astro
@@ -1,0 +1,137 @@
+---
+/**
+ * Astro performance of the input-group score. Server-renders the light-DOM
+ * assembly -- the bordered root, the optional leading/trailing affixes, and the
+ * control -- with the score's projection already applied, so the group is
+ * correct and correctly styled before any JS runs. The `<script>` then hands
+ * each instance to bindInputGroup, the SAME DOM-native client the Web Component
+ * uses. One score, three performances, zero drift.
+ *
+ * The affixes are named slots (`start` / `end`) and are rendered only when
+ * filled, so an unused side contributes no empty padded cell and no stray
+ * divider -- the light-DOM answer to the shadow-slot cost the oracle paid.
+ *
+ * `data-disabled` and `data-invalid` are HOST SIGNALS the client reads back;
+ * `data-state` is the score's own output. Keeping them separate is what lets
+ * bindInputGroup recover the config from server markup without mistaking its
+ * own projection for author input.
+ */
+import classy from '../../primitives/classy';
+import {
+  inputGroupBehavior,
+  isControlDisabled,
+  type InputGroupConfig,
+  type InputGroupSize,
+} from './input-group.behavior';
+import {
+  composeInputGroupAddonClasses,
+  inputGroupClassSet,
+  type InputGroupAddonVariant,
+} from './input-group.classes';
+
+interface Props {
+  /** The control's id -- the target a Label `for` or a Field association points at. */
+  id: string;
+  size?: InputGroupSize;
+  disabled?: boolean;
+  invalid?: boolean;
+  name?: string;
+  type?: string;
+  placeholder?: string;
+  value?: string;
+  'aria-label'?: string;
+  /** Fill treatment for the leading affix. Decoration only. */
+  startVariant?: InputGroupAddonVariant;
+  /** Fill treatment for the trailing affix. Decoration only. */
+  endVariant?: InputGroupAddonVariant;
+}
+
+const {
+  id,
+  size = 'default',
+  disabled = false,
+  invalid = false,
+  name,
+  type = 'text',
+  placeholder,
+  value,
+  'aria-label': ariaLabel,
+  startVariant = 'default',
+  endVariant = 'default',
+} = Astro.props;
+
+const config: InputGroupConfig = { size, disabled, invalid };
+const classes = inputGroupClassSet(config, {});
+const projection = inputGroupBehavior.aria({}, config, {
+  root: '',
+  control: id,
+  addonStart: '',
+  addonEnd: '',
+});
+
+const hasStart = Astro.slots.has('start');
+const hasEnd = Astro.slots.has('end');
+// The group's disabled reaches the SSR control through the score's rule, not
+// through a second reading of the prop.
+const controlDisabled = isControlDisabled(config, false);
+---
+
+<rafters-input-group
+  data-part="root"
+  data-size={size}
+  data-disabled={disabled ? '' : undefined}
+  data-invalid={invalid ? '' : undefined}
+  class={classy(classes.root)}
+  {...projection.root}
+>
+  {
+    hasStart && (
+      <div
+        data-part="addonStart"
+        class={composeInputGroupAddonClasses('start', startVariant)}
+        {...projection.addonStart}
+      >
+        <slot name="start" />
+      </div>
+    )
+  }
+
+  <input
+    data-part="control"
+    id={id}
+    type={type}
+    name={name}
+    placeholder={placeholder}
+    value={value}
+    aria-label={ariaLabel}
+    disabled={controlDisabled}
+    class={classes.control}
+    {...projection.control}
+  />
+
+  {
+    hasEnd && (
+      <div
+        data-part="addonEnd"
+        class={composeInputGroupAddonClasses('end', endVariant)}
+        {...projection.addonEnd}
+      >
+        <slot name="end" />
+      </div>
+    )
+  }
+</rafters-input-group>
+
+<script>
+  import { bindInputGroup } from './input-group.behavior';
+
+  // The <script> is bundled and runs once per page; bind every instance's
+  // server-rendered markup. Same client as the Web Component.
+  for (const root of document.querySelectorAll<HTMLElement>(
+    'rafters-input-group[data-part="root"]',
+  )) {
+    if (root.dataset['bound'] === 'true') continue;
+    root.dataset['bound'] = 'true';
+    bindInputGroup(root);
+  }
+</script>

--- a/packages/ui/src/components/input-group/input-group.behavior.ts
+++ b/packages/ui/src/components/input-group/input-group.behavior.ts
@@ -1,0 +1,261 @@
+import { compose, type Slice } from '../../lib/compose';
+import { type BehaviorSpec, type PartIds } from '../../lib/contract';
+import { updateAriaAttribute } from '../../primitives/aria-manager';
+
+/**
+ * InputGroup: a text control adjoined with leading/trailing addons (a currency
+ * symbol, a unit, a search icon, an action button) so the whole assembly reads
+ * and focuses as ONE control.
+ *
+ * The archetype is the WRAPPER, not the value-owner -- the same shape `field`
+ * proves. The group does not hold the text: the contained native `<input>`
+ * owns its value, caret, IME composition, selection, and form participation,
+ * exactly as it does when it stands alone. Introducing a `setValue` reducer
+ * here would install a SECOND memory cell over a control that already has one,
+ * and the two would fight the moment a consumer nested the ported `<Input>`
+ * (whose own score owns the value) inside a group. The issue's `value` state is
+ * therefore satisfied by composition rather than duplication.
+ *
+ * What the score owns (the earned semantics, extracted from
+ * `src/old/ui/input-group.*`):
+ *  - the disabled propagation rule: a disabled GROUP disables every control it
+ *    contains, and -- correcting an oracle defect -- an ENABLED group never
+ *    re-enables a control the author disabled individually (`isControlDisabled`);
+ *  - the validity projection: `aria-invalid` on the contained control plus the
+ *    `data-state` both the root and the control style off, so the destructive
+ *    border lands on the GROUP's border (the group draws the box, the control
+ *    has none);
+ *  - the addon position vocabulary (`start`/`end`) as two distinct parts, so
+ *    each side's divider class and `data-position` are asserted identically
+ *    across React, the Web Component, and Astro.
+ *
+ * What the score does NOT own:
+ *  - the value, and every editing concern attached to it -- the contained
+ *    control's, per above;
+ *  - `required` / error-message wiring -- `field` owns those and composes
+ *    AROUND a group; duplicating them here would produce two `aria-describedby`
+ *    authorities over one control;
+ *  - the focus-within ring, size heights, and addon dividers -- decoration,
+ *    painted from `input-group.classes.ts`.
+ *
+ * There is no keymap: every keystroke belongs to the contained control, and the
+ * addons hold ordinary focusable content that keeps its own native behavior.
+ */
+
+export type InputGroupSize = 'sm' | 'default' | 'lg';
+
+export type InputGroupAddonPosition = 'start' | 'end';
+
+export interface InputGroupConfig {
+  /** Control height vocabulary, shared with the standalone input. */
+  size?: InputGroupSize | undefined;
+  /** Disables the whole assembly: the contained control and any focusable
+   *  addon content (an "Apply" button must not stay live inside a dead group). */
+  disabled?: boolean | undefined;
+  /** Advertised to AT via `aria-invalid` on the contained control, and reflected
+   *  as `data-state` so the GROUP's border carries the destructive treatment. */
+  invalid?: boolean | undefined;
+}
+
+/** No state axis: the group is a total function from config to projection. */
+export type InputGroupState = Record<never, never>;
+
+/** No actions: nothing about the group is dispatchable. */
+export type InputGroupActions = Record<never, never>;
+
+/**
+ * root       -- the bordered box that draws the control's chrome and focus ring.
+ * control    -- the contained text control the group wraps (never rendered by
+ *               the group in the WC/Astro performances: it is authored/slotted).
+ * addonStart -- optional leading affix.
+ * addonEnd   -- optional trailing affix.
+ */
+export type InputGroupPart = 'root' | 'control' | 'addonStart' | 'addonEnd';
+
+const SIZES: ReadonlyArray<InputGroupSize> = ['sm', 'default', 'lg'];
+
+const POSITIONS: ReadonlyArray<InputGroupAddonPosition> = ['start', 'end'];
+
+/** Unknown size values silently fall back to `default` (the oracle's rule). */
+export function parseInputGroupSize(value: string | null | undefined): InputGroupSize {
+  return typeof value === 'string' && (SIZES as ReadonlyArray<string>).includes(value)
+    ? (value as InputGroupSize)
+    : 'default';
+}
+
+/** Unknown position values silently fall back to `start` (the oracle's rule). */
+export function parseAddonPosition(value: string | null | undefined): InputGroupAddonPosition {
+  return typeof value === 'string' && (POSITIONS as ReadonlyArray<string>).includes(value)
+    ? (value as InputGroupAddonPosition)
+    : 'start';
+}
+
+/** The part name a given addon position renders as. */
+export function addonPart(position: InputGroupAddonPosition): InputGroupPart {
+  return position === 'end' ? 'addonEnd' : 'addonStart';
+}
+
+/**
+ * The disabled rule, stated ONCE for all three performances: a disabled group
+ * disables what it contains, and an enabled group leaves an individually
+ * disabled control alone.
+ *
+ * The oracle propagated unconditionally (`child.disabled = disabled`), which
+ * silently RE-ENABLED a control the author had disabled on its own whenever the
+ * group was enabled -- dispositioned `defect-do-not-port` in the component doc.
+ * Expressing the rule as an OR fixes it in one place; `bindInputGroup` and the
+ * React decorator both read this function rather than restating it.
+ */
+export function isControlDisabled(config: InputGroupConfig, ownDisabled: boolean): boolean {
+  return config.disabled === true || ownDisabled;
+}
+
+const inputGroup: Slice<InputGroupConfig, InputGroupState, InputGroupActions, InputGroupPart> = {
+  name: 'input-group',
+  parts: {
+    // No role on the root: `field` sets the precedent, and a `role="group"`
+    // with no accessible name adds a nameless landmark to the AT tree without
+    // adding meaning. The contained control carries the semantics.
+    root: {},
+    control: {},
+    addonStart: { optional: true },
+    addonEnd: { optional: true },
+  },
+  initialState: () => ({}),
+  actions: {},
+  canDispatch: () => true,
+  aria: (_state, config) => {
+    const invalid = config.invalid === true;
+    return {
+      // The root reflects validity because the root draws the border: the
+      // control inside has no border of its own to turn destructive.
+      root: { 'data-state': invalid ? 'invalid' : 'default' },
+      control: {
+        // Omitted when valid (field's convention, not input's always-present
+        // 'true'/'false'). The group is a wrapper: an absent attribute lets a
+        // contained control that projects its OWN validity -- the ported Input
+        // -- stay the single authority, instead of being overwritten with a
+        // literal 'false'. It also sidesteps aria-manager's truthy coercion of
+        // the string 'false' entirely.
+        'aria-invalid': invalid ? 'true' : undefined,
+        'data-state': invalid ? 'invalid' : 'default',
+      },
+      // Position is projected rather than hand-written into each decorator's
+      // markup, so the conformance harness asserts the same `data-position` in
+      // React, the Web Component, and Astro from one source.
+      addonStart: { 'data-position': 'start' },
+      addonEnd: { 'data-position': 'end' },
+    };
+  },
+  // The contained control owns every keystroke; the addons hold ordinary
+  // focusable content with its own native behavior. The group claims no key.
+  keymap: () => null,
+};
+
+export const inputGroupBehavior: BehaviorSpec<
+  InputGroupConfig,
+  InputGroupState,
+  InputGroupActions,
+  InputGroupPart
+> = compose('input-group', inputGroup);
+
+/**
+ * Locate the group's control. Prefer the explicit part marker; fall back to the
+ * first native form control so a light-DOM control the author did not annotate
+ * is still found (and is then stamped with `data-part="control"` so the
+ * conformance harness and any re-query find it too). Mirrors `findControl` in
+ * `field.behavior.ts` -- the same slotted-control problem, the same answer.
+ */
+function findControl(root: HTMLElement): HTMLElement | null {
+  return (
+    root.querySelector<HTMLElement>('[data-part="control"]') ??
+    root.querySelector<HTMLElement>('input, select, textarea')
+  );
+}
+
+/** Elements exposing a boolean `disabled` property (native controls, and our
+ *  own form-associated custom elements) -- narrowed from `unknown`, no `any`. */
+interface DisableableElement extends Element {
+  disabled: boolean;
+}
+
+function isDisableable(node: Element): node is DisableableElement {
+  // `in` narrows the unknown-shaped element without a cast and without `any`.
+  return 'disabled' in node && typeof node.disabled === 'boolean';
+}
+
+/**
+ * The DOM-native client of the input-group score -- shared by the Web Component
+ * and the Astro `<script>`. React (retained mode) reads the projection
+ * declaratively instead.
+ *
+ * Near-empty by construction, like `bindField`: the score has no state and no
+ * actions, so there is no `createBehavior`, no memory, no dispatch, and no
+ * event listener. The bind does exactly the two things SSR cannot reach into a
+ * slotted control:
+ *  1. apply the score's projection to the root, the control, and each addon;
+ *  2. propagate the group's `disabled` to every disableable descendant.
+ *
+ * Bind-once, matching input/field/radio-group: the client wires the
+ * server/author markup a single time. Re-toggling `disabled` or `data-invalid`
+ * at runtime is React's declarative affordance, not a WC lifecycle this client
+ * re-observes -- a disposition recorded in input-group.md.
+ */
+export function bindInputGroup(root: HTMLElement): () => void {
+  const control = findControl(root);
+  if (!control) return () => {};
+  // Stamp the marker so the harness (and a re-query) find a bare authored
+  // control, exactly as bindField does.
+  control.setAttribute('data-part', 'control');
+
+  // Host signals, read BEFORE the projection is applied so the score's own
+  // `data-state` output is never mistaken for author input. `disabled` is the
+  // attribute an author writes on the custom element; `data-disabled` is the
+  // form Astro server-renders.
+  const config: InputGroupConfig = {
+    size: parseInputGroupSize(root.getAttribute('data-size')),
+    disabled: root.hasAttribute('disabled') || root.hasAttribute('data-disabled'),
+    invalid: root.hasAttribute('data-invalid'),
+  };
+
+  const getPart = (part: InputGroupPart): HTMLElement | null =>
+    part === 'root'
+      ? root
+      : part === 'control'
+        ? control
+        : root.querySelector(`[data-part="${part}"]`);
+
+  // ids READ from the rendered parts, never generated (Spec 01).
+  const ids = {} as PartIds<InputGroupPart>;
+  for (const part of Object.keys(inputGroupBehavior.parts) as InputGroupPart[]) {
+    ids[part] = getPart(part)?.id ?? '';
+  }
+
+  // The projection is already resolved (final strings, undefined = absent), so
+  // apply it raw: validate:false skips aria-manager's author-input coercion.
+  const projection = inputGroupBehavior.aria({}, config, ids);
+  for (const part of Object.keys(projection) as InputGroupPart[]) {
+    const attrs = projection[part];
+    const element = getPart(part);
+    if (!element || !attrs) continue;
+    for (const [name, value] of Object.entries(attrs)) {
+      updateAriaAttribute(element, name as never, value as never, { validate: false });
+    }
+  }
+
+  // Disabled propagation -- native attribute AND property, so a disabled group
+  // both reflects and actually disables. Applied to every disableable
+  // descendant, not just the control: an addon's action button must not stay
+  // live inside a dead group (the oracle's earned rule). Guarded by the group's
+  // own disabled, so an enabled group never re-enables an individually disabled
+  // control -- the corrected propagation, see isControlDisabled.
+  if (config.disabled === true) {
+    for (const node of Array.from(root.querySelectorAll<Element>('*'))) {
+      if (!isDisableable(node)) continue;
+      node.setAttribute('disabled', '');
+      node.disabled = true;
+    }
+  }
+
+  return () => {};
+}

--- a/packages/ui/src/components/input-group/input-group.classes.ts
+++ b/packages/ui/src/components/input-group/input-group.classes.ts
@@ -1,0 +1,109 @@
+import type {
+  InputGroupAddonPosition,
+  InputGroupConfig,
+  InputGroupSize,
+  InputGroupState,
+} from './input-group.behavior';
+
+/**
+ * InputGroup decoration. The group draws the whole control's chrome -- the
+ * border, the radius, and the single focus ring that lights up when focus lands
+ * ANYWHERE inside it -- while the contained control draws nothing. That
+ * inversion is the point of the component: one box, several occupants.
+ *
+ * Token and semantic classes only. Heights come from the shared size
+ * vocabulary, type from the `text-body-small` role token (never a raw
+ * `text-sm`), colours from the frozen semantic tokens.
+ */
+
+/** Addon fill treatment. Purely decorative -- it carries no behavior, so unlike
+ *  position it never reaches the score. */
+export type InputGroupAddonVariant = 'default' | 'filled';
+
+export interface InputGroupClassSet {
+  root: string;
+  control: string;
+  /** The addon class WITHOUT position/variant; use `composeInputGroupAddonClasses`
+   *  for the resolved string the decorators paint. */
+  addon: string;
+}
+
+/**
+ * The box: a flex row that owns the border, the radius, and -- via
+ * `focus-within` -- the one focus ring for the whole assembly. `bg-transparent`,
+ * never `bg-background`: the control inherits the surface it sits on (the
+ * fill-never-background rule, the same correction the standalone input made).
+ * Validity is styled off the projected `data-state`, so light-DOM markup, the
+ * Web Component, and React all pick up the destructive border with no extra
+ * class; the dim keys off the authored `data-disabled` host signal.
+ */
+const rootClasses =
+  'flex items-center w-full rounded-md border border-input bg-transparent ' +
+  'ring-offset-background ' +
+  'focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 ' +
+  'transition-shadow duration-100 motion-reduce:transition-none ' +
+  'data-[state=invalid]:border-destructive data-[state=invalid]:focus-within:ring-destructive-ring ' +
+  'data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed';
+
+/** Per-size heights, ported from the oracle. `text-sm` becomes the
+ *  `text-body-small` typography role token. */
+const sizeClasses: Record<InputGroupSize, string> = {
+  sm: 'h-9 text-body-small',
+  default: 'h-10',
+  lg: 'h-11',
+};
+
+/**
+ * The contained control: it fills the remaining width and deliberately renders
+ * NO border, radius, or focus ring -- the root owns all three, which is what
+ * makes the group read as one control rather than a box around a box.
+ */
+const controlClasses =
+  'flex-1 h-full w-full min-w-0 bg-transparent px-3 py-2 text-body-small ' +
+  'text-foreground placeholder:text-muted-foreground ' +
+  'border-0 rounded-[inherit] ' +
+  'focus:outline-none focus-visible:outline-none ' +
+  'disabled:cursor-not-allowed disabled:opacity-50';
+
+/** Affix chrome: never grows, never competes with the control for width. */
+const addonBaseClasses = 'flex items-center justify-center shrink-0 text-muted-foreground px-3';
+
+/** The divider sits on the side facing the control, so the affix reads as
+ *  attached to it rather than floating in the box. */
+const addonPositionClasses: Record<InputGroupAddonPosition, string> = {
+  start: 'border-r border-input',
+  end: 'border-l border-input',
+};
+
+const addonVariantClasses: Record<InputGroupAddonVariant, string> = {
+  default: 'bg-transparent',
+  filled: 'bg-muted',
+};
+
+/**
+ * Compose an addon's resolved class string. Exported so all three performances
+ * paint the identical composition -- the parity guarantee the oracle's
+ * `composeInputGroupAddonClasses` established, kept.
+ */
+export function composeInputGroupAddonClasses(
+  position: InputGroupAddonPosition,
+  variant: InputGroupAddonVariant = 'default',
+): string {
+  return [
+    addonBaseClasses,
+    addonPositionClasses[position] ?? addonPositionClasses.start,
+    addonVariantClasses[variant] ?? addonVariantClasses.default,
+  ].join(' ');
+}
+
+export function inputGroupClassSet(
+  config: InputGroupConfig,
+  _state: InputGroupState,
+): InputGroupClassSet {
+  const size = config.size ?? 'default';
+  return {
+    root: `${rootClasses} ${sizeClasses[size] ?? sizeClasses.default}`,
+    control: controlClasses,
+    addon: addonBaseClasses,
+  };
+}

--- a/packages/ui/src/components/input-group/input-group.element.ts
+++ b/packages/ui/src/components/input-group/input-group.element.ts
@@ -1,0 +1,37 @@
+/**
+ * WC performance for input-group: the thinnest wrapper. The score AND the
+ * DOM-native client (bindInputGroup) live in input-group.behavior.ts, shared
+ * with the Astro performance. This file only adapts that client to the
+ * custom-element lifecycle -- deferring the bind one microtask because
+ * connectedCallback can fire before the light-DOM children (the affixes and the
+ * control) are parsed.
+ *
+ * InputGroup is a LIGHT-DOM enhancer. The oracle was a shadow-DOM element that
+ * rebuilt an inner wrapper, carried `::slotted()` normalisation, and shipped a
+ * SECOND custom element (`<rafters-input-group-addon>`) purely so an affix could
+ * own a shadow root. None of that survives: in light DOM an affix is a `<div>`
+ * with a `data-part`, the focus-within ring is an ordinary class on the root
+ * rather than a `:host(:focus-within)` rule reaching across the boundary, and
+ * the control needs no `::slotted` normalisation because it is not slotted.
+ * See the disposition table in input-group.md.
+ */
+import { bindInputGroup } from './input-group.behavior';
+
+export class RaftersInputGroup extends HTMLElement {
+  private teardown: (() => void) | null = null;
+
+  connectedCallback(): void {
+    queueMicrotask(() => {
+      if (this.isConnected && !this.teardown) this.teardown = bindInputGroup(this);
+    });
+  }
+
+  disconnectedCallback(): void {
+    this.teardown?.();
+    this.teardown = null;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-input-group')) {
+  customElements.define('rafters-input-group', RaftersInputGroup);
+}

--- a/packages/ui/src/components/input-group/input-group.tsx
+++ b/packages/ui/src/components/input-group/input-group.tsx
@@ -1,0 +1,198 @@
+/**
+ * Adjoins a text control with leading/trailing affixes -- a currency symbol, a
+ * unit, a search icon, an action button -- into one box with one border and one
+ * focus ring. The group supplies chrome and the disabled/validity rules; the
+ * contained control keeps its own value, caret, and form participation.
+ *
+ * @cognitive-load 3/10 - decision 0, information 2, interaction 1, disruption 0,
+ * learning 0. The group asks nothing of the user; the affixes ADD information
+ * (what unit, what currency, what this field searches) that a bare input would
+ * otherwise have to spend its placeholder on, and interaction is just the
+ * familiar act of typing into a field.
+ * @attention-economics Affixes are context, not competition: muted foreground,
+ * no fill by default, and never wider than their content. Reading order puts the
+ * leading affix before the value so a currency symbol is understood before the
+ * number is typed. An action button in a trailing affix is the one element that
+ * may claim attention, and only after the field holds a value.
+ * @trust-building One border and one focus ring around the whole assembly tell
+ * the user this is a single control, not a row of loosely arranged pieces. A
+ * disabled group disables its affix buttons too, so nothing inside a dead
+ * control looks clickable -- the honesty that stops a user testing whether it
+ * still works.
+ * @accessibility The affixes are decoration around the control, not
+ * replacements for its name: an icon affix must be aria-hidden and the control
+ * still needs a real label (Field, or aria-label). The score puts no nameless
+ * role="group" on the wrapper, projects aria-invalid onto the CONTROL where
+ * assistive tech expects validity, and propagates disabled to every focusable
+ * descendant so a dead group holds no reachable tab stop. The focus ring is a
+ * focus-within ring, so keyboard focus is always visible wherever it lands.
+ */
+import * as React from 'react';
+import classy from '../../primitives/classy';
+import {
+  addonPart,
+  inputGroupBehavior,
+  isControlDisabled,
+  type InputGroupAddonPosition,
+  type InputGroupConfig,
+  type InputGroupSize,
+} from './input-group.behavior';
+import {
+  composeInputGroupAddonClasses,
+  inputGroupClassSet,
+  type InputGroupAddonVariant,
+} from './input-group.classes';
+
+export type { InputGroupAddonPosition, InputGroupAddonVariant, InputGroupSize };
+
+// ==================== Config distribution (React-only affordance) ====================
+
+interface InputGroupContextValue {
+  config: InputGroupConfig;
+}
+
+const InputGroupContext = React.createContext<InputGroupContextValue | null>(null);
+
+/**
+ * Read the enclosing group's config from a child. Returns null outside a group,
+ * so `InputGroupInput` and `InputGroupAddon` still render standalone.
+ *
+ * Context DISTRIBUTES config; it decides nothing. Every rule the children apply
+ * -- the disabled OR, the validity projection -- is read back out of
+ * `input-group.behavior.ts`. The Web Component and Astro performances reach the
+ * same children through the DOM in `bindInputGroup`, which is why the seam is a
+ * framework affordance rather than a second source of truth.
+ */
+export function useInputGroupContext(): InputGroupContextValue | null {
+  return React.useContext(InputGroupContext);
+}
+
+// ==================== InputGroup ====================
+
+export interface InputGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Control height, shared with the standalone input's vocabulary. */
+  size?: InputGroupSize;
+  /** Disables the whole assembly, affix buttons included. */
+  disabled?: boolean;
+  /** Advertised to AT via aria-invalid on the contained control; turns the
+   *  group's border destructive. */
+  invalid?: boolean;
+}
+
+export const InputGroup = React.forwardRef<HTMLDivElement, InputGroupProps>(
+  ({ size = 'default', disabled = false, invalid = false, className, children, ...props }, ref) => {
+    const config: InputGroupConfig = { size, disabled, invalid };
+    const classes = inputGroupClassSet(config, {});
+
+    // A static score: no state, no ids, no memory -- config in, classes + aria
+    // out (the button-group/field shape, no useBehavior). The projection ignores
+    // ids, so an empty set is passed.
+    const projection = inputGroupBehavior.aria({}, config, {
+      root: '',
+      control: '',
+      addonStart: '',
+      addonEnd: '',
+    });
+
+    const contextValue = React.useMemo<InputGroupContextValue>(
+      () => ({ config: { size, disabled, invalid } }),
+      [size, disabled, invalid],
+    );
+
+    return (
+      <InputGroupContext.Provider value={contextValue}>
+        <div
+          ref={ref}
+          data-part="root"
+          data-size={size}
+          data-disabled={disabled ? '' : undefined}
+          className={classy(classes.root, className)}
+          {...projection.root}
+          {...props}
+        >
+          {children}
+        </div>
+      </InputGroupContext.Provider>
+    );
+  },
+);
+
+InputGroup.displayName = 'InputGroup';
+
+// ==================== InputGroupAddon ====================
+
+export interface InputGroupAddonProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Which side of the control this affix sits on. */
+  position: InputGroupAddonPosition;
+  /** Fill treatment. Decoration only. */
+  variant?: InputGroupAddonVariant;
+}
+
+export const InputGroupAddon = React.forwardRef<HTMLDivElement, InputGroupAddonProps>(
+  ({ position, variant = 'default', className, ...props }, ref) => {
+    // The part name and the data-position both come from the score, so the
+    // decorator picks no names of its own.
+    const part = addonPart(position);
+    const projection = inputGroupBehavior.aria(
+      {},
+      {},
+      { root: '', control: '', addonStart: '', addonEnd: '' },
+    );
+
+    return (
+      <div
+        ref={ref}
+        data-part={part}
+        className={classy(composeInputGroupAddonClasses(position, variant), className)}
+        {...projection[part]}
+        {...props}
+      />
+    );
+  },
+);
+
+InputGroupAddon.displayName = 'InputGroupAddon';
+
+// ==================== InputGroupInput ====================
+
+export interface InputGroupInputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+/**
+ * The control inside the group. A bare `<input>` that renders no chrome of its
+ * own (the group owns border, radius, and ring) and keeps every native
+ * affordance -- value, caret, IME, selection, form participation. The group's
+ * disabled and validity reach it through the score, not through markup.
+ */
+export const InputGroupInput = React.forwardRef<HTMLInputElement, InputGroupInputProps>(
+  ({ className, type = 'text', disabled = false, ...props }, ref) => {
+    const context = useInputGroupContext();
+    const config: InputGroupConfig = context?.config ?? {};
+    const classes = inputGroupClassSet(config, {});
+
+    // The disabled rule lives in the score: the group's disabled wins, and an
+    // enabled group never re-enables an individually disabled control.
+    const effectiveDisabled = isControlDisabled(config, disabled);
+    const projection = inputGroupBehavior.aria({}, config, {
+      root: '',
+      control: '',
+      addonStart: '',
+      addonEnd: '',
+    });
+
+    return (
+      <input
+        ref={ref}
+        data-part="control"
+        type={type}
+        disabled={effectiveDisabled}
+        className={classy(classes.control, className)}
+        {...projection.control}
+        {...props}
+      />
+    );
+  },
+);
+
+InputGroupInput.displayName = 'InputGroupInput';
+
+export default InputGroup;

--- a/packages/ui/test/components/input-group/input-group.astro.conformance.test.ts
+++ b/packages/ui/test/components/input-group/input-group.astro.conformance.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Astro performance of the input-group score, driven end to end. AstroContainer
+ * renders the SSR assembly with the projection already applied, but does NOT run
+ * the `<script>`, so the test calls bindInputGroup directly on the root -- that
+ * IS the script's job -- then drives the same score React and the WC drive.
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import InputGroup from '../../../src/components/input-group/input-group.astro';
+import {
+  bindInputGroup,
+  inputGroupBehavior,
+} from '../../../src/components/input-group/input-group.behavior';
+import { assertContractFulfillment, partElement } from '../../harness/conformance';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+async function mount(
+  props: Record<string, unknown> = {},
+  slots: Record<string, string> = {},
+): Promise<HTMLElement> {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(InputGroup, {
+    props: { id: 'amount', 'aria-label': 'Amount', ...props },
+    slots,
+  });
+  document.body.innerHTML = html;
+  const root = document.body.querySelector<HTMLElement>(
+    'rafters-input-group[data-part="root"]',
+  ) as HTMLElement;
+  bindInputGroup(root);
+  return root;
+}
+
+const control = () => document.body.querySelector<HTMLInputElement>('[data-part="control"]')!;
+
+describe('input-group conformance [astro]', () => {
+  it('valid: SSR markup fulfils the contract with both affixes', async () => {
+    const root = await mount({}, { start: '$', end: 'USD' });
+    assertContractFulfillment(inputGroupBehavior, root, {}, { invalid: false }, [
+      'root',
+      'control',
+      'addonStart',
+      'addonEnd',
+    ]);
+    expect(control().hasAttribute('aria-invalid')).toBe(false);
+    expect(root.getAttribute('data-state')).toBe('default');
+  });
+
+  it('renders no affix cell for an unfilled side', async () => {
+    const root = await mount({}, { start: '$' });
+    expect(partElement(root, 'addonStart')).not.toBeNull();
+    expect(partElement(root, 'addonEnd')).toBeNull();
+  });
+
+  it('invalid: server-rendered projection puts aria-invalid on the control', async () => {
+    const root = await mount({ invalid: true }, { start: '$' });
+    assertContractFulfillment(inputGroupBehavior, root, {}, { invalid: true }, [
+      'root',
+      'control',
+      'addonStart',
+    ]);
+    expect(control().getAttribute('aria-invalid')).toBe('true');
+    expect(root.getAttribute('data-state')).toBe('invalid');
+  });
+
+  it('affixes carry the side they sit on', async () => {
+    const root = await mount({}, { start: '$', end: 'USD' });
+    expect(partElement(root, 'addonStart')?.getAttribute('data-position')).toBe('start');
+    expect(partElement(root, 'addonEnd')?.getAttribute('data-position')).toBe('end');
+  });
+
+  it('a disabled group server-renders the control already disabled', async () => {
+    await mount({ disabled: true });
+    expect(control().disabled).toBe(true);
+  });
+
+  it('reflects the size onto the host signal the client reads back', async () => {
+    const root = await mount({ size: 'sm' });
+    expect(root.getAttribute('data-size')).toBe('sm');
+  });
+
+  it('the contained control keeps its own value: typing works', async () => {
+    const user = userEvent.setup();
+    await mount({}, { start: '$' });
+    await user.type(control(), '42');
+    expect(control().value).toBe('42');
+  });
+});

--- a/packages/ui/test/components/input-group/input-group.behavior.test.ts
+++ b/packages/ui/test/components/input-group/input-group.behavior.test.ts
@@ -1,0 +1,143 @@
+/**
+ * The input-group score, driven purely -- no DOM. Everything asserted here is a
+ * decision the three decorators are forbidden to restate.
+ */
+import { describe, expect, it } from 'vitest';
+import type { PartIds } from '../../../src/lib/contract';
+import {
+  addonPart,
+  inputGroupBehavior,
+  isControlDisabled,
+  parseAddonPosition,
+  parseInputGroupSize,
+  type InputGroupConfig,
+  type InputGroupPart,
+} from '../../../src/components/input-group/input-group.behavior';
+
+const idsOf = (over: Partial<PartIds<InputGroupPart>> = {}): PartIds<InputGroupPart> => ({
+  root: '',
+  control: 'c',
+  addonStart: '',
+  addonEnd: '',
+  ...over,
+});
+
+function ariaAt(config: InputGroupConfig) {
+  return inputGroupBehavior.aria({}, config, idsOf());
+}
+
+describe('input-group parts', () => {
+  it('declares the root, the contained control, and two optional affixes', () => {
+    expect(Object.keys(inputGroupBehavior.parts).sort()).toEqual([
+      'addonEnd',
+      'addonStart',
+      'control',
+      'root',
+    ]);
+    expect(inputGroupBehavior.parts.root.optional).toBeUndefined();
+    expect(inputGroupBehavior.parts.control.optional).toBeUndefined();
+    expect(inputGroupBehavior.parts.addonStart.optional).toBe(true);
+    expect(inputGroupBehavior.parts.addonEnd.optional).toBe(true);
+  });
+
+  it('puts NO role on the root: a nameless group role would add no meaning', () => {
+    expect(inputGroupBehavior.parts.root.role).toBeUndefined();
+    expect(ariaAt({}).root?.role).toBeUndefined();
+  });
+});
+
+describe('input-group is a wrapper, not a value owner', () => {
+  it('has no state axis and no dispatchable action', () => {
+    expect(inputGroupBehavior.initialState({})).toEqual({});
+    expect(Object.keys(inputGroupBehavior.actions)).toEqual([]);
+  });
+
+  it('claims no key: the contained control owns every keystroke', () => {
+    for (const key of ['a', 'Enter', 'Escape', 'ArrowLeft', 'Backspace', 'Tab']) {
+      expect(inputGroupBehavior.keymap({ key }, {}, 'control', {})).toBeNull();
+      expect(inputGroupBehavior.keymap({ key }, {}, 'root', {})).toBeNull();
+    }
+  });
+});
+
+describe('input-group validity projection', () => {
+  it('omits aria-invalid when valid, so a contained control keeps its own authority', () => {
+    const aria = ariaAt({});
+    expect(aria.control?.['aria-invalid']).toBeUndefined();
+    expect(aria.control?.['data-state']).toBe('default');
+  });
+
+  it('projects aria-invalid onto the CONTROL, where assistive tech expects it', () => {
+    const aria = ariaAt({ invalid: true });
+    expect(aria.control?.['aria-invalid']).toBe('true');
+    expect(aria.control?.['data-state']).toBe('invalid');
+  });
+
+  it('reflects validity on the root too, because the root draws the border', () => {
+    expect(ariaAt({ invalid: true }).root?.['data-state']).toBe('invalid');
+    expect(ariaAt({ invalid: false }).root?.['data-state']).toBe('default');
+  });
+
+  it('never puts aria-invalid on the root: the wrapper is not the field', () => {
+    expect(ariaAt({ invalid: true }).root?.['aria-invalid']).toBeUndefined();
+  });
+});
+
+describe('input-group affix positions', () => {
+  it('projects the side each affix sits on, so all three decorators agree', () => {
+    const aria = ariaAt({});
+    expect(aria.addonStart?.['data-position']).toBe('start');
+    expect(aria.addonEnd?.['data-position']).toBe('end');
+  });
+
+  it('maps a position to its part name', () => {
+    expect(addonPart('start')).toBe('addonStart');
+    expect(addonPart('end')).toBe('addonEnd');
+  });
+
+  it('carries no aria-hidden: an affix may hold a focusable action button', () => {
+    const aria = ariaAt({});
+    expect(aria.addonStart?.['aria-hidden']).toBeUndefined();
+    expect(aria.addonEnd?.['aria-hidden']).toBeUndefined();
+  });
+});
+
+describe('input-group disabled rule', () => {
+  it('a disabled group disables the control', () => {
+    expect(isControlDisabled({ disabled: true }, false)).toBe(true);
+  });
+
+  it('an enabled group NEVER re-enables an individually disabled control', () => {
+    // The oracle assigned `child.disabled = disabled` unconditionally, which
+    // silently re-enabled the control here. The OR is the correction.
+    expect(isControlDisabled({ disabled: false }, true)).toBe(true);
+    expect(isControlDisabled({}, true)).toBe(true);
+  });
+
+  it('an enabled group leaves an enabled control alone', () => {
+    expect(isControlDisabled({ disabled: false }, false)).toBe(false);
+    expect(isControlDisabled({}, false)).toBe(false);
+  });
+});
+
+describe('input-group attribute parsing (unknown values fall back, the oracle rule)', () => {
+  it('parses the size vocabulary', () => {
+    expect(parseInputGroupSize('sm')).toBe('sm');
+    expect(parseInputGroupSize('lg')).toBe('lg');
+    expect(parseInputGroupSize('default')).toBe('default');
+  });
+
+  it('falls back to default for an unknown, empty, or missing size', () => {
+    expect(parseInputGroupSize('enormous')).toBe('default');
+    expect(parseInputGroupSize('')).toBe('default');
+    expect(parseInputGroupSize(null)).toBe('default');
+    expect(parseInputGroupSize(undefined)).toBe('default');
+  });
+
+  it('parses the position vocabulary and falls back to start', () => {
+    expect(parseAddonPosition('start')).toBe('start');
+    expect(parseAddonPosition('end')).toBe('end');
+    expect(parseAddonPosition('middle')).toBe('start');
+    expect(parseAddonPosition(null)).toBe('start');
+  });
+});

--- a/packages/ui/test/components/input-group/input-group.classes.test.ts
+++ b/packages/ui/test/components/input-group/input-group.classes.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  composeInputGroupAddonClasses,
+  inputGroupClassSet,
+} from '../../../src/components/input-group/input-group.classes';
+
+const classes = inputGroupClassSet({}, {});
+
+describe('input-group root decoration', () => {
+  it('fills transparently and borders on a semantic token, never a page bg', () => {
+    expect(classes.root).toContain('bg-transparent');
+    expect(classes.root).toContain('border-input');
+    expect(classes.root).not.toContain('bg-background');
+  });
+
+  it('carries the ONE focus ring for the whole assembly, as a focus-within ring', () => {
+    expect(classes.root).toContain('focus-within:ring-2');
+    expect(classes.root).toContain('focus-within:ring-ring');
+    expect(classes.root).toContain('focus-within:ring-offset-2');
+  });
+
+  it('styles validity off the projected data-state', () => {
+    expect(classes.root).toContain('data-[state=invalid]:border-destructive');
+    expect(classes.root).toContain('data-[state=invalid]:focus-within:ring-destructive-ring');
+  });
+
+  it('dims off the authored data-disabled host signal', () => {
+    expect(classes.root).toContain('data-[disabled]:opacity-50');
+    expect(classes.root).toContain('data-[disabled]:cursor-not-allowed');
+  });
+
+  it('motion respects reduced-motion', () => {
+    expect(classes.root).toContain('motion-reduce:transition-none');
+  });
+});
+
+describe('input-group size vocabulary', () => {
+  it('resolves each size to its height, defaulting when unset', () => {
+    expect(inputGroupClassSet({ size: 'sm' }, {}).root).toContain('h-9');
+    expect(inputGroupClassSet({ size: 'default' }, {}).root).toContain('h-10');
+    expect(inputGroupClassSet({ size: 'lg' }, {}).root).toContain('h-11');
+    expect(inputGroupClassSet({}, {}).root).toContain('h-10');
+  });
+
+  it('the small size uses the typography role token, never a raw text-sm', () => {
+    const small = inputGroupClassSet({ size: 'sm' }, {}).root;
+    expect(small).toContain('text-body-small');
+    expect(small).not.toContain('text-sm');
+  });
+});
+
+describe('input-group control decoration', () => {
+  it('renders no chrome of its own: the root owns border, radius, and ring', () => {
+    expect(classes.control).toContain('border-0');
+    expect(classes.control).toContain('rounded-[inherit]');
+    expect(classes.control).toContain('focus:outline-none');
+    expect(classes.control).not.toContain('border-input');
+    expect(classes.control).not.toContain('focus-visible:ring-2');
+  });
+
+  it('fills transparently and uses the typography role token', () => {
+    expect(classes.control).toContain('bg-transparent');
+    expect(classes.control).toContain('text-body-small');
+  });
+
+  it('honors the disabled affordance', () => {
+    expect(classes.control).toContain('disabled:cursor-not-allowed');
+    expect(classes.control).toContain('disabled:opacity-50');
+  });
+});
+
+describe('input-group affix decoration', () => {
+  it('never grows and never competes with the control for width', () => {
+    expect(composeInputGroupAddonClasses('start')).toContain('shrink-0');
+    expect(composeInputGroupAddonClasses('start')).toContain('text-muted-foreground');
+  });
+
+  it('puts the divider on the side facing the control', () => {
+    expect(composeInputGroupAddonClasses('start')).toContain('border-r');
+    expect(composeInputGroupAddonClasses('end')).toContain('border-l');
+  });
+
+  it('fills only on the filled variant', () => {
+    expect(composeInputGroupAddonClasses('start', 'default')).toContain('bg-transparent');
+    expect(composeInputGroupAddonClasses('start', 'filled')).toContain('bg-muted');
+  });
+
+  it('defaults the variant when omitted', () => {
+    expect(composeInputGroupAddonClasses('end')).toBe(
+      composeInputGroupAddonClasses('end', 'default'),
+    );
+  });
+});

--- a/packages/ui/test/components/input-group/input-group.conformance.test.tsx
+++ b/packages/ui/test/components/input-group/input-group.conformance.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * React performance of the input-group score, driven end to end. The oracle's
+ * three-export surface (InputGroup / InputGroupAddon / InputGroupInput) is a
+ * drop-in: same component names, same prop names, same composition order.
+ */
+import * as React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from '../../../src/components/input-group/input-group';
+import { inputGroupBehavior } from '../../../src/components/input-group/input-group.behavior';
+import { assertAxeClean, assertContractFulfillment, partElement } from '../../harness/conformance';
+
+afterEach(() => {
+  cleanup();
+});
+
+const rootOf = (host: HTMLElement) => partElement(host, 'root') as HTMLElement;
+const controlOf = (host: HTMLElement) => partElement(host, 'control') as HTMLInputElement;
+
+describe('input-group conformance [react]', () => {
+  it('valid group with both affixes fulfils the contract and is axe-clean', async () => {
+    const { container } = render(
+      <InputGroup>
+        <InputGroupAddon position="start">$</InputGroupAddon>
+        <InputGroupInput aria-label="Amount" />
+        <InputGroupAddon position="end">USD</InputGroupAddon>
+      </InputGroup>,
+    );
+    assertContractFulfillment(inputGroupBehavior, rootOf(container), {}, { invalid: false }, [
+      'root',
+      'control',
+      'addonStart',
+      'addonEnd',
+    ]);
+    expect(controlOf(container).hasAttribute('aria-invalid')).toBe(false);
+    expect(rootOf(container).getAttribute('data-state')).toBe('default');
+    await assertAxeClean(container);
+  });
+
+  it('invalid: aria-invalid lands on the control, data-state on both, axe-clean', async () => {
+    const { container } = render(
+      <InputGroup invalid>
+        <InputGroupAddon position="start">$</InputGroupAddon>
+        <InputGroupInput aria-label="Amount" />
+      </InputGroup>,
+    );
+    assertContractFulfillment(inputGroupBehavior, rootOf(container), {}, { invalid: true }, [
+      'root',
+      'control',
+      'addonStart',
+    ]);
+    expect(controlOf(container).getAttribute('aria-invalid')).toBe('true');
+    expect(controlOf(container).getAttribute('data-state')).toBe('invalid');
+    expect(rootOf(container).getAttribute('data-state')).toBe('invalid');
+    expect(rootOf(container).hasAttribute('aria-invalid')).toBe(false);
+    await assertAxeClean(container);
+  });
+
+  it('a group with no affixes renders neither optional part', () => {
+    const { container } = render(
+      <InputGroup>
+        <InputGroupInput aria-label="Bare" />
+      </InputGroup>,
+    );
+    assertContractFulfillment(inputGroupBehavior, rootOf(container), {}, { invalid: false }, [
+      'root',
+      'control',
+    ]);
+    expect(partElement(rootOf(container), 'addonStart')).toBeNull();
+    expect(partElement(rootOf(container), 'addonEnd')).toBeNull();
+  });
+
+  it('affixes project the side they sit on', () => {
+    const { container } = render(
+      <InputGroup>
+        <InputGroupAddon position="start">$</InputGroupAddon>
+        <InputGroupInput aria-label="Amount" />
+        <InputGroupAddon position="end">USD</InputGroupAddon>
+      </InputGroup>,
+    );
+    const root = rootOf(container);
+    expect(partElement(root, 'addonStart')?.getAttribute('data-position')).toBe('start');
+    expect(partElement(root, 'addonEnd')?.getAttribute('data-position')).toBe('end');
+  });
+
+  it('the contained control keeps its own value: typing works, the group holds nothing', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <InputGroup>
+        <InputGroupAddon position="start">$</InputGroupAddon>
+        <InputGroupInput aria-label="Amount" defaultValue="" />
+      </InputGroup>,
+    );
+    const control = controlOf(container);
+    await user.type(control, '42');
+    expect(control.value).toBe('42');
+  });
+
+  it('a disabled group disables the control it contains', () => {
+    const { container } = render(
+      <InputGroup disabled>
+        <InputGroupInput aria-label="Amount" />
+      </InputGroup>,
+    );
+    expect(controlOf(container).disabled).toBe(true);
+    expect(rootOf(container).hasAttribute('data-disabled')).toBe(true);
+  });
+
+  it('an enabled group never re-enables an individually disabled control', () => {
+    const { container } = render(
+      <InputGroup>
+        <InputGroupInput aria-label="Amount" disabled />
+      </InputGroup>,
+    );
+    expect(controlOf(container).disabled).toBe(true);
+  });
+
+  it('is a drop-in: passes native input props through to the control', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <InputGroup size="lg">
+        <InputGroupInput aria-label="Email" type="email" name="email" placeholder="you@x.com" />
+      </InputGroup>,
+    );
+    const control = controlOf(container);
+    expect(control.type).toBe('email');
+    expect(control.name).toBe('email');
+    expect(control.placeholder).toBe('you@x.com');
+    expect(rootOf(container).getAttribute('data-size')).toBe('lg');
+    await user.type(control, 'a');
+    expect(control.value).toBe('a');
+  });
+
+  it('an affix action button stays reachable and clickable in an enabled group', async () => {
+    const user = userEvent.setup();
+    const clicks: string[] = [];
+    const { container } = render(
+      <InputGroup>
+        <InputGroupInput aria-label="Code" />
+        <InputGroupAddon position="end">
+          <button type="button" onClick={() => clicks.push('apply')}>
+            Apply
+          </button>
+        </InputGroupAddon>
+      </InputGroup>,
+    );
+    await user.click(container.querySelector('button') as HTMLButtonElement);
+    expect(clicks).toEqual(['apply']);
+    await assertAxeClean(container);
+  });
+});

--- a/packages/ui/test/components/input-group/input-group.element.conformance.test.ts
+++ b/packages/ui/test/components/input-group/input-group.element.conformance.test.ts
@@ -1,0 +1,125 @@
+/**
+ * WC performance of the input-group score, driven end to end against light-DOM
+ * markup. Same score as the React conformance test -- proves the projection and
+ * the disabled propagation reach an AUTHORED control the element never rendered.
+ */
+import { cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { RaftersInputGroup } from '../../../src/components/input-group/input-group.element';
+import { inputGroupBehavior } from '../../../src/components/input-group/input-group.behavior';
+import { assertContractFulfillment, partElement } from '../../harness/conformance';
+
+beforeAll(() => {
+  if (!customElements.get('rafters-input-group')) {
+    customElements.define('rafters-input-group', RaftersInputGroup);
+  }
+});
+
+async function mount(markup: string): Promise<HTMLElement> {
+  document.body.innerHTML = markup;
+  await Promise.resolve(); // let the deferred connectedCallback bind run
+  return document.body.querySelector('rafters-input-group') as HTMLElement;
+}
+
+const control = () => document.body.querySelector<HTMLInputElement>('[data-part="control"]')!;
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+describe('input-group conformance [wc]', () => {
+  it('valid: fulfils the contract with both affixes, omitting aria-invalid', async () => {
+    const root = await mount(
+      `<rafters-input-group data-part="root">
+        <div data-part="addonStart">$</div>
+        <input data-part="control" id="amount" aria-label="Amount" />
+        <div data-part="addonEnd">USD</div>
+      </rafters-input-group>`,
+    );
+    assertContractFulfillment(inputGroupBehavior, root, {}, { invalid: false }, [
+      'root',
+      'control',
+      'addonStart',
+      'addonEnd',
+    ]);
+    expect(control().hasAttribute('aria-invalid')).toBe(false);
+    expect(root.getAttribute('data-state')).toBe('default');
+  });
+
+  it('invalid: the data-invalid host signal projects onto the control', async () => {
+    const root = await mount(
+      `<rafters-input-group data-part="root" data-invalid>
+        <input data-part="control" id="amount" aria-label="Amount" />
+      </rafters-input-group>`,
+    );
+    assertContractFulfillment(inputGroupBehavior, root, {}, { invalid: true }, ['root', 'control']);
+    expect(control().getAttribute('aria-invalid')).toBe('true');
+    expect(control().getAttribute('data-state')).toBe('invalid');
+    expect(root.getAttribute('data-state')).toBe('invalid');
+  });
+
+  it('affixes get the side they sit on from the score, not from the markup', async () => {
+    const root = await mount(
+      `<rafters-input-group data-part="root">
+        <div data-part="addonStart">$</div>
+        <input data-part="control" id="amount" aria-label="Amount" />
+        <div data-part="addonEnd">USD</div>
+      </rafters-input-group>`,
+    );
+    expect(partElement(root, 'addonStart')?.getAttribute('data-position')).toBe('start');
+    expect(partElement(root, 'addonEnd')?.getAttribute('data-position')).toBe('end');
+  });
+
+  it('finds and stamps a bare authored control that carries no data-part', async () => {
+    const root = await mount(
+      `<rafters-input-group data-part="root">
+        <input id="amount" aria-label="Amount" />
+      </rafters-input-group>`,
+    );
+    const input = root.querySelector('input') as HTMLInputElement;
+    expect(input.getAttribute('data-part')).toBe('control');
+  });
+
+  it('a disabled group disables the control AND an affix action button', async () => {
+    await mount(
+      `<rafters-input-group data-part="root" disabled>
+        <input data-part="control" id="code" aria-label="Code" />
+        <div data-part="addonEnd"><button type="button">Apply</button></div>
+      </rafters-input-group>`,
+    );
+    expect(control().disabled).toBe(true);
+    const button = document.body.querySelector('button') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+
+  it('an enabled group never re-enables an individually disabled control', async () => {
+    await mount(
+      `<rafters-input-group data-part="root">
+        <input data-part="control" id="code" aria-label="Code" disabled />
+      </rafters-input-group>`,
+    );
+    // The oracle assigned disabled unconditionally and would have cleared this.
+    expect(control().disabled).toBe(true);
+  });
+
+  it('the contained control keeps its own value: typing works with no group state', async () => {
+    const user = userEvent.setup();
+    await mount(
+      `<rafters-input-group data-part="root">
+        <div data-part="addonStart">$</div>
+        <input data-part="control" id="amount" aria-label="Amount" value="" />
+      </rafters-input-group>`,
+    );
+    await user.type(control(), '42');
+    expect(control().value).toBe('42');
+  });
+
+  it('binds nothing when the group contains no control at all', async () => {
+    const root = await mount(
+      `<rafters-input-group data-part="root"><div data-part="addonStart">$</div></rafters-input-group>`,
+    );
+    expect(root.hasAttribute('data-state')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Ports `input-group` to the behavior layer as a WRAPPER, not a value owner.

The component looks like one control -- one border, one focus ring, one apparent
field -- and the issue lists `value` among its states. It does not follow that it
owns a control's state, and the oracle settles it: `old/ui/input-group.tsx` ships
an `InputGroupInput` that is a bare styled `<input>` with no value handling and
no validity wiring, and `old/ui/input-group.element.ts` propagates `disabled` and
draws a focus-within ring and nothing else. Neither surface ever held a value.

So the score is `field`-shaped rather than `input`-shaped: no state axis, no
actions, no keymap, no value cell, no bind-time listener. The contained native
control keeps its value, caret, IME composition, selection, and form
participation. This also avoids installing a second memory cell over a control
that already has one -- they would diverge the moment a consumer nested the
ported `<Input>` inside a group. `value` is satisfied by composition; `invalid`
is a config the group projects onto the control.

What the score does own:

- **Validity projection.** `aria-invalid` lands on the CONTROL, where assistive
  tech expects it, and is omitted when valid (field's convention) so a contained
  control projecting its own validity stays the single authority. `data-state`
  is reflected on the root as well, because the root is what draws the border the
  destructive treatment has to land on.
- **Affix position**, promoted from a class-only concern to two declared parts
  (`addonStart` / `addonEnd`), so the harness asserts `data-position`
  identically in all three frameworks from one source.
- **The disabled rule**, with one behavioral correction. The oracle assigned
  `child.disabled = disabled` unconditionally, so an ENABLED group silently
  re-enabled a control the author had disabled individually. Propagation is now
  an OR (`isControlDisabled`), stated once and read by all three performances,
  and it reaches every disableable descendant -- an affix's action button must
  not stay live inside a dead group.

The shadow DOM goes. The second custom element (`<rafters-input-group-addon>`),
the `::slotted()` normalisation, the `:host` shims, and the rebuilt inner wrapper
all existed to work around the shadow boundary. As a light-DOM enhancer an affix
is a `<div data-part="addonStart">` and the ring is an ordinary class.

Conformance is green across React, Web Component, and Astro (55 tests).

## Acceptance criteria mapping

### Component doc written

`docs/spec/components/input-group.md` follows the dialog/input article pattern
and leads with the archetype question this port had to answer -- whether a
component that looks like one control must own one -- resolving it from the
oracle files rather than from preference. It carries the parts/ARIA table, the
host-signal versus projection-output split that `bindInputGroup` depends on to
avoid reading back its own output, the keyboard and motion sections, the full
oracle disposition table, and the WCAG obligations.

Evidence: packages/ui/docs/spec/components/input-group.md:26

### JSDoc intelligence tags present

The four tags sit on the React performance and describe this component
specifically rather than restating generic guidance: the cognitive-load entry
gives the five-dimension breakdown and explains why affixes SUBTRACT load (they
carry information a bare input would spend its placeholder on), and the
accessibility tag records the three real obligations -- an icon affix must be
aria-hidden, the control still needs a real label, and the wrapper carries no
nameless group role.

Evidence: packages/ui/src/components/input-group/input-group.tsx:7

### Behavior test (pure, no DOM)

`input-group.behavior.test.ts` drives the score with no DOM at all and asserts
the negative decisions that are easiest to regress silently: no state, no
actions, no key claimed on any part, no role and no `aria-invalid` on the root,
and no `aria-hidden` on an affix (which would bury a slotted action button from
assistive tech). The disabled block exercises the OR correction directly, pinning
that an enabled group cannot re-enable an individually disabled control.

Evidence: packages/ui/test/components/input-group/input-group.behavior.test.ts:116

### Classes parity test

`input-group.classes.test.ts` pins the decoration decisions a later refactor
could quietly undo, in particular the inversion the component exists for: the
ring is `focus-within` on the root and the control carries no border or ring of
its own, so the assembly reads as a single field. It also holds the two oracle
values that were deliberately replaced -- transparent fill instead of
`bg-background`, and the `text-body-small` role token instead of a raw `text-sm`.

Evidence: packages/ui/test/components/input-group/input-group.classes.test.ts:19

### Conformance test via the shared harness (aria + keymap against rendered DOM)

Three suites drive `assertContractFulfillment` from the shared harness against
real rendered DOM in React, the Web Component, and Astro, comparing every
projected attribute -- including projected absence -- to what each framework
actually rendered. The Web Component suite additionally covers what React cannot
reach: a bare authored `<input>` with no `data-part` is located and stamped, and
a disabled group is verified to disable an affix button as well as the control.
There is no keymap to exercise because the score claims no key, which the
behavior suite asserts explicitly rather than leaving implied.

Evidence: packages/ui/test/components/input-group/input-group.element.conformance.test.ts:96

### shadcn drop-in parity where the component exists in shadcn

The oracle's three-export React surface is preserved exactly -- same component
names, same prop names (`size`, `disabled`, `position`, `variant`), same
composition order -- so existing call sites compile unchanged. The conformance
suite exercises this by passing native input props (`type`, `name`,
`placeholder`) straight through to the control and confirming they land. The one
divergence is a bug fix, not an API change: an enabled group no longer re-enables
an individually disabled control.

Evidence: packages/ui/src/components/input-group/input-group.tsx:82

### `pnpm --filter @rafters/ui test:unit` green, `pnpm preflight` green

Both were run from the worktree after merging the latest `origin/main` (which
brought in the tabs and accordion ports) and both exit 0, so the port is verified
against current main rather than against the branch point. `preflight` covers
typecheck, lint, format check, the unit and a11y suites, and the full build
including the registry.

Evidence: packages/ui/CHANGELOG.md:12

## Not done

- **`form-value` and `input-events` are not composed**, though the issue lists
  both under "Add". `form-value` builds a hidden mirror input for controls that
  are NOT native form fields; the contained `<input>` is form-associated already,
  so a mirror would submit the field twice. `input-events` is the
  contenteditable/IME handler belonging to the editor subsystem, and the group
  runs no editing path at all. Both are recorded as `not ported` with this
  reasoning in the disposition table -- the same call `input.md` made.
- **`required` and error-message wiring are not implemented here.** `field` owns
  them and composes around a group; duplicating them would put two authorities on
  one control's `aria-describedby`.
- **The bind is bind-once.** Re-toggling `disabled` or `data-invalid` at runtime
  is React's declarative affordance, not a lifecycle the DOM client re-observes.
  This matches input, field, and radio-group, and is recorded as a disposition
  rather than left as a surprise.
- **Vue remains unported**, consistent with every other component in the wave.
- **The `~45-line projection scaffolding block` is still duplicated** into this
  component's bind, as 05-authoring.md steps 2/4/5/6 prescribe. Factoring a
  shared helper is a pending decision that should not be made unilaterally
  inside a component port.

Closes #1778
