### PR TITLE
feat(ui): port command to the behavior layer

### DIFF
--- a/packages/ui/docs/spec/components/command.md
+++ b/packages/ui/docs/spec/components/command.md
@@ -1,0 +1,139 @@
+# Component Spec — Command
+
+Status: DRAFT. Wave-4 port. Archetype: menu-collection-popup.
+
+A command palette: a search combobox that fuzzy-filters a listbox of options,
+invoked keyboard-first. Ports the React-only `src/old/ui/command.tsx` to the
+behavior layer with three performances (React, Web Component, Astro).
+
+Files (`src/components/command/`):
+
+```
+command.classes.ts   command.behavior.ts   command.tsx   command.element.ts   command.astro
+```
+
+Tests mirror into `test/components/command/` (behavior, classes, and React / WC
+/ Astro conformance).
+
+## Composition
+
+```
+command slice   state {query, highlighted}, actions setQuery/highlight/
+                highlightNext/Prev/First/Last/select, parts root/input/list/
+                item/empty, combobox+listbox aria, input keymap
+```
+
+Single slice over the one `createBehavior` cell. The active option is a plain
+reducer value, not a second cell: `createSelectionGroup`/`createCommandPalette`
+own their own cells and do not compose, so the highlight is re-expressed as
+`highlighted` on this cell (the pattern radio-group/select/tabs follow).
+
+Filtering composes the `command-palette` primitive's **pure** `fuzzyMatch`. The
+`createCommandPalette` CONTROLLER does not compose: it owns a cell and is
+editor-specific (its `shouldTrigger` reads contenteditable selection ranges);
+only the pure matcher is a seam.
+
+`roving-focus` is deliberately NOT composed. See the oracle dispositions.
+
+## Config, state, actions
+
+```ts
+interface CommandConfig {
+  value?: string;        // controlled query
+  defaultValue?: string; // uncontrolled seed
+  label?: string;        // accessible name for the listbox (default 'Suggestions')
+}
+interface CommandState {
+  query: string;                    // intrinsic search query
+  highlighted: string | undefined;  // active option value (aria-activedescendant)
+}
+type CommandActions = {
+  setQuery: string;         // set query, reset highlight
+  highlight: string;        // point at a value (pointer)
+  highlightNext: string[];  // step over the ordered visible values
+  highlightPrev: string[];
+  highlightFirst: string[];
+  highlightLast: string[];
+  select: string;           // commit: settle highlight; bindings fire the invoke
+};
+```
+
+Controlled/uncontrolled per boundary 4: `config.value` shadows `state.query`;
+projections read `queryValue(state, config)`. Changing the query resets the
+highlight (ported `activeIndex = -1`). The navigation actions take the ordered
+set of currently-visible option values as their payload, because that set is
+DOM-derived (fuzzy match against the live option list) and the score is pure —
+`moveHighlight` computes the next value over it, clamping (never wrapping).
+
+There is **no open axis**: the palette list is always present. Open/close lives
+only in the `CommandDialog` wrapper.
+
+## Parts and ARIA
+
+| Part | Presence | ARIA |
+| --- | --- | --- |
+| root | always | container; no role |
+| input | always | `role="combobox"`, `aria-autocomplete="list"`, `aria-expanded="true"`, `aria-controls` (listbox id, only when rendered), `aria-activedescendant` (highlighted option id, set by the bindings) |
+| list | always | `role="listbox"`, `aria-label` (from `label`, default `Suggestions`) |
+| item | many | `role="option"`, `aria-selected` (highlighted), `data-selected`/`data-highlighted`, `hidden` when it does not match the query |
+| empty | present-but-hidden | shown only when the query is non-empty and nothing matches |
+
+The consumer must give the `input` an accessible name (`aria-label` or an
+associated `<label>`); it is a combobox and axe requires a name.
+
+`aria-activedescendant` is set imperatively (its target is a per-instance option
+id, not a part-name id), so it is not in `aria()` — the harness asserts it via
+interaction, not contract equality.
+
+## Keyboard
+
+Focus stays on the input (virtual focus); options are never individually
+focusable. On the input:
+
+- `ArrowDown` / `ArrowUp`: move the highlight to the next / previous visible
+  option, clamping at the ends (no wrap).
+- `Home` / `End`: jump to the first / last visible option.
+- `Enter`: invoke the highlighted option (routed through the option's click path
+  so keyboard and pointer commit identically).
+- Typing: filters; the highlight resets so no stale option stays active.
+
+Invocation raises a `command-select` CustomEvent (`detail.value`) on the root
+for WC/Astro consumers; React consumers use the item's `onSelect` prop, which
+fires from the same click path.
+
+## Oracle dispositions (`src/old/ui/command.tsx`, React-only)
+
+| Oracle feature | Disposition |
+| --- | --- |
+| combobox input + listbox + option roles, aria-activedescendant virtual focus | contract |
+| controlled/uncontrolled search value + onValueChange | contract |
+| Command / Dialog / Input / List / Empty / Group / Item / Separator / Shortcut surface + `Command.*` namespace | contract (shadcn drop-in floor) |
+| ArrowDown/Up clamp (no wrap), Home/End to first/last, reset highlight on query change | contract (extracted from the oracle's `min`/`max` on activeIndex) |
+| mouse-enter highlights the pointed option | contract (moved to `pointermove` -> `highlight`) |
+| substring `includes` filter | upgraded to fuzzy matching via the command-palette primitive's `fuzzyMatch` (issue-directed; a deliberate contract change, not a silent swap) |
+| Enter only set `selectedValue`, never fired the item's action | defect-do-not-port — Enter now invokes the highlighted option through the same click path as pointer, so the option's `onSelect` fires |
+| `roving-focus` (issue's "add" list) | dropped — a combobox keeps DOM focus on the input and points at the active option virtually (aria-activedescendant); roving-focus moves DOM focus and item tabindex (and wraps), which would pull focus off the search box and break typing. Three signals converge: the oracle's aria-activedescendant + its explicit "options not individually focusable" note, the issue's `highlighted` state axis (a reducer value, not DOM focus), and shadcn/cmdk parity (aria-activedescendant). The primitive list is INTENT; this is the INTENT-vs-FACT escape hatch the issue names |
+| `CommandDialog` (React-only convenience) | contract, upgraded: the oracle wrapped Command in a backdrop + Escape listener; it now composes the modal trio (focus-trap + preventBodyScroll + outside-dismiss) via `startCommandDialogEffects`, imitating `dialog` per the issue. Provided in React (the surface the oracle shipped); WC/Astro consumers compose the merged `dialog` + `command` |
+| slash-trigger / contenteditable activation (command-palette primitive) | framework-affordance not ported — that is the editor palette, a separate surface from the shadcn command list |
+
+## Motion
+
+Enter/exit intent is **fade** for the `CommandDialog` overlay. The core palette
+has no open axis and therefore no enter/exit motion. The semantic motion tokens
+(`motion-modal-in`/`-out`, #1899) do not exist yet, so per the issue the dialog
+enter/exit motion is left **undeclared** rather than hardcoding a raw duration;
+the option color swap uses `transition-colors` with `motion-reduce:transition-none`
+and no numeric duration.
+
+## WCAG 2.1 AA obligations
+
+- 1.3.1 / 4.1.2: combobox + listbox + option roles and the aria-controls /
+  aria-activedescendant wiring asserted against real DOM ids by the harness.
+- 2.1.1 Keyboard: full navigation and invocation from the input; no pointer
+  requirement.
+- 2.4.3 Focus Order: focus stays on the input; the active option is virtual and
+  singular.
+
+The empty state is a presentational (`role="presentation"`) visual affordance
+that appears only when a query matches nothing; it is not a live region and
+makes no 4.1.3 status-message announcement.

--- a/packages/ui/src/components/command/command.astro
+++ b/packages/ui/src/components/command/command.astro
@@ -1,0 +1,122 @@
+---
+/**
+ * Astro performance for command. Server-renders the full light-DOM palette with
+ * the initial projection already applied (correct and inert before JS), then the
+ * <script> hands each instance to bindCommand -- the SAME DOM-native client the
+ * Web Component uses. One score, three performances.
+ *
+ * The list is always present (the palette has no open axis); options hide
+ * individually when they do not match the query, which the bind applies once JS
+ * runs. Before JS every option is shown (the empty query matches all).
+ */
+import { command, commandItemAria, type CommandConfig, type CommandPart } from './command.behavior';
+import { commandClasses } from './command.classes';
+import type { PartIds } from '../../lib/contract';
+
+interface Item {
+  value: string;
+  label: string;
+  disabled?: boolean;
+  shortcut?: string;
+}
+
+interface Props {
+  id: string;
+  items: Item[];
+  label?: string;
+  placeholder?: string;
+  emptyText?: string;
+}
+
+const {
+  id,
+  items,
+  label = 'Suggestions',
+  placeholder = 'Type a command...',
+  emptyText = 'No results found.',
+} = Astro.props;
+
+const config: CommandConfig = { label };
+const state = command.initialState(config);
+const classes = commandClasses(config, state);
+
+const ids = {} as PartIds<CommandPart>;
+for (const part of Object.keys(command.parts) as CommandPart[]) {
+  ids[part] = `${id}-${part}`;
+}
+const aria = command.aria(state, config, ids);
+
+const sanitize = (value: string): string => value.replace(/[^a-zA-Z0-9_-]/g, '-');
+---
+
+<rafters-command data-part="root" id={ids.root} data-label={label} class={classes.root}>
+  <div data-part="input-wrapper" class={classes.inputWrapper}>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      class={classes.inputIcon}
+      aria-hidden="true"
+    >
+      <circle cx="11" cy="11" r="8"></circle>
+      <path d="m21 21-4.3-4.3"></path>
+    </svg>
+    <input
+      data-part="input"
+      id={ids.input}
+      type="text"
+      value=""
+      placeholder={placeholder}
+      autocomplete="off"
+      autocorrect="off"
+      spellcheck="false"
+      aria-label={placeholder}
+      {...aria.input}
+      class={classes.input}
+    />
+  </div>
+
+  <div data-part="list" id={ids.list} {...aria.list} class={classes.list}>
+    <div data-part="empty" id={ids.empty} class={classes.empty} role="presentation" hidden>
+      {emptyText}
+    </div>
+    {
+      items.map((item) => {
+        const itemAria = commandItemAria(item.value, state, config);
+        return (
+          <div
+            role="option"
+            id={`${id}-item-${sanitize(item.value)}`}
+            data-part="item"
+            data-value={item.value}
+            data-disabled={item.disabled ? '' : undefined}
+            aria-disabled={item.disabled ? 'true' : undefined}
+            class={classes.item}
+            {...itemAria}
+          >
+            <span>{item.label}</span>
+            {item.shortcut && (
+              <kbd data-part="shortcut" class={classes.shortcut}>
+                {item.shortcut}
+              </kbd>
+            )}
+          </div>
+        );
+      })
+    }
+  </div>
+</rafters-command>
+
+<script>
+  import { bindCommand } from './command.behavior';
+
+  for (const root of document.querySelectorAll<HTMLElement>('rafters-command[data-part="root"]')) {
+    if (root.dataset['bound'] === 'true') continue;
+    root.dataset['bound'] = 'true';
+    bindCommand(root);
+  }
+</script>

--- a/packages/ui/src/components/command/command.behavior.ts
+++ b/packages/ui/src/components/command/command.behavior.ts
@@ -1,0 +1,412 @@
+import { compose, type Slice } from '../../lib/compose';
+import {
+  createBehavior,
+  type AriaAttrs,
+  type BehaviorSpec,
+  type PartIds,
+} from '../../lib/contract';
+import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { fuzzyMatch } from '../../primitives/command-palette';
+import { createFocusTrap, preventBodyScroll } from '../../primitives/focus-trap';
+import { onPointerDownOutside } from '../../primitives/outside-click';
+
+/**
+ * Command: a filtered command palette. A search combobox narrows a listbox of
+ * options; the highlighted option is virtual (aria-activedescendant), so DOM
+ * focus never leaves the input and the user keeps typing. Ports the React-only
+ * old/ui/command.tsx wholesale.
+ *
+ * The two state axes are `query` and `highlighted`:
+ *  - query is the search string. Controlled/uncontrolled per boundary 4:
+ *    config.value shadows state.query; the effective read is queryValue().
+ *    Changing the query resets the highlight (ported activeIndex = -1), so a
+ *    fresh keystroke never leaves a stale option active.
+ *  - highlighted is the option the user is pointed at. Unlike select (which
+ *    roves real DOM focus across options) a combobox keeps focus on the input
+ *    and points at the active option VIRTUALLY via aria-activedescendant. So
+ *    roving-focus -- which moves DOM focus and item tabindex -- is deliberately
+ *    NOT composed here; it would pull focus off the search box. highlighted is
+ *    a plain reducer value and the navigation math (moveHighlight) is pure over
+ *    the ordered set of currently-visible option values, which the bindings
+ *    read from the DOM and pass as the action payload.
+ *
+ * Filtering composes the command-palette primitive's pure `fuzzyMatch` (the
+ * createCommandPalette CONTROLLER is cell-owning and editor-specific -- it reads
+ * contenteditable selection ranges -- so it does not compose; only the pure
+ * matcher does). This upgrades the oracle's substring `includes` filter to
+ * fuzzy matching, the behaviour the issue calls for.
+ */
+export interface CommandConfig {
+  /** Controlled search query. */
+  value?: string | undefined;
+  /** Uncontrolled seed. */
+  defaultValue?: string | undefined;
+  /** Accessible name for the listbox popup (default 'Suggestions'). */
+  label?: string | undefined;
+}
+
+export interface CommandState {
+  /** Intrinsic search query. */
+  query: string;
+  /** The option value the user is pointed at (aria-activedescendant target). */
+  highlighted: string | undefined;
+}
+
+export type CommandActions = {
+  /** Set the query and reset the highlight (payload: query). */
+  setQuery: string;
+  /** Point at an option value (payload: value). */
+  highlight: string;
+  /** Move to the next visible option (payload: ordered visible values). */
+  highlightNext: string[];
+  /** Move to the previous visible option (payload: ordered visible values). */
+  highlightPrev: string[];
+  /** Jump to the first visible option (payload: ordered visible values). */
+  highlightFirst: string[];
+  /** Jump to the last visible option (payload: ordered visible values). */
+  highlightLast: string[];
+  /** Commit an option: point at it; the bindings fire the consumer select
+   *  (payload: value). */
+  select: string;
+};
+
+export type CommandPart = 'root' | 'input' | 'list' | 'item' | 'empty';
+
+/** The effective query: controlled config shadows intrinsic state. */
+export function queryValue(state: CommandState, config: CommandConfig): string {
+  return config.value ?? state.query;
+}
+
+/** Whether an option's searchable text matches the query. An empty query
+ *  matches everything; otherwise the command-palette primitive's fuzzyMatch
+ *  decides (case-insensitive, prefix/consecutive scored). */
+export function matchesQuery(text: string, query: string): boolean {
+  if (query === '') return true;
+  return fuzzyMatch(text, query).matches;
+}
+
+/** The next highlight given the ordered visible option values, the current
+ *  highlight, and a direction. Clamp, never wrap (ported from the oracle's
+ *  min/max on activeIndex): the reason roving-focus -- which wraps -- is wrong
+ *  for a combobox. Undefined highlight reads as index -1, so 'next' lands on the
+ *  first option and 'prev' clamps to the first. */
+export function moveHighlight(
+  visible: string[],
+  current: string | undefined,
+  direction: 'next' | 'prev' | 'first' | 'last',
+): string | undefined {
+  if (visible.length === 0) return undefined;
+  const index = current === undefined ? -1 : visible.indexOf(current);
+  switch (direction) {
+    case 'next':
+      return visible[Math.min(index + 1, visible.length - 1)];
+    case 'prev':
+      return visible[Math.max(index - 1, 0)];
+    case 'first':
+      return visible[0];
+    case 'last':
+      return visible[visible.length - 1];
+  }
+}
+
+const commandSlice: Slice<CommandConfig, CommandState, CommandActions, CommandPart> = {
+  name: 'command',
+  parts: {
+    root: {},
+    input: { role: 'combobox' },
+    list: { role: 'listbox' },
+    item: { many: true, role: 'option' },
+    // The empty state is present-but-hidden; the bindings toggle its visibility
+    // from the live match count, which the score cannot know (it has no item
+    // set), so it carries no aria projection.
+    empty: { optional: true },
+  },
+  initialState: (config) => ({
+    query: config.value ?? config.defaultValue ?? '',
+    highlighted: undefined,
+  }),
+  actions: {
+    // A fresh query resets the highlight (ported activeIndex = -1): a keystroke
+    // never leaves a stale option active-descendant.
+    setQuery: (_state, query) => ({ query, highlighted: undefined }),
+    highlight: (state, value) => ({ ...state, highlighted: value }),
+    highlightNext: (state, visible) => ({
+      ...state,
+      highlighted: moveHighlight(visible, state.highlighted, 'next'),
+    }),
+    highlightPrev: (state, visible) => ({
+      ...state,
+      highlighted: moveHighlight(visible, state.highlighted, 'prev'),
+    }),
+    highlightFirst: (state, visible) => ({
+      ...state,
+      highlighted: moveHighlight(visible, state.highlighted, 'first'),
+    }),
+    highlightLast: (state, visible) => ({
+      ...state,
+      highlighted: moveHighlight(visible, state.highlighted, 'last'),
+    }),
+    // Commit points at the option; the bindings fire the consumer select and
+    // emit the command-select event. State-wise this only settles the highlight.
+    select: (state, value) => ({ ...state, highlighted: value }),
+  },
+  canDispatch: () => true,
+  aria: (_state, config, ids) => ({
+    input: {
+      role: 'combobox',
+      'aria-autocomplete': 'list',
+      // The listbox is always present in the palette, so the combobox is always
+      // expanded. aria-activedescendant is per-highlighted-option and set by the
+      // bindings (its id is not in the part-name id map), not projected here.
+      'aria-expanded': 'true',
+      'aria-controls': ids.list || undefined,
+    },
+    list: {
+      role: 'listbox',
+      'aria-label': config.label ?? 'Suggestions',
+    },
+  }),
+  keymap: (event, _state, part) => {
+    if (part !== 'input') return null;
+    switch (event.key) {
+      case 'ArrowDown':
+        return 'highlightNext';
+      case 'ArrowUp':
+        return 'highlightPrev';
+      case 'Home':
+        return 'highlightFirst';
+      case 'End':
+        return 'highlightLast';
+      case 'Enter':
+        return 'select';
+      default:
+        return null;
+    }
+  },
+};
+
+export const command: BehaviorSpec<CommandConfig, CommandState, CommandActions, CommandPart> =
+  compose('command', commandSlice);
+
+/**
+ * Per-instance projection for the many-instance `item` part. Its visibility is
+ * a pure function of the query (fuzzy match against the option's value) and its
+ * active look a pure function of the highlight -- so React, the WC and Astro all
+ * hide and mark options identically. `hidden` is a boolean presence attr (the
+ * harness asserts it via hasAttribute, which holds across all three frameworks).
+ */
+export function commandItemAria(
+  value: string,
+  state: CommandState,
+  config: CommandConfig,
+): AriaAttrs {
+  const visible = matchesQuery(value, queryValue(state, config));
+  const active = state.highlighted === value;
+  return {
+    'aria-selected': active ? 'true' : 'false',
+    'data-selected': active ? '' : undefined,
+    'data-highlighted': active ? '' : undefined,
+    hidden: visible ? undefined : true,
+  };
+}
+
+/** The ordered, enabled option values currently matching the query -- the set
+ *  navigation moves over and the empty state keys off. Shared by every binding
+ *  so keyboard order agrees with DOM order. */
+export function visibleItemValues(root: HTMLElement, query: string): string[] {
+  const values: string[] = [];
+  for (const item of root.querySelectorAll<HTMLElement>('[data-part="item"]')) {
+    if (item.hasAttribute('data-disabled') || item.getAttribute('aria-disabled') === 'true') {
+      continue;
+    }
+    const value = item.dataset['value'];
+    if (value !== undefined && matchesQuery(value, query)) values.push(value);
+  }
+  return values;
+}
+
+/** The empty state shows only when the user has typed and nothing matches
+ *  (ported: `visibleItems.length > 0 || !value` hides it otherwise). */
+export function isEmptyShown(visibleCount: number, query: string): boolean {
+  return query !== '' && visibleCount === 0;
+}
+
+/** The parts and dispatch the modal-dialog trio composes against. */
+export interface CommandDialogPorts {
+  /** The palette surface: focus is trapped inside it and an outside pointerdown
+   *  dismisses. */
+  content: HTMLElement;
+  /** Resolves the trigger so the opening gesture's pointerdown is spared. */
+  getTrigger: () => HTMLElement | null;
+  /** Outside-pointerdown handler, already spared of the trigger. */
+  onDismiss: (event: Event) => void;
+}
+
+/**
+ * The modal overlay trio for the CommandDialog wrapper, composed directly the
+ * way dialog.behavior.ts's startDialogModalEffects does (imitate, do not import
+ * across components): trap Tab focus inside `content`, lock body scroll, and
+ * dismiss on a pointerdown outside `content` sparing the trigger. Level-
+ * triggered: started on the open transition, torn down (LIFO) on close/unmount.
+ */
+export function startCommandDialogEffects({
+  content,
+  getTrigger,
+  onDismiss,
+}: CommandDialogPorts): () => void {
+  const releaseTrap = createFocusTrap(content);
+  const releaseScroll = preventBodyScroll();
+  const releaseDismiss = onPointerDownOutside(content, (event) => {
+    const target = event.target as Node;
+    if (getTrigger()?.contains(target)) return;
+    onDismiss(event);
+  });
+  return () => {
+    releaseDismiss();
+    releaseScroll();
+    releaseTrap();
+  };
+}
+
+/** The invoke event a palette raises when an option is committed (click or
+ *  Enter). WC and Astro consumers listen for it; React consumers use the item's
+ *  `onSelect` prop, which fires from the same click path. */
+export const COMMAND_SELECT_EVENT = 'command-select';
+
+/**
+ * The DOM-native binding of the command score -- the client the Web Component
+ * and the Astro <script> share. Only React reads the projections declaratively.
+ * The palette has no open axis (the list is always visible), so unlike bindSelect
+ * there is no presence toggle and no focus roving: the input keeps focus and the
+ * active option is virtual (aria-activedescendant).
+ */
+export function bindCommand(root: HTMLElement): () => void {
+  const getPart = (part: string): HTMLElement | null =>
+    part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
+
+  const inputEl = getPart('input') as HTMLInputElement | null;
+  const config: CommandConfig = {
+    defaultValue: inputEl?.value ?? undefined,
+    label: root.dataset['label'] ?? undefined,
+  };
+
+  const { memory, dispatch } = createBehavior(command, config);
+
+  const ids = {} as PartIds<CommandPart>;
+  for (const part of Object.keys(command.parts) as CommandPart[]) {
+    ids[part] = getPart(part)?.id ?? '';
+  }
+
+  const applyProjection = (el: HTMLElement, attrs: AriaAttrs) => {
+    for (const [name, value] of Object.entries(attrs)) {
+      updateAriaAttribute(el, name as never, value as never, { validate: false });
+    }
+  };
+
+  const itemById = (value: string): HTMLElement | null =>
+    root.querySelector<HTMLElement>(`[data-part="item"][data-value="${CSS.escape(value)}"]`);
+
+  const render = () => {
+    const state = memory.get();
+    const query = queryValue(state, config);
+
+    const projection = command.aria(state, config, ids);
+    for (const part of Object.keys(projection) as CommandPart[]) {
+      const attrs = projection[part];
+      const el = getPart(part);
+      if (el && attrs) applyProjection(el, attrs);
+    }
+
+    // Per-option projection: hide non-matches, mark the active one.
+    let visibleCount = 0;
+    for (const el of root.querySelectorAll<HTMLElement>('[data-part="item"]')) {
+      const value = el.dataset['value'];
+      if (value === undefined) continue;
+      applyProjection(el, commandItemAria(value, state, config));
+      if (!el.hidden && !el.hasAttribute('data-disabled')) visibleCount++;
+    }
+
+    // aria-activedescendant points at the highlighted option's real id.
+    if (inputEl) {
+      const activeEl = state.highlighted !== undefined ? itemById(state.highlighted) : null;
+      if (activeEl?.id) inputEl.setAttribute('aria-activedescendant', activeEl.id);
+      else inputEl.removeAttribute('aria-activedescendant');
+    }
+
+    // The empty state shows only when the query matches nothing.
+    const emptyEl = getPart('empty');
+    if (emptyEl) emptyEl.hidden = !isEmptyShown(visibleCount, query);
+  };
+  const unsubscribe = memory.subscribe(render); // fires immediately: first paint
+
+  const onInput = () => {
+    if (inputEl) dispatch('setQuery', config, inputEl.value);
+  };
+  inputEl?.addEventListener('input', onInput);
+
+  const commit = (value: string) => {
+    dispatch('select', config, value);
+    root.dispatchEvent(new CustomEvent(COMMAND_SELECT_EVENT, { detail: { value }, bubbles: true }));
+  };
+
+  const isDisabledItem = (item: HTMLElement): boolean =>
+    item.hasAttribute('data-disabled') || item.getAttribute('aria-disabled') === 'true';
+
+  const onClick = (event: Event) => {
+    const item = (event.target as HTMLElement).closest<HTMLElement>('[data-part="item"]');
+    if (!item || !root.contains(item) || isDisabledItem(item)) return;
+    const value = item.dataset['value'];
+    if (value !== undefined) commit(value);
+  };
+  root.addEventListener('click', onClick);
+
+  const onPointerMove = (event: Event) => {
+    const item = (event.target as HTMLElement).closest<HTMLElement>('[data-part="item"]');
+    if (!item || !root.contains(item) || isDisabledItem(item)) return;
+    const value = item.dataset['value'];
+    if (value !== undefined && value !== memory.get().highlighted) {
+      dispatch('highlight', config, value);
+    }
+  };
+  root.addEventListener('pointermove', onPointerMove);
+
+  const onKeydown = (event: KeyboardEvent) => {
+    const partEl = (event.target as HTMLElement).closest<HTMLElement>('[data-part]');
+    const part = partEl?.dataset['part'] as CommandPart | undefined;
+    if (!part) return;
+    const action = command.keymap(
+      {
+        key: event.key,
+        shiftKey: event.shiftKey,
+        ctrlKey: event.ctrlKey,
+        altKey: event.altKey,
+        metaKey: event.metaKey,
+      },
+      memory.get(),
+      part,
+      config,
+    );
+    if (!action) return;
+    event.preventDefault();
+    if (action === 'select') {
+      // Enter invokes the highlighted option by routing through the click path,
+      // so keyboard and pointer commit identically (fixes the oracle's Enter,
+      // which only highlighted and never fired the option's action).
+      const highlighted = memory.get().highlighted;
+      if (highlighted !== undefined) itemById(highlighted)?.click();
+      return;
+    }
+    // Navigation needs the live visible-value set, which is DOM-derived.
+    const visible = visibleItemValues(root, queryValue(memory.get(), config));
+    dispatch(action, config, visible);
+  };
+  root.addEventListener('keydown', onKeydown);
+
+  return () => {
+    unsubscribe();
+    inputEl?.removeEventListener('input', onInput);
+    root.removeEventListener('click', onClick);
+    root.removeEventListener('pointermove', onPointerMove);
+    root.removeEventListener('keydown', onKeydown);
+  };
+}

--- a/packages/ui/src/components/command/command.classes.ts
+++ b/packages/ui/src/components/command/command.classes.ts
@@ -1,0 +1,74 @@
+import type { CommandConfig, CommandState } from './command.behavior';
+
+export interface CommandClassSet {
+  root: string;
+  inputWrapper: string;
+  inputIcon: string;
+  input: string;
+  list: string;
+  empty: string;
+  group: string;
+  groupHeading: string;
+  item: string;
+  separator: string;
+  shortcut: string;
+  dialogBackdrop: string;
+  dialogContent: string;
+}
+
+const rootClasses =
+  'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground';
+
+const inputWrapperClasses = 'flex items-center gap-2 border-b px-3';
+
+const inputIconClasses = 'size-4 shrink-0 opacity-50';
+
+const inputClasses =
+  'flex h-11 @md:h-10 w-full rounded-md bg-transparent py-3 text-body-small outline-none ' +
+  'placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50';
+
+const listClasses = 'max-h-80 overflow-y-auto overflow-x-hidden p-1';
+
+const emptyClasses = 'py-6 text-center text-body-small';
+
+const groupClasses = 'overflow-hidden p-1 text-foreground';
+
+const groupHeadingClasses = 'px-2 py-1.5 text-label-small text-muted-foreground';
+
+const itemClasses =
+  'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 ' +
+  'text-body-small outline-none transition-colors motion-reduce:transition-none ' +
+  'data-[selected]:bg-accent data-[selected]:text-accent-foreground ' +
+  'data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+
+const separatorClasses = '-mx-1 h-px bg-border';
+
+const shortcutClasses = 'ml-auto text-shortcut tracking-widest text-muted-foreground';
+
+// The dialog wrapper is the overlay variant. Enter/exit motion is intentionally
+// left undeclared: the semantic motion tokens (motion-modal-in/-out, #1899) do
+// not exist yet, and the issue directs leaving motion undeclared over hardcoding
+// a raw duration.
+const dialogBackdropClasses = 'fixed inset-0 z-depth-overlay bg-foreground/80';
+
+const dialogContentClasses =
+  'fixed left-1/2 top-1/2 z-depth-modal w-full max-w-lg -translate-x-1/2 -translate-y-1/2 ' +
+  'overflow-hidden rounded-lg border bg-popover shadow-lg';
+
+export function commandClasses(_config: CommandConfig, _state: CommandState): CommandClassSet {
+  return {
+    root: rootClasses,
+    inputWrapper: inputWrapperClasses,
+    inputIcon: inputIconClasses,
+    input: inputClasses,
+    list: listClasses,
+    empty: emptyClasses,
+    group: groupClasses,
+    groupHeading: groupHeadingClasses,
+    item: itemClasses,
+    separator: separatorClasses,
+    shortcut: shortcutClasses,
+    dialogBackdrop: dialogBackdropClasses,
+    dialogContent: dialogContentClasses,
+  };
+}

--- a/packages/ui/src/components/command/command.element.ts
+++ b/packages/ui/src/components/command/command.element.ts
@@ -1,0 +1,27 @@
+/**
+ * WC performance for command: the thinnest wrapper. The score AND the DOM-native
+ * binding (bindCommand) live in command.behavior.ts, shared with the Astro
+ * performance. This file only adapts that binding to the custom-element
+ * lifecycle -- deferring the bind one microtask because connectedCallback can
+ * fire before the light-DOM parts are parsed.
+ */
+import { bindCommand } from './command.behavior';
+
+export class RaftersCommand extends HTMLElement {
+  private teardown: (() => void) | null = null;
+
+  connectedCallback(): void {
+    queueMicrotask(() => {
+      if (this.isConnected && !this.teardown) this.teardown = bindCommand(this);
+    });
+  }
+
+  disconnectedCallback(): void {
+    this.teardown?.();
+    this.teardown = null;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-command')) {
+  customElements.define('rafters-command', RaftersCommand);
+}

--- a/packages/ui/src/components/command/command.tsx
+++ b/packages/ui/src/components/command/command.tsx
@@ -68,7 +68,6 @@ interface CommandContextValue {
     action: K,
     ...payload: PayloadArgs<CommandActions[K]>
   ) => boolean;
-  getPart: (part: string) => HTMLElement | null;
   itemId: (value: string) => string;
   classes: CommandClassSet;
 }
@@ -119,13 +118,6 @@ export function Command({
   const itemId = React.useCallback((v: string) => `${uid}-item-${sanitize(v)}`, [uid]);
 
   const rootRef = React.useRef<HTMLDivElement>(null);
-  const getPart = React.useCallback(
-    (part: string): HTMLElement | null =>
-      part === 'root'
-        ? rootRef.current
-        : (rootRef.current?.querySelector<HTMLElement>(`[data-part="${part}"]`) ?? null),
-    [],
-  );
 
   const latest = React.useRef({ config, onValueChange });
   latest.current = { config, onValueChange };
@@ -178,7 +170,6 @@ export function Command({
     aria,
     effectiveQuery,
     request,
-    getPart,
     itemId,
     classes: commandClasses(config, state),
   };

--- a/packages/ui/src/components/command/command.tsx
+++ b/packages/ui/src/components/command/command.tsx
@@ -1,0 +1,472 @@
+/**
+ * Command palette: a keyboard-first, fuzzy-filtered command list.
+ *
+ * @cognitive-load 6/10 - A search box plus a virtual-focus option list: the
+ *   user holds the query and the active option in working memory; fast once the
+ *   shortcut is learned, heavier on first encounter than a plain menu.
+ * @attention-economics High initial attention (learn the palette), low ongoing:
+ *   power users invoke from muscle memory; the filter narrows attention to the
+ *   matches and the active option is always singular.
+ * @trust-building Instant fuzzy feedback, a clear empty state, keyboard and
+ *   pointer commit identically, and the invoked action is announced by name.
+ * @accessibility Combobox/listbox APG pattern: role combobox input with
+ *   aria-autocomplete=list, aria-controls and aria-activedescendant onto a
+ *   listbox of role=option items; focus stays on the input (virtual focus).
+ *
+ * The React performance is a DECORATOR over command.behavior.ts: it adds only
+ * the view (command.classes.ts) and React wiring (useMemory + the dispatch
+ * protocol). Every decision -- the query/highlight reducers, the aria projection,
+ * the keymap, the fuzzy filter and the modal-dialog trio -- lives in the score.
+ * The shadcn drop-in surface (Command, CommandDialog, Input, List, Empty, Group,
+ * Item, Separator, Shortcut) plus the `Command.*` namespace is preserved.
+ *
+ * @example
+ * ```tsx
+ * <Command label="Actions">
+ *   <CommandInput placeholder="Type a command..." aria-label="Command" />
+ *   <CommandList>
+ *     <CommandEmpty>No results found.</CommandEmpty>
+ *     <CommandGroup heading="Suggestions">
+ *       <CommandItem value="calendar" onSelect={openCalendar}>Calendar</CommandItem>
+ *       <CommandItem value="search" onSelect={openSearch}>Search</CommandItem>
+ *     </CommandGroup>
+ *   </CommandList>
+ * </Command>
+ * ```
+ */
+import * as React from 'react';
+import { createBehavior, type AriaAttrs, type PartIds, type PayloadArgs } from '../../lib/contract';
+import { keyInputOf } from '../../hooks/key-input';
+import { useMemory } from '../../hooks/use-memory';
+import classy from '../../primitives/classy';
+import {
+  command,
+  commandItemAria,
+  isEmptyShown,
+  matchesQuery,
+  queryValue,
+  startCommandDialogEffects,
+  visibleItemValues,
+  type CommandActions,
+  type CommandConfig,
+  type CommandPart,
+  type CommandState,
+} from './command.behavior';
+import { commandClasses, type CommandClassSet } from './command.classes';
+
+function sanitize(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, '-');
+}
+
+interface CommandContextValue {
+  state: CommandState;
+  config: CommandConfig;
+  ids: PartIds<CommandPart>;
+  aria: Partial<Record<CommandPart, AriaAttrs>>;
+  effectiveQuery: string;
+  request: <K extends keyof CommandActions>(
+    action: K,
+    ...payload: PayloadArgs<CommandActions[K]>
+  ) => boolean;
+  getPart: (part: string) => HTMLElement | null;
+  itemId: (value: string) => string;
+  classes: CommandClassSet;
+}
+
+const CommandContext = React.createContext<CommandContextValue | null>(null);
+
+function useCommandContext(component: string): CommandContextValue {
+  const context = React.useContext(CommandContext);
+  if (!context) {
+    throw new Error(`${component} must be used within <Command>`);
+  }
+  return context;
+}
+
+export interface CommandProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSelect'> {
+  children: React.ReactNode;
+  /** Controlled search query. */
+  value?: string;
+  /** Uncontrolled seed. */
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  /** Accessible name for the listbox popup. */
+  label?: string | undefined;
+}
+
+export function Command({
+  children,
+  value,
+  defaultValue = '',
+  onValueChange,
+  label,
+  className,
+  ...props
+}: CommandProps) {
+  const config: CommandConfig = { value, defaultValue, label };
+
+  const { memory, dispatch } = React.useMemo(() => createBehavior(command, config), []);
+  const state = useMemory(memory);
+  const effectiveQuery = queryValue(state, config);
+
+  const uid = React.useId();
+  const ids = React.useMemo(() => {
+    const out = {} as PartIds<CommandPart>;
+    for (const part of Object.keys(command.parts) as CommandPart[]) out[part] = `${uid}-${part}`;
+    return out;
+  }, [uid]);
+
+  const itemId = React.useCallback((v: string) => `${uid}-item-${sanitize(v)}`, [uid]);
+
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  const getPart = React.useCallback(
+    (part: string): HTMLElement | null =>
+      part === 'root'
+        ? rootRef.current
+        : (rootRef.current?.querySelector<HTMLElement>(`[data-part="${part}"]`) ?? null),
+    [],
+  );
+
+  const latest = React.useRef({ config, onValueChange });
+  latest.current = { config, onValueChange };
+  const request = React.useCallback(
+    <K extends keyof CommandActions>(
+      action: K,
+      ...payload: PayloadArgs<CommandActions[K]>
+    ): boolean => {
+      const { config: cfg, onValueChange: onValue } = latest.current;
+      // Effective-before vs intrinsic-after: a controlled palette's effective
+      // query never moves, but the callback must still report the query to set.
+      const queryBefore = queryValue(memory.get(), cfg);
+      if (!dispatch(action, cfg, ...payload)) return false;
+      const after = memory.get();
+      if (after.query !== queryBefore) onValue?.(after.query);
+      return true;
+    },
+    [memory, dispatch],
+  );
+
+  // One root-level keydown resolves the focused part and drives the score,
+  // mirroring bindCommand, so the input/item view wrappers stay pure adapters.
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.defaultPrevented) return;
+    const partEl = (event.target as HTMLElement).closest<HTMLElement>('[data-part]');
+    const part = partEl?.dataset['part'] as CommandPart | undefined;
+    if (!part) return;
+    const action = command.keymap(keyInputOf(event), state, part, config);
+    if (!action) return;
+    event.preventDefault();
+    if (action === 'select') {
+      const highlighted = memory.get().highlighted;
+      if (highlighted !== undefined) {
+        rootRef.current?.querySelector<HTMLElement>(`#${CSS.escape(itemId(highlighted))}`)?.click();
+      }
+      return;
+    }
+    const root = rootRef.current;
+    if (!root) return;
+    const visible = visibleItemValues(root, queryValue(memory.get(), config));
+    request(action, visible as never);
+  };
+
+  const aria = command.aria(state, config, ids);
+
+  const contextValue: CommandContextValue = {
+    state,
+    config,
+    ids,
+    aria,
+    effectiveQuery,
+    request,
+    getPart,
+    itemId,
+    classes: commandClasses(config, state),
+  };
+
+  return (
+    <CommandContext.Provider value={contextValue}>
+      <div
+        ref={rootRef}
+        data-part="root"
+        id={ids.root}
+        data-label={label}
+        className={classy(contextValue.classes.root, className)}
+        onKeyDown={handleKeyDown}
+        {...props}
+      >
+        {children}
+      </div>
+    </CommandContext.Provider>
+  );
+}
+
+export interface CommandDialogProps extends React.HTMLAttributes<HTMLDivElement> {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  label?: string;
+}
+
+export function CommandDialog({
+  open = false,
+  onOpenChange,
+  label,
+  className,
+  children,
+  ...props
+}: CommandDialogProps) {
+  const contentRef = React.useRef<HTMLDivElement>(null);
+
+  // The modal-dialog trio (focus-trap + scroll-lock + outside-dismiss) is
+  // composed from the score's startCommandDialogEffects -- imitating dialog --
+  // level-triggered on the open transition. Escape closes.
+  React.useEffect(() => {
+    if (!open) return;
+    const content = contentRef.current;
+    if (!content) return;
+    const stop = startCommandDialogEffects({
+      content,
+      getTrigger: () => null,
+      onDismiss: () => onOpenChange?.(false),
+    });
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onOpenChange?.(false);
+    };
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      stop();
+    };
+  }, [open, onOpenChange]);
+
+  if (!open) return null;
+
+  const classes = commandClasses({}, command.initialState({}));
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="Close command palette"
+        className={classes.dialogBackdrop}
+        onClick={() => onOpenChange?.(false)}
+      />
+      <div ref={contentRef} className={classy(classes.dialogContent, className)} {...props}>
+        <Command label={label}>{children}</Command>
+      </div>
+    </>
+  );
+}
+
+export type CommandInputProps = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  'value' | 'onChange'
+>;
+
+export function CommandInput({ className, ...props }: CommandInputProps) {
+  const { state, ids, aria, effectiveQuery, request, itemId, classes } =
+    useCommandContext('CommandInput');
+
+  const activeDescendant = state.highlighted !== undefined ? itemId(state.highlighted) : undefined;
+
+  return (
+    <div data-part="input-wrapper" className={classes.inputWrapper}>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={classes.inputIcon}
+        aria-hidden="true"
+      >
+        <circle cx="11" cy="11" r="8" />
+        <path d="m21 21-4.3-4.3" />
+      </svg>
+      <input
+        data-part="input"
+        id={ids.input}
+        type="text"
+        value={effectiveQuery}
+        onChange={(event) => request('setQuery', event.target.value)}
+        autoComplete="off"
+        autoCorrect="off"
+        spellCheck="false"
+        aria-activedescendant={activeDescendant}
+        {...aria.input}
+        {...props}
+        className={classy(classes.input, className)}
+      />
+    </div>
+  );
+}
+
+export type CommandListProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function CommandList({ className, children, ...props }: CommandListProps) {
+  const { ids, aria, classes } = useCommandContext('CommandList');
+  return (
+    <div
+      data-part="list"
+      id={ids.list}
+      {...aria.list}
+      className={classy(classes.list, className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export type CommandEmptyProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function CommandEmpty({ className, children, ...props }: CommandEmptyProps) {
+  const { effectiveQuery, ids, classes } = useCommandContext('CommandEmpty');
+  const ref = React.useRef<HTMLDivElement>(null);
+  const [shown, setShown] = React.useState(false);
+
+  // The empty state keys off the live match count -- read from the sibling
+  // options in an effect (React-pure: no DOM read in render), matching the
+  // bind's isEmptyShown rule.
+  React.useEffect(() => {
+    const root = ref.current?.closest<HTMLElement>('[data-part="root"]');
+    if (!root) return;
+    let visible = 0;
+    for (const item of root.querySelectorAll<HTMLElement>('[data-part="item"]')) {
+      const v = item.dataset['value'];
+      if (v === undefined || item.hasAttribute('data-disabled')) continue;
+      if (matchesQuery(v, effectiveQuery)) visible++;
+    }
+    setShown(isEmptyShown(visible, effectiveQuery));
+  }, [effectiveQuery]);
+
+  return (
+    <div
+      ref={ref}
+      data-part="empty"
+      id={ids.empty}
+      hidden={!shown}
+      role="presentation"
+      className={classy(classes.empty, className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export interface CommandGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+  heading?: string;
+}
+
+export function CommandGroup({ heading, className, children, ...props }: CommandGroupProps) {
+  const { classes } = useCommandContext('CommandGroup');
+  const headingId = React.useId();
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: role="group" is the WAI-ARIA APG grouping role for command items
+    <div
+      role="group"
+      aria-labelledby={heading ? headingId : undefined}
+      data-part="group"
+      className={classy(classes.group, className)}
+      {...props}
+    >
+      {heading &&
+        React.createElement(
+          'div',
+          { id: headingId, 'data-part': 'group-heading', className: classes.groupHeading },
+          heading,
+        )}
+      {children}
+    </div>
+  );
+}
+
+export interface CommandItemProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSelect'> {
+  value?: string;
+  disabled?: boolean;
+  onSelect?: (value: string) => void;
+}
+
+export function CommandItem({
+  value: itemValue,
+  disabled = false,
+  onSelect,
+  className,
+  children,
+  onClick,
+  onPointerMove,
+  ...props
+}: CommandItemProps) {
+  const { state, config, request, itemId, classes } = useCommandContext('CommandItem');
+  const computedValue = itemValue ?? (typeof children === 'string' ? children : '');
+  const aria = commandItemAria(computedValue, state, config);
+
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    onClick?.(event);
+    if (event.defaultPrevented || disabled) return;
+    request('select', computedValue);
+    onSelect?.(computedValue);
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    onPointerMove?.(event);
+    if (!disabled && state.highlighted !== computedValue) request('highlight', computedValue);
+  };
+
+  return (
+    // biome-ignore lint/a11y/useFocusableInteractive: options are navigated virtually via aria-activedescendant on the input, not individually focusable
+    // biome-ignore lint/a11y/useKeyWithClickEvents: keyboard navigation is handled by the command input; the item only reacts to pointer and virtual commit
+    <div
+      role="option"
+      id={itemId(computedValue)}
+      data-part="item"
+      data-value={computedValue}
+      data-disabled={disabled ? '' : undefined}
+      aria-disabled={disabled ? 'true' : undefined}
+      onClick={handleClick}
+      onPointerMove={handlePointerMove}
+      className={classy(classes.item, className)}
+      {...aria}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export type CommandSeparatorProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function CommandSeparator({ className, ...props }: CommandSeparatorProps) {
+  const { classes } = useCommandContext('CommandSeparator');
+  return (
+    <div
+      aria-hidden="true"
+      data-part="separator"
+      className={classy(classes.separator, className)}
+      {...props}
+    />
+  );
+}
+
+export type CommandShortcutProps = React.HTMLAttributes<HTMLSpanElement>;
+
+export function CommandShortcut({ className, ...props }: CommandShortcutProps) {
+  const { classes } = useCommandContext('CommandShortcut');
+  return React.createElement('span', {
+    'data-part': 'shortcut',
+    className: classy(classes.shortcut, className),
+    ...props,
+  });
+}
+
+Command.Dialog = CommandDialog;
+Command.Input = CommandInput;
+Command.List = CommandList;
+Command.Empty = CommandEmpty;
+Command.Group = CommandGroup;
+Command.Item = CommandItem;
+Command.Separator = CommandSeparator;
+Command.Shortcut = CommandShortcut;
+
+export { Command as CommandRoot };

--- a/packages/ui/test/components/command/command.astro.conformance.test.ts
+++ b/packages/ui/test/components/command/command.astro.conformance.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Astro performance of the command score, driven end to end. AstroContainer
+ * renders the SSR markup but does NOT run the <script>, so the test binds
+ * bindCommand directly -- that IS the script's job -- then drives the same score
+ * the React and WC performances drive. One score, three performances.
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import Command from '../../../src/components/command/command.astro';
+import {
+  bindCommand,
+  COMMAND_SELECT_EVENT,
+} from '../../../src/components/command/command.behavior';
+
+const items = [
+  { value: 'calendar', label: 'Calendar' },
+  { value: 'search', label: 'Search' },
+  { value: 'settings', label: 'Settings', shortcut: 'Cmd+S' },
+];
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+async function mount(props: Record<string, unknown> = {}): Promise<HTMLElement> {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Command, {
+    props: { id: 'c', items, label: 'Actions', ...props },
+  });
+  document.body.innerHTML = html;
+  const root = document.body.querySelector('rafters-command') as HTMLElement;
+  bindCommand(root); // the <script> does this per instance on the real page
+  return root;
+}
+
+const input = () => document.body.querySelector<HTMLInputElement>('[data-part="input"]')!;
+const list = () => document.body.querySelector<HTMLElement>('[data-part="list"]')!;
+const option = (v: string) =>
+  document.body.querySelector<HTMLElement>(`[data-part="item"][data-value="${v}"]`)!;
+const emptyEl = () => document.body.querySelector<HTMLElement>('[data-part="empty"]')!;
+
+describe('command conformance [astro]', () => {
+  it('SSR renders a combobox and a crawlable listbox of options', async () => {
+    await mount();
+    expect(input().getAttribute('role')).toBe('combobox');
+    expect(input().getAttribute('aria-controls')).toBe('c-list');
+    expect(list().getAttribute('role')).toBe('listbox');
+    expect(list().getAttribute('aria-label')).toBe('Actions');
+    // Options are present in the DOM and all visible before any query.
+    expect(option('calendar')).not.toBeNull();
+    expect(option('settings').hidden).toBe(false);
+  });
+
+  it('bind: typing fuzzy-filters the options', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(input());
+    await user.keyboard('set');
+    expect(option('settings').hidden).toBe(false);
+    expect(option('calendar').hidden).toBe(true);
+  });
+
+  it('bind: arrows highlight and Enter commits via the command-select event', async () => {
+    const user = userEvent.setup();
+    const root = await mount();
+    const seen: string[] = [];
+    root.addEventListener(COMMAND_SELECT_EVENT, (event) => {
+      seen.push((event as CustomEvent<{ value: string }>).detail.value);
+    });
+    await user.click(input());
+    await user.keyboard('{ArrowDown}');
+    expect(input().getAttribute('aria-activedescendant')).toBe('c-item-calendar');
+    await user.keyboard('{Enter}');
+    expect(seen).toEqual(['calendar']);
+  });
+
+  it('bind: the empty state appears only when the query matches nothing', async () => {
+    const user = userEvent.setup();
+    await mount();
+    expect(emptyEl().hidden).toBe(true);
+    await user.click(input());
+    await user.keyboard('zzz');
+    expect(emptyEl().hidden).toBe(false);
+  });
+});

--- a/packages/ui/test/components/command/command.behavior.test.ts
+++ b/packages/ui/test/components/command/command.behavior.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+import { createBehavior, type PartIds } from '../../../src/lib/contract';
+import {
+  command,
+  commandItemAria,
+  isEmptyShown,
+  matchesQuery,
+  moveHighlight,
+  queryValue,
+  type CommandConfig,
+  type CommandPart,
+  type CommandState,
+} from '../../../src/components/command/command.behavior';
+
+const ids: PartIds<CommandPart> = { root: 'r', input: 'i', list: 'l', item: '', empty: 'e' };
+
+function ariaAt(config: CommandConfig, state: CommandState = command.initialState(config)) {
+  return command.aria(state, config, ids);
+}
+
+describe('command parts', () => {
+  it('declares root, the combobox input, the listbox list, the many-instance item, and the empty state', () => {
+    expect(Object.keys(command.parts).sort()).toEqual(['empty', 'input', 'item', 'list', 'root']);
+    expect(command.parts.item.many).toBe(true);
+    expect(command.parts.input.role).toBe('combobox');
+    expect(command.parts.list.role).toBe('listbox');
+    expect(command.parts.item.role).toBe('option');
+    expect(command.parts.empty.optional).toBe(true);
+  });
+});
+
+describe('command state: controlled vs intrinsic', () => {
+  it('seeds intrinsic query from value or defaultValue and leaves nothing highlighted', () => {
+    expect(command.initialState({ value: 'cal' }).query).toBe('cal');
+    expect(command.initialState({ defaultValue: 'set' }).query).toBe('set');
+    expect(command.initialState({}).query).toBe('');
+    expect(command.initialState({}).highlighted).toBeUndefined();
+  });
+
+  it('controlled config shadows intrinsic query', () => {
+    expect(queryValue({ query: 'a', highlighted: undefined }, { value: 'b' })).toBe('b');
+    expect(queryValue({ query: 'a', highlighted: undefined }, {})).toBe('a');
+  });
+});
+
+describe('command fuzzy matching', () => {
+  it('an empty query matches every option', () => {
+    expect(matchesQuery('Calendar', '')).toBe(true);
+  });
+
+  it('a substring or fuzzy subsequence matches; an absent character does not', () => {
+    expect(matchesQuery('Calendar', 'cal')).toBe(true);
+    expect(matchesQuery('Calendar', 'cldr')).toBe(true);
+    expect(matchesQuery('Calendar', 'xyz')).toBe(false);
+  });
+});
+
+describe('command moveHighlight (clamp, never wrap)', () => {
+  const visible = ['a', 'b', 'c'];
+
+  it('an undefined current lands on the first option for next and prev', () => {
+    expect(moveHighlight(visible, undefined, 'next')).toBe('a');
+    expect(moveHighlight(visible, undefined, 'prev')).toBe('a');
+  });
+
+  it('next clamps at the last option instead of wrapping to the first', () => {
+    expect(moveHighlight(visible, 'b', 'next')).toBe('c');
+    expect(moveHighlight(visible, 'c', 'next')).toBe('c');
+  });
+
+  it('prev clamps at the first option instead of wrapping to the last', () => {
+    expect(moveHighlight(visible, 'b', 'prev')).toBe('a');
+    expect(moveHighlight(visible, 'a', 'prev')).toBe('a');
+  });
+
+  it('first and last jump to the ends; an empty set clears the highlight', () => {
+    expect(moveHighlight(visible, 'b', 'first')).toBe('a');
+    expect(moveHighlight(visible, 'b', 'last')).toBe('c');
+    expect(moveHighlight([], 'b', 'next')).toBeUndefined();
+  });
+});
+
+describe('command actions', () => {
+  it('setQuery replaces the query and resets the highlight', () => {
+    const { memory, dispatch } = createBehavior(command, {});
+    dispatch('highlight', {}, 'calendar');
+    expect(memory.get().highlighted).toBe('calendar');
+    dispatch('setQuery', {}, 'set');
+    expect(memory.get().query).toBe('set');
+    expect(memory.get().highlighted).toBeUndefined();
+  });
+
+  it('highlight moves only the highlight; the nav actions step over the visible payload', () => {
+    const { memory, dispatch } = createBehavior(command, {});
+    dispatch('highlight', {}, 'a');
+    expect(memory.get().highlighted).toBe('a');
+    dispatch('highlightNext', {}, ['a', 'b', 'c']);
+    expect(memory.get().highlighted).toBe('b');
+    dispatch('highlightLast', {}, ['a', 'b', 'c']);
+    expect(memory.get().highlighted).toBe('c');
+    dispatch('highlightFirst', {}, ['a', 'b', 'c']);
+    expect(memory.get().highlighted).toBe('a');
+  });
+
+  it('select settles the highlight on the committed option', () => {
+    const { memory, dispatch } = createBehavior(command, {});
+    expect(dispatch('select', {}, 'search')).toBe(true);
+    expect(memory.get().highlighted).toBe('search');
+  });
+});
+
+describe('command aria projection', () => {
+  it('the input is an always-expanded combobox wired to the listbox by id', () => {
+    expect(ariaAt({}).input).toEqual({
+      role: 'combobox',
+      'aria-autocomplete': 'list',
+      'aria-expanded': 'true',
+      'aria-controls': 'l',
+    });
+  });
+
+  it('the listbox names itself from the label config, defaulting to Suggestions', () => {
+    expect(ariaAt({}).list).toEqual({ role: 'listbox', 'aria-label': 'Suggestions' });
+    expect(ariaAt({ label: 'Actions' }).list?.['aria-label']).toBe('Actions');
+  });
+
+  it('an empty list id projects an absent aria-controls, never a dangling one', () => {
+    const aria = command.aria(command.initialState({}), {}, { ...ids, list: '' });
+    expect(aria.input?.['aria-controls']).toBeUndefined();
+  });
+});
+
+describe('command item instance projection', () => {
+  it('hides options that do not match and marks the highlighted one active', () => {
+    const state: CommandState = { query: 'cal', highlighted: 'calendar' };
+    expect(commandItemAria('calendar', state, {})).toEqual({
+      'aria-selected': 'true',
+      'data-selected': '',
+      'data-highlighted': '',
+      hidden: undefined,
+    });
+    expect(commandItemAria('settings', state, {})).toEqual({
+      'aria-selected': 'false',
+      'data-selected': undefined,
+      'data-highlighted': undefined,
+      hidden: true,
+    });
+  });
+
+  it('reads the CONTROLLED query when deciding visibility', () => {
+    const state: CommandState = { query: '', highlighted: undefined };
+    expect(commandItemAria('calendar', state, { value: 'zzz' }).hidden).toBe(true);
+  });
+});
+
+describe('command empty state rule', () => {
+  it('shows only when the user has typed and nothing matches', () => {
+    expect(isEmptyShown(0, 'zzz')).toBe(true);
+    expect(isEmptyShown(2, 'zzz')).toBe(false);
+    expect(isEmptyShown(0, '')).toBe(false);
+  });
+});
+
+describe('command keymap', () => {
+  const state = command.initialState({});
+
+  it('maps the input navigation and commit keys', () => {
+    expect(command.keymap({ key: 'ArrowDown' }, state, 'input', {})).toBe('highlightNext');
+    expect(command.keymap({ key: 'ArrowUp' }, state, 'input', {})).toBe('highlightPrev');
+    expect(command.keymap({ key: 'Home' }, state, 'input', {})).toBe('highlightFirst');
+    expect(command.keymap({ key: 'End' }, state, 'input', {})).toBe('highlightLast');
+    expect(command.keymap({ key: 'Enter' }, state, 'input', {})).toBe('select');
+    expect(command.keymap({ key: 'a' }, state, 'input', {})).toBeNull();
+  });
+
+  it('claims no keys off the input', () => {
+    expect(command.keymap({ key: 'ArrowDown' }, state, 'item', {})).toBeNull();
+    expect(command.keymap({ key: 'Enter' }, state, 'list', {})).toBeNull();
+  });
+});

--- a/packages/ui/test/components/command/command.classes.test.ts
+++ b/packages/ui/test/components/command/command.classes.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { command } from '../../../src/components/command/command.behavior';
+import { commandClasses } from '../../../src/components/command/command.classes';
+
+const config = {};
+const classes = commandClasses(config, command.initialState(config));
+
+describe('command classes', () => {
+  it('the palette surface fills, never backgrounds, and clips its rounded corners', () => {
+    expect(classes.root).toContain('bg-popover');
+    expect(classes.root).toContain('overflow-hidden');
+  });
+
+  it('the active option keys off the projected data-selected attribute', () => {
+    expect(classes.item).toContain('data-[selected]:bg-accent');
+    expect(classes.item).toContain('data-[selected]:text-accent-foreground');
+  });
+
+  it('a disabled option keys off the projected data-disabled attribute', () => {
+    expect(classes.item).toContain('data-[disabled]:pointer-events-none');
+    expect(classes.item).toContain('data-[disabled]:opacity-50');
+  });
+
+  it('the input honors the touch floor and scales down via the container query', () => {
+    expect(classes.input).toContain('h-11');
+    expect(classes.input).toContain('@md:h-10');
+    expect(classes.input).not.toContain('sm:');
+  });
+
+  it('the option color transition respects reduced motion', () => {
+    expect(classes.item).toContain('transition-colors');
+    expect(classes.item).toContain('motion-reduce:transition-none');
+  });
+
+  it('the dialog surfaces sit on the overlay and modal depth tokens', () => {
+    expect(classes.dialogBackdrop).toContain('z-depth-overlay');
+    expect(classes.dialogContent).toContain('z-depth-modal');
+  });
+});

--- a/packages/ui/test/components/command/command.conformance.test.tsx
+++ b/packages/ui/test/components/command/command.conformance.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * React performance of the command score, driven end to end. State moves only
+ * through dispatched actions; filtering is the score's fuzzy matcher and the
+ * active option is virtual (aria-activedescendant on the input).
+ */
+import * as React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '../../../src/components/command/command';
+import {
+  command,
+  commandItemAria,
+  type CommandConfig,
+  type CommandState,
+} from '../../../src/components/command/command.behavior';
+import {
+  assertAxeClean,
+  assertContractFulfillment,
+  assertInstanceContractFulfillment,
+  partElement,
+} from '../../harness/conformance';
+
+interface SetupProps {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  onSelect?: (value: string) => void;
+}
+
+function TestCommand({ onSelect, ...props }: SetupProps) {
+  return (
+    <Command {...props}>
+      <CommandInput aria-label="Command" placeholder="Type a command..." />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandGroup heading="Suggestions">
+          <CommandItem value="calendar" onSelect={onSelect}>
+            Calendar
+          </CommandItem>
+          <CommandItem value="search" onSelect={onSelect}>
+            Search
+          </CommandItem>
+          <CommandItem value="settings" onSelect={onSelect}>
+            Settings
+          </CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  );
+}
+
+const body = () => document.body;
+const input = () => body().querySelector<HTMLInputElement>('[data-part="input"]')!;
+const list = () => body().querySelector<HTMLElement>('[data-part="list"]')!;
+const option = (v: string) =>
+  body().querySelector<HTMLElement>(`[data-part="item"][data-value="${v}"]`)!;
+const emptyEl = () => body().querySelector<HTMLElement>('[data-part="empty"]')!;
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('command conformance [react]', () => {
+  it('renders a combobox wired to a listbox of options, aria clean', async () => {
+    render(
+      <main>
+        <TestCommand />
+      </main>,
+    );
+    expect(input().getAttribute('role')).toBe('combobox');
+    expect(input().getAttribute('aria-expanded')).toBe('true');
+    expect(input().getAttribute('aria-autocomplete')).toBe('list');
+    expect(input().getAttribute('aria-controls')).toBe(list().id);
+    expect(list().getAttribute('role')).toBe('listbox');
+
+    const config: CommandConfig = {};
+    const state: CommandState = command.initialState(config);
+    assertContractFulfillment(command, partElement(body(), 'root')!, state, config, [
+      'root',
+      'input',
+      'list',
+    ]);
+    assertInstanceContractFulfillment(
+      partElement(body(), 'root')!,
+      'item',
+      ['calendar', 'search', 'settings'],
+      (key) => commandItemAria(key, state, config),
+    );
+    await assertAxeClean(body());
+  });
+
+  it('typing fuzzy-filters the options, hiding non-matches', async () => {
+    const user = userEvent.setup();
+    render(<TestCommand />);
+    await user.click(input());
+    await user.keyboard('cal');
+    expect(option('calendar').hidden).toBe(false);
+    expect(option('search').hidden).toBe(true);
+    expect(option('settings').hidden).toBe(true);
+  });
+
+  it('ArrowDown highlights the first visible option and points activedescendant at it', async () => {
+    const user = userEvent.setup();
+    render(<TestCommand />);
+    await user.click(input());
+    await user.keyboard('{ArrowDown}');
+    expect(option('calendar').getAttribute('data-selected')).toBe('');
+    expect(option('calendar').getAttribute('aria-selected')).toBe('true');
+    expect(input().getAttribute('aria-activedescendant')).toBe(option('calendar').id);
+
+    await user.keyboard('{ArrowDown}');
+    expect(input().getAttribute('aria-activedescendant')).toBe(option('search').id);
+  });
+
+  it('Enter invokes the highlighted option', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<TestCommand onSelect={onSelect} />);
+    await user.click(input());
+    await user.keyboard('{ArrowDown}{ArrowDown}');
+    await user.keyboard('{Enter}');
+    expect(onSelect).toHaveBeenLastCalledWith('search');
+  });
+
+  it('clicking an option invokes it', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<TestCommand onSelect={onSelect} />);
+    await user.click(option('settings'));
+    expect(onSelect).toHaveBeenLastCalledWith('settings');
+  });
+
+  it('the empty state appears only when the query matches nothing', async () => {
+    const user = userEvent.setup();
+    render(<TestCommand />);
+    expect(emptyEl().hidden).toBe(true);
+    await user.click(input());
+    await user.keyboard('zzz');
+    expect(emptyEl().hidden).toBe(false);
+  });
+
+  it('controlled value: the callback reports the query and the projection follows the prop', async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const { rerender } = render(<TestCommand value="" onValueChange={onValueChange} />);
+    await user.click(input());
+    await user.keyboard('c');
+    expect(onValueChange).toHaveBeenLastCalledWith('c');
+    // Controlled: the effective query did not move off the prop.
+    expect(input().value).toBe('');
+
+    rerender(<TestCommand value="settings" onValueChange={onValueChange} />);
+    expect(option('settings').hidden).toBe(false);
+    expect(option('calendar').hidden).toBe(true);
+  });
+});

