### PR TITLE
fix(ui): accordion animates via motion-expand/collapse + inert

### DIFF
--- a/packages/ui/docs/spec/components/accordion.md
+++ b/packages/ui/docs/spec/components/accordion.md
@@ -88,7 +88,7 @@ consumer callback fires, so a refused edit must not look like a move.
 | item (many) | one per section | `data-state` |
 | heading (many) | one per section | `role="heading"`, `aria-level` |
 | trigger (many) | one per section | `aria-expanded`, `aria-controls`, `data-state` |
-| content (many) | one per section, always in the DOM | `role="region"`, `aria-labelledby`, `data-state`, `hidden` while collapsed |
+| content (many) | one per section, always in the DOM | `role="region"`, `aria-labelledby`, `data-state`, `inert` while collapsed |
 
 `item`/`heading`/`trigger`/`content` are `many` parts, so their attributes come
 from `BehaviorSpec.instanceAria(part, value, state, config, ids)` rather than
@@ -98,7 +98,7 @@ instances. The shared harness drives `spec.instanceAria` generically
 is asserted against the score with no per-component wiring.
 
 `aria-controls` is projected unconditionally -- guarded only on the sibling id
-being real, not on the open axis. Panels are present-but-hidden rather than
+being real, not on the open axis. Panels are present-and-inert rather than
 unmounted, so the reference is never dangling and the oracle advertised it while
 collapsed too. This deliberately diverges from the `disclosable` slice's
 `open && ids.content` guard, which exists for overlays whose content leaves the
@@ -139,25 +139,36 @@ files expose.
 | `role="heading"` wrapper with `aria-level={3}` around the header button | contract, generalized: the level is `config.headingLevel` and rides the `heading` instance projection instead of being hand-written per framework |
 | header button `aria-expanded` + `aria-controls`, set while collapsed too | contract |
 | panel `role="region"` + `aria-labelledby` back to its header | contract |
-| panel always mounted, visibility toggled by `hidden` | contract (crawlable content, and the height transition runs on the same node) |
+| panel always mounted, collapsed via grid-rows + `inert` (not `hidden`) | contract (crawlable content; `hidden` is display:none and would block the transition, so a collapsed panel projects `inert` -- out of the a11y tree + tab order, still rendered so the grid-rows transition runs on the same node) |
 | ArrowUp/ArrowDown/Home/End roving tabindex over `[data-roving-item]` headers | contract (the same `roving-focus` primitive, composed directly on the vertical axis) |
 | chevron `<svg>` rotating via `group-data-[state=open]:rotate-180` | contract |
 | `data-accordion-item` / `data-accordion-trigger` / `data-accordion-content` markers | framework-affordance -- replaced by the layer-wide `data-part` + `data-value` registry the harness and the binds query |
 | Astro `accordionId` prop threaded to every child to hand-template `${accordionId}-trigger-${value}` ids | framework-affordance -- the Astro decorator mints instance ids from the root `id`, as navigation-menu does; children no longer need the group id |
 | React `AccordionItem` minting ids from `useId()` per item | framework-affordance -- ids now derive from one root `useId()` so the trigger/panel pair is resolvable without an item-local context of its own |
 | `AccordionItemContext` throwing outside its provider | contract (both provider levels throw with a named message) |
-| `data-[state=closed]:animate-accordion-up` / `data-[state=open]:animate-accordion-down` on the panel | defect-do-not-port -- those keyframes interpolate `var(--radix-accordion-content-height)`, a Radix-owned variable nothing in this system ever sets, so the animation runs to an undefined height; replaced by `overflow-hidden transition-all duration-300 motion-reduce:transition-none` (declared height-axis intent) |
+| `data-[state=closed]:animate-accordion-up` / `data-[state=open]:animate-accordion-down` on the panel | defect-do-not-port -- those keyframes interpolate `var(--radix-accordion-content-height)`, a Radix-owned variable nothing in this system ever sets, so the animation runs to an undefined height; replaced by a `grid-template-rows` transition (`minmax(0,0fr)` <-> `minmax(0,1fr)`) driven by the `motion-expand` / `motion-collapse` semantic tokens |
 | React root rendering a bare `classy(className)` with no root class | contract -- `accordionClasses().root` is deliberately empty: the root is the styling anchor for the projected `data-*`, not a visual |
 
 ## Motion
 
-Expand/collapse along the height axis (y). Declared as intent only:
-`overflow-hidden transition-all duration-300 motion-reduce:transition-none` on
-the panel, plus `transition-transform duration-300` on the chevron. Duration and
-easing come from the token scale; reduced motion disables both. Padding lives on
-the panel's inner box, never on the panel itself, so the panel can collapse to
-zero height. A keyframed height animation waits on a real content-height
-utility in the token system.
+Expand/collapse along the height axis (y), via the semantic motion tokens (see
+`docs/MOTION.md`):
+
+- The panel is a grid whose single row animates `grid-template-rows`
+  `minmax(0,0fr)` <-> `minmax(0,1fr)` -- the transitionable stand-in for
+  `height:auto`. `motion-expand` (normal/enter) drives the open direction and
+  `motion-collapse` (moderate/exit) the close, so the exit is faster than the
+  entrance. Both carry the reduced-motion fallback (snap the rows, fade opacity)
+  in the token itself; the `data-[state]:opacity-0/100` pair is what those users
+  see. The `minmax(0, ...)` floor is load-bearing: a bare `0fr` track keeps its
+  min-content minimum, which the inner padding floors above zero, leaving a gap
+  on a "collapsed" panel. Padding lives on the inner clip box, never on the
+  panel, so the row collapses cleanly.
+- The chevron rotates via `motion-toggle` (transform, moderate/spring-snappy)
+  plus `group-data-[state=open]:rotate-180`.
+
+No raw numeric durations and no keyframes: the removed `animate-accordion-*`
+depended on a Radix-owned content-height variable this system never sets.
 
 ## WCAG 2.1 AA obligations
 
