### PR TITLE
feat(ui): port input-otp to the behavior layer

### DIFF
--- a/packages/ui/docs/spec/components/input-otp.md
+++ b/packages/ui/docs/spec/components/input-otp.md
@@ -1,0 +1,193 @@
+# Component Spec — InputOTP
+
+Status: DRAFT. Archetype `text-input-family`, imitates `input` for the
+value-primary score shape and `slider` for the many-part instance projection.
+
+Files (`src/components/input-otp/`):
+
+```
+input-otp.classes.ts    input-otp.behavior.ts    input-otp.tsx
+input-otp.element.ts    input-otp.astro
+```
+
+Tests mirror into `test/components/input-otp/` (behavior, classes, and React /
+WC / Astro conformance on the shared harness).
+
+## Composition
+
+One real `<input>` holds the code; the slots are a painted MIRROR of its value.
+This is the oracle's shape and it is load-bearing: an array of per-slot inputs
+would break paste, break `autocomplete="one-time-code"` autofill, and turn one
+field into N tab stops. The native input keeps caret, IME and selection — the
+score does not re-implement text editing (Spec 05, text-input archetype).
+
+The impure surface is COMPOSED from two primitives directly (no effects layer):
+
+```
+keyboard-handler   ArrowLeft / ArrowRight on the field -> move the lit slot
+input-events       IME composition tracking (the composition guard only)
+```
+
+`composeInputOtpInteractions({ root, input, getConfig, getState, requestValue,
+requestActive })` folds them plus the paste interception and the focus-on-click
+into one teardown, shared verbatim by `bindInputOtp` (WC + Astro) and the React
+controller's effect.
+
+The value math — the per-character pattern filter, truncation to `maxLength`,
+and active-slot resolution — is COMPONENT-INTERNAL pure state: the exported
+`filterAndTruncate` / `activeSlot` / `isSlotActive` / `slotState` /
+`activeForKey` helpers, never a reducer (a reducer receives no config, and the
+math needs `maxLength`/`pattern`).
+
+Controlled/uncontrolled per the ownership-of-truth boundary: `config.value`
+shadows `state.value`; projections and the callbacks read `effectiveOtpValue`.
+
+### Why `input-events` is composed for its guard only
+
+`createInputHandler` classifies `beforeinput`/`input` by `inputType` against an
+editor-oriented whitelist and drops anything outside it. The value path must
+never depend on that classification, so it stays on the plain `input` event and
+the primitive is composed for the one thing it uniquely owns: knowing whether an
+IME composition is in flight. Filtering a half-composed string would delete the
+characters the IME is still assembling.
+
+### Why `form-value` is NOT composed
+
+`form-value` mirrors a control's value into a hidden `<input>` for controls
+built out of divs (slider's thumbs), which a `<form>` submit would otherwise
+skip. InputOTP already HAS a real native input, so `name` on it submits
+`name=value` natively; rendering the mirror as well would submit the field
+twice. The conformance suites assert no hidden input exists.
+
+## Config, state, actions
+
+```ts
+interface InputOtpConfig {
+  maxLength: number;        // slot count AND the hard cap on the value
+  pattern?: string;         // per-CHARACTER accept test, as a regex source
+  value?: string;           // controlled
+  defaultValue?: string;    // uncontrolled seed
+  disabled?: boolean;
+  required?: boolean;
+  label?: string;           // accessible name override
+}
+interface InputOtpState { value: string; activeIndex: number }
+type InputOtpActions = { setValue: string; setActive: number };
+```
+
+`setValue` receives an ALREADY filtered and truncated value (the pure helpers
+own the math) and re-seats `activeIndex` at the value's end — that re-seating IS
+auto-advance. `activeIndex` is stored UNCLAMPED and clamped on read by
+`activeSlot`, so shrinking `maxLength` cannot strand the caret past the last
+rendered slot. `canDispatch` gates BOTH actions on `!disabled`, so a disabled
+field refuses edits and caret movement alike.
+
+`pattern` is a regex SOURCE string rather than a `RegExp` so one config crosses
+a DOM attribute and an Astro prop unchanged; a malformed source falls back to
+digits-only rather than throwing at paint time. The React surface still accepts
+a `RegExp` (the oracle's type) and reads its `.source`.
+
+## Parts and ARIA
+
+| Part | Presence | ARIA |
+| --- | --- | --- |
+| root | always | `data-disabled` / `data-complete` (only when true); no role (not the widget); the click surface that focuses the field |
+| input | always | `aria-label` (`Enter N character code` unless overridden), `aria-required` / `aria-disabled` (only when true); `inputmode=numeric`, `autocomplete=one-time-code` |
+| group | optional | layout only; groups slots for the 3-3 / 2-2-2 shapes |
+| slot | one per character | `data-index`, `data-active` / `data-filled` (only when true). NO ARIA — see below |
+| separator | optional | `aria-hidden="true"` (decorative) |
+
+The slot is a `many` part, so its projection lives in `otpSlotAttrs(index,
+state, config)`, first-classed onto `inputOtpBehavior.instanceAria` so the
+harness's generic `assertInstanceAriaFulfillment` drives it (each instance keyed
+by `data-value`).
+
+Slots carry no ARIA deliberately: the accessible name, the value and the focus
+all live on the single input, so exposing the slots would announce the code
+twice. They are also not tab stops — the field is one tab stop, not N.
+
+Every slot state is projected as a `data-` attribute and styled from it
+(`data-[active=true]:ring-1`, `data-[filled=true]:text-foreground`, and
+`group-data-[disabled=true]:*` reading the root). No framework recomposes a
+class string, so the three performances cannot drift in presentation.
+
+## Keyboard
+
+`keymap` is the pure claim record (Spec 01): the two arrow keys on the `input`
+part claim `setActive`. The bind computes the target index via `activeForKey`.
+
+| Key | Effect |
+| --- | --- |
+| ArrowLeft | lit slot back one, stops at the first |
+| ArrowRight | lit slot to the first EMPTY slot, never past the last |
+| Backspace | NOT claimed — the native field deletes, and the resulting `input` event carries the change back through `setValue` |
+| character keys | NOT claimed — the native field types, then the filter accepts or reverts |
+
+Arrows `preventDefault` so the native caret does not move inside the flat string
+and desync from the lit slot. Focus never leaves the input.
+
+## Events (WC / Astro)
+
+| Event | When |
+| --- | --- |
+| `input` | every accepted value change (bubbles, composed) |
+| `change` | the completion EDGE only |
+| `rafters-otp-complete` | the completion EDGE, `detail.value` = the code |
+
+The completion edge is latched: re-typing inside an already-full code does not
+re-fire. React reports the same edge through `onComplete`.
+
+## Motion
+
+`caret-blink`: the fake caret in the active empty slot. Intent only —
+`animate-pulse motion-reduce:animate-none`; durations and easing come from
+tokens. Reduced motion STILLS the caret rather than hiding it, so it still marks
+the slot. Slot state transitions honour `motion-reduce:transition-none`.
+
+## Oracle dispositions (src/old/ui/input-otp.{tsx,element.ts,classes.ts})
+
+| Oracle feature | Disposition |
+| --- | --- |
+| compound React API: `InputOTP` + `.Group` / `.Slot index` / `.Separator` | contract (preserved verbatim for shadcn drop-in parity) |
+| controlled/uncontrolled `value`/`defaultValue` + `onChange(value)` | contract |
+| `maxLength`, `pattern`, `disabled`, `autoFocus`, `onComplete` | contract |
+| per-character filter + truncation on typing AND paste | contract (one gate, `filterAndTruncate`) |
+| paste intercepted with `preventDefault`, split across slots | contract |
+| auto-advance: active slot follows the value length | contract (the `setValue` reducer re-seats it) |
+| ArrowLeft/ArrowRight move the active slot; Backspace left to the native field | contract |
+| click anywhere in the container focuses the hidden input | contract |
+| fake caret in the active empty slot | contract |
+| `sr-only` input carrying `aria-label`, `inputmode=numeric`, `autocomplete=one-time-code` | contract |
+| the complete-code OR: last slot stays lit while the code is full, so a full field can show TWO active slots | contract — preserved verbatim (`isSlotActive`). Deliberately NOT re-derived into a single-active rule |
+| `rafters-otp-complete` CustomEvent + `change` at max length | contract (now latched to the EDGE; the oracle re-fired on every input while full) |
+| WC `ElementInternals` form association, `setValidity({tooShort})`, `formResetCallback`, `formStateRestoreCallback`, `checkValidity` etc. | framework-affordance — a WC-only surface the React oracle never had. The behavior-layer control is a real native `<input>`, so `name`, submission, reset and constraint validation come from the platform |
+| WC `<rafters-input-otp>` auto-rendering `maxLength` slots into shadow DOM | framework-affordance — the behavior-layer WC is a light-DOM enhancer (Spec 05); Astro server-renders the slots, and `groups={[3,3]}` is the SSR equivalent of the React compound children |
+| WC `composeInputOtpSlotClasses` / `composeInputOtpContainerClasses` recomposing class strings per state | dropped — state now rides projected `data-` attributes the CSS reads, so no framework recomposes classes and the three cannot drift |
+| WC text-node surgery inside the slot (remove every child but the caret, insert a text node) | dropped — the slot has a dedicated `[data-otp-char]` element, so painting a character is one `textContent` write |
+| React default pattern `/^[0-9]*$/` vs WC default `^[0-9]$` | dropped — the two oracles disagreed; the per-character WC form is canonical (`^[0-9]$`). Both accept exactly the digits, so no behavior changes |
+| React `aria-label` "Enter N digit code" vs WC "Enter N character code" | dropped — the two oracles disagreed; "character" is canonical because `pattern` is configurable and the code need not be digits |
+| slots exposed to AT (no `aria-hidden`, no roles) | contract — preserved as-is. Marking the mirror `aria-hidden` was considered and rejected: the oracle and shadcn both leave it, and the container holds the focusable input, so hiding it would itself be an axe violation |
+| `onComplete` re-firing on every input event while the code is full | defect-do-not-port — the completion edge is now latched in both the bind and React |
+| container `opacity-50` applied via a JS-composed class on the disabled edge | dropped — `group-data-[disabled=true]:opacity-50` on the slots reads the root's projection with no JS |
+
+## WCAG 2.1 AA obligations
+
+- 1.3.1 / 4.1.2: one real `<input>` carries the name, role and value; the
+  segmented slots are presentational and asserted against the score's projection
+  by the harness across React / WC / Astro.
+- 2.1.1 Keyboard: the whole code is enterable, editable and pasteable from the
+  keyboard; the field is ONE tab stop, and arrows move the lit slot without
+  moving focus. Disabled gates every entry path.
+- 2.4.3 Focus Order: the slots add no tab stops, so a segmented field costs the
+  same traversal as a plain text input.
+- 2.4.7 Focus Visible: the active slot carries the token focus ring
+  (`data-[active=true]:ring-1 ring-ring`), because the real input is `sr-only`
+  and cannot show one.
+- 3.3.2 Labels: the field is self-naming (`Enter N character code`) so a
+  consumer who supplies no label still ships an announced control;
+  `aria-label` overrides it.
+- 1.3.5 Identify Input Purpose: `autocomplete="one-time-code"` lets the platform
+  autofill an SMS code, which is the single largest accessibility win available
+  to this control.
+- 1.4.13 / motion: the caret blink honours `motion-reduce:animate-none` and slot
+  transitions honour `motion-reduce:transition-none`.

--- a/packages/ui/src/components/input-otp/input-otp.astro
+++ b/packages/ui/src/components/input-otp/input-otp.astro
@@ -1,0 +1,163 @@
+---
+/**
+ * Astro performance (controller) for input-otp.
+ *
+ * Server-renders the full LIGHT-DOM field -- the one real <input> (named,
+ * autocomplete="one-time-code", carrying the score's accessible name) plus one
+ * painted slot per character -- with the score's initial projection already
+ * applied, so the code can be typed, pasted or autofilled before any JS runs.
+ * The <script> then hands each server-rendered root to bindInputOtp -- the SAME
+ * DOM-native controller the Web Component uses. One score, three performances,
+ * zero drift.
+ *
+ * Grouping is declarative: `groups={[3, 3]}` renders two groups of three with a
+ * separator between, the SSR equivalent of the React compound children.
+ */
+import {
+  inputOtpBehavior,
+  slotState,
+  otpSlotAttrs,
+  type InputOtpConfig,
+  type InputOtpPart,
+} from './input-otp.behavior';
+import { inputOtpClassSet } from './input-otp.classes';
+import type { PartIds } from '../../lib/contract';
+
+interface Props {
+  id: string;
+  maxLength: number;
+  /** Per-character accept test as a regex source string. */
+  pattern?: string;
+  defaultValue?: string;
+  disabled?: boolean;
+  required?: boolean;
+  name?: string;
+  /** Slot counts per group; defaults to one group holding every slot. */
+  groups?: number[];
+  'aria-label'?: string;
+}
+
+const {
+  id,
+  maxLength,
+  pattern,
+  defaultValue,
+  disabled = false,
+  required = false,
+  name,
+  groups,
+  'aria-label': ariaLabel,
+} = Astro.props;
+
+const config: InputOtpConfig = {
+  maxLength,
+  pattern,
+  defaultValue,
+  disabled,
+  required,
+  label: ariaLabel,
+};
+const state = inputOtpBehavior.initialState(config);
+const classes = inputOtpClassSet(config, state);
+
+const ids = {} as PartIds<InputOtpPart>;
+for (const part of Object.keys(inputOtpBehavior.parts) as InputOtpPart[]) {
+  ids[part] = `${id}-${part}`;
+}
+const aria = inputOtpBehavior.aria(state, config, ids);
+
+// Split the flat slot range into the requested groups; an absent/empty `groups`
+// prop is one group holding every slot.
+const sizes = groups && groups.length > 0 ? groups : [maxLength];
+let cursor = 0;
+const groupedIndexes = sizes.map((size) => {
+  const indexes = Array.from({ length: size }, (_, offset) => cursor + offset).filter(
+    (index) => index < maxLength,
+  );
+  cursor += size;
+  return indexes;
+});
+
+// Class-bearing spans ride a spread attrs object rather than a literal class=,
+// the same escape slider.astro uses -- these carry no typography role.
+const slots = groupedIndexes.map((indexes) =>
+  indexes.map((index) => {
+    const slot = slotState(index, state, config);
+    return {
+      attrs: {
+        'data-part': 'slot',
+        'data-value': index,
+        class: classes.slot,
+        ...otpSlotAttrs(String(index), state, config),
+      },
+      char: { 'data-otp-char': '', class: classes.char },
+      caret: {
+        'data-otp-caret': '',
+        'aria-hidden': 'true',
+        hidden: !slot.caret,
+        class: classes.caret,
+      },
+      caretBar: { class: classes.caretBar },
+      text: slot.char,
+    };
+  }),
+);
+const separatorAttrs = {
+  'data-part': 'separator',
+  'aria-hidden': 'true',
+  class: classes.separator,
+};
+---
+
+<div
+  data-part="root"
+  id={ids.root}
+  data-max-length={maxLength}
+  data-pattern={pattern}
+  class={classes.root}
+  {...aria.root}
+>
+  <input
+    data-part="input"
+    id={ids.input}
+    type="text"
+    inputmode="numeric"
+    autocomplete="one-time-code"
+    name={name}
+    value={state.value}
+    maxlength={maxLength}
+    disabled={disabled}
+    required={required}
+    class={classes.input}
+    {...aria.input}
+  />
+  {
+    slots.map((group, groupIndex) => (
+      <>
+        {groupIndex > 0 && <div {...separatorAttrs}>-</div>}
+        <div data-part="group" class={classes.group}>
+          {/* One line, deliberately: any whitespace between these children
+              lands in the slot's textContent, and the slot's text IS the
+              rendered character -- the React and WC performances emit it with
+              no surrounding whitespace, so the SSR markup must match. */}
+          {group.map((slot) => (
+            <div {...slot.attrs}><span {...slot.char}>{slot.text}</span><span {...slot.caret}><span {...slot.caretBar} /></span></div>
+          ))}
+        </div>
+      </>
+    ))
+  }
+</div>
+
+<script>
+  import { bindInputOtp } from './input-otp.behavior';
+
+  // The <script> is bundled and runs once per page; bind every instance's
+  // server-rendered root. Same controller as the Web Component.
+  const roots = document.querySelectorAll<HTMLElement>('div[data-part="root"][data-max-length]');
+  for (const root of roots) {
+    if (root.dataset['otpBound'] === 'true') continue;
+    root.dataset['otpBound'] = 'true';
+    bindInputOtp(root);
+  }
+</script>

--- a/packages/ui/src/components/input-otp/input-otp.behavior.ts
+++ b/packages/ui/src/components/input-otp/input-otp.behavior.ts
@@ -1,0 +1,507 @@
+import { compose, type Slice } from '../../lib/compose';
+import {
+  createBehavior,
+  type AriaAttrs,
+  type BehaviorSpec,
+  type PartIds,
+} from '../../lib/contract';
+import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { createInputHandler } from '../../primitives/input-events';
+import { createKeyboardHandler } from '../../primitives/keyboard-handler';
+
+/**
+ * InputOTP: a segmented one-time-code field. One character per visible slot,
+ * auto-advance as the code is typed, paste splits across every slot.
+ *
+ * The archetype is text-input (Spec 05): the primary state is a VALUE. The
+ * segmented look is a MIRROR -- a single real <input> holds the code, owns the
+ * caret, IME and selection, and carries the accessible name; the slots are
+ * painted from the value. That is the oracle's shape and it is preserved: a
+ * per-slot <input> array would break paste, break autofill of
+ * `autocomplete="one-time-code"`, and turn one field into N tab stops.
+ *
+ * Composition (Spec 05, "compose the primitive, never reimplement it"):
+ * - arrow-key slot navigation rides `keyboard-handler` (`createKeyboardHandler`);
+ *   the keymap projection is the pure claim record, `activeForKey` computes the
+ *   payload.
+ * - IME composition tracking rides `input-events` (`createInputHandler`). Only
+ *   its composition guard is used: the value path stays on the plain `input`
+ *   event, because filtering a half-composed string would eat characters.
+ * - the value math (pattern filter + truncation to maxLength, active-slot
+ *   resolution) is COMPONENT-INTERNAL pure state -- the exported helpers below,
+ *   never inside a reducer (a reducer gets no config, and the math needs
+ *   maxLength/pattern).
+ *
+ * Form association is NOT the `form-value` hidden-mirror: this control has a
+ * real native <input>, so a `name` on it submits `name=value` natively. The
+ * mirror exists for controls built out of divs (slider's thumbs); rendering one
+ * here would submit the field twice. See input-otp.md, dispositions.
+ */
+
+/** Per-character pattern the oracle's WC shipped: digits only. */
+export const DEFAULT_OTP_PATTERN = '^[0-9]$';
+
+/** Slot count the oracle's WC fell back to for a missing/unparseable maxlength. */
+export const DEFAULT_OTP_MAX_LENGTH = 6;
+
+export interface InputOtpConfig {
+  /** Number of slots; also the hard cap on the value's length. */
+  maxLength: number;
+  /**
+   * Per-CHARACTER accept test, as a regex SOURCE string so the same config
+   * crosses a DOM attribute and an Astro prop unchanged. Malformed sources fall
+   * back to digits-only rather than throwing at paint time.
+   */
+  pattern?: string | undefined;
+  /** Controlled value: shadows the intrinsic state when present. */
+  value?: string | undefined;
+  /** Uncontrolled seed for the intrinsic value. */
+  defaultValue?: string | undefined;
+  /** No edits and no slot movement while disabled. */
+  disabled?: boolean | undefined;
+  /** Advertised to AT via aria-required. */
+  required?: boolean | undefined;
+  /** Accessible name override; absent, the score names the field by slot count. */
+  label?: string | undefined;
+}
+
+export interface InputOtpState {
+  /** Intrinsic value -- ignored while a controlled value is present. Always
+   *  already filtered and truncated (the helpers own that math). */
+  value: string;
+  /** Slot the caret conceptually sits in. Stored UNCLAMPED; `activeSlot`
+   *  clamps it against the live maxLength, so shrinking maxLength cannot strand
+   *  the active slot past the last rendered one. */
+  activeIndex: number;
+}
+
+export type InputOtpActions = {
+  /** Write an already-filtered, already-truncated value. */
+  setValue: string;
+  /** Move the active slot to an already-resolved index. */
+  setActive: number;
+};
+
+export type InputOtpPart = 'root' | 'input' | 'group' | 'slot' | 'separator';
+
+/** The effective value: a controlled `config.value` shadows intrinsic state. */
+export function effectiveOtpValue(state: InputOtpState, config: InputOtpConfig): string {
+  return config.value ?? state.value;
+}
+
+/**
+ * The per-character accept test. A malformed source falls back to digits-only:
+ * the oracle's WC swallowed the SyntaxError the same way, because a bad
+ * `pattern` attribute must not take the whole field down.
+ */
+export function otpPattern(config: InputOtpConfig): RegExp {
+  const source = config.pattern;
+  if (!source) return new RegExp(DEFAULT_OTP_PATTERN);
+  try {
+    return new RegExp(source);
+  } catch {
+    return new RegExp(DEFAULT_OTP_PATTERN);
+  }
+}
+
+/**
+ * Reject every character the pattern refuses, then stop at maxLength. This is
+ * the ONE gate every entry path funnels through -- typing, paste, the
+ * programmatic value setter -- so no path can seed a value the slots cannot
+ * render. Filtering before truncating is deliberate: pasting "12-34-56" into a
+ * six-slot field yields "123456", not "12-34-".
+ */
+export function filterAndTruncate(raw: string, config: InputOtpConfig): string {
+  if (!raw) return '';
+  const pattern = otpPattern(config);
+  const max = Math.max(0, config.maxLength);
+  let out = '';
+  for (const char of raw) {
+    if (out.length >= max) break;
+    if (pattern.test(char)) out += char;
+  }
+  return out;
+}
+
+/** The active slot index, clamped into the rendered slot range. */
+export function activeSlot(state: InputOtpState, config: InputOtpConfig): number {
+  const last = Math.max(0, config.maxLength - 1);
+  return Math.min(Math.max(state.activeIndex, 0), last);
+}
+
+/**
+ * Whether a slot reads as active. The trailing OR is the oracle's, preserved
+ * verbatim: once the code is complete the LAST slot stays lit even after
+ * ArrowLeft walks the active index backwards, so a full code never looks like
+ * it lost its end. That means a full field can show two active slots -- an
+ * earned semantic, not a bug (see input-otp.md, dispositions).
+ */
+export function isSlotActive(index: number, state: InputOtpState, config: InputOtpConfig): boolean {
+  const value = effectiveOtpValue(state, config);
+  const last = config.maxLength - 1;
+  return (
+    index === activeSlot(state, config) || (value.length === config.maxLength && index === last)
+  );
+}
+
+export interface OtpSlotState {
+  /** The character this slot displays, or '' when the slot is empty. */
+  char: string;
+  /** Whether a character has landed in this slot. */
+  filled: boolean;
+  /** Whether this slot reads as the caret's slot. */
+  active: boolean;
+  /** Whether the fake caret paints: the active slot, still empty. */
+  caret: boolean;
+}
+
+/** Everything a decorator needs to paint one slot. Pure, index-addressed. */
+export function slotState(
+  index: number,
+  state: InputOtpState,
+  config: InputOtpConfig,
+): OtpSlotState {
+  const value = effectiveOtpValue(state, config);
+  const char = value[index] ?? '';
+  const filled = char !== '';
+  const active = isSlotActive(index, state, config);
+  return { char, filled, active, caret: active && !filled };
+}
+
+/** Whether every slot is filled -- the completion edge the decorators report. */
+export function isComplete(state: InputOtpState, config: InputOtpConfig): boolean {
+  return config.maxLength > 0 && effectiveOtpValue(state, config).length === config.maxLength;
+}
+
+/**
+ * The active index a navigation key targets, or `null` when the key does not
+ * move the caret. ArrowLeft walks back one slot and stops at the first;
+ * ArrowRight lands on the first EMPTY slot (value.length), never past the last
+ * -- the oracle's rule, which keeps the caret where the next character will go
+ * instead of letting it wander into unreachable empty slots.
+ */
+export function activeForKey(
+  key: string,
+  state: InputOtpState,
+  config: InputOtpConfig,
+): number | null {
+  const current = activeSlot(state, config);
+  const last = Math.max(0, config.maxLength - 1);
+  if (key === 'ArrowLeft') {
+    const next = Math.max(0, current - 1);
+    return next === current ? null : next;
+  }
+  if (key === 'ArrowRight') {
+    const next = Math.min(effectiveOtpValue(state, config).length, last);
+    return next === current ? null : next;
+  }
+  return null;
+}
+
+const NAVIGATION_KEYS = ['ArrowLeft', 'ArrowRight'] as const;
+
+const inputOtp: Slice<InputOtpConfig, InputOtpState, InputOtpActions, InputOtpPart> = {
+  name: 'input-otp',
+  parts: {
+    // The container is not the widget -- the single <input> is. root/group are
+    // layout, slot/separator are the visual mirror of the value.
+    root: {},
+    input: {},
+    group: { optional: true },
+    slot: { many: true },
+    separator: { optional: true },
+  },
+  initialState: (config) => {
+    const value = filterAndTruncate(config.value ?? config.defaultValue ?? '', config);
+    return { value, activeIndex: value.length };
+  },
+  actions: {
+    // The value arrives already filtered and truncated (the helpers own that
+    // math, since a reducer gets no config). Writing the value re-seats the
+    // caret at the first empty slot, which is what makes typing auto-advance.
+    setValue: (_state, value) => ({ value, activeIndex: value.length }),
+    setActive: (state, activeIndex) => ({ ...state, activeIndex }),
+  },
+  // The gate: a disabled field refuses edits AND caret movement, so a
+  // controlled consumer's callback never fires for a change it would refuse.
+  canDispatch: (_state, _action, config) => !config.disabled,
+  aria: (state, config) => ({
+    root: {
+      'data-disabled': config.disabled ? 'true' : undefined,
+      'data-complete': isComplete(state, config) ? 'true' : undefined,
+    },
+    input: {
+      // The visual slots carry no accessible name of their own, so the single
+      // input must announce the whole obligation: how many characters to enter.
+      'aria-label': config.label ?? `Enter ${config.maxLength} character code`,
+      'aria-required': config.required ? 'true' : undefined,
+      'aria-disabled': config.disabled ? 'true' : undefined,
+    },
+  }),
+  // The pure claim record (Spec 01): these keys move the active slot. Every
+  // other key -- including Backspace, whose deletion the native input performs
+  // and reports back through the input event -- is left to the native field.
+  keymap: (event, _state, part) =>
+    part === 'input' && (NAVIGATION_KEYS as ReadonlyArray<string>).includes(event.key)
+      ? 'setActive'
+      : null,
+};
+
+/**
+ * Per-instance projection for the `slot` many-part. Slots are addressed by
+ * index (their `data-value`), and their whole projection is state data the CSS
+ * reads -- no ARIA, because the slots are a mirror: the accessible name, the
+ * value and the focus all live on the single input, and duplicating them here
+ * would announce the code twice.
+ */
+export function otpSlotAttrs(
+  index: string,
+  state: InputOtpState,
+  config: InputOtpConfig,
+): AriaAttrs {
+  const parsed = Number(index);
+  if (!Number.isInteger(parsed)) return {};
+  const slot = slotState(parsed, state, config);
+  return {
+    'data-index': index,
+    'data-active': slot.active ? 'true' : undefined,
+    'data-filled': slot.filled ? 'true' : undefined,
+  };
+}
+
+// First-class the slot's per-instance projection on the spec (Spec 05's open
+// gap): the harness's generic `assertInstanceAriaFulfillment` reads
+// `spec.instanceAria`, and `compose` does not carry it, so it is attached here.
+export const inputOtpBehavior: BehaviorSpec<
+  InputOtpConfig,
+  InputOtpState,
+  InputOtpActions,
+  InputOtpPart
+> = {
+  ...compose('input-otp', inputOtp),
+  instanceAria: (part, value, state, config) =>
+    part === 'slot' ? otpSlotAttrs(value, state, config) : {},
+};
+
+export interface InputOtpInteractionOptions {
+  /** The container: the click surface that focuses the field. */
+  root: HTMLElement;
+  /** The single real input: the keyboard, paste and value surface. */
+  input: HTMLInputElement;
+  getConfig: () => InputOtpConfig;
+  /** Effective (controlled-aware) state at call time. */
+  getState: () => InputOtpState;
+  /** Commit a raw (unfiltered) value; returns the EFFECTIVE value that landed. */
+  requestValue: (raw: string) => string;
+  /** Commit an already-resolved active slot index. */
+  requestActive: (index: number) => void;
+}
+
+/**
+ * Compose the impure keyboard + paste + focus surface. Shared verbatim by
+ * `bindInputOtp` (WC + Astro) and the React controller's effect -- one
+ * composition, three performances, so the entry rules can never drift.
+ */
+export function composeInputOtpInteractions(options: InputOtpInteractionOptions): () => void {
+  const { root, input, getConfig, getState, requestValue, requestActive } = options;
+
+  /**
+   * Reconcile the field to what the score accepted. This is the ONE place a
+   * refused character is erased, and it has to live on the entry path rather
+   * than in a state subscription: a rejected keystroke moves the DOM but NOT
+   * the state, so no re-render or memory notification would ever fire to undo
+   * it. Both a refused pattern character and a controlled consumer pinning the
+   * value land here.
+   */
+  const commit = (raw: string): void => {
+    const landed = requestValue(raw);
+    if (input.value !== landed) input.value = landed;
+  };
+
+  // Clicking anywhere in the segmented mirror focuses the real field: the slots
+  // look like inputs, so they must behave like one target.
+  const onRootClick = (): void => {
+    if (getConfig().disabled) return;
+    input.focus();
+  };
+  root.addEventListener('click', onRootClick);
+
+  // IME composition rides the input-events primitive. ONLY its composition
+  // guard is used: filtering a half-composed string would delete the characters
+  // the IME is still assembling, so the value path waits for compositionend.
+  const inputHandler = createInputHandler({ element: input });
+
+  // The value path stays on the plain `input` event -- deliberately NOT routed
+  // through the primitive's onInput, which drops events whose `inputType` is
+  // outside its editor-oriented whitelist. Every character, deletion and drop
+  // must reach the filter.
+  const onInput = (): void => {
+    if (inputHandler.isComposing) return;
+    commit(input.value);
+  };
+  input.addEventListener('input', onInput);
+
+  // compositionend fires after the composed text lands in .value, so this is
+  // the first safe moment to filter an IME-entered code.
+  const onCompositionEnd = (): void => {
+    commit(input.value);
+  };
+  input.addEventListener('compositionend', onCompositionEnd);
+
+  // Paste is intercepted rather than allowed through: the native paste would
+  // insert at the caret and could exceed maxLength before the filter sees it.
+  // Taking the clipboard text directly makes "paste the whole code" the rule.
+  const onPaste = (event: ClipboardEvent): void => {
+    event.preventDefault();
+    commit(event.clipboardData?.getData('text') ?? '');
+  };
+  input.addEventListener('paste', onPaste);
+
+  // Arrow navigation rides the keyboard-handler primitive; preventDefault stops
+  // the native caret from moving inside the flat string, which would desync the
+  // real caret from the lit slot.
+  const cleanupKeyboard = createKeyboardHandler(input, {
+    key: [...NAVIGATION_KEYS],
+    preventDefault: true,
+    handler: (event) => {
+      const config = getConfig();
+      if (config.disabled) return;
+      const next = activeForKey(event.key, getState(), config);
+      if (next === null) return;
+      requestActive(next);
+    },
+  });
+
+  return () => {
+    root.removeEventListener('click', onRootClick);
+    input.removeEventListener('input', onInput);
+    input.removeEventListener('compositionend', onCompositionEnd);
+    input.removeEventListener('paste', onPaste);
+    inputHandler.cleanup();
+    cleanupKeyboard();
+  };
+}
+
+/**
+ * The DOM-native binding of the input-otp score -- the client the Web Component
+ * and the Astro <script> both import. React (retained-mode) reads the
+ * projections declaratively instead, but composes the SAME
+ * `composeInputOtpInteractions`.
+ *
+ * Uncontrolled: WC/Astro have no reactive prop, so `config.value` stays
+ * undefined and the effective value is the intrinsic state, seeded from the
+ * server-rendered input.
+ */
+export function bindInputOtp(root: HTMLElement): () => void {
+  const input = root.querySelector<HTMLInputElement>('input[data-part="input"]');
+  if (!input) return () => {};
+
+  const parsedMax = Number.parseInt(root.dataset['maxLength'] ?? '', 10);
+  const config: InputOtpConfig = {
+    maxLength: Number.isFinite(parsedMax) && parsedMax > 0 ? parsedMax : DEFAULT_OTP_MAX_LENGTH,
+    pattern: root.dataset['pattern'] ?? undefined,
+    disabled: input.disabled || root.dataset['disabled'] === 'true',
+    required: input.required,
+    label: input.getAttribute('aria-label') ?? undefined,
+    // Seed the intrinsic value from the server-rendered markup.
+    defaultValue: input.value,
+  };
+
+  const getPart = (part: string): HTMLElement | null =>
+    part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
+
+  const { memory, dispatch } = createBehavior(inputOtpBehavior, config);
+
+  // ids READ from the server/author markup, never generated.
+  const ids = {} as PartIds<InputOtpPart>;
+  for (const part of Object.keys(inputOtpBehavior.parts) as InputOtpPart[]) {
+    ids[part] = getPart(part)?.id ?? '';
+  }
+
+  // The projection is already resolved (final strings, undefined = absent), so
+  // apply it raw: validate:false skips aria-manager's author-input coercion.
+  const applyProjection = (el: HTMLElement, attrs: AriaAttrs) => {
+    for (const [name, value] of Object.entries(attrs)) {
+      updateAriaAttribute(el, name as never, value as never, { validate: false });
+    }
+  };
+
+  let complete = isComplete(memory.get(), config);
+
+  const render = () => {
+    const state = memory.get();
+    const projection = inputOtpBehavior.aria(state, config, ids);
+    for (const part of ['root', 'input'] as const) {
+      const attrs = projection[part];
+      const el = getPart(part);
+      if (el && attrs) applyProjection(el, attrs);
+    }
+
+    for (const el of root.querySelectorAll<HTMLElement>('[data-part="slot"]')) {
+      const index = el.dataset['value'];
+      if (index === undefined) continue;
+      applyProjection(el, otpSlotAttrs(index, state, config));
+      const slot = slotState(Number(index), state, config);
+      const charEl = el.querySelector<HTMLElement>('[data-otp-char]');
+      if (charEl) charEl.textContent = slot.char;
+      const caretEl = el.querySelector<HTMLElement>('[data-otp-caret]');
+      if (caretEl) caretEl.hidden = !slot.caret;
+    }
+
+    // Value-sync: write only when the DOM and the effective value diverge, so
+    // the caret survives the common typing case. This is also where a rejected
+    // character is visibly reverted -- the filter refused it, so the input goes
+    // back to the accepted value.
+    const eff = effectiveOtpValue(state, config);
+    if (input.value !== eff) input.value = eff;
+  };
+  const unsubscribe = memory.subscribe(render); // fires immediately: first paint
+
+  const requestValue = (raw: string): string => {
+    const next = filterAndTruncate(raw, config);
+    const before = effectiveOtpValue(memory.get(), config);
+    // Refused (disabled): the score is the truth, the caller reverts the DOM.
+    if (!dispatch('setValue', config, next)) return before;
+    const after = effectiveOtpValue(memory.get(), config);
+    if (after !== before) {
+      root.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+    }
+    // The completion EDGE, not the completion state: re-typing inside a full
+    // code must not re-fire, so the edge is latched.
+    const nowComplete = isComplete(memory.get(), config);
+    if (nowComplete && !complete) {
+      root.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+      root.dispatchEvent(
+        new CustomEvent('rafters-otp-complete', {
+          bubbles: true,
+          composed: true,
+          detail: { value: after },
+        }),
+      );
+    }
+    complete = nowComplete;
+    return after;
+  };
+
+  const requestActive = (index: number): void => {
+    dispatch('setActive', config, index);
+  };
+
+  const stopInteractions = composeInputOtpInteractions({
+    root,
+    input,
+    getConfig: () => config,
+    getState: () => memory.get(),
+    requestValue,
+    requestActive,
+  });
+
+  // autofocus is an author attribute the browser honours only on initial parse;
+  // an upgraded custom element misses that window, so the bind re-asserts it.
+  if (root.hasAttribute('data-autofocus') && !config.disabled) input.focus();
+
+  return () => {
+    unsubscribe();
+    stopInteractions();
+  };
+}

--- a/packages/ui/src/components/input-otp/input-otp.classes.ts
+++ b/packages/ui/src/components/input-otp/input-otp.classes.ts
@@ -1,0 +1,60 @@
+import type { InputOtpConfig, InputOtpState } from './input-otp.behavior';
+
+export interface InputOtpClassSet {
+  root: string;
+  input: string;
+  group: string;
+  slot: string;
+  char: string;
+  caret: string;
+  caretBar: string;
+  separator: string;
+}
+
+// `group` is load-bearing, not decoration: the slots read the ROOT's projected
+// data-disabled through group-data-*, so disabled presentation needs no second
+// state channel and no per-slot class recomposition in any framework.
+const rootClasses = 'group flex items-center gap-2';
+
+// The real field is present to AT and to autofill (it keeps its accessible
+// name, its value and its focus ring obligations) but never painted -- the
+// slots are its visible surface. sr-only, never display:none.
+const inputClasses = 'sr-only';
+
+const groupClasses = 'flex items-center';
+
+// Every state rides a projected data-attribute, so light-DOM markup, the WC and
+// React all reach the same presentation with no class recomposition anywhere:
+// active from data-active, filled from data-filled, disabled from the root.
+const slotClasses =
+  'relative flex h-9 w-9 items-center justify-center ' +
+  'border-y border-r border-input text-body-small shadow-sm ' +
+  'transition-all duration-150 motion-reduce:transition-none ' +
+  'first:rounded-l-md first:border-l last:rounded-r-md ' +
+  'data-[active=true]:z-10 data-[active=true]:ring-1 data-[active=true]:ring-ring ' +
+  'data-[filled=true]:text-foreground ' +
+  'group-data-[disabled=true]:cursor-not-allowed group-data-[disabled=true]:opacity-50';
+
+const charClasses = 'pointer-events-none';
+
+const caretClasses = 'pointer-events-none absolute inset-0 flex items-center justify-center';
+
+// The caret-blink feedback loop. Duration and easing come from the token-backed
+// animate-pulse utility; reduced motion stills it rather than hiding it, so the
+// caret still marks the slot for a user who asked for less movement.
+const caretBarClasses = 'h-4 w-px animate-pulse bg-foreground motion-reduce:animate-none';
+
+const separatorClasses = 'flex items-center justify-center text-muted-foreground';
+
+export function inputOtpClassSet(_config: InputOtpConfig, _state: InputOtpState): InputOtpClassSet {
+  return {
+    root: rootClasses,
+    input: inputClasses,
+    group: groupClasses,
+    slot: slotClasses,
+    char: charClasses,
+    caret: caretClasses,
+    caretBar: caretBarClasses,
+    separator: separatorClasses,
+  };
+}

--- a/packages/ui/src/components/input-otp/input-otp.element.ts
+++ b/packages/ui/src/components/input-otp/input-otp.element.ts
@@ -1,0 +1,34 @@
+/**
+ * WC performance for input-otp: the thinnest wrapper. The score AND the
+ * DOM-native binding (bindInputOtp) live in input-otp.behavior.ts, shared with
+ * the Astro performance. This file only adapts that binding to the
+ * custom-element lifecycle.
+ *
+ * A light-DOM enhancer: the author (or Astro) provides the real container with
+ * its input and slot children, so the field is a working, named, autofillable
+ * <input> before any JS -- the WC never renders a shadow tree of its own. The
+ * bind is deferred one microtask because connectedCallback can fire before the
+ * light-DOM children are parsed (upgrade order).
+ */
+import { bindInputOtp } from './input-otp.behavior';
+
+export class RaftersInputOtp extends HTMLElement {
+  private teardown: (() => void) | null = null;
+
+  connectedCallback(): void {
+    queueMicrotask(() => {
+      if (!this.isConnected || this.teardown) return;
+      const root = this.querySelector<HTMLElement>('[data-part="root"]');
+      if (root) this.teardown = bindInputOtp(root);
+    });
+  }
+
+  disconnectedCallback(): void {
+    this.teardown?.();
+    this.teardown = null;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-input-otp')) {
+  customElements.define('rafters-input-otp', RaftersInputOtp);
+}

--- a/packages/ui/src/components/input-otp/input-otp.tsx
+++ b/packages/ui/src/components/input-otp/input-otp.tsx
@@ -195,12 +195,12 @@ export function InputOTP({
   });
   const classes = inputOtpClassSet(config, state);
 
-  const contextValue = React.useMemo<InputOTPContextValue>(
-    () => ({ state, config }),
-    // The slots re-paint on state; config identity changes every render, so the
-    // memo keys on the fields the slot projection actually reads.
-    [state, config.maxLength, config.value, config.disabled, config.pattern],
-  );
+  // Deliberately unmemoized. `config` is rebuilt from props every render, so a
+  // memo could only key on its individual fields -- which is both a lie to the
+  // linter and a cache that misses whenever any of them moves. The slots are
+  // pure projections of (state, config) and must re-paint on exactly those, so
+  // a fresh context value per render is the correct behavior, not a leak.
+  const contextValue: InputOTPContextValue = { state, config };
 
   return (
     <InputOTPContext.Provider value={contextValue}>

--- a/packages/ui/src/components/input-otp/input-otp.tsx
+++ b/packages/ui/src/components/input-otp/input-otp.tsx
@@ -30,11 +30,11 @@ import { inputOtpClassSet } from './input-otp.classes';
  * controlled input would fight the native caret the score deliberately does not
  * own.
  *
- * @cognitive-load 4/10 - decision 1, information 2, interaction 1, disruption 3,
- * learning 1. There is only one thing to enter and it is dictated by another
- * device, so no decision is being made; the load is transcription under a time
- * limit. The slot count tells the user exactly how much is left, but the task
- * interrupts whatever they were doing, which is where the disruption sits.
+ * @cognitive-load 4/10 - decision 0, information 1, interaction 1, disruption 1,
+ * learning 1. Nothing is being decided: the code is dictated by another device,
+ * so the load is transcription, and the slot count is the only information to
+ * read. The task interrupts whatever the user was doing, and the segmented shape
+ * has to be recognised as one field rather than several.
  * @attention-economics The segmented slots make remaining work countable at a
  * glance and the caret marks the exact next position, so attention never has to
  * re-scan the field. Auto-advance and whole-code paste remove the per-character

--- a/packages/ui/src/components/input-otp/input-otp.tsx
+++ b/packages/ui/src/components/input-otp/input-otp.tsx
@@ -1,0 +1,328 @@
+import * as React from 'react';
+import { createBehavior } from '../../lib/contract';
+import { useMemory } from '../../hooks/use-memory';
+import classy from '../../primitives/classy';
+import {
+  composeInputOtpInteractions,
+  effectiveOtpValue,
+  filterAndTruncate,
+  inputOtpBehavior,
+  otpSlotAttrs,
+  slotState,
+  type InputOtpConfig,
+  type InputOtpState,
+} from './input-otp.behavior';
+import { inputOtpClassSet } from './input-otp.classes';
+
+/**
+ * InputOTP -- the React performance of the input-otp score. The oracle's
+ * compound surface is preserved exactly: `<InputOTP maxLength>` with
+ * `InputOTP.Group` / `InputOTP.Slot index` / `InputOTP.Separator` children, so
+ * a consumer chooses their own grouping (3-3, 2-2-2) and the separators that go
+ * between. `value` / `defaultValue` / `onChange` / `pattern` / `disabled` /
+ * `autoFocus` / `onComplete` all keep their oracle meanings.
+ *
+ * Thin by construction: the score owns the filter, the active-slot rule and the
+ * projections, and the ONE keyboard/paste/focus surface
+ * (`composeInputOtpInteractions`) is the same composition the WC/Astro bind
+ * runs. The real input stays DOM-uncontrolled and is synced to the effective
+ * value in an effect -- the same value-sync the bind performs -- because a React
+ * controlled input would fight the native caret the score deliberately does not
+ * own.
+ *
+ * @cognitive-load 4/10 - decision 1, information 2, interaction 1, disruption 3,
+ * learning 1. There is only one thing to enter and it is dictated by another
+ * device, so no decision is being made; the load is transcription under a time
+ * limit. The slot count tells the user exactly how much is left, but the task
+ * interrupts whatever they were doing, which is where the disruption sits.
+ * @attention-economics The segmented slots make remaining work countable at a
+ * glance and the caret marks the exact next position, so attention never has to
+ * re-scan the field. Auto-advance and whole-code paste remove the per-character
+ * decisions that would otherwise multiply a six-character task by six.
+ * @trust-building Rejected characters never appear -- the pattern filters before
+ * the value is committed, so the field cannot show a code it will not accept.
+ * Paste splits a copied code across every slot, backspace walks back
+ * destructively, and completion is reported once on the edge, never repeatedly.
+ * @accessibility One real <input> owns the caret, IME, selection and focus, and
+ * carries the accessible name ("Enter N character code") plus
+ * autocomplete="one-time-code" for platform SMS autofill; the slots are a
+ * painted mirror and add no tab stops. Arrow keys move the lit slot without
+ * moving focus. Disabled projects aria-disabled and gates every entry path.
+ */
+
+export interface InputOTPContextValue {
+  state: InputOtpState;
+  config: InputOtpConfig;
+}
+
+const InputOTPContext = React.createContext<InputOTPContextValue | null>(null);
+
+function useInputOTPContext(): InputOTPContextValue {
+  const context = React.useContext(InputOTPContext);
+  if (!context) {
+    throw new Error('InputOTP components must be used within InputOTP');
+  }
+  return context;
+}
+
+export interface InputOTPProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'onChange' | 'defaultValue'
+> {
+  /** Controlled value: shadows the intrinsic state when present. */
+  value?: string;
+  /** Uncontrolled seed for the intrinsic value. */
+  defaultValue?: string;
+  /** Fires on every accepted edit with the value the consumer should adopt. */
+  onChange?: (value: string) => void;
+  /** Number of slots; also the hard cap on the value's length. */
+  maxLength: number;
+  /** Per-character accept test. A RegExp (oracle surface) or its source string. */
+  pattern?: RegExp | string;
+  disabled?: boolean;
+  autoFocus?: boolean;
+  /** Fires once on the edge where the last slot fills. */
+  onComplete?: (value: string) => void;
+  required?: boolean;
+  /** Form field name: the real input submits natively, no hidden mirror. */
+  name?: string;
+  'aria-label'?: string;
+}
+
+export function InputOTP({
+  value,
+  defaultValue,
+  onChange,
+  maxLength,
+  pattern,
+  disabled = false,
+  autoFocus = false,
+  onComplete,
+  required = false,
+  name,
+  'aria-label': ariaLabel,
+  className,
+  children,
+  ...rest
+}: InputOTPProps): React.JSX.Element {
+  const config: InputOtpConfig = {
+    maxLength,
+    pattern: typeof pattern === 'string' ? pattern : pattern?.source,
+    value,
+    defaultValue,
+    disabled,
+    required,
+    label: ariaLabel,
+  };
+
+  const { memory, dispatch } = React.useMemo(() => createBehavior(inputOtpBehavior, config), []);
+  const state = useMemory(memory);
+  const effective = effectiveOtpValue(state, config);
+
+  const rootRef = React.useRef<HTMLDivElement | null>(null);
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+
+  // The callbacks read the CURRENT config, so a controlled consumer's callback
+  // reports the intended value even though the effective value never moves.
+  // Riding in a ref keeps them off the dispatch closure.
+  const latest = React.useRef({ config, onChange, onComplete });
+  latest.current = { config, onChange, onComplete };
+
+  const requestValue = React.useCallback(
+    (raw: string): string => {
+      const { config: cfg, onChange: change, onComplete: complete } = latest.current;
+      const next = filterAndTruncate(raw, cfg);
+      // Gotcha #1: effective-BEFORE vs intrinsic-AFTER. A controlled field's
+      // effective value is pinned by config.value, but the intrinsic reducer
+      // still moves, so the callback fires with the value to adopt.
+      const before = effectiveOtpValue(memory.get(), cfg);
+      if (!dispatch('setValue', cfg, next)) return before;
+      const after = memory.get().value;
+      if (after === before) return effectiveOtpValue(memory.get(), cfg);
+      change?.(after);
+      // The completion EDGE: crossing into a full code, never re-reported while
+      // the code stays full. Measured on the intrinsic before/after pair rather
+      // than isComplete, which reads the EFFECTIVE value a controlled field pins
+      // -- the edge the consumer needs is the one the value they are handed
+      // crosses.
+      if (before.length !== cfg.maxLength && after.length === cfg.maxLength) {
+        complete?.(after);
+      }
+      // The value the FIELD should now show: a controlled consumer pins it, so
+      // the caller reconciles the DOM against this, not against `after`.
+      return effectiveOtpValue(memory.get(), cfg);
+    },
+    [memory, dispatch],
+  );
+
+  const requestActive = React.useCallback(
+    (index: number): void => {
+      dispatch('setActive', latest.current.config, index);
+    },
+    [dispatch],
+  );
+
+  // Compose the ONE keyboard/paste/focus surface -- the same composition the
+  // bind runs. Nothing in it closes over config (it is read live via
+  // getConfig), so it is created once per mounted element.
+  React.useEffect(() => {
+    const root = rootRef.current;
+    const input = inputRef.current;
+    if (!root || !input) return;
+    return composeInputOtpInteractions({
+      root,
+      input,
+      getConfig: () => latest.current.config,
+      getState: () => memory.get(),
+      requestValue,
+      requestActive,
+    });
+  }, [memory, requestValue, requestActive]);
+
+  // Value-sync, the same rule the bind applies: write only on divergence, so
+  // the native caret survives typing and a refused character is reverted.
+  React.useEffect(() => {
+    const input = inputRef.current;
+    if (input && input.value !== effective) input.value = effective;
+  }, [effective]);
+
+  const aria = inputOtpBehavior.aria(state, config, {
+    root: '',
+    input: '',
+    group: '',
+    slot: '',
+    separator: '',
+  });
+  const classes = inputOtpClassSet(config, state);
+
+  const contextValue = React.useMemo<InputOTPContextValue>(
+    () => ({ state, config }),
+    // The slots re-paint on state; config identity changes every render, so the
+    // memo keys on the fields the slot projection actually reads.
+    [state, config.maxLength, config.value, config.disabled, config.pattern],
+  );
+
+  return (
+    <InputOTPContext.Provider value={contextValue}>
+      <div
+        ref={rootRef}
+        data-part="root"
+        data-max-length={maxLength}
+        className={classy(classes.root, className)}
+        {...aria.root}
+        {...rest}
+      >
+        <input
+          ref={inputRef}
+          data-part="input"
+          type="text"
+          inputMode="numeric"
+          autoComplete="one-time-code"
+          name={name}
+          required={required}
+          disabled={disabled}
+          maxLength={maxLength}
+          defaultValue={effective}
+          // biome-ignore lint/a11y/noAutofocus: the oracle's autoFocus surface; an
+          // OTP field is the sole purpose of the screen it appears on.
+          autoFocus={autoFocus}
+          className={classes.input}
+          {...aria.input}
+        />
+        {children}
+      </div>
+    </InputOTPContext.Provider>
+  );
+}
+
+export interface InputOTPGroupProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function InputOTPGroup({
+  className,
+  children,
+  ...props
+}: InputOTPGroupProps): React.JSX.Element {
+  const { state, config } = useInputOTPContext();
+  const classes = inputOtpClassSet(config, state);
+  return (
+    <div data-part="group" className={classy(classes.group, className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export interface InputOTPSlotProps extends React.HTMLAttributes<HTMLDivElement> {
+  index: number;
+}
+
+export function InputOTPSlot({ index, className, ...props }: InputOTPSlotProps): React.JSX.Element {
+  const { state, config } = useInputOTPContext();
+  const classes = inputOtpClassSet(config, state);
+  const slot = slotState(index, state, config);
+
+  // The character and the caret are built with createElement so the class
+  // strings stay plain composition -- the same escape slider uses for its
+  // track/thumb spans; these carry no typography role.
+  const char = React.createElement(
+    'span',
+    { 'data-otp-char': '', className: classes.char },
+    slot.char,
+  );
+  const caret = React.createElement(
+    'span',
+    {
+      'data-otp-caret': '',
+      'aria-hidden': 'true',
+      hidden: !slot.caret,
+      className: classes.caret,
+    },
+    React.createElement('span', { className: classes.caretBar }),
+  );
+
+  return (
+    <div
+      data-part="slot"
+      data-value={index}
+      className={classy(classes.slot, className)}
+      {...otpSlotAttrs(String(index), state, config)}
+      {...props}
+    >
+      {char}
+      {caret}
+    </div>
+  );
+}
+
+export interface InputOTPSeparatorProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function InputOTPSeparator({
+  className,
+  children,
+  ...props
+}: InputOTPSeparatorProps): React.JSX.Element {
+  const { state, config } = useInputOTPContext();
+  const classes = inputOtpClassSet(config, state);
+  // Decorative: the separator carries no meaning the value does not already
+  // carry, so it is hidden from AT rather than read out as punctuation.
+  return (
+    <div
+      data-part="separator"
+      aria-hidden="true"
+      className={classy(classes.separator, className)}
+      {...props}
+    >
+      {children ?? '-'}
+    </div>
+  );
+}
+
+InputOTP.displayName = 'InputOTP';
+InputOTPGroup.displayName = 'InputOTPGroup';
+InputOTPSlot.displayName = 'InputOTPSlot';
+InputOTPSeparator.displayName = 'InputOTPSeparator';
+
+InputOTP.Group = InputOTPGroup;
+InputOTP.Slot = InputOTPSlot;
+InputOTP.Separator = InputOTPSeparator;
+
+export default InputOTP;

--- a/packages/ui/src/primitives/input-events.ts
+++ b/packages/ui/src/primitives/input-events.ts
@@ -142,7 +142,12 @@ export function createInputHandler(options: InputHandlerOptions): InputHandler {
       inputType,
       data: event.data,
       isComposing: event.isComposing || composing,
-      targetRanges: event.getTargetRanges(),
+      // getTargetRanges() is only meaningful for contenteditable, and is absent
+      // on the InputEvent of a native <input> in some engines (and in the test
+      // environment). Calling it unguarded threw and took the whole listener
+      // down, which meant this primitive could not be composed by a
+      // native-input component at all. Absent ranges are simply none.
+      targetRanges: typeof event.getTargetRanges === 'function' ? event.getTargetRanges() : [],
     };
   };
 

--- a/packages/ui/test/components/input-otp/input-otp.astro.conformance.test.ts
+++ b/packages/ui/test/components/input-otp/input-otp.astro.conformance.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Astro performance of the input-otp score, driven end to end. AstroContainer
+ * renders the SSR field with the projection and the painted slots already
+ * applied, but does NOT run the <script>, so the test calls bindInputOtp
+ * directly on the server-rendered root -- that IS the script's job -- then
+ * drives the same score the React and WC performances drive.
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import InputOtp from '../../../src/components/input-otp/input-otp.astro';
+import { bindInputOtp } from '../../../src/components/input-otp/input-otp.behavior';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+async function mount(props: Record<string, unknown> = {}): Promise<HTMLElement> {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(InputOtp, {
+    props: { id: 'otp', maxLength: 6, ...props },
+  });
+  document.body.innerHTML = `<div>${html}</div>`;
+  const root = document.body.querySelector<HTMLElement>('[data-part="root"]')!;
+  bindInputOtp(root);
+  return root;
+}
+
+const input = () => document.body.querySelector<HTMLInputElement>('input[data-part="input"]')!;
+const slots = () => Array.from(document.body.querySelectorAll<HTMLElement>('[data-part="slot"]'));
+
+describe('input-otp conformance [astro]', () => {
+  it('server-renders one slot per character, named and autofillable before any JS', async () => {
+    await mount();
+    expect(slots()).toHaveLength(6);
+    expect(input().getAttribute('aria-label')).toBe('Enter 6 character code');
+    expect(input().getAttribute('autocomplete')).toBe('one-time-code');
+  });
+
+  it('groups split declaratively, with a separator between them', async () => {
+    const root = await mount({ groups: [3, 3] });
+    expect(root.querySelectorAll('[data-part="group"]')).toHaveLength(2);
+    expect(root.querySelectorAll('[data-part="separator"]')).toHaveLength(1);
+    expect(root.querySelector('[data-part="separator"]')?.getAttribute('aria-hidden')).toBe('true');
+    expect(slots()).toHaveLength(6);
+  });
+
+  it('a seeded value is painted into the slots server-side', async () => {
+    await mount({ defaultValue: '12-34' });
+    expect(input().value).toBe('1234');
+    expect(slots().map((slot) => slot.textContent)).toEqual(['1', '2', '3', '4', '', '']);
+    expect(slots()[0]?.getAttribute('data-filled')).toBe('true');
+    expect(slots()[4]?.getAttribute('data-active')).toBe('true');
+  });
+
+  it('typing fills slots through the setValue dispatch', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.type(input(), '123');
+    expect(input().value).toBe('123');
+    expect(slots()[2]?.textContent).toBe('3');
+    expect(slots()[3]?.getAttribute('data-active')).toBe('true');
+  });
+
+  it('the pattern prop crosses to the client through data-pattern', async () => {
+    const user = userEvent.setup();
+    await mount({ pattern: '^[a-z]$' });
+    await user.type(input(), 'a1b');
+    expect(input().value).toBe('ab');
+  });
+
+  it('paste splits a whole code and fires the completion event', async () => {
+    const user = userEvent.setup();
+    const root = await mount();
+    const onComplete = vi.fn();
+    root.addEventListener('rafters-otp-complete', onComplete);
+    input().focus();
+    await user.paste('123456');
+    expect(input().value).toBe('123456');
+    expect(root.getAttribute('data-complete')).toBe('true');
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('arrows move the lit slot without moving focus', async () => {
+    const user = userEvent.setup();
+    await mount({ defaultValue: '123' });
+    input().focus();
+    await user.keyboard('{ArrowLeft}');
+    expect(slots()[2]?.getAttribute('data-active')).toBe('true');
+    expect(document.activeElement).toBe(input());
+  });
+
+  it('disabled gates entry and projects the state', async () => {
+    const user = userEvent.setup();
+    const root = await mount({ disabled: true, defaultValue: '12' });
+    expect(root.getAttribute('data-disabled')).toBe('true');
+    await user.type(input(), '3');
+    expect(input().value).toBe('12');
+  });
+
+  it('required and name make it a real form field, no hidden mirror', async () => {
+    const root = await mount({ required: true, name: 'code' });
+    expect(input().getAttribute('aria-required')).toBe('true');
+    expect(input().name).toBe('code');
+    expect(root.querySelectorAll('input[type="hidden"]')).toHaveLength(0);
+  });
+});

--- a/packages/ui/test/components/input-otp/input-otp.behavior.test.ts
+++ b/packages/ui/test/components/input-otp/input-otp.behavior.test.ts
@@ -1,0 +1,238 @@
+/**
+ * The input-otp score, driven purely -- no DOM. Everything here is a total
+ * function of (state, config): the pattern filter, the active-slot rule, the
+ * slot projection, the keymap claim and the reducers.
+ */
+import { describe, expect, it } from 'vitest';
+import { createBehavior } from '../../../src/lib/contract';
+import {
+  activeForKey,
+  activeSlot,
+  DEFAULT_OTP_PATTERN,
+  effectiveOtpValue,
+  filterAndTruncate,
+  inputOtpBehavior,
+  isComplete,
+  isSlotActive,
+  otpPattern,
+  otpSlotAttrs,
+  slotState,
+  type InputOtpConfig,
+  type InputOtpState,
+} from '../../../src/components/input-otp/input-otp.behavior';
+
+const config = (overrides: Partial<InputOtpConfig> = {}): InputOtpConfig => ({
+  maxLength: 6,
+  ...overrides,
+});
+
+const stateOf = (value: string, activeIndex = value.length): InputOtpState => ({
+  value,
+  activeIndex,
+});
+
+describe('input-otp behavior: the pattern filter', () => {
+  it('defaults to digits only, one character at a time', () => {
+    expect(otpPattern(config()).source).toBe(DEFAULT_OTP_PATTERN);
+    expect(filterAndTruncate('12a3', config())).toBe('123');
+  });
+
+  it('drops separators so a pasted "12-34-56" fills every slot', () => {
+    expect(filterAndTruncate('12-34-56', config())).toBe('123456');
+  });
+
+  it('truncates at maxLength AFTER filtering', () => {
+    expect(filterAndTruncate('1234567890', config({ maxLength: 4 }))).toBe('1234');
+    expect(filterAndTruncate('1-2-3-4-5', config({ maxLength: 4 }))).toBe('1234');
+  });
+
+  it('honours a custom pattern source', () => {
+    expect(filterAndTruncate('a1B2', config({ pattern: '^[a-z]$' }))).toBe('a');
+  });
+
+  it('falls back to digits when the pattern source is malformed', () => {
+    expect(otpPattern(config({ pattern: '[' })).source).toBe(DEFAULT_OTP_PATTERN);
+    expect(filterAndTruncate('1a2', config({ pattern: '[' }))).toBe('12');
+  });
+
+  it('an empty input filters to an empty value', () => {
+    expect(filterAndTruncate('', config())).toBe('');
+  });
+});
+
+describe('input-otp behavior: the active slot', () => {
+  it('clamps into the rendered slot range, so shrinking maxLength cannot strand it', () => {
+    expect(activeSlot(stateOf('123456', 6), config({ maxLength: 6 }))).toBe(5);
+    expect(activeSlot({ value: '12', activeIndex: 99 }, config({ maxLength: 4 }))).toBe(3);
+    expect(activeSlot({ value: '', activeIndex: -3 }, config())).toBe(0);
+  });
+
+  it('lights the slot the caret sits in', () => {
+    const state = stateOf('12');
+    expect(isSlotActive(2, state, config())).toBe(true);
+    expect(isSlotActive(1, state, config())).toBe(false);
+  });
+
+  it('keeps the LAST slot lit while the code is complete, even after ArrowLeft', () => {
+    // The oracle's OR predicate, preserved: a full code shows both the walked-to
+    // slot and the final slot as active.
+    const state = { value: '123456', activeIndex: 2 };
+    expect(isSlotActive(2, state, config())).toBe(true);
+    expect(isSlotActive(5, state, config())).toBe(true);
+    expect(isSlotActive(3, state, config())).toBe(false);
+  });
+});
+
+describe('input-otp behavior: the slot projection', () => {
+  it('reports char, filled, active and the fake caret', () => {
+    const state = stateOf('12');
+    expect(slotState(0, state, config())).toEqual({
+      char: '1',
+      filled: true,
+      active: false,
+      caret: false,
+    });
+    expect(slotState(2, state, config())).toEqual({
+      char: '',
+      filled: false,
+      active: true,
+      caret: true,
+    });
+  });
+
+  it('never paints a caret on a filled slot', () => {
+    const state = { value: '123456', activeIndex: 5 };
+    expect(slotState(5, state, config()).caret).toBe(false);
+  });
+
+  it('projects only present state as data attributes', () => {
+    const state = stateOf('1');
+    expect(otpSlotAttrs('0', state, config())).toEqual({
+      'data-index': '0',
+      'data-active': undefined,
+      'data-filled': 'true',
+    });
+    expect(otpSlotAttrs('1', state, config())).toEqual({
+      'data-index': '1',
+      'data-active': 'true',
+      'data-filled': undefined,
+    });
+  });
+
+  it('ignores a non-numeric instance key rather than projecting nonsense', () => {
+    expect(otpSlotAttrs('x', stateOf('1'), config())).toEqual({});
+  });
+});
+
+describe('input-otp behavior: keyboard claims', () => {
+  it('claims only the arrows, and only on the input part', () => {
+    const state = stateOf('12');
+    const cfg = config();
+    expect(inputOtpBehavior.keymap({ key: 'ArrowLeft' }, state, 'input', cfg)).toBe('setActive');
+    expect(inputOtpBehavior.keymap({ key: 'ArrowRight' }, state, 'input', cfg)).toBe('setActive');
+    // Backspace belongs to the native field: it deletes, and the resulting
+    // input event carries the change back through setValue.
+    expect(inputOtpBehavior.keymap({ key: 'Backspace' }, state, 'input', cfg)).toBeNull();
+    expect(inputOtpBehavior.keymap({ key: 'ArrowLeft' }, state, 'slot', cfg)).toBeNull();
+  });
+
+  it('ArrowLeft walks back one slot and stops at the first', () => {
+    expect(activeForKey('ArrowLeft', stateOf('12'), config())).toBe(1);
+    expect(activeForKey('ArrowLeft', { value: '', activeIndex: 0 }, config())).toBeNull();
+  });
+
+  it('ArrowRight lands on the first empty slot, never past the last', () => {
+    expect(activeForKey('ArrowRight', { value: '123', activeIndex: 0 }, config())).toBe(3);
+    expect(activeForKey('ArrowRight', { value: '123456', activeIndex: 2 }, config())).toBe(5);
+    expect(activeForKey('ArrowRight', stateOf('12'), config())).toBeNull();
+  });
+
+  it('returns null for keys that do not move the caret', () => {
+    expect(activeForKey('Enter', stateOf('12'), config())).toBeNull();
+  });
+});
+
+describe('input-otp behavior: state', () => {
+  it('seeds the value through the filter and parks the caret after it', () => {
+    expect(inputOtpBehavior.initialState(config({ defaultValue: '12-34' }))).toEqual({
+      value: '1234',
+      activeIndex: 4,
+    });
+  });
+
+  it('a controlled value shadows the intrinsic state', () => {
+    expect(effectiveOtpValue(stateOf('11'), config({ value: '99' }))).toBe('99');
+    expect(effectiveOtpValue(stateOf('11'), config())).toBe('11');
+  });
+
+  it('setValue re-seats the caret at the first empty slot -- that is auto-advance', () => {
+    const { memory, dispatch } = createBehavior(inputOtpBehavior, config());
+    expect(dispatch('setValue', config(), '12')).toBe(true);
+    expect(memory.get()).toEqual({ value: '12', activeIndex: 2 });
+  });
+
+  it('setActive moves the caret without touching the value', () => {
+    const cfg = config();
+    const { memory, dispatch } = createBehavior(inputOtpBehavior, cfg);
+    dispatch('setValue', cfg, '123');
+    dispatch('setActive', cfg, 1);
+    expect(memory.get()).toEqual({ value: '123', activeIndex: 1 });
+  });
+
+  it('disabled refuses BOTH edits and caret movement', () => {
+    const cfg = config({ disabled: true, defaultValue: '12' });
+    const { memory, dispatch } = createBehavior(inputOtpBehavior, cfg);
+    expect(dispatch('setValue', cfg, '123')).toBe(false);
+    expect(dispatch('setActive', cfg, 0)).toBe(false);
+    expect(memory.get()).toEqual({ value: '12', activeIndex: 2 });
+  });
+
+  it('completion is the full-slot condition, read off the effective value', () => {
+    expect(isComplete(stateOf('12345'), config())).toBe(false);
+    expect(isComplete(stateOf('123456'), config())).toBe(true);
+    expect(isComplete(stateOf(''), config({ value: '123456' }))).toBe(true);
+  });
+});
+
+describe('input-otp behavior: the aria projection', () => {
+  it('names the field by its slot count when the consumer gives no label', () => {
+    const cfg = config({ maxLength: 4 });
+    const aria = inputOtpBehavior.aria(inputOtpBehavior.initialState(cfg), cfg, {
+      root: '',
+      input: '',
+      group: '',
+      slot: '',
+      separator: '',
+    });
+    expect(aria.input?.['aria-label']).toBe('Enter 4 character code');
+    expect(aria.input?.['aria-required']).toBeUndefined();
+    expect(aria.root?.['data-disabled']).toBeUndefined();
+    expect(aria.root?.['data-complete']).toBeUndefined();
+  });
+
+  it('a consumer label wins, and required/disabled/complete all project', () => {
+    const cfg = config({ label: 'Verification code', required: true, disabled: true });
+    const aria = inputOtpBehavior.aria(stateOf('123456'), cfg, {
+      root: '',
+      input: '',
+      group: '',
+      slot: '',
+      separator: '',
+    });
+    expect(aria.input?.['aria-label']).toBe('Verification code');
+    expect(aria.input?.['aria-required']).toBe('true');
+    expect(aria.input?.['aria-disabled']).toBe('true');
+    expect(aria.root?.['data-disabled']).toBe('true');
+    expect(aria.root?.['data-complete']).toBe('true');
+  });
+
+  it('declares the slot as a many part and projects it per instance', () => {
+    expect(inputOtpBehavior.parts.slot.many).toBe(true);
+    expect(inputOtpBehavior.instanceAria?.('slot', '0', stateOf('9'), config(), {})).toEqual({
+      'data-index': '0',
+      'data-active': undefined,
+      'data-filled': 'true',
+    });
+    expect(inputOtpBehavior.instanceAria?.('root', '0', stateOf('9'), config(), {})).toEqual({});
+  });
+});

--- a/packages/ui/test/components/input-otp/input-otp.classes.test.ts
+++ b/packages/ui/test/components/input-otp/input-otp.classes.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { inputOtpBehavior } from '../../../src/components/input-otp/input-otp.behavior';
+import { inputOtpClassSet } from '../../../src/components/input-otp/input-otp.classes';
+
+const config = { maxLength: 6 };
+const classes = inputOtpClassSet(config, inputOtpBehavior.initialState(config));
+
+describe('input-otp classes', () => {
+  it('the real field is sr-only, never display:none -- AT and autofill still reach it', () => {
+    expect(classes.input).toContain('sr-only');
+    expect(classes.input).not.toContain('hidden');
+  });
+
+  it('borders on a semantic token and never fills a page background', () => {
+    expect(classes.slot).toContain('border-input');
+    expect(classes.slot).not.toContain('bg-background');
+  });
+
+  it('styles every slot state off the projected data attributes', () => {
+    expect(classes.slot).toContain('data-[active=true]:ring-1');
+    expect(classes.slot).toContain('data-[active=true]:ring-ring');
+    expect(classes.slot).toContain('data-[filled=true]:text-foreground');
+  });
+
+  it('reads disabled from the root through the group, not a second state channel', () => {
+    expect(classes.root).toContain('group');
+    expect(classes.slot).toContain('group-data-[disabled=true]:opacity-50');
+    expect(classes.slot).toContain('group-data-[disabled=true]:cursor-not-allowed');
+  });
+
+  it('the caret is a blink feedback loop that stills under reduced motion', () => {
+    expect(classes.caretBar).toContain('animate-pulse');
+    expect(classes.caretBar).toContain('motion-reduce:animate-none');
+  });
+
+  it('slot motion respects reduced motion', () => {
+    expect(classes.slot).toContain('motion-reduce:transition-none');
+  });
+
+  it('the separator is muted, not a foreground element', () => {
+    expect(classes.separator).toContain('text-muted-foreground');
+  });
+});

--- a/packages/ui/test/components/input-otp/input-otp.conformance.test.tsx
+++ b/packages/ui/test/components/input-otp/input-otp.conformance.test.tsx
@@ -1,0 +1,223 @@
+/**
+ * React performance of the input-otp score, driven end to end. The oracle's
+ * compound surface (InputOTP + Group/Slot/Separator) over one real input.
+ */
+import * as React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { InputOTP } from '../../../src/components/input-otp/input-otp';
+import { inputOtpBehavior } from '../../../src/components/input-otp/input-otp.behavior';
+import {
+  assertAxeClean,
+  assertContractFulfillment,
+  assertInstanceAriaFulfillment,
+  partElement,
+  partElements,
+} from '../../harness/conformance';
+
+afterEach(() => {
+  cleanup();
+});
+
+function Field(props: React.ComponentProps<typeof InputOTP>): React.JSX.Element {
+  const { children, ...rest } = props;
+  return (
+    <InputOTP maxLength={6} {...rest}>
+      <InputOTP.Group>
+        <InputOTP.Slot index={0} />
+        <InputOTP.Slot index={1} />
+        <InputOTP.Slot index={2} />
+      </InputOTP.Group>
+      <InputOTP.Separator />
+      <InputOTP.Group>
+        <InputOTP.Slot index={3} />
+        <InputOTP.Slot index={4} />
+        <InputOTP.Slot index={5} />
+      </InputOTP.Group>
+      {children}
+    </InputOTP>
+  );
+}
+
+const inputOf = (host: HTMLElement) => partElement(host, 'input') as HTMLInputElement;
+
+describe('input-otp conformance [react]', () => {
+  it('empty: every declared part renders, the projection matches, axe is clean', async () => {
+    const { container } = render(<Field />);
+    const config = { maxLength: 6 };
+    const state = { value: '', activeIndex: 0 };
+    assertContractFulfillment(inputOtpBehavior, container, state, config, [
+      'root',
+      'input',
+      'group',
+      'slot',
+      'separator',
+    ]);
+    assertInstanceAriaFulfillment(inputOtpBehavior, container, state, config);
+    expect(partElements(container, 'slot')).toHaveLength(6);
+    await assertAxeClean(container);
+  });
+
+  it('names the field by its slot count and offers one-time-code autofill', () => {
+    const { container } = render(<Field />);
+    const el = inputOf(container);
+    expect(el.getAttribute('aria-label')).toBe('Enter 6 character code');
+    expect(el.getAttribute('autocomplete')).toBe('one-time-code');
+    expect(el.getAttribute('inputmode')).toBe('numeric');
+  });
+
+  it('the slots are the only visible surface: no extra tab stops', () => {
+    const { container } = render(<Field />);
+    for (const slot of partElements(container, 'slot')) {
+      expect(slot.hasAttribute('tabindex')).toBe(false);
+    }
+  });
+
+  it('typing fills slots left to right and advances the caret', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Field />);
+    await user.type(inputOf(container), '12');
+    const slots = partElements(container, 'slot');
+    expect(slots[0]?.textContent).toBe('1');
+    expect(slots[1]?.textContent).toBe('2');
+    expect(slots[0]?.getAttribute('data-filled')).toBe('true');
+    expect(slots[2]?.getAttribute('data-active')).toBe('true');
+    expect(slots[1]?.hasAttribute('data-active')).toBe(false);
+  });
+
+  it('refuses characters the pattern rejects -- they never reach a slot', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { container } = render(<Field onChange={onChange} />);
+    await user.type(inputOf(container), 'a1b');
+    expect(inputOf(container).value).toBe('1');
+    expect(partElements(container, 'slot')[0]?.textContent).toBe('1');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith('1');
+  });
+
+  it('a custom pattern replaces the digit rule', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Field pattern={/^[a-z]$/} />);
+    await user.type(inputOf(container), 'a1b');
+    expect(inputOf(container).value).toBe('ab');
+  });
+
+  it('backspace walks back through the code', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Field defaultValue="123" />);
+    const el = inputOf(container);
+    el.focus();
+    await user.keyboard('{Backspace}');
+    expect(el.value).toBe('12');
+    expect(partElements(container, 'slot')[2]?.hasAttribute('data-filled')).toBe(false);
+  });
+
+  it('paste splits a whole code across the slots, separators and all', async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    const { container } = render(<Field onComplete={onComplete} />);
+    const el = inputOf(container);
+    el.focus();
+    await user.paste('12-34-56');
+    expect(el.value).toBe('123456');
+    expect(partElements(container, 'slot').map((slot) => slot.textContent)).toEqual([
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+    ]);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenLastCalledWith('123456');
+  });
+
+  it('a paste longer than maxLength is truncated, not rejected', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Field />);
+    inputOf(container).focus();
+    await user.paste('1234567890');
+    expect(inputOf(container).value).toBe('123456');
+  });
+
+  it('completion fires once on the edge, and the root reports it', async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    const { container } = render(<Field defaultValue="12345" onComplete={onComplete} />);
+    const el = inputOf(container);
+    el.focus();
+    await user.keyboard('6');
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(partElement(container, 'root')?.getAttribute('data-complete')).toBe('true');
+    // Deleting and re-typing crosses the edge again -- but staying full does not.
+    await user.keyboard('{Backspace}');
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('arrows move the lit slot without moving focus or the value', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Field defaultValue="123" />);
+    const el = inputOf(container);
+    el.focus();
+    await user.keyboard('{ArrowLeft}');
+    const slots = partElements(container, 'slot');
+    expect(slots[2]?.getAttribute('data-active')).toBe('true');
+    expect(document.activeElement).toBe(el);
+    expect(el.value).toBe('123');
+    await user.keyboard('{ArrowRight}');
+    expect(slots[3]?.getAttribute('data-active')).toBe('true');
+  });
+
+  it('a complete code keeps the last slot lit after ArrowLeft (the oracle rule)', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Field defaultValue="123456" />);
+    inputOf(container).focus();
+    await user.keyboard('{ArrowLeft}{ArrowLeft}');
+    const slots = partElements(container, 'slot');
+    expect(slots[3]?.getAttribute('data-active')).toBe('true');
+    expect(slots[5]?.getAttribute('data-active')).toBe('true');
+  });
+
+  it('clicking a slot focuses the real field', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Field />);
+    await user.click(partElements(container, 'slot')[3] as HTMLElement);
+    expect(document.activeElement).toBe(inputOf(container));
+  });
+
+  it('controlled: the value follows the prop, the callback reports the intended edit', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { container, rerender } = render(<Field value="12" onChange={onChange} />);
+    const el = inputOf(container);
+    expect(el.value).toBe('12');
+    await user.type(el, '3');
+    expect(onChange).toHaveBeenLastCalledWith('123');
+    expect(el.value).toBe('12');
+    rerender(<Field value="99" onChange={onChange} />);
+    expect(el.value).toBe('99');
+  });
+
+  it('disabled gates every entry path and projects the state', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { container } = render(<Field disabled onChange={onChange} />);
+    const el = inputOf(container);
+    await user.type(el, '123');
+    expect(el.value).toBe('');
+    expect(onChange).not.toHaveBeenCalled();
+    expect(partElement(container, 'root')?.getAttribute('data-disabled')).toBe('true');
+    expect(el.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('required and name make it a real form field, no hidden mirror', async () => {
+    const { container } = render(<Field required name="code" defaultValue="123456" />);
+    const el = inputOf(container);
+    expect(el.getAttribute('aria-required')).toBe('true');
+    expect(el.name).toBe('code');
+    expect(container.querySelectorAll('input[type="hidden"]')).toHaveLength(0);
+    await assertAxeClean(container);
+  });
+});

