### PR TITLE
feat(ui): port dropdown-menu to the behavior layer

### DIFF
--- a/packages/ui/docs/spec/components/dropdown-menu.md
+++ b/packages/ui/docs/spec/components/dropdown-menu.md
@@ -1,0 +1,134 @@
+# Component Spec — Dropdown Menu
+
+Status: PORTED (wave-4). Archetype: `menu-collection-popup`.
+
+An anchored action menu disclosed by a trigger. Opening lands focus on the first
+item; roving-focus moves it with the arrow keys, typeahead jumps to the first
+matching label, and activating an item runs its action and closes. The overlay
+composes its dismissal DIRECTLY (outside-click + Escape via the keymap), the
+canonical port-wave path -- never the `dismissable-layer` stack.
+
+Files (`src/components/dropdown-menu/`):
+
+```
+dropdown-menu.classes.ts   dropdown-menu.behavior.ts
+dropdown-menu.tsx          dropdown-menu.element.ts   dropdown-menu.astro
+```
+
+Tests mirror into `test/components/dropdown-menu/`: behavior (pure), classes
+parity, and conformance across React + WC + Astro via the shared harness.
+
+## Composition
+
+```
+disclosable (lib)        state {open}, actions open/close, trigger/content parts
+dropdown-menu-structure  parts only: root, item (many)
+dropdown-menu glue       trigger haspopup, menu role/orientation/labelledby, Escape keymap
+```
+
+`disclosable` is the reusable open/closed axis (dialog folds it too): a reducer
+over the ONE `createBehavior` cell, never a second `createDisclosure`. Controlled
+config shadows intrinsic state; projections and the idempotence gate read
+`isOpen(state, config)`, so a controlled consumer's callback fires once per real
+transition.
+
+The impure work is composed directly by the bindings (there is no effect
+runner): `startDropdownMenuEffects({ content, getTrigger, onDismiss })` starts
+`createRovingFocus` (vertical) + `createTypeahead` + `onPointerDownOutside`
+(sparing the trigger) on the open transition and tears them down on close.
+`bindDropdownMenu` (WC/Astro) and a React `useEffect` call the same function.
+
+### Highlighted item = roving-focus current item (not score state)
+
+The issue lists "open, highlighted item" as the states. `open` is score state.
+The highlighted item is NOT: it is ephemeral DOM focus owned by `roving-focus`,
+styled via `:focus`, exactly the stance navigation-menu documents for its
+trigger focus movement. The oracle carried no `data-highlighted` and no
+pointer-move-to-focus; select tracks a highlight only because it projects
+`data-highlighted` keyed by an option `value`, which menu action items do not
+have. Reducing it to `:focus` is faithful extraction, not a dropped state.
+
+## Config, state, actions
+
+```ts
+type DropdownMenuConfig = { open?: boolean; defaultOpen?: boolean }; // = DisclosableConfig
+type DropdownMenuState = { open: boolean };                          // intrinsic only
+type DropdownMenuActions = { open: undefined; close: undefined };
+```
+
+No `toggle` action: the trigger dispatches `open` or `close` computed from the
+effective value, so intrinsic state can never drift from a controlled consumer.
+
+## Parts and ARIA
+
+| Part | Presence | ARIA |
+| --- | --- | --- |
+| root | always | `data-state` |
+| trigger | always | `aria-haspopup="menu"`, `aria-expanded`, `aria-controls` (only while the menu id is real and open), `data-state` |
+| content | present, hidden while closed | `role="menu"`, `aria-orientation="vertical"`, `aria-labelledby` (the trigger, only when its id is real), `data-state` |
+| item (many) | present | role is author markup (`menuitem` / `menuitemcheckbox` / `menuitemradio`); `data-roving-item`, `tabindex=-1`, `aria-disabled`/`data-disabled` when disabled; `aria-checked` + `data-state` on checkbox/radio items (consumer-controlled) |
+
+The `item` PartDecl carries NO `role`, so checkbox/radio variants keep their own
+role. Empty-id convention (ratified 2026-07-08): a binding passes `''` as the
+PartId of a part it did not render; projections emit `undefined` for references
+to empty ids, so `aria-controls`/`aria-labelledby` never dangle (an axe
+violation). The menu stays in light DOM present-but-hidden so the
+roving/typeahead/dismiss effects can read it and the markup is crawlable/SSR
+stable.
+
+## Keyboard
+
+- Trigger `ArrowDown`/`ArrowUp`/`Enter`/`Space` -> `open` (score keymap). The
+  decorator `preventDefault`s, suppressing the native button click Enter/Space
+  would otherwise fire (which would toggle back closed).
+- Content/item `Escape` -> `close` (score keymap); focus returns to the trigger.
+- Arrow keys within the menu rove focus (roving-focus, vertical, looping),
+  skipping disabled items; `Home`/`End` jump to the first/last.
+- Typing jumps focus to the first item whose label matches (typeahead).
+- `Enter`/`Space` on a focused item ACTIVATE it. This is the div-as-button
+  affordance (the oracle's `handleKeyDown === handleClick`): the decorator routes
+  it through the item's single click path, which runs the consumer action and
+  dispatches the score's `close`. It is deliberately NOT a score keymap action --
+  activation is a consumer concern; only its state effect (close) is the score's.
+
+## Motion
+
+Enter/exit and interaction motion are left UNDECLARED. The semantic
+`motion-dropdown-in`/`-out` utilities are not yet emitted by the token layer
+(#1899/#1902-1904), and the oracle's `animate-in`/`zoom`/`fade`/`slide` +
+`duration-N` string is precisely the prohibited hand-rolled form
+(05-authoring.md, MOTION.md). Per the issue, the motion is left undeclared rather
+than hardcoded; the menu shows/hides via `hidden`. When the token layer ships,
+`classes.content` gains `motion-dropdown-in`/`-out` with `data-[state]`-toggled
+from/to values and a presence adapter to keep the exiting node mounted.
+
+## Oracle dispositions (src/old/ui/dropdown-menu.tsx)
+
+| Oracle feature | Disposition |
+| --- | --- |
+| controlled/uncontrolled open + onOpenChange | contract (reducer over the disclosable cell; the oracle's second `createDisclosure` cell dropped) |
+| Trigger / Content / Group / Label / Item / Separator / Shortcut surface + `DropdownMenu.*` namespace | contract |
+| CheckboxItem / RadioGroup / RadioItem | contract (React); `checked`/`value` are consumer-controlled state, NOT a score axis |
+| roving focus + typeahead across all three item roles | contract (composed directly via startDropdownMenuEffects; `data-roving-item` on every item so checkbox/radio roles rove too) |
+| Escape closes, focus returns to the trigger | contract (moved from a document listener to the content keymap) |
+| outside-pointerdown closes, sparing the trigger | contract (`onPointerDownOutside`, trigger spared) |
+| focus first item on open | contract |
+| Enter/Space activates a menu item | contract (div-as-button click path; state effect is the score's `close`) |
+| asChild on Trigger / Content / Item | framework affordance (React) |
+| checkbox toggle / radio selection | framework affordance (React `onCheckedChange`/`onValueChange`); in WC/Astro `aria-checked` is author markup the bind does not own |
+| Sub / SubTrigger / SubContent (nested submenus) | dropped -- the issue's state model is "open, highlighted item" (no submenu-open axis); faithful submenu open-on-hover needs `hover-delay` (the issue adds no primitives) or the oracle's raw `setTimeout` (a forbidden half-solution); neither cited reference has submenus. Tracked for a later wave |
+| collision-aware positioning (computePosition on scroll/resize) | dropped -- positioning is not behavior state and not modelled here (same disposition select took); reduced positioning fidelity vs the old React-only path |
+| Portal (portals the content to `document.body`) | framework affordance -> pass-through: the menu lives in light DOM present-but-hidden, so there is no portal to open; the API is preserved |
+| `highlighted` as tracked state | not ported -- the highlight is the roving-focus current item via `:focus` (see above), matching navigation-menu; the oracle never tracked it either |
+
+## WCAG 2.1 AA obligations
+
+- 1.3.1 / 4.1.2: `aria-haspopup="menu"`, `role="menu"` + `aria-orientation`,
+  `aria-controls`/`aria-labelledby` wired to real DOM ids, asserted by the
+  harness against rendered markup in all three frameworks.
+- 2.1.1: full keyboard operation -- open, arrow-rove, Home/End, typeahead,
+  activate, Escape.
+- 2.4.3 Focus Order: opening moves focus to the first item; Escape/activate
+  restore focus to the trigger.
+- 2.4.7: token focus ring on the trigger; the active item is visible via
+  `focus:bg-accent`.

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu.astro
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu.astro
@@ -1,0 +1,77 @@
+---
+/**
+ * Astro performance for dropdown-menu. Server-renders the full light-DOM menu
+ * with the closed-state projection already applied (correct and inert before
+ * JS), then the <script> hands each instance to bindDropdownMenu -- the SAME
+ * DOM-native client the Web Component uses. One score, three performances.
+ *
+ * The menu stays in light DOM (present-but-hidden) so the effects the bind runs
+ * -- roving-focus, typeahead, dismiss-on-outside -- can read it.
+ */
+import {
+  dropdownMenu,
+  type DropdownMenuConfig,
+  type DropdownMenuPart,
+} from './dropdown-menu.behavior';
+import { dropdownMenuClasses } from './dropdown-menu.classes';
+import type { PartIds } from '../../lib/contract';
+
+interface Item {
+  label: string;
+  disabled?: boolean;
+}
+
+interface Props {
+  id: string;
+  label: string;
+  items: Item[];
+}
+
+const { id, label, items } = Astro.props;
+
+const config: DropdownMenuConfig = {};
+const state = dropdownMenu.initialState(config);
+const classes = dropdownMenuClasses(config, state);
+
+const ids = {} as PartIds<DropdownMenuPart>;
+for (const part of Object.keys(dropdownMenu.parts) as DropdownMenuPart[]) {
+  ids[part] = `${id}-${part}`;
+}
+const aria = dropdownMenu.aria(state, config, ids);
+---
+
+<rafters-dropdown-menu data-part="root" id={ids.root} {...aria.root}>
+  <button type="button" id={ids.trigger} data-part="trigger" class={classes.trigger} {...aria.trigger}>
+    {label}
+  </button>
+
+  <div id={ids.content} data-part="content" class={classes.content} hidden={!state.open} {...aria.content}>
+    {
+      items.map((item) => (
+        <div
+          role="menuitem"
+          data-part="item"
+          data-roving-item=""
+          data-disabled={item.disabled ? '' : undefined}
+          aria-disabled={item.disabled ? 'true' : undefined}
+          tabindex={item.disabled ? undefined : -1}
+          class={classes.item}
+        >
+          {item.label}
+        </div>
+      ))
+    }
+  </div>
+</rafters-dropdown-menu>
+
+<script>
+  import { bindDropdownMenu } from './dropdown-menu.behavior';
+
+  for (const root of document.querySelectorAll<HTMLElement>(
+    'rafters-dropdown-menu[data-part="root"]',
+  )) {
+    if (root.dataset['bound'] === 'true') continue;
+    root.dataset['bound'] = 'true';
+    bindDropdownMenu(root);
+  }
+</script>

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu.behavior.ts
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu.behavior.ts
@@ -1,0 +1,338 @@
+import { compose, type GlueSlice, type Slice } from '../../lib/compose';
+import {
+  createBehavior,
+  type AriaAttrs,
+  type BehaviorSpec,
+  type PartIds,
+} from '../../lib/contract';
+import {
+  disclosable,
+  isOpen,
+  type DisclosableActions,
+  type DisclosableConfig,
+  type DisclosablePart,
+  type DisclosableState,
+} from '../../lib/disclosable';
+import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { onPointerDownOutside } from '../../primitives/outside-click';
+import { createRovingFocus } from '../../primitives/roving-focus';
+import { createTypeahead } from '../../primitives/typeahead';
+
+/**
+ * Dropdown menu: a trigger discloses an anchored action menu. Opening lands
+ * focus on the first item; roving-focus moves it with the arrow keys, typeahead
+ * jumps to the first matching label, and activating an item runs its action and
+ * closes. Replaces the imperative old/ui/dropdown-menu.tsx wholesale.
+ *
+ * The score's only state axis is `open`. The "highlighted item" is NOT state
+ * here -- it is ephemeral DOM focus owned by roving-focus and styled via
+ * `:focus`, exactly the stance navigation-menu documents for its trigger focus
+ * movement. The oracle carried no `data-highlighted` and no pointer-move-to-
+ * focus; select tracks a highlight only because it projects `data-highlighted`
+ * keyed by an option `value`, which menu action items do not have.
+ *
+ * open/close reuse the `disclosable` lib slice (the dialog pattern): a reducer
+ * over the ONE createBehavior cell, controlled config shadowing intrinsic state,
+ * idempotence-gated so consumer callbacks fire once per real transition.
+ */
+export type DropdownMenuConfig = DisclosableConfig;
+export type DropdownMenuState = DisclosableState;
+export type DropdownMenuActions = DisclosableActions;
+
+export type DropdownMenuPart = DisclosablePart | 'root' | 'item';
+
+export { isOpen };
+
+/** Structure-only slice: the parts a menu has beyond the disclosable
+ *  trigger/content pair. Contributes no state and no actions. The `item` part
+ *  carries NO `role` in its PartDecl -- checkbox/radio items use
+ *  menuitemcheckbox/menuitemradio, so the role is author markup, not forced. */
+const menuStructure: Slice<
+  DropdownMenuConfig,
+  Record<never, never>,
+  Record<never, never>,
+  'root' | 'item'
+> = {
+  name: 'dropdown-menu-structure',
+  parts: {
+    root: {},
+    item: { many: true },
+  },
+  initialState: () => ({}),
+};
+
+/** The menu glue: the trigger's haspopup, the menu role/orientation/name over
+ *  the disclosable open axis, and the Escape contract. Roving/typeahead/dismiss
+ *  are composed directly by the bindings, not declared here. */
+const menuGlue: GlueSlice<
+  DropdownMenuConfig,
+  DropdownMenuState,
+  DisclosableActions,
+  DropdownMenuPart
+> = {
+  kind: 'glue',
+  name: 'dropdown-menu',
+  aria: (state, config, ids) => {
+    const open = isOpen(state, config);
+    return {
+      root: {
+        'data-state': open ? 'open' : 'closed',
+      },
+      trigger: {
+        'aria-haspopup': 'menu',
+      },
+      content: {
+        role: 'menu',
+        'aria-orientation': 'vertical',
+        // The menu is named by the trigger that controls it. An empty id means
+        // the trigger part is not rendered; project absence rather than a
+        // dangling aria-labelledby (an axe violation).
+        'aria-labelledby': ids.trigger || undefined,
+      },
+    };
+  },
+  keymap: (event, _state, part, _config) => {
+    if (part === 'trigger') {
+      // A menu button opens on ArrowDown/ArrowUp/Enter/Space; canDispatch drops
+      // it when already open. The decorator preventDefaults, suppressing the
+      // native button click that Enter/Space would otherwise also fire.
+      if (
+        event.key === 'ArrowDown' ||
+        event.key === 'ArrowUp' ||
+        event.key === 'Enter' ||
+        event.key === ' '
+      ) {
+        return 'open';
+      }
+      return null;
+    }
+    // Focus is inside the menu, on an item or the menu container.
+    if (part === 'content' || part === 'item') {
+      if (event.key === 'Escape') return 'close';
+    }
+    return null;
+  },
+};
+
+export const dropdownMenu: BehaviorSpec<
+  DropdownMenuConfig,
+  DropdownMenuState,
+  DropdownMenuActions,
+  DropdownMenuPart
+> = compose('dropdown-menu', disclosable<DropdownMenuConfig>(), menuStructure, menuGlue);
+
+/** The parts and dispatch the open-menu trio composes against. */
+export interface DropdownMenuOpenPorts {
+  /** The menu: focus roves inside it, typeahead jumps within it, and a
+   *  pointerdown landing outside it dismisses. */
+  content: HTMLElement;
+  /** Resolves the trigger so the opening gesture's pointerdown is spared --
+   *  otherwise it would both dismiss the menu and re-open it. */
+  getTrigger: () => HTMLElement | null;
+  /** Outside-pointerdown handler, already spared of the trigger. Receives the
+   *  native event so a boundary could offer a consumer veto before closing. */
+  onDismiss: (event: Event) => void;
+}
+
+/** The enabled menu items -- the set roving and typeahead operate over, shared
+ *  so both agree. All three item roles (menuitem/menuitemcheckbox/
+ *  menuitemradio) carry data-part="item", so this globs them uniformly. */
+export function enabledItems(content: HTMLElement): HTMLElement[] {
+  return Array.from(content.querySelectorAll<HTMLElement>('[data-part="item"]')).filter(
+    (item) => !item.hasAttribute('data-disabled') && item.getAttribute('aria-disabled') !== 'true',
+  );
+}
+
+/**
+ * The open-menu effect trio, composed directly (replacing the retired effects
+ * runner): rove arrow/Home/End focus across the items, type-to-jump to the
+ * first matching item, and dismiss on a pointerdown outside `content` --
+ * sparing the trigger. Level-triggered: BOTH bindDropdownMenu and the React
+ * DropdownMenu start this on the open transition (after content is un-hidden so
+ * the item set is focusable) and call the returned cleanup on close/unmount.
+ * Cleanup releases LIFO.
+ */
+export function startDropdownMenuEffects({
+  content,
+  getTrigger,
+  onDismiss,
+}: DropdownMenuOpenPorts): () => void {
+  const stopRoving = createRovingFocus(content, { orientation: 'vertical', loop: true });
+  const stopTypeahead = createTypeahead(content, {
+    getItems: () => enabledItems(content),
+    onMatch: (item) => item.focus(),
+  });
+  const stopDismiss = onPointerDownOutside(content, (event) => {
+    const target = event.target as Node;
+    if (getTrigger()?.contains(target)) return;
+    onDismiss(event);
+  });
+  return () => {
+    stopDismiss();
+    stopTypeahead();
+    stopRoving();
+  };
+}
+
+/** Move focus to the first enabled item -- the open-focus semantic (keyboard
+ *  users land on the first action). Shared by the bind and the React decorator
+ *  so all three performances behave alike. */
+export function focusFirstItem(content: HTMLElement | null): void {
+  if (!content) return;
+  enabledItems(content)[0]?.focus();
+}
+
+/**
+ * The DOM-native binding of the dropdown-menu score -- the client. The Web
+ * Component and the Astro <script> both import THIS; only React (retained-mode)
+ * reads the projections declaratively. Same shape as bindSelect/bindDialog,
+ * plus the menu concerns: presence (the menu hides off the open axis, staying
+ * in light DOM so the roving/typeahead/dismiss effects can read it), open-focus
+ * of the first item, and Enter/Space item activation via the shared click path.
+ */
+export function bindDropdownMenu(root: HTMLElement): () => void {
+  const contentEl = root.querySelector<HTMLElement>('[data-part="content"]');
+  const config: DropdownMenuConfig = {
+    defaultOpen:
+      root.getAttribute('default-open') === 'true' || contentEl?.dataset['state'] === 'open',
+  };
+
+  const getPart = (part: string): HTMLElement | null =>
+    part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
+
+  const { memory, dispatch } = createBehavior(dropdownMenu, config);
+
+  const request = (action: keyof DropdownMenuActions): boolean => dispatch(action, config);
+
+  // The open-menu trio is level-triggered: present only while open. render()
+  // starts it on the transition and this cleanup stops it on close.
+  let openEffectsCleanup: (() => void) | null = null;
+
+  // ids READ from the server/author markup, never generated.
+  const ids = {} as PartIds<DropdownMenuPart>;
+  for (const part of Object.keys(dropdownMenu.parts) as DropdownMenuPart[]) {
+    ids[part] = getPart(part)?.id ?? '';
+  }
+
+  // Resolved projection: apply raw (validate:false skips aria-manager's
+  // author-input coercion that would flip the string 'false' to truthy).
+  const applyProjection = (el: HTMLElement, attrs: AriaAttrs) => {
+    for (const [name, value] of Object.entries(attrs)) {
+      updateAriaAttribute(el, name as never, value as never, { validate: false });
+    }
+  };
+
+  const render = () => {
+    const state = memory.get();
+    const open = isOpen(state, config);
+
+    const projection = dropdownMenu.aria(state, config, ids);
+    for (const part of Object.keys(projection) as DropdownMenuPart[]) {
+      const attrs = projection[part];
+      const el = getPart(part);
+      if (el && attrs) applyProjection(el, attrs);
+    }
+
+    // Presence: the menu hides off the open axis (stays in light DOM).
+    if (contentEl) contentEl.hidden = !open;
+
+    // Compose the open-menu trio directly, level-triggered: start it once on the
+    // open transition (content is now un-hidden above so roving and typeahead
+    // see focusable items), tear it down when the menu closes.
+    if (open && !openEffectsCleanup) {
+      const content = getPart('content');
+      if (content) {
+        openEffectsCleanup = startDropdownMenuEffects({
+          content,
+          getTrigger: () => getPart('trigger'),
+          onDismiss: () => {
+            request('close');
+          },
+        });
+      }
+    } else if (!open && openEffectsCleanup) {
+      openEffectsCleanup();
+      openEffectsCleanup = null;
+    }
+
+    // Open-focus: land on the first item when the menu opens and focus is not
+    // already inside it. Once focus is in, subsequent renders see it contained
+    // and do not steal it back.
+    if (open && contentEl && !contentEl.contains(document.activeElement)) {
+      focusFirstItem(contentEl);
+    }
+  };
+  const unsubscribe = memory.subscribe(render); // fires immediately: first paint
+
+  const isDisabledItem = (item: HTMLElement): boolean =>
+    item.hasAttribute('data-disabled') || item.getAttribute('aria-disabled') === 'true';
+
+  const onClick = (event: Event) => {
+    const target = event.target as HTMLElement;
+    const item = target.closest<HTMLElement>('[data-part="item"]');
+    if (item && root.contains(item)) {
+      if (isDisabledItem(item)) return;
+      // Activating an item runs its action (author markup / the consumer's own
+      // handler) and closes; the score owns the close, focus returns to trigger.
+      request('close');
+      getPart('trigger')?.focus();
+      return;
+    }
+    const trigger = target.closest<HTMLElement>('[data-part="trigger"]');
+    if (trigger && root.contains(trigger)) {
+      request(isOpen(memory.get(), config) ? 'close' : 'open');
+    }
+  };
+  root.addEventListener('click', onClick);
+
+  const onKeydown = (event: KeyboardEvent) => {
+    const partEl = (event.target as HTMLElement).closest<HTMLElement>('[data-part]');
+    const part = partEl?.dataset['part'] as DropdownMenuPart | undefined;
+    if (!part) return;
+
+    // Enter/Space on a menu item activate it -- the div-as-button affordance the
+    // oracle spelled out (handleKeyDown === handleClick). The STATE effect
+    // (close) rides the single click path; the keymap owns only Escape/open.
+    const item = partEl?.closest<HTMLElement>('[data-part="item"]');
+    if (item && (event.key === 'Enter' || event.key === ' ')) {
+      if (isDisabledItem(item)) return;
+      event.preventDefault();
+      item.click();
+      return;
+    }
+
+    const action = dropdownMenu.keymap(
+      {
+        key: event.key,
+        shiftKey: event.shiftKey,
+        ctrlKey: event.ctrlKey,
+        altKey: event.altKey,
+        metaKey: event.metaKey,
+      },
+      memory.get(),
+      part,
+      config,
+    );
+    if (!action) return;
+    // preventDefault suppresses the native button click Enter/Space would
+    // otherwise fire on the trigger (which would toggle back closed).
+    event.preventDefault();
+    if (action === 'open') {
+      request('open');
+      return;
+    }
+    if (action === 'close') {
+      request('close');
+      getPart('trigger')?.focus();
+    }
+  };
+  root.addEventListener('keydown', onKeydown);
+
+  return () => {
+    unsubscribe();
+    openEffectsCleanup?.();
+    openEffectsCleanup = null;
+    root.removeEventListener('click', onClick);
+    root.removeEventListener('keydown', onKeydown);
+  };
+}

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu.classes.ts
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu.classes.ts
@@ -1,0 +1,78 @@
+import type { DropdownMenuConfig, DropdownMenuState } from './dropdown-menu.behavior';
+
+export interface DropdownMenuClassSet {
+  trigger: string;
+  content: string;
+  item: string;
+  checkboxItem: string;
+  radioItem: string;
+  itemIndicator: string;
+  checkIcon: string;
+  radioDot: string;
+  separator: string;
+  shortcut: string;
+  label: string;
+  group: string;
+}
+
+// The trigger is usually composed onto a Button via asChild; these are the
+// modest defaults for the bare <button> the decorators fall back to.
+const triggerClasses =
+  'inline-flex items-center justify-center gap-2 rounded-md ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
+
+// z-depth-dropdown is the semantic depth token; fill (bg-popover), not a raw
+// color. Enter/exit motion is intentionally UNDECLARED -- see the component doc:
+// the semantic motion-dropdown-in/-out utilities are not yet emitted by the
+// token layer (#1899/#1902-1904), and the oracle's animate-in/zoom/fade/slide
+// string is the prohibited hand-rolled form (05-authoring, MOTION.md).
+const contentClasses =
+  'z-depth-dropdown min-w-32 overflow-hidden rounded-md border bg-popover p-1 ' +
+  'text-popover-foreground shadow-lg';
+
+// The active item is the roving-focus current item, styled via :focus. No
+// data-highlighted axis (the highlight is ephemeral DOM focus, not score state).
+const itemBase =
+  'relative flex cursor-default select-none items-center rounded-sm text-body-small outline-none ' +
+  'focus:bg-accent focus:text-accent-foreground ' +
+  'data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+
+const itemClasses = `${itemBase} gap-2 px-2 py-1.5`;
+
+const checkboxItemClasses = `${itemBase} py-1.5 pl-8 pr-2`;
+
+const radioItemClasses = `${itemBase} py-1.5 pl-8 pr-2`;
+
+const itemIndicatorClasses = 'absolute left-2 flex h-3.5 w-3.5 items-center justify-center';
+
+const checkIconClasses = 'h-4 w-4';
+
+const radioDotClasses = 'h-2 w-2 rounded-full bg-current';
+
+const separatorClasses = '-mx-1 my-1 h-px border-0 bg-muted';
+
+const shortcutClasses = 'ml-auto text-shortcut opacity-60';
+
+const labelClasses = 'px-2 py-1.5 text-label-medium';
+
+const groupClasses = '';
+
+export function dropdownMenuClasses(
+  _config: DropdownMenuConfig,
+  _state: DropdownMenuState,
+): DropdownMenuClassSet {
+  return {
+    trigger: triggerClasses,
+    content: contentClasses,
+    item: itemClasses,
+    checkboxItem: checkboxItemClasses,
+    radioItem: radioItemClasses,
+    itemIndicator: itemIndicatorClasses,
+    checkIcon: checkIconClasses,
+    radioDot: radioDotClasses,
+    separator: separatorClasses,
+    shortcut: shortcutClasses,
+    label: labelClasses,
+    group: groupClasses,
+  };
+}

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu.element.ts
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu.element.ts
@@ -1,0 +1,27 @@
+/**
+ * WC performance for dropdown-menu: the thinnest wrapper. The score AND the
+ * DOM-native binding (bindDropdownMenu) live in dropdown-menu.behavior.ts,
+ * shared with the Astro performance. This file only adapts that binding to the
+ * custom-element lifecycle -- deferring the bind one microtask because
+ * connectedCallback can fire before the light-DOM parts are parsed.
+ */
+import { bindDropdownMenu } from './dropdown-menu.behavior';
+
+export class RaftersDropdownMenu extends HTMLElement {
+  private teardown: (() => void) | null = null;
+
+  connectedCallback(): void {
+    queueMicrotask(() => {
+      if (this.isConnected && !this.teardown) this.teardown = bindDropdownMenu(this);
+    });
+  }
+
+  disconnectedCallback(): void {
+    this.teardown?.();
+    this.teardown = null;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-dropdown-menu')) {
+  customElements.define('rafters-dropdown-menu', RaftersDropdownMenu);
+}

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu.tsx
@@ -1,0 +1,578 @@
+/**
+ * Dropdown menu: an anchored action menu disclosed by a trigger.
+ *
+ * @cognitive-load 4/10 - familiarity low (universal menu pattern), choice count
+ *   moderate (7 plus/minus 2 items per level), visual complexity low (a single
+ *   list), interaction depth low (open, arrow/type, activate), recovery high
+ *   (Escape closes, focus returns to the trigger).
+ * @attention-economics Contextual actions on demand: the menu is compact when
+ *   closed and reveals a focused option list only when summoned; typeahead
+ *   narrows attention to the matching item.
+ * @trust-building Keyboard-first navigation, a visible focus ring on the active
+ *   item, and focus returned to the trigger on activate or dismiss keep the
+ *   user oriented and in control.
+ * @accessibility Menu-button APG pattern: trigger aria-haspopup="menu" +
+ *   aria-expanded + aria-controls, content role="menu" aria-orientation, roving
+ *   focus across menuitem/menuitemcheckbox/menuitemradio, type-to-search,
+ *   Escape closes and restores focus.
+ *
+ * The React performance is a DECORATOR over dropdown-menu.behavior.ts: it adds
+ * only the view (dropdown-menu.classes.ts) and React wiring (useMemory + a
+ * useEffect that composes startDropdownMenuEffects + the dispatch protocol).
+ * Every decision -- the open/close reducer, aria, keymap, the open-menu effect
+ * trio -- lives in the score. The shadcn drop-in surface (Trigger, Portal,
+ * Content, Group, Label, Item, CheckboxItem, RadioGroup, RadioItem, Separator,
+ * Shortcut) plus the `DropdownMenu.*` namespace is preserved; each extra is a
+ * thin view wrapper. Submenus (Sub/SubTrigger/SubContent) are dropped -- see the
+ * component doc's oracle dispositions.
+ *
+ * Indicator/shortcut inline spans are built with React.createElement, the same
+ * documented escape hatch card/alert/select use for raw inline tags.
+ *
+ * @example
+ * ```tsx
+ * import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@rafters/ui';
+ *
+ * <DropdownMenu>
+ *   <DropdownMenuTrigger>Options</DropdownMenuTrigger>
+ *   <DropdownMenuContent>
+ *     <DropdownMenuItem onSelect={edit}>Edit</DropdownMenuItem>
+ *     <DropdownMenuSeparator />
+ *     <DropdownMenuItem onSelect={remove}>Delete</DropdownMenuItem>
+ *   </DropdownMenuContent>
+ * </DropdownMenu>
+ * ```
+ */
+import * as React from 'react';
+import { createBehavior, type AriaAttrs, type PartIds } from '../../lib/contract';
+import { keyInputOf } from '../../hooks/key-input';
+import { useMemory } from '../../hooks/use-memory';
+import classy from '../../primitives/classy';
+import { mergeProps } from '../../primitives/slot';
+import {
+  dropdownMenu,
+  focusFirstItem,
+  isOpen,
+  startDropdownMenuEffects,
+  type DropdownMenuActions,
+  type DropdownMenuConfig,
+  type DropdownMenuPart,
+} from './dropdown-menu.behavior';
+import { dropdownMenuClasses, type DropdownMenuClassSet } from './dropdown-menu.classes';
+
+interface DropdownMenuContextValue {
+  ids: PartIds<DropdownMenuPart>;
+  aria: Partial<Record<DropdownMenuPart, AriaAttrs>>;
+  request: (action: keyof DropdownMenuActions) => boolean;
+  getPart: (part: string) => HTMLElement | null;
+  effectiveOpen: boolean;
+  classes: DropdownMenuClassSet;
+}
+
+const DropdownMenuContext = React.createContext<DropdownMenuContextValue | null>(null);
+
+function useDropdownMenuContext(component: string): DropdownMenuContextValue {
+  const context = React.useContext(DropdownMenuContext);
+  if (!context) {
+    throw new Error(`${component} must be used within <DropdownMenu>`);
+  }
+  return context;
+}
+
+/** Consumer-controlled checked state for the radio group is carried in a
+ *  separate context (the score owns only open/close). */
+interface DropdownMenuRadioContextValue {
+  value: string;
+  onValueChange: (value: string) => void;
+}
+
+const DropdownMenuRadioContext = React.createContext<DropdownMenuRadioContextValue | null>(null);
+
+export interface DropdownMenuProps {
+  children: React.ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function DropdownMenu({
+  children,
+  open,
+  defaultOpen = false,
+  onOpenChange,
+}: DropdownMenuProps) {
+  const config: DropdownMenuConfig = { open, defaultOpen };
+
+  // The controller composes the score with the substrate -- no useBehavior.
+  const { memory, dispatch } = React.useMemo(() => createBehavior(dropdownMenu, config), []);
+  const state = useMemory(memory);
+  const effectiveOpen = isOpen(state, config);
+
+  const uid = React.useId();
+  const ids = React.useMemo(() => {
+    const out = {} as PartIds<DropdownMenuPart>;
+    for (const part of Object.keys(dropdownMenu.parts) as DropdownMenuPart[])
+      out[part] = `${uid}-${part}`;
+    return out;
+  }, [uid]);
+
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  const getPart = React.useCallback(
+    (part: string): HTMLElement | null =>
+      part === 'root'
+        ? rootRef.current
+        : (rootRef.current?.querySelector<HTMLElement>(`[data-part="${part}"]`) ?? null),
+    [],
+  );
+
+  // Effect-initiated dispatches (outside dismissal) must read the CURRENT config
+  // and callback, so those ride in a ref rather than captured stale.
+  const latest = React.useRef({ config, onOpenChange });
+  latest.current = { config, onOpenChange };
+  const request = React.useCallback(
+    (action: keyof DropdownMenuActions): boolean => {
+      const { config: cfg, onOpenChange: cb } = latest.current;
+      if (!dispatch(action, cfg)) return false;
+      cb?.(action === 'open');
+      return true;
+    },
+    [dispatch],
+  );
+
+  // The open-menu effect trio, composed directly on the open transition
+  // (replacing the retired effects runner): roving focus, typeahead, and outside
+  // dismissal sparing the trigger. Level-triggered via the dependency array;
+  // declared ABOVE the open-focus effect so roving sets the roving tabindex
+  // before focusFirstItem lands focus.
+  React.useEffect(() => {
+    if (!effectiveOpen) return;
+    const content = getPart('content');
+    if (!content) return;
+    return startDropdownMenuEffects({
+      content,
+      getTrigger: () => getPart('trigger'),
+      onDismiss: () => {
+        request('close');
+      },
+    });
+  }, [effectiveOpen, getPart, request]);
+
+  // Open-focus: land on the first item when the menu opens and focus is not
+  // already inside it -- the same rule bindDropdownMenu runs.
+  React.useEffect(() => {
+    if (!effectiveOpen) return;
+    const content = getPart('content');
+    if (content && !content.contains(document.activeElement)) {
+      focusFirstItem(content);
+    }
+  }, [effectiveOpen, getPart]);
+
+  // One root-level keydown handler resolves the focused part and drives the
+  // score, mirroring bindDropdownMenu -- so the trigger/item view wrappers stay
+  // pure click adapters with no keymap logic of their own.
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.defaultPrevented) return;
+    const partEl = (event.target as HTMLElement).closest<HTMLElement>('[data-part]');
+    const part = partEl?.dataset['part'] as DropdownMenuPart | undefined;
+    if (!part) return;
+
+    // Enter/Space on a menu item activate it -- the div-as-button affordance,
+    // routed through the item's own click path (which runs onSelect and closes).
+    const item = partEl?.closest<HTMLElement>('[data-part="item"]');
+    if (item && (event.key === 'Enter' || event.key === ' ')) {
+      if (item.getAttribute('aria-disabled') === 'true') return;
+      event.preventDefault();
+      item.click();
+      return;
+    }
+
+    const action = dropdownMenu.keymap(keyInputOf(event), state, part, config);
+    if (!action) return;
+    // preventDefault suppresses the native button click Enter/Space would
+    // otherwise fire on the trigger (which would toggle back closed).
+    event.preventDefault();
+    if (action === 'open') {
+      request('open');
+      return;
+    }
+    if (action === 'close') {
+      request('close');
+      getPart('trigger')?.focus();
+    }
+  };
+
+  const aria = dropdownMenu.aria(state, config, ids);
+
+  const contextValue: DropdownMenuContextValue = {
+    ids,
+    aria,
+    request,
+    getPart,
+    effectiveOpen,
+    classes: dropdownMenuClasses(config, state),
+  };
+
+  return (
+    <DropdownMenuContext.Provider value={contextValue}>
+      <div ref={rootRef} data-part="root" id={ids.root} {...aria.root} onKeyDown={handleKeyDown}>
+        {children}
+      </div>
+    </DropdownMenuContext.Provider>
+  );
+}
+
+export interface DropdownMenuTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+}
+
+export function DropdownMenuTrigger({
+  className,
+  children,
+  asChild,
+  onClick,
+  ...props
+}: DropdownMenuTriggerProps) {
+  const { ids, aria, request, effectiveOpen, classes } =
+    useDropdownMenuContext('DropdownMenuTrigger');
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    if (event.defaultPrevented) return;
+    request(effectiveOpen ? 'close' : 'open');
+  };
+
+  const partProps = {
+    'data-part': 'trigger',
+    id: ids.trigger,
+    ...aria.trigger,
+    onClick: handleClick,
+  };
+
+  if (asChild && React.isValidElement(children)) {
+    const childProps = children.props as Record<string, unknown>;
+    return React.cloneElement(children, mergeProps(partProps, childProps) as React.Attributes);
+  }
+
+  return (
+    <button type="button" className={classy(classes.trigger, className)} {...partProps} {...props}>
+      {children}
+    </button>
+  );
+}
+
+/** Kept for shadcn drop-in compatibility. In the behavior-layer model the menu
+ *  lives in light DOM (present-but-hidden), so there is no portal to open; this
+ *  is a pass-through that preserves the API. */
+export function DropdownMenuPortal({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}
+
+export interface DropdownMenuContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  asChild?: boolean;
+}
+
+export function DropdownMenuContent({
+  className,
+  children,
+  asChild,
+  ...props
+}: DropdownMenuContentProps) {
+  const { ids, aria, effectiveOpen, classes } = useDropdownMenuContext('DropdownMenuContent');
+
+  const partProps = {
+    'data-part': 'content',
+    id: ids.content,
+    hidden: effectiveOpen ? undefined : true,
+    ...aria.content,
+  };
+
+  if (asChild && React.isValidElement(children)) {
+    const childProps = children.props as Record<string, unknown>;
+    return React.cloneElement(children, mergeProps(partProps, childProps) as React.Attributes);
+  }
+
+  return (
+    <div className={classy(classes.content, className)} {...partProps} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export type DropdownMenuGroupProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function DropdownMenuGroup({ className, ...props }: DropdownMenuGroupProps) {
+  const { classes } = useDropdownMenuContext('DropdownMenuGroup');
+  // biome-ignore lint/a11y/useSemanticElements: role="group" is correct for menu groups per WAI-ARIA APG
+  return <div role="group" className={classy(classes.group, className)} {...props} />;
+}
+
+export interface DropdownMenuLabelProps extends React.HTMLAttributes<HTMLDivElement> {
+  inset?: boolean;
+}
+
+export function DropdownMenuLabel({ className, inset, ...props }: DropdownMenuLabelProps) {
+  const { classes } = useDropdownMenuContext('DropdownMenuLabel');
+  return <div className={classy(classes.label, inset && 'pl-8', className)} {...props} />;
+}
+
+/** The shared select-then-close path: fire a cancelable `select` event, and
+ *  unless the consumer vetoes it, run an optional side effect (a checked/value
+ *  change), close the menu, and return focus to the trigger. Mirrors the
+ *  oracle's handleSelect. */
+function useItemSelect(disabled: boolean, onSelect?: (event: Event) => void) {
+  const { request, getPart } = useDropdownMenuContext('DropdownMenuItem');
+  return React.useCallback(
+    (before?: () => void): boolean => {
+      if (disabled) return false;
+      const event = new Event('select', { cancelable: true });
+      onSelect?.(event);
+      if (event.defaultPrevented) return false;
+      before?.();
+      request('close');
+      getPart('trigger')?.focus();
+      return true;
+    },
+    [disabled, onSelect, request, getPart],
+  );
+}
+
+export interface DropdownMenuItemProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'onSelect'
+> {
+  inset?: boolean;
+  disabled?: boolean;
+  asChild?: boolean;
+  onSelect?: (event: Event) => void;
+}
+
+export function DropdownMenuItem({
+  className,
+  children,
+  inset,
+  disabled = false,
+  asChild,
+  onSelect,
+  onClick,
+  ...props
+}: DropdownMenuItemProps) {
+  const { classes } = useDropdownMenuContext('DropdownMenuItem');
+  const select = useItemSelect(disabled, onSelect);
+
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    onClick?.(event);
+    if (event.defaultPrevented) return;
+    select();
+  };
+
+  const partProps = {
+    'data-part': 'item',
+    role: 'menuitem',
+    'data-roving-item': '',
+    tabIndex: disabled ? undefined : -1,
+    'aria-disabled': disabled || undefined,
+    'data-disabled': disabled ? '' : undefined,
+    onClick: handleClick,
+  };
+
+  if (asChild && React.isValidElement(children)) {
+    const childProps = children.props as Record<string, unknown>;
+    return React.cloneElement(children, mergeProps(partProps, childProps) as React.Attributes);
+  }
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: role="menuitem" is the menu APG pattern
+    <div className={classy(classes.item, inset && 'pl-8', className)} {...partProps} {...props}>
+      {children}
+    </div>
+  );
+}
+
+function CheckIcon({ className }: { className: string }) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+      aria-hidden="true"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+    </svg>
+  );
+}
+
+export interface DropdownMenuCheckboxItemProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'onSelect'
+> {
+  checked?: boolean;
+  disabled?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+  onSelect?: (event: Event) => void;
+}
+
+export function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked = false,
+  disabled = false,
+  onCheckedChange,
+  onSelect,
+  onClick,
+  ...props
+}: DropdownMenuCheckboxItemProps) {
+  const { classes } = useDropdownMenuContext('DropdownMenuCheckboxItem');
+  const select = useItemSelect(disabled, onSelect);
+
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    onClick?.(event);
+    if (event.defaultPrevented) return;
+    // Checked state is consumer-controlled; the score owns only open/close.
+    select(() => onCheckedChange?.(!checked));
+  };
+
+  const indicator = React.createElement(
+    'span',
+    { className: classes.itemIndicator, 'aria-hidden': 'true' },
+    checked ? <CheckIcon className={classes.checkIcon} /> : null,
+  );
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: role="menuitemcheckbox" is the menu APG pattern
+    <div
+      data-part="item"
+      role="menuitemcheckbox"
+      data-roving-item=""
+      aria-checked={checked}
+      tabIndex={disabled ? undefined : -1}
+      aria-disabled={disabled ? 'true' : undefined}
+      data-disabled={disabled ? '' : undefined}
+      data-state={checked ? 'checked' : 'unchecked'}
+      className={classy(classes.checkboxItem, className)}
+      onClick={handleClick}
+      {...props}
+    >
+      {indicator}
+      {children}
+    </div>
+  );
+}
+
+export interface DropdownMenuRadioGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+  value?: string;
+  onValueChange?: (value: string) => void;
+}
+
+export function DropdownMenuRadioGroup({
+  value = '',
+  onValueChange,
+  className,
+  children,
+  ...props
+}: DropdownMenuRadioGroupProps) {
+  const { classes } = useDropdownMenuContext('DropdownMenuRadioGroup');
+  const contextValue = React.useMemo<DropdownMenuRadioContextValue>(
+    () => ({ value, onValueChange: (next: string) => onValueChange?.(next) }),
+    [value, onValueChange],
+  );
+  return (
+    <DropdownMenuRadioContext.Provider value={contextValue}>
+      {/* biome-ignore lint/a11y/useSemanticElements: role="group" is correct for menu radio groups per WAI-ARIA APG */}
+      <div role="group" className={classy(classes.group, className)} {...props}>
+        {children}
+      </div>
+    </DropdownMenuRadioContext.Provider>
+  );
+}
+
+export interface DropdownMenuRadioItemProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'onSelect'
+> {
+  value: string;
+  disabled?: boolean;
+  onSelect?: (event: Event) => void;
+}
+
+export function DropdownMenuRadioItem({
+  className,
+  children,
+  value: itemValue,
+  disabled = false,
+  onSelect,
+  onClick,
+  ...props
+}: DropdownMenuRadioItemProps) {
+  const { classes } = useDropdownMenuContext('DropdownMenuRadioItem');
+  const radio = React.useContext(DropdownMenuRadioContext);
+  if (!radio) {
+    throw new Error('DropdownMenuRadioItem must be used within DropdownMenuRadioGroup');
+  }
+  const select = useItemSelect(disabled, onSelect);
+  const checked = radio.value === itemValue;
+
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    onClick?.(event);
+    if (event.defaultPrevented) return;
+    select(() => radio.onValueChange(itemValue));
+  };
+
+  const indicator = React.createElement(
+    'span',
+    { className: classes.itemIndicator, 'aria-hidden': 'true' },
+    checked
+      ? React.createElement('span', { className: classes.radioDot, 'aria-hidden': 'true' })
+      : null,
+  );
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: role="menuitemradio" is the menu APG pattern
+    <div
+      data-part="item"
+      role="menuitemradio"
+      data-value={itemValue}
+      data-roving-item=""
+      aria-checked={checked}
+      tabIndex={disabled ? undefined : -1}
+      aria-disabled={disabled ? 'true' : undefined}
+      data-disabled={disabled ? '' : undefined}
+      data-state={checked ? 'checked' : 'unchecked'}
+      className={classy(classes.radioItem, className)}
+      onClick={handleClick}
+      {...props}
+    >
+      {indicator}
+      {children}
+    </div>
+  );
+}
+
+export type DropdownMenuSeparatorProps = React.HTMLAttributes<HTMLHRElement>;
+
+export function DropdownMenuSeparator({ className, ...props }: DropdownMenuSeparatorProps) {
+  const { classes } = useDropdownMenuContext('DropdownMenuSeparator');
+  return <hr className={classy(classes.separator, className)} {...props} />;
+}
+
+export type DropdownMenuShortcutProps = React.HTMLAttributes<HTMLSpanElement>;
+
+export function DropdownMenuShortcut({ className, ...props }: DropdownMenuShortcutProps) {
+  const { classes } = useDropdownMenuContext('DropdownMenuShortcut');
+  return React.createElement('span', { className: classy(classes.shortcut, className), ...props });
+}
+
+DropdownMenu.Trigger = DropdownMenuTrigger;
+DropdownMenu.Portal = DropdownMenuPortal;
+DropdownMenu.Content = DropdownMenuContent;
+DropdownMenu.Group = DropdownMenuGroup;
+DropdownMenu.Label = DropdownMenuLabel;
+DropdownMenu.Item = DropdownMenuItem;
+DropdownMenu.CheckboxItem = DropdownMenuCheckboxItem;
+DropdownMenu.RadioGroup = DropdownMenuRadioGroup;
+DropdownMenu.RadioItem = DropdownMenuRadioItem;
+DropdownMenu.Separator = DropdownMenuSeparator;
+DropdownMenu.Shortcut = DropdownMenuShortcut;
+
+export { DropdownMenu as DropdownMenuRoot };

