### PR TITLE
feat(ui): port alert-dialog to the behavior layer

### DIFF
--- a/packages/ui/docs/spec/components/alert-dialog.md
+++ b/packages/ui/docs/spec/components/alert-dialog.md
@@ -69,8 +69,12 @@ axe violation) never appears.
 
 ## Keyboard and effects
 
-- `keymap`: Escape on `content` -> `close`. Focus containment (the trap) makes
-  the content-scoped listener sufficient.
+- `keymap`: Escape on `content` | `cancel` | `action` -> `close`. Unlike dialog's
+  content-only listener, the keymap is widened because initial focus lands on the
+  `cancel` part (not `content`): the DOM-native bind resolves the keydown's part
+  via `closest('[data-part]')`, so a content-only listener would silently fail to
+  close when focus sits on Cancel. Escape dismisses from anywhere inside the
+  dialog (correct WCAG behavior).
 - Modal overlay pair (composed directly, always on while open):
   `createFocusTrap(content)` then focus the `cancel` part (initial focus lands
   on the safer choice, overriding the trap's first-focusable default), plus

--- a/packages/ui/docs/spec/components/alert-dialog.md
+++ b/packages/ui/docs/spec/components/alert-dialog.md
@@ -90,7 +90,7 @@ axe violation) never appears.
 | Trigger/Portal/Overlay/Content/Header/Footer/Title/Description/Cancel/Action surface | contract |
 | Escape closes | contract (moved from a document listener to the content keymap) |
 | `onEscapeKeyDown` veto prop | contract (oracle signature: native event, preventDefault to veto) |
-| asChild on Trigger/Cancel/Action/Title/Description | framework affordance (React) |
+| asChild on Trigger/Cancel/Action | framework affordance (React); Title/Description omit it, matching dialog |
 | `forceMount` | contract, with a divergence: force-mounted closed layers carry `hidden` (a closed modal must be inert to AT and must not block the page). The Presence adapter (wave 0-B) replaces this for exit animation |
 | explicit AlertDialogPortal / AlertDialogOverlay / `container` prop | contract (shadcn surface is the floor) |
 | always-set `aria-describedby` when no description | defect-do-not-port -- dangling reference; replaced by registration + empty-id convention |

