### PR TITLE
feat(ui): port drawer to the behavior layer

### DIFF
--- a/packages/ui/docs/spec/components/drawer.md
+++ b/packages/ui/docs/spec/components/drawer.md
@@ -83,9 +83,15 @@ ids. A dangling `aria-describedby` is an axe violation; absence is honest.
 
 ## Keyboard and effects
 
-- `keymap`: Escape on `content` -> `close`. Focus containment makes the
-  content-scoped listener sufficient in modal mode; non-modal Escape works while
-  focus is inside the drawer.
+- `keymap`: Escape on `content` -> `close`. The keymap is content-scoped, but
+  the resolution is by CONTAINMENT, not by the event target's own `data-part`:
+  the DOM-native `bindDrawer` treats any keydown landing inside the content
+  element as `content` (mirroring the React decorator, which hardcodes
+  `'content'`). This matters because the focus-trap gives initial focus to the
+  first focusable DESCENDANT -- often the close button (`data-part="close"`) in a
+  bare drawer -- and a target-scoped resolution would then classify Escape as
+  `close` and drop it. Containment keeps Escape working from any focusable child;
+  non-modal Escape works the same while focus is inside the drawer.
 - Modal trio (open+modal): `createFocusTrap(content)`, `preventBodyScroll()`,
   `onPointerDownOutside(content, close)` sparing the trigger. Otherwise none.
 

--- a/packages/ui/docs/spec/components/drawer.md
+++ b/packages/ui/docs/spec/components/drawer.md
@@ -71,7 +71,9 @@ effective value, so intrinsic state can never drift from a controlled consumer.
 
 The grab handle is a decorative div (`aria-hidden="true"`) inside content, not a
 score part -- it signals a drag affordance whose gesture is not yet wired (see
-dispositions). In Astro the title renders as a `div[role="heading"][aria-level]`
+dispositions). It renders as a horizontal top-center pill, tuned for the default
+bottom edge; on the position-only top/left/right edges it is not re-oriented
+(intentional, not an oversight), since those edges' motion is deferred too. In Astro the title renders as a `div[role="heading"][aria-level]`
 (not a raw `<h2 class>`) to satisfy the typography-component guard while keeping
 heading semantics; React and the WC light-DOM use a real `<h2>`.
 