--- a/packages/ui/test/components/dropdown-menu/dropdown-menu.astro.conformance.test.ts
+++ b/packages/ui/test/components/dropdown-menu/dropdown-menu.astro.conformance.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Astro performance of the dropdown-menu score, driven end to end. AstroContainer
+ * renders the SSR markup but does NOT run the <script>, so the test binds
+ * bindDropdownMenu directly -- that IS the script's job -- then drives the same
+ * score the React and WC performances drive. One score, three performances.
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import DropdownMenu from '../../../src/components/dropdown-menu/dropdown-menu.astro';
+import { bindDropdownMenu } from '../../../src/components/dropdown-menu/dropdown-menu.behavior';
+
+const items = [
+  { label: 'Edit' },
+  { label: 'Duplicate' },
+  { label: 'Archive', disabled: true },
+  { label: 'Delete' },
+];
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+async function mount(props: Record<string, unknown> = {}): Promise<HTMLElement> {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(DropdownMenu, {
+    props: { id: 'dm', label: 'Options', items, ...props },
+  });
+  document.body.innerHTML = html;
+  const root = document.body.querySelector('rafters-dropdown-menu') as HTMLElement;
+  bindDropdownMenu(root); // the <script> does this per instance on the real page
+  return root;
+}
+
+const trigger = () => document.body.querySelector<HTMLElement>('[data-part="trigger"]')!;
+const content = () => document.body.querySelector<HTMLElement>('[data-part="content"]')!;
+const item = (label: string) =>
+  Array.from(document.body.querySelectorAll<HTMLElement>('[data-part="item"]')).find(
+    (el) => el.textContent?.trim() === label,
+  )!;
+
+describe('dropdown-menu conformance [astro]', () => {
+  it('SSR closed: menu hidden and crawlable, trigger a collapsed menu button', async () => {
+    await mount();
+    expect(content().hidden).toBe(true);
+    expect(trigger().getAttribute('aria-haspopup')).toBe('menu');
+    expect(trigger().getAttribute('aria-expanded')).toBe('false');
+    // Items are present in the DOM even while closed -- SSR-stable.
+    expect(item('Edit')).not.toBeUndefined();
+    expect(content().getAttribute('role')).toBe('menu');
+    expect(content().getAttribute('aria-labelledby')).toBe('dm-trigger');
+  });
+
+  it('bind: click opens and lands focus on the first item', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger());
+    expect(content().hidden).toBe(false);
+    expect(trigger().getAttribute('aria-controls')).toBe('dm-content');
+    expect(document.activeElement).toBe(item('Edit'));
+  });
+
+  it('bind: activating an item closes and returns focus to the trigger', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger());
+    await user.click(item('Duplicate'));
+    expect(content().hidden).toBe(true);
+    expect(document.activeElement).toBe(trigger());
+  });
+
+  it('bind: Escape closes and returns focus to the trigger', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger());
+    await user.keyboard('{Escape}');
+    expect(content().hidden).toBe(true);
+    expect(document.activeElement).toBe(trigger());
+  });
+});