--- a/packages/ui/docs/spec/components/alert-dialog.md
+++ b/packages/ui/docs/spec/components/alert-dialog.md
@@ -1,0 +1,130 @@
+# Component Spec — Alert Dialog
+
+Status: DRAFT. Modal-overlay port (wave 4). Imitates `dialog`.
+
+Alert dialog is `dialog` with three fixed divergences: it is ALWAYS modal (no
+`modal` prop), its content carries `role="alertdialog"`, and it has NO
+outside-pointerdown dismiss. It interrupts with a consequence-gated decision;
+focus defaults to Cancel, the non-destructive choice, and the layer closes only
+through Cancel, the action, or Escape. The modal overlay pair (focus-trap +
+scroll-lock) is composed DIRECTLY -- a `startAlertDialogModalEffects({ content,
+getCancel })` function in `alert-dialog.behavior.ts` starts `createFocusTrap` +
+`preventBodyScroll` on open and tears them down on close, called by both
+`bindAlertDialog` (WC/Astro) and a React `useEffect`. There is no effect list
+and, unlike dialog, no `onPointerDownOutside`/`onInteractOutside` surface.
+
+Files (`src/components/alert-dialog/`):
+
+```
+alert-dialog.classes.ts    alert-dialog.behavior.ts    alert-dialog.tsx
+alert-dialog.element.ts     alert-dialog.astro
+```
+
+Tests mirror into `test/components/alert-dialog/` across React, WC, and Astro.
+
+## Composition
+
+```
+disclosable (lib)        state {open}, actions open/close, trigger/content parts
+alert-dialog-surface     parts only: overlay, title, description, cancel, action
+alert-dialog glue        role=alertdialog, forced aria-modal, labelledby, Escape keymap
+```
+
+`disclosable` is the shared open/closed axis (dialog, popover, sheet fold it
+too). Controlled/uncontrolled per boundary 4: `config.open` is the consumer's
+controlled value, `state.open` is intrinsic, projections and gates read
+`isOpen(state, config)`. The idempotence gate (open only when effectively
+closed, close only when effectively open) makes consumer callbacks fire once per
+real transition.
+
+## Config, state, actions
+
+```ts
+type AlertDialogConfig = DisclosableConfig; // { open?; defaultOpen? } -- no modal
+interface AlertDialogState { open: boolean } // intrinsic only
+type AlertDialogActions = { open: undefined; close: undefined };
+```
+
+No `modal` prop: an alert dialog has no non-modal mode. No `toggle` action: the
+trigger dispatches `open` or `close` computed from the effective value, so
+intrinsic state can never drift from a controlled consumer.
+
+## Parts and ARIA
+
+| Part | Presence | ARIA |
+| --- | --- | --- |
+| trigger | always | `aria-haspopup="dialog"`, `aria-expanded`, `aria-controls` (only while content is in the DOM), `data-state` |
+| content | while open | `role="alertdialog"`, `aria-modal="true"` (always), `aria-labelledby`/`aria-describedby` (only when the part rendered) |
+| overlay | while open | `aria-hidden="true"`, `data-state` |
+| title | consumer renders | referenced by labelledby via registration |
+| description | consumer renders | referenced by describedby via registration |
+| cancel | consumer renders | none (plain button); receives initial focus |
+| action | consumer renders | none (plain button); carries the destructive styling |
+
+`aria-haspopup="dialog"` because there is no `alertdialog` haspopup token; it is
+what the oracle projected. Empty-id convention (ratified 2026-07-08): a binding
+passes `''` as the PartId of a part it did not render; projections emit
+`undefined` for references to empty ids, so a dangling `aria-describedby` (an
+axe violation) never appears.
+
+## Keyboard and effects
+
+- `keymap`: Escape on `content` -> `close`. Focus containment (the trap) makes
+  the content-scoped listener sufficient.
+- Modal overlay pair (composed directly, always on while open):
+  `createFocusTrap(content)` then focus the `cancel` part (initial focus lands
+  on the safer choice, overriding the trap's first-focusable default), plus
+  `preventBodyScroll`. Torn down on close/unmount; focus restore rides the trap
+  teardown (the trap captured the previously-focused element before the Cancel
+  override). There is deliberately NO outside-dismiss.
+
+## Oracle dispositions (src/old/ui/alert-dialog.tsx, boundary 9)
+
+| Oracle feature | Disposition |
+| --- | --- |
+| controlled/uncontrolled + onOpenChange | contract |
+| always modal (trap + scroll lock, no modal prop) | contract |
+| `role="alertdialog"` + `aria-modal="true"` | contract |
+| NO outside-click dismiss (intentional divergence from Dialog) | contract |
+| focus defaults to Cancel | contract (re-expressed: trap focuses first focusable, the pair overrides to `cancel`) |
+| Trigger/Portal/Overlay/Content/Header/Footer/Title/Description/Cancel/Action surface | contract |
+| Escape closes | contract (moved from a document listener to the content keymap) |
+| `onEscapeKeyDown` veto prop | contract (oracle signature: native event, preventDefault to veto) |
+| asChild on Trigger/Cancel/Action/Title/Description | framework affordance (React) |
+| `forceMount` | contract, with a divergence: force-mounted closed layers carry `hidden` (a closed modal must be inert to AT and must not block the page). The Presence adapter (wave 0-B) replaces this for exit animation |
+| explicit AlertDialogPortal / AlertDialogOverlay / `container` prop | contract (shadcn surface is the floor) |
+| always-set `aria-describedby` when no description | defect-do-not-port -- dangling reference; replaced by registration + empty-id convention |
+| `onOpenAutoFocus` / `onCloseAutoFocus` | dropped -- underscore-prefixed and never wired in the oracle; focus-to-Cancel replaces the auto-focus surface |
+| separate `AlertDialogRoot` alias + namespace object | dropped -- flat named exports only; the port ships one performance per framework |
+
+## Deltas from the oracle
+
+1. Decision-button sizing: `h-11` touch floor on both Cancel and the action.
+2. Header/footer breakpoints moved from viewport (`sm:`) to container (`@md:`)
+   per the CQ system rule; surface uses `bg-card`/`text-card-foreground`
+   (card tokens) rather than the oracle's raw `bg-background`.
+3. `tabIndex={-1}` on content so Escape works even before focus enters a child.
+
+## Motion
+
+Enter-only, mirroring dialog: the modal surface declares no enter animation
+(only `data-[state=closed]:pointer-events-none`, the ratified taste residue).
+Exit animation is gated on wave 0-B (Presence) and is not declared here.
+
+Interaction motion on the Cancel/Action buttons (the hover colour transition the
+oracle wrote as `transition-colors duration-150`) is LEFT UNDECLARED: the
+semantic motion token for it does not exist yet (the motion token layer is being
+rebuilt, #1899/#1902) and a raw numeric duration now is drift later. When
+`motion-hover` (or its equivalent) lands, the buttons should adopt it.
+
+## WCAG 2.1 AA obligations
+
+- 1.3.1/4.1.2: role alertdialog, aria-modal, labelledby/describedby wiring
+  asserted against real DOM ids by the harness.
+- 2.1.1/2.1.2 (no keyboard trap in the WCAG sense): Tab cycles inside while
+  open, Escape releases, focus restores to the trigger on close.
+- 2.4.3 Focus Order: initial focus moves to Cancel (the safer choice);
+  restoration on close is the trap executor's cleanup.
+- 2.4.7: token focus ring on both decision buttons.
+- 3.2.4: the destructive action carries consistent destructive styling so its
+  consequence is legible before the click.

--- a/packages/ui/src/components/alert-dialog/alert-dialog.astro
+++ b/packages/ui/src/components/alert-dialog/alert-dialog.astro
@@ -1,0 +1,109 @@
+---
+/**
+ * Astro performance for alert-dialog. Server-renders the full light-DOM
+ * structure with the closed-state projection already applied (correct and
+ * inert before JS), then the <script> hands each instance to bindAlertDialog --
+ * the SAME DOM-native client the Web Component uses. One score, three
+ * performances.
+ *
+ * Content stays in light DOM (present-but-hidden) so the effects the bind runs
+ * -- focus-trap, scroll-lock -- can read it. There is no outside-dismiss: an
+ * alert dialog closes only via Cancel, the action, or Escape. Exit animation
+ * waits on the Presence adapter; this is enter-only.
+ */
+import { alertDialog, type AlertDialogConfig, type AlertDialogPart } from './alert-dialog.behavior';
+import { alertDialogClasses } from './alert-dialog.classes';
+import type { PartIds } from '../../lib/contract';
+
+interface Props {
+  id: string;
+  defaultOpen?: boolean;
+  title?: string;
+  description?: string;
+  cancelLabel?: string;
+  actionLabel?: string;
+}
+
+const {
+  id,
+  defaultOpen = false,
+  title,
+  description,
+  cancelLabel = 'Cancel',
+  actionLabel = 'Continue',
+} = Astro.props;
+
+const config: AlertDialogConfig = { defaultOpen };
+const state = alertDialog.initialState(config);
+const classes = alertDialogClasses(config, state);
+
+// Optional cross-ref sources resolve to empty when their slot is absent, so
+// the score's `|| undefined` guards emit no dangling reference.
+const ids = {} as PartIds<AlertDialogPart>;
+for (const part of Object.keys(alertDialog.parts) as AlertDialogPart[]) {
+  const absent = (part === 'title' && !title) || (part === 'description' && !description);
+  ids[part] = absent ? '' : `${id}-${part}`;
+}
+const aria = alertDialog.aria(state, config, ids);
+const open = state.open;
+---
+
+<rafters-alert-dialog data-part="root" default-open={String(defaultOpen)}>
+  <button type="button" id={ids.trigger} data-part="trigger" {...aria.trigger}>
+    <slot name="trigger">Open</slot>
+  </button>
+
+  <div id={ids.overlay} data-part="overlay" class={classes.overlay} hidden={!open} {...aria.overlay}></div>
+
+  <div class={classes.container} hidden={!open}>
+    <div
+      id={ids.content}
+      data-part="content"
+      tabindex="-1"
+      class={classes.content}
+      {...aria.content}
+      hidden={!open}
+    >
+      <div class={classes.header}>
+        {
+          title && (
+            <h2
+              id={ids.title}
+              data-part="title"
+              class={classes.title}
+            >
+              {title}
+            </h2>
+          )
+        }
+        {
+          description && (
+            <div id={ids.description} data-part="description" class={classes.description}>
+              {description}
+            </div>
+          )
+        }
+      </div>
+      <slot />
+      <div class={classes.footer}>
+        <button type="button" id={ids.cancel} data-part="cancel" class={classes.cancel}>
+          <slot name="cancel">{cancelLabel}</slot>
+        </button>
+        <button type="button" id={ids.action} data-part="action" class={classes.action}>
+          <slot name="action">{actionLabel}</slot>
+        </button>
+      </div>
+    </div>
+  </div>
+</rafters-alert-dialog>
+
+<script>
+  import { bindAlertDialog } from './alert-dialog.behavior';
+
+  for (const root of document.querySelectorAll('rafters-alert-dialog[data-part="root"]')) {
+    const el = root as HTMLElement;
+    if (el.dataset['bound'] === 'true') continue;
+    el.dataset['bound'] = 'true';
+    bindAlertDialog(el);
+  }
+</script>

--- a/packages/ui/src/components/alert-dialog/alert-dialog.behavior.ts
+++ b/packages/ui/src/components/alert-dialog/alert-dialog.behavior.ts
@@ -1,0 +1,262 @@
+import { compose, type GlueSlice, type Slice } from '../../lib/compose';
+import {
+  createBehavior,
+  type AriaAttrs,
+  type BehaviorSpec,
+  type PartIds,
+} from '../../lib/contract';
+import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap';
+import {
+  disclosable,
+  isOpen,
+  type DisclosableActions,
+  type DisclosableConfig,
+  type DisclosablePart,
+  type DisclosableState,
+} from '../../lib/disclosable';
+
+/**
+ * Alert dialog: a consequence-gated confirm dialog. It is dialog with three
+ * fixed differences -- ALWAYS modal (no `modal` prop), `role="alertdialog"`,
+ * and NO outside-pointerdown dismiss. The user must choose Cancel or the
+ * action; the layer never closes from an errant click outside it.
+ */
+export type AlertDialogConfig = DisclosableConfig;
+
+export type AlertDialogState = DisclosableState;
+export type AlertDialogActions = DisclosableActions;
+
+export type AlertDialogSurfacePart = 'overlay' | 'title' | 'description' | 'cancel' | 'action';
+export type AlertDialogPart = DisclosablePart | AlertDialogSurfacePart;
+
+export { isOpen };
+
+/** Structure-only slice: the parts an alert dialog has beyond the disclosable
+ *  trigger/content pair. Contributes no state and no actions. cancel and action
+ *  are the two decision buttons (there is no close affordance). */
+const alertDialogSurface: Slice<
+  AlertDialogConfig,
+  Record<never, never>,
+  Record<never, never>,
+  AlertDialogSurfacePart
+> = {
+  name: 'alert-dialog-surface',
+  parts: {
+    overlay: { optional: true },
+    title: { optional: true },
+    description: { optional: true },
+    cancel: { optional: true },
+    action: { optional: true },
+  },
+  initialState: () => ({}),
+};
+
+/** The alert-dialog glue: ARIA identity and the Escape contract, written over
+ *  the merged state. `role="alertdialog"` and the forced `aria-modal="true"`
+ *  are the fixed divergences from dialog. The modal overlay concerns
+ *  (focus-trap, scroll-lock) are composed directly by the bindings; there is
+ *  deliberately no outside-dismiss. */
+const alertDialogGlue: GlueSlice<
+  AlertDialogConfig,
+  AlertDialogState,
+  { close: undefined },
+  AlertDialogPart
+> = {
+  kind: 'glue',
+  name: 'alert-dialog',
+  aria: (state, config, ids) => {
+    const open = isOpen(state, config);
+    return {
+      trigger: {
+        // No `alertdialog` haspopup token exists; `dialog` is the closest and
+        // is what the oracle projected.
+        'aria-haspopup': 'dialog',
+      },
+      content: {
+        role: 'alertdialog',
+        // Always modal -- an alert dialog has no non-modal mode.
+        'aria-modal': 'true',
+        // An empty id means the binding did not render that part; a reference
+        // to a missing id is an axe violation, so project absence.
+        'aria-labelledby': ids.title || undefined,
+        'aria-describedby': ids.description || undefined,
+      },
+      overlay: {
+        'aria-hidden': 'true',
+        'data-state': open ? 'open' : 'closed',
+      },
+    };
+  },
+  // Escape dismisses from anywhere inside the surface. Focus defaults to Cancel
+  // (a part-bearing button), so the DOM-native bind resolves the innermost part
+  // as `cancel`/`action`, not `content`; mapping all three keeps Escape working
+  // whichever focusable holds focus. The trigger sits outside the surface and is
+  // deliberately excluded.
+  keymap: (event, _state, part) =>
+    event.key === 'Escape' && (part === 'content' || part === 'cancel' || part === 'action')
+      ? 'close'
+      : null,
+};
+
+/** The parts the modal overlay pair composes against. */
+export interface AlertDialogModalPorts {
+  /** The dialog surface: focus is trapped inside it. */
+  content: HTMLElement;
+  /** Resolves the Cancel button so initial focus lands on the safer choice
+   *  (the earned alert-dialog semantic) rather than the first focusable. */
+  getCancel: () => HTMLElement | null;
+}
+
+/**
+ * The modal overlay pair, composed directly: trap Tab focus inside `content`
+ * and lock body scroll. Then default focus to Cancel -- the trap focuses the
+ * first focusable on entry, and this override moves it to the safer choice.
+ * There is NO outside-dismiss: an alert dialog closes only through an explicit
+ * decision. Level-triggered: BOTH the DOM-native bindAlertDialog and the React
+ * AlertDialogContent start this on the open transition and call the returned
+ * cleanup on close/unmount. Focus restore rides the trap teardown (the trap
+ * captured the previously-focused element before the Cancel override), so the
+ * cleanup releases LIFO.
+ */
+export function startAlertDialogModalEffects({
+  content,
+  getCancel,
+}: AlertDialogModalPorts): () => void {
+  const releaseTrap = createFocusTrap(content);
+  const releaseScroll = preventBodyScroll();
+  // Earned semantic: focus defaults to Cancel, the non-destructive choice.
+  getCancel()?.focus();
+  return () => {
+    releaseScroll();
+    releaseTrap();
+  };
+}
+
+export const alertDialog: BehaviorSpec<
+  AlertDialogConfig,
+  AlertDialogState,
+  AlertDialogActions,
+  AlertDialogPart
+> = compose('alert-dialog', disclosable<AlertDialogConfig>(), alertDialogSurface, alertDialogGlue);
+
+/**
+ * The DOM-native binding of the alert-dialog score -- the client the Web
+ * Component and the Astro <script> both import; only React reads the
+ * projections declaratively. Same shape as bindDialog, minus the `modal`
+ * axis (always modal) and minus outside-dismiss: PRESENCE (content/overlay are
+ * present-but-hidden, toggled on the open axis so the trap's activeElement read
+ * works) plus the modal overlay pair (focus-trap, scroll-lock), composed
+ * directly and level-triggered -- started on the open transition and torn down
+ * on close/unbind. Enter-only; exit animation waits on Presence.
+ */
+export function bindAlertDialog(root: HTMLElement): () => void {
+  const config: AlertDialogConfig = {
+    defaultOpen:
+      root.getAttribute('default-open') === 'true' ||
+      root.querySelector<HTMLElement>('[data-part="content"]')?.dataset['state'] === 'open',
+  };
+
+  const getPart = (part: string): HTMLElement | null =>
+    part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
+
+  const { memory, dispatch } = createBehavior(alertDialog, config);
+
+  const request = (action: keyof AlertDialogActions): boolean => dispatch(action, config);
+
+  // The modal overlay pair is level-triggered: present only while open.
+  // render() starts it on the transition and this cleanup stops it on close.
+  let modalCleanup: (() => void) | null = null;
+
+  // ids READ from the server/author markup, never generated.
+  const ids = {} as PartIds<AlertDialogPart>;
+  for (const part of Object.keys(alertDialog.parts) as AlertDialogPart[]) {
+    ids[part] = getPart(part)?.id ?? '';
+  }
+
+  // The projection is already resolved, so apply it raw (validate:false skips
+  // aria-manager's author-input coercion that flips the string 'false').
+  const applyProjection = (el: HTMLElement, attrs: AriaAttrs) => {
+    for (const [name, value] of Object.entries(attrs)) {
+      updateAriaAttribute(el, name as never, value as never, { validate: false });
+    }
+  };
+
+  const render = () => {
+    const state = memory.get();
+    const open = isOpen(state, config);
+    const projection = alertDialog.aria(state, config, ids);
+    for (const part of Object.keys(projection) as AlertDialogPart[]) {
+      const attrs = projection[part];
+      const el = getPart(part);
+      if (el && attrs) applyProjection(el, attrs);
+    }
+    // Presence: the overlay and the content container hide off the open axis.
+    // The parts stay in light DOM (crawlable, and the trap can read them).
+    for (const part of ['overlay', 'content'] as const) {
+      const el = getPart(part);
+      if (el) el.hidden = !open;
+    }
+    // Compose the modal overlay pair directly, level-triggered: start it once
+    // on the open transition (content is now un-hidden above so the trap can
+    // read its focusables), tear it down when it should no longer be present.
+    if (open && !modalCleanup) {
+      const content = getPart('content');
+      if (content) {
+        modalCleanup = startAlertDialogModalEffects({
+          content,
+          getCancel: () => getPart('cancel'),
+        });
+      }
+    } else if (!open && modalCleanup) {
+      modalCleanup();
+      modalCleanup = null;
+    }
+  };
+  const unsubscribe = memory.subscribe(render); // fires immediately: first paint
+
+  const onClick = (event: Event) => {
+    const target = event.target as HTMLElement;
+    // Both decision buttons close; there is no separate close affordance.
+    if (target.closest('[data-part="cancel"]') || target.closest('[data-part="action"]')) {
+      request('close');
+      return;
+    }
+    if (target.closest('[data-part="trigger"]')) {
+      request(isOpen(memory.get(), config) ? 'close' : 'open');
+    }
+  };
+  root.addEventListener('click', onClick);
+
+  const onKeydown = (event: KeyboardEvent) => {
+    const partEl = (event.target as HTMLElement).closest<HTMLElement>('[data-part]');
+    const part = partEl?.dataset['part'] as AlertDialogPart | undefined;
+    if (!part) return;
+    const action = alertDialog.keymap(
+      {
+        key: event.key,
+        shiftKey: event.shiftKey,
+        ctrlKey: event.ctrlKey,
+        altKey: event.altKey,
+        metaKey: event.metaKey,
+      },
+      memory.get(),
+      part,
+      config,
+    );
+    if (!action) return;
+    event.preventDefault();
+    const trigger = getPart('trigger');
+    request(action);
+    if (action === 'close') trigger?.focus();
+  };
+  root.addEventListener('keydown', onKeydown);
+
+  return () => {
+    unsubscribe();
+    modalCleanup?.();
+    modalCleanup = null;
+    root.removeEventListener('click', onClick);
+    root.removeEventListener('keydown', onKeydown);
+  };
+}

--- a/packages/ui/src/components/alert-dialog/alert-dialog.classes.ts
+++ b/packages/ui/src/components/alert-dialog/alert-dialog.classes.ts
@@ -1,0 +1,65 @@
+import type { AlertDialogConfig, AlertDialogState } from './alert-dialog.behavior';
+
+export interface AlertDialogClassSet {
+  overlay: string;
+  container: string;
+  content: string;
+  header: string;
+  footer: string;
+  title: string;
+  description: string;
+  action: string;
+  cancel: string;
+}
+
+const overlayClasses = 'fixed inset-0 z-depth-overlay bg-foreground/80';
+
+const containerClasses = 'fixed inset-0 z-depth-modal flex items-center justify-center p-4';
+
+// data-[state=closed]:pointer-events-none -- the ratified motion ruling's taste
+// residue: while a closing overlay is held present through its exit window
+// (usePresence defers the unmount), it must not swallow clicks. Mirrors dialog;
+// enter animation stays undeclared until the motion token layer (#1902) lands.
+const contentClasses =
+  'relative grid w-full max-w-lg gap-4 rounded-lg border border-card-border bg-card p-6 text-card-foreground shadow-lg ' +
+  'data-[state=closed]:pointer-events-none';
+
+const headerClasses = 'flex flex-col space-y-2 text-center @md:text-left';
+
+const footerClasses = 'flex flex-col-reverse @md:flex-row @md:justify-end @md:space-x-2';
+
+const titleClasses = 'text-title-medium leading-none';
+
+const descriptionClasses = 'text-body-small text-muted-foreground';
+
+// Interaction motion (hover/focus color transition) is deliberately undeclared:
+// the semantic motion token for it does not exist yet (#1902) and a raw numeric
+// duration is drift. Colour, ring and disabled states are token-based.
+const actionClasses =
+  'inline-flex h-11 items-center justify-center rounded-md bg-destructive px-4 py-2 ' +
+  'text-label-medium text-destructive-foreground ring-offset-background ' +
+  'hover:bg-destructive/90 focus-visible:outline-none focus-visible:ring-2 ' +
+  'focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50';
+
+const cancelClasses =
+  'mt-2 inline-flex h-11 items-center justify-center rounded-md border border-input bg-card px-4 py-2 ' +
+  'text-label-medium ring-offset-background hover:bg-accent hover:text-accent-foreground ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ' +
+  'disabled:pointer-events-none disabled:opacity-50 @md:mt-0';
+
+export function alertDialogClasses(
+  _config: AlertDialogConfig,
+  _state: AlertDialogState,
+): AlertDialogClassSet {
+  return {
+    overlay: overlayClasses,
+    container: containerClasses,
+    content: contentClasses,
+    header: headerClasses,
+    footer: footerClasses,
+    title: titleClasses,
+    description: descriptionClasses,
+    action: actionClasses,
+    cancel: cancelClasses,
+  };
+}

--- a/packages/ui/src/components/alert-dialog/alert-dialog.element.ts
+++ b/packages/ui/src/components/alert-dialog/alert-dialog.element.ts
@@ -1,0 +1,27 @@
+/**
+ * WC performance for alert-dialog: the thinnest wrapper. The score AND the
+ * DOM-native binding (bindAlertDialog) live in alert-dialog.behavior.ts, shared
+ * with the Astro performance. This file only adapts that binding to the
+ * custom-element lifecycle -- deferring the bind one microtask because
+ * connectedCallback can fire before the light-DOM parts are parsed.
+ */
+import { bindAlertDialog } from './alert-dialog.behavior';
+
+export class RaftersAlertDialog extends HTMLElement {
+  private teardown: (() => void) | null = null;
+
+  connectedCallback(): void {
+    queueMicrotask(() => {
+      if (this.isConnected && !this.teardown) this.teardown = bindAlertDialog(this);
+    });
+  }
+
+  disconnectedCallback(): void {
+    this.teardown?.();
+    this.teardown = null;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-alert-dialog')) {
+  customElements.define('rafters-alert-dialog', RaftersAlertDialog);
+}

--- a/packages/ui/src/components/alert-dialog/alert-dialog.tsx
+++ b/packages/ui/src/components/alert-dialog/alert-dialog.tsx
@@ -1,0 +1,439 @@
+/**
+ * Alert dialog: a consequence-gated confirm dialog for destructive or
+ * irreversible actions. It interrupts with a decision, traps focus, defaults
+ * focus to Cancel (the safer choice), and -- unlike Dialog -- never dismisses
+ * on an outside click. The user must choose.
+ *
+ * @cognitive-load 7/10 - high extraneous load: the dialog seizes the whole
+ *   viewport and forces a decision before any other interaction resumes;
+ *   intrinsic load is low (two choices), germane load is the consequence the
+ *   description spells out; working-memory cost is a single held question;
+ *   decision reversibility is the point (Cancel is always the escape hatch).
+ * @attention-economics Full-capture interrupt: the overlay and forced-modal
+ *   trap collapse the attention field to one decision. Reserve it for stakes
+ *   that justify blocking; routine confirmations belong elsewhere.
+ * @trust-building Focus defaults to Cancel so the reflexive Enter/Space keeps
+ *   the user safe; the action button carries the destructive styling so the
+ *   consequence is legible before the click; Escape offers a safe exit.
+ * @accessibility role="alertdialog" with aria-modal, aria-labelledby/
+ *   describedby wiring, a focus trap, and Escape-to-close with focus restored
+ *   to the trigger.
+ */
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import { createBehavior, type AriaAttrs, type PartIds } from '../../lib/contract';
+import { keyInputOf } from '../../hooks/key-input';
+import { useMemory } from '../../hooks/use-memory';
+import { usePresence } from '../../hooks/use-presence';
+import classy from '../../primitives/classy';
+import { mergeProps } from '../../primitives/slot';
+import {
+  alertDialog,
+  isOpen,
+  startAlertDialogModalEffects,
+  type AlertDialogActions,
+  type AlertDialogConfig,
+  type AlertDialogPart,
+  type AlertDialogState,
+} from './alert-dialog.behavior';
+import { alertDialogClasses, type AlertDialogClassSet } from './alert-dialog.classes';
+
+interface AlertDialogContextValue {
+  state: AlertDialogState;
+  ids: PartIds<AlertDialogPart>;
+  aria: Partial<Record<AlertDialogPart, AriaAttrs>>;
+  request: (action: keyof AlertDialogActions) => boolean;
+  setPart: (part: AlertDialogPart) => (element: HTMLElement | null) => void;
+  getPart: (part: string) => HTMLElement | null;
+  config: AlertDialogConfig;
+  effectiveOpen: boolean;
+  classes: AlertDialogClassSet;
+}
+
+const AlertDialogContext = React.createContext<AlertDialogContextValue | null>(null);
+
+function useAlertDialogContext(component: string): AlertDialogContextValue {
+  const context = React.useContext(AlertDialogContext);
+  if (!context) {
+    throw new Error(`${component} must be used within <AlertDialog>`);
+  }
+  return context;
+}
+
+/** True when rendering inside an explicit <AlertDialogPortal> (Radix-style
+ *  composition); AlertDialogContent then skips its automatic portal + overlay. */
+const AlertDialogPortalContext = React.createContext(false);
+
+export interface AlertDialogProps {
+  children: React.ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function AlertDialog({
+  children,
+  open,
+  defaultOpen = false,
+  onOpenChange,
+}: AlertDialogProps) {
+  const config: AlertDialogConfig = { open, defaultOpen };
+
+  // The controller composes the score with the substrate -- no useBehavior.
+  const { memory, dispatch } = React.useMemo(() => createBehavior(alertDialog, config), []);
+  const state = useMemory(memory);
+  const effectiveOpen = isOpen(state, config);
+
+  const uid = React.useId();
+
+  // Content portals to document.body with a unique id, so getPart resolves by
+  // id -- no ref registry. Optional parts still need a mount signal (setPart)
+  // purely so an omitted description projects no dangling aria-describedby.
+  const [presentParts, setPresentParts] = React.useState<ReadonlySet<string>>(new Set());
+  const partCallbacks = React.useRef<Map<string, (el: HTMLElement | null) => void>>(new Map());
+  const setPart = React.useCallback((part: AlertDialogPart) => {
+    let callback = partCallbacks.current.get(part);
+    if (!callback) {
+      callback = (element: HTMLElement | null) =>
+        setPresentParts((previous) => {
+          const present = element !== null;
+          if (previous.has(part) === present) return previous;
+          const next = new Set(previous);
+          if (present) next.add(part);
+          else next.delete(part);
+          return next;
+        });
+      partCallbacks.current.set(part, callback);
+    }
+    return callback;
+  }, []);
+  const getPart = React.useCallback(
+    (part: string): HTMLElement | null =>
+      typeof document === 'undefined' ? null : document.getElementById(`${uid}-${part}`),
+    [uid],
+  );
+
+  // title and description are the UNGUARDED cross-ref sources (labelledby/
+  // describedby have no `open` guard, unlike aria-controls), so an absent one
+  // must resolve to an empty id. Every other part keeps a stable id -- content
+  // especially, since the focus-trap effect finds it by id.
+  const ids = React.useMemo(() => {
+    const out = {} as PartIds<AlertDialogPart>;
+    for (const part of Object.keys(alertDialog.parts) as AlertDialogPart[]) {
+      const crossRefSource = part === 'title' || part === 'description';
+      out[part] = crossRefSource && !presentParts.has(part) ? '' : `${uid}-${part}`;
+    }
+    return out;
+  }, [uid, presentParts]);
+
+  const latest = React.useRef({ config, onOpenChange });
+  latest.current = { config, onOpenChange };
+  const request = React.useCallback(
+    (action: keyof AlertDialogActions): boolean => {
+      const { config: cfg, onOpenChange: cb } = latest.current;
+      if (!dispatch(action, cfg)) return false;
+      cb?.(action === 'open');
+      return true;
+    },
+    [dispatch],
+  );
+
+  const aria = alertDialog.aria(state, config, ids);
+
+  const contextValue: AlertDialogContextValue = {
+    state,
+    ids,
+    aria,
+    request,
+    setPart,
+    getPart,
+    config,
+    effectiveOpen,
+    classes: alertDialogClasses(config, state),
+  };
+
+  return <AlertDialogContext.Provider value={contextValue}>{children}</AlertDialogContext.Provider>;
+}
+
+export interface AlertDialogPortalProps {
+  children: React.ReactNode;
+  /** Portal target; defaults to document.body. */
+  container?: HTMLElement | null;
+  forceMount?: boolean;
+}
+
+export function AlertDialogPortal({ children, container, forceMount }: AlertDialogPortalProps) {
+  const { effectiveOpen } = useAlertDialogContext('AlertDialogPortal');
+  if (!(forceMount || effectiveOpen)) return null;
+  if (typeof document === 'undefined') return null;
+  return createPortal(
+    <AlertDialogPortalContext.Provider value={true}>{children}</AlertDialogPortalContext.Provider>,
+    container ?? document.body,
+  );
+}
+
+export interface AlertDialogOverlayProps extends React.HTMLAttributes<HTMLDivElement> {
+  forceMount?: boolean | undefined;
+}
+
+export function AlertDialogOverlay({ forceMount, className, ...props }: AlertDialogOverlayProps) {
+  const { effectiveOpen, ids, aria, classes, setPart } =
+    useAlertDialogContext('AlertDialogOverlay');
+  if (!(forceMount || effectiveOpen)) return null;
+  return (
+    <div
+      data-part="overlay"
+      id={ids.overlay || undefined}
+      ref={setPart('overlay')}
+      // A force-mounted closed overlay must not cover the page.
+      hidden={effectiveOpen ? undefined : true}
+      className={classy(classes.overlay, className)}
+      {...aria.overlay}
+      {...props}
+    />
+  );
+}
+
+export interface AlertDialogContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  forceMount?: boolean;
+  /** Portal target for the automatic portal; defaults to document.body. */
+  container?: HTMLElement | null;
+  /** Consumer veto: called before Escape closes; preventDefault to keep open. */
+  onEscapeKeyDown?: (event: KeyboardEvent) => void;
+}
+
+export function AlertDialogContent({
+  forceMount,
+  container,
+  onEscapeKeyDown,
+  className,
+  children,
+  onKeyDown,
+  ...props
+}: AlertDialogContentProps) {
+  const { config, state, effectiveOpen, ids, aria, classes, request, getPart } =
+    useAlertDialogContext('AlertDialogContent');
+  const isInsidePortal = React.useContext(AlertDialogPortalContext);
+  // Presence (wave 0-B): keep the content mounted through its exit animation.
+  // With no exit animation it releases immediately, so behavior is unchanged.
+  const { present, ref: presenceRef } = usePresence(effectiveOpen);
+
+  // The modal overlay pair, composed directly on the open transition (replacing
+  // the effects runner). Level-triggered via the dependency array; the cleanup
+  // tears the pair down (focus restore rides the trap teardown). Always modal.
+  React.useEffect(() => {
+    if (!effectiveOpen) return;
+    const content = getPart('content');
+    if (!content) return;
+    return startAlertDialogModalEffects({
+      content,
+      getCancel: () => getPart('cancel'),
+    });
+  }, [effectiveOpen, getPart]);
+
+  if (!(forceMount || present)) return null;
+  if (typeof document === 'undefined') return null;
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    onKeyDown?.(event);
+    if (event.defaultPrevented) return;
+    const action = alertDialog.keymap(keyInputOf(event), state, 'content', config);
+    if (!action) return;
+    if (action === 'close') {
+      onEscapeKeyDown?.(event.nativeEvent);
+      if (event.nativeEvent.defaultPrevented) return;
+    }
+    event.preventDefault();
+    request(action);
+  };
+
+  const content = (
+    // forceMount keeps the nodes for animation tooling; a closed modal must
+    // still be invisible to AT, untabbable, and must not block the page --
+    // hidden on the fixed-position container covers all three.
+    <div className={classes.container} hidden={present ? undefined : true}>
+      <div
+        data-part="content"
+        id={ids.content || undefined}
+        ref={presenceRef}
+        tabIndex={-1}
+        className={classy(classes.content, className)}
+        {...aria.content}
+        onKeyDown={handleKeyDown}
+        {...props}
+      >
+        {children}
+      </div>
+    </div>
+  );
+
+  // Inside an explicit <AlertDialogPortal>: the consumer owns portal + overlay.
+  if (isInsidePortal) return content;
+
+  // shadcn-style: Content brings its own portal and overlay (always modal).
+  return createPortal(
+    <>
+      <AlertDialogOverlay forceMount={forceMount} />
+      {content}
+    </>,
+    container ?? document.body,
+  );
+}
+
+export type AlertDialogHeaderProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function AlertDialogHeader({ className, ...props }: AlertDialogHeaderProps) {
+  const { classes } = useAlertDialogContext('AlertDialogHeader');
+  return <div className={classy(classes.header, className)} {...props} />;
+}
+
+export type AlertDialogFooterProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function AlertDialogFooter({ className, ...props }: AlertDialogFooterProps) {
+  const { classes } = useAlertDialogContext('AlertDialogFooter');
+  return <div className={classy(classes.footer, className)} {...props} />;
+}
+
+export type AlertDialogTitleProps = React.HTMLAttributes<HTMLHeadingElement>;
+
+export function AlertDialogTitle({ className, ...props }: AlertDialogTitleProps) {
+  const { ids, classes, setPart } = useAlertDialogContext('AlertDialogTitle');
+  return (
+    <h2
+      data-part="title"
+      id={ids.title || undefined}
+      ref={setPart('title')}
+      className={classy(classes.title, className)}
+      {...props}
+    />
+  );
+}
+
+export type AlertDialogDescriptionProps = React.HTMLAttributes<HTMLParagraphElement>;
+
+export function AlertDialogDescription({ className, ...props }: AlertDialogDescriptionProps) {
+  const { ids, classes, setPart } = useAlertDialogContext('AlertDialogDescription');
+  return (
+    <p
+      data-part="description"
+      id={ids.description || undefined}
+      ref={setPart('description')}
+      className={classy(classes.description, className)}
+      {...props}
+    />
+  );
+}
+
+export interface AlertDialogActionProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+}
+
+export function AlertDialogAction({
+  asChild,
+  onClick,
+  className,
+  children,
+  ...props
+}: AlertDialogActionProps) {
+  const { ids, classes, request, setPart } = useAlertDialogContext('AlertDialogAction');
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    request('close');
+  };
+
+  const partProps = {
+    'data-part': 'action',
+    id: ids.action,
+    ref: setPart('action'),
+    className: classy(classes.action, className),
+    onClick: handleClick,
+  };
+
+  if (asChild && React.isValidElement(children)) {
+    const childProps = children.props as Record<string, unknown>;
+    return React.cloneElement(children, mergeProps(partProps, childProps) as React.Attributes);
+  }
+
+  return (
+    <button type="button" {...partProps} {...props}>
+      {children}
+    </button>
+  );
+}
+
+export interface AlertDialogCancelProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+}
+
+export function AlertDialogCancel({
+  asChild,
+  onClick,
+  className,
+  children,
+  ...props
+}: AlertDialogCancelProps) {
+  const { ids, classes, request, setPart } = useAlertDialogContext('AlertDialogCancel');
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    request('close');
+  };
+
+  const partProps = {
+    'data-part': 'cancel',
+    id: ids.cancel,
+    ref: setPart('cancel'),
+    className: classy(classes.cancel, className),
+    onClick: handleClick,
+  };
+
+  if (asChild && React.isValidElement(children)) {
+    const childProps = children.props as Record<string, unknown>;
+    return React.cloneElement(children, mergeProps(partProps, childProps) as React.Attributes);
+  }
+
+  return (
+    <button type="button" {...partProps} {...props}>
+      {children}
+    </button>
+  );
+}
+
+export interface AlertDialogTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+}
+
+export function AlertDialogTrigger({
+  asChild,
+  onClick,
+  children,
+  ...props
+}: AlertDialogTriggerProps) {
+  const { effectiveOpen, ids, aria, request, setPart } =
+    useAlertDialogContext('AlertDialogTrigger');
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    request(effectiveOpen ? 'close' : 'open');
+  };
+
+  const partProps = {
+    'data-part': 'trigger',
+    id: ids.trigger,
+    ref: setPart('trigger'),
+    ...aria.trigger,
+    onClick: handleClick,
+  };
+
+  if (asChild && React.isValidElement(children)) {
+    const childProps = children.props as Record<string, unknown>;
+    return React.cloneElement(children, mergeProps(partProps, childProps) as React.Attributes);
+  }
+
+  return (
+    <button type="button" {...partProps} {...props}>
+      {children}
+    </button>
+  );
+}

