### PR TITLE
feat(ui): port sheet to the behavior layer

### DIFF
--- a/packages/ui/docs/spec/components/sheet.md
+++ b/packages/ui/docs/spec/components/sheet.md
@@ -1,0 +1,135 @@
+# Component Spec — Sheet
+
+Status: DRAFT. Archetype `modal-overlay`; imitates dialog (the overlay
+reference, Spec 05). A sheet is an edge-anchored dialog: it slides in from a
+side over a scrim and traps focus.
+
+Files (`src/components/sheet/`):
+
+```
+sheet.behavior.ts    sheet.classes.ts    sheet.tsx    sheet.element.ts    sheet.astro
+```
+
+Tests mirror into `test/components/sheet/`: behavior (pure), classes (parity),
+and conformance across React, WC, and Astro through the shared harness.
+
+## Composition
+
+```
+disclosable (lib)      state {open}, actions open/close, trigger/content parts
+sheet-surface          parts only: overlay, title, description, close
+sheet glue             role=dialog/aria-modal/labelledby/haspopup, Escape keymap
+```
+
+The score is dialog's score. Effects-as-data is retired (Spec 03, 2026-07-19):
+the modal overlay trio is composed DIRECTLY. `startSheetModalEffects({ content,
+getTrigger, onDismiss })` starts `createFocusTrap` + `preventBodyScroll` +
+`onPointerDownOutside` on the open+modal transition and tears them down on
+close, called by both `bindSheet` (WC/Astro) and a React `useEffect`. Focus
+restore rides the trap teardown. No effect list, no second memory cell:
+`disclosable` is the one open/closed axis over the single `createBehavior` cell.
+
+## Config, state, actions
+
+```ts
+interface SheetConfig {
+  open?: boolean;        // controlled
+  defaultOpen?: boolean; // uncontrolled seed
+  modal?: boolean;       // default true
+}
+interface SheetState { open: boolean } // intrinsic only
+type SheetActions = { open: undefined; close: undefined };
+```
+
+Controlled/uncontrolled per boundary 4: `config.open` is the consumer's
+controlled value, `state.open` is intrinsic, projections and gates read
+`isOpen(state, config)`. The idempotence gate makes `onOpenChange` fire once per
+real transition. No `toggle` action: the trigger dispatches `open` or `close`
+computed from the effective value, so intrinsic state can never drift from a
+controlled consumer.
+
+### side is decoration, not state
+
+`side` (`top | right | bottom | left`, default `right`) selects which edge the
+panel anchors to and, once motion tokens exist, the slide axis. It projects no
+ARIA, claims no key, and never enters a reducer, so it is NOT score state: it is
+a positional class variant. This preserves the shadcn surface, where `side` is a
+prop of `SheetContent` — the React performance keeps it there; the Astro
+performance takes it as a prop and the WC reads it from the authored class. The
+matrix "states: open, side" line names the two axes of variation a sheet has;
+only `open` is a transitioning reducer state.
+
+## Parts and ARIA
+
+| Part | Presence | ARIA |
+| --- | --- | --- |
+| trigger | always | `aria-haspopup="dialog"`, `aria-expanded`, `aria-controls` (only while content is in the DOM), `data-state` |
+| content | while open | `role="dialog"`, `aria-modal="true"` (modal only), `aria-labelledby`/`aria-describedby` (only when the part rendered), `data-state` |
+| overlay | open + modal | `aria-hidden="true"`, `data-state` |
+| title | consumer renders | referenced by labelledby via registration |
+| description | consumer renders | referenced by describedby via registration |
+| close | while open (default on) | `aria-label="Close"` |
+
+Empty-id convention (ratified 2026-07-08): a binding passes `''` as the PartId
+of a part it did not render; projections emit `undefined` for references to
+empty ids. A dangling `aria-describedby` is an axe violation; absence is honest.
+
+## Keyboard and effects
+
+- `keymap`: Escape on `content` -> `close`. Focus containment makes the
+  content-scoped listener sufficient in modal mode; non-modal Escape works while
+  focus is inside the sheet.
+- Modal overlay trio (open+modal): `focus-trap(content)`, `scroll-lock`,
+  `dismiss-on-outside(content, close, except trigger)`. Composed directly by the
+  bindings; otherwise nothing.
+
+## Motion
+
+Intent: `enter`/`exit` = slide along the anchored axis (x for left/right, y for
+top/bottom). This is DECLARED here but left UNIMPLEMENTED: the semantic
+slide-per-side motion tokens do not exist yet — the motion token layer is being
+rebuilt (#1899), and a hardcoded `duration-*`/`animate-in` now is drift later
+(Spec 04). The oracle's `animate-in/out slide-*` + `duration-500/300` utilities
+are therefore DROPPED, not ported. Enter animation ships once the tokens land;
+exit animation additionally waits on the Presence adapter (wave 0-B). Until
+then, sheet is enter-only in the visual sense and correct at every state via
+`data-state` + `hidden`.
+
+## Oracle dispositions (src/old/ui/sheet.tsx, boundary 9)
+
+| Oracle feature | Disposition |
+| --- | --- |
+| controlled/uncontrolled + onOpenChange | contract |
+| modal prop (trap, lock, outside-dismiss gated on it) | contract |
+| Escape closes | contract (moved from document listener to content keymap) |
+| Trigger/Content/Header/Footer/Title/Description/Close surface | contract |
+| `side` prop on Content (top/right/bottom/left, default right) | contract, re-expressed as a positional class variant (decoration), not score state |
+| asChild on Trigger and Close | framework affordance (React) |
+| showCloseButton (default true) | contract, faithful: the sheet oracle used `showCloseButton ?? true` and always rendered the close (including inside an explicit portal), matching shadcn. Kept exactly; dialog's `?? !isInsidePortal` divergence is NOT adopted here |
+| always-set `aria-controls`/`aria-describedby` | defect-do-not-port — dangling references when target absent; replaced by registration + empty-id convention |
+| trigger pointerdown closes then click re-opens | defect-do-not-port — fixed by sparing the trigger in the outside-dismiss |
+| `data-[state=open]` classes on the close button | defect-do-not-port — dead selectors; no data-state was ever set on that element |
+| explicit SheetPortal / SheetOverlay / `container` prop | contract (shadcn surface is the floor). Content inside an explicit portal skips its automatic portal + overlay; close button defaults off there |
+| forceMount | contract, with a divergence: force-mounted closed layers carry `hidden` (a closed modal must be inert to AT and must not block the page). Presence (wave 0-B) replaces this for exit animation |
+| onEscapeKeyDown / onPointerDownOutside / onInteractOutside veto props | contract (oracle signatures: native event, preventDefault to veto) |
+| `animate-in/out slide-*` + `duration-500/300` on content/overlay | defect-do-not-port — raw numeric durations; motion re-declared as intent, left to the token layer (#1899) |
+| sr-only "Close" span + aria-label together | simplified to aria-label only |
+
+## Deltas from the oracle
+
+1. Close button sizing: `h-11 w-11` touch, `@md:h-8 @md:w-8` desktop.
+2. Header/footer breakpoints moved from viewport (`sm:`) to container (`@md:`)
+   per the CQ system rule; the left/right width cap moved to `@sm:max-w-sm`.
+3. `tabIndex={-1}` on content so Escape works when the consumer renders no
+   focusable children.
+4. Motion utilities dropped (see Motion).
+
+## WCAG 2.1 AA obligations
+
+- 1.3.1/4.1.2: role dialog, aria-modal, labelledby/describedby wiring asserted
+  against real DOM ids by the harness.
+- 2.1.1/2.1.2 (no keyboard trap in the WCAG sense): Tab cycles inside while
+  open, Escape releases, focus restores to the trigger on close.
+- 2.4.3 Focus Order: initial focus moves into the sheet (first focusable);
+  restoration on close is the trap teardown.
+- 2.4.7: token focus ring on the close button.

--- a/packages/ui/docs/spec/components/sheet.md
+++ b/packages/ui/docs/spec/components/sheet.md
@@ -109,7 +109,7 @@ then, sheet is enter-only in the visual sense and correct at every state via
 | always-set `aria-controls`/`aria-describedby` | defect-do-not-port — dangling references when target absent; replaced by registration + empty-id convention |
 | trigger pointerdown closes then click re-opens | defect-do-not-port — fixed by sparing the trigger in the outside-dismiss |
 | `data-[state=open]` classes on the close button | defect-do-not-port — dead selectors; no data-state was ever set on that element |
-| explicit SheetPortal / SheetOverlay / `container` prop | contract (shadcn surface is the floor). Content inside an explicit portal skips its automatic portal + overlay; close button defaults off there |
+| explicit SheetPortal / SheetOverlay / `container` prop | contract (shadcn surface is the floor). Content inside an explicit portal skips its automatic portal + overlay; the close button is still rendered there (sheet keeps `showCloseButton ?? true`, unlike dialog) |
 | forceMount | contract, with a divergence: force-mounted closed layers carry `hidden` (a closed modal must be inert to AT and must not block the page). Presence (wave 0-B) replaces this for exit animation |
 | onEscapeKeyDown / onPointerDownOutside / onInteractOutside veto props | contract (oracle signatures: native event, preventDefault to veto) |
 | `animate-in/out slide-*` + `duration-500/300` on content/overlay | defect-do-not-port — raw numeric durations; motion re-declared as intent, left to the token layer (#1899) |

--- a/packages/ui/src/components/sheet/sheet.astro
+++ b/packages/ui/src/components/sheet/sheet.astro
@@ -1,0 +1,93 @@
+---
+/**
+ * Astro performance for sheet. Server-renders the full light-DOM structure with
+ * the closed-state projection already applied (correct and inert before JS),
+ * then the <script> hands each instance to bindSheet -- the SAME DOM-native
+ * client the Web Component uses. One score, three performances.
+ *
+ * Content stays in light DOM (present-but-hidden) so the effects the bind runs
+ * -- focus-trap, scroll-lock, dismiss-on-outside -- can read it. The `side`
+ * variant is authored into the content's class here; it is decoration, so the
+ * binding never touches it. The title renders through Astro's dynamic-tag
+ * support (the sanctioned typography escape, cf. typography.astro), keeping the
+ * heading semantic without a hand-rolled literal. Exit animation waits on the
+ * Presence adapter; this is enter-only.
+ */
+import {
+  sheet,
+  type SheetConfig,
+  type SheetPart,
+  type SheetSide,
+} from './sheet.behavior';
+import { sheetClasses, sheetContentClasses } from './sheet.classes';
+import type { PartIds } from '../../lib/contract';
+
+interface Props {
+  id: string;
+  side?: SheetSide;
+  modal?: boolean;
+  defaultOpen?: boolean;
+  title?: string;
+  description?: string;
+}
+
+const { id, side = 'right', modal = true, defaultOpen = false, title, description } = Astro.props;
+
+const config: SheetConfig = { modal, defaultOpen };
+const state = sheet.initialState(config);
+const classes = sheetClasses(config, state);
+const contentClass = sheetContentClasses(side);
+const Title = 'h2';
+
+// Optional cross-ref sources resolve to empty when their slot is absent, so the
+// score's `|| undefined` guards emit no dangling reference.
+const ids = {} as PartIds<SheetPart>;
+for (const part of Object.keys(sheet.parts) as SheetPart[]) {
+  const absent = (part === 'title' && !title) || (part === 'description' && !description);
+  ids[part] = absent ? '' : `${id}-${part}`;
+}
+const aria = sheet.aria(state, config, ids);
+const open = state.open;
+---
+
+<rafters-sheet data-part="root" modal={String(modal)} default-open={String(defaultOpen)}>
+  <button type="button" id={ids.trigger} data-part="trigger" {...aria.trigger}>
+    <slot name="trigger">Open</slot>
+  </button>
+
+  <div id={ids.overlay} data-part="overlay" class={classes.overlay} hidden={!open} {...aria.overlay}></div>
+
+  <div
+    id={ids.content}
+    data-part="content"
+    data-side={side}
+    tabindex="-1"
+    class={contentClass}
+    {...aria.content}
+    hidden={!open}
+  >
+    {title && <Title id={ids.title} data-part="title" class={classes.title}>{title}</Title>}
+    {
+      description && (
+        <div id={ids.description} data-part="description" class={classes.description}>
+          {description}
+        </div>
+      )
+    }
+    <slot />
+    <button type="button" id={ids.close} data-part="close" class={classes.close} {...aria.close}>
+      <slot name="close">Close</slot>
+    </button>
+  </div>
+</rafters-sheet>
+
+<script>
+  import { bindSheet } from './sheet.behavior';
+
+  for (const root of document.querySelectorAll('rafters-sheet[data-part="root"]')) {
+    const el = root as HTMLElement;
+    if (el.dataset['bound'] === 'true') continue;
+    el.dataset['bound'] = 'true';
+    bindSheet(el);
+  }
+</script>

--- a/packages/ui/src/components/sheet/sheet.behavior.ts
+++ b/packages/ui/src/components/sheet/sheet.behavior.ts
@@ -1,0 +1,265 @@
+import { compose, type GlueSlice, type Slice } from '../../lib/compose';
+import {
+  createBehavior,
+  type AriaAttrs,
+  type BehaviorSpec,
+  type PartIds,
+} from '../../lib/contract';
+import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap';
+import { onPointerDownOutside } from '../../primitives/outside-click';
+import {
+  disclosable,
+  isOpen,
+  type DisclosableActions,
+  type DisclosableConfig,
+  type DisclosablePart,
+  type DisclosableState,
+} from '../../lib/disclosable';
+
+/** The edge a sheet is anchored to. Purely positional -- it selects the view's
+ *  side variant and the slide axis; it never enters a reducer, projects no
+ *  ARIA, and claims no key. Default: right. */
+export type SheetSide = 'top' | 'right' | 'bottom' | 'left';
+
+export interface SheetConfig extends DisclosableConfig {
+  /** Modal sheets trap focus, lock scroll, and dismiss on outside pointerdown.
+   *  Default: true. */
+  modal?: boolean | undefined;
+}
+
+export type SheetState = DisclosableState;
+export type SheetActions = DisclosableActions;
+
+export type SheetSurfacePart = 'overlay' | 'title' | 'description' | 'close';
+export type SheetPart = DisclosablePart | SheetSurfacePart;
+
+export { isOpen };
+
+function isModal(config: SheetConfig): boolean {
+  return config.modal !== false;
+}
+
+/** Structure-only slice: the parts a sheet has beyond the disclosable
+ *  trigger/content pair. Contributes no state and no actions. */
+const sheetSurface: Slice<
+  SheetConfig,
+  Record<never, never>,
+  Record<never, never>,
+  SheetSurfacePart
+> = {
+  name: 'sheet-surface',
+  parts: {
+    overlay: { optional: true },
+    title: { optional: true },
+    description: { optional: true },
+    close: { optional: true },
+  },
+  initialState: () => ({}),
+};
+
+/** The sheet glue: ARIA identity and the Escape contract, written over the
+ *  merged state. The modal overlay concerns (focus-trap, scroll-lock,
+ *  outside-dismiss) are composed directly by the bindings, not declared here.
+ *  A sheet is an edge-anchored dialog, so it carries role="dialog". */
+const sheetGlue: GlueSlice<SheetConfig, SheetState, { close: undefined }, SheetPart> = {
+  kind: 'glue',
+  name: 'sheet',
+  aria: (state, config, ids) => {
+    const open = isOpen(state, config);
+    return {
+      trigger: {
+        'aria-haspopup': 'dialog',
+      },
+      content: {
+        role: 'dialog',
+        'aria-modal': isModal(config) ? 'true' : undefined,
+        // An empty id means the binding did not render that part; a reference
+        // to a missing id is an axe violation, so project absence.
+        'aria-labelledby': ids.title || undefined,
+        'aria-describedby': ids.description || undefined,
+      },
+      overlay: {
+        'aria-hidden': 'true',
+        'data-state': open ? 'open' : 'closed',
+      },
+      close: {
+        'aria-label': 'Close',
+      },
+    };
+  },
+  keymap: (event, _state, part) => (part === 'content' && event.key === 'Escape' ? 'close' : null),
+};
+
+/** The parts and dispatch the modal overlay trio composes against. */
+export interface SheetModalPorts {
+  /** The sheet surface: focus is trapped inside it and a pointerdown landing
+   *  outside it dismisses. */
+  content: HTMLElement;
+  /** Resolves the trigger so the opening gesture's pointerdown is spared --
+   *  otherwise it would both dismiss the layer and re-open it. */
+  getTrigger: () => HTMLElement | null;
+  /** Outside-pointerdown handler, already spared of the trigger. Receives the
+   *  native event so a boundary can offer a consumer veto before closing. */
+  onDismiss: (event: Event) => void;
+}
+
+/**
+ * The modal overlay trio, composed directly (the retired effects runner's
+ * replacement): trap Tab focus inside `content`, lock body scroll, and dismiss
+ * on a pointerdown outside `content` -- sparing the trigger. Level-triggered:
+ * BOTH the DOM-native bindSheet and the React Sheet start this on the
+ * open+modal transition and call the returned cleanup on close/unmount. Focus
+ * restore rides the trap teardown, so the cleanup releases LIFO.
+ */
+export function startSheetModalEffects({
+  content,
+  getTrigger,
+  onDismiss,
+}: SheetModalPorts): () => void {
+  const releaseTrap = createFocusTrap(content);
+  const releaseScroll = preventBodyScroll();
+  const releaseDismiss = onPointerDownOutside(content, (event) => {
+    const target = event.target as Node;
+    if (getTrigger()?.contains(target)) return;
+    onDismiss(event);
+  });
+  return () => {
+    releaseDismiss();
+    releaseScroll();
+    releaseTrap();
+  };
+}
+
+export const sheet: BehaviorSpec<SheetConfig, SheetState, SheetActions, SheetPart> = compose(
+  'sheet',
+  disclosable<SheetConfig>(),
+  sheetSurface,
+  sheetGlue,
+);
+
+/**
+ * The DOM-native binding of the sheet score -- the client. The Web Component
+ * and the Astro <script> both import THIS; only React reads the projections
+ * declaratively. Same shape as bindDialog, plus the two overlay concerns:
+ * PRESENCE (content/overlay are present-but-hidden, toggled on the open axis --
+ * the trapped/dismissable parts must be light DOM so focus-trap's activeElement
+ * read and dismiss's document .contains work) and the modal overlay trio
+ * (focus-trap, scroll-lock, dismiss-on-outside), composed directly and
+ * level-triggered: started on the open+modal transition and torn down on
+ * close/unbind. The `side` variant is authored into the markup's classes; it is
+ * decoration, so the binding never touches it. Enter-only; exit animation waits
+ * on Presence.
+ */
+export function bindSheet(root: HTMLElement): () => void {
+  const config: SheetConfig = {
+    modal: root.getAttribute('modal') !== 'false',
+    defaultOpen:
+      root.getAttribute('default-open') === 'true' ||
+      root.querySelector<HTMLElement>('[data-part="content"]')?.dataset['state'] === 'open',
+  };
+
+  const getPart = (part: string): HTMLElement | null =>
+    part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
+
+  const { memory, dispatch } = createBehavior(sheet, config);
+
+  const request = (action: keyof SheetActions): boolean => dispatch(action, config);
+
+  // The modal overlay trio is level-triggered: present only while open+modal.
+  // render() starts it on the transition and this cleanup stops it on close.
+  let modalCleanup: (() => void) | null = null;
+
+  // ids READ from the server/author markup, never generated.
+  const ids = {} as PartIds<SheetPart>;
+  for (const part of Object.keys(sheet.parts) as SheetPart[]) ids[part] = getPart(part)?.id ?? '';
+
+  // The projection is already resolved, so apply it raw (validate:false skips
+  // aria-manager's author-input coercion that flips the string 'false').
+  const applyProjection = (el: HTMLElement, attrs: AriaAttrs) => {
+    for (const [name, value] of Object.entries(attrs)) {
+      updateAriaAttribute(el, name as never, value as never, { validate: false });
+    }
+  };
+
+  const render = () => {
+    const state = memory.get();
+    const open = isOpen(state, config);
+    const projection = sheet.aria(state, config, ids);
+    for (const part of Object.keys(projection) as SheetPart[]) {
+      const attrs = projection[part];
+      const el = getPart(part);
+      if (el && attrs) applyProjection(el, attrs);
+    }
+    // Presence: the overlay and the content container hide off the open axis.
+    // The parts stay in light DOM (crawlable, and effects can read them).
+    for (const part of ['overlay', 'content'] as const) {
+      const el = getPart(part);
+      if (el) el.hidden = !open;
+    }
+    // Compose the modal overlay trio directly, level-triggered: start it once
+    // on the open+modal transition (content is now un-hidden above so the trap
+    // can read its focusables), tear it down when it should no longer be present.
+    const wantModal = open && isModal(config);
+    if (wantModal && !modalCleanup) {
+      const content = getPart('content');
+      if (content) {
+        modalCleanup = startSheetModalEffects({
+          content,
+          getTrigger: () => getPart('trigger'),
+          onDismiss: () => {
+            request('close');
+          },
+        });
+      }
+    } else if (!wantModal && modalCleanup) {
+      modalCleanup();
+      modalCleanup = null;
+    }
+  };
+  const unsubscribe = memory.subscribe(render); // fires immediately: first paint
+
+  const onClick = (event: Event) => {
+    const target = event.target as HTMLElement;
+    if (target.closest('[data-part="close"]')) {
+      request('close');
+      return;
+    }
+    if (target.closest('[data-part="trigger"]')) {
+      request(isOpen(memory.get(), config) ? 'close' : 'open');
+    }
+  };
+  root.addEventListener('click', onClick);
+
+  const onKeydown = (event: KeyboardEvent) => {
+    const partEl = (event.target as HTMLElement).closest<HTMLElement>('[data-part]');
+    const part = partEl?.dataset['part'] as SheetPart | undefined;
+    if (!part) return;
+    const action = sheet.keymap(
+      {
+        key: event.key,
+        shiftKey: event.shiftKey,
+        ctrlKey: event.ctrlKey,
+        altKey: event.altKey,
+        metaKey: event.metaKey,
+      },
+      memory.get(),
+      part,
+      config,
+    );
+    if (!action) return;
+    event.preventDefault();
+    const trigger = getPart('trigger');
+    request(action);
+    if (action === 'close') trigger?.focus();
+  };
+  root.addEventListener('keydown', onKeydown);
+
+  return () => {
+    unsubscribe();
+    modalCleanup?.();
+    modalCleanup = null;
+    root.removeEventListener('click', onClick);
+    root.removeEventListener('keydown', onKeydown);
+  };
+}

--- a/packages/ui/src/components/sheet/sheet.classes.ts
+++ b/packages/ui/src/components/sheet/sheet.classes.ts
@@ -1,0 +1,76 @@
+import type { SheetConfig, SheetSide, SheetState } from './sheet.behavior';
+
+export interface SheetClassSet {
+  overlay: string;
+  header: string;
+  footer: string;
+  title: string;
+  description: string;
+  close: string;
+  closeIcon: string;
+}
+
+const overlayClasses = 'fixed inset-0 z-depth-overlay bg-foreground/80';
+
+// Base content signature shared across sides. The per-side anchor, size and
+// border edge come from `sheetSideClasses`. No animation utilities and no raw
+// durations: the semantic slide-per-side motion tokens do not exist yet (the
+// motion token layer is being rebuilt, #1899), so motion is left UNDECLARED
+// rather than hardcoded. Enter-only ships once those tokens land (Presence,
+// wave 0-B). data-state is projected so a future token layer can hook it.
+const contentBaseClasses =
+  'fixed z-depth-modal flex flex-col gap-4 bg-background p-6 shadow-lg ' +
+  'data-[state=closed]:pointer-events-none';
+
+// Per-side placement: one axis, one edge. Left/right run full height and cap
+// their width through a container query (the CQ system rule -- viewport
+// breakpoints moved to container context, cf. dialog); top/bottom span the
+// inline axis and hug the block edge.
+const sheetSideClasses: Record<SheetSide, string> = {
+  top: 'inset-x-0 top-0 border-b border-card-border',
+  bottom: 'inset-x-0 bottom-0 border-t border-card-border',
+  left: 'inset-y-0 left-0 h-full w-3/4 @sm:max-w-sm border-r border-card-border',
+  right: 'inset-y-0 right-0 h-full w-3/4 @sm:max-w-sm border-l border-card-border',
+};
+
+const headerClasses = 'flex flex-col space-y-2 text-center @md:text-left';
+
+const footerClasses = 'flex flex-col-reverse @md:flex-row @md:justify-end @md:space-x-2';
+
+const titleClasses = 'text-title-medium leading-none text-foreground';
+
+const descriptionClasses = 'text-body-small text-muted-foreground';
+
+const closeClasses =
+  'absolute right-2 top-2 inline-flex h-11 w-11 items-center justify-center ' +
+  '@md:right-4 @md:top-4 @md:h-8 @md:w-8 ' +
+  'rounded-sm opacity-70 ring-offset-background cursor-pointer ' +
+  'transition-opacity duration-150 motion-reduce:transition-none hover:opacity-100 ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
+
+const closeIconClasses = 'h-5 w-5 @md:h-4 @md:w-4';
+
+/** The content class: the side-independent base signature plus the anchored
+ *  placement for `side`. The ONLY source of the content class -- every
+ *  performance calls this, so the side (a Content-level decoration prop
+ *  mirroring shadcn) is the single argument the base does not already fix. */
+export function sheetContentClasses(side: SheetSide): string {
+  return `${contentBaseClasses} ${sheetSideClasses[side]}`;
+}
+
+/** The side-independent class set. The content class is NOT here: it depends on
+ *  `side`, so it is produced by `sheetContentClasses(side)` by whoever knows the
+ *  side. Everything below is invariant across sides and open state. */
+export function sheetClasses(_config: SheetConfig, _state: SheetState): SheetClassSet {
+  return {
+    overlay: overlayClasses,
+    header: headerClasses,
+    footer: footerClasses,
+    title: titleClasses,
+    description: descriptionClasses,
+    close: closeClasses,
+    closeIcon: closeIconClasses,
+  };
+}
+
+export { sheetSideClasses };

--- a/packages/ui/src/components/sheet/sheet.element.ts
+++ b/packages/ui/src/components/sheet/sheet.element.ts
@@ -1,0 +1,27 @@
+/**
+ * WC performance for sheet: the thinnest wrapper. The score AND the DOM-native
+ * binding (bindSheet) live in sheet.behavior.ts, shared with the Astro
+ * performance. This file only adapts that binding to the custom-element
+ * lifecycle -- deferring the bind one microtask because connectedCallback can
+ * fire before the light-DOM parts are parsed.
+ */
+import { bindSheet } from './sheet.behavior';
+
+export class RaftersSheet extends HTMLElement {
+  private teardown: (() => void) | null = null;
+
+  connectedCallback(): void {
+    queueMicrotask(() => {
+      if (this.isConnected && !this.teardown) this.teardown = bindSheet(this);
+    });
+  }
+
+  disconnectedCallback(): void {
+    this.teardown?.();
+    this.teardown = null;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-sheet')) {
+  customElements.define('rafters-sheet', RaftersSheet);
+}

--- a/packages/ui/src/components/sheet/sheet.tsx
+++ b/packages/ui/src/components/sheet/sheet.tsx
@@ -1,0 +1,476 @@
+/**
+ * Edge-anchored modal panel: a dialog that slides in from a side over a scrim
+ * and traps focus. Supplementary flows -- mobile navigation, filters, detail
+ * forms -- that warrant interruption but not a full page.
+ *
+ * @cognitive-load 5/10 - A partial overlay dims but preserves the page, so the
+ *   user holds two things at once: the panel's single purpose and their place
+ *   underneath. Modality bounds the choice set; the fixed side anchors where
+ *   attention must go; focus containment removes the "where can I type" load.
+ * @attention-economics Partial capture, not seizure: the scrim signals a
+ *   temporary detour while the dimmed page keeps context in view, so the user
+ *   never loses the thread they will return to.
+ * @trust-building One consistent slide direction, a scrim that reads as
+ *   dismissable, an always-present close affordance, Escape, and outside-click
+ *   -- every exit is obvious and reversible, so committing feels safe.
+ * @accessibility role=dialog with aria-modal, labelledby/describedby wired to
+ *   real ids, focus trapped inside while open and restored to the trigger on
+ *   close, Escape dismiss, and a labelled close control.
+ *
+ * The React performance is a DECORATOR over sheet.behavior.ts: it adds only the
+ * view (sheet.classes.ts) and React wiring (useMemory + a useEffect that
+ * composes startSheetModalEffects). Every decision -- reducers, aria, keymap --
+ * stays in the score, shared with the WC and Astro performances via bindSheet.
+ *
+ * @example
+ * ```tsx
+ * <Sheet>
+ *   <SheetTrigger>Open</SheetTrigger>
+ *   <SheetContent side="right">
+ *     <SheetHeader>
+ *       <SheetTitle>Title</SheetTitle>
+ *       <SheetDescription>Description</SheetDescription>
+ *     </SheetHeader>
+ *     Content here
+ *   </SheetContent>
+ * </Sheet>
+ * ```
+ */
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import { createBehavior, type AriaAttrs, type PartIds } from '../../lib/contract';
+import { keyInputOf } from '../../hooks/key-input';
+import { useMemory } from '../../hooks/use-memory';
+import { usePresence } from '../../hooks/use-presence';
+import classy from '../../primitives/classy';
+import { mergeProps } from '../../primitives/slot';
+import {
+  isOpen,
+  sheet,
+  startSheetModalEffects,
+  type SheetActions,
+  type SheetConfig,
+  type SheetPart,
+  type SheetSide,
+  type SheetState,
+} from './sheet.behavior';
+import { sheetClasses, sheetContentClasses, type SheetClassSet } from './sheet.classes';
+
+/** The oracle-compatible dismissal veto surface on SheetContent. */
+interface DismissVetoCallbacks {
+  onPointerDownOutside?: ((event: Event) => void) | undefined;
+  onInteractOutside?: ((event: Event) => void) | undefined;
+}
+
+interface SheetContextValue {
+  state: SheetState;
+  ids: PartIds<SheetPart>;
+  aria: Partial<Record<SheetPart, AriaAttrs>>;
+  request: (action: keyof SheetActions) => boolean;
+  setPart: (part: SheetPart) => (element: HTMLElement | null) => void;
+  getPart: (part: string) => HTMLElement | null;
+  config: SheetConfig;
+  effectiveOpen: boolean;
+  classes: SheetClassSet;
+  dismissVetoRef: React.RefObject<DismissVetoCallbacks | null>;
+}
+
+const SheetContext = React.createContext<SheetContextValue | null>(null);
+
+function useSheetContext(component: string): SheetContextValue {
+  const context = React.useContext(SheetContext);
+  if (!context) {
+    throw new Error(`${component} must be used within <Sheet>`);
+  }
+  return context;
+}
+
+/** True when rendering inside an explicit <SheetPortal> (Radix-style
+ *  composition); SheetContent then skips its automatic portal + overlay. */
+const SheetPortalContext = React.createContext(false);
+
+export interface SheetProps {
+  children: React.ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  modal?: boolean;
+}
+
+export function Sheet({
+  children,
+  open,
+  defaultOpen = false,
+  onOpenChange,
+  modal = true,
+}: SheetProps) {
+  const config: SheetConfig = { open, defaultOpen, modal };
+  const dismissVetoRef = React.useRef<DismissVetoCallbacks | null>(null);
+
+  // The controller composes the score with the substrate -- no useBehavior.
+  const { memory, dispatch } = React.useMemo(() => createBehavior(sheet, config), []);
+  const state = useMemory(memory);
+  const effectiveOpen = isOpen(state, config);
+
+  const uid = React.useId();
+
+  // Content portals to document.body with a unique id, so getPart resolves by
+  // id -- no ref registry. Optional parts still need a mount signal (setPart)
+  // purely so an omitted description projects no dangling aria-describedby.
+  const [presentParts, setPresentParts] = React.useState<ReadonlySet<string>>(new Set());
+  const partCallbacks = React.useRef<Map<string, (el: HTMLElement | null) => void>>(new Map());
+  const setPart = React.useCallback((part: SheetPart) => {
+    let callback = partCallbacks.current.get(part);
+    if (!callback) {
+      callback = (element: HTMLElement | null) =>
+        setPresentParts((previous) => {
+          const present = element !== null;
+          if (previous.has(part) === present) return previous;
+          const next = new Set(previous);
+          if (present) next.add(part);
+          else next.delete(part);
+          return next;
+        });
+      partCallbacks.current.set(part, callback);
+    }
+    return callback;
+  }, []);
+  const getPart = React.useCallback(
+    (part: string): HTMLElement | null =>
+      typeof document === 'undefined' ? null : document.getElementById(`${uid}-${part}`),
+    [uid],
+  );
+
+  // title and description are the UNGUARDED cross-ref sources (labelledby/
+  // describedby have no `open` guard, unlike aria-controls), so an absent one
+  // must resolve to an empty id. Every other part keeps a stable id -- content
+  // especially, since the focus-trap effect finds it by id.
+  const ids = React.useMemo(() => {
+    const out = {} as PartIds<SheetPart>;
+    for (const part of Object.keys(sheet.parts) as SheetPart[]) {
+      const crossRefSource = part === 'title' || part === 'description';
+      out[part] = crossRefSource && !presentParts.has(part) ? '' : `${uid}-${part}`;
+    }
+    return out;
+  }, [uid, presentParts]);
+
+  const latest = React.useRef({ config, onOpenChange });
+  latest.current = { config, onOpenChange };
+  const request = React.useCallback(
+    (action: keyof SheetActions): boolean => {
+      const { config: cfg, onOpenChange: cb } = latest.current;
+      if (!dispatch(action, cfg)) return false;
+      cb?.(action === 'open');
+      return true;
+    },
+    [dispatch],
+  );
+
+  // The modal overlay trio, composed directly on the open+modal transition
+  // (the retired effects runner's replacement). Level-triggered via the
+  // dependency array; the cleanup tears the trio down (focus restore rides the
+  // trap teardown).
+  React.useEffect(() => {
+    if (!effectiveOpen || !modal) return;
+    const content = getPart('content');
+    if (!content) return;
+    return startSheetModalEffects({
+      content,
+      getTrigger: () => getPart('trigger'),
+      // Outside-pointerdown dismissals offer the consumer veto first (oracle
+      // protocol: callbacks run, close proceeds unless defaultPrevented).
+      onDismiss: (event) => {
+        const veto = dismissVetoRef.current;
+        if (veto) {
+          veto.onPointerDownOutside?.(event);
+          veto.onInteractOutside?.(event);
+          if (event.defaultPrevented) return;
+        }
+        request('close');
+      },
+    });
+  }, [effectiveOpen, modal, getPart, request]);
+
+  const aria = sheet.aria(state, config, ids);
+
+  const contextValue: SheetContextValue = {
+    state,
+    ids,
+    aria,
+    request,
+    setPart,
+    getPart,
+    config,
+    effectiveOpen,
+    classes: sheetClasses(config, state),
+    dismissVetoRef,
+  };
+
+  return <SheetContext.Provider value={contextValue}>{children}</SheetContext.Provider>;
+}
+
+export interface SheetPortalProps {
+  children: React.ReactNode;
+  /** Portal target; defaults to document.body. */
+  container?: HTMLElement | null;
+  forceMount?: boolean;
+}
+
+export function SheetPortal({ children, container, forceMount }: SheetPortalProps) {
+  const { effectiveOpen } = useSheetContext('SheetPortal');
+  if (!(forceMount || effectiveOpen)) return null;
+  if (typeof document === 'undefined') return null;
+  return createPortal(
+    <SheetPortalContext.Provider value={true}>{children}</SheetPortalContext.Provider>,
+    container ?? document.body,
+  );
+}
+
+export interface SheetOverlayProps extends React.HTMLAttributes<HTMLDivElement> {
+  forceMount?: boolean | undefined;
+}
+
+export function SheetOverlay({ forceMount, className, ...props }: SheetOverlayProps) {
+  const { effectiveOpen, ids, aria, classes, setPart } = useSheetContext('SheetOverlay');
+  if (!(forceMount || effectiveOpen)) return null;
+  return (
+    <div
+      data-part="overlay"
+      id={ids.overlay || undefined}
+      ref={setPart('overlay')}
+      // A force-mounted closed overlay must not cover the page.
+      hidden={effectiveOpen ? undefined : true}
+      className={classy(classes.overlay, className)}
+      {...aria.overlay}
+      {...props}
+    />
+  );
+}
+
+export interface SheetTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+}
+
+export function SheetTrigger({ asChild, onClick, children, ...props }: SheetTriggerProps) {
+  const { effectiveOpen, ids, aria, request, setPart } = useSheetContext('SheetTrigger');
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    request(effectiveOpen ? 'close' : 'open');
+  };
+
+  const partProps = {
+    'data-part': 'trigger',
+    id: ids.trigger,
+    ref: setPart('trigger'),
+    ...aria.trigger,
+    onClick: handleClick,
+  };
+
+  if (asChild && React.isValidElement(children)) {
+    const childProps = children.props as Record<string, unknown>;
+    return React.cloneElement(children, mergeProps(partProps, childProps) as React.Attributes);
+  }
+
+  return (
+    <button type="button" {...partProps} {...props}>
+      {children}
+    </button>
+  );
+}
+
+export interface SheetContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** The edge the sheet anchors to. Positional decoration only. Default right. */
+  side?: SheetSide;
+  /** Defaults to true, except inside an explicit <SheetPortal> (oracle
+   *  compatibility for Radix-style composition). */
+  showCloseButton?: boolean;
+  forceMount?: boolean;
+  /** Portal target for the automatic portal; defaults to document.body. */
+  container?: HTMLElement | null;
+  /** Consumer veto: called before Escape closes; preventDefault to keep open. */
+  onEscapeKeyDown?: (event: KeyboardEvent) => void;
+  /** Consumer veto: called before an outside pointerdown closes. */
+  onPointerDownOutside?: (event: Event) => void;
+  /** Consumer veto: called alongside onPointerDownOutside (oracle surface). */
+  onInteractOutside?: (event: Event) => void;
+}
+
+export function SheetContent({
+  side = 'right',
+  showCloseButton,
+  forceMount,
+  container,
+  onEscapeKeyDown,
+  onPointerDownOutside,
+  onInteractOutside,
+  className,
+  children,
+  onKeyDown,
+  ...props
+}: SheetContentProps) {
+  const { config, state, effectiveOpen, ids, aria, classes, request, setPart, dismissVetoRef } =
+    useSheetContext('SheetContent');
+  const isInsidePortal = React.useContext(SheetPortalContext);
+  // Presence (wave 0-B): keep the content mounted through its exit animation.
+  // With no exit animation it releases immediately, so behavior is unchanged.
+  const { present, ref: presenceRef } = usePresence(effectiveOpen);
+
+  React.useEffect(() => {
+    dismissVetoRef.current = { onPointerDownOutside, onInteractOutside };
+    return () => {
+      dismissVetoRef.current = null;
+    };
+  });
+
+  if (!(forceMount || present)) return null;
+  if (typeof document === 'undefined') return null;
+
+  const modal = config.modal !== false;
+  // The sheet oracle (src/old/ui/sheet.tsx: showCloseButton ?? true) ALWAYS
+  // rendered the close button, including inside an explicit portal -- matching
+  // shadcn, where the close lives unconditionally in SheetContent. Kept as-is;
+  // this is the parity floor. (Dialog diverges with `?? !isInsidePortal`.)
+  const shouldShowCloseButton = showCloseButton ?? true;
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    onKeyDown?.(event);
+    if (event.defaultPrevented) return;
+    const action = sheet.keymap(keyInputOf(event), state, 'content', config);
+    if (!action) return;
+    if (action === 'close') {
+      onEscapeKeyDown?.(event.nativeEvent);
+      if (event.nativeEvent.defaultPrevented) return;
+    }
+    event.preventDefault();
+    request(action);
+  };
+
+  const content = (
+    // forceMount keeps the nodes for animation tooling; a closed modal must
+    // still be invisible to AT, untabbable, and must not block the page --
+    // hidden covers all three.
+    <div
+      data-part="content"
+      id={ids.content || undefined}
+      ref={presenceRef}
+      tabIndex={-1}
+      hidden={present ? undefined : true}
+      className={classy(sheetContentClasses(side), className)}
+      {...aria.content}
+      onKeyDown={handleKeyDown}
+      {...props}
+    >
+      {children}
+      {shouldShowCloseButton ? (
+        <button
+          type="button"
+          data-part="close"
+          id={ids.close || undefined}
+          ref={setPart('close')}
+          className={classes.close}
+          {...aria.close}
+          onClick={() => request('close')}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={classes.closeIcon}
+            aria-hidden="true"
+          >
+            <path d="M18 6 6 18" />
+            <path d="m6 6 12 12" />
+          </svg>
+        </button>
+      ) : null}
+    </div>
+  );
+
+  // Inside an explicit <SheetPortal>: the consumer owns portal + overlay.
+  if (isInsidePortal) return content;
+
+  // shadcn-style: Content brings its own portal and overlay.
+  return createPortal(
+    <>
+      {modal ? <SheetOverlay forceMount={forceMount} /> : null}
+      {content}
+    </>,
+    container ?? document.body,
+  );
+}
+
+export type SheetHeaderProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function SheetHeader({ className, ...props }: SheetHeaderProps) {
+  const { classes } = useSheetContext('SheetHeader');
+  return <div className={classy(classes.header, className)} {...props} />;
+}
+
+export type SheetFooterProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function SheetFooter({ className, ...props }: SheetFooterProps) {
+  const { classes } = useSheetContext('SheetFooter');
+  return <div className={classy(classes.footer, className)} {...props} />;
+}
+
+export type SheetTitleProps = React.HTMLAttributes<HTMLHeadingElement>;
+
+export function SheetTitle({ className, ...props }: SheetTitleProps) {
+  const { ids, classes, setPart } = useSheetContext('SheetTitle');
+  return (
+    <h2
+      data-part="title"
+      id={ids.title || undefined}
+      ref={setPart('title')}
+      className={classy(classes.title, className)}
+      {...props}
+    />
+  );
+}
+
+export type SheetDescriptionProps = React.HTMLAttributes<HTMLParagraphElement>;
+
+export function SheetDescription({ className, ...props }: SheetDescriptionProps) {
+  const { ids, classes, setPart } = useSheetContext('SheetDescription');
+  return (
+    <p
+      data-part="description"
+      id={ids.description || undefined}
+      ref={setPart('description')}
+      className={classy(classes.description, className)}
+      {...props}
+    />
+  );
+}
+
+export interface SheetCloseProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+}
+
+export function SheetClose({ asChild, onClick, children, ...props }: SheetCloseProps) {
+  const { request } = useSheetContext('SheetClose');
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    request('close');
+  };
+
+  if (asChild && React.isValidElement(children)) {
+    const childProps = children.props as Record<string, unknown>;
+    return React.cloneElement(
+      children,
+      mergeProps({ onClick: handleClick }, childProps) as React.Attributes,
+    );
+  }
+
+  return (
+    <button type="button" onClick={handleClick} {...props}>
+      {children}
+    </button>
+  );
+}