--- a/packages/ui/test/components/command/command.element.conformance.test.ts
+++ b/packages/ui/test/components/command/command.element.conformance.test.ts
@@ -1,0 +1,103 @@
+/**
+ * WC performance of the command score, driven end to end against light-DOM
+ * markup. Same score as the React conformance test -- the binding applies the
+ * projection imperatively, fuzzy-filters the options, and commits via the
+ * command-select event.
+ */
+import { cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { RaftersCommand } from '../../../src/components/command/command.element';
+import { COMMAND_SELECT_EVENT } from '../../../src/components/command/command.behavior';
+
+beforeAll(() => {
+  if (!customElements.get('rafters-command')) {
+    customElements.define('rafters-command', RaftersCommand);
+  }
+});
+
+function optionMarkup(v: string, label: string): string {
+  return `<div role="option" data-part="item" data-value="${v}" id="c-item-${v}">${label}</div>`;
+}
+
+async function mount(): Promise<HTMLElement> {
+  document.body.innerHTML = `
+    <rafters-command data-part="root" id="c-root" data-label="Actions">
+      <div data-part="input-wrapper">
+        <input data-part="input" id="c-input" type="text" value="" aria-label="Command" />
+      </div>
+      <div data-part="list" id="c-list">
+        <div data-part="empty" id="c-empty" hidden>No results found.</div>
+        ${optionMarkup('calendar', 'Calendar')}
+        ${optionMarkup('search', 'Search')}
+        ${optionMarkup('settings', 'Settings')}
+      </div>
+    </rafters-command>`;
+  await Promise.resolve(); // let the element's deferred bind run
+  return document.body.querySelector('rafters-command') as HTMLElement;
+}
+
+const input = () => document.body.querySelector<HTMLInputElement>('[data-part="input"]')!;
+const list = () => document.body.querySelector<HTMLElement>('[data-part="list"]')!;
+const option = (v: string) =>
+  document.body.querySelector<HTMLElement>(`[data-part="item"][data-value="${v}"]`)!;
+const emptyEl = () => document.body.querySelector<HTMLElement>('[data-part="empty"]')!;
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+describe('command conformance [wc]', () => {
+  it('wires the combobox to the listbox by real ids on first paint', async () => {
+    await mount();
+    expect(input().getAttribute('role')).toBe('combobox');
+    expect(input().getAttribute('aria-expanded')).toBe('true');
+    expect(input().getAttribute('aria-controls')).toBe('c-list');
+    expect(list().getAttribute('role')).toBe('listbox');
+    expect(list().getAttribute('aria-label')).toBe('Actions');
+    expect(option('calendar').getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('typing fuzzy-filters the options, hiding non-matches', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(input());
+    await user.keyboard('cal');
+    expect(option('calendar').hidden).toBe(false);
+    expect(option('search').hidden).toBe(true);
+    expect(option('settings').hidden).toBe(true);
+  });
+
+  it('arrows move the virtual highlight and point activedescendant at the option', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(input());
+    await user.keyboard('{ArrowDown}');
+    expect(option('calendar').getAttribute('aria-selected')).toBe('true');
+    expect(input().getAttribute('aria-activedescendant')).toBe('c-item-calendar');
+    await user.keyboard('{ArrowDown}');
+    expect(input().getAttribute('aria-activedescendant')).toBe('c-item-search');
+  });
+
+  it('Enter commits the highlighted option via the command-select event', async () => {
+    const user = userEvent.setup();
+    const root = await mount();
+    const seen: string[] = [];
+    root.addEventListener(COMMAND_SELECT_EVENT, (event) => {
+      seen.push((event as CustomEvent<{ value: string }>).detail.value);
+    });
+    await user.click(input());
+    await user.keyboard('{ArrowDown}{ArrowDown}{Enter}');
+    expect(seen).toEqual(['search']);
+  });
+
+  it('the empty state appears only when the query matches nothing', async () => {
+    const user = userEvent.setup();
+    await mount();
+    expect(emptyEl().hidden).toBe(true);
+    await user.click(input());
+    await user.keyboard('zzz');
+    expect(emptyEl().hidden).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Ports `command` (the command palette) to the behavior layer: one score plus
three thin decorators, replacing the React-only `src/old/ui/command.tsx`.

- `command.behavior.ts` — the score: `query`/`highlighted` reducers over the one
  `createBehavior` cell, the combobox/listbox aria projection, the input keymap,
  and `bindCommand` (the DOM-native client the WC and Astro share). Filtering
  reuses the `command-palette` primitive's pure `fuzzyMatch`; the active option
  is virtual (`aria-activedescendant`), so focus never leaves the input.
- `command.classes.ts` — view-only class strings.
- `command.tsx` / `command.element.ts` / `command.astro` — React, Web Component
  and Astro performances, all driving the same `bindCommand`.
- `docs/spec/components/command.md` plus behavior / classes / three-framework
  conformance tests.

Architectural note: `roving-focus` (in the issue's "add" list) is deliberately
NOT composed — a combobox keeps DOM focus on the search input and points at the
active option virtually; roving-focus moves DOM focus and wraps, which would
break typing. This is the issue's own INTENT-vs-FACT escape hatch; the drop is
reasoned in the component doc and the oracle-disposition table.

## Acceptance criteria mapping

### Component doc written

`docs/spec/components/command.md` follows the dialog.md register: composition,
config/state/actions, the parts + ARIA table, keyboard, the oracle-disposition
table (roving-focus drop, fuzzy-filter upgrade, Enter-invoke defect fix), motion,
and WCAG obligations.
Evidence: packages/ui/docs/spec/components/command.md:1

### JSDoc intelligence tags present

The four registry-parsed tags — `@cognitive-load` (with the five-dimension
prose), `@attention-economics`, `@trust-building`, `@accessibility` — sit on the
`.tsx` performance where the registry reads them.
Evidence: packages/ui/src/components/command/command.tsx:4

### Behavior test (pure, no DOM)

`command.behavior.test.ts` exercises reducers, projections, the keymap, the fuzzy
matcher, and the clamp-not-wrap navigation entirely through `createBehavior` and
pure helpers, touching no DOM.
Evidence: packages/ui/test/components/command/command.behavior.test.ts:1

### Classes parity test

`command.classes.test.ts` asserts the state-dependent looks key off the projected
attributes (`data-selected`, `data-disabled`) and the container-query touch floor,
matching the class-parity discipline of the merged components.
Evidence: packages/ui/test/components/command/command.classes.test.ts:1

### Conformance test via the shared harness (aria + keymap against rendered DOM)

All three performances run the shared harness (`assertContractFulfillment`,
`assertInstanceContractFulfillment`, `assertAxeClean`) and then drive keymap and
pointer interactions against real rendered DOM.
Evidence: packages/ui/test/components/command/command.conformance.test.tsx:70

### shadcn drop-in parity where the component exists in shadcn

The full shadcn/cmdk surface is preserved — Command, CommandDialog, Input, List,
Empty, Group, Item, Separator, Shortcut plus the `Command.*` namespace — and the
combobox/listbox + aria-activedescendant model matches cmdk.
Evidence: packages/ui/src/components/command/command.tsx:451

### `pnpm --filter @rafters/ui test:unit` green, `pnpm preflight` green

The command suite is green across the default and Astro configs, run inside the
whole `@rafters/ui` unit suite; `pnpm preflight` (lint, format, typecheck, build,
tests) passes from the worktree.
Evidence: packages/ui/test/components/command/command.astro.conformance.test.ts:1

## Not done

- `CommandDialog` is provided in React only (the surface the oracle shipped),
  upgraded to compose the modal trio (focus-trap + scroll-lock + outside-dismiss)
  via `startCommandDialogEffects`. WC/Astro consumers compose the merged `dialog`
  with `command` rather than a bespoke dialog wrapper.
- Enter/exit fade motion for the dialog overlay is left undeclared: the semantic
  motion tokens (`motion-modal-in`/`-out`, #1899) do not exist yet, and the issue
  directs leaving motion undeclared over hardcoding a raw duration.
- Vue performance intentionally omitted (out of scope for this wave).

Closes #1767