--- a/packages/ui/test/components/alert-dialog/alert-dialog.astro.conformance.test.ts
+++ b/packages/ui/test/components/alert-dialog/alert-dialog.astro.conformance.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Astro performance of the alert-dialog score, driven end to end. AstroContainer
+ * renders the SSR markup but does NOT run the <script>, so the test binds
+ * bindAlertDialog directly -- that IS the script's job -- then drives the same
+ * score the React and WC performances drive. One score, three performances.
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import AlertDialog from '../../../src/components/alert-dialog/alert-dialog.astro';
+import { bindAlertDialog } from '../../../src/components/alert-dialog/alert-dialog.behavior';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+async function mount(
+  props: Record<string, unknown> = {},
+  slots: Record<string, string> = {},
+): Promise<HTMLElement> {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(AlertDialog, { props: { id: 'a', ...props }, slots });
+  document.body.innerHTML = html;
+  const root = document.body.querySelector('rafters-alert-dialog') as HTMLElement;
+  bindAlertDialog(root); // the <script> does this per instance on the real page
+  return root;
+}
+
+const trigger = () => document.body.querySelector<HTMLElement>('[data-part="trigger"]')!;
+const content = () => document.body.querySelector<HTMLElement>('[data-part="content"]')!;
+const cancel = () => document.body.querySelector<HTMLElement>('[data-part="cancel"]')!;
+
+describe('alert-dialog conformance [astro]', () => {
+  it('SSR closed: content hidden and crawlable, trigger collapsed', async () => {
+    await mount({ title: 'Are you sure?' });
+    expect(content().hidden).toBe(true);
+    expect(trigger().getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('SSR content is an alertdialog, always modal; aria wired by real ids', async () => {
+    await mount({ title: 'Are you sure?' });
+    expect(content().getAttribute('role')).toBe('alertdialog');
+    expect(content().getAttribute('aria-modal')).toBe('true');
+    expect(content().getAttribute('aria-labelledby')).toBe('a-title');
+  });
+
+  it('omitted description projects no aria-describedby', async () => {
+    await mount({ title: 'Are you sure?' });
+    expect(content().hasAttribute('aria-describedby')).toBe(false);
+  });
+
+  it('bind: trigger opens, focus lands on Cancel, scroll locked; Escape closes + restores focus', async () => {
+    const user = userEvent.setup();
+    await mount({ title: 'Are you sure?' });
+    await user.click(trigger());
+    expect(content().hidden).toBe(false);
+    expect(document.activeElement).toBe(cancel());
+    expect(document.body.style.overflow).toBe('hidden');
+    await user.keyboard('{Escape}');
+    expect(content().hidden).toBe(true);
+    expect(document.activeElement).toBe(trigger());
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+
+  it('an outside pointerdown does NOT dismiss', async () => {
+    const user = userEvent.setup();
+    await mount({ title: 'Are you sure?' });
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    await user.click(trigger());
+    expect(content().hidden).toBe(false);
+    await user.click(outside);
+    expect(content().hidden).toBe(false);
+  });
+});

--- a/packages/ui/test/components/alert-dialog/alert-dialog.behavior.test.ts
+++ b/packages/ui/test/components/alert-dialog/alert-dialog.behavior.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import { createBehavior, type PartIds } from '../../../src/lib/contract';
+import {
+  alertDialog,
+  isOpen,
+  type AlertDialogConfig,
+  type AlertDialogPart,
+} from '../../../src/components/alert-dialog/alert-dialog.behavior';
+
+const ids: PartIds<AlertDialogPart> = {
+  trigger: 't',
+  content: 'c',
+  overlay: 'o',
+  title: 'ti',
+  description: 'd',
+  cancel: 'ca',
+  action: 'ac',
+};
+
+const closed: AlertDialogConfig = {};
+const openUncontrolled: AlertDialogConfig = { defaultOpen: true };
+
+function ariaAt(config: AlertDialogConfig, partIds: PartIds<AlertDialogPart> = ids) {
+  return alertDialog.aria(alertDialog.initialState(config), config, partIds);
+}
+
+describe('alert-dialog parts', () => {
+  it('declares the full surface with cancel/action and no close', () => {
+    expect(Object.keys(alertDialog.parts).sort()).toEqual([
+      'action',
+      'cancel',
+      'content',
+      'description',
+      'overlay',
+      'title',
+      'trigger',
+    ]);
+    expect(alertDialog.parts.content.optional).toBe(true);
+    expect(alertDialog.parts.trigger.optional).toBeUndefined();
+    expect(alertDialog.parts.cancel.optional).toBe(true);
+    expect(alertDialog.parts.action.optional).toBe(true);
+  });
+});
+
+describe('alert-dialog state: controlled vs intrinsic', () => {
+  it('seeds intrinsic open from defaultOpen', () => {
+    expect(alertDialog.initialState({ defaultOpen: true }).open).toBe(true);
+    expect(alertDialog.initialState({}).open).toBe(false);
+  });
+
+  it('controlled config shadows intrinsic state', () => {
+    const state = alertDialog.initialState({});
+    expect(isOpen(state, { open: true })).toBe(true);
+    expect(isOpen({ open: true }, { open: false })).toBe(false);
+    expect(isOpen({ open: true }, {})).toBe(true);
+  });
+});
+
+describe('alert-dialog canDispatch (idempotence gate)', () => {
+  it('open only when effectively closed, close only when effectively open', () => {
+    const state = alertDialog.initialState(closed);
+    expect(alertDialog.canDispatch(state, 'open', closed)).toBe(true);
+    expect(alertDialog.canDispatch(state, 'close', closed)).toBe(false);
+
+    const openState = { open: true };
+    expect(alertDialog.canDispatch(openState, 'open', closed)).toBe(false);
+    expect(alertDialog.canDispatch(openState, 'close', closed)).toBe(true);
+  });
+
+  it('gates on the CONTROLLED value when present', () => {
+    const drifted = { open: false };
+    expect(alertDialog.canDispatch(drifted, 'close', { open: true })).toBe(true);
+    expect(alertDialog.canDispatch(drifted, 'open', { open: true })).toBe(false);
+  });
+});
+
+describe('alert-dialog actions', () => {
+  it('open and close move intrinsic state through dispatch', () => {
+    const { memory, dispatch } = createBehavior(alertDialog, closed);
+    expect(dispatch('open', closed)).toBe(true);
+    expect(memory.get().open).toBe(true);
+    expect(dispatch('open', closed)).toBe(false);
+    expect(dispatch('close', closed)).toBe(true);
+    expect(memory.get().open).toBe(false);
+  });
+});
+
+describe('alert-dialog aria projection', () => {
+  it('closed: trigger collapsed, no dangling aria-controls', () => {
+    const aria = ariaAt(closed);
+    expect(aria.trigger).toEqual({
+      'aria-expanded': 'false',
+      'aria-controls': undefined,
+      'data-state': 'closed',
+      'aria-haspopup': 'dialog',
+    });
+  });
+
+  it('open: trigger expanded and wired to content', () => {
+    const aria = ariaAt(openUncontrolled);
+    expect(aria.trigger?.['aria-expanded']).toBe('true');
+    expect(aria.trigger?.['aria-controls']).toBe('c');
+    expect(aria.trigger?.['data-state']).toBe('open');
+  });
+
+  it('content: role alertdialog, ALWAYS modal, labelled and described', () => {
+    const aria = ariaAt(openUncontrolled);
+    expect(aria.content).toEqual({
+      role: 'alertdialog',
+      'aria-modal': 'true',
+      'aria-labelledby': 'ti',
+      'aria-describedby': 'd',
+      'data-state': 'open',
+    });
+  });
+
+  it('has no non-modal escape hatch: aria-modal stays true even if a modal flag is smuggled in', () => {
+    const aria = ariaAt({ ...openUncontrolled, modal: false } as AlertDialogConfig);
+    expect(aria.content?.['aria-modal']).toBe('true');
+  });
+
+  it('empty part ids project ABSENT references, never dangling ones', () => {
+    const aria = ariaAt(openUncontrolled, { ...ids, title: '', description: '' });
+    expect(aria.content?.['aria-labelledby']).toBeUndefined();
+    expect(aria.content?.['aria-describedby']).toBeUndefined();
+  });
+
+  it('overlay is presentation only', () => {
+    const aria = ariaAt(openUncontrolled);
+    expect(aria.overlay).toEqual({ 'aria-hidden': 'true', 'data-state': 'open' });
+  });
+
+  it('projects no aria for the decision buttons (they are plain buttons)', () => {
+    const aria = ariaAt(openUncontrolled);
+    expect(aria.cancel).toBeUndefined();
+    expect(aria.action).toBeUndefined();
+  });
+});
+
+describe('alert-dialog keymap', () => {
+  const state = { open: true };
+  it('Escape closes from anywhere inside the surface (content, cancel, action)', () => {
+    expect(alertDialog.keymap({ key: 'Escape' }, state, 'content')).toBe('close');
+    // Focus defaults to Cancel, so the bind resolves cancel/action as the part;
+    // Escape must still close whichever focusable holds focus.
+    expect(alertDialog.keymap({ key: 'Escape' }, state, 'cancel')).toBe('close');
+    expect(alertDialog.keymap({ key: 'Escape' }, state, 'action')).toBe('close');
+  });
+  it('Escape on the (outside) trigger and other keys are not claimed', () => {
+    expect(alertDialog.keymap({ key: 'Escape' }, state, 'trigger')).toBeNull();
+    expect(alertDialog.keymap({ key: 'Enter' }, state, 'content')).toBeNull();
+  });
+});
+
+// The modal overlay pair (focus-trap, scroll-lock, focus-to-Cancel) and the
+// deliberate ABSENCE of outside-dismiss are asserted end to end in the
+// conformance suites (alert-dialog.conformance.test.tsx / .astro. / .element.).

--- a/packages/ui/test/components/alert-dialog/alert-dialog.classes.test.ts
+++ b/packages/ui/test/components/alert-dialog/alert-dialog.classes.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { alertDialog } from '../../../src/components/alert-dialog/alert-dialog.behavior';
+import { alertDialogClasses } from '../../../src/components/alert-dialog/alert-dialog.classes';
+
+const config = {};
+const classes = alertDialogClasses(config, alertDialog.initialState(config));
+
+describe('alert-dialog classes', () => {
+  it('layers sit on depth tokens', () => {
+    expect(classes.overlay).toContain('z-depth-overlay');
+    expect(classes.container).toContain('z-depth-modal');
+  });
+
+  it('the action button carries the destructive intent', () => {
+    expect(classes.action).toContain('bg-destructive');
+    expect(classes.action).toContain('text-destructive-foreground');
+  });
+
+  it('the cancel button reads as the neutral, outlined choice', () => {
+    expect(classes.cancel).toContain('border-input');
+    expect(classes.cancel).not.toContain('bg-destructive');
+  });
+
+  it('both decision buttons honor the touch floor and the focus ring', () => {
+    expect(classes.action).toContain('h-11');
+    expect(classes.cancel).toContain('h-11');
+    expect(classes.action).toContain('focus-visible:ring-ring');
+    expect(classes.cancel).toContain('focus-visible:ring-ring');
+  });
+
+  it('header and footer respond to the container, not the viewport', () => {
+    expect(classes.header).toContain('@md:text-left');
+    expect(classes.footer).toContain('@md:flex-row');
+    expect(classes.header).not.toContain('sm:');
+    expect(classes.footer).not.toContain('sm:');
+  });
+
+  it('declares no raw numeric transition duration (motion token layer pending)', () => {
+    for (const value of Object.values(classes)) {
+      expect(value).not.toMatch(/\bduration-\d/);
+    }
+  });
+});

--- a/packages/ui/test/components/alert-dialog/alert-dialog.conformance.test.tsx
+++ b/packages/ui/test/components/alert-dialog/alert-dialog.conformance.test.tsx
@@ -1,0 +1,324 @@
+/**
+ * React performance of the alert-dialog score, driven end to end. The portal
+ * renders into document.body, so part queries run against body, not the RTL
+ * container. Where dialog dismisses on an outside click and focuses the first
+ * focusable, alert-dialog does NEITHER: it never closes on an outside click,
+ * and focus defaults to Cancel.
+ */
+import * as React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '../../../src/components/alert-dialog/alert-dialog';
+import { alertDialog } from '../../../src/components/alert-dialog/alert-dialog.behavior';
+import {
+  assertAxeClean,
+  assertContractFulfillment,
+  domPartIds,
+  partElement,
+} from '../../harness/conformance';
+
+interface SetupProps {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  withDescription?: boolean;
+}
+
+function TestAlertDialog({ withDescription = true, ...props }: SetupProps) {
+  return (
+    <AlertDialog {...props}>
+      <AlertDialogTrigger>Delete account</AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+          {withDescription ? (
+            <AlertDialogDescription>This action cannot be undone.</AlertDialogDescription>
+          ) : null}
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction>Delete</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+const body = () => document.body;
+
+afterEach(() => {
+  cleanup();
+  document.body.replaceChildren();
+});
+
+describe('alert-dialog conformance [react]', () => {
+  it('closed: only the trigger renders, collapsed and axe-clean', async () => {
+    render(<TestAlertDialog />);
+    const trigger = partElement(body(), 'trigger');
+    expect(trigger).not.toBeNull();
+    expect(partElement(body(), 'content')).toBeNull();
+    expect(trigger?.getAttribute('aria-expanded')).toBe('false');
+    expect(trigger?.hasAttribute('aria-controls')).toBe(false);
+    await assertAxeClean(body());
+  });
+
+  it('open: every part renders and ARIA equals the projection', async () => {
+    const user = userEvent.setup();
+    render(<TestAlertDialog />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+
+    const config = { defaultOpen: false };
+    const state = { open: true };
+    assertContractFulfillment(alertDialog, body(), state, config, [
+      'trigger',
+      'content',
+      'overlay',
+      'title',
+      'description',
+      'cancel',
+      'action',
+    ]);
+    await assertAxeClean(body());
+  });
+
+  it('content carries role=alertdialog and is always modal', async () => {
+    const user = userEvent.setup();
+    render(<TestAlertDialog />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    const content = partElement(body(), 'content');
+    expect(content?.getAttribute('role')).toBe('alertdialog');
+    expect(content?.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('omitted description projects NO aria-describedby', async () => {
+    const user = userEvent.setup();
+    render(<TestAlertDialog withDescription={false} />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    const content = partElement(body(), 'content');
+    expect(content?.hasAttribute('aria-describedby')).toBe(false);
+    expect(content?.getAttribute('aria-labelledby')).toBeTruthy();
+    await assertAxeClean(body());
+  });
+
+  it('trigger and content are wired by real DOM ids', async () => {
+    const user = userEvent.setup();
+    render(<TestAlertDialog />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    const ids = domPartIds(body(), ['trigger', 'content', 'title', 'description'] as const);
+    const trigger = partElement(body(), 'trigger');
+    const content = partElement(body(), 'content');
+    expect(trigger?.getAttribute('aria-controls')).toBe(ids.content);
+    expect(content?.getAttribute('aria-labelledby')).toBe(ids.title);
+    expect(content?.getAttribute('aria-describedby')).toBe(ids.description);
+  });
+
+  it('initial focus defaults to Cancel, the safer choice', async () => {
+    const user = userEvent.setup();
+    render(<TestAlertDialog />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    expect(document.activeElement).toBe(partElement(body(), 'cancel'));
+  });
+
+  it('focus is trapped inside the dialog and Tab cycles within', async () => {
+    const user = userEvent.setup();
+    render(<TestAlertDialog />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+
+    const content = partElement(body(), 'content') as HTMLElement;
+    expect(content.contains(document.activeElement)).toBe(true);
+
+    const focusable = Array.from(content.querySelectorAll<HTMLElement>('button:not([disabled])'));
+    for (let i = 0; i < focusable.length + 1; i += 1) {
+      await user.tab();
+      expect(content.contains(document.activeElement)).toBe(true);
+    }
+  });
+
+  it('Escape closes and restores focus to the trigger', async () => {
+    const user = userEvent.setup();
+    render(<TestAlertDialog />);
+    const trigger = partElement(body(), 'trigger') as HTMLElement;
+    await user.click(trigger);
+    expect(partElement(body(), 'content')).not.toBeNull();
+
+    await user.keyboard('{Escape}');
+    expect(partElement(body(), 'content')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('an outside pointerdown does NOT dismiss -- the decision is mandatory', async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <button type="button">Elsewhere</button>
+        <TestAlertDialog />
+      </div>,
+    );
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    expect(partElement(body(), 'content')).not.toBeNull();
+    await user.click(document.querySelector('button') as HTMLElement);
+    // Still open: unlike Dialog, the outside click is inert.
+    expect(partElement(body(), 'content')).not.toBeNull();
+  });
+
+  it('Cancel closes', async () => {
+    const user = userEvent.setup();
+    render(<TestAlertDialog />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    await user.click(partElement(body(), 'cancel') as HTMLElement);
+    expect(partElement(body(), 'content')).toBeNull();
+  });
+
+  it('the action closes and runs the consumer handler', async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    render(
+      <AlertDialog>
+        <AlertDialogTrigger>Delete</AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogTitle>Sure?</AlertDialogTitle>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={onConfirm}>Delete</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>,
+    );
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    await user.click(partElement(body(), 'action') as HTMLElement);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(partElement(body(), 'content')).toBeNull();
+  });
+
+  it('scroll is locked while open and released on close', async () => {
+    const user = userEvent.setup();
+    render(<TestAlertDialog />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    expect(document.body.style.overflow).toBe('hidden');
+    await user.keyboard('{Escape}');
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+
+  it('defaultOpen mounts open with the trap live and focus on Cancel', () => {
+    render(<TestAlertDialog defaultOpen />);
+    const content = partElement(body(), 'content');
+    expect(content).not.toBeNull();
+    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.activeElement).toBe(partElement(body(), 'cancel'));
+  });
+
+  it('controlled: callbacks fire, state follows the prop, never the gesture', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const { rerender } = render(<TestAlertDialog open={false} onOpenChange={onOpenChange} />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    expect(partElement(body(), 'content')).toBeNull();
+
+    rerender(<TestAlertDialog open onOpenChange={onOpenChange} />);
+    expect(partElement(body(), 'content')).not.toBeNull();
+
+    await user.keyboard('{Escape}');
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+    expect(partElement(body(), 'content')).not.toBeNull();
+
+    rerender(<TestAlertDialog open={false} onOpenChange={onOpenChange} />);
+    expect(partElement(body(), 'content')).toBeNull();
+  });
+
+  it('explicit Portal + Overlay composition renders without the automatic wrappers', async () => {
+    const user = userEvent.setup();
+    render(
+      <AlertDialog>
+        <AlertDialogTrigger>Open</AlertDialogTrigger>
+        <AlertDialogPortal>
+          <AlertDialogOverlay />
+          <AlertDialogContent>
+            <AlertDialogTitle>Composed</AlertDialogTitle>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction>Delete</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogPortal>
+      </AlertDialog>,
+    );
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    expect(partElement(body(), 'content')).not.toBeNull();
+    expect(document.querySelectorAll('[data-part="overlay"]')).toHaveLength(1);
+    await assertAxeClean(body());
+  });
+
+  it('forceMount keeps the content in the DOM, hidden and inert, while closed', () => {
+    render(
+      <AlertDialog>
+        <AlertDialogTrigger>Open</AlertDialogTrigger>
+        <AlertDialogContent forceMount>
+          <AlertDialogTitle>Always mounted</AlertDialogTitle>
+        </AlertDialogContent>
+      </AlertDialog>,
+    );
+    const content = partElement(body(), 'content');
+    expect(content).not.toBeNull();
+    expect(content?.getAttribute('data-state')).toBe('closed');
+    expect(content?.closest('[hidden]')).not.toBeNull();
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+
+  it('container portals the content into the given element', async () => {
+    const user = userEvent.setup();
+    const target = document.createElement('div');
+    target.id = 'portal-target';
+    document.body.appendChild(target);
+    render(
+      <AlertDialog>
+        <AlertDialogTrigger>Open</AlertDialogTrigger>
+        <AlertDialogContent container={target}>
+          <AlertDialogTitle>Housed</AlertDialogTitle>
+        </AlertDialogContent>
+      </AlertDialog>,
+    );
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    expect(target.querySelector('[data-part="content"]')).not.toBeNull();
+  });
+
+  it('onEscapeKeyDown veto keeps the dialog open', async () => {
+    const user = userEvent.setup();
+    render(
+      <AlertDialog defaultOpen>
+        <AlertDialogContent onEscapeKeyDown={(event) => event.preventDefault()}>
+          <AlertDialogTitle>Stubborn</AlertDialogTitle>
+        </AlertDialogContent>
+      </AlertDialog>,
+    );
+    await user.keyboard('{Escape}');
+    expect(partElement(body(), 'content')).not.toBeNull();
+  });
+
+  it('uncontrolled callback fires once per real transition', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(<TestAlertDialog onOpenChange={onOpenChange} />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    await user.keyboard('{Escape}');
+    expect(onOpenChange).toHaveBeenCalledTimes(2);
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/packages/ui/test/components/alert-dialog/alert-dialog.element.conformance.test.ts
+++ b/packages/ui/test/components/alert-dialog/alert-dialog.element.conformance.test.ts
@@ -1,0 +1,92 @@
+/**
+ * WC performance of the alert-dialog score, driven end to end against light-DOM
+ * markup. Same score as the React conformance test -- proves presence (content
+ * hidden off the open axis), the focus-trap + scroll-lock pair, focus-to-Cancel,
+ * and the deliberate ABSENCE of outside-dismiss, all through the DOM binding.
+ */
+import { cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { RaftersAlertDialog } from '../../../src/components/alert-dialog/alert-dialog.element';
+
+beforeAll(() => {
+  if (!customElements.get('rafters-alert-dialog')) {
+    customElements.define('rafters-alert-dialog', RaftersAlertDialog);
+  }
+});
+
+async function mount(): Promise<HTMLElement> {
+  document.body.innerHTML = `
+    <rafters-alert-dialog data-part="root">
+      <button type="button" data-part="trigger" id="a-trigger" aria-haspopup="dialog" aria-expanded="false" data-state="closed">Delete</button>
+      <div data-part="overlay" id="a-overlay" aria-hidden="true" data-state="closed" hidden></div>
+      <div data-part="content" id="a-content" role="alertdialog" aria-modal="true" tabindex="-1" aria-labelledby="a-title" data-state="closed" hidden>
+        <h2 data-part="title" id="a-title">Are you sure?</h2>
+        <button type="button" data-part="cancel" id="a-cancel">Cancel</button>
+        <button type="button" data-part="action" id="a-action">Delete</button>
+      </div>
+    </rafters-alert-dialog>`;
+  await Promise.resolve();
+  return document.body.querySelector('rafters-alert-dialog') as HTMLElement;
+}
+
+const trigger = () => document.body.querySelector<HTMLElement>('[data-part="trigger"]')!;
+const content = () => document.body.querySelector<HTMLElement>('[data-part="content"]')!;
+const cancel = () => document.body.querySelector<HTMLElement>('[data-part="cancel"]')!;
+const action = () => document.body.querySelector<HTMLElement>('[data-part="action"]')!;
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+describe('alert-dialog conformance [wc]', () => {
+  it('closed: content hidden, trigger collapsed', async () => {
+    await mount();
+    expect(content().hidden).toBe(true);
+    expect(trigger().getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('trigger opens: content shows, aria wired, focus lands on Cancel, scroll locked', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger());
+    expect(content().hidden).toBe(false);
+    expect(trigger().getAttribute('aria-expanded')).toBe('true');
+    expect(trigger().getAttribute('aria-controls')).toBe('a-content');
+    expect(document.activeElement).toBe(cancel());
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('Escape closes, restores focus to the trigger, releases scroll', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger());
+    await user.keyboard('{Escape}');
+    expect(content().hidden).toBe(true);
+    expect(document.activeElement).toBe(trigger());
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+
+  it('Cancel and the action both close', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger());
+    await user.click(action());
+    expect(content().hidden).toBe(true);
+    await user.click(trigger());
+    await user.click(cancel());
+    expect(content().hidden).toBe(true);
+  });
+
+  it('an outside pointerdown does NOT dismiss', async () => {
+    const user = userEvent.setup();
+    await mount();
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    await user.click(trigger());
+    expect(content().hidden).toBe(false);
+    await user.click(outside);
+    expect(content().hidden).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Ports `alert-dialog` to the behavior layer as one score plus three thin
decorators (React, WC, Astro), imitating `dialog`. alert-dialog is dialog with
three fixed divergences: it is ALWAYS modal (no `modal` prop), its content
carries `role="alertdialog"`, and it has NO outside-pointerdown dismiss -- the
decision is mandatory.

- `alert-dialog.behavior.ts`: reuses the `disclosable` lib for the open/close
  axis (one memory cell, no second store), an `alert-dialog-surface` slice for
  the overlay/title/description/cancel/action parts, and a glue projecting
  `role="alertdialog"` with a forced `aria-modal="true"`.
  `startAlertDialogModalEffects` composes `createFocusTrap` + `preventBodyScroll`
  directly and defaults focus to Cancel (the safer choice); no outside-click
  primitive is composed. Escape maps from content/cancel/action so it still fires
  with focus on the Cancel button. `bindAlertDialog` is the shared DOM-native
  client the WC and Astro both drive.
- Three decorators drive the one bind. Classes are token-based; button
  interaction motion is left undeclared rather than hardcoding a raw numeric
  duration (the motion token layer is being rebuilt, #1899/#1902).
- Tests: pure behavior, classes parity, and conformance across React + WC +
  Astro via the shared harness, asserting focus-to-Cancel and the absence of
  outside-dismiss. Component doc with the oracle-disposition table.

Per-component folder only: no shared-file edits (components.jsonl is deleted;
components.md/CHANGELOG untouched), no package.json exports.

## Acceptance criteria mapping

### Component doc written
A register modeled on dialog.md was authored covering composition, the config/
state/actions shape, the parts-and-ARIA table, keyboard and effects, the oracle
dispositions, the motion note, and the WCAG obligations.
Evidence: packages/ui/docs/spec/components/alert-dialog.md:1

### JSDoc intelligence tags present
The React performance carries the four parsed tags (`@cognitive-load`,
`@attention-economics`, `@trust-building`, `@accessibility`) with the
five-dimension load breakdown the registry reads.
Evidence: packages/ui/src/components/alert-dialog/alert-dialog.tsx:7

### Behavior test (pure, no DOM)
Pure assertions cover the part surface, controlled-versus-intrinsic state, the
idempotence gate, the always-modal aria projection, and the widened Escape
keymap, with no DOM rendering anywhere in the file.
Evidence: packages/ui/test/components/alert-dialog/alert-dialog.behavior.test.ts:1

### Classes parity test
A classes suite asserts depth tokens, destructive-versus-neutral button intent,
the touch floor and focus ring, container-query breakpoints, and a guard that no
raw numeric transition duration is present.
Evidence: packages/ui/test/components/alert-dialog/alert-dialog.classes.test.ts:36

### Conformance test via the shared harness (aria + keymap against rendered DOM)
`assertContractFulfillment` and `assertAxeClean` from the shared harness run
against rendered DOM in all three frameworks, checking projected ARIA and the
Escape keymap end to end.
Evidence: packages/ui/test/components/alert-dialog/alert-dialog.conformance.test.tsx:83

### shadcn drop-in parity where the component exists in shadcn
The React surface keeps the shadcn API -- Trigger, Portal, Overlay, Content,
Header, Footer, Title, Description, Cancel, Action, plus asChild, forceMount,
container, and the onEscapeKeyDown veto -- so existing markup drops in.
Evidence: packages/ui/src/components/alert-dialog/alert-dialog.tsx:305

### `pnpm --filter @rafters/ui test:unit` green, `pnpm preflight` green
The package unit suite (main plus astro configs) runs green and the full
workspace preflight (typecheck, lint, format, tests, a11y, build) completes with
exit code zero from the worktree.
Evidence: packages/ui/test/components/alert-dialog/alert-dialog.astro.conformance.test.ts:32

## Not done

- Exit-presence animation (fade+zoom out) is not declared: it is gated on wave
  0-B (Presence) and the semantic motion token layer (#1899/#1902). Enter-only,
  matching dialog's current pattern.
- Button interaction motion (the oracle's `transition-colors duration-150`) is
  left undeclared until a `motion-*` semantic token exists; noted in the doc.
- No Vue performance (out of scope; the three mandated frameworks ship).
- No distribution wiring (registry #1896): no package.json export entry or
  namespace, per the issue.

Closes #1755