--- a/packages/ui/test/components/dropdown-menu/dropdown-menu.behavior.test.ts
+++ b/packages/ui/test/components/dropdown-menu/dropdown-menu.behavior.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import { createBehavior, type PartIds } from '../../../src/lib/contract';
+import {
+  dropdownMenu,
+  isOpen,
+  type DropdownMenuConfig,
+  type DropdownMenuPart,
+  type DropdownMenuState,
+} from '../../../src/components/dropdown-menu/dropdown-menu.behavior';
+
+const ids: PartIds<DropdownMenuPart> = { root: 'r', trigger: 't', content: 'c', item: '' };
+
+const closed: DropdownMenuConfig = {};
+const openSeed: DropdownMenuConfig = { defaultOpen: true };
+
+function ariaAt(
+  config: DropdownMenuConfig,
+  state: DropdownMenuState = dropdownMenu.initialState(config),
+) {
+  return dropdownMenu.aria(state, config, ids);
+}
+
+describe('dropdown-menu parts', () => {
+  it('declares root, trigger, the menu content, and the many-instance item', () => {
+    expect(Object.keys(dropdownMenu.parts).sort()).toEqual(['content', 'item', 'root', 'trigger']);
+    expect(dropdownMenu.parts.item.many).toBe(true);
+    expect(dropdownMenu.parts.content.optional).toBe(true);
+    expect(dropdownMenu.parts.trigger.optional).toBeUndefined();
+  });
+
+  it('does NOT force a role on the item part (checkbox/radio items vary the role)', () => {
+    expect(dropdownMenu.parts.item.role).toBeUndefined();
+  });
+});
+
+describe('dropdown-menu state: controlled vs intrinsic', () => {
+  it('seeds intrinsic open from the default', () => {
+    expect(dropdownMenu.initialState({ defaultOpen: true }).open).toBe(true);
+    expect(dropdownMenu.initialState({}).open).toBe(false);
+  });
+
+  it('controlled config shadows intrinsic state', () => {
+    expect(isOpen({ open: false }, { open: true })).toBe(true);
+    expect(isOpen({ open: true }, { open: false })).toBe(false);
+    expect(isOpen({ open: true }, {})).toBe(true);
+  });
+});
+
+describe('dropdown-menu canDispatch (idempotence gate)', () => {
+  it('open only when effectively closed, close only when effectively open', () => {
+    const state = dropdownMenu.initialState(closed);
+    expect(dropdownMenu.canDispatch(state, 'open', closed)).toBe(true);
+    expect(dropdownMenu.canDispatch(state, 'close', closed)).toBe(false);
+    const openState: DropdownMenuState = { open: true };
+    expect(dropdownMenu.canDispatch(openState, 'open', closed)).toBe(false);
+    expect(dropdownMenu.canDispatch(openState, 'close', closed)).toBe(true);
+  });
+
+  it('gates on the CONTROLLED value when present', () => {
+    const drifted: DropdownMenuState = { open: false };
+    expect(dropdownMenu.canDispatch(drifted, 'close', { open: true })).toBe(true);
+    expect(dropdownMenu.canDispatch(drifted, 'open', { open: true })).toBe(false);
+  });
+});
+
+describe('dropdown-menu actions', () => {
+  it('open and close move intrinsic open once per real transition', () => {
+    const { memory, dispatch } = createBehavior(dropdownMenu, closed);
+    expect(dispatch('open', closed)).toBe(true);
+    expect(memory.get().open).toBe(true);
+    // Idempotent: opening the open is rejected.
+    expect(dispatch('open', closed)).toBe(false);
+    expect(dispatch('close', closed)).toBe(true);
+    expect(memory.get().open).toBe(false);
+    expect(dispatch('close', closed)).toBe(false);
+  });
+});
+
+describe('dropdown-menu aria projection', () => {
+  it('closed: trigger is a collapsed menu button with no dangling aria-controls', () => {
+    expect(ariaAt(closed).trigger).toEqual({
+      'aria-haspopup': 'menu',
+      'aria-expanded': 'false',
+      'aria-controls': undefined,
+      'data-state': 'closed',
+    });
+  });
+
+  it('open: trigger expands and wires to the menu by id', () => {
+    const aria = ariaAt(openSeed);
+    expect(aria.trigger?.['aria-expanded']).toBe('true');
+    expect(aria.trigger?.['aria-controls']).toBe('c');
+    expect(aria.trigger?.['data-state']).toBe('open');
+    expect(aria.trigger?.['aria-haspopup']).toBe('menu');
+  });
+
+  it('content is a vertical menu named by its trigger', () => {
+    expect(ariaAt(openSeed).content).toEqual({
+      role: 'menu',
+      'aria-orientation': 'vertical',
+      'aria-labelledby': 't',
+      'data-state': 'open',
+    });
+  });
+
+  it('root carries the open data-state', () => {
+    expect(ariaAt(closed).root).toEqual({ 'data-state': 'closed' });
+    expect(ariaAt(openSeed).root).toEqual({ 'data-state': 'open' });
+  });
+
+  it('empty trigger id projects an absent aria-labelledby, never a dangling one', () => {
+    const aria = dropdownMenu.aria(dropdownMenu.initialState(openSeed), openSeed, {
+      ...ids,
+      trigger: '',
+    });
+    expect(aria.content?.['aria-labelledby']).toBeUndefined();
+  });
+
+  it('empty content id projects an absent aria-controls, never a dangling one', () => {
+    const aria = dropdownMenu.aria(dropdownMenu.initialState(openSeed), openSeed, {
+      ...ids,
+      content: '',
+    });
+    expect(aria.trigger?.['aria-controls']).toBeUndefined();
+  });
+});
+
+describe('dropdown-menu keymap', () => {
+  const state = dropdownMenu.initialState(closed);
+
+  it('trigger opens on ArrowDown/ArrowUp/Enter/Space', () => {
+    for (const key of ['ArrowDown', 'ArrowUp', 'Enter', ' ']) {
+      expect(dropdownMenu.keymap({ key }, state, 'trigger', closed)).toBe('open');
+    }
+    expect(dropdownMenu.keymap({ key: 'a' }, state, 'trigger', closed)).toBeNull();
+  });
+
+  it('the menu closes on Escape from the content or an item', () => {
+    expect(dropdownMenu.keymap({ key: 'Escape' }, state, 'content', closed)).toBe('close');
+    expect(dropdownMenu.keymap({ key: 'Escape' }, state, 'item', closed)).toBe('close');
+  });
+
+  it('Enter/Space on an item is NOT a score keymap action (div-as-button click path)', () => {
+    expect(dropdownMenu.keymap({ key: 'Enter' }, state, 'item', closed)).toBeNull();
+    expect(dropdownMenu.keymap({ key: ' ' }, state, 'item', closed)).toBeNull();
+  });
+});
+
+// The open-menu effect trio (roving focus, typeahead, trigger-spared outside
+// dismissal) is not a declarative effect-spec on the score; the bindings compose
+// the primitives directly via startDropdownMenuEffects. The BEHAVIOR is asserted
+// end to end in the conformance suites (dropdown-menu.conformance.test.tsx /
+// .astro. / .element.): arrows rove the items, a keystroke jumps focus to the
+// matching item, activating an item closes, and a pointerdown outside dismisses.

