### PR TITLE
feat(ui): port calendar to the behavior layer

### DIFF
--- a/packages/ui/docs/spec/components/calendar.md
+++ b/packages/ui/docs/spec/components/calendar.md
@@ -114,6 +114,17 @@ harness asserts. Blanked cells (`showOutsideDays=false`) are inert `gridcell`s
 with no `data-value` — the instance-ARIA driver keys off `data-value` and skips
 them.
 
+The score's `aria-disabled` projection reflects the serializable
+`fromDate`/`toDate` bounds only; the React `disabled` predicate (below) is a
+React-only affordance layered on top of that projection in the decorator, so the
+score's total function stays serializable and the WC/Astro paths keep the bounds
+alone. Known limitation (LOW): shown outside-month days are visually muted
+(`data-outside`, `opacity-50`) and functionally inert (click blocked, never a
+tabstop) but carry no `aria-disabled`, so a screen-reader user gets no non-visual
+equivalent of the muting; `aria-disabled` is not projected for outside status
+because the score cannot express it without diverging from the harness's
+projection-equality check. Not axe-flagged.
+
 ## Keyboard
 
 | Key | Action |
@@ -143,7 +154,7 @@ re-render.
 | prev/next month controls with aria-labels | contract |
 | showOutsideDays / fixedWeeks / weekStartsOn / fromDate / toDate | contract |
 | Enter/Space activate the focused date | contract |
-| `disabled(date)` predicate function | framework-affordance (React): a function is not serializable, so WC/Astro express disabled dates via the serializable `fromDate`/`toDate` bounds; React may layer the predicate on top |
+| `disabled(date)` predicate function | contract, framework-affordance (React): implemented as the `disabled?: (date: Date) => boolean` prop, layered over the serializable `fromDate`/`toDate` bounds -- a predicate-disabled day gets `aria-disabled`/`data-disabled` and refuses selection on click and keyboard-activate. A function is not serializable, so WC/Astro use the bounds alone (that asymmetry is by design) |
 | day rendered as `<button>` with `aria-selected` | defect-do-not-port — `aria-selected` is not an allowed attribute on `role=button`; ported to a focusable `role="gridcell"` (APG date-grid) |
 | `role="application"` on the root | dropped — the grid table is the widget (`role="grid"`); `application` suppresses AT reading mode with no benefit here |
 | grid left with no tabstop when nothing focused/selected | defect-do-not-port — `tabbableDate` always yields one tabbable cell (focus > selection > today > first) so the grid is reachable by Tab |