--- a/packages/ui/test/components/input-otp/input-otp.element.conformance.test.ts
+++ b/packages/ui/test/components/input-otp/input-otp.element.conformance.test.ts
@@ -1,0 +1,213 @@
+/**
+ * WC performance of the input-otp score, driven end to end against light-DOM
+ * markup. Same score as the React conformance test -- proves the filter, the
+ * active-slot rule, paste and the completion edge through the DOM binding.
+ */
+import { cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { RaftersInputOtp } from '../../../src/components/input-otp/input-otp.element';
+import { inputOtpBehavior } from '../../../src/components/input-otp/input-otp.behavior';
+import {
+  assertAxeClean,
+  assertContractFulfillment,
+  assertInstanceAriaFulfillment,
+  partElements,
+} from '../../harness/conformance';
+
+beforeAll(() => {
+  if (!customElements.get('rafters-input-otp')) {
+    customElements.define('rafters-input-otp', RaftersInputOtp);
+  }
+});
+
+interface MarkupOptions {
+  maxLength?: number;
+  value?: string;
+  disabled?: boolean;
+  required?: boolean;
+  pattern?: string;
+  name?: string;
+}
+
+function markup(options: MarkupOptions = {}): string {
+  const { maxLength = 6, value = '', disabled = false, required = false, pattern, name } = options;
+  const slots = Array.from(
+    { length: maxLength },
+    (_, index) =>
+      `<div data-part="slot" data-value="${index}">` +
+      `<span data-otp-char></span>` +
+      `<span data-otp-caret aria-hidden="true" hidden></span>` +
+      `</div>`,
+  ).join('');
+  return `<rafters-input-otp>
+    <div data-part="root" data-max-length="${maxLength}"${pattern ? ` data-pattern="${pattern}"` : ''}>
+      <input data-part="input" type="text" inputmode="numeric" autocomplete="one-time-code"
+        aria-label="Enter ${maxLength} character code" value="${value}"
+        ${name ? `name="${name}"` : ''} ${disabled ? 'disabled' : ''} ${required ? 'required' : ''} />
+      <div data-part="group">${slots}</div>
+    </div>
+  </rafters-input-otp>`;
+}
+
+async function mount(options: MarkupOptions = {}): Promise<HTMLElement> {
+  document.body.innerHTML = markup(options);
+  await Promise.resolve(); // let the deferred connectedCallback bind run
+  return document.body.querySelector('[data-part="root"]') as HTMLElement;
+}
+
+const input = () => document.body.querySelector<HTMLInputElement>('input[data-part="input"]')!;
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+describe('input-otp conformance [wc]', () => {
+  it('empty: the projection matches the rendered DOM and axe is clean', async () => {
+    const root = await mount();
+    const config = { maxLength: 6 };
+    const state = { value: '', activeIndex: 0 };
+    assertContractFulfillment(inputOtpBehavior, root, state, config, [
+      'root',
+      'input',
+      'group',
+      'slot',
+    ]);
+    assertInstanceAriaFulfillment(inputOtpBehavior, root, state, config);
+    await assertAxeClean(root);
+  });
+
+  it('seeds the value from the server markup and paints the slots on first bind', async () => {
+    const root = await mount({ value: '123' });
+    const slots = partElements(root, 'slot');
+    expect(slots.map((slot) => slot.textContent)).toEqual(['1', '2', '3', '', '', '']);
+    expect(slots[0]?.getAttribute('data-filled')).toBe('true');
+    expect(slots[3]?.getAttribute('data-active')).toBe('true');
+  });
+
+  it('typing fills slots and advances the caret', async () => {
+    const user = userEvent.setup();
+    const root = await mount();
+    await user.type(input(), '12');
+    const slots = partElements(root, 'slot');
+    expect(slots[1]?.textContent).toBe('2');
+    expect(slots[2]?.getAttribute('data-active')).toBe('true');
+  });
+
+  it('refuses characters the pattern rejects and reverts the field', async () => {
+    const user = userEvent.setup();
+    const root = await mount();
+    await user.type(input(), 'a1b');
+    expect(input().value).toBe('1');
+    expect(partElements(root, 'slot')[0]?.textContent).toBe('1');
+  });
+
+  it('a data-pattern attribute replaces the digit rule', async () => {
+    const user = userEvent.setup();
+    await mount({ pattern: '^[a-z]$' });
+    await user.type(input(), 'a1b');
+    expect(input().value).toBe('ab');
+  });
+
+  it('paste splits a whole code across the slots and fires the completion events', async () => {
+    const user = userEvent.setup();
+    const root = await mount();
+    const onChange = vi.fn();
+    const onComplete = vi.fn();
+    root.addEventListener('change', onChange);
+    root.addEventListener('rafters-otp-complete', onComplete);
+    input().focus();
+    await user.paste('12-34-56');
+    expect(input().value).toBe('123456');
+    expect(partElements(root, 'slot').map((slot) => slot.textContent)).toEqual([
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+    ]);
+    expect(root.getAttribute('data-complete')).toBe('true');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const event = onComplete.mock.calls[0]?.[0] as CustomEvent<{ value: string }>;
+    expect(event.detail.value).toBe('123456');
+  });
+
+  it('the completion event fires on the EDGE, not on every full-code edit', async () => {
+    const user = userEvent.setup();
+    const root = await mount({ value: '12345' });
+    const onComplete = vi.fn();
+    root.addEventListener('rafters-otp-complete', onComplete);
+    input().focus();
+    await user.keyboard('6');
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    // Already full: a further keystroke is truncated away, so no second edge.
+    await user.keyboard('7');
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('backspace deletes through the native field and repaints the slots', async () => {
+    const user = userEvent.setup();
+    const root = await mount({ value: '123' });
+    input().focus();
+    await user.keyboard('{Backspace}');
+    expect(input().value).toBe('12');
+    expect(partElements(root, 'slot')[2]?.hasAttribute('data-filled')).toBe(false);
+  });
+
+  it('arrows move the lit slot without moving focus', async () => {
+    const user = userEvent.setup();
+    const root = await mount({ value: '123' });
+    input().focus();
+    await user.keyboard('{ArrowLeft}');
+    expect(partElements(root, 'slot')[2]?.getAttribute('data-active')).toBe('true');
+    expect(document.activeElement).toBe(input());
+  });
+
+  it('a complete code keeps the last slot lit after ArrowLeft (the oracle rule)', async () => {
+    const user = userEvent.setup();
+    const root = await mount({ value: '123456' });
+    input().focus();
+    await user.keyboard('{ArrowLeft}');
+    const slots = partElements(root, 'slot');
+    expect(slots[4]?.getAttribute('data-active')).toBe('true');
+    expect(slots[5]?.getAttribute('data-active')).toBe('true');
+  });
+
+  it('clicking a slot focuses the real field', async () => {
+    const user = userEvent.setup();
+    const root = await mount();
+    await user.click(partElements(root, 'slot')[2] as HTMLElement);
+    expect(document.activeElement).toBe(input());
+  });
+
+  it('disabled projects the state and refuses entry', async () => {
+    const user = userEvent.setup();
+    const root = await mount({ disabled: true });
+    expect(root.getAttribute('data-disabled')).toBe('true');
+    expect(input().getAttribute('aria-disabled')).toBe('true');
+    await user.type(input(), '123');
+    expect(input().value).toBe('');
+  });
+
+  it('required projects aria-required and the field submits natively by name', async () => {
+    const root = await mount({ required: true, name: 'code' });
+    expect(input().getAttribute('aria-required')).toBe('true');
+    expect(input().name).toBe('code');
+    expect(root.querySelectorAll('input[type="hidden"]')).toHaveLength(0);
+  });
+
+  it('disconnecting tears the binding down: the slots stop tracking', async () => {
+    const root = await mount();
+    const field = input();
+    const host = document.body.querySelector('rafters-input-otp') as HTMLElement;
+    host.remove();
+
+    // Drive the detached field directly -- the teardown removed the listener,
+    // so nothing repaints the slots.
+    field.value = '1';
+    field.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(partElements(root, 'slot')[0]?.textContent).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Ports `input-otp` to the behavior layer as one score plus three thin
performances (React, Web Component, Astro), closing #1779.

The oracle's central structural decision is preserved because it was earned: a
single real `<input>` holds the code and owns caret, IME, selection and focus,
and the visible slots are a painted MIRROR of its value. An array of per-slot
inputs would break paste, break `autocomplete="one-time-code"` autofill, and
turn one field into N tab stops. This is the text-input archetype from Spec 05 —
value-primary state, native field owns text editing.

The score composes `keyboard-handler` (arrow slot navigation) and `input-events`
(its IME composition guard) directly, per Spec 05's "compose the primitive,
never reimplement it". The value math — the per-character pattern filter,
truncation to `maxLength`, and active-slot resolution — lives in exported pure
helpers rather than reducers, because a reducer receives no config and the math
needs `maxLength`/`pattern`. `composeInputOtpInteractions` is shared verbatim by
`bindInputOtp` (WC + Astro) and the React effect, so the entry rules cannot
drift between frameworks.

Two deliberate departures from the issue's suggested composition, both recorded
as dispositions in the component doc:

- **`form-value` is NOT composed.** It mirrors a value into a hidden `<input>`
  for controls built out of divs (slider's thumbs). InputOTP already has a real
  native input, so `name` submits `name=value` natively; adding the mirror would
  submit the field twice. The conformance suites assert no hidden input exists.
- **`input-events` is composed for its composition guard only.** Its
  `createInputHandler` classifies events by `inputType` against an
  editor-oriented whitelist and drops the rest, so the value path must not
  depend on it; it stays on the plain `input` event.

**One file outside the component folder:** `src/primitives/input-events.ts`
gains a type guard around `event.getTargetRanges()`. Unguarded, it threw for the
`InputEvent` of a native `<input>` (the method is contenteditable-oriented and
absent in some engines and in the test environment), which meant the primitive
could not be composed by any native-input component at all. Spec 05 mandates
EXTENDING a primitive over writing a local half-solution, so hand-rolling
composition tracking inside input-otp was rejected. Absent ranges are none, and
the full `test:unit` suite stays green, so no existing consumer regressed.

Faithfulness notes: the oracle's complete-code OR is preserved verbatim — a full
code keeps the LAST slot lit even after ArrowLeft walks the active index back,
so a full field can show two active slots. It looks like a bug and is not, which
is why it has its own behavior test. One oracle behavior is classified
`defect-do-not-port`: the completion event re-fired on every input while the
code was already full; it is now latched to the completion EDGE in both the bind
and React. Where the two oracles disagreed with each other (pattern default
`^[0-9]*$` vs `^[0-9]$`; `aria-label` "digit" vs "character"), the doc records
which is canonical and why.

## Acceptance criteria mapping

### Component doc written

`docs/spec/components/input-otp.md` follows the dialog.md/slider.md article
shape: composition, config/state/actions, the parts + ARIA table, keyboard,
events, motion intent, the full oracle disposition table and the WCAG
obligations. The disposition table carries the reasoning a future reader needs
most — why `form-value` is absent, why the slots carry no ARIA, and which oracle
behaviors were dropped versus preserved.

Evidence: packages/ui/docs/spec/components/input-otp.md:160

### JSDoc intelligence tags present

The four tags sit on the React performance where the registry parses them, with
the five-dimension cognitive-load breakdown summing to the headline score in the
same convention slider uses. Each tag carries component-specific reasoning
rather than generic copy: the attention argument is about countable remaining
slots, the trust argument about rejected characters never rendering.

Evidence: packages/ui/src/components/input-otp/input-otp.tsx:33

### Behavior test (pure, no DOM)

The behavior suite drives the score entirely through pure functions and
`createBehavior`, touching no DOM at all. It pins the rules most vulnerable to
being silently re-derived by a later edit: filtering before truncating, the
malformed-pattern fallback, the disabled gate covering both actions, and the
two-active-slot OR the oracle earned.

Evidence: packages/ui/test/components/input-otp/input-otp.behavior.test.ts:96

### Classes parity test

The classes suite asserts the decisions embedded in the class strings rather
than restating them: that the real field is `sr-only` and never `hidden` so AT
and autofill still reach it, that slot state is styled from projected data
attributes instead of recomposed class strings, and that both motion surfaces
honour reduced motion.

Evidence: packages/ui/test/components/input-otp/input-otp.classes.test.ts:10

### Conformance test via the shared harness (aria + keymap against rendered DOM)

All three frameworks drive the one score through the shared harness:
`assertContractFulfillment` compares the aria projection to real rendered DOM,
`assertInstanceAriaFulfillment` drives the `slot` many-part per instance, and
`assertAxeClean` runs on each scenario. The keymap is exercised against real
DOM — arrows move the lit slot while focus provably stays on the field.

Evidence: packages/ui/test/components/input-otp/input-otp.conformance.test.tsx:48

### shadcn drop-in parity where the component exists in shadcn

The compound surface is preserved exactly rather than simplified into a single
auto-rendering component: `InputOTP` with `.Group`, `.Slot index` and
`.Separator` children, plus `value`/`defaultValue`/`onChange`/`maxLength`/
`pattern`/`disabled`/`autoFocus`/`onComplete` keeping their oracle meanings.
`pattern` still accepts a `RegExp` (the oracle's type) and reads its `.source`.

Evidence: packages/ui/src/components/input-otp/input-otp.tsx:92

### `pnpm --filter @rafters/ui test:unit` green, `pnpm preflight` green

Both were run to a zero exit code from the worktree after the final commit, and
the unit run covers the whole package rather than just this component, so the
`input-events` guard is verified against every existing consumer of that
primitive rather than only against the new one.

Evidence: packages/ui/package.json:8

## Not done

- **Vue.** Out of scope for this wave; the score is framework-agnostic and a Vue
  performance would be a fourth decorator over the same `bindInputOtp`.
- **The oracle's `ElementInternals` form-association surface**
  (`setValidity({tooShort})`, `formResetCallback`, `formStateRestoreCallback`,
  `checkValidity`) is not reimplemented. It was a WC-only surface the React
  oracle never had; the behavior-layer control is a real native `<input>`, so
  submission, reset and constraint validation come from the platform. Recorded
  as `framework-affordance`, not dropped silently.
- **No `package.json` export entry**, per the issue and #1896 — distribution is
  the registry's job.
- **The ~45-line projection scaffolding** duplicated across every ported
  component is written by hand here too, following the existing pattern. A
  shared helper remains a separate pending decision.
- **`docs/spec/matrix/components.md` is not updated.** It is generated from live
  index evidence, and the most recent ports (slider, tabs, accordion) do not
  touch it.

Closes #1779