--- a/packages/ui/test/components/dropdown-menu/dropdown-menu.classes.test.ts
+++ b/packages/ui/test/components/dropdown-menu/dropdown-menu.classes.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { dropdownMenu } from '../../../src/components/dropdown-menu/dropdown-menu.behavior';
+import { dropdownMenuClasses } from '../../../src/components/dropdown-menu/dropdown-menu.classes';
+
+const config = {};
+const classes = dropdownMenuClasses(config, dropdownMenu.initialState(config));
+
+describe('dropdown-menu classes', () => {
+  it('the menu sits on the dropdown depth token and fills popover, not a raw color', () => {
+    expect(classes.content).toContain('z-depth-dropdown');
+    expect(classes.content).toContain('bg-popover');
+    expect(classes.content).toContain('text-popover-foreground');
+  });
+
+  it('the active item look keys off :focus (roving-focus current item), not a data-highlighted axis', () => {
+    expect(classes.item).toContain('focus:bg-accent');
+    expect(classes.item).toContain('focus:text-accent-foreground');
+    expect(classes.item).not.toContain('data-[highlighted]');
+  });
+
+  it('disabled looks key off the projected data-disabled', () => {
+    expect(classes.item).toContain('data-[disabled]:pointer-events-none');
+    expect(classes.item).toContain('data-[disabled]:opacity-50');
+  });
+
+  it('the separator fills muted, the label uses a semantic text token', () => {
+    expect(classes.separator).toContain('bg-muted');
+    expect(classes.label).toContain('text-label-medium');
+  });
+
+  it('enter/exit and interaction motion are left UNDECLARED (no hand-rolled animation or raw durations)', () => {
+    // The semantic motion-dropdown-in/-out tokens are not yet emitted by the
+    // token layer; the oracle's animate-in/zoom/fade/slide + duration-N string
+    // is the prohibited hand-rolled form (05-authoring, MOTION.md). See the doc.
+    for (const value of Object.values(classes)) {
+      expect(value).not.toContain('animate-in');
+      expect(value).not.toContain('animate-out');
+      expect(value).not.toContain('zoom-in');
+      expect(value).not.toContain('fade-in');
+      expect(value).not.toContain('slide-in');
+      expect(value).not.toMatch(/duration-\d/);
+    }
+  });
+});