@@ -171,7 +182,8 @@ utility in the token system.
   and leaves the accordion once rather than stepping through every section.
 - 2.4.7: a token focus ring on each header (`focus-visible:ring-ring` with an
   offset).
-- Collapsed panels carry `hidden`, so they are inert and out of the tab order
-  rather than merely invisible.
+- Collapsed panels carry `inert`, so they are removed from the a11y tree and the
+  tab order rather than merely clipped -- `inert` (not `hidden`) because the
+  panel must stay rendered for the grid-rows transition to run.
 - A disabled section advertises the native `disabled` state, leaves the tab
   order, and cannot be toggled by pointer or keyboard.

--- a/packages/ui/src/components/accordion/accordion.astro
+++ b/packages/ui/src/components/accordion/accordion.astro
@@ -4,8 +4,8 @@
  *
  * Server-renders the full LIGHT-DOM markup with classes and the score's initial
  * projection already applied, so the sections are correct, crawlable, and
- * accessible before any JS -- the seeded panel is open and the rest are hidden
- * with no flash. The <script> then hands each server-rendered root to
+ * accessible before any JS -- the seeded panel is open and the rest are inert
+ * (collapsed via grid-rows) with no flash. The <script> then hands each server-rendered root to
  * bindAccordion -- the SAME DOM-native controller the Web Component uses. Astro
  * imports the behavior binding like any other module; there is no astro-specific
  * runtime.

--- a/packages/ui/src/components/accordion/accordion.behavior.ts
+++ b/packages/ui/src/components/accordion/accordion.behavior.ts
@@ -129,8 +129,9 @@ const accordionSlice: Slice<AccordionConfig, AccordionState, AccordionActions, A
     // accordion pattern requires the button to be contained by a heading.
     heading: { many: true, role: 'heading' },
     trigger: { many: true },
-    // Panels stay in the DOM hidden when collapsed: the content must be
-    // crawlable and SSR-stable, and the height transition needs the same node.
+    // Panels stay in the DOM when collapsed (inert, not hidden -- see
+    // instanceAria): the content must be crawlable and SSR-stable, and the
+    // grid-rows transition needs the same node.
     content: { many: true, role: 'region' },
   },
   initialState: (config) => {
@@ -201,11 +202,21 @@ const accordionSlice: Slice<AccordionConfig, AccordionState, AccordionActions, A
  * its trigger's).
  *
  * `aria-controls` is projected UNCONDITIONALLY (guarded only on the id being
- * real), not on the open axis: the panel is present-but-hidden rather than
+ * real), not on the open axis: the panel is present-and-inert rather than
  * unmounted, so the reference is never dangling and the oracle advertised it
  * closed as well as open. That is the opposite of the `disclosable` slice's
  * `open && ids.content` guard, which exists for overlays whose content leaves
  * the DOM.
