### PR TITLE
feat(ui): port combobox to the behavior layer

### DIFF
--- a/packages/ui/docs/spec/components/combobox.md
+++ b/packages/ui/docs/spec/components/combobox.md
@@ -1,0 +1,168 @@
+# Component Spec — Combobox
+
+Status: PORTED (wave-4). A filtering autocomplete: a text input that discloses a
+listbox of options, filtered by what is typed, committed by selection.
+
+Files (`src/components/combobox/`):
+
+```
+combobox.behavior.ts   combobox.classes.ts
+combobox.tsx           combobox.element.ts   combobox.astro
+```
+
+Tests mirror into `test/components/combobox/`: a pure behavior test, a classes
+parity test, and conformance across React, WC, and Astro through the shared
+harness.
+
+## Archetype
+
+`menu-collection-popup`, in its EDITABLE combobox variant (WAI-ARIA APG
+"Combobox" with `aria-autocomplete="list"`). DOM focus never leaves the input;
+the active option is advertised with `aria-activedescendant`, not by moving
+focus into the list. This is the semantic the old React code earned and the port
+preserves.
+
+## Composition
+
+The behavior is a single slice over the one `createBehavior` cell. Impure work is
+composed DIRECTLY (effects-as-data is retired, Spec 03):
+
+```
+collision-detector   positionCombobox(input, content) -- fixed positioning,
+                     listbox width matched to the input, run after un-hide
+outside-click        onPointerDownOutside(content, close) -- light dismiss,
+                     sparing the input and the toggle
+```
+
+Escape rides the score's `keymap` (no `escape-keydown` primitive needed: focus is
+on the input, inside the root, so the root keydown listener sees it).
+
+### Primitives the archetype names but this variant does not compose
+
+| Primitive | Why not here |
+| --- | --- |
+| roving-focus | Moves DOM focus and tabindex across options. The editable combobox keeps focus on the input and tracks the active option with `aria-activedescendant`, so there is no focus to rove. `highlighted` is a plain reducer over the cell. |
+| typeahead | Type-to-jump over a focused list. Here keystrokes go to the input and FILTER; there is no separate typeahead surface. |
+| selection-group | Cell-owning (returns its own memory cell) and therefore cannot compose. The selected value is re-expressed as the `value` reducer, as radio-group/select/tabs did. |
+| form-value | Builds a hidden mirror input for controls that are NOT native form fields. This component already has a real `<input>`; mirroring would submit twice. |
+| input-events | The contenteditable/IME editor handler, not a plain-input primitive (input, input-group, input-otp all refused it). The native `<input>` owns caret/IME. |
+
+roving-focus and typeahead are live primitives (select composes both). Their
+absence here is a fits-this-component call, not a rejected-primitive call.
+
+## Config, state, actions
+
+```ts
+interface ComboboxConfig {
+  value?: string;        // controlled selected value ('' = none)
+  defaultValue?: string; // uncontrolled seed
+  open?: boolean;        // controlled open
+  defaultOpen?: boolean; // uncontrolled seed
+  disabled?: boolean;
+}
+interface ComboboxState {
+  open: boolean;
+  query: string;                    // the input's text
+  value: string;                    // intrinsic selected value
+  highlighted: string | undefined;  // value of the active option
+}
+type ComboboxActions = {
+  open: undefined;
+  close: undefined;
+  setQuery: string;                        // type -> filter, opens, clears highlight
+  highlight: string;                       // pointer hover -> point at a value
+  highlightNext: string[];                 // arrow down; payload = visible values (DOM order)
+  highlightPrev: string[];                 // arrow up; payload = visible values
+  select: { value: string; label: string }; // commit: set value + fill input, close
+};
+```
+
+`open` and `value` follow the controlled-vs-intrinsic boundary (config shadows
+state; effective reads are `isOpen`/`selectedValue`). The idempotence gate on the
+open axis makes `onOpenChange` fire once per real transition. `highlighted` is a
+VALUE, not an index, so `comboboxItemAria` and the `aria-activedescendant`
+projection resolve it directly; the navigation actions take the visible
+(filtered) values the binding supplies and clamp against them purely
+(`nextHighlight`).
+
+The filter predicate is pure and shared by all three performances:
+`matchesQuery(label, value, query)` matches on label OR value, case-insensitively,
+with an empty query matching everything.
+
+## Parts and ARIA
+
+| Part | Presence | ARIA |
+| --- | --- | --- |
+| root | always | `data-state`, `data-disabled` |
+| input | always | `role="combobox"`, `aria-autocomplete="list"`, `aria-haspopup="listbox"`, `aria-expanded`, `aria-controls` (open + real id), `aria-activedescendant` (open + highlight + real id), `aria-disabled`, `data-state` |
+| trigger | optional (toggle chevron) | `aria-label` (view), `tabindex="-1"` (view) |
+| content | present, hidden when closed | `role="listbox"`, `aria-labelledby` (the input), `data-state` |
+| item | many | `role="option"`, `aria-selected`, `data-state` checked/unchecked, `data-highlighted`, `aria-disabled`, `id = \`${content-id}-option-${value}\`` |
+| empty | optional | shown by the binding when the filter leaves no visible option |
+
+Option-id contract: each option renders `id="${content-id}-option-${value}"`, and
+the `aria-activedescendant` projection keys off it via the empty-id sentinel (only
+referenced when open, highlighted, and the content id is real -- a dangling
+reference is an axe violation).
+
+## Keyboard
+
+All keys ride the input (focus never leaves it):
+
+- ArrowDown: open a closed list; step the highlight to the next visible option
+  (clamped at the end).
+- ArrowUp: step to the previous visible option while open (clamped at the start);
+  no-op while closed (ported: no open-on-ArrowUp).
+- Enter: commit the highlighted option (set value, fill the input with the label,
+  close). No-op with no highlight.
+- Escape: close an open list, keeping focus on the input.
+- Tab: close an open list and let focus move on (no `preventDefault`).
+- Printable keys: handled natively by the input, dispatched as `setQuery`, which
+  filters and opens.
+
+## Motion
+
+Enter/exit intent: fade + zoom on the listbox, exit shorter than entrance
+(dropdown scale). The semantic token `motion-dropdown-in`/`-out` is documented in
+`docs/MOTION.md` but NOT yet generated as a utility class (the token layer is
+being rebuilt under #1899/#1902); there is no CSS `@utility` for it and zero
+component usage. Per the port rules the motion is left UNDECLARED rather than
+hardcoding a numeric duration -- the listbox appears/disappears via the `hidden`
+toggle. The chevron's open-state rotation and the input's shadow transition carry
+`motion-reduce:transition-none` and no explicit duration. Re-declare the enter/exit
+motion when the dropdown token ships.
+
+## Oracle dispositions (src/old/ui/combobox.tsx, boundary 9)
+
+The old React controller (`combobox.controller.ts`) is the rejected architecture
+and was NOT read; dispositions are taken from `combobox.tsx` and the archetype.
+
+| Oracle feature | Disposition |
+| --- | --- |
+| controlled/uncontrolled value + onValueChange | contract |
+| controlled/uncontrolled open + onOpenChange | contract |
+| `role="combobox"` + `aria-autocomplete="list"` + `aria-expanded`/`aria-controls` on the input | contract |
+| `aria-activedescendant` tracking the active option (focus stays on the input) | contract (now a pure projection off the option-id contract) |
+| typing filters options by label/value substring, case-insensitive | contract (`matchesQuery`, pure) |
+| ArrowDown/ArrowUp move the highlight; Enter commits; Escape/Tab close | contract (score keymap) |
+| toggle chevron button (tabindex -1) opens/closes | contract |
+| clicking/hovering an option selects/highlights it | contract |
+| empty-state message when no option matches | contract |
+| option group + separator surface | contract (thin view wrappers) |
+| collision positioning against the input, width-matched | contract (composed collision-detector; select had dropped positioning, combobox keeps it) |
+| outside-pointerdown dismissal sparing the input wrapper | contract (`outside-click`, sparing input + toggle) |
+| portal of the listbox to `document.body` | dropped — the listbox lives in light DOM present-but-hidden (select precedent), so all three performances share one bind; portaling is a framework affordance not needed for behavior |
+| selecting fills the input with the option's label, then closes | reconstructed from the archetype: the exact post-select display lived in the off-limits controller. The standard editable-autocomplete behavior (input shows the committed label, list closes) is the sanctioned reconstruction |
+| React unmounts filtered-out options | defect-avoided — the port HIDES filtered options (`hidden`) instead of unmounting, so option ids stay stable for `aria-activedescendant` |
+
+## WCAG 2.1 AA obligations
+
+- 1.3.1 / 4.1.2: `role="combobox"`/`role="listbox"`/`role="option"`,
+  `aria-expanded`, `aria-controls`, `aria-labelledby`, and `aria-activedescendant`
+  wired against real DOM ids, asserted by the harness (axe clean).
+- 2.1.1: fully operable from the keyboard on the input alone (arrows, Enter,
+  Escape, Tab, typing); no keyboard trap.
+- 2.4.3 Focus Order: focus stays on the input; the active option is announced via
+  `aria-activedescendant` without a focus move.
+- 4.1.3 Status: the empty state is surfaced in the listbox when the filter empties.
+- 2.4.7: token focus ring on the input.

--- a/packages/ui/src/components/combobox/combobox.astro
+++ b/packages/ui/src/components/combobox/combobox.astro
@@ -1,0 +1,133 @@
+---
+/**
+ * Astro performance for combobox. Server-renders the full light-DOM listbox
+ * with the closed-state projection already applied (correct and inert before
+ * JS), then the <script> hands each instance to bindCombobox -- the SAME
+ * DOM-native client the Web Component uses. One score, three performances.
+ *
+ * The listbox stays in light DOM (present-but-hidden) so the binding can filter
+ * options in place, position against the input, and light-dismiss on outside
+ * pointerdown. Options carry the fixed `${content-id}-option-${value}` id the
+ * aria-activedescendant projection references.
+ */
+import type { PartIds } from '../../lib/contract';
+import {
+  combobox,
+  comboboxItemAria,
+  type ComboboxConfig,
+  type ComboboxPart,
+} from './combobox.behavior';
+import { comboboxClasses } from './combobox.classes';
+
+interface Option {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+interface Props {
+  id: string;
+  options: Option[];
+  value?: string;
+  placeholder?: string;
+  disabled?: boolean;
+  empty?: string;
+}
+
+const {
+  id,
+  options,
+  value = '',
+  placeholder = 'Search...',
+  disabled = false,
+  empty = 'No results found.',
+} = Astro.props;
+
+const config: ComboboxConfig = { defaultValue: value, disabled };
+const state = combobox.initialState(config);
+const classes = comboboxClasses(config, state);
+
+const ids = {} as PartIds<ComboboxPart>;
+for (const part of Object.keys(combobox.parts) as ComboboxPart[]) {
+  ids[part] = `${id}-${part}`;
+}
+const aria = combobox.aria(state, config, ids);
+---
+
+<rafters-combobox
+  data-part="root"
+  id={ids.root}
+  value={value}
+  disabled={disabled ? '' : undefined}
+  class={classes.root}
+  {...aria.root}
+>
+  <div data-part="field" class={classes.field}>
+    <input
+      data-part="input"
+      id={ids.input}
+      type="text"
+      autocomplete="off"
+      placeholder={placeholder}
+      value={state.query}
+      disabled={disabled}
+      class={classes.input}
+      {...aria.input}
+    />
+    <button
+      type="button"
+      data-part="trigger"
+      tabindex="-1"
+      aria-label="Open"
+      class={classes.trigger}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class={classes.chevron}
+        aria-hidden="true"
+      >
+        <path d="m6 9 6 6 6-6"></path>
+      </svg>
+    </button>
+  </div>
+
+  <div id={ids.content} data-part="content" class={classes.content} hidden={!state.open} {...aria.content}>
+    {
+      options.map((option) => {
+        const itemAria = comboboxItemAria(option.value, state, config);
+        return (
+          <div
+            role="option"
+            data-part="item"
+            id={`${ids.content}-option-${option.value}`}
+            data-value={option.value}
+            data-disabled={option.disabled ? '' : undefined}
+            aria-disabled={option.disabled ? 'true' : undefined}
+            class={classes.item}
+            {...itemAria}
+          >
+            <div class={classes.itemIndicator} aria-hidden="true"></div>
+            <div class={classes.itemText}>{option.label}</div>
+          </div>
+        );
+      })
+    }
+    <div data-part="empty" class={classes.empty} hidden={options.length > 0}>{empty}</div>
+  </div>
+</rafters-combobox>
+
+<script>
+  import { bindCombobox } from './combobox.behavior';
+
+  for (const root of document.querySelectorAll<HTMLElement>('rafters-combobox[data-part="root"]')) {
+    if (root.dataset['bound'] === 'true') continue;
+    root.dataset['bound'] = 'true';
+    bindCombobox(root);
+  }
+</script>

--- a/packages/ui/src/components/combobox/combobox.astro
+++ b/packages/ui/src/components/combobox/combobox.astro
@@ -78,8 +78,8 @@ const aria = combobox.aria(state, config, ids);
       type="button"
       data-part="trigger"
       tabindex="-1"
-      aria-label="Open"
       class={classes.trigger}
+      {...aria.trigger}
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/components/combobox/combobox.behavior.ts
+++ b/packages/ui/src/components/combobox/combobox.behavior.ts
@@ -1,0 +1,527 @@
+import { compose, type Slice } from '../../lib/compose';
+import {
+  createBehavior,
+  type AriaAttrs,
+  type BehaviorSpec,
+  type PartIds,
+} from '../../lib/contract';
+import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { computePosition } from '../../primitives/collision-detector';
+import { onPointerDownOutside } from '../../primitives/outside-click';
+import type { Align, Side } from '../../primitives/types';
+
+/**
+ * Combobox: a filtering autocomplete. A single-line text input discloses a
+ * listbox of options; typing filters the options, arrows move a highlight, and
+ * committing an option persists its value and fills the input with its label.
+ * Extracted from the imperative old/ui/combobox.tsx (+ its rejected
+ * combobox.controller.ts, which was NOT read).
+ *
+ * This is the EDITABLE combobox APG pattern, not the listbox-focus one:
+ * DOM focus never leaves the input. The active option is advertised with
+ * `aria-activedescendant` on the input, and each option carries `data-highlighted`
+ * for styling -- so roving-focus (which moves DOM focus and tabindex across the
+ * options) does NOT fit and is deliberately not composed. Likewise typeahead
+ * (type-to-jump over a focused list) does not apply here: keystrokes go to the
+ * input and FILTER. Both primitives are live (select composes them), but they
+ * belong to the listbox-focus variant, not this one.
+ *
+ * Not composed, per the issue's caveats: selection-group owns its own memory
+ * cell and cannot compose, so the selected value is a plain reducer over the one
+ * createBehavior cell; form-value builds a hidden mirror input for controls that
+ * are NOT native form fields, and this component already has a real <input>;
+ * input-events is the contenteditable/IME editor handler, not a plain-input
+ * primitive. What IS composed is collision-detector (positioning) and
+ * outside-click (light dismiss); Escape rides the score's keymap.
+ *
+ * The four state axes are `open`, `query`, `value`, and `highlighted`:
+ *  - open/value follow the controlled-vs-intrinsic boundary (config shadows
+ *    state; the effective reads are isOpen/selectedValue), like select & dialog.
+ *  - query is the input's text. Typing sets it (and opens the list); committing
+ *    an option replaces it with that option's label.
+ *  - highlighted is the VALUE of the active option (undefined = none). It is a
+ *    value, not an index, so `comboboxItemAria` and the aria-activedescendant
+ *    projection can resolve it directly; navigation clamps against the visible
+ *    (filtered) values the binding supplies in DOM order.
+ */
+export interface ComboboxConfig {
+  /** Controlled value ('' = no selection): shadows the intrinsic state. */
+  value?: string | undefined;
+  /** Uncontrolled seed for the intrinsic value. */
+  defaultValue?: string | undefined;
+  /** Controlled open. */
+  open?: boolean | undefined;
+  /** Uncontrolled seed. */
+  defaultOpen?: boolean | undefined;
+  /** Disable the whole control (no open, no edits). */
+  disabled?: boolean | undefined;
+}
+
+export interface ComboboxState {
+  open: boolean;
+  /** The input's text. */
+  query: string;
+  /** Intrinsic selected value ('' = no selection). */
+  value: string;
+  /** The value of the currently active option (undefined = none). */
+  highlighted: string | undefined;
+}
+
+export type ComboboxActions = {
+  /** Open the listbox; clears the highlight. */
+  open: undefined;
+  /** Close the listbox; clears the highlight (ported reset). */
+  close: undefined;
+  /** Write the input text; opens the list and clears the highlight (payload: text). */
+  setQuery: string;
+  /** Point at an option directly, e.g. pointer hover (payload: value). */
+  highlight: string;
+  /** Move the highlight to the next visible option; opens the list. Payload: the
+   *  visible option values in DOM order (the binding knows the filtered set). */
+  highlightNext: string[];
+  /** Move the highlight to the previous visible option. Payload: as highlightNext. */
+  highlightPrev: string[];
+  /** Commit an option: set value, fill the input with the label, close, clear
+   *  the highlight (payload: the chosen value and its display label). */
+  select: { value: string; label: string };
+};
+
+export type ComboboxPart = 'root' | 'input' | 'trigger' | 'content' | 'item' | 'empty';
+
+/** The effective open: controlled config shadows intrinsic state. */
+export function isOpen(state: ComboboxState, config: ComboboxConfig): boolean {
+  return config.open ?? state.open;
+}
+
+/** The effective value: controlled config shadows intrinsic state. */
+export function selectedValue(state: ComboboxState, config: ComboboxConfig): string {
+  return config.value ?? state.value;
+}
+
+/** An option matches the query when its label OR its value contains the query,
+ *  case-insensitively. An empty query matches everything (ported filter rule). */
+export function matchesQuery(label: string, value: string, query: string): boolean {
+  if (query === '') return true;
+  const q = query.toLowerCase();
+  return label.toLowerCase().includes(q) || value.toLowerCase().includes(q);
+}
+
+/** The next highlighted value when moving through `values` (DOM order) by
+ *  `direction` (+1 next, -1 previous), clamped at the ends. From no highlight,
+ *  +1 lands on the first and -1 lands on the first as well (ported ArrowUp
+ *  clamp to 0). Undefined only when there are no visible values. */
+export function nextHighlight(
+  values: string[],
+  current: string | undefined,
+  direction: 1 | -1,
+): string | undefined {
+  if (values.length === 0) return undefined;
+  const index = current === undefined ? -1 : values.indexOf(current);
+  const target = direction === 1 ? Math.min(index + 1, values.length - 1) : Math.max(index - 1, 0);
+  return values[target] ?? current;
+}
+
+const comboboxSlice: Slice<ComboboxConfig, ComboboxState, ComboboxActions, ComboboxPart> = {
+  name: 'combobox',
+  parts: {
+    root: {},
+    input: {},
+    // The toggle chevron: an optional pointer affordance (tabindex -1 in the
+    // view) that opens/closes without stealing focus from the input.
+    trigger: { optional: true },
+    // The listbox stays in light DOM, hidden when closed: the dismiss listener
+    // reads it and the options are filtered in place. Presence is constant.
+    content: { optional: true },
+    item: { many: true },
+    // The no-results message, shown by the binding when the filter empties.
+    empty: { optional: true },
+  },
+  initialState: (config) => ({
+    open: config.open ?? config.defaultOpen ?? false,
+    query: '',
+    value: config.value ?? config.defaultValue ?? '',
+    highlighted: undefined,
+  }),
+  actions: {
+    open: (state) => ({ ...state, open: true, highlighted: undefined }),
+    close: (state) => ({ ...state, open: false, highlighted: undefined }),
+    setQuery: (state, query) => ({ ...state, query, open: true, highlighted: undefined }),
+    highlight: (state, value) => ({ ...state, highlighted: value }),
+    highlightNext: (state, values) => ({
+      ...state,
+      open: true,
+      highlighted: nextHighlight(values, state.highlighted, 1),
+    }),
+    highlightPrev: (state, values) => ({
+      ...state,
+      highlighted: nextHighlight(values, state.highlighted, -1),
+    }),
+    select: (state, { value, label }) => ({
+      ...state,
+      value,
+      query: label,
+      open: false,
+      highlighted: undefined,
+    }),
+  },
+  // Idempotence gate on the open axis so consumer callbacks fire once per real
+  // transition. Every other action is always allowed (a disabled control is
+  // guarded at the binding, where the native <input>/click already refuse).
+  canDispatch: (state, action, config) => {
+    if (action === 'open') return !isOpen(state, config);
+    if (action === 'close') return isOpen(state, config);
+    return true;
+  },
+  aria: (state, config, ids) => {
+    const open = isOpen(state, config);
+    const disabled = config.disabled ?? false;
+    return {
+      root: {
+        'data-state': open ? 'open' : 'closed',
+        'data-disabled': disabled ? '' : undefined,
+      },
+      input: {
+        role: 'combobox',
+        'aria-autocomplete': 'list',
+        'aria-haspopup': 'listbox',
+        'aria-expanded': open ? 'true' : 'false',
+        // Empty-id sentinel: reference the listbox only when open and its id is
+        // real, so an initially-closed input leaks no dangling ref.
+        'aria-controls': open && ids.content ? ids.content : undefined,
+        // The active option, advertised without moving DOM focus. Keyed off the
+        // fixed option-id contract each decorator renders. Absent when closed or
+        // when nothing is highlighted -- a dangling ref is an axe violation.
+        'aria-activedescendant':
+          open && state.highlighted !== undefined && ids.content
+            ? `${ids.content}-option-${state.highlighted}`
+            : undefined,
+        'aria-disabled': disabled ? 'true' : undefined,
+        'data-state': open ? 'open' : 'closed',
+      },
+      content: {
+        role: 'listbox',
+        // The listbox is named by the input that controls it.
+        'aria-labelledby': ids.input || undefined,
+        'data-state': open ? 'open' : 'closed',
+      },
+    };
+  },
+  // Focus stays on the input, so it is the only part that claims keys.
+  keymap: (event, state, part, config) => {
+    if (part !== 'input') return null;
+    const open = isOpen(state, config);
+    if (event.key === 'Escape') return open ? 'close' : null;
+    // Tab commits nothing but closes an open list, letting focus move on.
+    if (event.key === 'Tab') return open ? 'close' : null;
+    // ArrowDown opens a closed list and steps the highlight down.
+    if (event.key === 'ArrowDown') return 'highlightNext';
+    // ArrowUp only steps while open (ported: no open-on-ArrowUp).
+    if (event.key === 'ArrowUp') return open ? 'highlightPrev' : null;
+    // Enter commits the highlighted option, if any.
+    if (event.key === 'Enter') return open && state.highlighted !== undefined ? 'select' : null;
+    return null;
+  },
+};
+
+export const combobox: BehaviorSpec<ComboboxConfig, ComboboxState, ComboboxActions, ComboboxPart> =
+  compose('combobox', comboboxSlice);
+
+/**
+ * Per-instance projection for the many-instance `item` part. Spec 01's aria()
+ * projects one AriaAttrs per part NAME; options occur once per value, so their
+ * projection takes the instance value (mirrors selectItemAria). role, id,
+ * data-value and aria-disabled are static markup.
+ */
+export function comboboxItemAria(
+  itemValue: string,
+  state: ComboboxState,
+  config: ComboboxConfig,
+): AriaAttrs {
+  const selected = selectedValue(state, config) === itemValue;
+  const highlighted = state.highlighted === itemValue;
+  return {
+    'aria-selected': selected ? 'true' : 'false',
+    'data-state': selected ? 'checked' : 'unchecked',
+    'data-highlighted': highlighted ? '' : undefined,
+  };
+}
+
+export const DEFAULT_SIDE: Side = 'bottom';
+export const DEFAULT_ALIGN: Align = 'start';
+export const DEFAULT_SIDE_OFFSET = 4;
+export const DEFAULT_ALIGN_OFFSET = 0;
+
+/** The anchor/align intent for positioning. Decorator/view config, NOT score
+ *  config: the resolved side is post-collision ephemeral DOM state. */
+export interface ComboboxPositionOptions {
+  side?: Side | undefined;
+  align?: Align | undefined;
+  sideOffset?: number | undefined;
+  alignOffset?: number | undefined;
+}
+
+/**
+ * Position the listbox against the input -- a framework-affordance shared by
+ * every decorator. Composes the collision-detector primitive and applies the
+ * result with fixed positioning, matching the listbox width to the input
+ * (ported minWidth). Must run AFTER the content is un-hidden so measurement
+ * sees layout, exactly as bindPopover orders it.
+ */
+export function positionCombobox(
+  input: HTMLElement | null,
+  content: HTMLElement | null,
+  options: ComboboxPositionOptions = {},
+): void {
+  if (!input || !content) return;
+  const result = computePosition(input, content, {
+    side: options.side ?? DEFAULT_SIDE,
+    align: options.align ?? DEFAULT_ALIGN,
+    sideOffset: options.sideOffset ?? DEFAULT_SIDE_OFFSET,
+    alignOffset: options.alignOffset ?? DEFAULT_ALIGN_OFFSET,
+    avoidCollisions: true,
+  });
+  content.style.position = 'fixed';
+  content.style.left = '0';
+  content.style.top = '0';
+  content.style.transform = `translate(${Math.round(result.x)}px, ${Math.round(result.y)}px)`;
+  content.style.minWidth = `${input.offsetWidth}px`;
+  content.setAttribute('data-side', result.side);
+  content.setAttribute('data-align', result.align);
+}
+
+/** A visible, enabled option element -- the set the filter leaves showing and
+ *  navigation/commit operate over (shared so all readers agree). */
+function isVisibleOption(item: HTMLElement): boolean {
+  return (
+    !item.hidden &&
+    !item.hasAttribute('data-disabled') &&
+    item.getAttribute('aria-disabled') !== 'true'
+  );
+}
+
+/** The values of the currently visible (filtered, enabled) options, in DOM
+ *  order -- the array the navigation actions clamp against. */
+export function visibleOptionValues(content: HTMLElement | null): string[] {
+  if (!content) return [];
+  const values: string[] = [];
+  for (const item of content.querySelectorAll<HTMLElement>('[data-part="item"]')) {
+    if (!isVisibleOption(item)) continue;
+    const value = item.dataset['value'];
+    if (value !== undefined) values.push(value);
+  }
+  return values;
+}
+
+/**
+ * The DOM-native binding of the combobox score -- the client the Web Component
+ * and the Astro <script> both import. Only React reads the projections
+ * declaratively. Beyond the pure score it carries the combobox concerns:
+ * PRESENCE (the listbox hides off the open axis, staying in light DOM), FILTER
+ * (options and the empty message toggle on the query), value-text sync (the
+ * input mirrors the query), and the two composed primitives -- collision
+ * positioning and outside-pointerdown dismissal -- started on the open edge and
+ * torn down on close, sparing the input and the toggle so a gesture does not
+ * dismiss then re-open.
+ */
+export function bindCombobox(root: HTMLElement): () => void {
+  const inputEl = root.querySelector<HTMLInputElement>('[data-part="input"]');
+  const contentEl = root.querySelector<HTMLElement>('[data-part="content"]');
+  const config: ComboboxConfig = {
+    disabled:
+      root.hasAttribute('disabled') ||
+      root.dataset['disabled'] === '' ||
+      (inputEl?.disabled ?? false),
+    defaultValue: root.getAttribute('value') ?? undefined,
+    defaultOpen: contentEl?.dataset['state'] === 'open',
+  };
+
+  const getPart = (part: string): HTMLElement | null =>
+    part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
+
+  const { memory, dispatch } = createBehavior(combobox, config);
+
+  const positionOptions: ComboboxPositionOptions = {
+    side: (root.getAttribute('side') as Side | null) ?? undefined,
+    align: (root.getAttribute('align') as Align | null) ?? undefined,
+  };
+
+  // The open-listbox affordances (positioning + light dismiss) are
+  // level-triggered: present only while open.
+  let openCleanup: (() => void) | null = null;
+
+  // ids READ from the server/author markup, never generated.
+  const ids = {} as PartIds<ComboboxPart>;
+  for (const part of Object.keys(combobox.parts) as ComboboxPart[])
+    ids[part] = getPart(part)?.id ?? '';
+
+  const applyProjection = (el: HTMLElement, attrs: AriaAttrs) => {
+    for (const [name, value] of Object.entries(attrs)) {
+      updateAriaAttribute(el, name as never, value as never, { validate: false });
+    }
+  };
+
+  const startOpenAffordances = () => {
+    const content = getPart('content');
+    if (!content) return;
+    const reposition = () => positionCombobox(getPart('input'), content, positionOptions);
+    reposition();
+    window.addEventListener('scroll', reposition, { capture: true, passive: true });
+    window.addEventListener('resize', reposition, { passive: true });
+    const stopDismiss = onPointerDownOutside(content, (event) => {
+      const target = event.target as Node;
+      // Spare the input and the toggle so a toggle gesture does not dismiss
+      // then re-open (ported: the old code spared the input wrapper).
+      if (getPart('input')?.contains(target)) return;
+      if (getPart('trigger')?.contains(target)) return;
+      dispatch('close', config);
+    });
+    openCleanup = () => {
+      window.removeEventListener('scroll', reposition, { capture: true } as EventListenerOptions);
+      window.removeEventListener('resize', reposition);
+      stopDismiss();
+    };
+  };
+
+  const render = () => {
+    const state = memory.get();
+    const open = isOpen(state, config);
+
+    const projection = combobox.aria(state, config, ids);
+    for (const part of Object.keys(projection) as ComboboxPart[]) {
+      const attrs = projection[part];
+      const el = getPart(part);
+      if (el && attrs) applyProjection(el, attrs);
+    }
+
+    // Filter the options in place and toggle the empty message. Hidden options
+    // stay in the DOM so their ids remain stable for aria-activedescendant.
+    let visibleCount = 0;
+    for (const item of root.querySelectorAll<HTMLElement>('[data-part="item"]')) {
+      const value = item.dataset['value'] ?? '';
+      const label = (item.textContent ?? '').trim();
+      const shown = matchesQuery(label, value, state.query);
+      item.hidden = !shown;
+      if (shown) visibleCount += 1;
+    }
+    const emptyEl = getPart('empty');
+    if (emptyEl) emptyEl.hidden = visibleCount > 0;
+
+    // Per-instance option projection (aria-selected / highlight / checked).
+    for (const el of root.querySelectorAll<HTMLElement>('[data-part="item"]')) {
+      const itemValue = el.dataset['value'];
+      if (itemValue === undefined) continue;
+      applyProjection(el, comboboxItemAria(itemValue, state, config));
+    }
+
+    // Presence: the listbox hides off the open axis (stays in light DOM).
+    if (contentEl) contentEl.hidden = !open;
+
+    // Value-text sync: the input mirrors the query. Write only on divergence so
+    // the caret is preserved while typing.
+    if (inputEl && inputEl.value !== state.query) inputEl.value = state.query;
+
+    // Composed affordances, level-triggered: start on the open edge (after the
+    // listbox is un-hidden so positioning can measure), tear down on close.
+    if (open && !openCleanup) {
+      startOpenAffordances();
+    } else if (!open && openCleanup) {
+      openCleanup();
+      openCleanup = null;
+    }
+  };
+  const unsubscribe = memory.subscribe(render); // fires immediately: first paint
+
+  const isDisabledItem = (item: HTMLElement): boolean =>
+    item.hasAttribute('data-disabled') || item.getAttribute('aria-disabled') === 'true';
+
+  const onInput = (event: Event) => {
+    if (event.target !== inputEl || !inputEl) return;
+    if (config.disabled) return;
+    dispatch('setQuery', config, inputEl.value);
+  };
+  root.addEventListener('input', onInput);
+
+  const onClick = (event: Event) => {
+    const target = event.target as HTMLElement;
+    const item = target.closest<HTMLElement>('[data-part="item"]');
+    if (item && root.contains(item)) {
+      if (isDisabledItem(item)) return;
+      const value = item.dataset['value'];
+      if (value !== undefined) {
+        dispatch('select', config, { value, label: (item.textContent ?? '').trim() });
+        getPart('input')?.focus();
+      }
+      return;
+    }
+    const trigger = target.closest<HTMLElement>('[data-part="trigger"]');
+    if (trigger && root.contains(trigger)) {
+      if (config.disabled) return;
+      dispatch(isOpen(memory.get(), config) ? 'close' : 'open', config);
+      getPart('input')?.focus();
+    }
+  };
+  root.addEventListener('click', onClick);
+
+  const onKeydown = (event: KeyboardEvent) => {
+    const partEl = (event.target as HTMLElement).closest<HTMLElement>('[data-part]');
+    const part = partEl?.dataset['part'] as ComboboxPart | undefined;
+    if (!part) return;
+    const action = combobox.keymap(
+      {
+        key: event.key,
+        shiftKey: event.shiftKey,
+        ctrlKey: event.ctrlKey,
+        altKey: event.altKey,
+        metaKey: event.metaKey,
+      },
+      memory.get(),
+      part,
+      config,
+    );
+    if (!action) return;
+    if (action === 'highlightNext' || action === 'highlightPrev') {
+      if (config.disabled) return;
+      event.preventDefault();
+      dispatch(action, config, visibleOptionValues(getPart('content')));
+      return;
+    }
+    if (action === 'select') {
+      const value = memory.get().highlighted;
+      if (value === undefined) return;
+      const item = getPart('content')?.querySelector<HTMLElement>(
+        `[data-part="item"][data-value="${value}"]`,
+      );
+      if (!item || isDisabledItem(item)) return;
+      event.preventDefault();
+      dispatch('select', config, { value, label: (item.textContent ?? '').trim() });
+      return;
+    }
+    if (action === 'close') {
+      // Escape keeps focus on the input; Tab is allowed to move focus on.
+      if (event.key === 'Escape') event.preventDefault();
+      dispatch('close', config);
+    }
+  };
+  root.addEventListener('keydown', onKeydown);
+
+  // Pointer over an option points the highlight at it (ported handleMouseEnter),
+  // matching the pointer-follows-highlight of the listbox pattern.
+  const onPointerMove = (event: Event) => {
+    const item = (event.target as HTMLElement).closest<HTMLElement>('[data-part="item"]');
+    if (item && root.contains(item) && !isDisabledItem(item)) {
+      const value = item.dataset['value'];
+      if (value !== undefined) dispatch('highlight', config, value);
+    }
+  };
+  root.addEventListener('pointermove', onPointerMove);
+
+  return () => {
+    unsubscribe();
+    openCleanup?.();
+    openCleanup = null;
+    root.removeEventListener('input', onInput);
+    root.removeEventListener('click', onClick);
+    root.removeEventListener('keydown', onKeydown);
+    root.removeEventListener('pointermove', onPointerMove);
+  };
+}

--- a/packages/ui/src/components/combobox/combobox.behavior.ts
+++ b/packages/ui/src/components/combobox/combobox.behavior.ts
@@ -198,6 +198,12 @@ const comboboxSlice: Slice<ComboboxConfig, ComboboxState, ComboboxActions, Combo
         'aria-disabled': disabled ? 'true' : undefined,
         'data-state': open ? 'open' : 'closed',
       },
+      // The toggle's accessible name tracks what the gesture does next. It lives
+      // in the projection (not inline in a decorator) so all three performances
+      // update it: the WC/Astro binds apply it on every render, React reads it.
+      trigger: {
+        'aria-label': open ? 'Close' : 'Open',
+      },
       content: {
         role: 'listbox',
         // The listbox is named by the input that controls it.

--- a/packages/ui/src/components/combobox/combobox.classes.ts
+++ b/packages/ui/src/components/combobox/combobox.classes.ts
@@ -1,0 +1,85 @@
+import type { ComboboxConfig, ComboboxState } from './combobox.behavior';
+
+export interface ComboboxClassSet {
+  root: string;
+  field: string;
+  input: string;
+  trigger: string;
+  chevron: string;
+  content: string;
+  item: string;
+  itemIndicator: string;
+  itemText: string;
+  empty: string;
+  group: string;
+  groupLabel: string;
+  separator: string;
+}
+
+// `group` scopes the chevron's open-state rotation to the root's data-state.
+const rootClasses = 'group';
+
+// The positioning context for the toggle chevron, which sits absolutely inside.
+const fieldClasses = 'relative w-full';
+
+// Touch floor at h-11, scaling down via the container query (repo CQ
+// convention). Right padding leaves room for the chevron. Fill, not background.
+const inputClasses =
+  'flex h-11 @md:h-9 w-full rounded-md border border-input bg-background px-3 py-1 pr-9 ' +
+  'text-body-small shadow-sm ring-offset-background transition-shadow motion-reduce:transition-none ' +
+  'placeholder:text-muted-foreground hover:border-input-hover ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ' +
+  'disabled:cursor-not-allowed disabled:opacity-50 ' +
+  'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50';
+
+const triggerClasses =
+  'absolute inset-y-0 right-0 flex items-center px-2 text-muted-foreground hover:text-foreground';
+
+const chevronClasses =
+  'size-4 shrink-0 opacity-50 transition-transform motion-reduce:transition-none ' +
+  'group-data-[state=open]:rotate-180';
+
+// Enter/exit motion is intentionally undeclared: the semantic dropdown motion
+// token (motion-dropdown-in/-out) is documented in docs/MOTION.md but not yet
+// generated as a utility (#1899/#1902). Per the port rules we leave motion
+// undeclared rather than hardcode a numeric duration; the token gap is recorded
+// in docs/spec/components/combobox.md.
+const contentClasses =
+  'z-depth-dropdown max-h-60 min-w-32 overflow-auto rounded-md border bg-popover p-1 ' +
+  'text-popover-foreground shadow-md';
+
+const itemClasses =
+  'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 ' +
+  'text-body-small outline-none ' +
+  'data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground ' +
+  'data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+
+const itemIndicatorClasses = 'absolute left-2 flex size-3.5 items-center justify-center';
+
+const itemTextClasses = 'truncate';
+
+const emptyClasses = 'py-6 text-center text-body-small text-muted-foreground';
+
+const groupClasses = 'overflow-hidden p-1';
+
+const groupLabelClasses = 'px-2 py-1.5 text-label-medium text-muted-foreground';
+
+const separatorClasses = '-mx-1 my-1 h-px bg-muted';
+
+export function comboboxClasses(_config: ComboboxConfig, _state: ComboboxState): ComboboxClassSet {
+  return {
+    root: rootClasses,
+    field: fieldClasses,
+    input: inputClasses,
+    trigger: triggerClasses,
+    chevron: chevronClasses,
+    content: contentClasses,
+    item: itemClasses,
+    itemIndicator: itemIndicatorClasses,
+    itemText: itemTextClasses,
+    empty: emptyClasses,
+    group: groupClasses,
+    groupLabel: groupLabelClasses,
+    separator: separatorClasses,
+  };
+}

--- a/packages/ui/src/components/combobox/combobox.element.ts
+++ b/packages/ui/src/components/combobox/combobox.element.ts
@@ -1,0 +1,27 @@
+/**
+ * WC performance for combobox: the thinnest wrapper. The score AND the
+ * DOM-native binding (bindCombobox) live in combobox.behavior.ts, shared with
+ * the Astro performance. This file only adapts that binding to the
+ * custom-element lifecycle -- deferring the bind one microtask because
+ * connectedCallback can fire before the light-DOM parts are parsed.
+ */
+import { bindCombobox } from './combobox.behavior';
+
+export class RaftersCombobox extends HTMLElement {
+  private teardown: (() => void) | null = null;
+
+  connectedCallback(): void {
+    queueMicrotask(() => {
+      if (this.isConnected && !this.teardown) this.teardown = bindCombobox(this);
+    });
+  }
+
+  disconnectedCallback(): void {
+    this.teardown?.();
+    this.teardown = null;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-combobox')) {
+  customElements.define('rafters-combobox', RaftersCombobox);
+}

--- a/packages/ui/src/components/combobox/combobox.tsx
+++ b/packages/ui/src/components/combobox/combobox.tsx
@@ -1,0 +1,467 @@
+/**
+ * Combobox: a filtering autocomplete input paired with a listbox of options.
+ *
+ * @cognitive-load 6/10 - Holds three things at once: the free-text query, the
+ *   filtered option set, and the current highlight; typing and scanning run in
+ *   parallel, heavier than a plain Select.
+ * @attention-economics Closed it reads as a single input; typing narrows the
+ *   option list so attention collapses onto the matches, and the highlight plus
+ *   aria-activedescendant keep one focal option at a time.
+ * @trust-building Immediate filter feedback, an explicit empty state when nothing
+ *   matches, a visible checkmark on the committed option, and keyboard-first
+ *   navigation that never moves focus off the field.
+ * @accessibility Editable combobox APG pattern: role="combobox" with
+ *   aria-autocomplete="list" on the input, aria-expanded/aria-controls to the
+ *   listbox, and aria-activedescendant tracking the highlighted option so screen
+ *   readers announce it without stealing DOM focus.
+ *
+ * The React performance is a DECORATOR over combobox.behavior.ts: it adds only
+ * the view (combobox.classes.ts) and React wiring (useMemory + a useEffect that
+ * positions and light-dismisses, plus the dispatch protocol). Every decision --
+ * reducers, aria, keymap, the filter predicate -- lives in the score. The shadcn
+ * drop-in surface (Input, Content, Empty, Group, Item, Separator) plus the
+ * `Combobox.*` namespace is preserved as thin view wrappers.
+ *
+ * @example
+ * ```tsx
+ * import { Combobox } from '@rafters/ui';
+ *
+ * <Combobox onValueChange={save}>
+ *   <Combobox.Input placeholder="Select framework..." />
+ *   <Combobox.Content>
+ *     <Combobox.Empty>No framework found.</Combobox.Empty>
+ *     <Combobox.Item value="react">React</Combobox.Item>
+ *     <Combobox.Item value="vue">Vue</Combobox.Item>
+ *   </Combobox.Content>
+ * </Combobox>
+ * ```
+ */
+import * as React from 'react';
+import { keyInputOf } from '../../hooks/key-input';
+import { useMemory } from '../../hooks/use-memory';
+import { createBehavior, type AriaAttrs, type PartIds, type PayloadArgs } from '../../lib/contract';
+import classy from '../../primitives/classy';
+import { onPointerDownOutside } from '../../primitives/outside-click';
+import {
+  combobox,
+  comboboxItemAria,
+  isOpen,
+  matchesQuery,
+  positionCombobox,
+  selectedValue,
+  visibleOptionValues,
+  type ComboboxActions,
+  type ComboboxConfig,
+  type ComboboxPart,
+  type ComboboxState,
+} from './combobox.behavior';
+import { comboboxClasses, type ComboboxClassSet } from './combobox.classes';
+
+interface ComboboxContextValue {
+  state: ComboboxState;
+  config: ComboboxConfig;
+  ids: PartIds<ComboboxPart>;
+  aria: Partial<Record<ComboboxPart, AriaAttrs>>;
+  request: <K extends keyof ComboboxActions>(
+    action: K,
+    ...payload: PayloadArgs<ComboboxActions[K]>
+  ) => boolean;
+  getPart: (part: string) => HTMLElement | null;
+  effectiveOpen: boolean;
+  effectiveValue: string;
+  query: string;
+  disabled: boolean;
+  classes: ComboboxClassSet;
+}
+
+const ComboboxContext = React.createContext<ComboboxContextValue | null>(null);
+
+function useComboboxContext(component: string): ComboboxContextValue {
+  const context = React.useContext(ComboboxContext);
+  if (!context) {
+    throw new Error(`${component} must be used within <Combobox>`);
+  }
+  return context;
+}
+
+/** Checkmark shown on the committed option. */
+function CheckIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+export interface ComboboxProps {
+  children: React.ReactNode;
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  disabled?: boolean;
+}
+
+export function Combobox({
+  children,
+  value,
+  defaultValue = '',
+  onValueChange,
+  open,
+  defaultOpen = false,
+  onOpenChange,
+  disabled = false,
+}: ComboboxProps) {
+  const config: ComboboxConfig = { value, defaultValue, open, defaultOpen, disabled };
+
+  const { memory, dispatch } = React.useMemo(() => createBehavior(combobox, config), []);
+  const state = useMemory(memory);
+  const effectiveOpen = isOpen(state, config);
+  const effectiveValue = selectedValue(state, config);
+
+  const uid = React.useId();
+  const ids = React.useMemo(() => {
+    const out = {} as PartIds<ComboboxPart>;
+    for (const part of Object.keys(combobox.parts) as ComboboxPart[]) out[part] = `${uid}-${part}`;
+    return out;
+  }, [uid]);
+
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  const getPart = React.useCallback(
+    (part: string): HTMLElement | null =>
+      part === 'root'
+        ? rootRef.current
+        : (rootRef.current?.querySelector<HTMLElement>(`[data-part="${part}"]`) ?? null),
+    [],
+  );
+
+  // Effect-initiated dispatches (outside dismissal) must read the CURRENT config
+  // and callbacks, so those ride in a ref rather than being captured stale.
+  const latest = React.useRef({ config, onValueChange, onOpenChange });
+  latest.current = { config, onValueChange, onOpenChange };
+  const request = React.useCallback(
+    <K extends keyof ComboboxActions>(
+      action: K,
+      ...payload: PayloadArgs<ComboboxActions[K]>
+    ): boolean => {
+      const { config: cfg, onValueChange: onValue, onOpenChange: onOpen } = latest.current;
+      // Effective-before vs intrinsic-after, on BOTH axes: a controlled
+      // combobox's effective value/open never moves, but the callback must still
+      // report what it should set next.
+      const openBefore = isOpen(memory.get(), cfg);
+      const valueBefore = selectedValue(memory.get(), cfg);
+      if (!dispatch(action, cfg, ...payload)) return false;
+      const after = memory.get();
+      if (after.value !== valueBefore) onValue?.(after.value);
+      if (after.open !== openBefore) onOpen?.(after.open);
+      return true;
+    },
+    [memory, dispatch],
+  );
+
+  // Position the listbox against the input and light-dismiss on outside
+  // pointerdown -- the same two affordances bindCombobox composes, level-
+  // triggered on the open axis. Positioning follows scroll/resize while open.
+  React.useEffect(() => {
+    if (!effectiveOpen) return;
+    const input = getPart('input');
+    const content = getPart('content');
+    if (!content) return;
+    const reposition = () => positionCombobox(input, content, {});
+    reposition();
+    window.addEventListener('scroll', reposition, { capture: true, passive: true });
+    window.addEventListener('resize', reposition, { passive: true });
+    const stopDismiss = onPointerDownOutside(content, (event) => {
+      const target = event.target as Node;
+      if (getPart('input')?.contains(target)) return;
+      if (getPart('trigger')?.contains(target)) return;
+      request('close');
+    });
+    return () => {
+      window.removeEventListener('scroll', reposition, { capture: true } as EventListenerOptions);
+      window.removeEventListener('resize', reposition);
+      stopDismiss();
+    };
+  }, [effectiveOpen, getPart, request]);
+
+  // One root-level keydown resolves the focused part and drives the score,
+  // mirroring bindCombobox -- so the input/item view wrappers stay pure
+  // change/click/pointer adapters with no keymap logic of their own.
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.defaultPrevented) return;
+    const partEl = (event.target as HTMLElement).closest<HTMLElement>('[data-part]');
+    const part = partEl?.dataset['part'] as ComboboxPart | undefined;
+    if (!part) return;
+    const action = combobox.keymap(keyInputOf(event), state, part, config);
+    if (!action) return;
+    if (action === 'highlightNext' || action === 'highlightPrev') {
+      if (disabled) return;
+      event.preventDefault();
+      request(action, visibleOptionValues(getPart('content')));
+      return;
+    }
+    if (action === 'select') {
+      const value = memory.get().highlighted;
+      if (value === undefined) return;
+      const item = getPart('content')?.querySelector<HTMLElement>(
+        `[data-part="item"][data-value="${value}"]`,
+      );
+      if (!item || item.getAttribute('aria-disabled') === 'true') return;
+      event.preventDefault();
+      request('select', { value, label: (item.textContent ?? '').trim() });
+      return;
+    }
+    if (action === 'close') {
+      if (event.key === 'Escape') event.preventDefault();
+      request('close');
+    }
+  };
+
+  const aria = combobox.aria(state, config, ids);
+  const classes = comboboxClasses(config, state);
+
+  const contextValue: ComboboxContextValue = {
+    state,
+    config,
+    ids,
+    aria,
+    request,
+    getPart,
+    effectiveOpen,
+    effectiveValue,
+    query: state.query,
+    disabled,
+    classes,
+  };
+
+  return (
+    <ComboboxContext.Provider value={contextValue}>
+      <div
+        ref={rootRef}
+        data-part="root"
+        id={ids.root}
+        {...aria.root}
+        className={classes.root}
+        onKeyDown={handleKeyDown}
+      >
+        {children}
+      </div>
+    </ComboboxContext.Provider>
+  );
+}
+
+export interface ComboboxInputProps extends Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  'value' | 'onChange'
+> {}
+
+export function ComboboxInput({ className, ...props }: ComboboxInputProps) {
+  const { ids, aria, request, query, effectiveOpen, getPart, disabled, classes } =
+    useComboboxContext('Combobox.Input');
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (disabled) return;
+    request('setQuery', event.target.value);
+  };
+
+  const handleToggle = () => {
+    if (disabled) return;
+    request(effectiveOpen ? 'close' : 'open');
+    // Keep focus on the input after a pointer toggle.
+    getPart('input')?.focus();
+  };
+
+  return (
+    <div data-part="field" className={classes.field}>
+      <input
+        data-part="input"
+        id={ids.input}
+        type="text"
+        autoComplete="off"
+        value={query}
+        disabled={disabled}
+        onChange={handleChange}
+        className={classy(classes.input, className)}
+        {...aria.input}
+        {...props}
+      />
+      <button
+        type="button"
+        data-part="trigger"
+        tabIndex={-1}
+        aria-label={effectiveOpen ? 'Close' : 'Open'}
+        onClick={handleToggle}
+        className={classes.trigger}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={classes.chevron}
+          aria-hidden="true"
+        >
+          <path d="m6 9 6 6 6-6" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+export interface ComboboxContentProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function ComboboxContent({ className, children, ...props }: ComboboxContentProps) {
+  const { ids, aria, effectiveOpen, classes } = useComboboxContext('Combobox.Content');
+  return (
+    <div
+      data-part="content"
+      id={ids.content}
+      hidden={effectiveOpen ? undefined : true}
+      className={classy(classes.content, className)}
+      {...aria.content}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export interface ComboboxEmptyProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function ComboboxEmpty({ className, children, ...props }: ComboboxEmptyProps) {
+  const { state, getPart, classes } = useComboboxContext('Combobox.Empty');
+  // Shown only when the filter leaves no visible option. Read after render so
+  // the count reflects the items React has committed (DOM read in an effect).
+  const [hasVisible, setHasVisible] = React.useState(true);
+  React.useEffect(() => {
+    setHasVisible(visibleOptionValues(getPart('content')).length > 0);
+  }, [state.query, getPart]);
+
+  return (
+    <div
+      data-part="empty"
+      hidden={hasVisible ? true : undefined}
+      className={classy(classes.empty, className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export interface ComboboxGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+  heading?: string;
+}
+
+export function ComboboxGroup({ heading, className, children, ...props }: ComboboxGroupProps) {
+  const { classes } = useComboboxContext('Combobox.Group');
+  const headingId = React.useId();
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: role="group" is the WAI-ARIA role for grouping listbox options
+    <div
+      role="group"
+      aria-labelledby={heading ? headingId : undefined}
+      className={classy(classes.group, className)}
+      {...props}
+    >
+      {heading &&
+        React.createElement('div', { id: headingId, className: classes.groupLabel }, heading)}
+      {children}
+    </div>
+  );
+}
+
+export interface ComboboxItemProps extends React.HTMLAttributes<HTMLDivElement> {
+  value: string;
+  disabled?: boolean;
+}
+
+export function ComboboxItem({
+  value: itemValue,
+  disabled = false,
+  className,
+  children,
+  onClick,
+  onPointerMove,
+  ...props
+}: ComboboxItemProps) {
+  const { state, config, ids, request, getPart, query, classes } =
+    useComboboxContext('Combobox.Item');
+  const label = typeof children === 'string' ? children : itemValue;
+  const aria = comboboxItemAria(itemValue, state, config);
+  const isSelected = selectedValue(state, config) === itemValue;
+  // Filter in place (hidden, not unmounted) so the option id stays stable for
+  // aria-activedescendant across queries.
+  const filtered = !matchesQuery(label, itemValue, query);
+
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    onClick?.(event);
+    if (event.defaultPrevented || disabled) return;
+    request('select', { value: itemValue, label });
+    getPart('input')?.focus();
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    onPointerMove?.(event);
+    if (!disabled) request('highlight', itemValue);
+  };
+
+  const indicator = React.createElement(
+    'span',
+    { className: classes.itemIndicator },
+    isSelected ? <CheckIcon /> : null,
+  );
+  const text = React.createElement('span', { className: classes.itemText }, children);
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: role="option" is the listbox APG pattern
+    // biome-ignore lint/a11y/useKeyWithClickEvents: keyboard navigation runs on the combobox input, not the option
+    <div
+      role="option"
+      data-part="item"
+      id={`${ids.content}-option-${itemValue}`}
+      data-value={itemValue}
+      data-disabled={disabled ? '' : undefined}
+      aria-disabled={disabled ? 'true' : undefined}
+      hidden={filtered ? true : undefined}
+      className={classy(classes.item, className)}
+      {...aria}
+      onClick={handleClick}
+      onPointerMove={handlePointerMove}
+      {...props}
+    >
+      {indicator}
+      {text}
+    </div>
+  );
+}
+
+export interface ComboboxSeparatorProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function ComboboxSeparator({ className, ...props }: ComboboxSeparatorProps) {
+  const { classes } = useComboboxContext('Combobox.Separator');
+  return <div aria-hidden="true" className={classy(classes.separator, className)} {...props} />;
+}
+
+Combobox.Input = ComboboxInput;
+Combobox.Content = ComboboxContent;
+Combobox.Empty = ComboboxEmpty;
+Combobox.Group = ComboboxGroup;
+Combobox.Item = ComboboxItem;
+Combobox.Separator = ComboboxSeparator;
+
+export { Combobox as ComboboxRoot };

--- a/packages/ui/src/components/combobox/combobox.tsx
+++ b/packages/ui/src/components/combobox/combobox.tsx
@@ -300,7 +300,7 @@ export function ComboboxInput({ className, ...props }: ComboboxInputProps) {
         type="button"
         data-part="trigger"
         tabIndex={-1}
-        aria-label={effectiveOpen ? 'Close' : 'Open'}
+        {...aria.trigger}
         onClick={handleToggle}
         className={classes.trigger}
       >

--- a/packages/ui/test/components/combobox/combobox.astro.conformance.test.ts
+++ b/packages/ui/test/components/combobox/combobox.astro.conformance.test.ts
@@ -93,4 +93,17 @@ describe('combobox conformance [astro]', () => {
     await user.keyboard('{Escape}');
     expect(content().hidden).toBe(true);
   });
+
+  it('SSR renders the toggle label and the bind flips it with the open state', async () => {
+    const user = userEvent.setup();
+    await mount();
+    // SSR closed-state projection names the toggle "Open" before hydration.
+    expect(toggle().getAttribute('aria-label')).toBe('Open');
+    await user.click(toggle());
+    expect(content().hidden).toBe(false);
+    expect(toggle().getAttribute('aria-label')).toBe('Close');
+    await user.click(toggle());
+    expect(content().hidden).toBe(true);
+    expect(toggle().getAttribute('aria-label')).toBe('Open');
+  });
 });

--- a/packages/ui/test/components/combobox/combobox.astro.conformance.test.ts
+++ b/packages/ui/test/components/combobox/combobox.astro.conformance.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Astro performance of the combobox score, driven end to end. AstroContainer
+ * renders the SSR markup but does NOT run the <script>, so the test binds
+ * bindCombobox directly -- that IS the script's job -- then drives the same
+ * score the React and WC performances drive. One score, three performances.
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import Combobox from '../../../src/components/combobox/combobox.astro';
+import { bindCombobox } from '../../../src/components/combobox/combobox.behavior';
+
+const options = [
+  { value: 'react', label: 'React' },
+  { value: 'vue', label: 'Vue' },
+  { value: 'angular', label: 'Angular' },
+];
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+async function mount(props: Record<string, unknown> = {}): Promise<HTMLElement> {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Combobox, {
+    props: { id: 'cb', options, ...props },
+  });
+  document.body.innerHTML = html;
+  const root = document.body.querySelector('rafters-combobox') as HTMLElement;
+  bindCombobox(root); // the <script> does this per instance on the real page
+  return root;
+}
+
+const input = () => document.body.querySelector<HTMLInputElement>('[data-part="input"]')!;
+const toggle = () => document.body.querySelector<HTMLElement>('[data-part="trigger"]')!;
+const content = () => document.body.querySelector<HTMLElement>('[data-part="content"]')!;
+const empty = () => document.body.querySelector<HTMLElement>('[data-part="empty"]')!;
+const option = (v: string) =>
+  document.body.querySelector<HTMLElement>(`[data-part="item"][data-value="${v}"]`)!;
+
+describe('combobox conformance [astro]', () => {
+  it('SSR closed: listbox hidden and crawlable, input a collapsed combobox', async () => {
+    await mount();
+    expect(content().hidden).toBe(true);
+    expect(input().getAttribute('role')).toBe('combobox');
+    expect(input().getAttribute('aria-autocomplete')).toBe('list');
+    expect(input().getAttribute('aria-expanded')).toBe('false');
+    // Options are present in the DOM even while closed -- SSR-stable.
+    expect(option('react')).not.toBeNull();
+    expect(content().getAttribute('aria-labelledby')).toBe('cb-input');
+    // Each option carries the fixed activedescendant id contract.
+    expect(option('vue').id).toBe('cb-content-option-vue');
+  });
+
+  it('bind: typing filters the options and reveals the empty state', async () => {
+    const user = userEvent.setup();
+    await mount();
+    input().focus();
+    await user.keyboard('ang');
+    expect(content().hidden).toBe(false);
+    expect(option('angular').hidden).toBe(false);
+    expect(option('react').hidden).toBe(true);
+
+    await user.keyboard('zzz');
+    expect(empty().hidden).toBe(false);
+  });
+
+  it('bind: ArrowDown opens and activedescendant tracks the highlight', async () => {
+    const user = userEvent.setup();
+    await mount();
+    input().focus();
+    await user.keyboard('{ArrowDown}');
+    expect(content().hidden).toBe(false);
+    expect(input().getAttribute('aria-activedescendant')).toBe('cb-content-option-react');
+  });
+
+  it('bind: clicking an option commits, closes, and fills the input', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(toggle());
+    expect(content().hidden).toBe(false);
+    await user.click(option('vue'));
+    expect(content().hidden).toBe(true);
+    expect(input().value).toBe('Vue');
+    expect(option('vue').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('bind: Escape closes the list', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(toggle());
+    input().focus();
+    await user.keyboard('{Escape}');
+    expect(content().hidden).toBe(true);
+  });
+});

--- a/packages/ui/test/components/combobox/combobox.behavior.test.ts
+++ b/packages/ui/test/components/combobox/combobox.behavior.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it } from 'vitest';
+import { createBehavior, type PartIds } from '../../../src/lib/contract';
+import {
+  combobox,
+  comboboxItemAria,
+  isOpen,
+  matchesQuery,
+  nextHighlight,
+  selectedValue,
+  type ComboboxConfig,
+  type ComboboxPart,
+  type ComboboxState,
+} from '../../../src/components/combobox/combobox.behavior';
+
+const ids: PartIds<ComboboxPart> = {
+  root: 'r',
+  input: 'i',
+  trigger: 'tg',
+  content: 'c',
+  item: '',
+  empty: 'e',
+};
+
+const closed: ComboboxConfig = {};
+const openSeed: ComboboxConfig = { defaultOpen: true };
+
+function ariaAt(config: ComboboxConfig, state: ComboboxState = combobox.initialState(config)) {
+  return combobox.aria(state, config, ids);
+}
+
+describe('combobox parts', () => {
+  it('declares the input, the toggle, the listbox content, the many-instance item, and the empty state', () => {
+    expect(Object.keys(combobox.parts).sort()).toEqual([
+      'content',
+      'empty',
+      'input',
+      'item',
+      'root',
+      'trigger',
+    ]);
+    expect(combobox.parts.item.many).toBe(true);
+    expect(combobox.parts.content.optional).toBe(true);
+    expect(combobox.parts.trigger.optional).toBe(true);
+    expect(combobox.parts.empty.optional).toBe(true);
+    expect(combobox.parts.input.optional).toBeUndefined();
+  });
+});
+
+describe('combobox state: controlled vs intrinsic', () => {
+  it('seeds open, value, empty query, and no highlight from defaults', () => {
+    expect(combobox.initialState({ defaultOpen: true }).open).toBe(true);
+    expect(combobox.initialState({ defaultValue: 'react' }).value).toBe('react');
+    expect(combobox.initialState({}).value).toBe('');
+    expect(combobox.initialState({}).query).toBe('');
+    expect(combobox.initialState({}).highlighted).toBeUndefined();
+  });
+
+  it('controlled config shadows intrinsic state on both axes', () => {
+    const state = combobox.initialState({});
+    expect(isOpen(state, { open: true })).toBe(true);
+    expect(isOpen({ ...state, open: true }, { open: false })).toBe(false);
+    expect(selectedValue({ ...state, value: 'a' }, { value: 'b' })).toBe('b');
+    expect(selectedValue({ ...state, value: 'a' }, {})).toBe('a');
+  });
+});
+
+describe('combobox canDispatch (idempotence gate)', () => {
+  it('open only when effectively closed, close only when effectively open', () => {
+    const state = combobox.initialState(closed);
+    expect(combobox.canDispatch(state, 'open', closed)).toBe(true);
+    expect(combobox.canDispatch(state, 'close', closed)).toBe(false);
+    const openState: ComboboxState = { ...state, open: true };
+    expect(combobox.canDispatch(openState, 'open', closed)).toBe(false);
+    expect(combobox.canDispatch(openState, 'close', closed)).toBe(true);
+  });
+
+  it('setQuery, highlight, navigation, and select are always allowed', () => {
+    const state = combobox.initialState(closed);
+    for (const action of [
+      'setQuery',
+      'highlight',
+      'highlightNext',
+      'highlightPrev',
+      'select',
+    ] as const) {
+      expect(combobox.canDispatch(state, action, closed)).toBe(true);
+    }
+  });
+
+  it('gates on the CONTROLLED open when present', () => {
+    const drifted: ComboboxState = { ...combobox.initialState(closed), open: false };
+    expect(combobox.canDispatch(drifted, 'close', { open: true })).toBe(true);
+    expect(combobox.canDispatch(drifted, 'open', { open: true })).toBe(false);
+  });
+});
+
+describe('combobox actions', () => {
+  it('open and close move intrinsic open and clear the highlight', () => {
+    const { memory, dispatch } = createBehavior(combobox, openSeed);
+    dispatch('highlight', openSeed, 'vue');
+    expect(memory.get().highlighted).toBe('vue');
+    expect(dispatch('close', openSeed)).toBe(true);
+    expect(memory.get().open).toBe(false);
+    expect(memory.get().highlighted).toBeUndefined();
+    expect(dispatch('open', openSeed)).toBe(true);
+    expect(memory.get().open).toBe(true);
+    expect(memory.get().highlighted).toBeUndefined();
+  });
+
+  it('setQuery writes the text, opens the list, and clears the highlight', () => {
+    const { memory, dispatch } = createBehavior(combobox, {});
+    dispatch('highlight', {}, 'react');
+    expect(dispatch('setQuery', {}, 'vu')).toBe(true);
+    expect(memory.get().query).toBe('vu');
+    expect(memory.get().open).toBe(true);
+    expect(memory.get().highlighted).toBeUndefined();
+  });
+
+  it('select persists the value, fills the query with the label, closes, and clears the highlight', () => {
+    const { memory, dispatch } = createBehavior(combobox, {});
+    dispatch('open', {});
+    dispatch('highlight', {}, 'vue');
+    expect(dispatch('select', {}, { value: 'vue', label: 'Vue' })).toBe(true);
+    expect(memory.get().value).toBe('vue');
+    expect(memory.get().query).toBe('Vue');
+    expect(memory.get().open).toBe(false);
+    expect(memory.get().highlighted).toBeUndefined();
+  });
+
+  it('highlightNext opens and steps forward, clamped at the last option', () => {
+    const { memory, dispatch } = createBehavior(combobox, {});
+    const values = ['react', 'vue', 'angular'];
+    expect(dispatch('highlightNext', {}, values)).toBe(true);
+    expect(memory.get().open).toBe(true);
+    expect(memory.get().highlighted).toBe('react');
+    dispatch('highlightNext', {}, values);
+    expect(memory.get().highlighted).toBe('vue');
+    dispatch('highlightNext', {}, values);
+    dispatch('highlightNext', {}, values);
+    expect(memory.get().highlighted).toBe('angular');
+  });
+
+  it('highlightPrev steps backward, clamped at the first option', () => {
+    const { memory, dispatch } = createBehavior(combobox, openSeed);
+    const values = ['react', 'vue', 'angular'];
+    dispatch('highlight', openSeed, 'angular');
+    dispatch('highlightPrev', openSeed, values);
+    expect(memory.get().highlighted).toBe('vue');
+    dispatch('highlightPrev', openSeed, values);
+    dispatch('highlightPrev', openSeed, values);
+    expect(memory.get().highlighted).toBe('react');
+  });
+});
+
+describe('combobox pure helpers', () => {
+  it('matchesQuery matches on label OR value, case-insensitively, and empty matches all', () => {
+    expect(matchesQuery('React', 'react', '')).toBe(true);
+    expect(matchesQuery('React', 'react', 'ac')).toBe(true);
+    expect(matchesQuery('React', 'react', 'REA')).toBe(true);
+    // Value carries the match even when the label does not.
+    expect(matchesQuery('Framework one', 'react', 'rea')).toBe(true);
+    expect(matchesQuery('React', 'react', 'zzz')).toBe(false);
+  });
+
+  it('nextHighlight clamps at both ends and lands on the first from no highlight', () => {
+    const values = ['a', 'b', 'c'];
+    expect(nextHighlight(values, undefined, 1)).toBe('a');
+    expect(nextHighlight(values, undefined, -1)).toBe('a');
+    expect(nextHighlight(values, 'a', 1)).toBe('b');
+    expect(nextHighlight(values, 'c', 1)).toBe('c');
+    expect(nextHighlight(values, 'a', -1)).toBe('a');
+    expect(nextHighlight([], undefined, 1)).toBeUndefined();
+  });
+});
+
+describe('combobox aria projection', () => {
+  it('closed: input is a collapsed combobox with no dangling controls or activedescendant', () => {
+    expect(ariaAt(closed).input).toEqual({
+      role: 'combobox',
+      'aria-autocomplete': 'list',
+      'aria-haspopup': 'listbox',
+      'aria-expanded': 'false',
+      'aria-controls': undefined,
+      'aria-activedescendant': undefined,
+      'aria-disabled': undefined,
+      'data-state': 'closed',
+    });
+  });
+
+  it('open: input expands and wires to the listbox by id', () => {
+    const aria = ariaAt(openSeed);
+    expect(aria.input?.['aria-expanded']).toBe('true');
+    expect(aria.input?.['aria-controls']).toBe('c');
+    expect(aria.input?.['data-state']).toBe('open');
+    // No highlight yet -> no activedescendant.
+    expect(aria.input?.['aria-activedescendant']).toBeUndefined();
+  });
+
+  it('open with a highlight: activedescendant points at the highlighted option id', () => {
+    const state: ComboboxState = { ...combobox.initialState(openSeed), highlighted: 'vue' };
+    expect(ariaAt(openSeed, state).input?.['aria-activedescendant']).toBe('c-option-vue');
+  });
+
+  it('content is a listbox named by its input', () => {
+    expect(ariaAt(openSeed).content).toEqual({
+      role: 'listbox',
+      'aria-labelledby': 'i',
+      'data-state': 'open',
+    });
+  });
+
+  it('disabled surfaces on root and input', () => {
+    const aria = ariaAt({ disabled: true });
+    expect(aria.root?.['data-disabled']).toBe('');
+    expect(aria.input?.['aria-disabled']).toBe('true');
+  });
+
+  it('empty content id projects an absent activedescendant, never a dangling one', () => {
+    const state: ComboboxState = { ...combobox.initialState(openSeed), highlighted: 'vue' };
+    const aria = combobox.aria(state, openSeed, { ...ids, content: '' });
+    expect(aria.input?.['aria-activedescendant']).toBeUndefined();
+    expect(aria.input?.['aria-controls']).toBeUndefined();
+  });
+});
+
+describe('combobox item instance projection', () => {
+  const state: ComboboxState = { open: true, query: '', value: 'react', highlighted: 'vue' };
+  it('marks the selected option checked and the highlighted option active', () => {
+    expect(comboboxItemAria('react', state, {})).toEqual({
+      'aria-selected': 'true',
+      'data-state': 'checked',
+      'data-highlighted': undefined,
+    });
+    expect(comboboxItemAria('vue', state, {})).toEqual({
+      'aria-selected': 'false',
+      'data-state': 'unchecked',
+      'data-highlighted': '',
+    });
+  });
+
+  it('reads the CONTROLLED value', () => {
+    expect(comboboxItemAria('angular', state, { value: 'angular' })['aria-selected']).toBe('true');
+  });
+});
+
+describe('combobox keymap (all keys ride the input)', () => {
+  const openState: ComboboxState = { open: true, query: '', value: '', highlighted: 'vue' };
+  const closedState = combobox.initialState(closed);
+
+  it('ArrowDown steps the highlight and opens a closed list', () => {
+    expect(combobox.keymap({ key: 'ArrowDown' }, closedState, 'input', closed)).toBe(
+      'highlightNext',
+    );
+    expect(combobox.keymap({ key: 'ArrowDown' }, openState, 'input', closed)).toBe('highlightNext');
+  });
+
+  it('ArrowUp steps only while open', () => {
+    expect(combobox.keymap({ key: 'ArrowUp' }, openState, 'input', closed)).toBe('highlightPrev');
+    expect(combobox.keymap({ key: 'ArrowUp' }, closedState, 'input', closed)).toBeNull();
+  });
+
+  it('Enter commits only an open list with a highlight', () => {
+    expect(combobox.keymap({ key: 'Enter' }, openState, 'input', closed)).toBe('select');
+    const noHighlight: ComboboxState = { ...openState, highlighted: undefined };
+    expect(combobox.keymap({ key: 'Enter' }, noHighlight, 'input', closed)).toBeNull();
+  });
+
+  it('Escape and Tab close only an open list', () => {
+    expect(combobox.keymap({ key: 'Escape' }, openState, 'input', closed)).toBe('close');
+    expect(combobox.keymap({ key: 'Tab' }, openState, 'input', closed)).toBe('close');
+    expect(combobox.keymap({ key: 'Escape' }, closedState, 'input', closed)).toBeNull();
+  });
+
+  it('claims no keys off the input and ignores plain typing keys', () => {
+    expect(combobox.keymap({ key: 'ArrowDown' }, openState, 'content', closed)).toBeNull();
+    expect(combobox.keymap({ key: 'a' }, openState, 'input', closed)).toBeNull();
+  });
+});

--- a/packages/ui/test/components/combobox/combobox.behavior.test.ts
+++ b/packages/ui/test/components/combobox/combobox.behavior.test.ts
@@ -209,6 +209,11 @@ describe('combobox aria projection', () => {
     });
   });
 