--- a/packages/ui/test/components/dropdown-menu/dropdown-menu.conformance.test.tsx
+++ b/packages/ui/test/components/dropdown-menu/dropdown-menu.conformance.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * React performance of the dropdown-menu score, driven end to end. State moves
+ * only through dispatched actions; roving focus, typeahead, and outside
+ * dismissal are composed directly from primitives by startDropdownMenuEffects.
+ */
+import * as React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '../../../src/components/dropdown-menu/dropdown-menu';
+import {
+  dropdownMenu,
+  type DropdownMenuConfig,
+  type DropdownMenuState,
+} from '../../../src/components/dropdown-menu/dropdown-menu.behavior';
+import { assertAxeClean, assertContractFulfillment, partElement } from '../../harness/conformance';
+
+interface SetupProps {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  onEdit?: () => void;
+}
+
+function TestMenu({ onEdit, ...props }: SetupProps) {
+  return (
+    <DropdownMenu {...props}>
+      <DropdownMenuTrigger aria-label="Options">Options</DropdownMenuTrigger>
+      <DropdownMenuContent aria-label="Options">
+        <DropdownMenuItem onSelect={onEdit}>Edit</DropdownMenuItem>
+        <DropdownMenuItem>Duplicate</DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem disabled>Archive</DropdownMenuItem>
+        <DropdownMenuItem>Delete</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+const body = () => document.body;
+const trigger = () => body().querySelector<HTMLElement>('[data-part="trigger"]')!;
+const content = () => body().querySelector<HTMLElement>('[data-part="content"]')!;
+const item = (label: string) =>
+  Array.from(body().querySelectorAll<HTMLElement>('[data-part="item"]')).find(
+    (el) => el.textContent === label,
+  )!;
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('dropdown-menu conformance [react]', () => {
+  it('closed: menu hidden, trigger is a collapsed menu button, aria clean', async () => {
+    render(
+      <main>
+        <TestMenu />
+      </main>,
+    );
+    expect(content().hidden).toBe(true);
+    expect(trigger().getAttribute('aria-haspopup')).toBe('menu');
+    expect(trigger().getAttribute('aria-expanded')).toBe('false');
+    expect(trigger().hasAttribute('aria-controls')).toBe(false);
+
+    const config: DropdownMenuConfig = {};
+    const state: DropdownMenuState = dropdownMenu.initialState(config);
+    assertContractFulfillment(dropdownMenu, partElement(body(), 'root')!, state, config, [
+      'root',
+      'trigger',
+      'content',
+    ]);
+    await assertAxeClean(body());
+  });
+
+  it('trigger and menu are wired by real ids', () => {
+    render(<TestMenu defaultOpen />);
+    expect(trigger().getAttribute('aria-controls')).toBe(content().id);
+    expect(content().getAttribute('aria-labelledby')).toBe(trigger().id);
+    expect(content().getAttribute('role')).toBe('menu');
+    expect(content().getAttribute('aria-orientation')).toBe('vertical');
+  });
+
+  it('click opens and lands focus on the first item; aria clean while open', async () => {
+    const user = userEvent.setup();
+    render(
+      <main>
+        <TestMenu />
+      </main>,
+    );
+    await user.click(trigger());
+    expect(content().hidden).toBe(false);
+    expect(trigger().getAttribute('aria-expanded')).toBe('true');
+    expect(document.activeElement).toBe(item('Edit'));
+    await assertAxeClean(body());
+  });
+
+  it('clicking an item runs its action, closes, and returns focus to the trigger', async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    render(<TestMenu onEdit={onEdit} />);
+    await user.click(trigger());
+    await user.click(item('Edit'));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(content().hidden).toBe(true);
+    expect(document.activeElement).toBe(trigger());
+  });
+
+  it('Enter on a focused item activates it (div-as-button), closes, refocuses trigger', async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    render(<TestMenu onEdit={onEdit} />);
+    await user.click(trigger());
+    expect(document.activeElement).toBe(item('Edit'));
+    await user.keyboard('{Enter}');
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(content().hidden).toBe(true);
+    expect(document.activeElement).toBe(trigger());
+  });
+
+  it('arrows rove the items, skipping the disabled one', async () => {
+    const user = userEvent.setup();
+    render(<TestMenu defaultOpen />);
+    item('Edit').focus();
+    await user.keyboard('{ArrowDown}');
+    expect(document.activeElement).toBe(item('Duplicate'));
+    await user.keyboard('{ArrowDown}');
+    // Archive is disabled -> roving skips it.
+    expect(document.activeElement).toBe(item('Delete'));
+  });
+
+  it('ArrowDown on the closed trigger opens the menu', async () => {
+    const user = userEvent.setup();
+    render(<TestMenu />);
+    trigger().focus();
+    await user.keyboard('{ArrowDown}');
+    expect(content().hidden).toBe(false);
+  });
+
+  it('typeahead jumps focus to the first matching item', async () => {
+    const user = userEvent.setup();
+    render(<TestMenu defaultOpen />);
+    item('Edit').focus();
+    await user.keyboard('d');
+    expect(document.activeElement).toBe(item('Duplicate'));
+  });
+
+  it('Escape closes and returns focus to the trigger', async () => {
+    const user = userEvent.setup();
+    render(<TestMenu defaultOpen />);
+    item('Edit').focus();
+    await user.keyboard('{Escape}');
+    expect(content().hidden).toBe(true);
+    expect(document.activeElement).toBe(trigger());
+  });
+
+  it('pointerdown outside closes', async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <button type="button">Elsewhere</button>
+        <TestMenu />
+      </div>,
+    );
+    await user.click(trigger());
+    expect(content().hidden).toBe(false);
+    await user.click(body().querySelector('button') as HTMLElement);
+    expect(content().hidden).toBe(true);
+  });
+
+  it('controlled open: onOpenChange fires and state follows the prop', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const { rerender } = render(<TestMenu open={false} onOpenChange={onOpenChange} />);
+    await user.click(trigger());
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    expect(content().hidden).toBe(true);
+
+    rerender(<TestMenu open onOpenChange={onOpenChange} />);
+    expect(content().hidden).toBe(false);
+  });
+});