--- a/packages/ui/docs/spec/components/drawer.md
+++ b/packages/ui/docs/spec/components/drawer.md
@@ -1,0 +1,145 @@
+# Component Spec — Drawer
+
+Status: DRAFT. Wave-4 port. An edge-anchored dialog (archetype `modal-overlay`),
+built by imitating `dialog` (Spec 05, the overlay reference).
+
+> A drawer is a dialog positioned against a screen edge instead of centered.
+> The behavior is dialog's exactly -- disclosable open/close, a directly-composed
+> `focus-trap` + `scroll-lock` + outside-dismiss trio while open+modal, Escape
+> closes and restores focus to the trigger. `startDrawerModalEffects({ content,
+> getTrigger, onDismiss })` in `drawer.behavior.ts` composes those three
+> primitives on the open+modal transition and tears them down on close, called
+> by both `bindDrawer` (WC/Astro) and a React `useEffect`. No effect list; the
+> retired effects-as-data layer (Spec 03) is not reintroduced.
+
+Files (`src/components/drawer/`):
+
+```
+drawer.behavior.ts   drawer.classes.ts   drawer.tsx   drawer.element.ts   drawer.astro
+```
+
+Tests mirror into `test/components/drawer/`: behavior (pure), classes, and
+conformance across React + WC + Astro through the shared harness.
+
+## Composition
+
+```
+disclosable (lib)      state {open}, actions open/close, trigger/content parts
+drawer-surface         parts only: overlay, title, description, close
+drawer glue            role/aria-modal/labelledby/haspopup, Escape keymap
+```
+
+The surface and glue are dialog's, unchanged: a drawer earns no new score. The
+only additive is the `side` config, and it is deliberately kept OUT of the score
+-- an edge-anchored panel is still `role="dialog"`, so `side` reaches classes
+only and the ARIA/keymap projections are edge-independent (asserted in the
+behavior test).
+
+`disclosable` is the shared open/closed axis (dialog, popover, sheet fold it).
+Controlled/uncontrolled per boundary 4: `config.open` is the consumer's
+controlled value, `state.open` is intrinsic, projections and gates read
+`isOpen(state, config)`. The idempotence gate makes consumer callbacks fire once
+per real transition.
+
+## Config, state, actions
+
+```ts
+type DrawerSide = 'top' | 'right' | 'bottom' | 'left';
+interface DrawerConfig {
+  open?: boolean;        // controlled
+  defaultOpen?: boolean; // uncontrolled seed
+  modal?: boolean;       // default true
+  side?: DrawerSide;     // default 'bottom' (touch); position classes only
+}
+interface DrawerState { open: boolean } // intrinsic only
+type DrawerActions = { open: undefined; close: undefined };
+```
+
+No `toggle` action: the trigger dispatches `open` or `close` computed from the
+effective value, so intrinsic state can never drift from a controlled consumer.
+
+## Parts and ARIA
+
+| Part | Presence | ARIA |
+| --- | --- | --- |
+| trigger | always | `aria-haspopup="dialog"`, `aria-expanded`, `aria-controls` (only while content is in the DOM), `data-state` |
+| content | while open | `role="dialog"`, `aria-modal="true"` (modal only), `aria-labelledby`/`aria-describedby` (only when the part rendered), `data-state` |
+| overlay | open + modal | `aria-hidden="true"`, `data-state` |
+| title | consumer renders | referenced by labelledby via registration |
+| description | consumer renders | referenced by describedby via registration |
+| close | while open (default on) | `aria-label="Close"` |
+
+The grab handle is a decorative div (`aria-hidden="true"`) inside content, not a
+score part -- it signals a drag affordance whose gesture is not yet wired (see
+dispositions). In Astro the title renders as a `div[role="heading"][aria-level]`
+(not a raw `<h2 class>`) to satisfy the typography-component guard while keeping
+heading semantics; React and the WC light-DOM use a real `<h2>`.
+
+Empty-id convention (ratified 2026-07-08): a binding passes `''` as the PartId of
+a part it did not render; projections emit `undefined` for references to empty
+ids. A dangling `aria-describedby` is an axe violation; absence is honest.
+
+## Keyboard and effects
+
+- `keymap`: Escape on `content` -> `close`. Focus containment makes the
+  content-scoped listener sufficient in modal mode; non-modal Escape works while
+  focus is inside the drawer.
+- Modal trio (open+modal): `createFocusTrap(content)`, `preventBodyScroll()`,
+  `onPointerDownOutside(content, close)` sparing the trigger. Otherwise none.
+
+## Motion
+
+Intent: enter is a slide along axis y (the bottom drawer slides up); exit is the
+reverse. Per Spec 05, motion consumes a **semantic motion token** only. The token
+for this archetype is `motion-sheet-in` (MOTION.md: slow, spring-smooth,
+transform). It is NOT declared here: no ported component consumes a `motion-*`
+token yet, `dialog` (the reference) declares no enter motion, and the motion
+token layer is being rebuilt (#1899, #1902-1904). Rather than hardcode a numeric
+duration (the old tree's `duration-300`/`slide-in-from-bottom`, now prohibited),
+the enter motion is left **undeclared** until the token lands. Exit motion is
+additionally gated on Presence (wave 0-B). This ships enter-only.
+
+## Oracle dispositions (src/old/ui/drawer.tsx, boundary 9)
+
+Disposition vocabulary: `contract | framework-affordance | dropped | defect-do-not-port`.
+
+| Oracle feature | Disposition |
+| --- | --- |
+| controlled/uncontrolled + onOpenChange | contract |
+| modal prop (trap, lock, outside-dismiss gated on it) | contract |
+| Escape closes | contract (moved from a document listener to the content keymap) |
+| Trigger/Content/Header/Footer/Title/Description/Close surface | contract |
+| Portal / Overlay / `container` prop | contract (shadcn surface is the floor; Content inside an explicit portal skips its automatic portal + overlay, close defaults off there) |
+| `forceMount` | contract, with the dialog divergence: a force-mounted closed panel carries `hidden` (inert to AT, cannot block the page). Presence (wave 0-B) replaces this for exit animation |
+| `showCloseButton` (default true) | contract |
+| onEscapeKeyDown / onPointerDownOutside / onInteractOutside veto props | contract (oracle signatures: native event, preventDefault to veto) |
+| asChild on Trigger and Close | framework affordance (React) |
+| `side` prop (top/right/bottom/left, default bottom) | contract, but edge-only: it drives position/rounding/border classes, never the score. bottom is the plain stated case; top/left/right are position parity, their slide motion deferred with the rest |
+| decorative drag handle | contract as decoration (aria-hidden); the drag GESTURE it advertises is deferred -- see below |
+| drag-to-dismiss (`draggable`, `dismissThreshold`, touch/mouse pointer math) | dropped (deferred). The named `drag-drop` primitive is LIVE (importers under `hooks/`, `block-wrapper` -- not old/) but the WRONG SHAPE: `createDraggable` injects `role="button"` + `aria-grabbed` + `draggable="true"`, drives HTML5 drag events, a 300ms touch long-press, and a drop-zone registry -- sortable/drop-target semantics that would corrupt the `role="dialog"` ARIA and fail axe. Follow-pointer-threshold dismissal is a different gesture, and its release transform is exit-presence motion (wave 0-B) plus a raw-numeric `translateY(px)` the token rules prohibit. The issue marks it "optional"; dismissal stays via overlay tap, Escape, and the close button |
+| snap points (partial-height detents) | dropped (deferred). The oracle ships NO snap-point behavior to extract; snap points need the same deferred drag gesture plus exit-presence machinery (wave 0-B). Recorded here so the issue's `States: open, snap point` is answered, not silently dropped |
+| namespaced `Drawer.Trigger` / `Drawer.Content` aliases | dropped -- `dialog` is the reference and exports named parts only; shadcn drop-in parity is met by the named `Drawer*` exports (`DrawerTrigger`, `DrawerContent`, ...) |
+| inline `transform`/`transition` style + `animate-in`/`slide-in-from-*` + `duration-300`/`duration-200` | defect-do-not-port -- raw numeric motion the token/motion rules now prohibit; replaced by undeclared motion pending `motion-sheet-in` |
+| `data-[state=open]:bg-secondary` on the close button | defect-do-not-port -- dead selector; no data-state is set on that element |
+
+## Deltas from the oracle
+
+1. Close button sizing: `h-11 w-11` touch floor, `@md:h-8 @md:w-8` desktop (the
+   dialog ruling), replacing the oracle's fixed `h-4 w-4` icon-only hit area.
+2. Header/footer breakpoints on the container (`@md:`), not the viewport
+   (`sm:`), per the CQ system rule.
+3. `tabIndex={-1}` on content so Escape works when the consumer renders no
+   focusable children.
+4. Title token is `text-title-medium` (was `text-lg font-semibold`);
+   description is `text-body-small text-muted-foreground`.
+
+## WCAG 2.1 AA obligations
+
+- 1.3.1 / 4.1.2: role dialog, aria-modal, labelledby/describedby wiring asserted
+  against real DOM ids by the harness.
+- 2.1.1 / 2.1.2 (no keyboard trap in the WCAG sense): Tab cycles inside while
+  open, Escape releases, focus restores to the trigger on close.
+- 2.4.3 Focus Order: initial focus moves into the drawer; restoration on close
+  is the trap teardown's cleanup.
+- 2.4.7: token focus ring on the close button.
+- 2.5.5 (target size): close button meets the 44px touch floor by default.

--- a/packages/ui/src/components/drawer/drawer.astro
+++ b/packages/ui/src/components/drawer/drawer.astro
@@ -1,0 +1,105 @@
+---
+/**
+ * Astro performance for drawer. Server-renders the full light-DOM structure
+ * with the closed-state projection already applied (correct and inert before
+ * JS), then the <script> hands each instance to bindDrawer -- the SAME
+ * DOM-native client the Web Component uses. One score, three performances.
+ *
+ * Content stays in light DOM (present-but-hidden) so the effects the bind
+ * runs -- focus-trap, scroll-lock, dismiss-on-outside -- can read it. Exit and
+ * drag motion wait on the Presence adapter (wave 0-B); this is enter-only.
+ *
+ * The title renders as a div with role="heading" (not a raw <h2 class>) so it
+ * carries its token styling without tripping the typography-component guard;
+ * aria-labelledby needs only the id and text, and the heading role preserves
+ * the semantics the React <h2> provides.
+ */
+import { drawer, drawerSide, type DrawerConfig, type DrawerPart } from './drawer.behavior';
+import { drawerClasses } from './drawer.classes';
+import type { PartIds } from '../../lib/contract';
+
+interface Props {
+  id: string;
+  modal?: boolean;
+  defaultOpen?: boolean;
+  side?: DrawerConfig['side'];
+  title?: string;
+  description?: string;
+}
+
+const {
+  id,
+  modal = true,
+  defaultOpen = false,
+  side = 'bottom',
+  title,
+  description,
+} = Astro.props;
+
+const config: DrawerConfig = { modal, defaultOpen, side };
+const state = drawer.initialState(config);
+const classes = drawerClasses(config, state);
+
+// Optional cross-ref sources resolve to empty when their slot is absent, so
+// the score's `|| undefined` guards emit no dangling reference.
+const ids = {} as PartIds<DrawerPart>;
+for (const part of Object.keys(drawer.parts) as DrawerPart[]) {
+  const absent = (part === 'title' && !title) || (part === 'description' && !description);
+  ids[part] = absent ? '' : `${id}-${part}`;
+}
+const aria = drawer.aria(state, config, ids);
+const open = state.open;
+---
+
+<rafters-drawer
+  data-part="root"
+  modal={String(modal)}
+  default-open={String(defaultOpen)}
+  side={drawerSide(config)}
+>
+  <button type="button" id={ids.trigger} data-part="trigger" {...aria.trigger}>
+    <slot name="trigger">Open</slot>
+  </button>
+
+  <div id={ids.overlay} data-part="overlay" class={classes.overlay} hidden={!open} {...aria.overlay}></div>
+
+  <div
+    id={ids.content}
+    data-part="content"
+    tabindex="-1"
+    class={classes.content}
+    {...aria.content}
+    hidden={!open}
+  >
+    <div class={classes.handle} aria-hidden="true"></div>
+    {
+      title && (
+        <div id={ids.title} data-part="title" role="heading" aria-level="2" class={classes.title}>
+          {title}
+        </div>
+      )
+    }
+    {
+      description && (
+        <div id={ids.description} data-part="description" class={classes.description}>
+          {description}
+        </div>
+      )
+    }
+    <slot />
+    <button type="button" id={ids.close} data-part="close" class={classes.close} {...aria.close}>
+      <slot name="close">Close</slot>
+    </button>
+  </div>
+</rafters-drawer>
+
+<script>
+  import { bindDrawer } from './drawer.behavior';
+
+  for (const root of document.querySelectorAll('rafters-drawer[data-part="root"]')) {
+    const el = root as HTMLElement;
+    if (el.dataset['bound'] === 'true') continue;
+    el.dataset['bound'] = 'true';
+    bindDrawer(el);
+  }
+</script>

--- a/packages/ui/src/components/drawer/drawer.behavior.ts
+++ b/packages/ui/src/components/drawer/drawer.behavior.ts
@@ -1,0 +1,273 @@
+import { compose, type GlueSlice, type Slice } from '../../lib/compose';
+import {
+  createBehavior,
+  type AriaAttrs,
+  type BehaviorSpec,
+  type PartIds,
+} from '../../lib/contract';
+import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap';
+import { onPointerDownOutside } from '../../primitives/outside-click';
+import {
+  disclosable,
+  isOpen,
+  type DisclosableActions,
+  type DisclosableConfig,
+  type DisclosablePart,
+  type DisclosableState,
+} from '../../lib/disclosable';
+
+/** The edge the drawer is anchored to. The plain, stated case is `bottom`
+ *  (a touch drawer that slides up); top/left/right are position-only parity
+ *  with the old surface -- see the component doc's motion dispositions. */
+export type DrawerSide = 'top' | 'right' | 'bottom' | 'left';
+
+export interface DrawerConfig extends DisclosableConfig {
+  /** Modal drawers trap focus, lock scroll, and dismiss on outside
+   *  pointerdown. Default: true. */
+  modal?: boolean | undefined;
+  /** The edge the drawer is anchored to. Drives position classes only; the
+   *  score's ARIA and keymap are edge-independent. Default: 'bottom'. */
+  side?: DrawerSide | undefined;
+}
+
+export type DrawerState = DisclosableState;
+export type DrawerActions = DisclosableActions;
+
+export type DrawerSurfacePart = 'overlay' | 'title' | 'description' | 'close';
+export type DrawerPart = DisclosablePart | DrawerSurfacePart;
+
+export { isOpen };
+
+function isModal(config: DrawerConfig): boolean {
+  return config.modal !== false;
+}
+
+/** The edge the drawer defaults to when none is configured. */
+export function drawerSide(config: DrawerConfig): DrawerSide {
+  return config.side ?? 'bottom';
+}
+
+/** Structure-only slice: the parts a drawer has beyond the disclosable
+ *  trigger/content pair. Contributes no state and no actions -- identical to
+ *  the dialog surface, because a drawer is an edge-anchored dialog. */
+const drawerSurface: Slice<
+  DrawerConfig,
+  Record<never, never>,
+  Record<never, never>,
+  DrawerSurfacePart
+> = {
+  name: 'drawer-surface',
+  parts: {
+    overlay: { optional: true },
+    title: { optional: true },
+    description: { optional: true },
+    close: { optional: true },
+  },
+  initialState: () => ({}),
+};
+
+/** The drawer glue: ARIA identity and the Escape contract, written over the
+ *  merged state. Same dialog role/modal semantics dialog proves; the modal
+ *  overlay concerns (focus-trap, scroll-lock, outside-dismiss) are composed
+ *  directly by the bindings, not declared here. The `side` config never
+ *  reaches this projection -- an anchored panel is still a `role="dialog"`. */
+const drawerGlue: GlueSlice<DrawerConfig, DrawerState, { close: undefined }, DrawerPart> = {
+  kind: 'glue',
+  name: 'drawer',
+  aria: (state, config, ids) => {
+    const open = isOpen(state, config);
+    return {
+      trigger: {
+        'aria-haspopup': 'dialog',
+      },
+      content: {
+        role: 'dialog',
+        'aria-modal': isModal(config) ? 'true' : undefined,
+        // An empty id means the binding did not render that part; a
+        // reference to a missing id is an axe violation, so project absence.
+        'aria-labelledby': ids.title || undefined,
+        'aria-describedby': ids.description || undefined,
+      },
+      overlay: {
+        'aria-hidden': 'true',
+        'data-state': open ? 'open' : 'closed',
+      },
+      close: {
+        'aria-label': 'Close',
+      },
+    };
+  },
+  keymap: (event, _state, part) => (part === 'content' && event.key === 'Escape' ? 'close' : null),
+};
+
+/** The parts and dispatch the modal overlay trio composes against. */
+export interface DrawerModalPorts {
+  /** The drawer surface: focus is trapped inside it and a pointerdown landing
+   *  outside it dismisses. */
+  content: HTMLElement;
+  /** Resolves the trigger so the opening gesture's pointerdown is spared --
+   *  otherwise it would both dismiss the layer and re-open it. */
+  getTrigger: () => HTMLElement | null;
+  /** Outside-pointerdown handler, already spared of the trigger. Receives the
+   *  native event so a boundary can offer a consumer veto before closing. */
+  onDismiss: (event: Event) => void;
+}
+
+/**
+ * The modal overlay trio, composed directly (the same shape dialog proves):
+ * trap Tab focus inside `content`, lock body scroll, and dismiss on a
+ * pointerdown outside `content` -- sparing the trigger. Level-triggered:
+ * BOTH the DOM-native bindDrawer and the React Drawer start this on the
+ * open+modal transition and call the returned cleanup on close/unmount.
+ * Focus restore rides the trap teardown, so the cleanup releases LIFO.
+ */
+export function startDrawerModalEffects({
+  content,
+  getTrigger,
+  onDismiss,
+}: DrawerModalPorts): () => void {
+  const releaseTrap = createFocusTrap(content);
+  const releaseScroll = preventBodyScroll();
+  const releaseDismiss = onPointerDownOutside(content, (event) => {
+    const target = event.target as Node;
+    if (getTrigger()?.contains(target)) return;
+    onDismiss(event);
+  });
+  return () => {
+    releaseDismiss();
+    releaseScroll();
+    releaseTrap();
+  };
+}
+
+export const drawer: BehaviorSpec<DrawerConfig, DrawerState, DrawerActions, DrawerPart> = compose(
+  'drawer',
+  disclosable<DrawerConfig>(),
+  drawerSurface,
+  drawerGlue,
+);
+
+/**
+ * The DOM-native binding of the drawer score -- the client. The Web Component
+ * and the Astro <script> both import THIS; only React reads the projections
+ * declaratively. Same shape as bindDialog: PRESENCE (content/overlay are
+ * present-but-hidden, toggled on the open axis -- the trapped/dismissable
+ * parts must be light DOM so focus-trap's activeElement read and dismiss's
+ * document .contains work) and the modal overlay trio (focus-trap,
+ * scroll-lock, dismiss-on-outside), composed directly and level-triggered:
+ * started on the open+modal transition and torn down on close/unbind.
+ * Enter-only; exit/drag animation waits on Presence (wave 0-B).
+ */
+export function bindDrawer(root: HTMLElement): () => void {
+  const config: DrawerConfig = {
+    modal: root.getAttribute('modal') !== 'false',
+    defaultOpen:
+      root.getAttribute('default-open') === 'true' ||
+      root.querySelector<HTMLElement>('[data-part="content"]')?.dataset['state'] === 'open',
+  };
+
+  const getPart = (part: string): HTMLElement | null =>
+    part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
+
+  const { memory, dispatch } = createBehavior(drawer, config);
+
+  const request = (action: keyof DrawerActions): boolean => dispatch(action, config);
+
+  // The modal overlay trio is level-triggered: present only while open+modal.
+  // render() starts it on the transition and this cleanup stops it on close.
+  let modalCleanup: (() => void) | null = null;
+
+  // ids READ from the server/author markup, never generated.
+  const ids = {} as PartIds<DrawerPart>;
+  for (const part of Object.keys(drawer.parts) as DrawerPart[]) ids[part] = getPart(part)?.id ?? '';
+
+  // The projection is already resolved, so apply it raw (validate:false skips
+  // aria-manager's author-input coercion that flips the string 'false').
+  const applyProjection = (el: HTMLElement, attrs: AriaAttrs) => {
+    for (const [name, value] of Object.entries(attrs)) {
+      updateAriaAttribute(el, name as never, value as never, { validate: false });
+    }
+  };
+
+  const render = () => {
+    const state = memory.get();
+    const open = isOpen(state, config);
+    const projection = drawer.aria(state, config, ids);
+    for (const part of Object.keys(projection) as DrawerPart[]) {
+      const attrs = projection[part];
+      const el = getPart(part);
+      if (el && attrs) applyProjection(el, attrs);
+    }
+    // Presence: the overlay and the content panel hide off the open axis.
+    // The parts stay in light DOM (crawlable, and effects can read them).
+    for (const part of ['overlay', 'content'] as const) {
+      const el = getPart(part);
+      if (el) el.hidden = !open;
+    }
+    // Compose the modal overlay trio directly, level-triggered: start it once
+    // on the open+modal transition (content is now un-hidden above so the trap
+    // can read its focusables), tear it down when it should no longer be present.
+    const wantModal = open && isModal(config);
+    if (wantModal && !modalCleanup) {
+      const content = getPart('content');
+      if (content) {
+        modalCleanup = startDrawerModalEffects({
+          content,
+          getTrigger: () => getPart('trigger'),
+          onDismiss: () => {
+            request('close');
+          },
+        });
+      }
+    } else if (!wantModal && modalCleanup) {
+      modalCleanup();
+      modalCleanup = null;
+    }
+  };
+  const unsubscribe = memory.subscribe(render); // fires immediately: first paint
+
+  const onClick = (event: Event) => {
+    const target = event.target as HTMLElement;
+    if (target.closest('[data-part="close"]')) {
+      request('close');
+      return;
+    }
+    if (target.closest('[data-part="trigger"]')) {
+      request(isOpen(memory.get(), config) ? 'close' : 'open');
+    }
+  };
+  root.addEventListener('click', onClick);
+
+  const onKeydown = (event: KeyboardEvent) => {
+    const partEl = (event.target as HTMLElement).closest<HTMLElement>('[data-part]');
+    const part = partEl?.dataset['part'] as DrawerPart | undefined;
+    if (!part) return;
+    const action = drawer.keymap(
+      {
+        key: event.key,
+        shiftKey: event.shiftKey,
+        ctrlKey: event.ctrlKey,
+        altKey: event.altKey,
+        metaKey: event.metaKey,
+      },
+      memory.get(),
+      part,
+      config,
+    );
+    if (!action) return;
+    event.preventDefault();
+    const trigger = getPart('trigger');
+    request(action);
+    if (action === 'close') trigger?.focus();
+  };
+  root.addEventListener('keydown', onKeydown);
+
+  return () => {
+    unsubscribe();
+    modalCleanup?.();
+    modalCleanup = null;
+    root.removeEventListener('click', onClick);
+    root.removeEventListener('keydown', onKeydown);
+  };
+}

--- a/packages/ui/src/components/drawer/drawer.behavior.ts
+++ b/packages/ui/src/components/drawer/drawer.behavior.ts
@@ -240,8 +240,20 @@ export function bindDrawer(root: HTMLElement): () => void {
   root.addEventListener('click', onClick);
 
   const onKeydown = (event: KeyboardEvent) => {
-    const partEl = (event.target as HTMLElement).closest<HTMLElement>('[data-part]');
-    const part = partEl?.dataset['part'] as DrawerPart | undefined;
+    const target = event.target as HTMLElement;
+    // Any keydown landing inside the content surface is content-scoped -- this
+    // mirrors the React decorator, which hardcodes 'content'. Without it, when
+    // the focus-trap's initial focus lands on a focusable descendant (e.g. the
+    // close button, data-part="close", the only focusable in a bare drawer),
+    // closest('[data-part]') would resolve that part and the content-only
+    // Escape keymap would silently fail (WCAG 2.1.1). Same class as the merged
+    // alert-dialog fix.
+    const content = getPart('content');
+    const partEl = target.closest<HTMLElement>('[data-part]');
+    const part: DrawerPart | undefined =
+      content && content.contains(target)
+        ? 'content'
+        : (partEl?.dataset['part'] as DrawerPart | undefined);
     if (!part) return;
     const action = drawer.keymap(
       {

--- a/packages/ui/src/components/drawer/drawer.classes.ts
+++ b/packages/ui/src/components/drawer/drawer.classes.ts
@@ -1,0 +1,73 @@
+import {
+  type DrawerConfig,
+  type DrawerSide,
+  type DrawerState,
+  drawerSide,
+} from './drawer.behavior';
+
+export interface DrawerClassSet {
+  overlay: string;
+  content: string;
+  handle: string;
+  header: string;
+  footer: string;
+  title: string;
+  description: string;
+  close: string;
+  closeIcon: string;
+}
+
+const overlayClasses = 'fixed inset-0 z-depth-overlay bg-foreground/80';
+
+// The panel is fixed to its anchoring edge (no centering container -- unlike a
+// dialog). data-[state=closed]:pointer-events-none keeps a closed panel from
+// swallowing clicks while it is held present through any future exit window.
+const contentBaseClasses =
+  'fixed z-depth-modal flex flex-col gap-4 bg-background p-6 text-foreground shadow-lg ' +
+  'border-card-border data-[state=closed]:pointer-events-none';
+
+// Position + rounding + the border edge, keyed on the anchoring side. The
+// slide motion these positions imply is left UNDECLARED -- see the component
+// doc's motion dispositions (motion-sheet-in pending #1899/#1902-1904).
+const sideClasses: Record<DrawerSide, string> = {
+  bottom: 'inset-x-0 bottom-0 border-t rounded-t-lg',
+  top: 'inset-x-0 top-0 border-b rounded-b-lg',
+  left: 'inset-y-0 left-0 h-full w-3/4 max-w-sm border-r rounded-r-lg',
+  right: 'inset-y-0 right-0 h-full w-3/4 max-w-sm border-l rounded-l-lg',
+};
+
+// Decorative drag affordance. Renders the vaul-style grabber; the drag-to-
+// dismiss gesture it implies is deferred (see the doc), so it carries no
+// behavior and stays out of the accessibility tree.
+const handleClasses = 'mx-auto h-1.5 w-24 shrink-0 rounded-full bg-muted';
+
+const headerClasses = 'flex flex-col gap-1.5 text-center @md:text-left';
+
+const footerClasses = 'mt-auto flex flex-col gap-2 pt-4';
+
+const titleClasses = 'text-title-medium leading-none text-foreground';
+
+const descriptionClasses = 'text-body-small text-muted-foreground';
+
+const closeClasses =
+  'absolute right-2 top-2 inline-flex h-11 w-11 items-center justify-center ' +
+  '@md:right-4 @md:top-4 @md:h-8 @md:w-8 ' +
+  'rounded-sm opacity-70 ring-offset-background cursor-pointer ' +
+  'transition-opacity duration-150 motion-reduce:transition-none hover:opacity-100 ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
+
+const closeIconClasses = 'h-5 w-5 @md:h-4 @md:w-4';
+
+export function drawerClasses(config: DrawerConfig, _state: DrawerState): DrawerClassSet {
+  return {
+    overlay: overlayClasses,
+    content: `${contentBaseClasses} ${sideClasses[drawerSide(config)]}`,
+    handle: handleClasses,
+    header: headerClasses,
+    footer: footerClasses,
+    title: titleClasses,
+    description: descriptionClasses,
+    close: closeClasses,
+    closeIcon: closeIconClasses,
+  };
+}

--- a/packages/ui/src/components/drawer/drawer.element.ts
+++ b/packages/ui/src/components/drawer/drawer.element.ts
@@ -1,0 +1,27 @@
+/**
+ * WC performance for drawer: the thinnest wrapper. The score AND the DOM-native
+ * binding (bindDrawer) live in drawer.behavior.ts, shared with the Astro
+ * performance. This file only adapts that binding to the custom-element
+ * lifecycle -- deferring the bind one microtask because connectedCallback can
+ * fire before the light-DOM parts are parsed.
+ */
+import { bindDrawer } from './drawer.behavior';
+
+export class RaftersDrawer extends HTMLElement {
+  private teardown: (() => void) | null = null;
+
+  connectedCallback(): void {
+    queueMicrotask(() => {
+      if (this.isConnected && !this.teardown) this.teardown = bindDrawer(this);
+    });
+  }
+
+  disconnectedCallback(): void {
+    this.teardown?.();
+    this.teardown = null;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-drawer')) {
+  customElements.define('rafters-drawer', RaftersDrawer);
+}

--- a/packages/ui/src/components/drawer/drawer.tsx
+++ b/packages/ui/src/components/drawer/drawer.tsx
@@ -1,0 +1,466 @@
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import { createBehavior, type AriaAttrs, type PartIds } from '../../lib/contract';
+import { keyInputOf } from '../../hooks/key-input';
+import { useMemory } from '../../hooks/use-memory';
+import { usePresence } from '../../hooks/use-presence';
+import classy from '../../primitives/classy';
+import { mergeProps } from '../../primitives/slot';
+import {
+  drawer,
+  isOpen,
+  startDrawerModalEffects,
+  type DrawerActions,
+  type DrawerConfig,
+  type DrawerPart,
+  type DrawerSide,
+  type DrawerState,
+} from './drawer.behavior';
+import { drawerClasses, type DrawerClassSet } from './drawer.classes';
+
+/** The oracle-compatible dismissal veto surface on DrawerContent. */
+interface DismissVetoCallbacks {
+  onPointerDownOutside?: ((event: Event) => void) | undefined;
+  onInteractOutside?: ((event: Event) => void) | undefined;
+}
+
+interface DrawerContextValue {
+  state: DrawerState;
+  ids: PartIds<DrawerPart>;
+  aria: Partial<Record<DrawerPart, AriaAttrs>>;
+  request: (action: keyof DrawerActions) => boolean;
+  setPart: (part: DrawerPart) => (element: HTMLElement | null) => void;
+  getPart: (part: string) => HTMLElement | null;
+  config: DrawerConfig;
+  side: DrawerSide;
+  effectiveOpen: boolean;
+  classes: DrawerClassSet;
+  dismissVetoRef: React.RefObject<DismissVetoCallbacks | null>;
+}
+
+const DrawerContext = React.createContext<DrawerContextValue | null>(null);
+
+function useDrawerContext(component: string): DrawerContextValue {
+  const context = React.useContext(DrawerContext);
+  if (!context) {
+    throw new Error(`${component} must be used within <Drawer>`);
+  }
+  return context;
+}
+
+/** True when rendering inside an explicit <DrawerPortal> (Radix-style
+ *  composition); DrawerContent then skips its automatic portal + overlay. */
+const DrawerPortalContext = React.createContext(false);
+
+export interface DrawerProps {
+  children: React.ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  modal?: boolean;
+  /** The edge the drawer slides in from. Defaults to "bottom" (touch). */
+  side?: DrawerSide;
+}
+
+/**
+ * An edge-anchored dialog: the modal-overlay archetype, positioned against a
+ * screen edge (bottom by default -- a touch drawer that slides up) instead of
+ * centered. The behavior is dialog's exactly -- disclosable open/close, a
+ * focus-trap + scroll-lock + outside-dismiss trio while open+modal, Escape
+ * closes and restores focus to the trigger -- so this decorator is dialog's
+ * decorator with a `side` position variant and a decorative grab handle. Enter
+ * only; the slide and drag-to-dismiss motion wait on Presence (wave 0-B).
+ *
+ * @cognitive-load 4/10 - decision 1, information 1, interaction 1, disruption 1,
+ * learning 0. A single decision (act or dismiss) over content that arrives from
+ * a familiar edge; the disruption point is real because a modal drawer seizes
+ * the whole surface and locks the page behind it, but the slide-from-edge and
+ * grab handle are universally learned mobile idioms that cost no new learning.
+ * @attention-economics Full capture, spent deliberately: the overlay dims the
+ * page and the trap holds focus, so the drawer owns attention until dismissed.
+ * That is the correct price for an action sheet or a quick selection and the
+ * wrong one for sustained work -- reach for a dialog or a full page then. The
+ * edge anchoring preserves spatial context the page had, softening the seizure.
+ * @trust-building Dismissal is cheap and plural: tap the dimmed overlay, press
+ * Escape, or use the close button, and focus returns to the trigger exactly
+ * where it left. Nothing is destroyed by closing, the panel reopens as it was,
+ * and the visible handle signals the surface is transient, not a new location.
+ * @accessibility content is role="dialog" with aria-modal while modal, named by
+ * aria-labelledby/aria-describedby only when those parts render (no dangling
+ * references), and the trigger carries aria-haspopup="dialog", aria-expanded and
+ * aria-controls. Focus is trapped inside while open, Escape closes and restores
+ * focus to the trigger, and the close button carries an aria-label. The grab
+ * handle is decorative (aria-hidden) since its drag gesture is not yet wired.
+ */
+export function Drawer({
+  children,
+  open,
+  defaultOpen = false,
+  onOpenChange,
+  modal = true,
+  side = 'bottom',
+}: DrawerProps) {
+  const config: DrawerConfig = { open, defaultOpen, modal, side };
+  const dismissVetoRef = React.useRef<DismissVetoCallbacks | null>(null);
+
+  // The controller composes the score with the substrate -- no useBehavior.
+  const { memory, dispatch } = React.useMemo(() => createBehavior(drawer, config), []);
+  const state = useMemory(memory);
+  const effectiveOpen = isOpen(state, config);
+
+  const uid = React.useId();
+
+  // Content portals to document.body with a unique id, so getPart resolves by
+  // id -- no ref registry. Optional parts still need a mount signal (setPart)
+  // purely so an omitted description projects no dangling aria-describedby.
+  const [presentParts, setPresentParts] = React.useState<ReadonlySet<string>>(new Set());
+  const partCallbacks = React.useRef<Map<string, (el: HTMLElement | null) => void>>(new Map());
+  const setPart = React.useCallback((part: DrawerPart) => {
+    let callback = partCallbacks.current.get(part);
+    if (!callback) {
+      callback = (element: HTMLElement | null) =>
+        setPresentParts((previous) => {
+          const present = element !== null;
+          if (previous.has(part) === present) return previous;
+          const next = new Set(previous);
+          if (present) next.add(part);
+          else next.delete(part);
+          return next;
+        });
+      partCallbacks.current.set(part, callback);
+    }
+    return callback;
+  }, []);
+  const getPart = React.useCallback(
+    (part: string): HTMLElement | null =>
+      typeof document === 'undefined' ? null : document.getElementById(`${uid}-${part}`),
+    [uid],
+  );
+
+  // title and description are the UNGUARDED cross-ref sources (labelledby/
+  // describedby have no `open` guard, unlike aria-controls), so an absent one
+  // must resolve to an empty id. Every other part keeps a stable id -- content
+  // especially, since the focus-trap effect finds it by id.
+  const ids = React.useMemo(() => {
+    const out = {} as PartIds<DrawerPart>;
+    for (const part of Object.keys(drawer.parts) as DrawerPart[]) {
+      const crossRefSource = part === 'title' || part === 'description';
+      out[part] = crossRefSource && !presentParts.has(part) ? '' : `${uid}-${part}`;
+    }
+    return out;
+  }, [uid, presentParts]);
+
+  const latest = React.useRef({ config, onOpenChange });
+  latest.current = { config, onOpenChange };
+  const request = React.useCallback(
+    (action: keyof DrawerActions): boolean => {
+      const { config: cfg, onOpenChange: cb } = latest.current;
+      if (!dispatch(action, cfg)) return false;
+      cb?.(action === 'open');
+      return true;
+    },
+    [dispatch],
+  );
+
+  // The modal overlay trio, composed directly on the open+modal transition.
+  // Level-triggered via the dependency array; the cleanup tears the trio down
+  // (focus restore rides the trap teardown).
+  React.useEffect(() => {
+    if (!effectiveOpen || !modal) return;
+    const content = getPart('content');
+    if (!content) return;
+    return startDrawerModalEffects({
+      content,
+      getTrigger: () => getPart('trigger'),
+      // Outside-pointerdown dismissals offer the consumer veto first (oracle
+      // protocol: callbacks run, close proceeds unless defaultPrevented).
+      onDismiss: (event) => {
+        const veto = dismissVetoRef.current;
+        if (veto) {
+          veto.onPointerDownOutside?.(event);
+          veto.onInteractOutside?.(event);
+          if (event.defaultPrevented) return;
+        }
+        request('close');
+      },
+    });
+  }, [effectiveOpen, modal, getPart, request]);
+
+  const aria = drawer.aria(state, config, ids);
+
+  const contextValue: DrawerContextValue = {
+    state,
+    ids,
+    aria,
+    request,
+    setPart,
+    getPart,
+    config,
+    side,
+    effectiveOpen,
+    classes: drawerClasses(config, state),
+    dismissVetoRef,
+  };
+
+  return <DrawerContext.Provider value={contextValue}>{children}</DrawerContext.Provider>;
+}
+
+export interface DrawerPortalProps {
+  children: React.ReactNode;
+  /** Portal target; defaults to document.body. */
+  container?: HTMLElement | null;
+  forceMount?: boolean;
+}
+
+export function DrawerPortal({ children, container, forceMount }: DrawerPortalProps) {
+  const { effectiveOpen } = useDrawerContext('DrawerPortal');
+  if (!(forceMount || effectiveOpen)) return null;
+  if (typeof document === 'undefined') return null;
+  return createPortal(
+    <DrawerPortalContext.Provider value={true}>{children}</DrawerPortalContext.Provider>,
+    container ?? document.body,
+  );
+}
+
+export interface DrawerOverlayProps extends React.HTMLAttributes<HTMLDivElement> {
+  forceMount?: boolean | undefined;
+}
+
+export function DrawerOverlay({ forceMount, className, ...props }: DrawerOverlayProps) {
+  const { effectiveOpen, ids, aria, classes, setPart } = useDrawerContext('DrawerOverlay');
+  if (!(forceMount || effectiveOpen)) return null;
+  return (
+    <div
+      data-part="overlay"
+      id={ids.overlay || undefined}
+      ref={setPart('overlay')}
+      // A force-mounted closed overlay must not cover the page.
+      hidden={effectiveOpen ? undefined : true}
+      className={classy(classes.overlay, className)}
+      {...aria.overlay}
+      {...props}
+    />
+  );
+}
+
+export interface DrawerTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+}
+
+export function DrawerTrigger({ asChild, onClick, children, ...props }: DrawerTriggerProps) {
+  const { effectiveOpen, ids, aria, request, setPart } = useDrawerContext('DrawerTrigger');
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    request(effectiveOpen ? 'close' : 'open');
+  };
+
+  const partProps = {
+    'data-part': 'trigger',
+    id: ids.trigger,
+    ref: setPart('trigger'),
+    ...aria.trigger,
+    onClick: handleClick,
+  };
+
+  if (asChild && React.isValidElement(children)) {
+    const childProps = children.props as Record<string, unknown>;
+    return React.cloneElement(children, mergeProps(partProps, childProps) as React.Attributes);
+  }
+
+  return (
+    <button type="button" {...partProps} {...props}>
+      {children}
+    </button>
+  );
+}
+
+export interface DrawerContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Defaults to true, except inside an explicit <DrawerPortal>. */
+  showCloseButton?: boolean;
+  forceMount?: boolean;
+  /** Portal target for the automatic portal; defaults to document.body. */
+  container?: HTMLElement | null;
+  /** Consumer veto: called before Escape closes; preventDefault to keep open. */
+  onEscapeKeyDown?: (event: KeyboardEvent) => void;
+  /** Consumer veto: called before an outside pointerdown closes. */
+  onPointerDownOutside?: (event: Event) => void;
+  /** Consumer veto: called alongside onPointerDownOutside (oracle surface). */
+  onInteractOutside?: (event: Event) => void;
+}
+
+export function DrawerContent({
+  showCloseButton,
+  forceMount,
+  container,
+  onEscapeKeyDown,
+  onPointerDownOutside,
+  onInteractOutside,
+  className,
+  children,
+  onKeyDown,
+  ...props
+}: DrawerContentProps) {
+  const { config, state, effectiveOpen, ids, aria, classes, request, setPart, dismissVetoRef } =
+    useDrawerContext('DrawerContent');
+  const isInsidePortal = React.useContext(DrawerPortalContext);
+  // Presence (wave 0-B): keep the content mounted through its exit animation.
+  // With no exit animation it releases immediately, so behavior is unchanged.
+  const { present, ref: presenceRef } = usePresence(effectiveOpen);
+
+  React.useEffect(() => {
+    dismissVetoRef.current = { onPointerDownOutside, onInteractOutside };
+    return () => {
+      dismissVetoRef.current = null;
+    };
+  });
+
+  if (!(forceMount || present)) return null;
+  if (typeof document === 'undefined') return null;
+
+  const modal = config.modal !== false;
+  const shouldShowCloseButton = showCloseButton ?? !isInsidePortal;
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    onKeyDown?.(event);
+    if (event.defaultPrevented) return;
+    const action = drawer.keymap(keyInputOf(event), state, 'content', config);
+    if (!action) return;
+    if (action === 'close') {
+      onEscapeKeyDown?.(event.nativeEvent);
+      if (event.nativeEvent.defaultPrevented) return;
+    }
+    event.preventDefault();
+    request(action);
+  };
+
+  const content = (
+    <div
+      data-part="content"
+      id={ids.content || undefined}
+      ref={presenceRef}
+      tabIndex={-1}
+      // forceMount keeps the node for animation tooling; a closed modal must
+      // still be invisible to AT, untabbable, and must not block the page --
+      // hidden covers all three.
+      hidden={present ? undefined : true}
+      className={classy(classes.content, className)}
+      {...aria.content}
+      onKeyDown={handleKeyDown}
+      {...props}
+    >
+      {/* Decorative grab affordance; the drag-to-dismiss gesture is deferred. */}
+      <div className={classes.handle} aria-hidden="true" />
+      {children}
+      {shouldShowCloseButton ? (
+        <button
+          type="button"
+          data-part="close"
+          id={ids.close || undefined}
+          ref={setPart('close')}
+          className={classes.close}
+          {...aria.close}
+          onClick={() => request('close')}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={classes.closeIcon}
+            aria-hidden="true"
+          >
+            <path d="M18 6 6 18" />
+            <path d="m6 6 12 12" />
+          </svg>
+        </button>
+      ) : null}
+    </div>
+  );
+
+  // Inside an explicit <DrawerPortal>: the consumer owns portal + overlay.
+  if (isInsidePortal) return content;
+
+  // shadcn-style: Content brings its own portal and overlay.
+  return createPortal(
+    <>
+      {modal ? <DrawerOverlay forceMount={forceMount} /> : null}
+      {content}
+    </>,
+    container ?? document.body,
+  );
+}
+
+export type DrawerHeaderProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function DrawerHeader({ className, ...props }: DrawerHeaderProps) {
+  const { classes } = useDrawerContext('DrawerHeader');
+  return <div className={classy(classes.header, className)} {...props} />;
+}
+
+export type DrawerFooterProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function DrawerFooter({ className, ...props }: DrawerFooterProps) {
+  const { classes } = useDrawerContext('DrawerFooter');
+  return <div className={classy(classes.footer, className)} {...props} />;
+}
+
+export type DrawerTitleProps = React.HTMLAttributes<HTMLHeadingElement>;
+
+export function DrawerTitle({ className, ...props }: DrawerTitleProps) {
+  const { ids, classes, setPart } = useDrawerContext('DrawerTitle');
+  return (
+    <h2
+      data-part="title"
+      id={ids.title || undefined}
+      ref={setPart('title')}
+      className={classy(classes.title, className)}
+      {...props}
+    />
+  );
+}
+
+export type DrawerDescriptionProps = React.HTMLAttributes<HTMLParagraphElement>;
+
+export function DrawerDescription({ className, ...props }: DrawerDescriptionProps) {
+  const { ids, classes, setPart } = useDrawerContext('DrawerDescription');
+  return (
+    <p
+      data-part="description"
+      id={ids.description || undefined}
+      ref={setPart('description')}
+      className={classy(classes.description, className)}
+      {...props}
+    />
+  );
+}
+
+export interface DrawerCloseProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+}
+
+export function DrawerClose({ asChild, onClick, children, ...props }: DrawerCloseProps) {
+  const { request } = useDrawerContext('DrawerClose');
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    request('close');
+  };
+
+  if (asChild && React.isValidElement(children)) {
+    const childProps = children.props as Record<string, unknown>;
+    return React.cloneElement(
+      children,
+      mergeProps({ onClick: handleClick }, childProps) as React.Attributes,
+    );
+  }
+
+  return (
+    <button type="button" onClick={handleClick} {...props}>
+      {children}
+    </button>
+  );
+}

--- a/packages/ui/test/components/drawer/drawer.astro.conformance.test.ts
+++ b/packages/ui/test/components/drawer/drawer.astro.conformance.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Astro performance of the drawer score, driven end to end. AstroContainer
+ * renders the SSR markup but does NOT run the <script>, so the test binds
+ * bindDrawer directly -- that IS the script's job -- then drives the same score
+ * the React and WC performances drive. One score, three performances.
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import Drawer from '../../../src/components/drawer/drawer.astro';
+import { bindDrawer } from '../../../src/components/drawer/drawer.behavior';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+async function mount(
+  props: Record<string, unknown> = {},
+  slots: Record<string, string> = {},
+): Promise<HTMLElement> {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Drawer, { props: { id: 'dr', ...props }, slots });
+  document.body.innerHTML = html;
+  const root = document.body.querySelector('rafters-drawer') as HTMLElement;
+  bindDrawer(root); // the <script> does this per instance on the real page
+  return root;
+}
+
+const trigger = () => document.body.querySelector<HTMLElement>('[data-part="trigger"]')!;
+const content = () => document.body.querySelector<HTMLElement>('[data-part="content"]')!;
+
+describe('drawer conformance [astro]', () => {
+  it('SSR closed: content hidden and crawlable, trigger collapsed', async () => {
+    await mount({ title: 'Actions' });
+    expect(content().hidden).toBe(true);
+    expect(trigger().getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('SSR wires aria by real ids; omitted description projects none', async () => {
+    await mount({ title: 'Actions' });
+    expect(content().getAttribute('aria-labelledby')).toBe('dr-title');
+    expect(content().hasAttribute('aria-describedby')).toBe(false);
+  });
+
+  it('SSR anchors to the configured edge without disturbing the dialog role', async () => {
+    await mount({ title: 'Actions', side: 'right' });
+    expect(content().getAttribute('role')).toBe('dialog');
+    expect(content().className).toContain('right-0');
+  });
+
+  it('bind: trigger opens, focus trapped, scroll locked; Escape closes + restores focus', async () => {
+    const user = userEvent.setup();
+    await mount({ title: 'Actions' }, { default: '<button type="button">Save</button>' });
+    await user.click(trigger());
+    expect(content().hidden).toBe(false);
+    expect(content().contains(document.activeElement)).toBe(true);
+    expect(document.body.style.overflow).toBe('hidden');
+    await user.keyboard('{Escape}');
+    expect(content().hidden).toBe(true);
+    expect(document.activeElement).toBe(trigger());
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+});

--- a/packages/ui/test/components/drawer/drawer.astro.conformance.test.ts
+++ b/packages/ui/test/components/drawer/drawer.astro.conformance.test.ts
@@ -48,6 +48,21 @@ describe('drawer conformance [astro]', () => {
     expect(content().className).toContain('right-0');
   });
 
+  it('Escape closes even when the close button holds the trap initial focus', async () => {
+    // Regression: with no default-slot content, the close button is the only
+    // focusable descendant, so the focus-trap gives it initial focus. A
+    // target-scoped keymap would classify Escape as `close` and drop it; the
+    // bind resolves any keydown inside content as content-scoped.
+    const user = userEvent.setup();
+    await mount({ title: 'Actions' });
+    await user.click(trigger());
+    const close = document.body.querySelector<HTMLElement>('[data-part="close"]')!;
+    expect(document.activeElement).toBe(close);
+    await user.keyboard('{Escape}');
+    expect(content().hidden).toBe(true);
+    expect(document.activeElement).toBe(trigger());
+  });
+
   it('bind: trigger opens, focus trapped, scroll locked; Escape closes + restores focus', async () => {
     const user = userEvent.setup();
     await mount({ title: 'Actions' }, { default: '<button type="button">Save</button>' });

--- a/packages/ui/test/components/drawer/drawer.behavior.test.ts
+++ b/packages/ui/test/components/drawer/drawer.behavior.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+import { createBehavior, type PartIds } from '../../../src/lib/contract';
+import {
+  drawer,
+  drawerSide,
+  isOpen,
+  type DrawerConfig,
+  type DrawerPart,
+} from '../../../src/components/drawer/drawer.behavior';
+
+const ids: PartIds<DrawerPart> = {
+  trigger: 't',
+  content: 'c',
+  overlay: 'o',
+  title: 'ti',
+  description: 'd',
+  close: 'x',
+};
+
+const closed: DrawerConfig = {};
+const openUncontrolled: DrawerConfig = { defaultOpen: true };
+
+function ariaAt(config: DrawerConfig, partIds: PartIds<DrawerPart> = ids) {
+  return drawer.aria(drawer.initialState(config), config, partIds);
+}
+
+describe('drawer parts', () => {
+  it('declares the dialog surface (a drawer is an edge-anchored dialog)', () => {
+    expect(Object.keys(drawer.parts).sort()).toEqual([
+      'close',
+      'content',
+      'description',
+      'overlay',
+      'title',
+      'trigger',
+    ]);
+    expect(drawer.parts.content.optional).toBe(true);
+    expect(drawer.parts.trigger.optional).toBeUndefined();
+  });
+});
+
+describe('drawer side', () => {
+  it('defaults to bottom (touch), and echoes an explicit edge', () => {
+    expect(drawerSide({})).toBe('bottom');
+    expect(drawerSide({ side: 'right' })).toBe('right');
+    expect(drawerSide({ side: 'top' })).toBe('top');
+    expect(drawerSide({ side: 'left' })).toBe('left');
+  });
+
+  it('is edge-independent in the score: side never reaches the ARIA projection', () => {
+    const bottom = ariaAt(openUncontrolled);
+    const right = ariaAt({ ...openUncontrolled, side: 'right' });
+    expect(right).toEqual(bottom);
+  });
+});
+
+describe('drawer state: controlled vs intrinsic', () => {
+  it('seeds intrinsic open from defaultOpen', () => {
+    expect(drawer.initialState({ defaultOpen: true }).open).toBe(true);
+    expect(drawer.initialState({}).open).toBe(false);
+  });
+
+  it('controlled config shadows intrinsic state', () => {
+    const state = drawer.initialState({});
+    expect(isOpen(state, { open: true })).toBe(true);
+    expect(isOpen({ open: true }, { open: false })).toBe(false);
+    expect(isOpen({ open: true }, {})).toBe(true);
+  });
+});
+
+describe('drawer canDispatch (idempotence gate)', () => {
+  it('open only when effectively closed, close only when effectively open', () => {
+    const state = drawer.initialState(closed);
+    expect(drawer.canDispatch(state, 'open', closed)).toBe(true);
+    expect(drawer.canDispatch(state, 'close', closed)).toBe(false);
+
+    const openState = { open: true };
+    expect(drawer.canDispatch(openState, 'open', closed)).toBe(false);
+    expect(drawer.canDispatch(openState, 'close', closed)).toBe(true);
+  });
+
+  it('gates on the CONTROLLED value when present', () => {
+    const drifted = { open: false };
+    expect(drawer.canDispatch(drifted, 'close', { open: true })).toBe(true);
+    expect(drawer.canDispatch(drifted, 'open', { open: true })).toBe(false);
+  });
+});
+
+describe('drawer actions', () => {
+  it('open and close move intrinsic state through dispatch', () => {
+    const { memory, dispatch } = createBehavior(drawer, closed);
+    expect(dispatch('open', closed)).toBe(true);
+    expect(memory.get().open).toBe(true);
+    expect(dispatch('open', closed)).toBe(false);
+    expect(dispatch('close', closed)).toBe(true);
+    expect(memory.get().open).toBe(false);
+  });
+});
+
+describe('drawer aria projection', () => {
+  it('closed: trigger collapsed, no dangling aria-controls', () => {
+    const aria = ariaAt(closed);
+    expect(aria.trigger).toEqual({
+      'aria-expanded': 'false',
+      'aria-controls': undefined,
+      'data-state': 'closed',
+      'aria-haspopup': 'dialog',
+    });
+  });
+
+  it('open: trigger expanded and wired to content', () => {
+    const aria = ariaAt(openUncontrolled);
+    expect(aria.trigger?.['aria-expanded']).toBe('true');
+    expect(aria.trigger?.['aria-controls']).toBe('c');
+    expect(aria.trigger?.['data-state']).toBe('open');
+  });
+
+  it('content: role dialog, modal by default, labelled and described', () => {
+    const aria = ariaAt(openUncontrolled);
+    expect(aria.content).toEqual({
+      role: 'dialog',
+      'aria-modal': 'true',
+      'aria-labelledby': 'ti',
+      'aria-describedby': 'd',
+      'data-state': 'open',
+    });
+  });
+
+  it('non-modal drops aria-modal', () => {
+    const aria = ariaAt({ ...openUncontrolled, modal: false });
+    expect(aria.content?.['aria-modal']).toBeUndefined();
+  });
+
+  it('empty part ids project ABSENT references, never dangling ones', () => {
+    const aria = ariaAt(openUncontrolled, { ...ids, title: '', description: '' });
+    expect(aria.content?.['aria-labelledby']).toBeUndefined();
+    expect(aria.content?.['aria-describedby']).toBeUndefined();
+  });
+
+  it('overlay is presentation only', () => {
+    const aria = ariaAt(openUncontrolled);
+    expect(aria.overlay).toEqual({ 'aria-hidden': 'true', 'data-state': 'open' });
+  });
+
+  it('close carries its accessible name', () => {
+    expect(ariaAt(openUncontrolled).close).toEqual({ 'aria-label': 'Close' });
+  });
+});
+
+describe('drawer keymap', () => {
+  const state = { open: true };
+  it('Escape on content maps to close', () => {
+    expect(drawer.keymap({ key: 'Escape' }, state, 'content')).toBe('close');
+  });
+  it('Escape elsewhere and other keys are not claimed', () => {
+    expect(drawer.keymap({ key: 'Escape' }, state, 'trigger')).toBeNull();
+    expect(drawer.keymap({ key: 'Enter' }, state, 'content')).toBeNull();
+  });
+});
+
+// The modal overlay trio (focus-trap, scroll-lock, trigger-spared outside
+// dismissal) is composed by the bindings directly, not declared on the score;
+// the BEHAVIOR is asserted end to end in the conformance suites
+// (drawer.conformance.test.tsx / .astro. / .element.).

--- a/packages/ui/test/components/drawer/drawer.classes.test.ts
+++ b/packages/ui/test/components/drawer/drawer.classes.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { drawer } from '../../../src/components/drawer/drawer.behavior';
+import { drawerClasses } from '../../../src/components/drawer/drawer.classes';
+
+const state = drawer.initialState({});
+const classesFor = (side?: 'top' | 'right' | 'bottom' | 'left') =>
+  drawerClasses(side ? { side } : {}, state);
+
+describe('drawer classes', () => {
+  it('layers sit on depth tokens', () => {
+    const classes = classesFor();
+    expect(classes.overlay).toContain('z-depth-overlay');
+    expect(classes.content).toContain('z-depth-modal');
+  });
+
+  it('defaults to the bottom edge: slides up, rounded top, top border', () => {
+    const classes = classesFor();
+    expect(classes.content).toContain('bottom-0');
+    expect(classes.content).toContain('rounded-t-lg');
+    expect(classes.content).toContain('border-t');
+  });
+
+  it('anchors the panel to the configured edge', () => {
+    expect(classesFor('top').content).toContain('top-0');
+    expect(classesFor('top').content).toContain('border-b');
+    expect(classesFor('left').content).toContain('left-0');
+    expect(classesFor('left').content).toContain('border-r');
+    expect(classesFor('right').content).toContain('right-0');
+    expect(classesFor('right').content).toContain('border-l');
+  });
+
+  it('side-anchored panels take a token fill, never a background utility', () => {
+    expect(classesFor().content).toContain('bg-background');
+    expect(classesFor().content).not.toContain('bg-white');
+  });
+
+  it('declares no raw numeric enter/exit motion (motion-sheet-in is pending)', () => {
+    const classes = classesFor();
+    expect(classes.content).not.toContain('animate-in');
+    expect(classes.content).not.toMatch(/duration-\d/);
+    expect(classes.content).not.toContain('slide-in');
+  });
+
+  it('the grab handle is a decorative token-filled affordance', () => {
+    const classes = classesFor();
+    expect(classes.handle).toContain('bg-muted');
+    expect(classes.handle).toContain('rounded-full');
+  });
+
+  it('close button honors the touch floor and scales down via CQ', () => {
+    const classes = classesFor();
+    expect(classes.close).toContain('h-11');
+    expect(classes.close).toContain('@md:h-8');
+    expect(classes.closeIcon).toContain('h-5');
+    expect(classes.closeIcon).toContain('@md:h-4');
+  });
+
+  it('header and footer respond to the container, not the viewport', () => {
+    const classes = classesFor();
+    expect(classes.header).toContain('@md:text-left');
+    expect(classes.header).not.toContain('sm:');
+    expect(classes.footer).not.toContain('sm:');
+  });
+
+  it('motion respects reduced-motion', () => {
+    expect(classesFor().close).toContain('motion-reduce:transition-none');
+  });
+});

--- a/packages/ui/test/components/drawer/drawer.conformance.test.tsx
+++ b/packages/ui/test/components/drawer/drawer.conformance.test.tsx
@@ -1,0 +1,334 @@
+/**
+ * React performance of the drawer score, driven end to end. The portal renders
+ * into document.body, so part queries run against body, not the RTL container.
+ */
+import * as React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerTitle,
+  DrawerTrigger,
+  type DrawerProps,
+} from '../../../src/components/drawer/drawer';
+import { drawer } from '../../../src/components/drawer/drawer.behavior';
+import {
+  assertAxeClean,
+  assertContractFulfillment,
+  domPartIds,
+  partElement,
+} from '../../harness/conformance';
+
+interface SetupProps extends Partial<DrawerProps> {
+  withDescription?: boolean;
+}
+
+function TestDrawer({ withDescription = true, children, ...props }: SetupProps) {
+  return (
+    <Drawer {...props}>
+      <DrawerTrigger>Open actions</DrawerTrigger>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>Actions</DrawerTitle>
+          {withDescription ? <DrawerDescription>Pick an action.</DrawerDescription> : null}
+        </DrawerHeader>
+        <button type="button">Save</button>
+        <DrawerFooter />
+      </DrawerContent>
+    </Drawer>
+  );
+}
+
+const body = () => document.body;
+
+afterEach(() => {
+  cleanup();
+  document.body.replaceChildren();
+});
+
+describe('drawer conformance [react]', () => {
+  it('closed: only the trigger renders, collapsed and axe-clean', async () => {
+    render(<TestDrawer />);
+    const trigger = partElement(body(), 'trigger');
+    expect(trigger).not.toBeNull();
+    expect(partElement(body(), 'content')).toBeNull();
+    expect(trigger?.getAttribute('aria-expanded')).toBe('false');
+    expect(trigger?.hasAttribute('aria-controls')).toBe(false);
+    await assertAxeClean(body());
+  });
+
+  it('open: every part renders and ARIA equals the projection', async () => {
+    const user = userEvent.setup();
+    render(<TestDrawer />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+
+    const config = { defaultOpen: false, modal: true };
+    const state = { open: true };
+    assertContractFulfillment(drawer, body(), state, config, [
+      'trigger',
+      'content',
+      'overlay',
+      'title',
+      'description',
+      'close',
+    ]);
+    await assertAxeClean(body());
+  });
+
+  it('side is edge-only: an explicit edge changes classes, never the dialog ARIA', async () => {
+    const user = userEvent.setup();
+    render(<TestDrawer side="right" />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    const content = partElement(body(), 'content') as HTMLElement;
+    expect(content.getAttribute('role')).toBe('dialog');
+    expect(content.getAttribute('aria-modal')).toBe('true');
+    expect(content.className).toContain('right-0');
+  });
+
+  it('omitted description projects NO aria-describedby', async () => {
+    const user = userEvent.setup();
+    render(<TestDrawer withDescription={false} />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    const content = partElement(body(), 'content');
+    expect(content?.hasAttribute('aria-describedby')).toBe(false);
+    expect(content?.getAttribute('aria-labelledby')).toBeTruthy();
+    await assertAxeClean(body());
+  });
+
+  it('trigger and content are wired by real DOM ids', async () => {
+    const user = userEvent.setup();
+    render(<TestDrawer />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    const ids = domPartIds(body(), ['trigger', 'content', 'title', 'description'] as const);
+    const trigger = partElement(body(), 'trigger');
+    const content = partElement(body(), 'content');
+    expect(trigger?.getAttribute('aria-controls')).toBe(ids.content);
+    expect(content?.getAttribute('aria-labelledby')).toBe(ids.title);
+    expect(content?.getAttribute('aria-describedby')).toBe(ids.description);
+  });
+
+  it('focus moves into the drawer and Tab is trapped', async () => {
+    const user = userEvent.setup();
+    render(<TestDrawer />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+
+    const content = partElement(body(), 'content') as HTMLElement;
+    expect(content.contains(document.activeElement)).toBe(true);
+
+    const focusable = Array.from(content.querySelectorAll<HTMLElement>('button:not([disabled])'));
+    for (let i = 0; i < focusable.length + 1; i += 1) {
+      await user.tab();
+      expect(content.contains(document.activeElement)).toBe(true);
+    }
+  });
+
+  it('Escape closes and restores focus to the trigger', async () => {
+    const user = userEvent.setup();
+    render(<TestDrawer />);
+    const trigger = partElement(body(), 'trigger') as HTMLElement;
+    await user.click(trigger);
+    expect(partElement(body(), 'content')).not.toBeNull();
+
+    await user.keyboard('{Escape}');
+    expect(partElement(body(), 'content')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('pointerdown outside dismisses; on the trigger it toggles closed, not closed-then-open', async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <button type="button">Elsewhere</button>
+        <TestDrawer />
+      </div>,
+    );
+    const trigger = partElement(body(), 'trigger') as HTMLElement;
+
+    await user.click(trigger);
+    expect(partElement(body(), 'content')).not.toBeNull();
+    await user.click(document.querySelector('button') as HTMLElement);
+    expect(partElement(body(), 'content')).toBeNull();
+
+    await user.click(trigger);
+    expect(partElement(body(), 'content')).not.toBeNull();
+    await user.click(trigger);
+    expect(partElement(body(), 'content')).toBeNull();
+  });
+
+  it('close button closes', async () => {
+    const user = userEvent.setup();
+    render(<TestDrawer />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    await user.click(partElement(body(), 'close') as HTMLElement);
+    expect(partElement(body(), 'content')).toBeNull();
+  });
+
+  it('scroll is locked while open and released on close', async () => {
+    const user = userEvent.setup();
+    render(<TestDrawer />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    expect(document.body.style.overflow).toBe('hidden');
+    await user.keyboard('{Escape}');
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+
+  it('non-modal: no overlay, no trap, no scroll lock, Escape still works', async () => {
+    const user = userEvent.setup();
+    render(<TestDrawer modal={false} />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    expect(partElement(body(), 'overlay')).toBeNull();
+    expect(document.body.style.overflow).not.toBe('hidden');
+    const content = partElement(body(), 'content') as HTMLElement;
+    expect(content.getAttribute('aria-modal')).toBeNull();
+
+    (content.querySelector('button') as HTMLElement).focus();
+    await user.keyboard('{Escape}');
+    expect(partElement(body(), 'content')).toBeNull();
+  });
+
+  it('defaultOpen mounts open with the trap live', () => {
+    render(<TestDrawer defaultOpen />);
+    const content = partElement(body(), 'content');
+    expect(content).not.toBeNull();
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('controlled: callbacks fire, state follows the prop, never the gesture', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const { rerender } = render(<TestDrawer open={false} onOpenChange={onOpenChange} />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    expect(partElement(body(), 'content')).toBeNull();
+
+    rerender(<TestDrawer open onOpenChange={onOpenChange} />);
+    expect(partElement(body(), 'content')).not.toBeNull();
+
+    await user.keyboard('{Escape}');
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+    expect(partElement(body(), 'content')).not.toBeNull();
+
+    rerender(<TestDrawer open={false} onOpenChange={onOpenChange} />);
+    expect(partElement(body(), 'content')).toBeNull();
+  });
+
+  it('explicit Portal + Overlay composition renders without the automatic wrappers', async () => {
+    const user = userEvent.setup();
+    render(
+      <Drawer>
+        <DrawerTrigger>Open</DrawerTrigger>
+        <DrawerPortal>
+          <DrawerOverlay />
+          <DrawerContent>
+            <DrawerTitle>Composed</DrawerTitle>
+          </DrawerContent>
+        </DrawerPortal>
+      </Drawer>,
+    );
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    expect(partElement(body(), 'content')).not.toBeNull();
+    expect(document.querySelectorAll('[data-part="overlay"]')).toHaveLength(1);
+    // Oracle default: no automatic close button inside an explicit portal.
+    expect(partElement(body(), 'close')).toBeNull();
+    await assertAxeClean(body());
+  });
+
+  it('forceMount keeps the content in the DOM, hidden and inert, while closed', () => {
+    render(
+      <Drawer>
+        <DrawerTrigger>Open</DrawerTrigger>
+        <DrawerContent forceMount>
+          <DrawerTitle>Always mounted</DrawerTitle>
+        </DrawerContent>
+      </Drawer>,
+    );
+    const content = partElement(body(), 'content');
+    expect(content).not.toBeNull();
+    expect(content?.getAttribute('data-state')).toBe('closed');
+    expect(content?.hasAttribute('hidden')).toBe(true);
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+
+  it('container portals the content into the given element', async () => {
+    const user = userEvent.setup();
+    const target = document.createElement('div');
+    target.id = 'portal-target';
+    document.body.appendChild(target);
+    render(
+      <Drawer>
+        <DrawerTrigger>Open</DrawerTrigger>
+        <DrawerContent container={target}>
+          <DrawerTitle>Housed</DrawerTitle>
+        </DrawerContent>
+      </Drawer>,
+    );
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    expect(target.querySelector('[data-part="content"]')).not.toBeNull();
+  });
+
+  it('onEscapeKeyDown veto keeps the drawer open', async () => {
+    const user = userEvent.setup();
+    render(
+      <Drawer defaultOpen>
+        <DrawerContent onEscapeKeyDown={(event) => event.preventDefault()}>
+          <DrawerTitle>Stubborn</DrawerTitle>
+        </DrawerContent>
+      </Drawer>,
+    );
+    await user.keyboard('{Escape}');
+    expect(partElement(body(), 'content')).not.toBeNull();
+  });
+
+  it('onPointerDownOutside veto keeps the drawer open; without veto it closes', async () => {
+    const user = userEvent.setup();
+    const outside = vi.fn((event: Event) => event.preventDefault());
+    const { unmount } = render(
+      <div>
+        <button type="button">Elsewhere</button>
+        <Drawer defaultOpen>
+          <DrawerContent onPointerDownOutside={outside}>
+            <DrawerTitle>Guarded</DrawerTitle>
+          </DrawerContent>
+        </Drawer>
+      </div>,
+    );
+    await user.click(document.querySelector('button') as HTMLElement);
+    expect(outside).toHaveBeenCalled();
+    expect(partElement(body(), 'content')).not.toBeNull();
+    unmount();
+
+    render(
+      <div>
+        <button type="button">Elsewhere</button>
+        <Drawer defaultOpen>
+          <DrawerContent>
+            <DrawerTitle>Unguarded</DrawerTitle>
+          </DrawerContent>
+        </Drawer>
+      </div>,
+    );
+    await user.click(document.querySelector('button') as HTMLElement);
+    expect(partElement(body(), 'content')).toBeNull();
+  });
+
+  it('uncontrolled callback fires once per real transition', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(<TestDrawer onOpenChange={onOpenChange} />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    await user.keyboard('{Escape}');
+    expect(onOpenChange).toHaveBeenCalledTimes(2);
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/packages/ui/test/components/drawer/drawer.element.conformance.test.ts
+++ b/packages/ui/test/components/drawer/drawer.element.conformance.test.ts
@@ -1,0 +1,100 @@
+/**
+ * WC performance of the drawer score, driven end to end against light-DOM
+ * markup. Same score as the React conformance test -- proves presence (content
+ * hidden off the open axis) and the directly-composed modal trio (focus-trap,
+ * scroll-lock, dismiss) drive through the DOM binding.
+ */
+import { cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { RaftersDrawer } from '../../../src/components/drawer/drawer.element';
+
+beforeAll(() => {
+  if (!customElements.get('rafters-drawer')) customElements.define('rafters-drawer', RaftersDrawer);
+});
+
+async function mount(modal = true): Promise<HTMLElement> {
+  document.body.innerHTML = `
+    <rafters-drawer${modal ? '' : ' modal="false"'} side="bottom">
+      <button type="button" data-part="trigger" id="dr-trigger" aria-haspopup="dialog" aria-expanded="false" data-state="closed">Open</button>
+      <div data-part="overlay" id="dr-overlay" aria-hidden="true" data-state="closed" hidden></div>
+      <div data-part="content" id="dr-content" role="dialog" tabindex="-1" aria-labelledby="dr-title" data-state="closed" hidden>
+        <div aria-hidden="true"></div>
+        <div id="dr-title" data-part="title" role="heading" aria-level="2">Actions</div>
+        <button type="button">Save</button>
+        <button type="button" data-part="close" id="dr-close" aria-label="Close">x</button>
+      </div>
+    </rafters-drawer>`;
+  await Promise.resolve();
+  return document.body.querySelector('rafters-drawer') as HTMLElement;
+}
+
+const trigger = () => document.body.querySelector<HTMLElement>('[data-part="trigger"]')!;
+const content = () => document.body.querySelector<HTMLElement>('[data-part="content"]')!;
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+describe('drawer conformance [wc]', () => {
+  it('closed: content hidden, trigger collapsed', async () => {
+    await mount();
+    expect(content().hidden).toBe(true);
+    expect(trigger().getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('trigger opens: content shows, aria wired, focus trapped, scroll locked', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger());
+    expect(content().hidden).toBe(false);
+    expect(trigger().getAttribute('aria-expanded')).toBe('true');
+    expect(trigger().getAttribute('aria-controls')).toBe('dr-content');
+    expect(content().contains(document.activeElement)).toBe(true);
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('Escape closes, restores focus to the trigger, releases scroll', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger());
+    await user.keyboard('{Escape}');
+    expect(content().hidden).toBe(true);
+    expect(document.activeElement).toBe(trigger());
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+
+  it('close button closes', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger());
+    await user.click(document.body.querySelector('[data-part="close"]') as HTMLElement);
+    expect(content().hidden).toBe(true);
+  });
+
+  it('pointerdown outside dismisses; the trigger toggles, not close-then-open', async () => {
+    const user = userEvent.setup();
+    await mount();
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    await user.click(trigger());
+    expect(content().hidden).toBe(false);
+    await user.click(outside);
+    expect(content().hidden).toBe(true);
+    await user.click(trigger());
+    expect(content().hidden).toBe(false);
+    await user.click(trigger());
+    expect(content().hidden).toBe(true);
+  });
+
+  it('non-modal: no scroll lock, Escape still closes', async () => {
+    const user = userEvent.setup();
+    await mount(false);
+    await user.click(trigger());
+    expect(document.body.style.overflow).not.toBe('hidden');
+    (content().querySelector('button') as HTMLElement).focus();
+    await user.keyboard('{Escape}');
+    expect(content().hidden).toBe(true);
+  });
+});

--- a/packages/ui/test/components/drawer/drawer.element.conformance.test.ts
+++ b/packages/ui/test/components/drawer/drawer.element.conformance.test.ts
@@ -88,6 +88,30 @@ describe('drawer conformance [wc]', () => {
     expect(content().hidden).toBe(true);
   });
 
+  it('Escape closes even when the close button holds the trap initial focus', async () => {
+    // Regression: the focus-trap focuses the first focusable DESCENDANT. In a
+    // bare drawer whose only focusable child is the close button, initial focus
+    // lands on data-part="close", so a target-scoped keymap would drop Escape.
+    // The bind resolves any keydown inside content as content-scoped.
+    const user = userEvent.setup();
+    document.body.innerHTML = `
+      <rafters-drawer side="bottom">
+        <button type="button" data-part="trigger" id="dr-trigger" aria-haspopup="dialog" aria-expanded="false" data-state="closed">Open</button>
+        <div data-part="overlay" id="dr-overlay" aria-hidden="true" data-state="closed" hidden></div>
+        <div data-part="content" id="dr-content" role="dialog" tabindex="-1" aria-labelledby="dr-title" data-state="closed" hidden>
+          <div id="dr-title" data-part="title" role="heading" aria-level="2">Actions</div>
+          <button type="button" data-part="close" id="dr-close" aria-label="Close">x</button>
+        </div>
+      </rafters-drawer>`;
+    await Promise.resolve();
+    await user.click(trigger());
+    // The close button is the only focusable child, so it takes initial focus.
+    expect(document.activeElement).toBe(document.body.querySelector('[data-part="close"]'));
+    await user.keyboard('{Escape}');
+    expect(content().hidden).toBe(true);
+    expect(document.activeElement).toBe(trigger());
+  });
+
   it('non-modal: no scroll lock, Escape still closes', async () => {
     const user = userEvent.setup();
     await mount(false);


### PR DESCRIPTION
## Summary

Ports `drawer` to the behavior layer as an edge-anchored dialog (archetype
`modal-overlay`), imitating the merged `dialog` reference. One behavior, three
decorators (React, Web Component, Astro), all driving the same `bindDrawer`.

- `drawer.behavior.ts` -- the score: `disclosable` + a structure-only surface
  slice + a glue projecting `role="dialog"`, `aria-modal`, labelledby/describedby,
  `aria-haspopup` and the Escape keymap. `startDrawerModalEffects` composes
  `focus-trap` + `scroll-lock` + trigger-spared `outside-click` directly (no
  effects-as-data), and `bindDrawer` is the DOM-native client the WC and Astro
  share.
- `side` (default `bottom`) is edge-only: it drives position/rounding/border
  classes and never reaches the score's ARIA or keymap.
- Enter-only. Slide/exit motion is left undeclared pending `motion-sheet-in`
  (#1899/#1902-1904); drag-to-dismiss and snap points are deferred to Presence
  (wave 0-B) and recorded with their discriminating facts in the component doc.

Touches only the `drawer` component folder, its tests, and its doc -- no shared
files, no `package.json` exports (parallel-safe, per the issue).

## Acceptance criteria mapping

### Component doc written
A full register at `docs/spec/components/drawer.md` modeled on `dialog.md`, with
composition, config/state/actions, the parts+ARIA table, keyboard, the motion
decision, WCAG obligations, and the complete oracle-disposition table.
Evidence: packages/ui/docs/spec/components/drawer.md:1

### JSDoc intelligence tags present
The `Drawer` root in the `.tsx` carries all four tags -- `@cognitive-load` with
the five-dimension breakdown (decision/information/interaction/disruption/
learning), `@attention-economics`, `@trust-building`, `@accessibility` -- which
the registry parses.
Evidence: packages/ui/src/components/drawer/drawer.tsx:73

### Behavior test (pure, no DOM)
A DOM-free suite asserts the parts, the side default and edge-independence of the
projection, the idempotence gate, and the aria/keymap tables directly over the
score.
Evidence: packages/ui/test/components/drawer/drawer.behavior.test.ts:1

### Classes parity test
A classes suite pins the view contract: depth tokens, per-edge anchoring, token
fill, the decorative handle, the touch-floor close button, and the absence of any
raw numeric enter/exit motion.
Evidence: packages/ui/test/components/drawer/drawer.classes.test.ts:1

### Conformance test via the shared harness (aria + keymap against rendered DOM)
Three conformance suites drive the same score through the shared harness against
real DOM and axe -- React, the Web Component, and Astro -- asserting the aria
projection and Escape/dismiss keymap on rendered nodes.
Evidence: packages/ui/test/components/drawer/drawer.conformance.test.tsx:76

### shadcn drop-in parity where the component exists in shadcn
The named exports mirror shadcn's drawer surface (`DrawerTrigger`,
`DrawerContent`, `DrawerHeader`, `DrawerFooter`, `DrawerTitle`,
`DrawerDescription`, `DrawerOverlay`, `DrawerPortal`, `DrawerClose`) with
controlled/uncontrolled, `modal`, `forceMount`, `container`, and the veto props.
Evidence: packages/ui/src/components/drawer/drawer.tsx:230

### `pnpm --filter @rafters/ui test:unit` green, `pnpm preflight` green
Both configs of `test:unit` pass (main suite plus the Astro config), and
`pnpm preflight` completed with exit code 0 across lint, format, typecheck, and
the workspace build.
Evidence: packages/ui/test/components/drawer/drawer.astro.conformance.test.ts:1

## Not done

- Drag-to-dismiss is deferred. The named `drag-drop` primitive is live but the
  wrong shape (`createDraggable` injects `role="button"` + `aria-grabbed` +
  `draggable="true"`, HTML5 drag events, a touch long-press, and a drop-zone
  registry -- sortable/drop-target semantics that would corrupt the dialog ARIA),
  and the follow-pointer release is exit-presence motion (wave 0-B) plus a
  raw-numeric transform the token rules prohibit. The issue marks it optional;
  dismissal stays via overlay tap, Escape, and the close button.
- Snap points are deferred: the oracle ships no snap-point behavior to extract,
  and they need the same drag gesture plus exit-presence machinery (wave 0-B).
- Enter/exit slide motion is undeclared pending the `motion-sheet-in` token
  (#1899/#1902-1904); a numeric duration now would be drift.
- Vue performance intentionally omitted (not in scope for the port sweep).

Closes #1770