+ *
+ * A collapsed panel projects `inert` -- NOT `hidden`. `hidden` is
+ * `display:none`, which removes the panel from the a11y tree and tab order but
+ * also blocks the `grid-template-rows` transition (you cannot animate a
+ * display:none element). `inert` keeps the panel rendered (so it animates) while
+ * still removing it from the a11y tree and taking its focusables out of the tab
+ * order -- the same a11y guarantee `hidden` gave, minus the animation block. The
+ * visual collapse is the grid row going to 0fr; `inert` handles the semantics.
+ * This is the animated-presence pattern; dialog/popover inherit it (pending the
+ * spec ruling under #1899).
  */
 export function accordionInstanceAria(
   part: AccordionPart,
@@ -236,7 +247,7 @@ export function accordionInstanceAria(
       role: 'region',
       'aria-labelledby': ids.trigger || undefined,
       'data-state': stateAttr,
-      hidden: expanded ? undefined : true,
+      inert: expanded ? undefined : true,
     };
   }
   return {};
@@ -264,8 +275,8 @@ const TRIGGER_SELECTOR = '[data-part="trigger"][data-value]:not([disabled])';
  *
  * Activation is delegated click only: the header <button>s convert Enter/Space
  * to a native click, so no keydown branch is needed. Panels are
- * present-but-hidden -- `hidden` rides the instance projection, so the exit
- * transition runs on the same node.
+ * present-and-inert -- `inert` rides the instance projection (not `hidden`, which
+ * would block the animation), so the grid-rows transition runs on the same node.
  */
 export function bindAccordion(root: HTMLElement): () => void {
   const expandedAtMount = Array.from(

--- a/packages/ui/src/components/accordion/accordion.classes.ts
+++ b/packages/ui/src/components/accordion/accordion.classes.ts
@@ -11,10 +11,14 @@ export interface AccordionClassSet {
   trigger: string;
   /** The chevron, rotated off the trigger's data-state via the group variant. */
   triggerIcon: string;
-  /** The panel: clips its content and carries the height-axis motion intent. */
+  /** The panel: a grid whose single row animates 0fr<->1fr, the transitionable
+   *  stand-in for height:auto. Present in the DOM in both states (never
+   *  display:none, which would block the transition); the score projects `inert`
+   *  when collapsed to keep the clipped content out of the a11y tree + tab order. */
   content: string;
-  /** The panel's inner padding box (the panel itself must stay unpadded so it
-   *  can collapse to zero height). */
+  /** The panel's inner clip box: min-h-0 + overflow-hidden so the row can
+   *  collapse to zero and the padded content is clipped rather than forcing
+   *  height. The panel itself stays unpadded so it collapses cleanly. */
   contentInner: string;
 }
 
@@ -26,31 +30,45 @@ const itemClasses = 'border-b';
 
 const headingClasses = 'flex';
 
+// `motion-hover` is the semantic hover-feedback token (colors, fast/standard,
+// preserved under reduced motion) -- it replaces the raw `transition-all
+// duration-300`, which was both off the perceptual scale and untethered to a
+// token. The header's interactive feedback declares its intent by name.
 const triggerClasses =
-  'group flex flex-1 items-center justify-between py-4 text-title-small ' +
-  'transition-all duration-300 motion-reduce:transition-none ' +
+  'group flex flex-1 items-center justify-between py-4 text-title-small motion-hover ' +
   'hover:underline ' +
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ' +
   'disabled:pointer-events-none disabled:opacity-50';
 
-// The icon rotates off the trigger's data-state (projected by the score) via
-// the group variant, so the projection writes one attribute per trigger and the
-// chevron follows for free.
-const triggerIconClasses =
-  'h-4 w-4 shrink-0 transition-transform duration-300 motion-reduce:transition-none ' +
-  'group-data-[state=open]:rotate-180';
+// The chevron rotates off the trigger's data-state (projected by the score) via
+// the group variant. `motion-toggle` (transform, moderate, spring-snappy) is the
+// semantic token for a state-flip transform and carries the reduced-motion
+// behavior itself, replacing the raw `transition-transform duration-300`.
+const triggerIconClasses = 'h-4 w-4 shrink-0 motion-toggle group-data-[state=open]:rotate-180';
 
-// Motion intent (declared, not keyframed): expand/collapse along the height
-// axis. overflow-hidden clips the panel while it grows/shrinks; the transition
-// carries the token-scale duration and yields to reduced motion. The oracle's
-// `data-[state=*]:animate-accordion-up/down` utilities are NOT ported: their
-// keyframes interpolate `var(--radix-accordion-content-height)`, a Radix-owned
-// variable nothing in this system ever sets, so they animate to an undefined
-// height (see accordion.md dispositions).
+// Expand/collapse animate `grid-template-rows` 0fr<->1fr -- the transitionable
+// stand-in for height:auto -- via the `motion-expand` / `motion-collapse`
+// semantic tokens (normal/enter opening, the faster moderate/exit closing).
+// The panel is a grid, present in both states; `motion-reduce` snaps the rows
+// and fades opacity (the tokens' reduced-motion property is opacity, so the
+// state-driven opacity pair below is what reduced-motion users see). The
+// oracle's `animate-accordion-up/down` are NOT ported: they interpolate
+// `var(--radix-accordion-content-height)`, which nothing in this system sets.
+// grid-rows use `minmax(0, Nfr)`, not bare `Nfr`: a bare `0fr` track keeps its
+// automatic minimum at min-content, which the inner box's padding floors above
+// zero, so a "collapsed" panel keeps a padding-height gap. `minmax(0, 0fr)`
+// pins the floor to 0 so the row truly collapses. Verified in a browser --
+// happy-dom does no layout and cannot catch this.
 const contentClasses =
-  'overflow-hidden text-body-small transition-all duration-300 motion-reduce:transition-none';
+  'grid text-body-small ' +
+  'data-[state=closed]:grid-rows-[minmax(0,0fr)] data-[state=open]:grid-rows-[minmax(0,1fr)] ' +
+  'data-[state=closed]:opacity-0 data-[state=open]:opacity-100 ' +
+  'data-[state=open]:motion-expand data-[state=closed]:motion-collapse';
 
-const contentInnerClasses = 'pb-4 pt-0';
+// min-h-0 lets the grid row collapse below the child's min-content height (the
+// classic grid-rows-0fr requirement); overflow-hidden clips the padded content
+// while the row is closing.
+const contentInnerClasses = 'min-h-0 overflow-hidden pb-4 pt-0';
 
 /** The view: class strings keyed by config/state. No logic. */
 export function accordionClasses(

--- a/packages/ui/src/components/accordion/accordion.tsx
+++ b/packages/ui/src/components/accordion/accordion.tsx
@@ -81,9 +81,9 @@ export interface AccordionProps extends Omit<
  * Stacked expandable sections: header buttons that disclose regions, one open
  * at a time (`single`) or any number (`multiple`). ArrowUp/ArrowDown and
  * Home/End move focus across the headers via a roving tabindex; Enter, Space, or
- * click toggles the focused section. Panels stay in the DOM hidden when
- * collapsed, so their content is crawlable and the height transition runs on the
- * same node.
+ * click toggles the focused section. Panels stay in the DOM (inert, not hidden)
+ * when collapsed, so their content is crawlable and the grid-rows transition
+ * runs on the same node.
  *
  * @cognitive-load 3/10 - decision 1, information 1, interaction 1, disruption 0,
  * learning 0. One decision at a time (which section to open) over a visible list

--- a/packages/ui/test/components/accordion/accordion.astro.conformance.test.ts
+++ b/packages/ui/test/components/accordion/accordion.astro.conformance.test.ts
@@ -38,19 +38,21 @@ const content = (value: string) =>
   document.body.querySelector<HTMLElement>(`[data-part="content"][data-value="${value}"]`)!;
 
 describe('accordion conformance [astro]', () => {
-  it('SSR: the seeded section is open and the rest are hidden before any JS', async () => {
+  it('SSR: the seeded section is open and the rest are inert before any JS', async () => {
     const root = await mount({ value: 'b' });
     expect(root.getAttribute('data-orientation')).toBe('vertical');
     expect(root.getAttribute('data-type')).toBe('single');
     expect(trigger('b').getAttribute('aria-expanded')).toBe('true');
-    expect(content('b').hasAttribute('hidden')).toBe(false);
-    expect(content('a').hasAttribute('hidden')).toBe(true);
+    expect(content('b').hasAttribute('inert')).toBe(false);
+    expect(content('a').hasAttribute('inert')).toBe(true);
+    // Seeded inert, never hidden -- the collapsed panel animates on first open.
+    expect(content('a').hasAttribute('hidden')).toBe(false);
   });
 
   it('SSR: panel bodies are in the markup even while collapsed -- crawlable', async () => {
     await mount();
     expect(content('a').textContent).toContain('Body alpha');
-    expect(content('a').hasAttribute('hidden')).toBe(true);
+    expect(content('a').hasAttribute('inert')).toBe(true);
   });
 
   it('SSR: ids are minted from the root id and cross-referenced both ways', async () => {
@@ -77,25 +79,25 @@ describe('accordion conformance [astro]', () => {
     const user = userEvent.setup();
     await mount({ value: 'a' });
     await user.click(trigger('b'));
-    expect(content('b').hasAttribute('hidden')).toBe(false);
-    expect(content('a').hasAttribute('hidden')).toBe(true);
+    expect(content('b').hasAttribute('inert')).toBe(false);
+    expect(content('a').hasAttribute('inert')).toBe(true);
   });
 
   it('single collapsible: re-clicking the open header collapses everything', async () => {
     const user = userEvent.setup();
     await mount({ value: 'a', collapsible: true });
     await user.click(trigger('a'));
-    expect(content('a').hasAttribute('hidden')).toBe(true);
+    expect(content('a').hasAttribute('inert')).toBe(true);
   });
 
   it('multiple: SSR seeds every value and clicks accumulate', async () => {
     const user = userEvent.setup();
     await mount({ type: 'multiple', value: ['a', 'c'] });
-    expect(content('a').hasAttribute('hidden')).toBe(false);
-    expect(content('c').hasAttribute('hidden')).toBe(false);
+    expect(content('a').hasAttribute('inert')).toBe(false);
+    expect(content('c').hasAttribute('inert')).toBe(false);
     await user.click(trigger('b'));
-    expect(content('b').hasAttribute('hidden')).toBe(false);
-    expect(content('a').hasAttribute('hidden')).toBe(false);
+    expect(content('b').hasAttribute('inert')).toBe(false);
+    expect(content('a').hasAttribute('inert')).toBe(false);
   });
 
   it('ArrowDown/ArrowUp rove focus across the headers', async () => {
@@ -113,7 +115,7 @@ describe('accordion conformance [astro]', () => {
     await mount();
     trigger('c').focus();
     await user.keyboard(' ');
-    expect(content('c').hasAttribute('hidden')).toBe(false);
+    expect(content('c').hasAttribute('inert')).toBe(false);
   });
 
   it('a disabled section is natively disabled and refuses activation', async () => {
@@ -126,6 +128,6 @@ describe('accordion conformance [astro]', () => {
     });
     expect(trigger('b').hasAttribute('disabled')).toBe(true);
     await user.click(trigger('b'));
-    expect(content('b').hasAttribute('hidden')).toBe(true);
+    expect(content('b').hasAttribute('inert')).toBe(true);
   });
 });

--- a/packages/ui/test/components/accordion/accordion.behavior.test.ts
+++ b/packages/ui/test/components/accordion/accordion.behavior.test.ts
@@ -183,17 +183,22 @@ describe('accordion instance projection', () => {
     expect(orphan['aria-controls']).toBeUndefined();
   });
 
-  it('the panel is a region named by its trigger, hidden while collapsed', () => {
+  it('the panel is a region named by its trigger, inert while collapsed', () => {
+    // Collapsed panels project `inert` (not `hidden`): still removed from the
+    // a11y tree + tab order, but rendered so the grid-rows transition can run.
     const open = accordionInstanceAria('content', 'a', state, config, ids);
     expect(open['role']).toBe('region');
     expect(open['aria-labelledby']).toBe('t-a');
+    expect(open['inert']).toBeUndefined();
     expect(open['hidden']).toBeUndefined();
 
     const closed = accordionInstanceAria('content', 'b', state, config, {
       trigger: 't-b',
       content: 'c-b',
     });
-    expect(closed['hidden']).toBe(true);
+    expect(closed['inert']).toBe(true);
+    // Never `hidden` -- display:none would block the animation.
+    expect(closed['hidden']).toBeUndefined();
   });
 
   it('the heading wrapper carries role and the configured level', () => {

--- a/packages/ui/test/components/accordion/accordion.classes.test.ts
+++ b/packages/ui/test/components/accordion/accordion.classes.test.ts
@@ -44,20 +44,41 @@ describe('accordion trigger classes', () => {
     expect(classesFor({}).triggerIcon).toContain('group-data-[state=open]:rotate-180');
   });
 
-  it('the chevron rotation yields to reduced motion', () => {
-    expect(classesFor({}).triggerIcon).toContain('motion-reduce:transition-none');
+  it('the chevron rotation rides the motion-toggle semantic token', () => {
+    // motion-toggle (transform, moderate, spring-snappy) carries its own
+    // reduced-motion behavior -- no raw duration, no hand-written transition.
+    expect(classesFor({}).triggerIcon.split(/\s+/)).toContain('motion-toggle');
   });
 });
 
 describe('accordion content classes', () => {
-  it('the panel clips its content so it can collapse to zero height', () => {
-    expect(classesFor({}).content.split(/\s+/)).toContain('overflow-hidden');
+  it('the panel is a grid whose row animates, clipping happens on the inner box', () => {
+    // The panel itself is the grid track (0fr<->1fr); overflow-hidden + min-h-0
+    // ride the inner box so the row can collapse below min-content height.
+    expect(classesFor({}).content.split(/\s+/)).toContain('grid');
+    expect(classesFor({}).contentInner.split(/\s+/)).toContain('overflow-hidden');
+    expect(classesFor({}).contentInner.split(/\s+/)).toContain('min-h-0');
   });
 
-  it('the panel declares height-axis motion intent that yields to reduced motion', () => {
+  it('the panel animates grid-template-rows via the expand/collapse tokens', () => {
     const content = classesFor({}).content;
-    expect(content).toContain('transition-all');
-    expect(content).toContain('motion-reduce:transition-none');
+    // grid-rows minmax(0,0fr)<->minmax(0,1fr): the transitionable stand-in for
+    // height:auto, with the floor pinned to 0 so the row fully collapses.
+    expect(content).toContain('data-[state=open]:grid-rows-[minmax(0,1fr)]');
+    expect(content).toContain('data-[state=closed]:grid-rows-[minmax(0,0fr)]');
+    // The semantic tokens carry duration + curve + the reduced-motion fallback.
+    expect(content).toContain('data-[state=open]:motion-expand');
+    expect(content).toContain('data-[state=closed]:motion-collapse');
+    // No raw numeric duration survives.
+    expect(content).not.toMatch(/duration-\d/);
+  });
+
+  it('the reduced-motion opacity fallback is state-driven', () => {
+    // The tokens snap the rows and fade opacity under reduced motion, so the
+    // opacity pair is what those users see.
+    const content = classesFor({}).content;
+    expect(content).toContain('data-[state=open]:opacity-100');
+    expect(content).toContain('data-[state=closed]:opacity-0');
   });
 
   it('the oracle radix-variable keyframes are not ported', () => {

--- a/packages/ui/test/components/accordion/accordion.conformance.test.tsx
+++ b/packages/ui/test/components/accordion/accordion.conformance.test.tsx
@@ -63,10 +63,13 @@ afterEach(() => {
 });
 
 describe('accordion conformance [react]', () => {
-  it('collapsed: panels stay in the DOM, hidden -- the body is crawlable', async () => {
+  it('collapsed: panels stay in the DOM, inert -- the body is crawlable', async () => {
     render(<TestAccordion />);
     expect(partElements(body(), 'content')).toHaveLength(3);
-    expect(contentFor('a').hidden).toBe(true);
+    // inert, never hidden: removed from the a11y tree + tab order while staying
+    // rendered so the grid-rows transition can run.
+    expect(contentFor('a').hasAttribute('inert')).toBe(true);
+    expect(contentFor('a').hasAttribute('hidden')).toBe(false);
     expect(contentFor('a').getAttribute('data-state')).toBe('closed');
     expect(triggerFor('a').getAttribute('aria-expanded')).toBe('false');
     await assertAxeClean(body());
@@ -87,7 +90,7 @@ describe('accordion conformance [react]', () => {
       expect(triggerFor(value).getAttribute('aria-controls')).toBe(contentFor(value).id);
       expect(contentFor(value).getAttribute('aria-labelledby')).toBe(triggerFor(value).id);
     }
-    expect(contentFor('b').hidden).toBe(true);
+    expect(contentFor('b').hasAttribute('inert')).toBe(true);
   });
 
   it('per-instance ARIA equals the score projection, collapsed and expanded', async () => {
@@ -113,8 +116,8 @@ describe('accordion conformance [react]', () => {
     const user = userEvent.setup();
     render(<TestAccordion defaultValue="a" />);
     await user.click(triggerFor('b'));
-    expect(contentFor('b').hidden).toBe(false);
-    expect(contentFor('a').hidden).toBe(true);
+    expect(contentFor('b').hasAttribute('inert')).toBe(false);
+    expect(contentFor('a').hasAttribute('inert')).toBe(true);
     await assertAxeClean(body());
   });
 
@@ -122,14 +125,14 @@ describe('accordion conformance [react]', () => {
     const user = userEvent.setup();
     render(<TestAccordion defaultValue="a" />);
     await user.click(triggerFor('a'));
-    expect(contentFor('a').hidden).toBe(false);
+    expect(contentFor('a').hasAttribute('inert')).toBe(false);
   });
 
   it('single collapsible: clicking the open header closes everything', async () => {
     const user = userEvent.setup();
     render(<TestAccordion defaultValue="a" collapsible />);
     await user.click(triggerFor('a'));
-    expect(contentFor('a').hidden).toBe(true);
+    expect(contentFor('a').hasAttribute('inert')).toBe(true);
   });
 
   it('multiple: sections expand independently and accumulate', async () => {
@@ -137,12 +140,12 @@ describe('accordion conformance [react]', () => {
     render(<TestAccordion type="multiple" />);
     await user.click(triggerFor('a'));
     await user.click(triggerFor('c'));
-    expect(contentFor('a').hidden).toBe(false);
-    expect(contentFor('c').hidden).toBe(false);
+    expect(contentFor('a').hasAttribute('inert')).toBe(false);
+    expect(contentFor('c').hasAttribute('inert')).toBe(false);
     await assertAxeClean(body());
     await user.click(triggerFor('a'));
-    expect(contentFor('a').hidden).toBe(true);
-    expect(contentFor('c').hidden).toBe(false);
+    expect(contentFor('a').hasAttribute('inert')).toBe(true);
+    expect(contentFor('c').hasAttribute('inert')).toBe(false);
   });
 
   it('ArrowDown/ArrowUp rove focus across headers with wrap; Home/End jump', async () => {
@@ -164,7 +167,7 @@ describe('accordion conformance [react]', () => {
     render(<TestAccordion />);
     triggerFor('a').focus();
     await user.keyboard('{ArrowDown}');
-    expect(contentFor('b').hidden).toBe(true);
+    expect(contentFor('b').hasAttribute('inert')).toBe(true);
   });
 
   it('Enter and Space on the focused header toggle it', async () => {
@@ -172,17 +175,17 @@ describe('accordion conformance [react]', () => {
     render(<TestAccordion type="multiple" />);
     triggerFor('a').focus();
     await user.keyboard('{Enter}');
-    expect(contentFor('a').hidden).toBe(false);
+    expect(contentFor('a').hasAttribute('inert')).toBe(false);
     triggerFor('b').focus();
     await user.keyboard(' ');
-    expect(contentFor('b').hidden).toBe(false);
+    expect(contentFor('b').hasAttribute('inert')).toBe(false);
   });
 
   it('a disabled section cannot be opened and is skipped by roving', async () => {
     const user = userEvent.setup();
     render(<TestAccordion disabledItem="b" />);
     await user.click(triggerFor('b'));
-    expect(contentFor('b').hidden).toBe(true);
+    expect(contentFor('b').hasAttribute('inert')).toBe(true);
     triggerFor('a').focus();
     await user.keyboard('{ArrowDown}');
     expect(document.activeElement).toBe(triggerFor('c'));
@@ -193,7 +196,7 @@ describe('accordion conformance [react]', () => {
     const onValueChange = vi.fn();
     render(<TestAccordion disabled onValueChange={onValueChange} />);
     await user.click(triggerFor('a'));
-    expect(contentFor('a').hidden).toBe(true);
+    expect(contentFor('a').hasAttribute('inert')).toBe(true);
     expect(onValueChange).not.toHaveBeenCalled();
     expect(partElement(body(), 'root')?.getAttribute('data-disabled')).toBe('true');
   });
@@ -205,10 +208,10 @@ describe('accordion conformance [react]', () => {
 
     await user.click(triggerFor('a'));
     expect(onValueChange).toHaveBeenLastCalledWith('a');
-    expect(contentFor('a').hidden).toBe(true);
+    expect(contentFor('a').hasAttribute('inert')).toBe(true);
 
     rerender(<TestAccordion value="a" onValueChange={onValueChange} />);
-    expect(contentFor('a').hidden).toBe(false);
+    expect(contentFor('a').hasAttribute('inert')).toBe(false);
     expect(triggerFor('a').getAttribute('aria-expanded')).toBe('true');
   });
 
@@ -247,7 +250,7 @@ describe('accordion conformance [react]', () => {
         </Accordion.Item>
       </Accordion>,
     );
-    expect(contentFor('a').hidden).toBe(false);
+    expect(contentFor('a').hasAttribute('inert')).toBe(false);
     expect(triggerFor('a').getAttribute('aria-expanded')).toBe('true');
   });
 });

--- a/packages/ui/test/components/accordion/accordion.element.conformance.test.ts
+++ b/packages/ui/test/components/accordion/accordion.element.conformance.test.ts
@@ -47,7 +47,7 @@ function sectionMarkup(
                 aria-controls="acc-content-${value}"${disabled ? ' disabled' : ''}>${label}</button>
       </div>
       <div id="acc-content-${value}" data-part="content" data-value="${value}" role="region"
-           aria-labelledby="acc-trigger-${value}" data-state="${state}"${expanded ? '' : ' hidden'}>
+           aria-labelledby="acc-trigger-${value}" data-state="${state}"${expanded ? '' : ' inert'}>
         Body ${label}
       </div>
     </div>`;
@@ -95,9 +95,9 @@ describe('accordion conformance [wc]', () => {
   it('seeds the intrinsic set from the server-rendered open section', async () => {
     await mount({ open: ['b'] });
     expect(trigger('b').getAttribute('aria-expanded')).toBe('true');
-    expect(content('b').hasAttribute('hidden')).toBe(false);
+    expect(content('b').hasAttribute('inert')).toBe(false);
     expect(trigger('a').getAttribute('aria-expanded')).toBe('false');
-    expect(content('a').hasAttribute('hidden')).toBe(true);
+    expect(content('a').hasAttribute('inert')).toBe(true);
     await assertAxeClean(document.body);
   });
 
@@ -111,8 +111,8 @@ describe('accordion conformance [wc]', () => {
     const user = userEvent.setup();
     await mount({ open: ['a'] });
     await user.click(trigger('b'));
-    expect(content('b').hasAttribute('hidden')).toBe(false);
-    expect(content('a').hasAttribute('hidden')).toBe(true);
+    expect(content('b').hasAttribute('inert')).toBe(false);
+    expect(content('a').hasAttribute('inert')).toBe(true);
     expect(trigger('a').getAttribute('data-state')).toBe('closed');
   });
 
@@ -120,14 +120,14 @@ describe('accordion conformance [wc]', () => {
     const user = userEvent.setup();
     await mount({ open: ['a'] });
     await user.click(trigger('a'));
-    expect(content('a').hasAttribute('hidden')).toBe(false);
+    expect(content('a').hasAttribute('inert')).toBe(false);
   });
 
   it('single collapsible: re-clicking the open header collapses everything', async () => {
     const user = userEvent.setup();
     await mount({ open: ['a'], collapsible: true });
     await user.click(trigger('a'));
-    expect(content('a').hasAttribute('hidden')).toBe(true);
+    expect(content('a').hasAttribute('inert')).toBe(true);
   });
 
   it('multiple: sections accumulate and collapse independently', async () => {
@@ -135,11 +135,11 @@ describe('accordion conformance [wc]', () => {
     await mount({ type: 'multiple' });
     await user.click(trigger('a'));
     await user.click(trigger('c'));
-    expect(content('a').hasAttribute('hidden')).toBe(false);
-    expect(content('c').hasAttribute('hidden')).toBe(false);
+    expect(content('a').hasAttribute('inert')).toBe(false);
+    expect(content('c').hasAttribute('inert')).toBe(false);
     await user.click(trigger('a'));
-    expect(content('a').hasAttribute('hidden')).toBe(true);
-    expect(content('c').hasAttribute('hidden')).toBe(false);
+    expect(content('a').hasAttribute('inert')).toBe(true);
+    expect(content('c').hasAttribute('inert')).toBe(false);
   });
 
   it('ArrowDown/ArrowUp rove focus with wrap; Home/End jump to the ends', async () => {
@@ -161,7 +161,7 @@ describe('accordion conformance [wc]', () => {
     await mount();
     trigger('a').focus();
     await user.keyboard('{ArrowDown}');
-    expect(content('b').hasAttribute('hidden')).toBe(true);
+    expect(content('b').hasAttribute('inert')).toBe(true);
   });
 
   it('Enter and Space on the focused header toggle it', async () => {
@@ -169,17 +169,17 @@ describe('accordion conformance [wc]', () => {
     await mount({ type: 'multiple' });
     trigger('a').focus();
     await user.keyboard('{Enter}');
-    expect(content('a').hasAttribute('hidden')).toBe(false);
+    expect(content('a').hasAttribute('inert')).toBe(false);
     trigger('b').focus();
     await user.keyboard(' ');
-    expect(content('b').hasAttribute('hidden')).toBe(false);
+    expect(content('b').hasAttribute('inert')).toBe(false);
   });
 
   it('roving skips a disabled section and the click is refused', async () => {
     const user = userEvent.setup();
     await mount({ disabledItems: ['b'] });
     await user.click(trigger('b'));
-    expect(content('b').hasAttribute('hidden')).toBe(true);
+    expect(content('b').hasAttribute('inert')).toBe(true);
     trigger('a').focus();
     await user.keyboard('{ArrowDown}');
     expect(document.activeElement).toBe(trigger('c'));
@@ -189,7 +189,7 @@ describe('accordion conformance [wc]', () => {
     const user = userEvent.setup();
     await mount({ disabled: true });
     await user.click(trigger('a'));
-    expect(content('a').hasAttribute('hidden')).toBe(true);
+    expect(content('a').hasAttribute('inert')).toBe(true);
   });
 
   it('disconnecting the element tears the binding down', async () => {
@@ -201,6 +201,6 @@ describe('accordion conformance [wc]', () => {
     host.remove();
     document.body.append(panelA, headerA);
     await user.click(headerA);
-    expect(panelA.hasAttribute('hidden')).toBe(true);
+    expect(panelA.hasAttribute('inert')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Wires accordion to the semantic motion token layer -- the first real-component consumer, and the
validation case for the layer landed in #1904. Accordion had no working motion: the oracle keyframes
were dropped (they interpolate a Radix content-height variable nothing sets) and `hidden` on
collapsed panels is `display:none`, which blocks any transition. The panel is now a grid whose row
animates `grid-template-rows` via `motion-expand`/`motion-collapse`, and collapsed panels are `inert`
rather than `hidden` so they leave the a11y tree while staying rendered to animate.

## Acceptance criteria mapping

### 1. Panel animates grid-template-rows via motion-expand/collapse, replacing keyframes and duration-300
`accordion.classes.ts` `contentClasses` makes the panel a `grid` with
`data-[state=closed]:grid-rows-[minmax(0,0fr)]` / `data-[state=open]:grid-rows-[minmax(0,1fr)]` and
`data-[state=open]:motion-expand` / `data-[state=closed]:motion-collapse`. The compiled sheet
confirms `.data-[state=open]:motion-expand` emits `transition-property: grid-template-rows, opacity`
at `var(--duration-normal)` / `var(--ease-enter)`, and collapse at moderate/exit -- the exit is
faster than the entrance by construction.
Evidence: the classes-parity test asserts the `minmax` grid-rows and both motion tokens on the
content part; the compiled rule was read out of `registryToCompiled` output showing
`transition-property: grid-template-rows, opacity`.

### 2. Collapsed panels are inert, not hidden
`accordionInstanceAria`'s content branch projects `inert: expanded ? undefined : true`. `inert`
removes the panel from the a11y tree and takes its focusables out of the tab order -- the same
guarantee `hidden` gave -- without `display:none` blocking the animation. All three decorators spread
the projection, so the change propagates without a markup edit.
Evidence: the behavior unit test asserts `closed['inert']` is true and `closed['hidden']` is
undefined; every conformance suite asserts `hasAttribute('inert')` per state plus a `not hidden`
guard.

### 3. Reduced-motion snaps rows and fades opacity
The `motion-expand`/`motion-collapse` tokens carry `@media (prefers-reduced-motion: reduce) {
transition-property: opacity }` in their compiled `@utility` block, and the content classes include
the `data-[state]:opacity-0`/`opacity-100` pair that the reduced-motion path fades.
Evidence: the compiled sheet's `.data-[state=closed]:motion-collapse` rule contains the nested
`prefers-reduced-motion` block; the classes test asserts the opacity pair.

### 4. Chevron and header drop raw durations for semantic tokens
`triggerIconClasses` is `motion-toggle group-data-[state=open]:rotate-180` (transform,
moderate/spring-snappy); `triggerClasses` uses `motion-hover`. Both replace `transition-* duration-300`.
Evidence: the classes test asserts `motion-toggle` on the icon and `not.toMatch(/duration-\d/)` on the
content part; no `duration-300` remains in the file.

### 5. Panel collapses to zero height, verified against real layout
The `minmax(0, Nfr)` floor is the fix for a real bug found in a browser: a bare `0fr` track keeps its
min-content minimum, which the inner box's padding floored at 16px, so a "collapsed" panel kept a gap.
happy-dom does no layout and reported the projection correct while the panel would not have collapsed.
Measured in a headless browser: `minmax(0,0fr)` with the two-element clip structure yields a closed
height of 0 and an open height matching content.
Evidence: browser measurement of the compiled rule (closed=0, open>0); the classes test asserts the
`minmax` form and the min-h-0/overflow-hidden inner clip.

### 6. Conformance green across React + WC + Astro with the inert contract and axe in both states
All six accordion suites pass (110 tests). The `hidden` assertions became `hasAttribute('inert')`; the
WC hand-authored markup seeds `inert`; the Astro SSR test asserts seeded-inert-never-hidden pre-JS.
axe runs on both the open and collapsed states.
Evidence: `pnpm --filter @rafters/ui test accordion` -> 6 files / 110 passed.

### 7. preflight green
The full gate runs on the committed change: typecheck across the workspace, lint, oxfmt check, the
unit and a11y suites, and the build. The one format nit oxfmt flagged (a long class-string line) was
fixed before commit, and the lefthook pre-commit hook re-ran typecheck and format clean.
Evidence: `pnpm preflight` exited 0 on HEAD.

## Not done

- **The parent #1899 work is untouched here.** The keyframe-table authorship (the 7 verbatim shadcn
  lifts, `bounce` hardcoding beziers), the generator audit for the same copied-vocabulary defect, and
  the 13-component duration sweep are separate slices of #1899. This PR is the accordion slice only.
- **The presence-animation spec section is not written.** `inert`-not-`hidden` is now proven on
  accordion, but the spec-level ruling that dialog/popover will inherit belongs in `05-authoring.md`
  under #1899, and needs Sean's ratification of the pattern before it spreads. Flagged, not decided
  here.
- **The keyframe audit's open loop:** a repo-wide `grep radix-accordion-content-height` to confirm
  nothing else sets it (the audit agent had Bash denied) rides with the #1899 keyframe rewrite.

Advances #1899.

Closes #1910