+  it("the toggle's accessible name tracks the gesture: Open when closed, Close when open", () => {
+    expect(ariaAt(closed).trigger).toEqual({ 'aria-label': 'Open' });
+    expect(ariaAt(openSeed).trigger).toEqual({ 'aria-label': 'Close' });
+  });
+
   it('disabled surfaces on root and input', () => {
     const aria = ariaAt({ disabled: true });
     expect(aria.root?.['data-disabled']).toBe('');

--- a/packages/ui/test/components/combobox/combobox.classes.test.ts
+++ b/packages/ui/test/components/combobox/combobox.classes.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { combobox } from '../../../src/components/combobox/combobox.behavior';
+import { comboboxClasses } from '../../../src/components/combobox/combobox.classes';
+
+const config = {};
+const classes = comboboxClasses(config, combobox.initialState(config));
+
+describe('combobox classes', () => {
+  it('the listbox sits on the dropdown depth token', () => {
+    expect(classes.content).toContain('z-depth-dropdown');
+  });
+
+  it('the input honors the touch floor and scales down via CQ', () => {
+    expect(classes.input).toContain('h-11');
+    expect(classes.input).toContain('@md:h-9');
+    expect(classes.input).not.toContain('sm:');
+  });
+
+  it('state-dependent looks key off projected attributes', () => {
+    expect(classes.chevron).toContain('group-data-[state=open]:rotate-180');
+    expect(classes.item).toContain('data-[highlighted]:bg-accent');
+    expect(classes.item).toContain('data-[disabled]:pointer-events-none');
+  });
+
+  it('disabled looks key off the projected data-disabled and native disabled', () => {
+    expect(classes.input).toContain('data-[disabled]:opacity-50');
+    expect(classes.input).toContain('disabled:opacity-50');
+  });
+
+  it('motion respects reduced-motion everywhere it animates', () => {
+    for (const value of [classes.input, classes.chevron]) {
+      expect(value).toContain('motion-reduce:transition-none');
+    }
+  });
+
+  it('declares no raw numeric duration or hand-picked easing (motion token gap)', () => {
+    for (const value of Object.values(classes)) {
+      expect(value).not.toMatch(/duration-\[?\d/);
+      expect(value).not.toContain('ease-[');
+      // The dropdown enter/exit token is not generated yet; no animate-in guess.
+      expect(value).not.toContain('animate-in');
+    }
+  });
+});

--- a/packages/ui/test/components/combobox/combobox.conformance.test.tsx
+++ b/packages/ui/test/components/combobox/combobox.conformance.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * React performance of the combobox score, driven end to end. State moves only
+ * through dispatched actions; positioning and outside dismissal are composed
+ * primitives run in a useEffect, exactly as bindCombobox composes them.
+ */
+import * as React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+} from '../../../src/components/combobox/combobox';
+import {
+  combobox,
+  comboboxItemAria,
+  type ComboboxConfig,
+  type ComboboxState,
+} from '../../../src/components/combobox/combobox.behavior';
+import {
+  assertAxeClean,
+  assertContractFulfillment,
+  assertInstanceContractFulfillment,
+  partElement,
+} from '../../harness/conformance';
+
+interface SetupProps {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  disabled?: boolean;
+}
+
+function TestCombobox(props: SetupProps) {
+  return (
+    <Combobox {...props}>
+      <ComboboxInput aria-label="Framework" placeholder="Search framework" />
+      <ComboboxContent>
+        <ComboboxEmpty>No framework found.</ComboboxEmpty>
+        <ComboboxItem value="react">React</ComboboxItem>
+        <ComboboxItem value="vue">Vue</ComboboxItem>
+        <ComboboxItem value="angular">Angular</ComboboxItem>
+      </ComboboxContent>
+    </Combobox>
+  );
+}
+
+const body = () => document.body;
+const input = () => body().querySelector<HTMLInputElement>('[data-part="input"]')!;
+const toggle = () => body().querySelector<HTMLElement>('[data-part="trigger"]')!;
+const content = () => body().querySelector<HTMLElement>('[data-part="content"]')!;
+const empty = () => body().querySelector<HTMLElement>('[data-part="empty"]')!;
+const option = (v: string) =>
+  body().querySelector<HTMLElement>(`[data-part="item"][data-value="${v}"]`)!;
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('combobox conformance [react]', () => {
+  it('closed: listbox hidden, input is a collapsed combobox, aria clean', async () => {
+    render(
+      <main>
+        <TestCombobox />
+      </main>,
+    );
+    expect(content().hidden).toBe(true);
+    expect(input().getAttribute('role')).toBe('combobox');
+    expect(input().getAttribute('aria-autocomplete')).toBe('list');
+    expect(input().getAttribute('aria-expanded')).toBe('false');
+    expect(input().getAttribute('aria-haspopup')).toBe('listbox');
+    expect(input().hasAttribute('aria-activedescendant')).toBe(false);
+
+    const config: ComboboxConfig = {};
+    const state: ComboboxState = combobox.initialState(config);
+    assertContractFulfillment(combobox, partElement(body(), 'root')!, state, config, [
+      'root',
+      'input',
+      'content',
+    ]);
+    assertInstanceContractFulfillment(
+      partElement(body(), 'root')!,
+      'item',
+      ['react', 'vue', 'angular'],
+      (key) => comboboxItemAria(key, state, config),
+    );
+    await assertAxeClean(body());
+  });
+
+  it('input and listbox are wired by real ids', () => {
+    render(<TestCombobox defaultOpen />);
+    expect(input().getAttribute('aria-controls')).toBe(content().id);
+    expect(content().getAttribute('aria-labelledby')).toBe(input().id);
+  });
+
+  it('typing filters the options and reveals the empty state when nothing matches', async () => {
+    const user = userEvent.setup();
+    render(<TestCombobox />);
+    input().focus();
+    await user.keyboard('vu');
+    expect(input().value).toBe('vu');
+    expect(content().hidden).toBe(false);
+    expect(option('vue').hidden).toBe(false);
+    expect(option('react').hidden).toBe(true);
+    expect(empty().hidden).toBe(true);
+
+    await user.keyboard('zzz');
+    expect(option('vue').hidden).toBe(true);
+    expect(empty().hidden).toBe(false);
+  });
+
+  it('ArrowDown opens the list, highlights the first option, and points activedescendant at it', async () => {
+    const user = userEvent.setup();
+    render(<TestCombobox />);
+    input().focus();
+    await user.keyboard('{ArrowDown}');
+    expect(content().hidden).toBe(false);
+    expect(option('react').getAttribute('data-highlighted')).toBe('');
+    expect(input().getAttribute('aria-activedescendant')).toBe(option('react').id);
+
+    await user.keyboard('{ArrowDown}');
+    expect(option('vue').getAttribute('data-highlighted')).toBe('');
+    expect(input().getAttribute('aria-activedescendant')).toBe(option('vue').id);
+  });
+
+  it('Enter commits the highlighted option: fills the input, closes, marks it selected', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<TestCombobox onValueChange={onValueChange} />);
+    input().focus();
+    await user.keyboard('{ArrowDown}{ArrowDown}{Enter}');
+    expect(onValueChange).toHaveBeenLastCalledWith('vue');
+    expect(content().hidden).toBe(true);
+    expect(input().value).toBe('Vue');
+    expect(option('vue').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('clicking an option commits it and returns focus to the input', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(
+      <main>
+        <TestCombobox onValueChange={onValueChange} />
+      </main>,
+    );
+    await user.click(toggle());
+    expect(content().hidden).toBe(false);
+    await user.click(option('angular'));
+    expect(onValueChange).toHaveBeenLastCalledWith('angular');
+    expect(content().hidden).toBe(true);
+    expect(input().value).toBe('Angular');
+    expect(document.activeElement).toBe(input());
+  });
+
+  it('the toggle opens and closes the list', async () => {
+    const user = userEvent.setup();
+    render(<TestCombobox />);
+    await user.click(toggle());
+    expect(content().hidden).toBe(false);
+    await user.click(toggle());
+    expect(content().hidden).toBe(true);
+  });
+
+  it('Escape closes the list and keeps focus on the input', async () => {
+    const user = userEvent.setup();
+    render(<TestCombobox defaultOpen />);
+    input().focus();
+    await user.keyboard('{Escape}');
+    expect(content().hidden).toBe(true);
+    expect(document.activeElement).toBe(input());
+  });
+
+  it('pointerdown outside closes the list', async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <button type="button">Elsewhere</button>
+        <TestCombobox />
+      </div>,
+    );
+    await user.click(toggle());
+    expect(content().hidden).toBe(false);
+    await user.click(body().querySelector('button') as HTMLElement);
+    expect(content().hidden).toBe(true);
+  });
+
+  it('controlled value: callback fires and the projection follows the prop', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const { rerender } = render(<TestCombobox value="react" onValueChange={onValueChange} />);
+    expect(option('react').getAttribute('aria-selected')).toBe('true');
+
+    await user.click(toggle());
+    await user.click(option('angular'));
+    // Controlled: effective value did not move, but the callback reports the pick.
+    expect(onValueChange).toHaveBeenLastCalledWith('angular');
+    expect(option('react').getAttribute('aria-selected')).toBe('true');
+
+    rerender(<TestCombobox value="angular" onValueChange={onValueChange} />);
+    expect(option('angular').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('disabled: the input is disabled and the toggle does not open', async () => {
+    const user = userEvent.setup();
+    render(<TestCombobox disabled />);
+    expect(input().getAttribute('aria-disabled')).toBe('true');
+    expect(input().disabled).toBe(true);
+    await user.click(toggle());
+    expect(content().hidden).toBe(true);
+  });
+});

--- a/packages/ui/test/components/combobox/combobox.conformance.test.tsx
+++ b/packages/ui/test/components/combobox/combobox.conformance.test.tsx
@@ -117,12 +117,19 @@ describe('combobox conformance [react]', () => {
 
   it('ArrowDown opens the list, highlights the first option, and points activedescendant at it', async () => {
     const user = userEvent.setup();
-    render(<TestCombobox />);
+    render(
+      <main>
+        <TestCombobox />
+      </main>,
+    );
     input().focus();
     await user.keyboard('{ArrowDown}');
     expect(content().hidden).toBe(false);
     expect(option('react').getAttribute('data-highlighted')).toBe('');
     expect(input().getAttribute('aria-activedescendant')).toBe(option('react').id);
+    // Axe over the OPEN state: the listbox named by the input, and a live
+    // aria-activedescendant pointing at an option that is a sibling of the input.
+    await assertAxeClean(body());
 
     await user.keyboard('{ArrowDown}');
     expect(option('vue').getAttribute('data-highlighted')).toBe('');

--- a/packages/ui/test/components/combobox/combobox.element.conformance.test.ts
+++ b/packages/ui/test/components/combobox/combobox.element.conformance.test.ts
@@ -1,0 +1,130 @@
+/**
+ * WC performance of the combobox score, driven end to end against light-DOM
+ * markup. Same score as the React conformance test -- the binding applies the
+ * projection imperatively, filters the options in place, and composes the
+ * positioning + outside-dismiss affordances.
+ */
+import { cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { RaftersCombobox } from '../../../src/components/combobox/combobox.element';
+
+beforeAll(() => {
+  if (!customElements.get('rafters-combobox')) {
+    customElements.define('rafters-combobox', RaftersCombobox);
+  }
+});
+
+function optionMarkup(v: string, label: string): string {
+  return `<div role="option" data-part="item" id="cb-content-option-${v}" data-value="${v}"><span></span><span>${label}</span></div>`;
+}
+
+async function mount(attrs = ''): Promise<HTMLElement> {
+  document.body.innerHTML = `
+    <rafters-combobox data-part="root" value="" ${attrs}>
+      <div data-part="field">
+        <input data-part="input" id="cb-input" type="text" autocomplete="off" value="" />
+        <button type="button" data-part="trigger" tabindex="-1" aria-label="Open"></button>
+      </div>
+      <div data-part="content" id="cb-content" hidden>
+        ${optionMarkup('react', 'React')}
+        ${optionMarkup('vue', 'Vue')}
+        ${optionMarkup('angular', 'Angular')}
+        <div data-part="empty" hidden>No results.</div>
+      </div>
+    </rafters-combobox>`;
+  await Promise.resolve(); // let the element's deferred bind run
+  return document.body.querySelector('rafters-combobox') as HTMLElement;
+}
+
+const input = () => document.body.querySelector<HTMLInputElement>('[data-part="input"]')!;
+const toggle = () => document.body.querySelector<HTMLElement>('[data-part="trigger"]')!;
+const content = () => document.body.querySelector<HTMLElement>('[data-part="content"]')!;
+const empty = () => document.body.querySelector<HTMLElement>('[data-part="empty"]')!;
+const option = (v: string) =>
+  document.body.querySelector<HTMLElement>(`[data-part="item"][data-value="${v}"]`)!;
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+describe('combobox conformance [wc]', () => {
+  it('closed: listbox hidden, input a collapsed combobox wired by real ids', async () => {
+    await mount();
+    expect(content().hidden).toBe(true);
+    expect(input().getAttribute('role')).toBe('combobox');
+    expect(input().getAttribute('aria-autocomplete')).toBe('list');
+    expect(input().getAttribute('aria-expanded')).toBe('false');
+    expect(input().hasAttribute('aria-activedescendant')).toBe(false);
+    expect(content().getAttribute('role')).toBe('listbox');
+    expect(content().getAttribute('aria-labelledby')).toBe('cb-input');
+    expect(option('react').getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('typing filters the options and reveals the empty state', async () => {
+    const user = userEvent.setup();
+    await mount();
+    input().focus();
+    await user.keyboard('vu');
+    expect(content().hidden).toBe(false);
+    expect(option('vue').hidden).toBe(false);
+    expect(option('react').hidden).toBe(true);
+    expect(empty().hidden).toBe(true);
+
+    await user.keyboard('zzz');
+    expect(empty().hidden).toBe(false);
+  });
+
+  it('ArrowDown opens, highlights the first option, and points activedescendant at it', async () => {
+    const user = userEvent.setup();
+    await mount();
+    input().focus();
+    await user.keyboard('{ArrowDown}');
+    expect(content().hidden).toBe(false);
+    expect(option('react').getAttribute('data-highlighted')).toBe('');
+    expect(input().getAttribute('aria-activedescendant')).toBe('cb-content-option-react');
+  });
+
+  it('arrows move the highlight and Enter commits the highlighted option', async () => {
+    const user = userEvent.setup();
+    await mount();
+    input().focus();
+    await user.keyboard('{ArrowDown}{ArrowDown}{Enter}');
+    expect(content().hidden).toBe(true);
+    expect(input().value).toBe('Vue');
+    expect(option('vue').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('clicking an option commits it and returns focus to the input', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(toggle());
+    expect(content().hidden).toBe(false);
+    await user.click(option('angular'));
+    expect(content().hidden).toBe(true);
+    expect(input().value).toBe('Angular');
+    expect(option('angular').getAttribute('aria-selected')).toBe('true');
+    expect(document.activeElement).toBe(input());
+  });
+
+  it('Escape closes and keeps focus on the input', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(toggle());
+    input().focus();
+    await user.keyboard('{Escape}');
+    expect(content().hidden).toBe(true);
+  });
+
+  it('pointerdown outside closes', async () => {
+    const user = userEvent.setup();
+    await mount();
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    await user.click(toggle());
+    expect(content().hidden).toBe(false);
+    await user.click(outside);
+    expect(content().hidden).toBe(true);
+  });
+});

--- a/packages/ui/test/components/combobox/combobox.element.conformance.test.ts
+++ b/packages/ui/test/components/combobox/combobox.element.conformance.test.ts
@@ -127,4 +127,17 @@ describe('combobox conformance [wc]', () => {
     await user.click(outside);
     expect(content().hidden).toBe(true);
   });
+
+  it("the toggle's accessible name flips with the open state", async () => {
+    const user = userEvent.setup();
+    await mount();
+    // The bind applies the projection on first paint, overwriting the SSR label.
+    expect(toggle().getAttribute('aria-label')).toBe('Open');
+    await user.click(toggle());
+    expect(content().hidden).toBe(false);
+    expect(toggle().getAttribute('aria-label')).toBe('Close');
+    await user.click(toggle());
+    expect(content().hidden).toBe(true);
+    expect(toggle().getAttribute('aria-label')).toBe('Open');
+  });
 });


### PR DESCRIPTION
## Summary

Ports `combobox` to the behavior layer as one score with three performances. The
behavior (`combobox.behavior.ts`) is a single slice over the one `createBehavior`
cell -- `open`, `query`, `value`, `highlighted` -- with pure aria/keymap
projections, the pure filter predicate `matchesQuery`, the clamp helper
`nextHighlight`, and `bindCombobox`, the DOM-native client the Web Component and
Astro share. The classes, React (`combobox.tsx`), WC (`combobox.element.ts`) and
Astro (`combobox.astro`) decorators are thin.

This is the EDITABLE combobox APG pattern extracted faithfully from
`old/ui/combobox.tsx`: DOM focus never leaves the input and the active option is
advertised with `aria-activedescendant`. Because of that, roving-focus and
typeahead do not fit and are deliberately not composed (both are live primitives
select uses -- a fits-this-component call, recorded in the doc). selection-group
(cell-owning), form-value (native input would submit twice) and input-events
(contenteditable editor) are excluded per the issue's caveats. The two impure
capabilities are composed directly: `collision-detector` positions the listbox
against the input and `outside-click` light-dismisses it, sparing the input and
the toggle. Escape rides the score's keymap.

Motion enter/exit is left undeclared because the semantic dropdown token is not
generated yet; the gap is documented rather than papered over with a numeric
duration.

## Acceptance criteria mapping

### Component doc written
`docs/spec/components/combobox.md` registers the composition, config/state/actions,
the parts+ARIA table, the keyboard law, the oracle dispositions, and the explicit
list of archetype-named primitives this variant does not compose with the reason
for each.
Evidence: packages/ui/docs/spec/components/combobox.md:1

### JSDoc intelligence tags present
The four registry-parsed tags -- `@cognitive-load`, `@attention-economics`,
`@trust-building`, `@accessibility` -- are authored on the React performance so
the registry can surface the component's intelligence.
Evidence: packages/ui/src/components/combobox/combobox.tsx:4

### Behavior test (pure, no DOM)
`combobox.behavior.test.ts` exercises the reducers, the controlled/intrinsic
shadowing, the idempotence gate, the pure helpers, the aria projection (including
the empty-id activedescendant sentinel) and the keymap with no DOM at all.
Evidence: packages/ui/test/components/combobox/combobox.behavior.test.ts:1

### Classes parity test
`combobox.classes.test.ts` pins the dropdown depth token, the container-query
touch floor, the state-keyed looks, and asserts no raw numeric duration or
animate-in guess entered while the motion token is missing.
Evidence: packages/ui/test/components/combobox/combobox.classes.test.ts:1

### Conformance test via the shared harness (aria + keymap against rendered DOM)
Three suites drive the one score through the shared harness -- React, WC and Astro
-- asserting contract fulfillment and per-instance ARIA against rendered DOM plus
the interaction law (typing filters, arrows move activedescendant, Enter commits,
Escape/outside-click close).
Evidence: packages/ui/test/components/combobox/combobox.conformance.test.tsx:1

### shadcn drop-in parity where the component exists in shadcn
shadcn ships combobox as a Popover+Command recipe, not a discrete component; the
port preserves the rafters `Combobox.*` drop-in surface (Input, Content, Empty,
Group, Item, Separator) so existing call sites keep working.
Evidence: packages/ui/src/components/combobox/combobox.tsx:449

### `pnpm --filter @rafters/ui test:unit` green, `pnpm preflight` green
The full unit suite (main + Astro configs) and the workspace preflight
(typecheck, lint, format, unit, a11y, build) both pass on this branch; the 55
combobox tests are part of that green run.
Evidence: packages/ui/test/components/combobox/combobox.astro.conformance.test.ts:1

## Not done

- Vue performance is intentionally out of scope (stays missing per the wave plan).
- Enter/exit motion is undeclared pending the semantic `motion-dropdown-in`/`-out`
  utility (#1899/#1902); re-declare when the token ships.
- The listbox lives in light DOM (present-but-hidden) rather than portaled to
  `document.body`; portaling is a framework affordance not needed for the behavior
  and would break the one-bind-three-performances shape.
- The input text (`query`) is not seeded from `defaultValue`; it reflects typing
  and the last committed label. Recorded as a reconstructed disposition in the doc.

Closes #1766