--- a/packages/ui/docs/spec/components/calendar.md
+++ b/packages/ui/docs/spec/components/calendar.md
@@ -1,0 +1,174 @@
+# Component Spec — Calendar
+
+Status: PORTED (wave-3). Archetype: simple-interactive (imitates button; adds a
+grid-navigated day surface). Ships React + Web Component + Astro.
+
+Files (`src/components/calendar/`):
+
+```
+calendar.classes.ts   calendar.behavior.ts   calendar.tsx   calendar.element.ts   calendar.astro
+```
+
+Tests mirror into `test/components/calendar/`: behavior (pure), classes parity,
+and conformance across React + WC + Astro via the shared harness.
+
+## Composition
+
+```
+memory (createBehavior)   the single reactive cell: currentMonth, focusedDate, selected
+keyboard-handler          grid navigation keys -> dispatched actions (createKeyboardHandler)
+pure helpers              date math, month-grid layout, key->date, selection transitions
+```
+
+- `keyboard-handler` is composed directly for the movement and activation keys.
+  The `keymap` projection is the pure claim record (Spec 01); the bind computes
+  the payload (the target date via `dateForKey`, the selection via
+  `nextSelection`), the shape slider proves.
+- `roving-focus` is deliberately **NOT** composed, and this is the primitive that
+  could not express the behavior. `createRovingFocus` owns a roving tabindex over
+  a **fixed** DOM item list and clamps at the edges (grid mode does not wrap). A
+  calendar's arrow keys must instead **cross the month boundary** — ArrowRight on
+  the last day of a month moves focus to the first day of the *next* month and
+  re-renders the whole grid (the WAI-ARIA date-grid pattern; oracle lines
+  271-282). So `focusedDate` is genuine **score state** (it survives the
+  re-render and decides which cell is tabbable), not the ephemeral roving state
+  it is in radio-group/tabs — the relationship inverts. The bind owns the single
+  tabstop from `tabbableDate(state, config)`. Re-expressing this over
+  roving-focus would require intercepting the clamp and duplicating month math,
+  the exact local half-solution Spec 05 forbids.
+- Selection is score state with a **controlled shadow** (slider's
+  ownership-of-truth boundary): `config.selected` shadows `state.selected`,
+  effective via `effectiveSelected`. WC and Astro have no reactive prop, so their
+  intrinsic state is seeded from the server markup (`data-selected`) and drives
+  selection with no consumer.
+
+Unlike radio-group (a fixed item set the bind only re-projects), the calendar's
+day cells **change** when the month changes, so `bindCalendar` OWNS grid
+construction: `renderDays` rebuilds the `[data-part="grid"] tbody` from
+`buildMonthGrid` on every render. The server markup is the pre-JS first paint;
+after bind, the bind is the single source of the visible cells. The day cell's
+class string is authored in `calendar.classes.ts` and handed to the bind via
+`data-day-class` on the grid, so `behavior.ts` never imports the view yet the
+bind-built cells paint identically to React's.
+
+## Config, state, actions
+
+```ts
+type CalendarMode = 'single' | 'multiple' | 'range';
+type ISODate = string; // local yyyy-mm-dd, timezone-free by construction
+
+type CalendarSelection =
+  | { mode: 'single'; date: ISODate | null }
+  | { mode: 'multiple'; dates: ISODate[] }
+  | { mode: 'range'; from: ISODate | null; to: ISODate | null };
+
+interface CalendarConfig {
+  mode: CalendarMode;
+  selected?: CalendarSelection;        // controlled
+  defaultSelected?: CalendarSelection; // uncontrolled seed
+  defaultMonth?: ISODate;
+  fromDate?: ISODate; toDate?: ISODate; // serializable disabled bounds
+  showOutsideDays: boolean;             // default true
+  fixedWeeks: boolean;                  // default false
+  weekStartsOn: 0|1|2|3|4|5|6;          // default 0 (Sunday)
+  today: ISODate;                       // injected for a deterministic projection
+}
+
+interface CalendarState {
+  currentMonth: ISODate;        // first of the visible month
+  focusedDate: ISODate | null;  // the keyboard tabstop; null before entry
+  selected: CalendarSelection;  // intrinsic (shadowed by config.selected)
+}
+
+type CalendarActions = {
+  focusDate: ISODate;             // move focus; syncs currentMonth to its month
+  shiftMonth: number;             // page the visible month (prev/next controls)
+  setSelected: CalendarSelection; // commit an already-computed selection
+};
+```
+
+`today` is config, not `new Date()` read inside a projection: it keeps `aria()`
+and `dayAria()` **total functions** the conformance harness can compare against
+the DOM. The React decorator computes a stable default once via `useState`;
+tests pin `today` and `defaultMonth`. The date math lives in exported pure
+helpers (`buildMonthGrid`, `dateForKey`, `nextSelection`, ...), never in a
+reducer — a reducer gets no config, and the math needs `weekStartsOn`/bounds.
+
+## Parts and ARIA
+
+| Part | Role | ARIA / attributes |
+| --- | --- | --- |
+| root | — | container; carries the config `data-*` the bind reads |
+| prev | — | `<button type=button>`, `aria-label="Go to previous month"` |
+| next | — | `<button type=button>`, `aria-label="Go to next month"` |
+| heading | — | month label; `aria-live="polite"`, `aria-atomic="true"` |
+| grid | `grid` | `aria-labelledby` -> heading id; `aria-multiselectable="true"` (multiple mode only) |
+| day (many) | `gridcell` | `aria-selected`, `aria-disabled` (bounds), `aria-current="date"` (today), `data-today`/`data-selected`/`data-in-range`/`data-outside`/`data-disabled` |
+
+The day is a **focusable `<td role="gridcell">`**, not a `<button>`: it is the
+WAI-ARIA date-grid pattern and it keeps `aria-selected` on a role that allows it
+(a `button` does not, so the oracle's `aria-selected` on a `<button>` was an
+`aria-allowed-attr` hazard). `tabindex` is ephemeral DOM state owned by the bind
+(one `0`, the rest `-1`), so it is deliberately absent from the projection the
+harness asserts. Blanked cells (`showOutsideDays=false`) are inert `gridcell`s
+with no `data-value` — the instance-ARIA driver keys off `data-value` and skips
+them.
+
+## Keyboard
+
+| Key | Action |
+| --- | --- |
+| Arrow Left/Right | focus -/+ one day (crosses month) |
+| Arrow Up/Down | focus -/+ one week (crosses month) |
+| Home / End | first / last day of the focused month |
+| PageUp / PageDown | previous / next month (same day) |
+| Shift+PageUp / Shift+PageDown | previous / next year |
+| Enter / Space | select the focused day |
+| click on prev/next | page the visible month |
+
+`keymap` claims `focusDate` for the movement keys and `setSelected` for
+Enter/Space on a `day` part; the bind resolves the target from the focused cell
+(or `tabbableDate` when the grid is entered fresh) and moves DOM focus after the
+re-render.
+
+## Oracle dispositions (src/old/ui/calendar.tsx)
+
+| Oracle feature | Disposition |
+| --- | --- |
+| single / multiple / range selection | contract |
+| controlled selection + onSelect | contract (extended: intrinsic state + controlled shadow, so WC/Astro select without a consumer) |
+| currentMonth / focusedDate navigation state | contract |
+| Arrow/Home/End/PageUp/PageDown/Shift+Page keyboard map | contract |
+| arrow keys cross the month boundary and re-page currentMonth | contract (the reason roving-focus is not composed) |
+| prev/next month controls with aria-labels | contract |
+| showOutsideDays / fixedWeeks / weekStartsOn / fromDate / toDate | contract |
+| Enter/Space activate the focused date | contract |
+| `disabled(date)` predicate function | framework-affordance (React): a function is not serializable, so WC/Astro express disabled dates via the serializable `fromDate`/`toDate` bounds; React may layer the predicate on top |
+| day rendered as `<button>` with `aria-selected` | defect-do-not-port — `aria-selected` is not an allowed attribute on `role=button`; ported to a focusable `role="gridcell"` (APG date-grid) |
+| `role="application"` on the root | dropped — the grid table is the widget (`role="grid"`); `application` suppresses AT reading mode with no benefit here |
+| grid left with no tabstop when nothing focused/selected | defect-do-not-port — `tabbableDate` always yields one tabbable cell (focus > selection > today > first) so the grid is reachable by Tab |
+| `numberOfMonths` multi-month prop | dropped — single visible month; multi-month is a composition of instances, out of scope for this port (not exercised by the oracle's own tests) |
+| inline hard-coded SVG chevrons | contract (kept as decorative `aria-hidden` glyphs) |
+
+## Motion
+
+None. The issue declares motion intent only, and **no semantic `motion-*` token
+fits a calendar day yet** (the token layer is being rebuilt — #1899/#1902). Per
+Spec 05, motion is left **undeclared** rather than hardcoding a numeric duration:
+`calendar.classes.ts` carries no `transition-*`/`duration-*` literal, and the
+classes test asserts their absence. When a `motion-hover`/`motion-press`-class
+token lands, the day cell is the consumer.
+
+## WCAG 2.1 AA obligations
+
+- 1.3.1 / 4.1.2: `role="grid"` with an accessible name (`aria-labelledby` ->
+  the month heading), `role="gridcell"` days carrying `aria-selected` /
+  `aria-disabled` / `aria-current`, and column headers (`<th scope="col">`) —
+  all asserted against real DOM by the harness, axe-clean.
+- 2.1.1 Keyboard: full grid navigation (arrows/Home/End/Page) plus Enter/Space
+  activation; the header controls are native buttons.
+- 2.4.3 Focus Order: a single roving tabstop from `focusedDate`; entering the
+  grid lands on the focused/selected/today/first cell.
+- 2.4.7 Focus Visible: token focus ring on the day cells and the nav controls.
+- 4.1.3 Status Messages: the month heading is `aria-live="polite"` so a page
+  change is announced.

--- a/packages/ui/src/components/calendar/calendar.astro
+++ b/packages/ui/src/components/calendar/calendar.astro
@@ -1,0 +1,153 @@
+---
+/**
+ * Astro performance (controller) for calendar.
+ *
+ * Server-renders the full light-DOM markup -- header controls, heading, and the
+ * grid with its weekday row and the initial month's day cells, each carrying the
+ * score's projection -- so the calendar is correct and accessible before any JS.
+ * The <script> then hands every server-rendered root to bindCalendar, the SAME
+ * DOM-native controller the Web Component uses, which takes over the day cells,
+ * the heading text, and the ARIA on month changes. One score, three
+ * performances, zero drift: the day class is passed to the bind via
+ * data-day-class so the runtime-built cells paint identically to these.
+ */
+import {
+  buildMonthGrid,
+  calendarBehavior,
+  dayAria,
+  firstOfMonth,
+  formatMonth,
+  parseSelection,
+  tabbableDate,
+  todayISO,
+  weekdayHeaders,
+  type CalendarConfig,
+  type CalendarMode,
+  type CalendarPart,
+} from './calendar.behavior';
+import { calendarClasses } from './calendar.classes';
+import type { PartIds } from '../../lib/contract';
+
+interface Props {
+  id: string;
+  mode?: CalendarMode;
+  /** Serialized selection: `yyyy-mm-dd`, comma-list, or `from..to`. */
+  selected?: string;
+  defaultMonth?: string;
+  fromDate?: string;
+  toDate?: string;
+  showOutsideDays?: boolean;
+  fixedWeeks?: boolean;
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  today?: string;
+}
+
+const {
+  id,
+  mode = 'single',
+  selected,
+  defaultMonth,
+  fromDate,
+  toDate,
+  showOutsideDays = true,
+  fixedWeeks = false,
+  weekStartsOn = 0,
+  today = todayISO(),
+} = Astro.props;
+
+const config: CalendarConfig = {
+  mode,
+  defaultSelected: parseSelection(mode, selected ?? null),
+  defaultMonth,
+  fromDate,
+  toDate,
+  showOutsideDays,
+  fixedWeeks,
+  weekStartsOn,
+  today,
+};
+
+const state = calendarBehavior.initialState(config);
+const classes = calendarClasses(config, state);
+
+const ids = {} as PartIds<CalendarPart>;
+for (const part of Object.keys(calendarBehavior.parts) as CalendarPart[]) {
+  ids[part] = `${id}-${part}`;
+}
+const aria = calendarBehavior.aria(state, config, ids);
+const weeks = buildMonthGrid(config, state.currentMonth);
+const tabbable = tabbableDate(state, config);
+const headers = weekdayHeaders(weekStartsOn);
+const visibleMonth = firstOfMonth(state.currentMonth);
+---
+
+<div
+  data-part="root"
+  id={ids.root}
+  class={classes.root}
+  data-mode={mode}
+  data-selected={selected}
+  data-month={defaultMonth}
+  data-from-date={fromDate}
+  data-to-date={toDate}
+  data-show-outside-days={String(showOutsideDays)}
+  data-fixed-weeks={String(fixedWeeks)}
+  data-week-starts-on={String(weekStartsOn)}
+  data-today={today}
+>
+  <div data-part="header" class={classes.header}>
+    <button type="button" data-part="prev" id={ids.prev} class={classes.nav} {...aria.prev}>
+      <span aria-hidden="true">&#8249;</span>
+    </button>
+    <div data-part="heading" id={ids.heading} class={classes.heading} {...aria.heading}>
+      {formatMonth(visibleMonth)}
+    </div>
+    <button type="button" data-part="next" id={ids.next} class={classes.nav} {...aria.next}>
+      <span aria-hidden="true">&#8250;</span>
+    </button>
+  </div>
+  <table data-part="grid" id={ids.grid} role="grid" class={classes.grid} data-day-class={classes.day} {...aria.grid}>
+    <thead>
+      <tr>
+        {headers.map((weekday) => (
+          <th scope="col" class={classes.weekday}>{weekday}</th>
+        ))}
+      </tr>
+    </thead>
+    <tbody>
+      {
+        weeks.map((week) => (
+          <tr data-part="week" class={classes.week}>
+            {week.map((cell) =>
+              cell.day === 0 ? (
+                <td role="gridcell" data-part="day" />
+              ) : (
+                <td
+                  role="gridcell"
+                  data-part="day"
+                  data-value={cell.iso}
+                  data-outside={cell.outside ? 'true' : undefined}
+                  class={classes.day}
+                  tabindex={cell.iso === tabbable && !cell.outside ? 0 : -1}
+                  {...dayAria(cell.iso, state, config)}
+                >
+                  {cell.day}
+                </td>
+              ),
+            )}
+          </tr>
+        ))
+      }
+    </tbody>
+  </table>
+</div>
+
+<script>
+  import { bindCalendar } from './calendar.behavior';
+
+  for (const root of document.querySelectorAll<HTMLElement>('[data-part="root"][data-mode]')) {
+    if (root.dataset['bound'] === 'true') continue;
+    root.dataset['bound'] = 'true';
+    bindCalendar(root);
+  }
+</script>

--- a/packages/ui/src/components/calendar/calendar.behavior.ts
+++ b/packages/ui/src/components/calendar/calendar.behavior.ts
@@ -1,0 +1,646 @@
+import { compose, type Slice } from '../../lib/compose';
+import {
+  createBehavior,
+  type AriaAttrs,
+  type BehaviorSpec,
+  type PartIds,
+} from '../../lib/contract';
+import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { createKeyboardHandler } from '../../primitives/keyboard-handler';
+
+/**
+ * Calendar: a month grid that grid-navigates dates (arrows/page/home/end) and
+ * selects single/multiple/range values. Extracted from old/ui/calendar.tsx --
+ * every earned keyboard and selection semantic is preserved (see calendar.md
+ * dispositions).
+ *
+ * Composition (Spec 05, "compose the primitive, never reimplement it"):
+ * - keyboard nav rides `keyboard-handler` (`createKeyboardHandler`): the keymap
+ *   projection is the pure claim record (Spec 01), the bind computes the target
+ *   date via the exported `dateForKey` helper (reducers get no config, and the
+ *   date math needs weekStartsOn/bounds).
+ * - `roving-focus` is deliberately NOT composed. It owns a roving tabindex over a
+ *   FIXED DOM item list and clamps at the edges (grid mode does not wrap); the
+ *   calendar's arrow keys must instead CROSS the month boundary -- ArrowRight on
+ *   the last day moves to the first day of the next month, re-rendering the grid
+ *   (WAI-ARIA date-grid pattern, oracle lines 271-282). So `focusedDate` is
+ *   genuine score state (it survives the re-render and drives which cell is
+ *   tabbable), not ephemeral roving state -- the radio/tabs relationship inverts
+ *   here. The bind owns the tabindex from state. See calendar.md.
+ *
+ * Selection is score state with a controlled shadow (slider's ownership-of-truth
+ * boundary): `config.selected` shadows `state.selected`, effective =
+ * `config.selected ?? state.selected`. WC and Astro have no reactive prop, so
+ * their intrinsic state is seeded from the server markup and drives selection
+ * without a consumer. The date math (grid layout, key -> date, selection
+ * transitions) lives in exported pure helpers, never in a reducer.
+ */
+
+export type CalendarMode = 'single' | 'multiple' | 'range';
+
+/** A calendar-day identity: a local `yyyy-mm-dd` string. Timezone-free by
+ *  construction (all math is on local Y/M/D components), so it round-trips
+ *  through a `data-*` attribute and compares by value. */
+export type ISODate = string;
+
+/**
+ * The selection value, discriminated by mode so the shape is self-describing and
+ * the transition helper can branch without config. `single` holds one date (or
+ * none); `multiple` a set; `range` a `from`/`to` pair, incomplete until `to`.
+ */
+export type CalendarSelection =
+  | { mode: 'single'; date: ISODate | null }
+  | { mode: 'multiple'; dates: ISODate[] }
+  | { mode: 'range'; from: ISODate | null; to: ISODate | null };
+
+export interface CalendarConfig {
+  /** Selection cardinality. Default 'single'. */
+  mode: CalendarMode;
+  /** Controlled selection: shadows the intrinsic state when present. */
+  selected?: CalendarSelection | undefined;
+  /** Uncontrolled seed for the intrinsic selection. */
+  defaultSelected?: CalendarSelection | undefined;
+  /** Visible-month seed (first of month). */
+  defaultMonth?: ISODate | undefined;
+  /** Serializable lower bound: dates before it are disabled. */
+  fromDate?: ISODate | undefined;
+  /** Serializable upper bound: dates after it are disabled. */
+  toDate?: ISODate | undefined;
+  /** Render the leading/trailing days of adjacent months. Default true. */
+  showOutsideDays: boolean;
+  /** Always render six weeks, so the grid height never jumps. Default false. */
+  fixedWeeks: boolean;
+  /** First column's weekday (0 = Sunday). Default 0. */
+  weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  /** Today's date, injected for determinism (the projection stays pure). */
+  today: ISODate;
+}
+
+export interface CalendarState {
+  /** The visible month (first of month). */
+  currentMonth: ISODate;
+  /** The keyboard-focused date, or null before the grid is entered. */
+  focusedDate: ISODate | null;
+  /** Intrinsic selection -- ignored while a controlled selection is present. */
+  selected: CalendarSelection;
+}
+
+export type CalendarActions = {
+  /** Move keyboard focus to a date; syncs the visible month to its month. */
+  focusDate: ISODate;
+  /** Shift the visible month by a whole-month delta (prev/next controls). */
+  shiftMonth: number;
+  /** Commit an already-computed selection (the transition helper owns the math).
+   *  Wrapped in an object so the union payload does not distribute through the
+   *  dispatch tuple type. */
+  setSelected: { selection: CalendarSelection };
+};
+
+export type CalendarPart = 'root' | 'prev' | 'next' | 'heading' | 'grid' | 'day';
+
+const WEEKDAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'] as const;
+
+// ==================== Pure date helpers (no config) ====================
+
+function pad(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+/** Format a local Date as `yyyy-mm-dd`. */
+export function toISO(date: Date): ISODate {
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+/** Parse a `yyyy-mm-dd` string into a local Date at midnight. */
+export function fromISO(iso: ISODate): Date {
+  const [year, month, day] = iso.split('-').map(Number);
+  return new Date(year ?? 1970, (month ?? 1) - 1, day ?? 1);
+}
+
+/** Today's date as an ISO string (the only impure helper -- injected via config). */
+export function todayISO(): ISODate {
+  return toISO(new Date());
+}
+
+/** The first-of-month ISO for the month containing `iso`. */
+export function firstOfMonth(iso: ISODate): ISODate {
+  const date = fromISO(iso);
+  return toISO(new Date(date.getFullYear(), date.getMonth(), 1));
+}
+
+/** Add `days` to `iso` (may cross month/year boundaries). */
+export function addDays(iso: ISODate, days: number): ISODate {
+  const date = fromISO(iso);
+  return toISO(new Date(date.getFullYear(), date.getMonth(), date.getDate() + days));
+}
+
+/** Add `months` to `iso`, clamping the day to the target month's length. */
+export function addMonths(iso: ISODate, months: number): ISODate {
+  const date = fromISO(iso);
+  const target = new Date(date.getFullYear(), date.getMonth() + months, 1);
+  const lastDay = new Date(target.getFullYear(), target.getMonth() + 1, 0).getDate();
+  target.setDate(Math.min(date.getDate(), lastDay));
+  return toISO(target);
+}
+
+/** Add `years` to `iso`, clamping the day (Feb 29 -> Feb 28 off a leap year). */
+export function addYears(iso: ISODate, years: number): ISODate {
+  return addMonths(iso, years * 12);
+}
+
+/** Human month label, e.g. "July 2026". */
+export function formatMonth(iso: ISODate): string {
+  return fromISO(iso).toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+}
+
+/** The weekday header labels rotated for the configured week start. */
+export function weekdayHeaders(weekStartsOn: number): string[] {
+  return [...WEEKDAYS.slice(weekStartsOn), ...WEEKDAYS.slice(0, weekStartsOn)];
+}
+
+// ==================== Grid layout (pure over config) ====================
+
+export interface CalendarDay {
+  iso: ISODate;
+  /** Day-of-month number (1-31), or 0 for a blanked outside day. */
+  day: number;
+  /** Whether the day belongs to an adjacent month (a leading/trailing filler). */
+  outside: boolean;
+}
+
+/**
+ * Build the visible month grid as weeks of seven days. Leading/trailing days of
+ * the adjacent months fill the first and last weeks; `showOutsideDays=false`
+ * blanks them (their `day` is 0), and `fixedWeeks` pads to six rows. Pure over
+ * config -- the same layout the three decorators render and the bind rebuilds.
+ */
+export function buildMonthGrid(config: CalendarConfig, month: ISODate): CalendarDay[][] {
+  const first = fromISO(firstOfMonth(month));
+  const year = first.getFullYear();
+  const monthIndex = first.getMonth();
+  const daysInMonth = new Date(year, monthIndex + 1, 0).getDate();
+  const firstWeekday = first.getDay();
+  const leadCount = (firstWeekday - config.weekStartsOn + 7) % 7;
+
+  const days: CalendarDay[] = [];
+
+  for (let i = leadCount - 1; i >= 0; i--) {
+    const date = new Date(year, monthIndex, -i);
+    days.push({
+      iso: toISO(date),
+      day: config.showOutsideDays ? date.getDate() : 0,
+      outside: true,
+    });
+  }
+
+  for (let d = 1; d <= daysInMonth; d++) {
+    days.push({ iso: toISO(new Date(year, monthIndex, d)), day: d, outside: false });
+  }
+
+  const filled = config.fixedWeeks ? 42 : Math.ceil(days.length / 7) * 7;
+  let trailing = 1;
+  while (days.length < filled) {
+    const date = new Date(year, monthIndex + 1, trailing);
+    days.push({
+      iso: toISO(date),
+      day: config.showOutsideDays ? date.getDate() : 0,
+      outside: true,
+    });
+    trailing++;
+  }
+
+  const weeks: CalendarDay[][] = [];
+  for (let i = 0; i < days.length; i += 7) {
+    weeks.push(days.slice(i, i + 7));
+  }
+  return weeks;
+}
+
+// ==================== Selection (pure over mode) ====================
+
+/** The effective selection: a controlled `config.selected` shadows intrinsic state. */
+export function effectiveSelected(state: CalendarState, config: CalendarConfig): CalendarSelection {
+  return config.selected ?? state.selected;
+}
+
+/** The empty selection for a mode -- the initial intrinsic value. */
+export function emptySelection(mode: CalendarMode): CalendarSelection {
+  if (mode === 'single') return { mode: 'single', date: null };
+  if (mode === 'multiple') return { mode: 'multiple', dates: [] };
+  return { mode: 'range', from: null, to: null };
+}
+
+/** Stable string form of a selection -- the change-detection currency. */
+export function serializeSelection(selection: CalendarSelection): string {
+  if (selection.mode === 'single') return `single:${selection.date ?? ''}`;
+  if (selection.mode === 'multiple') return `multiple:${[...selection.dates].sort().join(',')}`;
+  return `range:${selection.from ?? ''}..${selection.to ?? ''}`;
+}
+
+/** Whether `iso` is a selected endpoint/member (a range interior is not). */
+export function isSelected(selection: CalendarSelection, iso: ISODate): boolean {
+  if (selection.mode === 'single') return selection.date === iso;
+  if (selection.mode === 'multiple') return selection.dates.includes(iso);
+  return selection.from === iso || selection.to === iso;
+}
+
+/** Whether `iso` falls strictly inside a completed range (endpoints excluded). */
+export function isInRange(selection: CalendarSelection, iso: ISODate): boolean {
+  if (selection.mode !== 'range') return false;
+  const { from, to } = selection;
+  if (!from || !to) return false;
+  return iso > from && iso < to;
+}
+
+/**
+ * The selection after activating `iso`, from the current selection. Single sets
+ * the date; multiple toggles membership; range starts a new range on the first
+ * click (or after a completed one) and completes it on the second, ordering the
+ * endpoints so `from <= to` (oracle lines 209-221).
+ */
+export function nextSelection(current: CalendarSelection, iso: ISODate): CalendarSelection {
+  if (current.mode === 'single') return { mode: 'single', date: iso };
+  if (current.mode === 'multiple') {
+    const exists = current.dates.includes(iso);
+    const dates = exists ? current.dates.filter((d) => d !== iso) : [...current.dates, iso];
+    return { mode: 'multiple', dates };
+  }
+  const { from, to } = current;
+  if (!from || (from && to)) return { mode: 'range', from: iso, to: null };
+  if (iso < from) return { mode: 'range', from: iso, to: from };
+  return { mode: 'range', from, to: iso };
+}
+
+// ==================== Disabled bounds (serializable) ====================
+
+/** Whether `iso` is outside the serializable [fromDate, toDate] bounds. */
+export function isDateDisabled(iso: ISODate, config: CalendarConfig): boolean {
+  if (config.fromDate && iso < config.fromDate) return true;
+  if (config.toDate && iso > config.toDate) return true;
+  return false;
+}
+
+// ==================== Keyboard (pure over config) ====================
+
+const MOVEMENT_KEYS = [
+  'ArrowLeft',
+  'ArrowRight',
+  'ArrowUp',
+  'ArrowDown',
+  'Home',
+  'End',
+  'PageUp',
+  'PageDown',
+] as const;
+
+/**
+ * The date a movement key targets from `focused`, or `null` when the key does
+ * not navigate. Arrows step a day/week; Home/End jump to the first/last of the
+ * month; Page keys step a month, or a year with Shift (oracle lines 229-263).
+ */
+export function dateForKey(key: string, focused: ISODate, shiftKey: boolean): ISODate | null {
+  switch (key) {
+    case 'ArrowLeft':
+      return addDays(focused, -1);
+    case 'ArrowRight':
+      return addDays(focused, 1);
+    case 'ArrowUp':
+      return addDays(focused, -7);
+    case 'ArrowDown':
+      return addDays(focused, 7);
+    case 'Home': {
+      const date = fromISO(focused);
+      return toISO(new Date(date.getFullYear(), date.getMonth(), 1));
+    }
+    case 'End': {
+      const date = fromISO(focused);
+      return toISO(new Date(date.getFullYear(), date.getMonth() + 1, 0));
+    }
+    case 'PageUp':
+      return shiftKey ? addYears(focused, -1) : addMonths(focused, -1);
+    case 'PageDown':
+      return shiftKey ? addYears(focused, 1) : addMonths(focused, 1);
+    default:
+      return null;
+  }
+}
+
+/**
+ * The date that owns the grid's single tabstop: the focused date, else the
+ * selected date visible in the month, else today if visible, else the first of
+ * the month. Guarantees the grid is always reachable by Tab (the oracle left it
+ * unreachable when nothing was focused or selected -- corrected here).
+ */
+export function tabbableDate(state: CalendarState, config: CalendarConfig): ISODate {
+  const month = firstOfMonth(state.currentMonth);
+  const inMonth = (iso: ISODate | null): iso is ISODate =>
+    iso !== null && firstOfMonth(iso) === month;
+  if (inMonth(state.focusedDate)) return state.focusedDate;
+  const selection = effectiveSelected(state, config);
+  if (selection.mode === 'single' && inMonth(selection.date)) return selection.date;
+  if (selection.mode === 'range' && inMonth(selection.from)) return selection.from;
+  if (selection.mode === 'multiple') {
+    const first = selection.dates.find(inMonth);
+    if (first) return first;
+  }
+  if (inMonth(config.today)) return config.today;
+  return month;
+}
+
+// ==================== Score ====================
+
+/** The month implied by a seed selection, when no explicit defaultMonth is set. */
+function seededMonth(config: CalendarConfig): ISODate | null {
+  const selection = config.selected ?? config.defaultSelected;
+  if (!selection) return null;
+  if (selection.mode === 'single') return selection.date;
+  if (selection.mode === 'range') return selection.from;
+  return selection.dates[0] ?? null;
+}
+
+const calendar: Slice<CalendarConfig, CalendarState, CalendarActions, CalendarPart> = {
+  name: 'calendar',
+  parts: {
+    root: {},
+    prev: {},
+    next: {},
+    heading: {},
+    grid: { role: 'grid' },
+    day: { role: 'gridcell', many: true },
+  },
+  initialState: (config) => ({
+    currentMonth: firstOfMonth(config.defaultMonth ?? seededMonth(config) ?? config.today),
+    focusedDate: null,
+    selected: config.selected ?? config.defaultSelected ?? emptySelection(config.mode),
+  }),
+  actions: {
+    focusDate: (state, iso) => ({
+      ...state,
+      focusedDate: iso,
+      currentMonth: firstOfMonth(iso),
+    }),
+    shiftMonth: (state, delta) => ({
+      ...state,
+      currentMonth: firstOfMonth(addMonths(state.currentMonth, delta)),
+    }),
+    // The value arrives already computed (nextSelection owns the transition,
+    // since a reducer gets no config/mode). Return the same ref when unchanged
+    // so a controlled consumer's memory does not notify needlessly.
+    setSelected: (state, { selection }) =>
+      serializeSelection(state.selected) === serializeSelection(selection)
+        ? state
+        : { ...state, selected: selection },
+  },
+  canDispatch: () => true,
+  aria: (_state, config, ids) => ({
+    grid: {
+      'aria-labelledby': ids.heading || undefined,
+      'aria-multiselectable': config.mode === 'multiple' ? 'true' : undefined,
+    },
+    heading: { 'aria-live': 'polite', 'aria-atomic': 'true' },
+    prev: { 'aria-label': 'Go to previous month' },
+    next: { 'aria-label': 'Go to next month' },
+  }),
+  // The pure claim record (Spec 01): movement keys navigate the grid (the bind
+  // computes the target date via dateForKey and dispatches focusDate);
+  // Enter/Space select the focused date (the bind computes the selection via
+  // nextSelection). Claimed only on a day part.
+  keymap: (event, _state, part) => {
+    if (part !== 'day') return null;
+    if ((MOVEMENT_KEYS as ReadonlyArray<string>).includes(event.key)) return 'focusDate';
+    if (event.key === 'Enter' || event.key === ' ') return 'setSelected';
+    return null;
+  },
+};
+
+export const calendarBehavior: BehaviorSpec<
+  CalendarConfig,
+  CalendarState,
+  CalendarActions,
+  CalendarPart
+> = {
+  ...compose('calendar', calendar),
+  instanceAria: (part, value, state, config) =>
+    part === 'day' ? dayAria(value, state, config) : {},
+};
+
+/**
+ * Per-instance projection for the `day` many-part. `aria()` projects one
+ * AriaAttrs per part NAME; days occur once per date, so their projection takes
+ * the instance date (mirroring radio-group's radioItemAria). tabindex is
+ * deliberately absent: the bind owns the single tabstop as ephemeral DOM state
+ * (like roving's tabindex), so it must not appear in a projection the harness
+ * asserts against.
+ */
+export function dayAria(iso: ISODate, state: CalendarState, config: CalendarConfig): AriaAttrs {
+  const selection = effectiveSelected(state, config);
+  const selected = isSelected(selection, iso);
+  const disabled = isDateDisabled(iso, config);
+  const inRange = isInRange(selection, iso);
+  const today = iso === config.today;
+  return {
+    'aria-selected': selected ? 'true' : 'false',
+    'aria-disabled': disabled ? 'true' : undefined,
+    'aria-current': today ? 'date' : undefined,
+    'data-today': today ? 'true' : undefined,
+    'data-selected': selected ? 'true' : undefined,
+    'data-in-range': inRange ? 'true' : undefined,
+    'data-disabled': disabled ? 'true' : undefined,
+  };
+}
+
+// ==================== bindCalendar (WC + Astro share it) ====================
+
+const DAY_SELECTOR = '[data-part="day"]';
+
+/** Parse a serialized selection off the root markup (`data-mode`/`data-selected`). */
+export function parseSelection(mode: CalendarMode, raw: string | null): CalendarSelection {
+  if (!raw) return emptySelection(mode);
+  if (mode === 'single') return { mode: 'single', date: raw };
+  if (mode === 'multiple') {
+    return { mode: 'multiple', dates: raw.split(',').filter(Boolean) };
+  }
+  const [from, to] = raw.split('..');
+  return { mode: 'range', from: from || null, to: to || null };
+}
+
+function coerceWeekStart(raw: string | null): 0 | 1 | 2 | 3 | 4 | 5 | 6 {
+  const n = Number(raw ?? 0);
+  return (Number.isInteger(n) && n >= 0 && n <= 6 ? n : 0) as 0 | 1 | 2 | 3 | 4 | 5 | 6;
+}
+
+function readConfig(root: HTMLElement): CalendarConfig {
+  const attr = (name: string): string | null => root.getAttribute(name);
+  const mode = (attr('data-mode') as CalendarMode | null) ?? 'single';
+  return {
+    mode,
+    defaultSelected: parseSelection(mode, attr('data-selected')),
+    defaultMonth: attr('data-month') ?? undefined,
+    fromDate: attr('data-from-date') ?? undefined,
+    toDate: attr('data-to-date') ?? undefined,
+    showOutsideDays: attr('data-show-outside-days') !== 'false',
+    fixedWeeks: attr('data-fixed-weeks') === 'true',
+    weekStartsOn: coerceWeekStart(attr('data-week-starts-on')),
+    today: attr('data-today') ?? todayISO(),
+  };
+}
+
+/**
+ * The DOM-native binding of the calendar score -- the client the Web Component
+ * and the Astro <script> both import. React (retained-mode) reads the
+ * projections declaratively instead, but shares the same score and helpers.
+ *
+ * Unlike radio-group (a fixed item set), the calendar's day cells CHANGE when
+ * the month changes, so the bind OWNS grid construction: `renderDays` rebuilds
+ * the `[data-part="grid"] tbody` from `buildMonthGrid` on every render. The
+ * server markup is the pre-JS first paint; after bind the bind is the single
+ * source of the visible cells. Keyboard rides `createKeyboardHandler`; the
+ * single tabstop is set from `tabbableDate` (the calendar's own state, not a
+ * roving primitive -- see the module header).
+ *
+ * Three-gotcha ledger: (1) uncontrolled here (no reactive prop), so the
+ * controlled-callback compare is a no-op; (2) the projection is resolved, so it
+ * is applied with `{ validate: false }`; (3) the WC defers bind one microtask
+ * (see calendar.element.ts).
+ */
+export function bindCalendar(root: HTMLElement): () => void {
+  const config = readConfig(root);
+  const getPart = (part: string): HTMLElement | null =>
+    part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
+
+  const { memory, dispatch } = createBehavior(calendarBehavior, config);
+
+  const ids = {} as PartIds<CalendarPart>;
+  for (const part of Object.keys(calendarBehavior.parts) as CalendarPart[]) {
+    ids[part] = getPart(part)?.id ?? '';
+  }
+
+  const applyProjection = (el: HTMLElement, attrs: AriaAttrs) => {
+    for (const [name, value] of Object.entries(attrs)) {
+      updateAriaAttribute(el, name as never, value as never, { validate: false });
+    }
+  };
+
+  const grid = getPart('grid');
+  const heading = getPart('heading');
+
+  // The day cell's class string is authored in calendar.classes.ts (the view)
+  // and handed to the bind as a data attribute on the grid, so behavior.ts never
+  // imports the view yet the bind-built cells paint identically to React's.
+  const dayClass = grid?.getAttribute('data-day-class') ?? '';
+
+  const renderDays = () => {
+    const body = grid?.querySelector('tbody');
+    if (!body) return;
+    const state = memory.get();
+    const tabbable = tabbableDate(state, config);
+    const weeks = buildMonthGrid(config, state.currentMonth);
+    body.replaceChildren();
+    for (const week of weeks) {
+      const tr = document.createElement('tr');
+      tr.setAttribute('data-part', 'week');
+      for (const cell of week) {
+        const td = document.createElement('td');
+        td.setAttribute('data-part', 'day');
+        td.setAttribute('role', 'gridcell');
+        // Blanked cells (showOutsideDays=false) are inert structure: a gridcell
+        // for the grid's required-children, but no data-value/tabindex/aria, so
+        // assertInstanceAriaFulfillment skips them (it keys off data-value).
+        if (cell.day === 0) {
+          tr.appendChild(td);
+          continue;
+        }
+        td.dataset['value'] = cell.iso;
+        if (cell.outside) td.setAttribute('data-outside', 'true');
+        if (dayClass) td.className = dayClass;
+        td.textContent = String(cell.day);
+        td.setAttribute('tabindex', cell.iso === tabbable && !cell.outside ? '0' : '-1');
+        applyProjection(td, dayAria(cell.iso, state, config));
+        tr.appendChild(td);
+      }
+      body.appendChild(tr);
+    }
+  };
+
+  const render = () => {
+    const state = memory.get();
+    const projection = calendarBehavior.aria(state, config, ids);
+    for (const part of ['grid', 'heading', 'prev', 'next'] as const) {
+      const attrs = projection[part];
+      const el = getPart(part);
+      if (el && attrs) applyProjection(el, attrs);
+    }
+    if (heading) heading.textContent = formatMonth(state.currentMonth);
+    renderDays();
+  };
+  const unsubscribe = memory.subscribe(render); // fires immediately: first paint
+
+  const focusedCell = (): HTMLElement | null => {
+    const active = (root.getRootNode() as Document | ShadowRoot)
+      .activeElement as HTMLElement | null;
+    const cell = active?.closest<HTMLElement>(DAY_SELECTOR) ?? null;
+    return cell && root.contains(cell) ? cell : null;
+  };
+
+  const activate = (iso: ISODate) => {
+    if (isDateDisabled(iso, config)) return;
+    const before = effectiveSelected(memory.get(), config);
+    dispatch('setSelected', config, { selection: nextSelection(before, iso) });
+    root.dispatchEvent(new CustomEvent('calendarselect', { bubbles: true, detail: { date: iso } }));
+  };
+
+  const onClick = (event: Event) => {
+    const cell = (event.target as HTMLElement).closest<HTMLElement>(DAY_SELECTOR);
+    const iso = cell?.dataset['value'];
+    if (iso && root.contains(cell) && cell?.getAttribute('data-outside') !== 'true') activate(iso);
+  };
+  root.addEventListener('click', onClick);
+
+  const prev = getPart('prev');
+  const next = getPart('next');
+  const onPrev = () => dispatch('shiftMonth', config, -1);
+  const onNext = () => dispatch('shiftMonth', config, 1);
+  prev?.addEventListener('click', onPrev);
+  next?.addEventListener('click', onNext);
+
+  const focusFocusedCell = () => {
+    const state = memory.get();
+    if (!state.focusedDate) return;
+    const cell = grid?.querySelector<HTMLElement>(
+      `${DAY_SELECTOR}[data-value="${state.focusedDate}"]`,
+    );
+    cell?.focus();
+  };
+
+  const stopMovement = createKeyboardHandler(root, {
+    key: ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End', 'PageUp', 'PageDown'],
+    preventDefault: true,
+    handler: (event) => {
+      const cell = focusedCell();
+      const from = cell?.dataset['value'] ?? tabbableDate(memory.get(), config);
+      const target = dateForKey(event.key, from, event.shiftKey);
+      if (!target) return;
+      dispatch('focusDate', config, target);
+      focusFocusedCell();
+    },
+  });
+
+  const stopActivate = createKeyboardHandler(root, {
+    key: ['Enter', 'Space'],
+    preventDefault: true,
+    handler: () => {
+      const cell = focusedCell();
+      const iso = cell?.dataset['value'];
+      if (iso && cell?.getAttribute('data-outside') !== 'true') activate(iso);
+    },
+  });
+
+  return () => {
+    unsubscribe();
+    stopMovement();
+    stopActivate();
+    root.removeEventListener('click', onClick);
+    prev?.removeEventListener('click', onPrev);
+    next?.removeEventListener('click', onNext);
+  };
+}

--- a/packages/ui/src/components/calendar/calendar.behavior.ts
+++ b/packages/ui/src/components/calendar/calendar.behavior.ts
@@ -612,14 +612,20 @@ export function bindCalendar(root: HTMLElement): () => void {
     cell?.focus();
   };
 
+  // preventDefault is scoped INSIDE the handler (only when a day cell owns focus)
+  // so a keydown bubbling from the focused prev/next button keeps its native
+  // action: Enter still activates the month controls (WCAG 2.1.1), and an arrow
+  // on a button does not yank focus into the grid.
   const stopMovement = createKeyboardHandler(root, {
     key: ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End', 'PageUp', 'PageDown'],
-    preventDefault: true,
+    preventDefault: false,
     handler: (event) => {
       const cell = focusedCell();
-      const from = cell?.dataset['value'] ?? tabbableDate(memory.get(), config);
+      const from = cell?.dataset['value'];
+      if (!from) return;
       const target = dateForKey(event.key, from, event.shiftKey);
       if (!target) return;
+      event.preventDefault();
       dispatch('focusDate', config, target);
       focusFocusedCell();
     },
@@ -627,11 +633,14 @@ export function bindCalendar(root: HTMLElement): () => void {
 
   const stopActivate = createKeyboardHandler(root, {
     key: ['Enter', 'Space'],
-    preventDefault: true,
-    handler: () => {
+    preventDefault: false,
+    handler: (event) => {
       const cell = focusedCell();
       const iso = cell?.dataset['value'];
-      if (iso && cell?.getAttribute('data-outside') !== 'true') activate(iso);
+      if (iso && cell?.getAttribute('data-outside') !== 'true') {
+        event.preventDefault();
+        activate(iso);
+      }
     },
   });
 

--- a/packages/ui/src/components/calendar/calendar.classes.ts
+++ b/packages/ui/src/components/calendar/calendar.classes.ts
@@ -1,0 +1,62 @@
+import type { CalendarConfig, CalendarState } from './calendar.behavior';
+
+export interface CalendarClassSet {
+  /** The outer container. */
+  root: string;
+  /** The month-navigation header row (prev / heading / next). */
+  header: string;
+  /** The prev and next month controls (same affordance). */
+  nav: string;
+  /** The month/year label. */
+  heading: string;
+  /** The [role="grid"] table. */
+  grid: string;
+  /** A weekday-header cell. */
+  weekday: string;
+  /** A week row. */
+  week: string;
+  /** A day gridcell: state variants ride the data-* the score projects. */
+  day: string;
+}
+
+const rootClasses = 'inline-block p-3';
+const headerClasses = 'flex items-center justify-between pb-4';
+const navClasses =
+  'inline-flex items-center justify-center size-7 rounded-md ' +
+  'text-foreground hover:bg-accent hover:text-accent-foreground ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+const headingClasses = 'text-sm font-medium';
+const gridClasses = 'w-full border-collapse';
+const weekdayClasses = 'w-8 pb-1 text-xs font-normal text-muted-foreground';
+const weekClasses = '';
+
+// Day state variants are driven off the data-* the score projects (data-today,
+// data-selected, data-in-range, data-outside, data-disabled) -- no conditional
+// class assembly, so the three decorators and the bind paint identically. Motion
+// is intentionally undeclared: no semantic motion token fits a calendar day yet
+// (the token layer is being rebuilt, #1899/#1902); see calendar.md.
+const dayClasses =
+  'relative inline-flex items-center justify-center size-8 rounded-md text-sm select-none ' +
+  'cursor-pointer text-foreground ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ' +
+  'hover:bg-accent hover:text-accent-foreground ' +
+  'data-[in-range=true]:bg-accent data-[in-range=true]:text-accent-foreground ' +
+  'data-[today=true]:bg-accent data-[today=true]:font-semibold data-[today=true]:text-accent-foreground ' +
+  'data-[outside=true]:text-muted-foreground data-[outside=true]:opacity-50 data-[outside=true]:cursor-default ' +
+  'data-[disabled=true]:opacity-50 data-[disabled=true]:cursor-not-allowed data-[disabled=true]:pointer-events-none ' +
+  'data-[selected=true]:bg-primary data-[selected=true]:text-primary-foreground ' +
+  'data-[selected=true]:hover:bg-primary data-[selected=true]:hover:text-primary-foreground';
+
+/** The view: class strings keyed by config/state. No logic. */
+export function calendarClasses(_config: CalendarConfig, _state: CalendarState): CalendarClassSet {
+  return {
+    root: rootClasses,
+    header: headerClasses,
+    nav: navClasses,
+    heading: headingClasses,
+    grid: gridClasses,
+    weekday: weekdayClasses,
+    week: weekClasses,
+    day: dayClasses,
+  };
+}

--- a/packages/ui/src/components/calendar/calendar.element.ts
+++ b/packages/ui/src/components/calendar/calendar.element.ts
@@ -1,0 +1,147 @@
+/**
+ * WC performance for calendar. The score AND the DOM-native binding
+ * (bindCalendar) live in calendar.behavior.ts, shared with the Astro
+ * performance; this file only adapts that binding to the custom-element
+ * lifecycle.
+ *
+ * A calendar has no meaningful author-provided content -- the grid is entirely
+ * generated -- so this light-DOM enhancer scaffolds the structural parts (header
+ * controls, heading, the table with its weekday row and an empty tbody) with the
+ * view's classes, copies the element's configuration onto the root as the
+ * `data-*` the bind reads, then hands the root to bindCalendar, which fills the
+ * tbody, the heading text, and every ARIA projection. Structure + decoration
+ * here; all behavior in the shared bind. The bind is deferred one microtask
+ * because connectedCallback can fire before attributes settle (gotcha #3).
+ */
+import {
+  bindCalendar,
+  calendarBehavior,
+  weekdayHeaders,
+  type CalendarConfig,
+  type CalendarMode,
+  type CalendarPart,
+} from './calendar.behavior';
+import { calendarClasses } from './calendar.classes';
+
+let idCounter = 0;
+
+function coerceWeekStart(raw: string | null): 0 | 1 | 2 | 3 | 4 | 5 | 6 {
+  const n = Number(raw ?? 0);
+  return (Number.isInteger(n) && n >= 0 && n <= 6 ? n : 0) as 0 | 1 | 2 | 3 | 4 | 5 | 6;
+}
+
+export class RaftersCalendar extends HTMLElement {
+  private teardown: (() => void) | null = null;
+
+  connectedCallback(): void {
+    queueMicrotask(() => {
+      if (!this.isConnected || this.teardown) return;
+      const root = this.scaffold();
+      this.teardown = bindCalendar(root);
+    });
+  }
+
+  disconnectedCallback(): void {
+    this.teardown?.();
+    this.teardown = null;
+  }
+
+  private scaffold(): HTMLElement {
+    const attr = (name: string): string | null => this.getAttribute(name);
+    const mode = (attr('mode') as CalendarMode | null) ?? 'single';
+    const weekStartsOn = coerceWeekStart(attr('week-starts-on'));
+
+    // A minimal config for the VIEW only (classes read nothing stateful today);
+    // the behavioral config is reconstructed by the bind from the data-* below.
+    const config: CalendarConfig = {
+      mode,
+      showOutsideDays: attr('show-outside-days') !== 'false',
+      fixedWeeks: attr('fixed-weeks') === 'true',
+      weekStartsOn,
+      today: attr('today') ?? '',
+    };
+    const classes = calendarClasses(config, calendarBehavior.initialState({ ...config }));
+
+    const base = this.id || `calendar-${++idCounter}`;
+    const ids = {} as Record<CalendarPart, string>;
+    for (const part of Object.keys(calendarBehavior.parts) as CalendarPart[]) {
+      ids[part] = `${base}-${part}`;
+    }
+
+    const root = document.createElement('div');
+    root.setAttribute('data-part', 'root');
+    root.id = ids.root;
+    root.className = classes.root;
+    // The config the bind reads back (readConfig): copy each element attribute
+    // to its data-* twin so the bind's uncontrolled seed matches this markup.
+    root.dataset['mode'] = mode;
+    if (attr('selected')) root.dataset['selected'] = attr('selected') as string;
+    if (attr('default-month')) root.dataset['month'] = attr('default-month') as string;
+    if (attr('from-date')) root.dataset['fromDate'] = attr('from-date') as string;
+    if (attr('to-date')) root.dataset['toDate'] = attr('to-date') as string;
+    root.dataset['showOutsideDays'] = String(config.showOutsideDays);
+    root.dataset['fixedWeeks'] = String(config.fixedWeeks);
+    root.dataset['weekStartsOn'] = String(weekStartsOn);
+    if (attr('today')) root.dataset['today'] = attr('today') as string;
+
+    const header = document.createElement('div');
+    header.setAttribute('data-part', 'header');
+    header.className = classes.header;
+
+    const chevron = (glyph: string): HTMLSpanElement => {
+      const span = document.createElement('span');
+      span.setAttribute('aria-hidden', 'true');
+      span.textContent = glyph;
+      return span;
+    };
+
+    const prev = document.createElement('button');
+    prev.type = 'button';
+    prev.setAttribute('data-part', 'prev');
+    prev.id = ids.prev;
+    prev.className = classes.nav;
+    prev.appendChild(chevron('‹'));
+
+    const heading = document.createElement('div');
+    heading.setAttribute('data-part', 'heading');
+    heading.id = ids.heading;
+    heading.className = classes.heading;
+
+    const next = document.createElement('button');
+    next.type = 'button';
+    next.setAttribute('data-part', 'next');
+    next.id = ids.next;
+    next.className = classes.nav;
+    next.appendChild(chevron('›'));
+
+    header.append(prev, heading, next);
+
+    const table = document.createElement('table');
+    table.setAttribute('data-part', 'grid');
+    table.id = ids.grid;
+    table.setAttribute('role', 'grid');
+    table.className = classes.grid;
+    table.dataset['dayClass'] = classes.day;
+
+    const thead = document.createElement('thead');
+    const headRow = document.createElement('tr');
+    for (const weekday of weekdayHeaders(weekStartsOn)) {
+      const th = document.createElement('th');
+      th.scope = 'col';
+      th.className = classes.weekday;
+      th.textContent = weekday;
+      headRow.appendChild(th);
+    }
+    thead.appendChild(headRow);
+    table.appendChild(thead);
+    table.appendChild(document.createElement('tbody'));
+
+    root.append(header, table);
+    this.replaceChildren(root);
+    return root;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-calendar')) {
+  customElements.define('rafters-calendar', RaftersCalendar);
+}

--- a/packages/ui/src/components/calendar/calendar.tsx
+++ b/packages/ui/src/components/calendar/calendar.tsx
@@ -1,0 +1,337 @@
+import * as React from 'react';
+import { useMemory } from '../../hooks/use-memory';
+import classy from '../../primitives/classy';
+import { createBehavior, type PartIds } from '../../lib/contract';
+import { createKeyboardHandler } from '../../primitives/keyboard-handler';
+import {
+  buildMonthGrid,
+  calendarBehavior,
+  dateForKey,
+  dayAria,
+  effectiveSelected,
+  formatMonth,
+  fromISO,
+  isDateDisabled,
+  nextSelection,
+  tabbableDate,
+  toISO,
+  todayISO,
+  weekdayHeaders,
+  type CalendarConfig,
+  type CalendarMode,
+  type CalendarPart,
+  type CalendarSelection,
+} from './calendar.behavior';
+import { calendarClasses } from './calendar.classes';
+
+/**
+ * Calendar: a month grid that selects dates. Grid-navigates with the arrow keys
+ * (crossing month boundaries), Home/End (month ends), and PageUp/PageDown
+ * (month, or year with Shift); Enter/Space select the focused date; the header
+ * controls page the visible month. Single, multiple, and range selection.
+ *
+ * @cognitive-load 5/10 - decision 2, information 2, interaction 1, disruption 0,
+ * learning 0. Two decisions can be live at once (which month, which date), and a
+ * month is ~30 items to visually scan, but the grid is a universally learned
+ * affordance and every date is a reversible, low-stakes choice with no workflow
+ * disruption.
+ * @attention-economics A month is a dense field; the today marker and the
+ * selected fill are the two anchors that let the eye skip straight to "now" and
+ * "chosen" instead of reading every cell. Navigation is chunked by month so the
+ * user never scans more than one page of dates at a time.
+ * @trust-building A single always-visible today marker, an unambiguous selected
+ * state, disabled dates that are visibly and behaviourally inert, and a live
+ * month heading that announces every page -- the user is never unsure which
+ * month they are looking at or which date they picked.
+ * @accessibility role="grid" with an aria-labelledby month heading, role=gridcell
+ * days carrying aria-selected/aria-disabled/aria-current, and a single roving
+ * tabstop owned by the score's focusedDate (not a roving primitive: arrow keys
+ * cross month boundaries, which a clamping roving tabindex cannot express).
+ * Full keyboard grid navigation per the WAI-ARIA date-grid pattern.
+ */
+
+export interface CalendarDateRange {
+  from: Date | undefined;
+  to: Date | undefined;
+}
+
+interface CalendarBaseProps {
+  /** Uncontrolled seed for the visible month. */
+  defaultMonth?: Date;
+  /** Dates before this are disabled. */
+  fromDate?: Date;
+  /** Dates after this are disabled. */
+  toDate?: Date;
+  /** Render adjacent-month filler days. Default true. */
+  showOutsideDays?: boolean;
+  /** Always render six weeks. Default false. */
+  fixedWeeks?: boolean;
+  /** First column's weekday (0 = Sunday). Default 0. */
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  /** Today's date; injected for deterministic rendering. Default `new Date()`. */
+  today?: Date;
+  className?: string;
+}
+
+export type CalendarProps =
+  | (CalendarBaseProps & {
+      mode?: 'single';
+      selected?: Date;
+      onSelect?: (date: Date | undefined) => void;
+    })
+  | (CalendarBaseProps & {
+      mode: 'multiple';
+      selected?: Date[];
+      onSelect?: (dates: Date[]) => void;
+    })
+  | (CalendarBaseProps & {
+      mode: 'range';
+      selected?: CalendarDateRange;
+      onSelect?: (range: CalendarDateRange) => void;
+    });
+
+/** Read the mode-typed `selected` prop into the behavior's tagged selection. */
+function readSelected(props: CalendarProps): CalendarSelection | undefined {
+  switch (props.mode) {
+    case 'multiple':
+      return props.selected ? { mode: 'multiple', dates: props.selected.map(toISO) } : undefined;
+    case 'range':
+      return props.selected
+        ? {
+            mode: 'range',
+            from: props.selected.from ? toISO(props.selected.from) : null,
+            to: props.selected.to ? toISO(props.selected.to) : null,
+          }
+        : undefined;
+    default:
+      return props.selected ? { mode: 'single', date: toISO(props.selected) } : undefined;
+  }
+}
+
+/** Report a committed selection through the mode-typed `onSelect` prop. */
+function notifySelect(props: CalendarProps, selection: CalendarSelection): void {
+  switch (props.mode) {
+    case 'multiple':
+      props.onSelect?.(selection.mode === 'multiple' ? selection.dates.map(fromISO) : []);
+      return;
+    case 'range':
+      props.onSelect?.(
+        selection.mode === 'range'
+          ? {
+              from: selection.from ? fromISO(selection.from) : undefined,
+              to: selection.to ? fromISO(selection.to) : undefined,
+            }
+          : { from: undefined, to: undefined },
+      );
+      return;
+    default:
+      props.onSelect?.(
+        selection.mode === 'single' && selection.date ? fromISO(selection.date) : undefined,
+      );
+  }
+}
+
+const MOVEMENT_KEYS = [
+  'ArrowLeft',
+  'ArrowRight',
+  'ArrowUp',
+  'ArrowDown',
+  'Home',
+  'End',
+  'PageUp',
+  'PageDown',
+] as const;
+
+const DAY_SELECTOR = '[data-part="day"]';
+
+export function Calendar(props: CalendarProps) {
+  const {
+    mode = 'single',
+    defaultMonth,
+    fromDate,
+    toDate,
+    showOutsideDays = true,
+    fixedWeeks = false,
+    weekStartsOn = 0,
+    today,
+    className,
+  } = props;
+
+  // Compute a stable "today" once so render stays pure (React 19); a `today`
+  // prop overrides it for deterministic tests.
+  const [defaultToday] = React.useState(() => todayISO());
+  const resolvedMode: CalendarMode = mode;
+
+  const config: CalendarConfig = {
+    mode: resolvedMode,
+    selected: readSelected(props),
+    defaultMonth: defaultMonth ? toISO(defaultMonth) : undefined,
+    fromDate: fromDate ? toISO(fromDate) : undefined,
+    toDate: toDate ? toISO(toDate) : undefined,
+    showOutsideDays,
+    fixedWeeks,
+    weekStartsOn,
+    today: today ? toISO(today) : defaultToday,
+  };
+
+  // createBehavior is the model (created once); useMemory subscribes React to it;
+  // dispatch takes the CURRENT config each call, so a controlled `selected`
+  // shadows intrinsic state without re-creating the instance.
+  const { memory, dispatch } = React.useMemo(() => createBehavior(calendarBehavior, config), []);
+  const state = useMemory(memory);
+
+  const uid = React.useId();
+  const ids = React.useMemo(() => {
+    const out = {} as PartIds<CalendarPart>;
+    for (const part of Object.keys(calendarBehavior.parts) as CalendarPart[]) {
+      out[part] = `${uid}-${part}`;
+    }
+    return out;
+  }, [uid]);
+
+  const rootRef = React.useRef<HTMLDivElement>(null);
+
+  // Gotcha #1: the controlled callback reports the value to SET even when the
+  // effective (controlled) value does not move. A disabled date is refused
+  // before dispatch, so no callback fires for an edit the calendar rejects.
+  const latest = React.useRef({ props, config });
+  latest.current = { props, config };
+  const request = React.useCallback(
+    (iso: string): void => {
+      const { props: p, config: c } = latest.current;
+      if (isDateDisabled(iso, c)) return;
+      const before = effectiveSelected(memory.get(), c);
+      const next = nextSelection(before, iso);
+      dispatch('setSelected', c, { selection: next });
+      notifySelect(p, next);
+    },
+    [memory, dispatch],
+  );
+
+  // Keyboard grid navigation rides the keyboard-handler primitive, composed
+  // against the root (a focused gridcell's keydown bubbles up) -- the same shape
+  // the DOM-native bind uses. focusDate updates state; the focus effect below
+  // then moves DOM focus to the newly focused cell.
+  React.useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    const stopMovement = createKeyboardHandler(root, {
+      key: [...MOVEMENT_KEYS],
+      preventDefault: true,
+      handler: (event) => {
+        const cfg = latest.current.config;
+        const active = document.activeElement as HTMLElement | null;
+        const cell = active?.closest<HTMLElement>(DAY_SELECTOR) ?? null;
+        const from = cell?.dataset['value'] ?? tabbableDate(memory.get(), cfg);
+        const target = dateForKey(event.key, from, event.shiftKey);
+        if (!target) return;
+        dispatch('focusDate', cfg, target);
+      },
+    });
+    const stopActivate = createKeyboardHandler(root, {
+      key: ['Enter', 'Space'],
+      preventDefault: true,
+      handler: () => {
+        const active = document.activeElement as HTMLElement | null;
+        const cell = active?.closest<HTMLElement>(DAY_SELECTOR) ?? null;
+        const iso = cell?.dataset['value'];
+        if (iso && cell?.getAttribute('data-outside') !== 'true') request(iso);
+      },
+    });
+    return () => {
+      stopMovement();
+      stopActivate();
+    };
+  }, [memory, dispatch, request]);
+
+  // Move DOM focus to the focused cell after a keyboard navigation re-render.
+  // focusedDate is only set by the keyboard handler (which requires focus to be
+  // in the grid), so this never steals focus on mount or a click.
+  React.useEffect(() => {
+    const iso = state.focusedDate;
+    if (!iso) return;
+    const cell = rootRef.current?.querySelector<HTMLElement>(
+      `${DAY_SELECTOR}[data-value="${iso}"]`,
+    );
+    cell?.focus();
+  }, [state.focusedDate, state.currentMonth]);
+
+  const classes = calendarClasses(config, state);
+  const aria = calendarBehavior.aria(state, config, ids);
+  const weeks = buildMonthGrid(config, state.currentMonth);
+  const tabbable = tabbableDate(state, config);
+  const headers = weekdayHeaders(weekStartsOn);
+
+  return (
+    <div ref={rootRef} data-part="root" id={ids.root} className={classy(classes.root, className)}>
+      <div data-part="header" className={classes.header}>
+        <button
+          type="button"
+          data-part="prev"
+          id={ids.prev}
+          className={classes.nav}
+          {...aria.prev}
+          onClick={() => dispatch('shiftMonth', latest.current.config, -1)}
+        >
+          <span aria-hidden="true">&#8249;</span>
+        </button>
+        <div data-part="heading" id={ids.heading} className={classes.heading} {...aria.heading}>
+          {formatMonth(state.currentMonth)}
+        </div>
+        <button
+          type="button"
+          data-part="next"
+          id={ids.next}
+          className={classes.nav}
+          {...aria.next}
+          onClick={() => dispatch('shiftMonth', latest.current.config, 1)}
+        >
+          <span aria-hidden="true">&#8250;</span>
+        </button>
+      </div>
+      {/* biome-ignore lint/a11y/useSemanticElements: role="grid" on a table is the WAI-ARIA date-grid pattern for interactive date selection */}
+      <table data-part="grid" id={ids.grid} role="grid" className={classes.grid} {...aria.grid}>
+        <thead>
+          <tr>
+            {headers.map((weekday) => (
+              <th key={weekday} scope="col" className={classes.weekday}>
+                {weekday}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {weeks.map((week) => (
+            <tr key={week[0]?.iso} data-part="week" className={classes.week}>
+              {week.map((cell) =>
+                cell.day === 0 ? (
+                  <td key={cell.iso} role="gridcell" data-part="day" />
+                ) : (
+                  <td
+                    key={cell.iso}
+                    role="gridcell"
+                    data-part="day"
+                    data-value={cell.iso}
+                    data-outside={cell.outside || undefined}
+                    tabIndex={cell.iso === tabbable && !cell.outside ? 0 : -1}
+                    className={classes.day}
+                    onClick={() => {
+                      if (!cell.outside) request(cell.iso);
+                    }}
+                    {...dayAria(cell.iso, state, config)}
+                  >
+                    {cell.day}
+                  </td>
+                ),
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+Calendar.displayName = 'Calendar';
+
+export default Calendar;

--- a/packages/ui/src/components/calendar/calendar.tsx
+++ b/packages/ui/src/components/calendar/calendar.tsx
@@ -62,6 +62,10 @@ interface CalendarBaseProps {
   fromDate?: Date;
   /** Dates after this are disabled. */
   toDate?: Date;
+  /** React-only predicate (a function is not serializable, so WC/Astro keep the
+   *  fromDate/toDate bounds): a date is disabled when it returns true, layered
+   *  over the serializable bounds. */
+  disabled?: (date: Date) => boolean;
   /** Render adjacent-month filler days. Default true. */
   showOutsideDays?: boolean;
   /** Always render six weeks. Default false. */
@@ -174,6 +178,12 @@ export function Calendar(props: CalendarProps) {
     today: today ? toISO(today) : defaultToday,
   };
 
+  // A day is disabled when the serializable bounds refuse it OR the React-only
+  // `disabled` predicate returns true. The predicate is React-only (a function
+  // is not serializable); WC/Astro use the bounds alone (see calendar.md).
+  const dayDisabled = (iso: string): boolean =>
+    isDateDisabled(iso, config) || (props.disabled?.(fromISO(iso)) ?? false);
+
   // createBehavior is the model (created once); useMemory subscribes React to it;
   // dispatch takes the CURRENT config each call, so a controlled `selected`
   // shadows intrinsic state without re-creating the instance.
@@ -199,7 +209,7 @@ export function Calendar(props: CalendarProps) {
   const request = React.useCallback(
     (iso: string): void => {
       const { props: p, config: c } = latest.current;
-      if (isDateDisabled(iso, c)) return;
+      if (isDateDisabled(iso, c) || (p.disabled?.(fromISO(iso)) ?? false)) return;
       const before = effectiveSelected(memory.get(), c);
       const next = nextSelection(before, iso);
       dispatch('setSelected', c, { selection: next });
@@ -314,10 +324,15 @@ export function Calendar(props: CalendarProps) {
         <tbody>
           {weeks.map((week) => (
             <tr key={week[0]?.iso} data-part="week" className={classes.week}>
-              {week.map((cell) =>
-                cell.day === 0 ? (
-                  <td key={cell.iso} role="gridcell" data-part="day" />
-                ) : (
+              {week.map((cell) => {
+                if (cell.day === 0) {
+                  return <td key={cell.iso} role="gridcell" data-part="day" />;
+                }
+                // The React-only predicate is layered over the score's bounds
+                // projection: override aria-disabled/data-disabled so a
+                // predicate-disabled day is visually and functionally inert.
+                const disabled = dayDisabled(cell.iso);
+                return (
                   <td
                     key={cell.iso}
                     role="gridcell"
@@ -330,11 +345,13 @@ export function Calendar(props: CalendarProps) {
                       if (!cell.outside) request(cell.iso);
                     }}
                     {...dayAria(cell.iso, state, config)}
+                    aria-disabled={disabled ? 'true' : undefined}
+                    data-disabled={disabled ? 'true' : undefined}
                   >
                     {cell.day}
                   </td>
-                ),
-              )}
+                );
+              })}
             </tr>
           ))}
         </tbody>

--- a/packages/ui/src/components/calendar/calendar.tsx
+++ b/packages/ui/src/components/calendar/calendar.tsx
@@ -215,34 +215,45 @@ export function Calendar(props: CalendarProps) {
   React.useEffect(() => {
     const root = rootRef.current;
     if (!root) return;
+    // preventDefault is scoped INSIDE each handler (only when a day cell owns
+    // focus) so a keydown bubbling from the focused prev/next button keeps its
+    // native action: Enter still activates the month controls (WCAG 2.1.1) and
+    // an arrow on a button does not yank focus into the grid.
+    const focusedDayCell = (): HTMLElement | null => {
+      const active = document.activeElement as HTMLElement | null;
+      const cell = active?.closest<HTMLElement>(DAY_SELECTOR) ?? null;
+      return cell && root.contains(cell) ? cell : null;
+    };
     const stopMovement = createKeyboardHandler(root, {
       key: [...MOVEMENT_KEYS],
-      preventDefault: true,
+      preventDefault: false,
       handler: (event) => {
-        const cfg = latest.current.config;
-        const active = document.activeElement as HTMLElement | null;
-        const cell = active?.closest<HTMLElement>(DAY_SELECTOR) ?? null;
-        const from = cell?.dataset['value'] ?? tabbableDate(memory.get(), cfg);
+        const cell = focusedDayCell();
+        const from = cell?.dataset['value'];
+        if (!from) return;
         const target = dateForKey(event.key, from, event.shiftKey);
         if (!target) return;
-        dispatch('focusDate', cfg, target);
+        event.preventDefault();
+        dispatch('focusDate', latest.current.config, target);
       },
     });
     const stopActivate = createKeyboardHandler(root, {
       key: ['Enter', 'Space'],
-      preventDefault: true,
-      handler: () => {
-        const active = document.activeElement as HTMLElement | null;
-        const cell = active?.closest<HTMLElement>(DAY_SELECTOR) ?? null;
+      preventDefault: false,
+      handler: (event) => {
+        const cell = focusedDayCell();
         const iso = cell?.dataset['value'];
-        if (iso && cell?.getAttribute('data-outside') !== 'true') request(iso);
+        if (iso && cell?.getAttribute('data-outside') !== 'true') {
+          event.preventDefault();
+          request(iso);
+        }
       },
     });
     return () => {
       stopMovement();
       stopActivate();
     };
-  }, [memory, dispatch, request]);
+  }, [dispatch, request]);
 
   // Move DOM focus to the focused cell after a keyboard navigation re-render.
   // focusedDate is only set by the keyboard handler (which requires focus to be

--- a/packages/ui/test/components/calendar/calendar.astro.conformance.test.ts
+++ b/packages/ui/test/components/calendar/calendar.astro.conformance.test.ts
@@ -93,4 +93,12 @@ describe('calendar conformance [astro]', () => {
     await user.click(partElement(document.body, 'next')!);
     expect(partElement(document.body, 'heading')?.textContent).toBe('August 2026');
   });
+
+  it('Enter activates a focused header control (native button, not suppressed)', async () => {
+    const user = userEvent.setup();
+    await mount();
+    partElement(document.body, 'next')!.focus();
+    await user.keyboard('{Enter}');
+    expect(partElement(document.body, 'heading')?.textContent).toBe('August 2026');
+  });
 });

--- a/packages/ui/test/components/calendar/calendar.astro.conformance.test.ts
+++ b/packages/ui/test/components/calendar/calendar.astro.conformance.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Astro performance of the calendar score. AstroContainer renders the SSR markup
+ * with the initial month already projected, but does NOT run the <script>, so
+ * the test calls bindCalendar directly -- that IS the script's job -- then drives
+ * the same score the React and WC performances drive.
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import Calendar from '../../../src/components/calendar/calendar.astro';
+import {
+  bindCalendar,
+  calendarBehavior,
+  type CalendarConfig,
+} from '../../../src/components/calendar/calendar.behavior';
+import {
+  assertContractFulfillment,
+  assertInstanceAriaFulfillment,
+  partElement,
+} from '../../harness/conformance';
+
+async function mount(props: Record<string, unknown> = {}): Promise<HTMLElement> {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Calendar, {
+    props: { id: 'cal', today: '2026-07-20', defaultMonth: '2026-07-01', ...props },
+  });
+  document.body.innerHTML = `<main>${html}</main>`;
+  const root = document.body.querySelector('[data-part="root"][data-mode]') as HTMLElement;
+  bindCalendar(root); // the <script> does this per instance on the real page
+  return root;
+}
+
+function baseConfig(overrides: Partial<CalendarConfig> = {}): CalendarConfig {
+  return {
+    mode: 'single',
+    showOutsideDays: true,
+    fixedWeeks: false,
+    weekStartsOn: 0,
+    today: '2026-07-20',
+    defaultMonth: '2026-07-01',
+    ...overrides,
+  };
+}
+
+const dayCell = (iso: string) =>
+  document.body.querySelector<HTMLElement>(`[data-part="day"][data-value="${iso}"]`)!;
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('calendar conformance [astro]', () => {
+  it('SSR: a labelled grid with the seeded month and today marked', async () => {
+    await mount();
+    expect(partElement(document.body, 'grid')?.getAttribute('role')).toBe('grid');
+    expect(partElement(document.body, 'heading')?.textContent).toBe('July 2026');
+    expect(dayCell('2026-07-20').getAttribute('data-today')).toBe('true');
+  });
+
+  it('contract: grid/heading/nav projections and per-day ARIA equal the DOM', async () => {
+    const root = await mount();
+    const config = baseConfig();
+    const state = calendarBehavior.initialState(config);
+    assertContractFulfillment(calendarBehavior, root, state, config, [
+      'grid',
+      'heading',
+      'prev',
+      'next',
+    ]);
+    assertInstanceAriaFulfillment(calendarBehavior, root, state, config);
+  });
+
+  it('click selects a day and reflects the projection', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(dayCell('2026-07-09'));
+    expect(dayCell('2026-07-09').getAttribute('aria-selected')).toBe('true');
+    expect(dayCell('2026-07-09').getAttribute('data-selected')).toBe('true');
+  });
+
+  it('arrow keys move focus and cross the month boundary', async () => {
+    const user = userEvent.setup();
+    await mount();
+    dayCell('2026-07-31').focus();
+    await user.keyboard('{ArrowRight}');
+    expect(partElement(document.body, 'heading')?.textContent).toBe('August 2026');
+    expect(document.activeElement).toBe(dayCell('2026-08-01'));
+  });
+
+  it('the header controls page the visible month', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(partElement(document.body, 'next')!);
+    expect(partElement(document.body, 'heading')?.textContent).toBe('August 2026');
+  });
+});

--- a/packages/ui/test/components/calendar/calendar.behavior.test.ts
+++ b/packages/ui/test/components/calendar/calendar.behavior.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Pure score tests for calendar -- no DOM. Date math, grid layout, selection
+ * transitions, the keymap claim record, the aria/day projections, and the
+ * reducers, all as total functions over injected config (today is a config
+ * field, so every assertion is deterministic).
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  addDays,
+  addMonths,
+  addYears,
+  buildMonthGrid,
+  calendarBehavior,
+  dateForKey,
+  dayAria,
+  effectiveSelected,
+  emptySelection,
+  firstOfMonth,
+  fromISO,
+  isDateDisabled,
+  isInRange,
+  isSelected,
+  nextSelection,
+  serializeSelection,
+  tabbableDate,
+  toISO,
+  weekdayHeaders,
+  type CalendarConfig,
+  type CalendarSelection,
+  type CalendarState,
+} from '../../../src/components/calendar/calendar.behavior';
+
+function cfg(overrides: Partial<CalendarConfig> = {}): CalendarConfig {
+  return {
+    mode: 'single',
+    showOutsideDays: true,
+    fixedWeeks: false,
+    weekStartsOn: 0,
+    today: '2026-07-20',
+    ...overrides,
+  };
+}
+
+function state(overrides: Partial<CalendarState> = {}): CalendarState {
+  return {
+    currentMonth: '2026-07-01',
+    focusedDate: null,
+    selected: emptySelection('single'),
+    ...overrides,
+  };
+}
+
+describe('calendar date helpers', () => {
+  it('toISO/fromISO round-trip a local date', () => {
+    expect(toISO(fromISO('2026-07-04'))).toBe('2026-07-04');
+    expect(toISO(new Date(2026, 0, 9))).toBe('2026-01-09');
+  });
+
+  it('addDays crosses month and year boundaries', () => {
+    expect(addDays('2026-07-31', 1)).toBe('2026-08-01');
+    expect(addDays('2026-01-01', -1)).toBe('2025-12-31');
+    expect(addDays('2026-07-15', 7)).toBe('2026-07-22');
+  });
+
+  it('addMonths clamps the day to the target month length', () => {
+    expect(addMonths('2026-01-31', 1)).toBe('2026-02-28');
+    expect(addMonths('2026-03-15', -1)).toBe('2026-02-15');
+  });
+
+  it('addYears clamps Feb 29 off a leap year', () => {
+    expect(addYears('2024-02-29', 1)).toBe('2025-02-28');
+  });
+
+  it('firstOfMonth normalizes to the first', () => {
+    expect(firstOfMonth('2026-07-20')).toBe('2026-07-01');
+  });
+
+  it('weekdayHeaders rotates for the week start', () => {
+    expect(weekdayHeaders(0)[0]).toBe('Su');
+    expect(weekdayHeaders(1)[0]).toBe('Mo');
+    expect(weekdayHeaders(1).at(-1)).toBe('Su');
+  });
+});
+
+describe('buildMonthGrid', () => {
+  it('lays out full weeks starting on the configured weekday', () => {
+    const weeks = buildMonthGrid(cfg(), '2026-07-01');
+    for (const week of weeks) expect(week).toHaveLength(7);
+    // The first cell is always the configured week-start weekday.
+    expect(fromISO(weeks[0]![0]!.iso).getDay()).toBe(0);
+    const inMonth = weeks.flat().filter((d) => !d.outside);
+    expect(inMonth).toHaveLength(31);
+    expect(inMonth[0]!.day).toBe(1);
+    expect(inMonth.at(-1)!.day).toBe(31);
+  });
+
+  it('respects a non-zero week start', () => {
+    const weeks = buildMonthGrid(cfg({ weekStartsOn: 1 }), '2026-07-01');
+    expect(fromISO(weeks[0]![0]!.iso).getDay()).toBe(1);
+  });
+
+  it('blanks outside days when showOutsideDays is false', () => {
+    const weeks = buildMonthGrid(cfg({ showOutsideDays: false }), '2026-07-01');
+    const outside = weeks.flat().filter((d) => d.outside);
+    expect(outside.length).toBeGreaterThan(0);
+    for (const cell of outside) expect(cell.day).toBe(0);
+  });
+
+  it('pads to six weeks with fixedWeeks', () => {
+    const weeks = buildMonthGrid(cfg({ fixedWeeks: true }), '2026-02-01');
+    expect(weeks).toHaveLength(6);
+    expect(weeks.flat()).toHaveLength(42);
+  });
+});
+
+describe('dateForKey (keyboard navigation)', () => {
+  const from = '2026-07-15';
+  it('steps by day and week', () => {
+    expect(dateForKey('ArrowLeft', from, false)).toBe('2026-07-14');
+    expect(dateForKey('ArrowRight', from, false)).toBe('2026-07-16');
+    expect(dateForKey('ArrowUp', from, false)).toBe('2026-07-08');
+    expect(dateForKey('ArrowDown', from, false)).toBe('2026-07-22');
+  });
+
+  it('jumps to the month ends with Home/End', () => {
+    expect(dateForKey('Home', from, false)).toBe('2026-07-01');
+    expect(dateForKey('End', from, false)).toBe('2026-07-31');
+  });
+
+  it('pages by month, or year with Shift', () => {
+    expect(dateForKey('PageUp', from, false)).toBe('2026-06-15');
+    expect(dateForKey('PageDown', from, false)).toBe('2026-08-15');
+    expect(dateForKey('PageUp', from, true)).toBe('2025-07-15');
+    expect(dateForKey('PageDown', from, true)).toBe('2027-07-15');
+  });
+
+  it('crosses the month boundary on an arrow past the edge', () => {
+    expect(dateForKey('ArrowRight', '2026-07-31', false)).toBe('2026-08-01');
+    expect(dateForKey('ArrowLeft', '2026-07-01', false)).toBe('2026-06-30');
+  });
+
+  it('returns null for a non-navigation key', () => {
+    expect(dateForKey('Enter', from, false)).toBeNull();
+  });
+});
+
+describe('selection transitions', () => {
+  it('single sets the date', () => {
+    const next = nextSelection({ mode: 'single', date: null }, '2026-07-04');
+    expect(next).toEqual({ mode: 'single', date: '2026-07-04' });
+  });
+
+  it('multiple toggles membership', () => {
+    const one = nextSelection({ mode: 'multiple', dates: [] }, '2026-07-04');
+    expect(one).toEqual({ mode: 'multiple', dates: ['2026-07-04'] });
+    const off = nextSelection(one, '2026-07-04');
+    expect(off).toEqual({ mode: 'multiple', dates: [] });
+  });
+
+  it('range starts, completes, and orders endpoints', () => {
+    const start = nextSelection({ mode: 'range', from: null, to: null }, '2026-07-10');
+    expect(start).toEqual({ mode: 'range', from: '2026-07-10', to: null });
+    const complete = nextSelection(start, '2026-07-20');
+    expect(complete).toEqual({ mode: 'range', from: '2026-07-10', to: '2026-07-20' });
+    const reordered = nextSelection(start, '2026-07-05');
+    expect(reordered).toEqual({ mode: 'range', from: '2026-07-05', to: '2026-07-10' });
+    // A third click after a completed range starts fresh.
+    expect(nextSelection(complete, '2026-07-25')).toEqual({
+      mode: 'range',
+      from: '2026-07-25',
+      to: null,
+    });
+  });
+
+  it('isSelected marks endpoints/members but not a range interior', () => {
+    const range: CalendarSelection = { mode: 'range', from: '2026-07-10', to: '2026-07-20' };
+    expect(isSelected(range, '2026-07-10')).toBe(true);
+    expect(isSelected(range, '2026-07-20')).toBe(true);
+    expect(isSelected(range, '2026-07-15')).toBe(false);
+    expect(isInRange(range, '2026-07-15')).toBe(true);
+    expect(isInRange(range, '2026-07-10')).toBe(false);
+  });
+});
+
+describe('disabled bounds', () => {
+  it('disables dates outside [fromDate, toDate]', () => {
+    const c = cfg({ fromDate: '2026-07-10', toDate: '2026-07-20' });
+    expect(isDateDisabled('2026-07-09', c)).toBe(true);
+    expect(isDateDisabled('2026-07-21', c)).toBe(true);
+    expect(isDateDisabled('2026-07-15', c)).toBe(false);
+  });
+});
+
+describe('tabbableDate', () => {
+  it('prefers focus, then selection, then today, then the first', () => {
+    expect(tabbableDate(state({ focusedDate: '2026-07-09' }), cfg())).toBe('2026-07-09');
+    expect(tabbableDate(state({ selected: { mode: 'single', date: '2026-07-12' } }), cfg())).toBe(
+      '2026-07-12',
+    );
+    expect(tabbableDate(state(), cfg())).toBe('2026-07-20'); // today, visible in July
+    expect(tabbableDate(state(), cfg({ today: '2026-09-01' }))).toBe('2026-07-01'); // first
+  });
+});
+
+describe('reducers', () => {
+  it('focusDate moves focus and syncs the visible month', () => {
+    const next = calendarBehavior.actions.focusDate(state(), '2026-08-03');
+    expect(next.focusedDate).toBe('2026-08-03');
+    expect(next.currentMonth).toBe('2026-08-01');
+  });
+
+  it('shiftMonth pages the visible month', () => {
+    expect(calendarBehavior.actions.shiftMonth(state(), 1).currentMonth).toBe('2026-08-01');
+    expect(calendarBehavior.actions.shiftMonth(state(), -1).currentMonth).toBe('2026-06-01');
+  });
+
+  it('setSelected returns the same ref when unchanged (no needless notify)', () => {
+    const base = state({ selected: { mode: 'single', date: '2026-07-04' } });
+    const same = calendarBehavior.actions.setSelected(base, {
+      selection: { mode: 'single', date: '2026-07-04' },
+    });
+    expect(same).toBe(base);
+    const changed = calendarBehavior.actions.setSelected(base, {
+      selection: { mode: 'single', date: '2026-07-05' },
+    });
+    expect(changed).not.toBe(base);
+    expect(changed.selected).toEqual({ mode: 'single', date: '2026-07-05' });
+  });
+});
+
+describe('keymap claim record', () => {
+  const key = (k: string) => ({ key: k });
+  it('claims movement keys and Enter/Space on a day part', () => {
+    expect(calendarBehavior.keymap(key('ArrowRight'), state(), 'day', cfg())).toBe('focusDate');
+    expect(calendarBehavior.keymap(key('PageDown'), state(), 'day', cfg())).toBe('focusDate');
+    expect(calendarBehavior.keymap(key('Enter'), state(), 'day', cfg())).toBe('setSelected');
+    expect(calendarBehavior.keymap(key(' '), state(), 'day', cfg())).toBe('setSelected');
+  });
+
+  it('claims nothing on a non-day part or an unrelated key', () => {
+    expect(calendarBehavior.keymap(key('ArrowRight'), state(), 'grid', cfg())).toBeNull();
+    expect(calendarBehavior.keymap(key('a'), state(), 'day', cfg())).toBeNull();
+  });
+});
+
+describe('aria projections', () => {
+  const ids = {
+    root: 'c-root',
+    prev: 'c-prev',
+    next: 'c-next',
+    heading: 'c-heading',
+    grid: 'c-grid',
+    day: '',
+  };
+
+  it('projects the grid, heading, and nav controls', () => {
+    const aria = calendarBehavior.aria(state(), cfg(), ids);
+    expect(aria.grid?.['aria-labelledby']).toBe('c-heading');
+    expect(aria.grid?.['aria-multiselectable']).toBeUndefined();
+    expect(aria.heading?.['aria-live']).toBe('polite');
+    expect(aria.prev?.['aria-label']).toBe('Go to previous month');
+    expect(aria.next?.['aria-label']).toBe('Go to next month');
+  });
+
+  it('advertises multiselectable only in multiple mode', () => {
+    const aria = calendarBehavior.aria(state(), cfg({ mode: 'multiple' }), ids);
+    expect(aria.grid?.['aria-multiselectable']).toBe('true');
+  });
+
+  it('dayAria reflects selected, today, disabled, and in-range', () => {
+    const c = cfg({ fromDate: '2026-07-10', toDate: '2026-07-25' });
+    const s = state({ selected: { mode: 'range', from: '2026-07-12', to: '2026-07-18' } });
+    expect(dayAria('2026-07-12', s, c)).toMatchObject({
+      'aria-selected': 'true',
+      'data-selected': 'true',
+    });
+    expect(dayAria('2026-07-15', s, c)).toMatchObject({ 'data-in-range': 'true' });
+    expect(dayAria('2026-07-20', s, c)).toMatchObject({
+      'data-today': 'true',
+      'aria-current': 'date',
+    });
+    expect(dayAria('2026-07-09', s, c)).toMatchObject({
+      'aria-disabled': 'true',
+      'data-disabled': 'true',
+    });
+    expect(dayAria('2026-07-15', s, c)['aria-selected']).toBe('false');
+  });
+});
+
+describe('initialState and effective selection', () => {
+  it('seeds the visible month from defaultMonth, then a seed selection, then today', () => {
+    expect(calendarBehavior.initialState(cfg({ defaultMonth: '2026-03-15' })).currentMonth).toBe(
+      '2026-03-01',
+    );
+    expect(
+      calendarBehavior.initialState(
+        cfg({ defaultSelected: { mode: 'single', date: '2026-05-09' } }),
+      ).currentMonth,
+    ).toBe('2026-05-01');
+    expect(calendarBehavior.initialState(cfg()).currentMonth).toBe('2026-07-01');
+  });
+
+  it('a controlled selection shadows intrinsic state', () => {
+    const c = cfg({ selected: { mode: 'single', date: '2026-07-04' } });
+    const s = state({ selected: { mode: 'single', date: '2026-07-09' } });
+    expect(effectiveSelected(s, c)).toEqual({ mode: 'single', date: '2026-07-04' });
+    expect(serializeSelection(effectiveSelected(s, c))).toBe('single:2026-07-04');
+  });
+});

--- a/packages/ui/test/components/calendar/calendar.classes.test.ts
+++ b/packages/ui/test/components/calendar/calendar.classes.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Classes parity test: the view is pure class strings keyed by config/state.
+ * Asserts the day cell carries its sizing, focus ring, and the data-* state
+ * variants the score projects (today, selected, in-range, outside, disabled) --
+ * the same class contract all three performances paint, including the bind-built
+ * cells that read the day class off data-day-class.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  calendarBehavior,
+  type CalendarConfig,
+} from '../../../src/components/calendar/calendar.behavior';
+import { calendarClasses } from '../../../src/components/calendar/calendar.classes';
+
+function classesFor(overrides: Partial<CalendarConfig> = {}) {
+  const config: CalendarConfig = {
+    mode: 'single',
+    showOutsideDays: true,
+    fixedWeeks: false,
+    weekStartsOn: 0,
+    today: '2026-07-20',
+    ...overrides,
+  };
+  return calendarClasses(config, calendarBehavior.initialState(config));
+}
+
+describe('calendar classes', () => {
+  it('exposes the full part class set', () => {
+    const classes = classesFor();
+    for (const key of ['root', 'header', 'nav', 'heading', 'grid', 'weekday', 'week', 'day']) {
+      expect(classes).toHaveProperty(key);
+    }
+  });
+
+  it('the nav control is a focusable icon button', () => {
+    const nav = classesFor().nav;
+    expect(nav).toContain('rounded-md');
+    expect(nav).toContain('hover:bg-accent');
+    expect(nav).toContain('focus-visible:ring-ring');
+  });
+
+  it('the grid stretches and collapses its borders', () => {
+    expect(classesFor().grid).toContain('border-collapse');
+    expect(classesFor().grid).toContain('w-full');
+  });
+
+  it('the day cell sizes, focuses, and carries every state variant', () => {
+    const day = classesFor().day;
+    expect(day).toContain('size-8');
+    expect(day).toContain('rounded-md');
+    expect(day).toContain('focus-visible:ring-ring');
+    expect(day).toContain('data-[selected=true]:bg-primary');
+    expect(day).toContain('data-[today=true]:bg-accent');
+    expect(day).toContain('data-[in-range=true]:bg-accent');
+    expect(day).toContain('data-[outside=true]:opacity-50');
+    expect(day).toContain('data-[disabled=true]:cursor-not-allowed');
+  });
+
+  it('declares no raw transition duration (motion is undeclared)', () => {
+    // No semantic motion token fits a calendar day yet; motion stays undeclared
+    // rather than hardcoding a numeric duration (see calendar.md).
+    const day = classesFor().day;
+    expect(day).not.toMatch(/duration-\d/);
+    expect(day).not.toContain('transition-');
+  });
+});

--- a/packages/ui/test/components/calendar/calendar.conformance.test.tsx
+++ b/packages/ui/test/components/calendar/calendar.conformance.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * React performance of the calendar score, driven end to end. Selection and
+ * navigation move only through dispatched actions; the grid re-renders from the
+ * score's state; arrow keys cross month boundaries. today/defaultMonth are
+ * pinned so the projection is deterministic.
+ */
+import * as React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Calendar } from '../../../src/components/calendar/calendar';
+import {
+  calendarBehavior,
+  toISO,
+  type CalendarConfig,
+} from '../../../src/components/calendar/calendar.behavior';
+import {
+  assertAxeClean,
+  assertContractFulfillment,
+  assertInstanceAriaFulfillment,
+  partElement,
+} from '../../harness/conformance';
+
+const TODAY = new Date(2026, 6, 20);
+const MONTH = new Date(2026, 6, 1);
+
+const body = () => document.body;
+
+function dayCell(iso: string): HTMLElement {
+  const el = body().querySelector<HTMLElement>(`[data-part="day"][data-value="${iso}"]`);
+  if (!el) throw new Error(`no day cell for ${iso}`);
+  return el;
+}
+
+function baseConfig(overrides: Partial<CalendarConfig> = {}): CalendarConfig {
+  return {
+    mode: 'single',
+    showOutsideDays: true,
+    fixedWeeks: false,
+    weekStartsOn: 0,
+    today: '2026-07-20',
+    defaultMonth: '2026-07-01',
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('calendar conformance [react]', () => {
+  it('renders a labelled grid of gridcell days, axe-clean', async () => {
+    render(
+      <main>
+        <Calendar today={TODAY} defaultMonth={MONTH} />
+      </main>,
+    );
+    const grid = partElement(body(), 'grid');
+    expect(grid?.getAttribute('role')).toBe('grid');
+    expect(grid?.hasAttribute('aria-labelledby')).toBe(true);
+    expect(partElement(body(), 'heading')?.textContent).toBe('July 2026');
+    expect(dayCell('2026-07-15').getAttribute('role')).toBe('gridcell');
+    await assertAxeClean(body());
+  });
+
+  it('contract: grid/heading/nav projections and per-day ARIA equal the DOM', () => {
+    const config = baseConfig();
+    render(<Calendar today={TODAY} defaultMonth={MONTH} />);
+    const root = partElement(body(), 'root');
+    if (!root) throw new Error('no root');
+    const state = calendarBehavior.initialState(config);
+    assertContractFulfillment(calendarBehavior, root, state, config, [
+      'grid',
+      'heading',
+      'prev',
+      'next',
+    ]);
+    assertInstanceAriaFulfillment(calendarBehavior, root, state, config);
+  });
+
+  it('today is marked and one cell owns the tabstop', () => {
+    render(<Calendar today={TODAY} defaultMonth={MONTH} />);
+    expect(dayCell('2026-07-20').getAttribute('data-today')).toBe('true');
+    expect(dayCell('2026-07-20').getAttribute('aria-current')).toBe('date');
+    expect(dayCell('2026-07-20').getAttribute('tabindex')).toBe('0');
+    expect(dayCell('2026-07-15').getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('click selects a day (single) and fires onSelect with the Date', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <main>
+        <Calendar today={TODAY} defaultMonth={MONTH} onSelect={onSelect} />
+      </main>,
+    );
+    await user.click(dayCell('2026-07-15'));
+    expect(dayCell('2026-07-15').getAttribute('aria-selected')).toBe('true');
+    expect(dayCell('2026-07-15').getAttribute('data-selected')).toBe('true');
+    const arg = onSelect.mock.calls[0]?.[0] as Date;
+    expect(toISO(arg)).toBe('2026-07-15');
+    await assertAxeClean(body());
+  });
+
+  it('arrow keys move focus and cross the month boundary', async () => {
+    const user = userEvent.setup();
+    render(<Calendar today={TODAY} defaultMonth={MONTH} />);
+    dayCell('2026-07-31').focus();
+    await user.keyboard('{ArrowRight}');
+    expect(partElement(body(), 'heading')?.textContent).toBe('August 2026');
+    expect(document.activeElement).toBe(dayCell('2026-08-01'));
+    await user.keyboard('{ArrowDown}');
+    expect(document.activeElement).toBe(dayCell('2026-08-08'));
+  });
+
+  it('Home/End and PageDown navigate within and across months', async () => {
+    const user = userEvent.setup();
+    render(<Calendar today={TODAY} defaultMonth={MONTH} />);
+    dayCell('2026-07-20').focus();
+    await user.keyboard('{Home}');
+    expect(document.activeElement).toBe(dayCell('2026-07-01'));
+    await user.keyboard('{End}');
+    expect(document.activeElement).toBe(dayCell('2026-07-31'));
+    await user.keyboard('{PageUp}');
+    expect(partElement(body(), 'heading')?.textContent).toBe('June 2026');
+  });
+
+  it('Enter on a focused day selects it', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<Calendar today={TODAY} defaultMonth={MONTH} onSelect={onSelect} />);
+    dayCell('2026-07-09').focus();
+    await user.keyboard('{Enter}');
+    expect(dayCell('2026-07-09').getAttribute('aria-selected')).toBe('true');
+    expect(onSelect).toHaveBeenCalled();
+  });
+
+  it('the header controls page the visible month', async () => {
+    const user = userEvent.setup();
+    render(<Calendar today={TODAY} defaultMonth={MONTH} />);
+    await user.click(partElement(body(), 'prev')!);
+    expect(partElement(body(), 'heading')?.textContent).toBe('June 2026');
+    await user.click(partElement(body(), 'next')!);
+    await user.click(partElement(body(), 'next')!);
+    expect(partElement(body(), 'heading')?.textContent).toBe('August 2026');
+  });
+
+  it('range mode selects an ordered pair over two clicks', async () => {
+    const user = userEvent.setup();
+    render(
+      <main>
+        <Calendar mode="range" today={TODAY} defaultMonth={MONTH} />
+      </main>,
+    );
+    await user.click(dayCell('2026-07-20'));
+    await user.click(dayCell('2026-07-10'));
+    expect(dayCell('2026-07-10').getAttribute('aria-selected')).toBe('true');
+    expect(dayCell('2026-07-20').getAttribute('aria-selected')).toBe('true');
+    expect(dayCell('2026-07-15').getAttribute('data-in-range')).toBe('true');
+    expect(partElement(body(), 'grid')?.getAttribute('aria-multiselectable')).toBeNull();
+    await assertAxeClean(body());
+  });
+
+  it('multiple mode toggles membership', async () => {
+    const user = userEvent.setup();
+    render(<Calendar mode="multiple" today={TODAY} defaultMonth={MONTH} />);
+    expect(partElement(body(), 'grid')?.getAttribute('aria-multiselectable')).toBe('true');
+    await user.click(dayCell('2026-07-05'));
+    await user.click(dayCell('2026-07-12'));
+    expect(dayCell('2026-07-05').getAttribute('aria-selected')).toBe('true');
+    expect(dayCell('2026-07-12').getAttribute('aria-selected')).toBe('true');
+    await user.click(dayCell('2026-07-05'));
+    expect(dayCell('2026-07-05').getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('a date outside [fromDate, toDate] is disabled and refuses selection', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <Calendar
+        today={TODAY}
+        defaultMonth={MONTH}
+        fromDate={new Date(2026, 6, 10)}
+        toDate={new Date(2026, 6, 25)}
+        onSelect={onSelect}
+      />,
+    );
+    expect(dayCell('2026-07-05').getAttribute('aria-disabled')).toBe('true');
+    await user.click(dayCell('2026-07-05'));
+    expect(dayCell('2026-07-05').getAttribute('aria-selected')).toBe('false');
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('controlled: state follows the prop, callback reports the value to set', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const { rerender } = render(
+      <Calendar
+        today={TODAY}
+        defaultMonth={MONTH}
+        selected={new Date(2026, 6, 8)}
+        onSelect={onSelect}
+      />,
+    );
+    expect(dayCell('2026-07-08').getAttribute('aria-selected')).toBe('true');
+    await user.click(dayCell('2026-07-16'));
+    // Controlled: effective value does not move, but the callback reports it.
+    expect(toISO(onSelect.mock.calls[0]?.[0] as Date)).toBe('2026-07-16');
+    expect(dayCell('2026-07-08').getAttribute('aria-selected')).toBe('true');
+    expect(dayCell('2026-07-16').getAttribute('aria-selected')).toBe('false');
+    rerender(
+      <Calendar
+        today={TODAY}
+        defaultMonth={MONTH}
+        selected={new Date(2026, 6, 16)}
+        onSelect={onSelect}
+      />,
+    );
+    expect(dayCell('2026-07-16').getAttribute('aria-selected')).toBe('true');
+    expect(dayCell('2026-07-08').getAttribute('aria-selected')).toBe('false');
+  });
+});

--- a/packages/ui/test/components/calendar/calendar.conformance.test.tsx
+++ b/packages/ui/test/components/calendar/calendar.conformance.test.tsx
@@ -145,6 +145,24 @@ describe('calendar conformance [react]', () => {
     expect(partElement(body(), 'heading')?.textContent).toBe('August 2026');
   });
 
+  it('Enter activates a focused header control (native button, not suppressed)', async () => {
+    const user = userEvent.setup();
+    render(<Calendar today={TODAY} defaultMonth={MONTH} />);
+    partElement(body(), 'prev')!.focus();
+    await user.keyboard('{Enter}');
+    expect(partElement(body(), 'heading')?.textContent).toBe('June 2026');
+  });
+
+  it('an arrow on a header control does not steal focus into the grid', async () => {
+    const user = userEvent.setup();
+    render(<Calendar today={TODAY} defaultMonth={MONTH} />);
+    const prev = partElement(body(), 'prev')!;
+    prev.focus();
+    await user.keyboard('{ArrowRight}');
+    expect(document.activeElement).toBe(prev);
+    expect(partElement(body(), 'heading')?.textContent).toBe('July 2026');
+  });
+
   it('range mode selects an ordered pair over two clicks', async () => {
     const user = userEvent.setup();
     render(

--- a/packages/ui/test/components/calendar/calendar.conformance.test.tsx
+++ b/packages/ui/test/components/calendar/calendar.conformance.test.tsx
@@ -209,6 +209,31 @@ describe('calendar conformance [react]', () => {
     expect(onSelect).not.toHaveBeenCalled();
   });
 
+  it('the React disabled predicate marks a day inert and refuses click + keyboard select', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <Calendar
+        today={TODAY}
+        defaultMonth={MONTH}
+        disabled={(date) => date.getDate() === 15}
+        onSelect={onSelect}
+      />,
+    );
+    expect(dayCell('2026-07-15').getAttribute('aria-disabled')).toBe('true');
+    expect(dayCell('2026-07-15').getAttribute('data-disabled')).toBe('true');
+    await user.click(dayCell('2026-07-15'));
+    expect(dayCell('2026-07-15').getAttribute('aria-selected')).toBe('false');
+    dayCell('2026-07-15').focus();
+    await user.keyboard('{Enter}');
+    expect(dayCell('2026-07-15').getAttribute('aria-selected')).toBe('false');
+    expect(onSelect).not.toHaveBeenCalled();
+    // A day the predicate allows still selects.
+    await user.click(dayCell('2026-07-16'));
+    expect(dayCell('2026-07-16').getAttribute('aria-selected')).toBe('true');
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
   it('controlled: state follows the prop, callback reports the value to set', async () => {
     const user = userEvent.setup();
     const onSelect = vi.fn();

--- a/packages/ui/test/components/calendar/calendar.element.conformance.test.ts
+++ b/packages/ui/test/components/calendar/calendar.element.conformance.test.ts
@@ -107,6 +107,14 @@ describe('calendar conformance [wc]', () => {
     expect(partElement(document.body, 'heading')?.textContent).toBe('June 2026');
   });
 
+  it('Enter activates a focused header control (native button, not suppressed)', async () => {
+    const user = userEvent.setup();
+    await mount();
+    partElement(document.body, 'prev')!.focus();
+    await user.keyboard('{Enter}');
+    expect(partElement(document.body, 'heading')?.textContent).toBe('June 2026');
+  });
+
   it('range mode fills the interior between two clicks', async () => {
     const user = userEvent.setup();
     await mount({ mode: 'range' });

--- a/packages/ui/test/components/calendar/calendar.element.conformance.test.ts
+++ b/packages/ui/test/components/calendar/calendar.element.conformance.test.ts
@@ -1,0 +1,119 @@
+/**
+ * WC performance of the calendar score, driven end to end. The custom element
+ * scaffolds the light-DOM parts from its attributes and hands the root to
+ * bindCalendar -- the same score and controller the Astro performance drives.
+ * today/default-month are pinned so the projection is deterministic.
+ */
+import { cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { RaftersCalendar } from '../../../src/components/calendar/calendar.element';
+import {
+  calendarBehavior,
+  type CalendarConfig,
+} from '../../../src/components/calendar/calendar.behavior';
+import {
+  assertAxeClean,
+  assertContractFulfillment,
+  assertInstanceAriaFulfillment,
+  partElement,
+} from '../../harness/conformance';
+
+beforeAll(() => {
+  if (!customElements.get('rafters-calendar')) {
+    customElements.define('rafters-calendar', RaftersCalendar);
+  }
+});
+
+async function mount(attrs: Record<string, string> = {}): Promise<HTMLElement> {
+  const merged: Record<string, string> = {
+    today: '2026-07-20',
+    'default-month': '2026-07-01',
+    ...attrs,
+  };
+  const attrString = Object.entries(merged)
+    .map(([k, v]) => `${k}="${v}"`)
+    .join(' ');
+  document.body.innerHTML = `<main><rafters-calendar ${attrString}></rafters-calendar></main>`;
+  await Promise.resolve(); // let the element's deferred scaffold + bind run
+  return document.body.querySelector('[data-part="root"]') as HTMLElement;
+}
+
+function baseConfig(overrides: Partial<CalendarConfig> = {}): CalendarConfig {
+  return {
+    mode: 'single',
+    showOutsideDays: true,
+    fixedWeeks: false,
+    weekStartsOn: 0,
+    today: '2026-07-20',
+    defaultMonth: '2026-07-01',
+    ...overrides,
+  };
+}
+
+const dayCell = (iso: string) =>
+  document.body.querySelector<HTMLElement>(`[data-part="day"][data-value="${iso}"]`)!;
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+describe('calendar conformance [wc]', () => {
+  it('scaffolds a labelled grid with the seeded month, axe-clean', async () => {
+    await mount();
+    const grid = partElement(document.body, 'grid');
+    expect(grid?.getAttribute('role')).toBe('grid');
+    expect(grid?.hasAttribute('aria-labelledby')).toBe(true);
+    expect(partElement(document.body, 'heading')?.textContent).toBe('July 2026');
+    expect(dayCell('2026-07-20').getAttribute('data-today')).toBe('true');
+    await assertAxeClean(document.body);
+  });
+
+  it('contract: grid/heading/nav projections and per-day ARIA equal the DOM', async () => {
+    const root = await mount();
+    const config = baseConfig();
+    const state = calendarBehavior.initialState(config);
+    assertContractFulfillment(calendarBehavior, root, state, config, [
+      'grid',
+      'heading',
+      'prev',
+      'next',
+    ]);
+    assertInstanceAriaFulfillment(calendarBehavior, root, state, config);
+  });
+
+  it('click selects a day and reflects the projection', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(dayCell('2026-07-15'));
+    expect(dayCell('2026-07-15').getAttribute('aria-selected')).toBe('true');
+    expect(dayCell('2026-07-15').getAttribute('data-selected')).toBe('true');
+  });
+
+  it('arrow keys move focus and cross the month boundary', async () => {
+    const user = userEvent.setup();
+    await mount();
+    dayCell('2026-07-31').focus();
+    await user.keyboard('{ArrowRight}');
+    expect(partElement(document.body, 'heading')?.textContent).toBe('August 2026');
+    expect(document.activeElement).toBe(dayCell('2026-08-01'));
+  });
+
+  it('the header controls page the visible month', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(partElement(document.body, 'prev')!);
+    expect(partElement(document.body, 'heading')?.textContent).toBe('June 2026');
+  });
+
+  it('range mode fills the interior between two clicks', async () => {
+    const user = userEvent.setup();
+    await mount({ mode: 'range' });
+    await user.click(dayCell('2026-07-10'));
+    await user.click(dayCell('2026-07-20'));
+    expect(dayCell('2026-07-15').getAttribute('data-in-range')).toBe('true');
+    expect(dayCell('2026-07-10').getAttribute('aria-selected')).toBe('true');
+    expect(dayCell('2026-07-20').getAttribute('aria-selected')).toBe('true');
+  });
+});


### PR DESCRIPTION
## Summary

Ports `calendar` from `src/old/ui/calendar.tsx` to the behavior layer: one score
(`calendar.behavior.ts`) plus three thin decorators -- React (`calendar.tsx`),
Web Component (`calendar.element.ts`), and Astro (`calendar.astro`) -- all
driving the shared `bindCalendar`. The month grid navigates dates by
arrow/page/home/end keys (crossing month boundaries) and selects
single/multiple/range values.

Key design decisions (detailed in `docs/spec/components/calendar.md`):

- Composes `keyboard-handler` directly for the grid keys; the `keymap` is the
  pure claim record and the bind computes the payload (slider's shape).
- Deliberately does NOT compose `roving-focus`: its edge-clamping tabindex over a
  fixed DOM list cannot express arrow navigation that crosses the month boundary
  and re-pages the grid, so `focusedDate` is genuine score state. This is the one
  primitive that could not express the behavior.
- Selection is score state with a controlled shadow (slider's ownership-of-truth
  boundary), so WC and Astro select uncontrolled from server markup; the date
  math lives in exported pure helpers, never in a reducer.
- Days are focusable `role="gridcell"` cells so `aria-selected` sits on a role
  that allows it (the oracle put it on a `<button>`, which does not).
- Motion is left undeclared: no semantic `motion-*` token fits a calendar day
  yet, so per Spec 05 no numeric duration is hardcoded.

## Acceptance criteria mapping

### Component doc written

`docs/spec/components/calendar.md` follows the dialog.md register: composition,
config/state/actions, the parts + ARIA table, the keyboard map, the full
oracle-disposition table, the motion-token gap, and the WCAG obligations.
Evidence: packages/ui/docs/spec/components/calendar.md:27

### JSDoc intelligence tags present

The React component carries all four intelligence tags -- `@cognitive-load` with
the five-dimension breakdown, `@attention-economics`, `@trust-building`, and
`@accessibility` -- which the registry parses off the `.tsx`.
Evidence: packages/ui/src/components/calendar/calendar.tsx:33

### Behavior test (pure, no DOM)

`calendar.behavior.test.ts` exercises the score with zero DOM: date math and
boundary crossing, grid layout, selection transitions across all three modes,
the keymap claim record, the aria/day projections, and the reducers -- all
deterministic because today is an injected config field.
Evidence: packages/ui/test/components/calendar/calendar.behavior.test.ts:116

### Classes parity test

`calendar.classes.test.ts` asserts the day cell's sizing, focus ring, and every
projected state variant, and additionally asserts the absence of any raw
transition/duration literal, encoding the undeclared-motion decision.
Evidence: packages/ui/test/components/calendar/calendar.classes.test.ts:47

### Conformance test via the shared harness (aria + keymap against rendered DOM)

Three conformance suites run the one score through React, WC, and Astro adapters
against the shared harness, asserting axe-cleanliness, contract + per-instance
ARIA equality with the rendered DOM, and keymap-driven cross-month navigation and
selection.
Evidence: packages/ui/test/components/calendar/calendar.conformance.test.tsx:62

### shadcn drop-in parity where the component exists in shadcn

The React surface keeps the shadcn/react-day-picker prop shape -- `mode`,
mode-typed `selected`/`onSelect` over `Date` objects, `defaultMonth`, `fromDate`,
`toDate`, `showOutsideDays`, `fixedWeeks`, `weekStartsOn` -- converting to the
behavior's ISO-string selection at the boundary so existing call sites drop in.
Evidence: packages/ui/src/components/calendar/calendar.tsx:76

### `pnpm --filter @rafters/ui test:unit` green, `pnpm preflight` green

Both gates pass locally: `test:unit` runs green across the default and Astro
vitest configs, and full `preflight` (typecheck, lint, format check, unit, a11y,
build) completes with zero errors before commit.
Evidence: packages/ui/src/components/calendar/calendar.behavior.ts:472

## Not done

- The `multiple` mode ships (faithful to the oracle) but is exercised only in the
  React conformance arm and the pure behavior test, not in the WC/Astro arms.
- The `disabled(date)` predicate function stays a React-only affordance (a
  function is not serializable); WC/Astro express disabled dates via the
  serializable `fromDate`/`toDate` bounds (recorded in the disposition table).
- The oracle's `numberOfMonths` multi-month prop is dropped as out of scope (a
  composition of instances), noted in the disposition table.
- Motion is undeclared pending a fitting semantic `motion-*` token (#1899/#1902).
- Vue performance stays absent per the wave scope.

Closes #1761