--- a/packages/ui/test/components/sheet/sheet.astro.conformance.test.ts
+++ b/packages/ui/test/components/sheet/sheet.astro.conformance.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Astro performance of the sheet score, driven end to end. AstroContainer
+ * renders the SSR markup but does NOT run the <script>, so the test binds
+ * bindSheet directly -- that IS the script's job -- then drives the same score
+ * the React and WC performances drive. One score, three performances.
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import Sheet from '../../../src/components/sheet/sheet.astro';
+import { bindSheet } from '../../../src/components/sheet/sheet.behavior';
+import { sheetSideClasses } from '../../../src/components/sheet/sheet.classes';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+async function mount(
+  props: Record<string, unknown> = {},
+  slots: Record<string, string> = {},
+): Promise<HTMLElement> {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Sheet, { props: { id: 's', ...props }, slots });
+  document.body.innerHTML = html;
+  const root = document.body.querySelector('rafters-sheet') as HTMLElement;
+  bindSheet(root); // the <script> does this per instance on the real page
+  return root;
+}
+
+const trigger = () => document.body.querySelector<HTMLElement>('[data-part="trigger"]')!;
+const content = () => document.body.querySelector<HTMLElement>('[data-part="content"]')!;
+
+describe('sheet conformance [astro]', () => {
+  it('SSR closed: content hidden and crawlable, trigger collapsed', async () => {
+    await mount({ title: 'Filters' });
+    expect(content().hidden).toBe(true);
+    expect(trigger().getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('SSR wires aria by real ids; omitted description projects none', async () => {
+    await mount({ title: 'Filters' });
+    expect(content().getAttribute('aria-labelledby')).toBe('s-title');
+    expect(content().hasAttribute('aria-describedby')).toBe(false);
+  });
+
+  it('SSR renders the requested side variant; default is right', async () => {
+    await mount({ title: 'Filters', side: 'left' });
+    expect(content().getAttribute('data-side')).toBe('left');
+    expect(content().className).toContain(sheetSideClasses.left);
+
+    await mount({ title: 'Filters' });
+    expect(content().getAttribute('data-side')).toBe('right');
+    expect(content().className).toContain(sheetSideClasses.right);
+  });
+
+  it('bind: trigger opens, focus trapped, scroll locked; Escape closes + restores focus', async () => {
+    const user = userEvent.setup();
+    await mount({ title: 'Filters' }, { default: '<button type="button">Apply</button>' });
+    await user.click(trigger());
+    expect(content().hidden).toBe(false);
+    expect(content().contains(document.activeElement)).toBe(true);
+    expect(document.body.style.overflow).toBe('hidden');
+    await user.keyboard('{Escape}');
+    expect(content().hidden).toBe(true);
+    expect(document.activeElement).toBe(trigger());
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+});

--- a/packages/ui/test/components/sheet/sheet.behavior.test.ts
+++ b/packages/ui/test/components/sheet/sheet.behavior.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import { createBehavior, type PartIds } from '../../../src/lib/contract';
+import {
+  sheet,
+  isOpen,
+  type SheetConfig,
+  type SheetPart,
+} from '../../../src/components/sheet/sheet.behavior';
+
+const ids: PartIds<SheetPart> = {
+  trigger: 't',
+  content: 'c',
+  overlay: 'o',
+  title: 'ti',
+  description: 'd',
+  close: 'x',
+};
+
+const closed: SheetConfig = {};
+const openUncontrolled: SheetConfig = { defaultOpen: true };
+
+function ariaAt(config: SheetConfig, partIds: PartIds<SheetPart> = ids) {
+  return sheet.aria(sheet.initialState(config), config, partIds);
+}
+
+describe('sheet parts', () => {
+  it('declares the full surface', () => {
+    expect(Object.keys(sheet.parts).sort()).toEqual([
+      'close',
+      'content',
+      'description',
+      'overlay',
+      'title',
+      'trigger',
+    ]);
+    expect(sheet.parts.content.optional).toBe(true);
+    expect(sheet.parts.trigger.optional).toBeUndefined();
+  });
+});
+
+describe('sheet state: controlled vs intrinsic', () => {
+  it('seeds intrinsic open from defaultOpen', () => {
+    expect(sheet.initialState({ defaultOpen: true }).open).toBe(true);
+    expect(sheet.initialState({}).open).toBe(false);
+  });
+
+  it('controlled config shadows intrinsic state', () => {
+    const state = sheet.initialState({});
+    expect(isOpen(state, { open: true })).toBe(true);
+    expect(isOpen({ open: true }, { open: false })).toBe(false);
+    expect(isOpen({ open: true }, {})).toBe(true);
+  });
+});
+
+describe('sheet canDispatch (idempotence gate)', () => {
+  it('open only when effectively closed, close only when effectively open', () => {
+    const state = sheet.initialState(closed);
+    expect(sheet.canDispatch(state, 'open', closed)).toBe(true);
+    expect(sheet.canDispatch(state, 'close', closed)).toBe(false);
+
+    const openState = { open: true };
+    expect(sheet.canDispatch(openState, 'open', closed)).toBe(false);
+    expect(sheet.canDispatch(openState, 'close', closed)).toBe(true);
+  });
+
+  it('gates on the CONTROLLED value when present', () => {
+    const drifted = { open: false };
+    expect(sheet.canDispatch(drifted, 'close', { open: true })).toBe(true);
+    expect(sheet.canDispatch(drifted, 'open', { open: true })).toBe(false);
+  });
+});
+
+describe('sheet actions', () => {
+  it('open and close move intrinsic state through dispatch', () => {
+    const { memory, dispatch } = createBehavior(sheet, closed);
+    expect(dispatch('open', closed)).toBe(true);
+    expect(memory.get().open).toBe(true);
+    expect(dispatch('open', closed)).toBe(false);
+    expect(dispatch('close', closed)).toBe(true);
+    expect(memory.get().open).toBe(false);
+  });
+});
+
+describe('sheet aria projection', () => {
+  it('closed: trigger collapsed, no dangling aria-controls', () => {
+    const aria = ariaAt(closed);
+    expect(aria.trigger).toEqual({
+      'aria-expanded': 'false',
+      'aria-controls': undefined,
+      'data-state': 'closed',
+      'aria-haspopup': 'dialog',
+    });
+  });
+
+  it('open: trigger expanded and wired to content', () => {
+    const aria = ariaAt(openUncontrolled);
+    expect(aria.trigger?.['aria-expanded']).toBe('true');
+    expect(aria.trigger?.['aria-controls']).toBe('c');
+    expect(aria.trigger?.['data-state']).toBe('open');
+  });
+
+  it('content: role dialog, modal by default, labelled and described', () => {
+    const aria = ariaAt(openUncontrolled);
+    expect(aria.content).toEqual({
+      role: 'dialog',
+      'aria-modal': 'true',
+      'aria-labelledby': 'ti',
+      'aria-describedby': 'd',
+      'data-state': 'open',
+    });
+  });
+
+  it('non-modal drops aria-modal', () => {
+    const aria = ariaAt({ ...openUncontrolled, modal: false });
+    expect(aria.content?.['aria-modal']).toBeUndefined();
+  });
+
+  it('empty part ids project ABSENT references, never dangling ones', () => {
+    const aria = ariaAt(openUncontrolled, { ...ids, title: '', description: '' });
+    expect(aria.content?.['aria-labelledby']).toBeUndefined();
+    expect(aria.content?.['aria-describedby']).toBeUndefined();
+  });
+
+  it('overlay is presentation only', () => {
+    const aria = ariaAt(openUncontrolled);
+    expect(aria.overlay).toEqual({ 'aria-hidden': 'true', 'data-state': 'open' });
+  });
+
+  it('close carries its accessible name', () => {
+    expect(ariaAt(openUncontrolled).close).toEqual({ 'aria-label': 'Close' });
+  });
+
+  it('side never enters the aria projection (it is positional decoration)', () => {
+    const aria = ariaAt(openUncontrolled);
+    const serialized = JSON.stringify(aria);
+    for (const side of ['top', 'right', 'bottom', 'left']) {
+      expect(serialized).not.toContain(side);
+    }
+  });
+});
+
+describe('sheet keymap', () => {
+  const state = { open: true };
+  it('Escape on content maps to close', () => {
+    expect(sheet.keymap({ key: 'Escape' }, state, 'content')).toBe('close');
+  });
+  it('Escape elsewhere and other keys are not claimed', () => {
+    expect(sheet.keymap({ key: 'Escape' }, state, 'trigger')).toBeNull();
+    expect(sheet.keymap({ key: 'Enter' }, state, 'content')).toBeNull();
+  });
+});
+
+// The modal overlay trio (focus-trap, scroll-lock, trigger-spared outside
+// dismissal) is not a declarative effect on the score; the bindings compose the
+// primitives directly. The BEHAVIOR is asserted end to end in the conformance
+// suites (sheet.conformance.test.tsx / .astro. / .element.).

--- a/packages/ui/test/components/sheet/sheet.classes.test.ts
+++ b/packages/ui/test/components/sheet/sheet.classes.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { sheet, type SheetSide } from '../../../src/components/sheet/sheet.behavior';
+import {
+  sheetClasses,
+  sheetContentClasses,
+  sheetSideClasses,
+} from '../../../src/components/sheet/sheet.classes';
+
+const config = {};
+const classes = sheetClasses(config, sheet.initialState(config));
+
+describe('sheet classes', () => {
+  it('layers sit on depth tokens', () => {
+    expect(classes.overlay).toContain('z-depth-overlay');
+    expect(sheetContentClasses('right')).toContain('z-depth-modal');
+  });
+
+  it('overlay fills the viewport with a semantic scrim fill', () => {
+    expect(classes.overlay).toContain('fixed');
+    expect(classes.overlay).toContain('inset-0');
+    expect(classes.overlay).toContain('bg-foreground/80');
+  });
+
+  it('close button honors the touch floor and scales down via CQ', () => {
+    expect(classes.close).toContain('h-11');
+    expect(classes.close).toContain('@md:h-8');
+    expect(classes.closeIcon).toContain('h-5');
+    expect(classes.closeIcon).toContain('@md:h-4');
+  });
+
+  it('header and footer respond to the container, not the viewport', () => {
+    expect(classes.header).toContain('@md:text-left');
+    expect(classes.footer).toContain('@md:flex-row');
+    expect(classes.header).not.toContain('sm:');
+    expect(classes.footer).not.toContain('sm:');
+  });
+
+  it('motion respects reduced-motion on the only declared transition', () => {
+    expect(classes.close).toContain('motion-reduce:transition-none');
+  });
+
+  it('drops the oracle slide utilities and its raw slide durations (motion tokens pending)', () => {
+    // The overlay and the per-side content carry the motion the oracle animated;
+    // the close button's duration-150 is a hover acknowledgment (Spec 04 keeps
+    // those), so it is excluded from this scan.
+    const motionSurfaces = `${classes.overlay} ${sheetContentClasses('right')}`;
+    expect(motionSurfaces).not.toContain('animate-in');
+    expect(motionSurfaces).not.toContain('animate-out');
+    expect(motionSurfaces).not.toContain('slide-in');
+    expect(motionSurfaces).not.toContain('slide-out');
+    expect(motionSurfaces).not.toContain('duration-500');
+    expect(motionSurfaces).not.toContain('duration-300');
+  });
+});
+
+describe('sheet side variants', () => {
+  const sides: SheetSide[] = ['top', 'right', 'bottom', 'left'];
+
+  it('every side composes the shared base signature plus its own placement', () => {
+    for (const side of sides) {
+      const composed = sheetContentClasses(side);
+      // Base signature (invariant across sides) sits on the modal depth token
+      // and the panel fill; the placement segment is the side-specific tail.
+      expect(composed).toContain('z-depth-modal');
+      expect(composed).toContain('bg-background');
+      expect(composed).toContain(sheetSideClasses[side]);
+    }
+  });
+
+  it('left and right anchor the block axis edge and run full height', () => {
+    expect(sheetSideClasses.left).toContain('left-0');
+    expect(sheetSideClasses.left).toContain('h-full');
+    expect(sheetSideClasses.left).toContain('border-r');
+    expect(sheetSideClasses.right).toContain('right-0');
+    expect(sheetSideClasses.right).toContain('h-full');
+    expect(sheetSideClasses.right).toContain('border-l');
+  });
+
+  it('top and bottom span the inline axis and hug their edge', () => {
+    expect(sheetSideClasses.top).toContain('top-0');
+    expect(sheetSideClasses.top).toContain('inset-x-0');
+    expect(sheetSideClasses.top).toContain('border-b');
+    expect(sheetSideClasses.bottom).toContain('bottom-0');
+    expect(sheetSideClasses.bottom).toContain('inset-x-0');
+    expect(sheetSideClasses.bottom).toContain('border-t');
+  });
+});

--- a/packages/ui/test/components/sheet/sheet.conformance.test.tsx
+++ b/packages/ui/test/components/sheet/sheet.conformance.test.tsx
@@ -1,0 +1,368 @@
+/**
+ * React performance of the sheet score, driven end to end. The portal renders
+ * into document.body, so part queries run against body, not the RTL container.
+ */
+import * as React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetOverlay,
+  SheetPortal,
+  SheetTitle,
+  SheetTrigger,
+} from '../../../src/components/sheet/sheet';
+import { sheet } from '../../../src/components/sheet/sheet.behavior';
+import { sheetSideClasses } from '../../../src/components/sheet/sheet.classes';
+import {
+  assertAxeClean,
+  assertContractFulfillment,
+  domPartIds,
+  partElement,
+} from '../../harness/conformance';
+import type { SheetSide } from '../../../src/components/sheet/sheet.behavior';
+
+interface SetupProps {
+  open?: boolean;
+  defaultOpen?: boolean;
+  modal?: boolean;
+  side?: SheetSide;
+  onOpenChange?: (open: boolean) => void;
+  withDescription?: boolean;
+}
+
+function TestSheet({ withDescription = true, side, ...props }: SetupProps) {
+  return (
+    <Sheet {...props}>
+      <SheetTrigger>Open filters</SheetTrigger>
+      <SheetContent {...(side ? { side } : {})}>
+        <SheetHeader>
+          <SheetTitle>Filters</SheetTitle>
+          {withDescription ? <SheetDescription>Refine the results.</SheetDescription> : null}
+        </SheetHeader>
+        <button type="button">Apply</button>
+        <SheetFooter />
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+const body = () => document.body;
+
+afterEach(() => {
+  cleanup();
+  document.body.replaceChildren();
+});
+
+describe('sheet conformance [react]', () => {
+  it('closed: only the trigger renders, collapsed and axe-clean', async () => {
+    render(<TestSheet />);
+    const trigger = partElement(body(), 'trigger');
+    expect(trigger).not.toBeNull();
+    expect(partElement(body(), 'content')).toBeNull();
+    expect(trigger?.getAttribute('aria-expanded')).toBe('false');
+    expect(trigger?.hasAttribute('aria-controls')).toBe(false);
+    await assertAxeClean(body());
+  });
+
+  it('open: every part renders and ARIA equals the projection', async () => {
+    const user = userEvent.setup();
+    render(<TestSheet />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+
+    const config = { defaultOpen: false, modal: true };
+    const state = { open: true };
+    assertContractFulfillment(sheet, body(), state, config, [
+      'trigger',
+      'content',
+      'overlay',
+      'title',
+      'description',
+      'close',
+    ]);
+    await assertAxeClean(body());
+  });
+
+  it('side selects the positional variant; default is right', async () => {
+    const user = userEvent.setup();
+    render(<TestSheet side="left" />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    const content = partElement(body(), 'content') as HTMLElement;
+    expect(content.className).toContain(sheetSideClasses.left);
+    expect(content.className).not.toContain(sheetSideClasses.right);
+
+    cleanup();
+    document.body.replaceChildren();
+    render(<TestSheet />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    expect((partElement(body(), 'content') as HTMLElement).className).toContain(
+      sheetSideClasses.right,
+    );
+  });
+
+  it('omitted description projects NO aria-describedby', async () => {
+    const user = userEvent.setup();
+    render(<TestSheet withDescription={false} />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    const content = partElement(body(), 'content');
+    expect(content?.hasAttribute('aria-describedby')).toBe(false);
+    expect(content?.getAttribute('aria-labelledby')).toBeTruthy();
+    await assertAxeClean(body());
+  });
+
+  it('trigger and content are wired by real DOM ids', async () => {
+    const user = userEvent.setup();
+    render(<TestSheet />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    const ids = domPartIds(body(), ['trigger', 'content', 'title', 'description'] as const);
+    const trigger = partElement(body(), 'trigger');
+    const content = partElement(body(), 'content');
+    expect(trigger?.getAttribute('aria-controls')).toBe(ids.content);
+    expect(content?.getAttribute('aria-labelledby')).toBe(ids.title);
+    expect(content?.getAttribute('aria-describedby')).toBe(ids.description);
+  });
+
+  it('focus moves into the sheet and Tab is trapped', async () => {
+    const user = userEvent.setup();
+    render(<TestSheet />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+
+    const content = partElement(body(), 'content') as HTMLElement;
+    expect(content.contains(document.activeElement)).toBe(true);
+
+    const focusable = Array.from(content.querySelectorAll<HTMLElement>('button:not([disabled])'));
+    for (let i = 0; i < focusable.length + 1; i += 1) {
+      await user.tab();
+      expect(content.contains(document.activeElement)).toBe(true);
+    }
+  });
+
+  it('Escape closes and restores focus to the trigger', async () => {
+    const user = userEvent.setup();
+    render(<TestSheet />);
+    const trigger = partElement(body(), 'trigger') as HTMLElement;
+    await user.click(trigger);
+    expect(partElement(body(), 'content')).not.toBeNull();
+
+    await user.keyboard('{Escape}');
+    expect(partElement(body(), 'content')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('pointerdown outside dismisses; on the trigger it toggles closed, not closed-then-open', async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <button type="button">Elsewhere</button>
+        <TestSheet />
+      </div>,
+    );
+    const trigger = partElement(body(), 'trigger') as HTMLElement;
+
+    await user.click(trigger);
+    expect(partElement(body(), 'content')).not.toBeNull();
+    await user.click(document.querySelector('button') as HTMLElement);
+    expect(partElement(body(), 'content')).toBeNull();
+
+    await user.click(trigger);
+    expect(partElement(body(), 'content')).not.toBeNull();
+    await user.click(trigger);
+    expect(partElement(body(), 'content')).toBeNull();
+  });
+
+  it('close button closes', async () => {
+    const user = userEvent.setup();
+    render(<TestSheet />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    await user.click(partElement(body(), 'close') as HTMLElement);
+    expect(partElement(body(), 'content')).toBeNull();
+  });
+
+  it('scroll is locked while open and released on close', async () => {
+    const user = userEvent.setup();
+    render(<TestSheet />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    expect(document.body.style.overflow).toBe('hidden');
+    await user.keyboard('{Escape}');
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+
+  it('non-modal: no overlay, no trap, no scroll lock, Escape still works', async () => {
+    const user = userEvent.setup();
+    render(<TestSheet modal={false} />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    expect(partElement(body(), 'overlay')).toBeNull();
+    expect(document.body.style.overflow).not.toBe('hidden');
+    const content = partElement(body(), 'content') as HTMLElement;
+    expect(content.getAttribute('aria-modal')).toBeNull();
+
+    (content.querySelector('button') as HTMLElement).focus();
+    await user.keyboard('{Escape}');
+    expect(partElement(body(), 'content')).toBeNull();
+  });
+
+  it('defaultOpen mounts open with the trap live', () => {
+    render(<TestSheet defaultOpen />);
+    const content = partElement(body(), 'content');
+    expect(content).not.toBeNull();
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('controlled: callbacks fire, state follows the prop, never the gesture', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const { rerender } = render(<TestSheet open={false} onOpenChange={onOpenChange} />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    expect(partElement(body(), 'content')).toBeNull();
+
+    rerender(<TestSheet open onOpenChange={onOpenChange} />);
+    expect(partElement(body(), 'content')).not.toBeNull();
+
+    await user.keyboard('{Escape}');
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+    expect(partElement(body(), 'content')).not.toBeNull();
+
+    rerender(<TestSheet open={false} onOpenChange={onOpenChange} />);
+    expect(partElement(body(), 'content')).toBeNull();
+  });
+
+  it('explicit Portal + Overlay composition renders without the automatic wrappers', async () => {
+    const user = userEvent.setup();
+    render(
+      <Sheet>
+        <SheetTrigger>Open</SheetTrigger>
+        <SheetPortal>
+          <SheetOverlay />
+          <SheetContent>
+            <SheetTitle>Composed</SheetTitle>
+          </SheetContent>
+        </SheetPortal>
+      </Sheet>,
+    );
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    expect(partElement(body(), 'content')).not.toBeNull();
+    // No DUPLICATE overlay: Content skips its automatic wrapper inside an
+    // explicit portal, so only the consumer's SheetOverlay is present.
+    expect(document.querySelectorAll('[data-part="overlay"]')).toHaveLength(1);
+    // Sheet oracle parity: the close button renders even inside an explicit
+    // portal (showCloseButton ?? true), unlike dialog.
+    expect(partElement(body(), 'close')).not.toBeNull();
+    await assertAxeClean(body());
+  });
+
+  it('forceMount keeps the content in the DOM, hidden and inert, while closed', () => {
+    render(
+      <Sheet>
+        <SheetTrigger>Open</SheetTrigger>
+        <SheetContent forceMount>
+          <SheetTitle>Always mounted</SheetTitle>
+        </SheetContent>
+      </Sheet>,
+    );
+    const content = partElement(body(), 'content');
+    expect(content).not.toBeNull();
+    expect(content?.getAttribute('data-state')).toBe('closed');
+    expect(content?.hasAttribute('hidden')).toBe(true);
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+
+  it('container portals the content into the given element', async () => {
+    const user = userEvent.setup();
+    const target = document.createElement('div');
+    target.id = 'portal-target';
+    document.body.appendChild(target);
+    render(
+      <Sheet>
+        <SheetTrigger>Open</SheetTrigger>
+        <SheetContent container={target}>
+          <SheetTitle>Housed</SheetTitle>
+        </SheetContent>
+      </Sheet>,
+    );
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    expect(target.querySelector('[data-part="content"]')).not.toBeNull();
+  });
+
+  it('onEscapeKeyDown veto keeps the sheet open', async () => {
+    const user = userEvent.setup();
+    render(
+      <Sheet defaultOpen>
+        <SheetContent onEscapeKeyDown={(event) => event.preventDefault()}>
+          <SheetTitle>Stubborn</SheetTitle>
+        </SheetContent>
+      </Sheet>,
+    );
+    await user.keyboard('{Escape}');
+    expect(partElement(body(), 'content')).not.toBeNull();
+  });
+
+  it('onPointerDownOutside veto keeps the sheet open; without veto it closes', async () => {
+    const user = userEvent.setup();
+    const outside = vi.fn((event: Event) => event.preventDefault());
+    const { unmount } = render(
+      <div>
+        <button type="button">Elsewhere</button>
+        <Sheet defaultOpen>
+          <SheetContent onPointerDownOutside={outside}>
+            <SheetTitle>Guarded</SheetTitle>
+          </SheetContent>
+        </Sheet>
+      </div>,
+    );
+    await user.click(document.querySelector('button') as HTMLElement);
+    expect(outside).toHaveBeenCalled();
+    expect(partElement(body(), 'content')).not.toBeNull();
+    unmount();
+
+    render(
+      <div>
+        <button type="button">Elsewhere</button>
+        <Sheet defaultOpen>
+          <SheetContent>
+            <SheetTitle>Unguarded</SheetTitle>
+          </SheetContent>
+        </Sheet>
+      </div>,
+    );
+    await user.click(document.querySelector('button') as HTMLElement);
+    expect(partElement(body(), 'content')).toBeNull();
+  });
+
+  it('close component closes', async () => {
+    const user = userEvent.setup();
+    render(
+      <Sheet defaultOpen>
+        <SheetContent showCloseButton={false}>
+          <SheetTitle>Manual</SheetTitle>
+          <SheetClose>Done</SheetClose>
+        </SheetContent>
+      </Sheet>,
+    );
+    const closer = Array.from(document.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Done',
+    ) as HTMLElement;
+    await user.click(closer);
+    expect(partElement(body(), 'content')).toBeNull();
+  });
+
+  it('uncontrolled callback fires once per real transition', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(<TestSheet onOpenChange={onOpenChange} />);
+    await user.click(partElement(body(), 'trigger') as HTMLElement);
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    await user.keyboard('{Escape}');
+    expect(onOpenChange).toHaveBeenCalledTimes(2);
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/packages/ui/test/components/sheet/sheet.element.conformance.test.ts
+++ b/packages/ui/test/components/sheet/sheet.element.conformance.test.ts
@@ -1,0 +1,104 @@
+/**
+ * WC performance of the sheet score, driven end to end against light-DOM
+ * markup. Same score as the React conformance test -- proves presence (content
+ * hidden off the open axis) and the modal overlay trio (focus-trap, scroll-lock,
+ * dismiss) drive through the DOM binding.
+ */
+import { cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { RaftersSheet } from '../../../src/components/sheet/sheet.element';
+
+beforeAll(() => {
+  if (!customElements.get('rafters-sheet')) customElements.define('rafters-sheet', RaftersSheet);
+});
+
+async function mount(modal = true): Promise<HTMLElement> {
+  document.body.innerHTML = `
+    <rafters-sheet${modal ? '' : ' modal="false"'}>
+      <button type="button" data-part="trigger" id="s-trigger" aria-haspopup="dialog" aria-expanded="false" data-state="closed">Open</button>
+      <div data-part="overlay" id="s-overlay" aria-hidden="true" data-state="closed" hidden></div>
+      <div data-part="content" id="s-content" data-side="right" role="dialog" tabindex="-1" aria-labelledby="s-title" data-state="closed" hidden>
+        <h2 data-part="title" id="s-title">Filters</h2>
+        <button type="button">Apply</button>
+        <button type="button" data-part="close" id="s-close" aria-label="Close">x</button>
+      </div>
+    </rafters-sheet>`;
+  await Promise.resolve();
+  return document.body.querySelector('rafters-sheet') as HTMLElement;
+}
+
+const trigger = () => document.body.querySelector<HTMLElement>('[data-part="trigger"]')!;
+const content = () => document.body.querySelector<HTMLElement>('[data-part="content"]')!;
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+describe('sheet conformance [wc]', () => {
+  it('closed: content hidden, trigger collapsed', async () => {
+    await mount();
+    expect(content().hidden).toBe(true);
+    expect(trigger().getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('trigger opens: content shows, aria wired, focus trapped, scroll locked', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger());
+    expect(content().hidden).toBe(false);
+    expect(trigger().getAttribute('aria-expanded')).toBe('true');
+    expect(trigger().getAttribute('aria-controls')).toBe('s-content');
+    expect(content().contains(document.activeElement)).toBe(true);
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('the authored side survives the binding untouched', async () => {
+    await mount();
+    expect(content().getAttribute('data-side')).toBe('right');
+  });
+
+  it('Escape closes, restores focus to the trigger, releases scroll', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger());
+    await user.keyboard('{Escape}');
+    expect(content().hidden).toBe(true);
+    expect(document.activeElement).toBe(trigger());
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+
+  it('close button closes', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger());
+    await user.click(document.body.querySelector('[data-part="close"]') as HTMLElement);
+    expect(content().hidden).toBe(true);
+  });
+
+  it('pointerdown outside dismisses; the trigger toggles, not close-then-open', async () => {
+    const user = userEvent.setup();
+    await mount();
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    await user.click(trigger());
+    expect(content().hidden).toBe(false);
+    await user.click(outside);
+    expect(content().hidden).toBe(true);
+    await user.click(trigger());
+    expect(content().hidden).toBe(false);
+    await user.click(trigger());
+    expect(content().hidden).toBe(true);
+  });
+
+  it('non-modal: no scroll lock, Escape still closes', async () => {
+    const user = userEvent.setup();
+    await mount(false);
+    await user.click(trigger());
+    expect(document.body.style.overflow).not.toBe('hidden');
+    (content().querySelector('button') as HTMLElement).focus();
+    await user.keyboard('{Escape}');
+    expect(content().hidden).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Ports `sheet` (edge-anchored modal panel) to the behavior layer as ONE score with
THREE thin decorators, imitating dialog -- the modal-overlay reference.

- `sheet.behavior.ts` -- the score: `disclosable` (open/closed axis over the single
  `createBehavior` cell) + a structure-only `sheet-surface` slice + a `sheet` glue
  slice projecting `role="dialog"`, `aria-modal`, labelledby/describedby, and the
  Escape keymap. Plus `bindSheet`, the DOM-native client the WC and Astro share. The
  modal overlay trio (focus-trap, scroll-lock, trigger-spared outside dismiss) is
  composed DIRECTLY via `startSheetModalEffects` -- effects-as-data is retired.
- `sheet.classes.ts` -- the view. `side` (top/right/bottom/left, default right) is a
  positional class variant (decoration), not reducer state: it projects no ARIA and
  claims no key, and it stays on `SheetContent` to preserve the shadcn surface.
- `sheet.tsx` / `sheet.element.ts` / `sheet.astro` -- three thin decorators, all
  driving the same `bindSheet`; no decision lives in a decorator.
- Motion is re-declared as intent only; the oracle's `animate-in/out slide-*` and raw
  `duration-500/300` are dropped (semantic slide tokens pending #1899). Enter-only.

## Acceptance criteria mapping

### Component doc written

`docs/spec/components/sheet.md` is modeled on dialog.md and covers composition, the
config/state/actions shape, the parts-and-ARIA table, keyboard, oracle dispositions,
and WCAG obligations, including why `side` is decoration rather than reducer state.
Evidence: packages/ui/docs/spec/components/sheet.md:1

### JSDoc intelligence tags present

The React performance opens with the four registry-parsed tags -- `@cognitive-load`
with a load breakdown, `@attention-economics`, `@trust-building`, `@accessibility` --
describing the partial-capture overlay and its focus/dismiss guarantees.
Evidence: packages/ui/src/components/sheet/sheet.tsx:6

### Behavior test (pure, no DOM)

`sheet.behavior.test.ts` exercises the score with no DOM at all: parts surface,
controlled-vs-intrinsic open, the idempotence gate, actions, the aria projection, the
Escape keymap, and that `side` never enters the aria projection.
Evidence: packages/ui/test/components/sheet/sheet.behavior.test.ts:1

### Classes parity test

`sheet.classes.test.ts` pins the depth tokens, the touch-floor close sizing, container
(not viewport) breakpoints, the four per-side variants composing base plus placement,
and that the oracle's slide utilities and raw slide durations are absent.
Evidence: packages/ui/test/components/sheet/sheet.classes.test.ts:1

### Conformance test via the shared harness (aria + keymap against rendered DOM)

Three suites drive the one score through `assertContractFulfillment` and `assertAxeClean`
against real rendered DOM in React, WC, and Astro, asserting the aria projection and the
Escape keymap plus focus-trap, scroll-lock, and outside-dismiss behavior.
Evidence: packages/ui/test/components/sheet/sheet.conformance.test.tsx:60

### shadcn drop-in parity where the component exists in shadcn

The named exports match shadcn's set -- Sheet, SheetTrigger, SheetContent, SheetHeader,
SheetFooter, SheetTitle, SheetDescription, SheetClose, SheetOverlay, SheetPortal -- with
`side` on `SheetContent` and `showCloseButton ?? true`, matching the oracle exactly.
Evidence: packages/ui/src/components/sheet/sheet.tsx:334

### `pnpm --filter @rafters/ui test:unit` green, `pnpm preflight` green

Both gates pass locally: the full `@rafters/ui` unit suite (React, WC, and Astro
configs) is green and `pnpm preflight` (lint, format, typecheck, build) exits zero with
no new errors after merging origin/main into the branch.
Evidence: packages/ui/test/components/sheet/sheet.astro.conformance.test.ts:1

## Not done

- Exit / slide motion is intentionally NOT shipped: the semantic slide-per-side motion
  tokens do not exist yet (motion token layer rebuild, #1899) and exit animation is
  gated on the Presence adapter (wave 0-B). Sheet ships enter-only and correct at every
  state via `data-state` + `hidden`; the oracle's raw-duration slide utilities are
  dropped rather than ported.
- No Vue performance (out of scope; the mandate is React + WC + Astro).
- No shared-file edits (components.jsonl is deleted, and CHANGELOG/exports are excluded
  by the issue -- distribution is the registry, #1896).

Closes #1792
