### PR TITLE
feat(#1905): give motion combination constraints a queryable home

### DIFF
--- a/docs/MOTION.md
+++ b/docs/MOTION.md
@@ -101,7 +101,7 @@ Every `-in`/`-out` pair has a shorter exit. The user chose to leave.
 
 ## Combination constraints
 
-These are rules, not values, and they have no home in a token. They exist because the number of possible parameter combinations is larger than intuition can navigate.[^audi-ci]
+These are rules, not values. A cross-parameter rule has no home in any single token -- so instead of leaving them as prose, they live as structured, queryable metadata an agent composing motion can read before it writes the wrong thing. They exist because the number of possible parameter combinations is larger than intuition can navigate.[^audi-ci]
 
 | Parameter | Rule | Why |
 |---|---|---|
@@ -110,6 +110,21 @@ These are rules, not values, and they have no home in a token. They exist becaus
 | Opacity | May combine with movement. | Fade plus slide is the standard enter/exit. Fade alone is for elements that do not move. |
 | Rotation | Small elements only. **Never combined with another parameter.** | Rotation is visually dominant; combined with translation it is chaos. Isolated, it reads as processing. |
 | Timing | Sequential, not simultaneous. | Staggered sequences create narrative. Simultaneous animation is noise. |
+
+### Where the constraints live
+
+The table above is mirrored by machine-readable data and a validator in `@rafters/design-tokens` (`packages/design-tokens/src/generators/motion-constraints.ts`), the package the CLI already depends on, so tooling can read the rule rather than re-deriving it from prose:
+
+- **`MOTION_COMBINATION_CONSTRAINTS`** -- the five constraints as data, each carrying an `id`, `rule`, `rationale`, and a `kind`.
+- **`MOTION_GOVERNING_RULE`** -- the rule below, with its three questions and its enforcement posture.
+- **`validateMotionComposition(composition)`** -- takes a proposed animation described by the *parameters it engages* (translate axis, scale, opacity, rotation, element size, timing) and returns the constraint violations. An empty list means legal. `isLegalMotionComposition` is the boolean wrapper.
+
+Two splits are deliberate and are recorded in the data itself:
+
+- **Permission vs prohibition.** Only Direction, Rotation, and Timing have teeth -- the validator rejects diagonal movement, rotation combined with anything (or on a large element), and simultaneous timing. Scaling and Opacity are `kind: 'permission'`: they *bless* combining with movement (`scale + move`, `fade + slide`), so the validator never rejects them. A validator that rejected "any two parameters combined" would contradict this spec.
+- **Mechanical vs advisory** for the governing rule (below). Its `enforcement` field is `mechanical-presence-advisory-truth`: the validator mechanically requires that a composition *declares* which question it answers, but whether the declared answer is *true* is a human or agent judgment and stays advisory.
+
+**Governing rule -- motion that answers no question does not move.** If an animation does not tell the user what happened, where they are, or what to expect next, it is decorative. This one has teeth: decorative animation measurably impairs recall.[^stokes-2020] `validateMotionComposition` enforces the presence half -- a composition with no declared `answers` is rejected.
 
 ## What gets no motion
 
@@ -150,7 +165,7 @@ This document is the specification. It is **not** what currently ships. Tracked 
 - The six curves above are not generated; the exporter emits a different easing vocabulary.
 - **No semantic motion token exists.** Components therefore hardcode raw numeric durations, which is what this layer exists to prevent.
 - The keyframe table in `packages/design-tokens/src/generators/motion.ts` is copied from shadcn, and `accordion-down`/`accordion-up` interpolate `var(--radix-accordion-content-height)`, which nothing in this system sets -- so they animate to an undefined height.
-- Combination constraints have no representation anywhere.
+- Combination constraints are represented as structured metadata and a mechanical validator (`motion-constraints.ts`), even though the token *values* above are not yet generated. This is the one part of this document that ships.
 
 ## Sources
 

--- a/packages/design-tokens/src/generators/index.ts
+++ b/packages/design-tokens/src/generators/index.ts
@@ -48,6 +48,21 @@ export * from './defaults.js';
 export { generateDepthTokens } from './depth.js';
 export { generateFocusTokens } from './focus.js';
 export { generateMotionTokens } from './motion.js';
+export {
+  isLegalMotionComposition,
+  MOTION_COMBINATION_CONSTRAINTS,
+  MOTION_GOVERNING_RULE,
+  type MotionAxis,
+  type MotionComposition,
+  type MotionConstraint,
+  type MotionConstraintId,
+  type MotionElementSize,
+  type MotionGoverningRule,
+  type MotionParameter,
+  type MotionQuestion,
+  type MotionViolation,
+  validateMotionComposition,
+} from './motion-constraints.js';
 export { generateRadiusTokens } from './radius.js';
 export { generateSemanticTokens } from './semantic.js';
 export { generateShadowTokens } from './shadow.js';

--- a/packages/design-tokens/src/generators/motion-constraints.ts
+++ b/packages/design-tokens/src/generators/motion-constraints.ts
@@ -1,0 +1,267 @@
+/**
+ * Motion combination constraints
+ *
+ * The duration scale, easing curves, and semantic motion tokens are VALUES --
+ * they live in tokens (see `motion.ts`). Combination constraints are RULES about
+ * how animation parameters may be combined, and a cross-parameter rule has no
+ * home in any single token. They exist because the number of possible parameter
+ * combinations is larger than intuition can navigate, which is the same argument
+ * for encoding designer judgment as queryable data rather than prose: an agent
+ * composing motion should be told "rotation is isolated" before it writes the
+ * wrong thing.
+ *
+ * This module is the single decision point for "is this combination legal". It
+ * is pure and dependency-free (no token imports, no node:fs), so it is
+ * browser-safe and exhaustively unit-testable in isolation, and it is exported
+ * from `@rafters/design-tokens` as importable, queryable metadata.
+ *
+ * Two deliberate splits govern the design:
+ *
+ * 1. Permission vs prohibition. Only three of the five constraints have teeth
+ *    (Direction, Rotation, Timing). Scaling and Opacity are PERMISSIONS -- they
+ *    bless combinations (`scale + move`, `fade + slide` are the standard
+ *    enter/exit). The validator therefore never rejects a scale/opacity combo;
+ *    rejecting "any two parameters combined" would contradict the spec.
+ *
+ * 2. Mechanical vs advisory, for the governing rule. "Motion that answers no
+ *    question does not move" is mechanically checkable only as "an answer was
+ *    declared"; whether the declared answer is TRUE is a human/agent judgment
+ *    and stays advisory.
+ *
+ * Parameters are keyed on their KIND (translate axis, scale-present,
+ * opacity-present, rotate-present, element-size, timing), never on token names.
+ * Token names for durations and curves are being rebuilt; keying on kinds keeps
+ * this module stable across that churn.
+ */
+
+/** Axis of translation. Diagonal (both at once) is the prohibited case. */
+export type MotionAxis = 'horizontal' | 'vertical';
+
+/** The animation parameters a composition can engage. */
+export type MotionParameter = 'translate' | 'scale' | 'opacity' | 'rotate';
+
+/** Size class of the animated element. Rotation is permitted on small only. */
+export type MotionElementSize = 'small' | 'large';
+
+/**
+ * The three questions motion may answer. The governing rule requires at least
+ * one to be declared.
+ */
+export type MotionQuestion = 'what-happened' | 'where-am-i' | 'what-next';
+
+/**
+ * A proposed animation, described by the parameters it engages rather than by
+ * the tokens it references. This is the input an author or agent hands the
+ * validator before committing to an animation.
+ */
+export interface MotionComposition {
+  /** Translation axes engaged. Empty/omitted means no spatial movement. */
+  translate?: MotionAxis[];
+  /** Whether the animation scales the element. */
+  scale?: boolean;
+  /** Whether the animation changes opacity. */
+  opacity?: boolean;
+  /** Whether the animation rotates the element. */
+  rotate?: boolean;
+  /** Size class of the animated element (rotation is small-only). */
+  elementSize?: MotionElementSize;
+  /**
+   * How co-occurring animated elements are timed. `sequential` staggers them
+   * into a narrative; `simultaneous` animates them together and reads as noise.
+   * Omitted means a single element, which is trivially sequential.
+   */
+  timing?: 'sequential' | 'simultaneous';
+  /**
+   * Which question(s) the motion answers. Mechanically, the governing rule only
+   * checks that this is non-empty; the TRUTH of the claim is advisory.
+   */
+  answers?: MotionQuestion[];
+}
+
+/** Stable identifiers for the five combination constraints. */
+export type MotionConstraintId = 'direction' | 'scaling' | 'opacity' | 'rotation' | 'timing';
+
+/**
+ * A single combination constraint as queryable metadata.
+ *
+ * `kind` distinguishes the two enforcement postures: a `prohibition` is
+ * mechanically rejectable by {@link validateMotionComposition}; a `permission`
+ * exists to record that a combination is explicitly blessed (so tooling does
+ * not wrongly flag it) and is never a source of violations.
+ */
+export interface MotionConstraint {
+  id: MotionConstraintId;
+  /** Human-facing parameter label. */
+  parameter: string;
+  kind: 'prohibition' | 'permission';
+  /** The rule, in the designer's words. */
+  rule: string;
+  /** Why the rule exists. */
+  rationale: string;
+}
+
+/**
+ * The five combination constraints, as structured data. Ordered to match the
+ * table in `docs/MOTION.md`.
+ */
+export const MOTION_COMBINATION_CONSTRAINTS: readonly MotionConstraint[] = [
+  {
+    id: 'direction',
+    parameter: 'Direction',
+    kind: 'prohibition',
+    rule: 'Horizontal or vertical. Never diagonal.',
+    rationale: 'The eye tracks one axis at a time. Axis-aligned movement creates order.',
+  },
+  {
+    id: 'scaling',
+    parameter: 'Scaling',
+    kind: 'permission',
+    rule: 'May combine with movement.',
+    rationale:
+      'Scale changes state, movement changes position; together they read as arriving at a new size.',
+  },
+  {
+    id: 'opacity',
+    parameter: 'Opacity',
+    kind: 'permission',
+    rule: 'May combine with movement.',
+    rationale:
+      'Fade plus slide is the standard enter/exit. Fade alone is for elements that do not move.',
+  },
+  {
+    id: 'rotation',
+    parameter: 'Rotation',
+    kind: 'prohibition',
+    rule: 'Small elements only. Never combined with another parameter.',
+    rationale:
+      'Rotation is visually dominant; combined with translation it is chaos. Isolated, it reads as processing.',
+  },
+  {
+    id: 'timing',
+    parameter: 'Timing',
+    kind: 'prohibition',
+    rule: 'Sequential, not simultaneous.',
+    rationale: 'Staggered sequences create narrative. Simultaneous animation is noise.',
+  },
+] as const;
+
+/**
+ * The governing rule, as metadata. `enforcement` records the mechanical/advisory
+ * split explicitly: presence of a declared answer is checked mechanically;
+ * whether the answer is true is left to human/agent judgment.
+ */
+export interface MotionGoverningRule {
+  statement: string;
+  rationale: string;
+  /** The questions a motion may answer; at least one must be declared. */
+  questions: readonly MotionQuestion[];
+  enforcement: 'mechanical-presence-advisory-truth';
+}
+
+export const MOTION_GOVERNING_RULE: MotionGoverningRule = {
+  statement: 'Motion that answers no question does not move.',
+  rationale:
+    'If an animation does not tell the user what happened, where they are, or what to expect next, it is decorative -- and decorative animation measurably impairs recall (Stokes 2020). It is not neutral.',
+  questions: ['what-happened', 'where-am-i', 'what-next'],
+  enforcement: 'mechanical-presence-advisory-truth',
+};
+
+/** A single rule violation found in a proposed composition. */
+export interface MotionViolation {
+  /** Which constraint was violated (or the governing rule). */
+  constraint: MotionConstraintId | 'governing-rule';
+  /** Whether enforcement of this rule is mechanical or advisory. */
+  enforcement: 'mechanical' | 'advisory';
+  /** Human-facing explanation of the violation and the fix. */
+  message: string;
+}
+
+/**
+ * Validate a proposed motion composition against the combination constraints.
+ *
+ * Returns the list of violations; an empty list means the composition is legal.
+ * Only the three prohibitions (Direction, Rotation, Timing) and the presence
+ * half of the governing rule can produce a MECHANICAL violation. The two
+ * permissions (Scaling, Opacity) never reject -- a scale+move or fade+slide
+ * composition passes by design.
+ */
+export function validateMotionComposition(composition: MotionComposition): MotionViolation[] {
+  const violations: MotionViolation[] = [];
+
+  const axes = composition.translate ?? [];
+  const hasHorizontal = axes.includes('horizontal');
+  const hasVertical = axes.includes('vertical');
+  const hasTranslate = hasHorizontal || hasVertical;
+  const hasScale = composition.scale === true;
+  const hasOpacity = composition.opacity === true;
+  const hasRotate = composition.rotate === true;
+
+  // Direction (prohibition): a single axis is order; both at once is diagonal.
+  if (hasHorizontal && hasVertical) {
+    violations.push({
+      constraint: 'direction',
+      enforcement: 'mechanical',
+      message:
+        'Movement combines horizontal and vertical translation (diagonal). The eye tracks one axis at a time -- move on a single axis.',
+    });
+  }
+
+  // Rotation (prohibition): isolated, and small elements only.
+  if (hasRotate) {
+    const combinedWith = [
+      hasTranslate ? 'translation' : null,
+      hasScale ? 'scale' : null,
+      hasOpacity ? 'opacity' : null,
+    ].filter((entry): entry is string => entry !== null);
+
+    if (combinedWith.length > 0) {
+      violations.push({
+        constraint: 'rotation',
+        enforcement: 'mechanical',
+        message: `Rotation is combined with ${combinedWith.join(
+          ', ',
+        )}. Rotation is visually dominant and must be isolated -- animate it on its own.`,
+      });
+    }
+
+    if (composition.elementSize === 'large') {
+      violations.push({
+        constraint: 'rotation',
+        enforcement: 'mechanical',
+        message:
+          'Rotation is applied to a large element. Rotation is for small elements only (icons, spinners, chevrons).',
+      });
+    }
+  }
+
+  // Timing (prohibition): co-occurring elements stagger, never fire together.
+  if (composition.timing === 'simultaneous') {
+    violations.push({
+      constraint: 'timing',
+      enforcement: 'mechanical',
+      message:
+        'Multiple elements animate simultaneously. Stagger them into a sequence -- the eye can track only one moving element.',
+    });
+  }
+
+  // Governing rule: presence is mechanical, truth is advisory.
+  if (!composition.answers || composition.answers.length === 0) {
+    violations.push({
+      constraint: 'governing-rule',
+      enforcement: 'mechanical',
+      message:
+        'Motion answers no question (what happened / where am I / what next). Motion that answers no question does not move.',
+    });
+  }
+
+  return violations;
+}
+
+/**
+ * Convenience predicate: `true` when a composition has no violations. Thin
+ * wrapper over {@link validateMotionComposition} for call sites that only need
+ * a yes/no gate.
+ */
+export function isLegalMotionComposition(composition: MotionComposition): boolean {
+  return validateMotionComposition(composition).length === 0;
+}

--- a/packages/design-tokens/test/motion-constraints.test.ts
+++ b/packages/design-tokens/test/motion-constraints.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isLegalMotionComposition,
+  MOTION_COMBINATION_CONSTRAINTS,
+  MOTION_GOVERNING_RULE,
+  type MotionComposition,
+  validateMotionComposition,
+} from '../src/index.js';
+
+/**
+ * A composition that answers a question and engages no prohibited combination.
+ * Reused as the baseline the negative cases mutate.
+ */
+const LEGAL_BASE: MotionComposition = {
+  translate: ['vertical'],
+  opacity: true,
+  answers: ['what-happened'],
+};
+
+describe('motion combination constraints (metadata)', () => {
+  it('exposes all five constraints as queryable data', () => {
+    const ids = MOTION_COMBINATION_CONSTRAINTS.map((c) => c.id);
+    expect(ids).toEqual(['direction', 'scaling', 'opacity', 'rotation', 'timing']);
+  });
+
+  it('marks Scaling and Opacity as permissions, the rest as prohibitions', () => {
+    const byId = Object.fromEntries(MOTION_COMBINATION_CONSTRAINTS.map((c) => [c.id, c.kind]));
+    expect(byId.scaling).toBe('permission');
+    expect(byId.opacity).toBe('permission');
+    expect(byId.direction).toBe('prohibition');
+    expect(byId.rotation).toBe('prohibition');
+    expect(byId.timing).toBe('prohibition');
+  });
+
+  it('records the governing rule with an explicit mechanical/advisory split', () => {
+    expect(MOTION_GOVERNING_RULE.statement).toMatch(/answers no question/i);
+    expect(MOTION_GOVERNING_RULE.enforcement).toBe('mechanical-presence-advisory-truth');
+    expect(MOTION_GOVERNING_RULE.questions).toEqual(['what-happened', 'where-am-i', 'what-next']);
+  });
+});
+
+describe('validateMotionComposition (mechanical enforcement)', () => {
+  it('accepts a legal single-axis fade+slide', () => {
+    expect(validateMotionComposition(LEGAL_BASE)).toEqual([]);
+    expect(isLegalMotionComposition(LEGAL_BASE)).toBe(true);
+  });
+
+  // Permission cases: multi-parameter combinations that MUST pass. These guard
+  // against an over-eager validator that rejects "any two parameters combined".
+  it('allows scale to combine with movement (permission)', () => {
+    expect(
+      isLegalMotionComposition({
+        translate: ['vertical'],
+        scale: true,
+        answers: ['where-am-i'],
+      }),
+    ).toBe(true);
+  });
+
+  it('allows scale + opacity + movement together (permission)', () => {
+    expect(
+      isLegalMotionComposition({
+        translate: ['horizontal'],
+        scale: true,
+        opacity: true,
+        answers: ['what-next'],
+      }),
+    ).toBe(true);
+  });
+
+  // Prohibition cases: illegal combinations that MUST be rejected.
+  it('rejects diagonal movement (both axes at once)', () => {
+    const violations = validateMotionComposition({
+      ...LEGAL_BASE,
+      translate: ['horizontal', 'vertical'],
+    });
+    expect(violations.map((v) => v.constraint)).toContain('direction');
+    expect(isLegalMotionComposition({ ...LEGAL_BASE, translate: ['horizontal', 'vertical'] })).toBe(
+      false,
+    );
+  });
+
+  it('rejects rotation combined with translation', () => {
+    const violations = validateMotionComposition({
+      translate: ['vertical'],
+      rotate: true,
+      elementSize: 'small',
+      answers: ['what-happened'],
+    });
+    expect(violations.map((v) => v.constraint)).toContain('rotation');
+  });
+
+  it('rejects rotation on a large element', () => {
+    const violations = validateMotionComposition({
+      rotate: true,
+      elementSize: 'large',
+      answers: ['what-happened'],
+    });
+    expect(violations.map((v) => v.constraint)).toContain('rotation');
+  });
+
+  it('allows isolated rotation on a small element', () => {
+    expect(
+      isLegalMotionComposition({
+        rotate: true,
+        elementSize: 'small',
+        answers: ['what-next'],
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects simultaneous timing', () => {
+    const violations = validateMotionComposition({
+      ...LEGAL_BASE,
+      timing: 'simultaneous',
+    });
+    expect(violations.map((v) => v.constraint)).toContain('timing');
+  });
+
+  it('accepts sequential timing', () => {
+    expect(isLegalMotionComposition({ ...LEGAL_BASE, timing: 'sequential' })).toBe(true);
+  });
+
+  // Governing rule: presence is mechanical.
+  it('rejects motion that declares no answered question', () => {
+    const violations = validateMotionComposition({ translate: ['vertical'] });
+    const governing = violations.find((v) => v.constraint === 'governing-rule');
+    expect(governing).toBeDefined();
+    expect(governing?.enforcement).toBe('mechanical');
+  });
+
+  it('reports every violation of a maximally-illegal composition', () => {
+    const violations = validateMotionComposition({
+      translate: ['horizontal', 'vertical'],
+      rotate: true,
+      elementSize: 'large',
+      timing: 'simultaneous',
+      // no answers
+    });
+    const constraints = new Set(violations.map((v) => v.constraint));
+    expect(constraints).toContain('direction');
+    expect(constraints).toContain('rotation');
+    expect(constraints).toContain('timing');
+    expect(constraints).toContain('governing-rule');
+  });
+});

--- a/packages/ui/docs/spec/05-authoring.md
+++ b/packages/ui/docs/spec/05-authoring.md
@@ -126,6 +126,37 @@ bind and the React `useEffect`):
 3. **WC bind deferred**: `connectedCallback` can fire before light-DOM children
    parse -- bind on the next microtask.
 
+## Composing motion (combination constraints)
+
+When a component animates, the duration and easing come from motion tokens --
+but *which parameters you combine* is governed by cross-parameter rules that no
+single token can hold. They are not prose to remember; they are queryable data
+plus a validator in `@rafters/design-tokens`
+(`generators/motion-constraints.ts`), so an agent composing motion is told the
+rule before it writes the wrong thing. The full rationale is `docs/MOTION.md`;
+the authoring shape is:
+
+- **`MOTION_COMBINATION_CONSTRAINTS`** and **`MOTION_GOVERNING_RULE`** -- the
+  five constraints and the governing rule as structured metadata (read them
+  when you need the *why*).
+- **`validateMotionComposition(composition)`** -- describe the animation by the
+  parameters it engages (`translate` axes, `scale`, `opacity`, `rotate`,
+  `elementSize`, `timing`, `answers`) and get back the violations. Empty means
+  legal; `isLegalMotionComposition` is the boolean form.
+
+Enforcement is **mechanical** for the three prohibitions and advisory for the
+rest, and the split is recorded in the data:
+
+- **Rejected** (mechanical): diagonal movement (both axes at once); rotation
+  combined with any other parameter, or on a large element; simultaneous timing
+  across co-occurring elements; a composition that declares no answered
+  question.
+- **Blessed** (permission, never rejected): scale combined with movement,
+  opacity combined with movement -- `fade + slide` is the standard enter/exit.
+- **Advisory**: the governing rule checks that you *declared* which question the
+  motion answers (what happened / where am I / what next); whether that answer
+  is genuinely true is your judgment, not the validator's.
+
 ## Honest costs (do not pretend these away)
 
 - **React compound decorators carry real hook weight.** A static (button,


### PR DESCRIPTION
## Summary

The five motion combination constraints and the governing rule ("motion that answers no
question does not move") existed only as prose in `docs/MOTION.md` -- a cross-parameter rule
that no single token can hold, and that an agent composing motion could not read. This gives
them a home: structured, importable metadata plus a pure mechanical validator in
`@rafters/design-tokens` (`generators/motion-constraints.ts`), the package the CLI already
depends on. Constraints are keyed on animation parameter KINDS (translate axis, scale,
opacity, rotation, element size, timing), never on the duration/easing token names being
rebuilt in #1902-1904, so this is genuinely independent of the token layer.

## Acceptance criteria mapping

### 1. The five constraints plus the governing rule are represented in a form something can read, not only prose
`MOTION_COMBINATION_CONSTRAINTS` is a typed array of the five constraints, each carrying an
`id`, `parameter`, `kind` (`prohibition` | `permission`), `rule`, and `rationale`.
`MOTION_GOVERNING_RULE` carries the statement, its three questions, and an `enforcement`
field. Both are exported from the package root via `generators/index.ts`, so any tool that
imports `@rafters/design-tokens` (the CLI does) can query the rule as data rather than parsing
the markdown table.
Evidence: `packages/design-tokens/src/generators/motion-constraints.ts` (MOTION_COMBINATION_CONSTRAINTS, MOTION_GOVERNING_RULE); re-exported at `packages/design-tokens/src/generators/index.ts:51`.

### 2. The chosen mechanism is documented in docs/MOTION.md and 05-authoring.md
`docs/MOTION.md` gains a "Where the constraints live" subsection naming the exports, the
validator, and the two deliberate splits; the implementation-status bullet that read "no
representation anywhere" is rewritten to state that the constraints now ship even though the
token values do not. `05-authoring.md` gains a "Composing motion (combination constraints)"
section pointing component authors at `validateMotionComposition` and the parameter-kind
input shape.
Evidence: `docs/MOTION.md:114` (### Where the constraints live) and `docs/MOTION.md:168`; `packages/ui/docs/spec/05-authoring.md:129` (## Composing motion).

### 3. If enforcement is mechanical, an illegal combination is demonstrably rejected with a test
`validateMotionComposition` mechanically rejects the three prohibitions and the presence half
of the governing rule. The test suite asserts rejection of diagonal movement (both axes),
rotation combined with translation, rotation on a large element, simultaneous timing, and
answer-less motion -- and, crucially, asserts the permission combos (scale+move, fade+slide)
PASS, guarding against an over-eager validator that would wrongly reject any two combined
parameters.
Evidence: `packages/design-tokens/test/motion-constraints.test.ts` (14 passing cases, including "rejects diagonal movement", "rejects rotation combined with translation", "allows scale + opacity + movement together").

### 4. If enforcement is advisory, that is stated explicitly rather than left ambiguous
The two permissions (Scaling, Opacity) carry `kind: 'permission'` in the data and are
documented as blessed combinations the validator never rejects. The governing rule's
`enforcement` field is the literal `'mechanical-presence-advisory-truth'`: the validator
mechanically requires a declared `answers`, but whether the declared answer is TRUE is stated,
in both the data and both docs, to be advisory human/agent judgment.
Evidence: `MOTION_GOVERNING_RULE.enforcement` in `motion-constraints.ts`; the "mechanical vs advisory" prose in `docs/MOTION.md` and `packages/ui/docs/spec/05-authoring.md`.

### 5. pnpm preflight green
`pnpm preflight` exits 0 (build, lint, format, typecheck, tests) and the pre-commit hook
(unit-tests, lint, format, typecheck) passed on the commit.
Evidence: preflight run captured EXIT=0; lefthook pre-commit reported 0 warnings 0 errors across all four stages.

## Not done

No MCP tool was wired. The MCP surface (`packages/cli/src/mcp/tools.ts`) is explicitly scoped
to assembly, not token/motion design ("Token design lives in Studio... not MCP"), and it is a
shared file outside this subsystem. The acceptance criteria require a readable representation,
not a live tool, and the exported metadata is already importable by the CLI/MCP process; a
dedicated `rafters_motion` tool, if wanted, is a separate follow-up. The token-layer files
(duration scale, easing curves, semantic tokens under #1902-1904) were left untouched by
design.

Closes #1905