--- a/packages/ui/test/components/dropdown-menu/dropdown-menu.element.conformance.test.ts
+++ b/packages/ui/test/components/dropdown-menu/dropdown-menu.element.conformance.test.ts
@@ -1,0 +1,115 @@
+/**
+ * WC performance of the dropdown-menu score, driven end to end against light-DOM
+ * markup. Same score as the React conformance test -- the binding applies the
+ * projection imperatively and runs the roving/typeahead/dismiss effects.
+ */
+import { cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { RaftersDropdownMenu } from '../../../src/components/dropdown-menu/dropdown-menu.element';
+
+beforeAll(() => {
+  if (!customElements.get('rafters-dropdown-menu'))
+    customElements.define('rafters-dropdown-menu', RaftersDropdownMenu);
+});
+
+function itemMarkup(label: string, disabled = false): string {
+  const dis = disabled ? 'data-disabled aria-disabled="true"' : 'tabindex="-1"';
+  return `<div role="menuitem" data-part="item" data-roving-item ${dis}>${label}</div>`;
+}
+
+async function mount(): Promise<HTMLElement> {
+  document.body.innerHTML = `
+    <rafters-dropdown-menu data-part="root">
+      <button type="button" data-part="trigger" id="dm-trigger">Options</button>
+      <div data-part="content" id="dm-content" hidden>
+        ${itemMarkup('Edit')}
+        ${itemMarkup('Duplicate')}
+        ${itemMarkup('Archive', true)}
+        ${itemMarkup('Delete')}
+      </div>
+    </rafters-dropdown-menu>`;
+  await Promise.resolve(); // let the element's deferred bind run
+  return document.body.querySelector('rafters-dropdown-menu') as HTMLElement;
+}
+
+const trigger = () => document.body.querySelector<HTMLElement>('[data-part="trigger"]')!;
+const content = () => document.body.querySelector<HTMLElement>('[data-part="content"]')!;
+const item = (label: string) =>
+  Array.from(document.body.querySelectorAll<HTMLElement>('[data-part="item"]')).find(
+    (el) => el.textContent === label,
+  )!;
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+describe('dropdown-menu conformance [wc]', () => {
+  it('closed: menu hidden, trigger a collapsed menu button, aria wired by real ids', async () => {
+    await mount();
+    expect(content().hidden).toBe(true);
+    expect(trigger().getAttribute('aria-haspopup')).toBe('menu');
+    expect(trigger().getAttribute('aria-expanded')).toBe('false');
+    expect(content().getAttribute('role')).toBe('menu');
+    expect(content().getAttribute('aria-orientation')).toBe('vertical');
+    expect(content().getAttribute('aria-labelledby')).toBe('dm-trigger');
+  });
+
+  it('click opens and lands focus on the first item; trigger wires aria-controls', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger());
+    expect(content().hidden).toBe(false);
+    expect(trigger().getAttribute('aria-expanded')).toBe('true');
+    expect(trigger().getAttribute('aria-controls')).toBe('dm-content');
+    expect(document.activeElement).toBe(item('Edit'));
+  });
+
+  it('arrows rove the items and skip the disabled one', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger());
+    await user.keyboard('{ArrowDown}');
+    expect(document.activeElement).toBe(item('Duplicate'));
+    await user.keyboard('{ArrowDown}');
+    expect(document.activeElement).toBe(item('Delete'));
+  });
+
+  it('typeahead jumps focus to the first matching item', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger());
+    await user.keyboard('d');
+    expect(document.activeElement).toBe(item('Duplicate'));
+  });
+
+  it('activating an item (Enter) closes and returns focus to the trigger', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger());
+    await user.keyboard('{Enter}');
+    expect(content().hidden).toBe(true);
+    expect(document.activeElement).toBe(trigger());
+  });
+
+  it('Escape closes and returns focus to the trigger', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger());
+    await user.keyboard('{Escape}');
+    expect(content().hidden).toBe(true);
+    expect(document.activeElement).toBe(trigger());
+  });
+
+  it('pointerdown outside closes', async () => {
+    const user = userEvent.setup();
+    await mount();
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    await user.click(trigger());
+    expect(content().hidden).toBe(false);
+    await user.click(outside);
+    expect(content().hidden).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Ports `dropdown-menu` (archetype `menu-collection-popup`) to the behavior layer:
one score plus three thin decorators (React, WC, Astro) over a single
`bindDropdownMenu`. The score's only state axis is `open`, reusing the
`disclosable` lib slice as a reducer over the one `createBehavior` cell; the
highlighted item is ephemeral DOM focus owned by `roving-focus` and styled via
`:focus`, matching the oracle and navigation-menu. Roving-focus, typeahead, and
outside-dismiss are composed directly via `startDropdownMenuEffects` (no effect
runner); the menu lives in light DOM present-but-hidden so those effects can
read it and the markup is SSR-stable. Submenus and collision positioning are
dropped with dispositions; enter/exit motion is left undeclared pending the
semantic `motion-*` token layer. Only the component's own folder, tests, and doc
are touched -- no shared files, no package exports.

## Acceptance criteria mapping

### Component doc written
A full article doc modelled on dialog.md registers the composition, config/state/
actions, the parts+ARIA table, keyboard map, the oracle-disposition table, and
the WCAG obligations, so every dropped feature reads as a deliberate choice.
Evidence: packages/ui/docs/spec/components/dropdown-menu.md:1

### JSDoc intelligence tags present
The React decorator's leading JSDoc carries all four registry-parsed tags --
`@cognitive-load` with the five-dimension breakdown, `@attention-economics`,
`@trust-building`, and `@accessibility` -- so the intelligence registry can index
the component.
Evidence: packages/ui/src/components/dropdown-menu/dropdown-menu.tsx:4

### Behavior test (pure, no DOM)
A DOM-free suite exercises the score directly: parts, controlled-vs-intrinsic
open, the idempotence gate, actions, the aria projection with empty-id absence,
and the keymap, including that item Enter/Space is not a score action.
Evidence: packages/ui/test/components/dropdown-menu/dropdown-menu.behavior.test.ts:79

### Classes parity test
A classes suite asserts the structural depth/fill tokens and pins the two design
choices -- the active item keys off `:focus` (no data-highlighted axis) and no
hand-rolled animation or raw duration appears in any class string.
Evidence: packages/ui/test/components/dropdown-menu/dropdown-menu.classes.test.ts:16

### Conformance test via the shared harness (aria + keymap against rendered DOM)
Three harness-driven suites (React, WC, Astro) assert axe-clean contract
fulfillment and drive the keymap against rendered DOM -- open, roving, typeahead,
activate, Escape, and outside-dismiss -- proving one score across all performances.
Evidence: packages/ui/test/components/dropdown-menu/dropdown-menu.conformance.test.tsx:58

### shadcn drop-in parity where the component exists in shadcn
The `DropdownMenu.*` namespace and the Trigger/Portal/Content/Group/Label/Item/
CheckboxItem/RadioGroup/RadioItem/Separator/Shortcut surface are preserved as
thin wrappers; submenus are dropped with an explicit disposition in the doc.
Evidence: packages/ui/src/components/dropdown-menu/dropdown-menu.tsx:497

### `pnpm --filter @rafters/ui test:unit` green, `pnpm preflight` green
The component's 39 non-Astro tests plus the 4 Astro conformance tests pass, and
a full `pnpm preflight` (typecheck, lint, format, unit, a11y, build) exits 0 from
the worktree before commit.
Evidence: packages/ui/test/components/dropdown-menu/dropdown-menu.element.conformance.test.ts:48

## Not done

- Submenus (Sub / SubTrigger / SubContent) are not ported: the issue's state
  model is "open, highlighted item" (no submenu-open axis), faithful open-on-hover
  needs `hover-delay` (the issue adds no primitives) or the oracle's raw
  `setTimeout` (a forbidden half-solution), and neither cited reference has
  submenus. Tracked as a dispositioned drop for a later wave.
- Collision-aware positioning (the oracle's `computePosition` on scroll/resize) is
  not modelled -- positioning is not behavior state; same disposition select took.
- Enter/exit motion is left undeclared: the semantic `motion-dropdown-in`/`-out`
  utilities are not yet emitted by the token layer (#1899/#1902-1904), so per the
  issue the motion is omitted rather than hardcoded.
- Vue performance stays absent (out of scope for this wave).

Closes #1771
