### PR TITLE
feat(ui): port context-menu to the behavior layer

### DIFF
--- a/packages/ui/docs/spec/components/context-menu.md
+++ b/packages/ui/docs/spec/components/context-menu.md
@@ -1,0 +1,163 @@
+# Component Spec -- Context Menu
+
+Status: PORTED (wave-4). The first menu-collection-popup on the behavior layer.
+
+Right-click contextual action popup. Same menu machinery as a dropdown -- a
+`role="menu"` surface of items with roving focus, typeahead, and dismissal -- but
+summoned by a pointer gesture AT the cursor point instead of anchored to a
+trigger. Replaces the imperative `old/ui/context-menu.tsx` effects wholesale.
+
+Files (`src/components/context-menu/`):
+
+```
+context-menu.classes.ts   context-menu.behavior.ts
+context-menu.tsx          context-menu.element.ts   context-menu.astro
+```
+
+Tests mirror into `test/components/context-menu/`: behavior (pure), classes,
+and React + WC + Astro conformance via the shared harness.
+
+## Composition
+
+One custom slice (not `disclosable`, because the open action carries the pointer
+point): `context-menu` owns the whole score. Impure work is composed DIRECTLY
+from the primitives -- effects-as-data is retired (Spec 03).
+
+```
+context-menu slice     state {open, x, y}, actions openAt/close, trigger/content parts,
+                       aria (menu orientation + presence), Escape keymap
+collision-detector     computePosition at a {x, y} point anchor (cursor placement)
+roving-focus           vertical roving tabindex across the items
+typeahead              type-to-search over the items
+outside-click          onPointerDownOutside dismissal
+```
+
+`startContextMenuEffects({ content, loop, onDismiss })` composes the
+roving/typeahead/dismiss trio and returns one cleanup; both `bindContextMenu`
+(WC/Astro) and a React `useEffect` call it on the open transition and tear it
+down on close. `positionContextMenuContent(content, point, config)` runs the
+collision math once, shared by every client so placement lives in ONE place.
+
+Submenus are a SECOND score, `contextSubMenu` -- a nested disclosure widget gets
+its own `createBehavior` instance (a distinct behavior, NOT a second cell folded
+into the parent's one cell). It has the same menu machinery, opened from a
+sub-trigger that is itself a menuitem of the parent and anchored to the RIGHT of
+that trigger via `positionSubContent`. The sub-content is moved to `document.body`
+so it escapes the parent's `overflow-hidden` AND leaves the parent's roving and
+keyboard scope (nested menuitems would otherwise pollute the parent's item list).
+`bindContextSubMenu` binds one submenu and recurses into nested ones; the React
+`ContextMenu.Sub`/`SubTrigger`/`SubContent` mirror it. Hover-open uses a plain
+`setTimeout` (`SUB_MENU_HOVER_DELAY`, a JS pointer-intent delay -- no motion token
+applies); keyboard is the required floor.
+
+Highlighted item is NOT score state: it is ephemeral DOM state owned by
+roving-focus (the focused item's tabindex), exactly as navigation-menu keeps
+focus movement out of the score. The pointer point IS score state (`openAt`
+records it), because a controlled/SSR client must be able to project it.
+
+## Config, state, actions
+
+```ts
+interface ContextMenuConfig {
+  open?: boolean;            // controlled
+  defaultOpen?: boolean;    // uncontrolled seed
+  loop?: boolean;           // roving wrap, default true
+  avoidCollisions?: boolean; // flip/clamp off viewport edges, default true
+}
+interface ContextMenuState { open: boolean; x: number; y: number }
+type ContextMenuActions = {
+  openAt: { x: number; y: number }; // right-click opens/repositions at the point
+  close: undefined;
+};
+```
+
+Controlled/uncontrolled per boundary 4: `config.open` shadows intrinsic
+`state.open`; projections and gates read `isContextMenuOpen(state, config)`. The
+idempotence gate rejects `close` when already closed, so a consumer callback
+fires once per real close. `openAt` is never gated: re-opening at a new point is
+a legitimate move (the menu follows the cursor).
+
+## Parts and ARIA
+
+| Part | Presence | ARIA |
+| --- | --- | --- |
+| trigger | always | `data-state`; no role (a right-click region has no keyboard equivalent, so an `aria-haspopup` on a non-interactive host would mislead AT). `tabindex="-1"` so focus can be restored here on close |
+| content | while open (React unmounts; WC/Astro `hidden`-toggle) | `role="menu"`, `aria-orientation="vertical"`, `data-state`, `hidden` (absent while open) |
+| sub-trigger | always (a menuitem of the parent) | `role="menuitem"`, `aria-haspopup="menu"`, `aria-expanded`, `aria-controls` (only while the submenu is open), `data-state` |
+| sub-content | while the submenu is open | `role="menu"`, `aria-orientation="vertical"`, `data-state`, `hidden` (absent while open) |
+
+Items are `menuitem` / `menuitemcheckbox` / `menuitemradio` in the decorators;
+they carry no per-instance sibling ids, so the score declares no `instanceAria`
+(roving owns their tabindex; typeahead owns their search). Disabled items carry
+`data-disabled` and are skipped by both primitives.
+
+## Keyboard and effects
+
+- `keymap`: Escape -> `close` (idempotence-gated). Focus opens inside the menu,
+  so a content-scoped listener is sufficient.
+- Arrow Up/Down, Home/End: roving-focus (vertical), wrapping when `loop`.
+- Printable keys: typeahead focuses the first matching item.
+- Enter/Space on a focused item: activate it (native `<div>` items emit no
+  click), then the click path selects-and-closes.
+- Outside pointerdown: `onPointerDownOutside(content, close)`.
+- On open: focus moves to the first enabled item. On close: focus restores to
+  the trigger.
+- Submenu: ArrowRight (or Enter/Space) on a sub-trigger opens the submenu and
+  focuses its first item; ArrowLeft or Escape from the sub-content closes it and
+  restores focus to the sub-trigger; hover-intent opens/closes after
+  `SUB_MENU_HOVER_DELAY`. Selecting a submenu item collapses the whole tree;
+  closing the parent collapses any open submenu.
+
+## Motion
+
+The content enters on the semantic `motion-dropdown-in` token (fade + zoom, the
+dropdown duration tier and enter curve), toggled by `data-[state=open]`. No raw
+numeric durations or hand-picked easings (Spec 05). Positioning uses `left`/`top`
+(not `transform`) so the enter transform (scale) is free for the token to drive.
+
+Exit motion (`motion-dropdown-out`) is intentionally NOT declared: the content
+toggles `hidden` when closed, so the exiting node leaves the box model before an
+out transition can play. A played exit awaits the Presence layer (Spec 04);
+declaring it now would be a silent no-op. No motion token is missing -- both
+`motion-dropdown-in` and `-out` exist; only the presence plumbing to run the exit
+does not yet.
+
+## Oracle dispositions (src/old/ui/context-menu.tsx, boundary 9)
+
+| Oracle feature | Disposition |
+| --- | --- |
+| right-click opens at the cursor `{clientX, clientY}` | contract (now score state `openAt`, placed via collision-detector's point anchor) |
+| controlled/uncontrolled + onOpenChange | contract |
+| Trigger / Content / Item / CheckboxItem / RadioGroup / RadioItem / Separator / Label / Group / Shortcut | contract |
+| Portal | contract (thin passthrough; Content brings its own portal) |
+| Escape closes | contract (moved from a document listener to the content keymap) |
+| outside pointerdown closes | contract (composed via outside-click, not the standalone dismissable-layer stack) |
+| roving focus + typeahead + focus-first-on-open | contract (composed from the primitives on the open transition) |
+| avoidCollisions / viewport-edge clamp | contract (hand-rolled edge math replaced by collision-detector `computePosition`) |
+| `asChild` on Trigger | framework affordance (React) |
+| CheckboxItem/RadioItem check + dot indicator SVGs | framework affordance (React markup) |
+| `onSelect` cancelable event, `onCheckedChange`, radio `onValueChange` | contract (consumer callbacks at the React boundary) |
+| Sub / SubTrigger / SubContent (nested submenu, hover-intent) | contract -- its own `contextSubMenu` score, composed from the same primitives (roving/typeahead + collision-detector anchored to the sub-trigger). Hover-open is a plain `setTimeout` (as the oracle had), not a new primitive. Bound in all three frameworks; supports arbitrary nesting |
+| `alignOffset` prop on Content | dropped -- cursor placement uses side='bottom' align='start' at the point; the offset knob had no wave-4 consumer and no oracle test exercised a non-zero value |
+| raw `duration-100` transitions and `animate-in`/`zoom-*` utilities | defect-do-not-port -- replaced by the semantic motion tokens (Spec 05 prohibits raw numeric durations) |
+
+## Deltas from the oracle
+
+1. `tabindex="-1"` on the trigger so `focus()` can restore focus to the
+   right-click region when the menu closes, without adding it to the Tab order.
+2. Positioning via `left`/`top` rather than the oracle's `left`/`top` on a React
+   state object -- the point now lives in the score, read by every client.
+3. Content presence: React unmounts the closed menu; WC/Astro keep it in light
+   DOM and toggle `hidden` (the bind reads it for the composed primitives) --
+   the same split dialog uses.
+
+## WCAG 2.1 AA obligations
+
+- 1.3.1 / 4.1.2: `role="menu"`, `aria-orientation`, and the menuitem roles are
+  asserted against real DOM by the harness; disabled items carry `aria-disabled`.
+- 2.1.1: full keyboard operation -- arrows/Home/End (roving), typeahead,
+  Enter/Space (activate), Escape (dismiss).
+- 2.4.3 Focus Order: focus moves into the menu on open (first enabled item) and
+  restores to the trigger on close.
+- 4.1.2 name/role/value: the menu carries an accessible name (consumer
+  `aria-label` in React/WC, the trigger label in the Astro SSR harness).

--- a/packages/ui/src/components/context-menu/context-menu-sub.astro
+++ b/packages/ui/src/components/context-menu/context-menu-sub.astro
@@ -1,0 +1,81 @@
+---
+/**
+ * Recursive submenu sub-template for the Astro performance. Renders a sub-trigger
+ * plus its (initially closed, hidden) sub-content, recursing into nested
+ * submenus via itself so the SSR markup supports arbitrary nesting -- the same
+ * depth bindContextSubMenu binds. Not a decorator; a fragment of the one Astro
+ * performance, sharing the same classes and the same data-part contract.
+ */
+import ContextMenuSub from './context-menu-sub.astro';
+import { contextMenuClasses } from './context-menu.classes';
+
+type SubEntry =
+  | { type?: 'item'; label: string; disabled?: boolean }
+  | { type: 'sub'; label: string; subItems: SubEntry[] };
+
+interface Props {
+  id: string;
+  label: string;
+  subItems: SubEntry[];
+}
+
+const { id, label, subItems } = Astro.props;
+const classes = contextMenuClasses({}, { open: false, x: 0, y: 0 });
+---
+
+<div data-part="sub">
+  <div
+    data-part="sub-trigger"
+    id={`${id}-trigger`}
+    role="menuitem"
+    tabindex="-1"
+    aria-haspopup="menu"
+    aria-expanded="false"
+    data-state="closed"
+    class={classes.subTrigger}
+  >
+    {label}
+    <svg
+      class={classes.subTriggerChevron}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      stroke-width="2"
+      aria-hidden="true"
+    >
+      <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+    </svg>
+  </div>
+  <div
+    data-part="sub-content"
+    id={`${id}-content`}
+    role="menu"
+    aria-label={label}
+    data-state="closed"
+    hidden
+    class={classes.content}
+    style="position: fixed; left: 0; top: 0;"
+  >
+    {
+      subItems.map((subEntry, subIndex) =>
+        subEntry.type === 'sub' ? (
+          <ContextMenuSub
+            id={`${id}-sub-${subIndex}`}
+            label={subEntry.label}
+            subItems={subEntry.subItems}
+          />
+        ) : (
+          <div
+            role="menuitem"
+            tabindex="-1"
+            aria-disabled={subEntry.disabled ? 'true' : undefined}
+            data-disabled={subEntry.disabled ? '' : undefined}
+            class={classes.item}
+          >
+            {subEntry.label}
+          </div>
+        ),
+      )
+    }
+  </div>
+</div>

--- a/packages/ui/src/components/context-menu/context-menu.astro
+++ b/packages/ui/src/components/context-menu/context-menu.astro
@@ -14,15 +14,21 @@ import {
   type ContextMenuPart,
 } from './context-menu.behavior';
 import { contextMenuClasses } from './context-menu.classes';
+import ContextMenuSub from './context-menu-sub.astro';
 import type { PartIds } from '../../lib/contract';
+
+/** A submenu item: a leaf, or a further nested submenu. */
+type SubEntry =
+  | { type?: 'item'; label: string; disabled?: boolean }
+  | { type: 'sub'; label: string; subItems: { label: string; disabled?: boolean }[] };
 
 interface MenuEntry {
   type?: 'item' | 'separator' | 'label' | 'sub';
   label?: string;
   shortcut?: string;
   disabled?: boolean;
-  /** Items of a submenu (type='sub'). */
-  subItems?: { label: string; disabled?: boolean }[];
+  /** Items of a submenu (type='sub'); a subItem may itself be a nested submenu. */
+  subItems?: SubEntry[];
 }
 
 interface Props {
@@ -82,54 +88,12 @@ const triggerProps = {
           return <div class={classes.label}>{entry.label}</div>;
         }
         if (entry.type === 'sub') {
-          const subId = `${id}-sub-${index}`;
           return (
-            <div data-part="sub">
-              <div
-                data-part="sub-trigger"
-                id={`${subId}-trigger`}
-                role="menuitem"
-                tabindex="-1"
-                aria-haspopup="menu"
-                aria-expanded="false"
-                data-state="closed"
-                class={classes.subTrigger}
-              >
-                {entry.label}
-                <svg
-                  class={classes.subTriggerChevron}
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  aria-hidden="true"
-                >
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
-                </svg>
-              </div>
-              <div
-                data-part="sub-content"
-                id={`${subId}-content`}
-                role="menu"
-                aria-label={entry.label}
-                data-state="closed"
-                hidden
-                class={classes.content}
-                style="position: fixed; left: 0; top: 0;"
-              >
-                {(entry.subItems ?? []).map((subEntry) => (
-                  <div
-                    role="menuitem"
-                    tabindex="-1"
-                    aria-disabled={subEntry.disabled ? 'true' : undefined}
-                    data-disabled={subEntry.disabled ? '' : undefined}
-                    class={classes.item}
-                  >
-                    {subEntry.label}
-                  </div>
-                ))}
-              </div>
-            </div>
+            <ContextMenuSub
+              id={`${id}-sub-${index}`}
+              label={entry.label ?? ''}
+              subItems={entry.subItems ?? []}
+            />
           );
         }
         return (

--- a/packages/ui/src/components/context-menu/context-menu.astro
+++ b/packages/ui/src/components/context-menu/context-menu.astro
@@ -1,0 +1,162 @@
+---
+/**
+ * Astro performance (controller) for context-menu.
+ *
+ * Server-renders the full LIGHT-DOM markup with classes and the score's initial
+ * (closed) projection already applied, so the menu is correct and inert before
+ * any JS. The <script> then hands each instance to bindContextMenu -- the SAME
+ * DOM-native controller the Web Component uses. One score, three performances,
+ * zero drift.
+ */
+import {
+  contextMenu,
+  type ContextMenuConfig,
+  type ContextMenuPart,
+} from './context-menu.behavior';
+import { contextMenuClasses } from './context-menu.classes';
+import type { PartIds } from '../../lib/contract';
+
+interface MenuEntry {
+  type?: 'item' | 'separator' | 'label' | 'sub';
+  label?: string;
+  shortcut?: string;
+  disabled?: boolean;
+  /** Items of a submenu (type='sub'). */
+  subItems?: { label: string; disabled?: boolean }[];
+}
+
+interface Props {
+  id: string;
+  triggerLabel: string;
+  items: MenuEntry[];
+  loop?: boolean;
+  avoidCollisions?: boolean;
+}
+
+const { id, triggerLabel, items, loop = true, avoidCollisions = true } = Astro.props;
+
+const config: ContextMenuConfig = { loop, avoidCollisions };
+const state = contextMenu.initialState(config);
+const classes = contextMenuClasses(config, state);
+
+const ids = {} as PartIds<ContextMenuPart>;
+for (const part of Object.keys(contextMenu.parts) as ContextMenuPart[]) {
+  ids[part] = `${id}-${part}`;
+}
+const aria = contextMenu.aria(state, config, ids);
+
+// The trigger's attributes are assembled here so the element carries no literal
+// class attribute in its tag (the inline wrapper is styling-neutral chrome).
+const triggerProps = {
+  'data-part': 'trigger',
+  id: ids.trigger,
+  tabindex: '-1',
+  class: classes.trigger,
+  ...aria.trigger,
+};
+---
+
+<div
+  data-part="root"
+  data-context-menu-root
+  id={ids.root}
+  loop={String(loop)}
+  avoid-collisions={String(avoidCollisions)}
+>
+  <span {...triggerProps}>{triggerLabel}</span>
+  <div
+    data-part="content"
+    id={ids.content}
+    role="menu"
+    aria-label={triggerLabel}
+    class={classes.content}
+    style="position: fixed; left: 0; top: 0;"
+    {...aria.content}
+  >
+    {
+      items.map((entry, index) => {
+        if (entry.type === 'separator') {
+          return <hr class={classes.separator} />;
+        }
+        if (entry.type === 'label') {
+          return <div class={classes.label}>{entry.label}</div>;
+        }
+        if (entry.type === 'sub') {
+          const subId = `${id}-sub-${index}`;
+          return (
+            <div data-part="sub">
+              <div
+                data-part="sub-trigger"
+                id={`${subId}-trigger`}
+                role="menuitem"
+                tabindex="-1"
+                aria-haspopup="menu"
+                aria-expanded="false"
+                data-state="closed"
+                class={classes.subTrigger}
+              >
+                {entry.label}
+                <svg
+                  class={classes.subTriggerChevron}
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  aria-hidden="true"
+                >
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                </svg>
+              </div>
+              <div
+                data-part="sub-content"
+                id={`${subId}-content`}
+                role="menu"
+                aria-label={entry.label}
+                data-state="closed"
+                hidden
+                class={classes.content}
+                style="position: fixed; left: 0; top: 0;"
+              >
+                {(entry.subItems ?? []).map((subEntry) => (
+                  <div
+                    role="menuitem"
+                    tabindex="-1"
+                    aria-disabled={subEntry.disabled ? 'true' : undefined}
+                    data-disabled={subEntry.disabled ? '' : undefined}
+                    class={classes.item}
+                  >
+                    {subEntry.label}
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        }
+        return (
+          <div
+            role="menuitem"
+            tabindex="-1"
+            aria-disabled={entry.disabled ? 'true' : undefined}
+            data-disabled={entry.disabled ? '' : undefined}
+            class={classes.item}
+          >
+            {entry.label}
+            {entry.shortcut ? <kbd class={classes.shortcut}>{entry.shortcut}</kbd> : null}
+          </div>
+        );
+      })
+    }
+  </div>
+</div>
+
+<script>
+  import { bindContextMenu } from './context-menu.behavior';
+
+  // The <script> is bundled and runs once per page; bind every instance's
+  // server-rendered markup. Same controller as the Web Component.
+  for (const root of document.querySelectorAll<HTMLElement>('[data-context-menu-root]')) {
+    if (root.dataset['bound'] === 'true') continue;
+    root.dataset['bound'] = 'true';
+    bindContextMenu(root);
+  }
+</script>

--- a/packages/ui/src/components/context-menu/context-menu.behavior.ts
+++ b/packages/ui/src/components/context-menu/context-menu.behavior.ts
@@ -1,0 +1,657 @@
+import { compose, type Slice } from '../../lib/compose';
+import {
+  createBehavior,
+  type AriaAttrs,
+  type BehaviorSpec,
+  type PartIds,
+} from '../../lib/contract';
+import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { computePosition } from '../../primitives/collision-detector';
+import { onPointerDownOutside } from '../../primitives/outside-click';
+import { createRovingFocus } from '../../primitives/roving-focus';
+import { createTypeahead } from '../../primitives/typeahead';
+
+/**
+ * Context menu: the right-click popup. Same menu machinery as a dropdown --
+ * a role="menu" surface of items with roving focus, typeahead, and dismissal --
+ * but opened by a pointer gesture AT the cursor point rather than anchored to a
+ * trigger. Replaces the imperative old/ui/context-menu.tsx effects wholesale.
+ *
+ * The score's state is the open axis plus the pointer point the menu opens at.
+ * Which item is HIGHLIGHTED is not state here: it is ephemeral DOM state owned
+ * by the roving-focus primitive (the focused item's tabindex), exactly as
+ * navigation-menu keeps focus movement out of the score.
+ */
+export interface ContextMenuConfig {
+  /** Controlled open value. Passed fresh, never stored. */
+  open?: boolean | undefined;
+  /** Uncontrolled seed. */
+  defaultOpen?: boolean | undefined;
+  /** Roving-focus wrap at the ends of the item list. Default true. */
+  loop?: boolean | undefined;
+  /** Flip/clamp the menu away from viewport edges. Default true. */
+  avoidCollisions?: boolean | undefined;
+}
+
+export interface ContextMenuState {
+  open: boolean;
+  /** Viewport x the menu opened at (the right-click clientX). */
+  x: number;
+  /** Viewport y the menu opened at (the right-click clientY). */
+  y: number;
+}
+
+export type ContextMenuActions = {
+  /** Open (or reposition) the menu at a pointer point. */
+  openAt: { x: number; y: number };
+  /** Close the menu. */
+  close: undefined;
+};
+
+export type ContextMenuPart = 'trigger' | 'content';
+
+/** Items the roving-focus and typeahead primitives navigate. Disabled items
+ *  carry data-disabled and are skipped (the primitives filter them too). */
+export const MENU_ITEM_SELECTOR =
+  '[role="menuitem"]:not([data-disabled]),' +
+  '[role="menuitemcheckbox"]:not([data-disabled]),' +
+  '[role="menuitemradio"]:not([data-disabled])';
+
+/** The effective open value: a controlled `open` shadows intrinsic state. */
+export function isContextMenuOpen(state: ContextMenuState, config: ContextMenuConfig): boolean {
+  return config.open ?? state.open;
+}
+
+const contextMenuSlice: Slice<
+  ContextMenuConfig,
+  ContextMenuState,
+  ContextMenuActions,
+  ContextMenuPart
+> = {
+  name: 'context-menu',
+  parts: {
+    // The right-clickable region. Deliberately no ARIA role: a context menu is
+    // summoned by a pointer gesture that has no keyboard equivalent, so the
+    // oracle kept the trigger a plain element (an aria-haspopup on a
+    // non-interactive host would mislead AT). data-state is the styling hook.
+    trigger: {},
+    // The menu surface. Present-but-hidden while closed (presence): kept in
+    // light DOM so roving-focus/typeahead read it, hidden so a closed menu is
+    // out of the accessibility tree.
+    content: { role: 'menu', optional: true },
+  },
+  initialState: (config) => ({
+    open: config.open ?? config.defaultOpen ?? false,
+    x: 0,
+    y: 0,
+  }),
+  actions: {
+    // openAt replaces the point so a second right-click moves the menu.
+    openAt: (_state, { x, y }) => ({ open: true, x, y }),
+    close: (state) => ({ ...state, open: false }),
+  },
+  // Idempotence gate on close so a controlled consumer's callback fires once
+  // per real transition. openAt is always allowed: re-opening at a new point is
+  // a legitimate move, not a no-op.
+  canDispatch: (state, action, config) =>
+    action === 'close' ? isContextMenuOpen(state, config) : true,
+  aria: (state, config) => {
+    const open = isContextMenuOpen(state, config);
+    return {
+      trigger: { 'data-state': open ? 'open' : 'closed' },
+      content: {
+        'aria-orientation': 'vertical',
+        'data-state': open ? 'open' : 'closed',
+        hidden: open ? undefined : true,
+      },
+    };
+  },
+  // WAI-ARIA menu: Escape dismisses. The idempotence gate makes it a no-op when
+  // already closed. Arrow/Home/End navigation belongs to roving-focus; printable
+  // keys to typeahead; Enter/Space activation to the item click path.
+  keymap: (event) => (event.key === 'Escape' ? 'close' : null),
+};
+
+export const contextMenu: BehaviorSpec<
+  ContextMenuConfig,
+  ContextMenuState,
+  ContextMenuActions,
+  ContextMenuPart
+> = compose('context-menu', contextMenuSlice);
+
+// ==================== Submenu score ====================
+
+/**
+ * A nested submenu is an independent disclosure widget, so it gets its OWN
+ * behavior instance (createBehavior(contextSubMenu)) -- NOT a second cell folded
+ * into the parent score. Same shape as the parent menu (a role="menu" surface of
+ * items with roving and typeahead), but opened from a sub-trigger that is itself
+ * a menuitem of the parent, and anchored to the RIGHT of that trigger.
+ */
+export interface ContextSubMenuConfig {
+  open?: boolean | undefined;
+  defaultOpen?: boolean | undefined;
+  loop?: boolean | undefined;
+  avoidCollisions?: boolean | undefined;
+}
+
+export interface ContextSubMenuState {
+  open: boolean;
+}
+
+export type ContextSubMenuActions = {
+  open: undefined;
+  close: undefined;
+};
+
+export type ContextSubMenuPart = 'subTrigger' | 'subContent';
+
+export function isSubMenuOpen(state: ContextSubMenuState, config: ContextSubMenuConfig): boolean {
+  return config.open ?? state.open;
+}
+
+const contextSubMenuSlice: Slice<
+  ContextSubMenuConfig,
+  ContextSubMenuState,
+  ContextSubMenuActions,
+  ContextSubMenuPart
+> = {
+  name: 'context-sub-menu',
+  parts: {
+    // The sub-trigger is a menuitem of the PARENT menu that discloses a submenu.
+    subTrigger: { role: 'menuitem' },
+    subContent: { role: 'menu', optional: true },
+  },
+  initialState: (config) => ({ open: config.open ?? config.defaultOpen ?? false }),
+  actions: {
+    open: () => ({ open: true }),
+    close: () => ({ open: false }),
+  },
+  canDispatch: (state, action, config) =>
+    action === 'open' ? !isSubMenuOpen(state, config) : isSubMenuOpen(state, config),
+  aria: (state, config, ids) => {
+    const open = isSubMenuOpen(state, config);
+    return {
+      subTrigger: {
+        'aria-haspopup': 'menu',
+        'aria-expanded': open ? 'true' : 'false',
+        // Empty-id sentinel: reference the content only when its id is real.
+        'aria-controls': open && ids.subContent ? ids.subContent : undefined,
+        'data-state': open ? 'open' : 'closed',
+      },
+      subContent: {
+        'aria-orientation': 'vertical',
+        'data-state': open ? 'open' : 'closed',
+        hidden: open ? undefined : true,
+      },
+    };
+  },
+  // WAI-ARIA submenu keyboard: ArrowRight (or Enter/Space) on the trigger opens
+  // and enters; ArrowLeft or Escape from the content closes back to the trigger.
+  keymap: (event, _state, part) => {
+    if (
+      part === 'subTrigger' &&
+      (event.key === 'ArrowRight' || event.key === 'Enter' || event.key === ' ')
+    ) {
+      return 'open';
+    }
+    if (part === 'subContent' && (event.key === 'ArrowLeft' || event.key === 'Escape')) {
+      return 'close';
+    }
+    return null;
+  },
+};
+
+export const contextSubMenu: BehaviorSpec<
+  ContextSubMenuConfig,
+  ContextSubMenuState,
+  ContextSubMenuActions,
+  ContextSubMenuPart
+> = compose('context-sub-menu', contextSubMenuSlice);
+
+/** Hover-open/close intent delay for submenus, ms (matches the oracle). This is
+ *  a JS pointer-intent timeout, not a CSS transition -- no motion token applies. */
+export const SUB_MENU_HOVER_DELAY = 100;
+
+/** Apply a resolved aria projection to an element (validate:false skips the
+ *  author-input coercion that would flip a projected 'false'). */
+function applyProjection(el: HTMLElement, attrs: AriaAttrs): void {
+  for (const [name, value] of Object.entries(attrs)) {
+    updateAriaAttribute(el, name as never, value as never, { validate: false });
+  }
+}
+
+/**
+ * Position the menu at the pointer point via the collision-detector primitive,
+ * treating the point as a zero-size anchor. side='bottom' align='start' places
+ * the menu's top-left corner at the cursor (the context-menu convention);
+ * avoidCollisions flips/clamps it away from the viewport edges. Positioning uses
+ * left/top (not transform) so the enter transform (scale) stays free for motion.
+ * Shared by every client so the placement decision lives in ONE place.
+ */
+export function positionContextMenuContent(
+  content: HTMLElement,
+  point: { x: number; y: number },
+  config: ContextMenuConfig,
+): void {
+  const result = computePosition(point, content, {
+    side: 'bottom',
+    align: 'start',
+    avoidCollisions: config.avoidCollisions ?? true,
+  });
+  content.style.position = 'fixed';
+  content.style.left = `${Math.round(result.x)}px`;
+  content.style.top = `${Math.round(result.y)}px`;
+}
+
+/** Focus the first enabled item -- the menu opens with keyboard focus inside it
+ *  (WAI-ARIA menu). */
+function focusFirstItem(content: HTMLElement): void {
+  content.querySelector<HTMLElement>(MENU_ITEM_SELECTOR)?.focus();
+}
+
+/** The parts/config the roving/typeahead/dismiss trio composes against. */
+export interface ContextMenuEffectPorts {
+  /** The menu surface: roving-focus and typeahead drive its items; an outside
+   *  pointerdown beyond it dismisses. */
+  content: HTMLElement;
+  /** Roving-focus wrap. */
+  loop: boolean;
+  /** Dismiss request (outside pointerdown). */
+  onDismiss: () => void;
+}
+
+/**
+ * The context-menu DOM trio, composed directly from the primitives: roving
+ * tabindex down the item list, type-to-search over the items, and
+ * outside-pointerdown dismissal. Started on the open transition and torn down on
+ * close by BOTH bindContextMenu and the React client's effect -- one instance
+ * per open, cleanup releases LIFO. Escape is NOT here: it rides the score's
+ * keymap (Spec 05 canonical dismissal), so the pure behavior test covers it.
+ */
+export function startContextMenuEffects({
+  content,
+  loop,
+  onDismiss,
+}: ContextMenuEffectPorts): () => void {
+  const releaseRoving = createRovingFocus(content, { orientation: 'vertical', loop });
+  const releaseTypeahead = createTypeahead(content, {
+    getItems: () => content.querySelectorAll<HTMLElement>(MENU_ITEM_SELECTOR),
+    onMatch: (item) => item.focus(),
+  });
+  const releaseDismiss = onPointerDownOutside(content, (event) => {
+    // An open submenu's content portals OUT of `content`, so a pointerdown
+    // inside it reads as "outside" -- spare it, or opening a submenu would
+    // dismiss the whole menu.
+    if ((event.target as HTMLElement).closest?.('[data-part="sub-content"]')) return;
+    onDismiss();
+  });
+  return () => {
+    releaseDismiss();
+    releaseTypeahead();
+    releaseRoving();
+  };
+}
+
+/**
+ * Anchor a submenu's content to the RIGHT of its sub-trigger via the
+ * collision-detector primitive (flipping to the left near the viewport edge).
+ * left/top positioning, shared by every client.
+ */
+export function positionSubContent(
+  subTrigger: HTMLElement,
+  subContent: HTMLElement,
+  config: ContextSubMenuConfig,
+): void {
+  const result = computePosition(subTrigger, subContent, {
+    side: 'right',
+    align: 'start',
+    avoidCollisions: config.avoidCollisions ?? true,
+  });
+  subContent.style.position = 'fixed';
+  subContent.style.left = `${Math.round(result.x)}px`;
+  subContent.style.top = `${Math.round(result.y)}px`;
+}
+
+/** Roving + typeahead over a submenu's items. Dismissal is NOT here: the parent
+ *  owns whole-tree outside-dismiss, and the submenu closes via ArrowLeft/Escape
+ *  or hover-leave. Shared by the bind and the React client. */
+export function startContextSubMenuEffects(subContent: HTMLElement, loop: boolean): () => void {
+  const releaseRoving = createRovingFocus(subContent, { orientation: 'vertical', loop });
+  const releaseTypeahead = createTypeahead(subContent, {
+    getItems: () => subContent.querySelectorAll<HTMLElement>(MENU_ITEM_SELECTOR),
+    onMatch: (item) => item.focus(),
+  });
+  return () => {
+    releaseTypeahead();
+    releaseRoving();
+  };
+}
+
+/** A live submenu binding: its teardown, plus a `close` the parent calls to
+ *  collapse the whole tree when it closes or an item is selected. */
+export interface SubMenuBinding {
+  teardown: () => void;
+  close: () => void;
+}
+
+/** The submenus that are DIRECT children of `container` -- those with no other
+ *  [data-part="sub"] between them and it. Each binding recurses into its own
+ *  content, so binding the direct ones binds the whole tree exactly once. */
+export function directSubMenus(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>('[data-part="sub"]')).filter((el) => {
+    const ancestorSub = el.parentElement?.closest<HTMLElement>('[data-part="sub"]') ?? null;
+    return ancestorSub === null || !container.contains(ancestorSub);
+  });
+}
+
+/**
+ * Bind ONE submenu (recursing into nested submenus). The sub-content is moved to
+ * document.body on bind so it escapes the parent's `overflow-hidden` AND leaves
+ * the parent's roving/keyboard scope (nested menuitems would otherwise pollute
+ * the parent's item list). Opens on ArrowRight/Enter/Space/click or hover-intent,
+ * closes on ArrowLeft/Escape/hover-leave; selecting an item calls `onSelect` to
+ * collapse the whole tree.
+ */
+export function bindContextSubMenu(
+  subEl: HTMLElement,
+  options: { onSelect: () => void },
+): SubMenuBinding {
+  const subTrigger = subEl.querySelector<HTMLElement>('[data-part="sub-trigger"]');
+  const subContent = subEl.querySelector<HTMLElement>('[data-part="sub-content"]');
+  if (!subTrigger || !subContent) return { teardown: () => {}, close: () => {} };
+
+  const config: ContextSubMenuConfig = {
+    loop: subEl.getAttribute('loop') !== 'false',
+    avoidCollisions: subEl.getAttribute('avoid-collisions') !== 'false',
+  };
+
+  // Move the sub-content out of the parent menu (see doc above). The original
+  // parent is remembered so unbind can restore the markup.
+  const parent = subContent.parentElement;
+  const nextSibling = subContent.nextSibling;
+  document.body.appendChild(subContent);
+
+  const { memory, dispatch } = createBehavior(contextSubMenu, config);
+  const request = (action: keyof ContextSubMenuActions): boolean => dispatch(action, config);
+
+  const ids = {
+    subTrigger: subTrigger.id,
+    subContent: subContent.id,
+  } as PartIds<ContextSubMenuPart>;
+
+  // Nested submenus live inside THIS sub-content -- bind the direct ones (each
+  // recurses) with the same whole-tree onSelect so a deep selection collapses
+  // everything.
+  const nested: SubMenuBinding[] = directSubMenus(subContent).map((child) =>
+    bindContextSubMenu(child, options),
+  );
+
+  let stopEffects: (() => void) | null = null;
+  let prevOpen = isSubMenuOpen(memory.get(), config);
+  let openTimer: ReturnType<typeof setTimeout> | undefined;
+  let closeTimer: ReturnType<typeof setTimeout> | undefined;
+  const clearTimers = () => {
+    if (openTimer) clearTimeout(openTimer);
+    if (closeTimer) clearTimeout(closeTimer);
+    openTimer = undefined;
+    closeTimer = undefined;
+  };
+
+  const render = () => {
+    const state = memory.get();
+    const open = isSubMenuOpen(state, config);
+    const projection = contextSubMenu.aria(state, config, ids);
+    applyProjection(subTrigger, projection.subTrigger ?? {});
+    applyProjection(subContent, projection.subContent ?? {});
+    if (open) {
+      positionSubContent(subTrigger, subContent, config);
+      if (!stopEffects) stopEffects = startContextSubMenuEffects(subContent, config.loop ?? true);
+      if (!prevOpen) focusFirstItem(subContent);
+    } else {
+      stopEffects?.();
+      stopEffects = null;
+      if (prevOpen) subTrigger.focus();
+    }
+    prevOpen = open;
+  };
+  const unsubscribe = memory.subscribe(render);
+
+  const onTriggerEnter = () => {
+    clearTimers();
+    openTimer = setTimeout(() => void request('open'), SUB_MENU_HOVER_DELAY);
+  };
+  const onTriggerLeave = () => {
+    clearTimers();
+    closeTimer = setTimeout(() => void request('close'), SUB_MENU_HOVER_DELAY);
+  };
+  const onTriggerClick = (event: Event) => {
+    event.stopPropagation();
+    clearTimers();
+    request('open');
+  };
+  const onTriggerKeydown = (event: KeyboardEvent) => {
+    const action = contextSubMenu.keymap(keyInput(event), memory.get(), 'subTrigger', config);
+    if (action === 'open') {
+      event.preventDefault();
+      event.stopPropagation();
+      request('open');
+    }
+  };
+  const onContentEnter = () => {
+    clearTimers();
+  };
+  const onContentLeave = () => {
+    clearTimers();
+    closeTimer = setTimeout(() => void request('close'), SUB_MENU_HOVER_DELAY);
+  };
+  const onContentKeydown = (event: KeyboardEvent) => {
+    const action = contextSubMenu.keymap(keyInput(event), memory.get(), 'subContent', config);
+    if (action === 'close') {
+      event.preventDefault();
+      event.stopPropagation();
+      request('close');
+      return;
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      const item = (event.target as HTMLElement).closest<HTMLElement>(MENU_ITEM_SELECTOR);
+      if (item && subContent.contains(item) && !item.closest('[data-part="sub-trigger"]')) {
+        event.preventDefault();
+        item.click();
+      }
+    }
+  };
+  const onContentClick = (event: Event) => {
+    const item = (event.target as HTMLElement).closest<HTMLElement>(MENU_ITEM_SELECTOR);
+    // A nested sub-trigger click is handled by its own binding, not a selection.
+    if (item && subContent.contains(item) && !item.closest('[data-part="sub-trigger"]')) {
+      options.onSelect();
+    }
+  };
+
+  subTrigger.addEventListener('pointerenter', onTriggerEnter);
+  subTrigger.addEventListener('pointerleave', onTriggerLeave);
+  subTrigger.addEventListener('click', onTriggerClick);
+  subTrigger.addEventListener('keydown', onTriggerKeydown);
+  subContent.addEventListener('pointerenter', onContentEnter);
+  subContent.addEventListener('pointerleave', onContentLeave);
+  subContent.addEventListener('keydown', onContentKeydown);
+  subContent.addEventListener('click', onContentClick);
+
+  return {
+    close: () => void request('close'),
+    teardown: () => {
+      clearTimers();
+      unsubscribe();
+      stopEffects?.();
+      stopEffects = null;
+      for (const binding of nested) binding.teardown();
+      subTrigger.removeEventListener('pointerenter', onTriggerEnter);
+      subTrigger.removeEventListener('pointerleave', onTriggerLeave);
+      subTrigger.removeEventListener('click', onTriggerClick);
+      subTrigger.removeEventListener('keydown', onTriggerKeydown);
+      subContent.removeEventListener('pointerenter', onContentEnter);
+      subContent.removeEventListener('pointerleave', onContentLeave);
+      subContent.removeEventListener('keydown', onContentKeydown);
+      subContent.removeEventListener('click', onContentClick);
+      // Restore the sub-content to its authored position in the markup.
+      if (parent) parent.insertBefore(subContent, nextSibling);
+    },
+  };
+}
+
+/** Minimal KeyInput from a native KeyboardEvent (the score's keymap contract). */
+function keyInput(event: KeyboardEvent): {
+  key: string;
+  shiftKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+} {
+  return {
+    key: event.key,
+    shiftKey: event.shiftKey,
+    ctrlKey: event.ctrlKey,
+    altKey: event.altKey,
+    metaKey: event.metaKey,
+  };
+}
+
+/**
+ * The DOM-native binding of the score -- the client the Web Component and the
+ * Astro <script> both import. Only React (retained-mode) reads the projections
+ * declaratively instead. Composes the substrate the same way the React client
+ * does: createBehavior is the model, startContextMenuEffects composes the
+ * roving/typeahead/dismiss primitives on open, aria-manager applies the
+ * projection, and the DOM is the part registry.
+ */
+export function bindContextMenu(root: HTMLElement): () => void {
+  const getPart = (part: string): HTMLElement | null =>
+    part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
+
+  const content = getPart('content');
+  const config: ContextMenuConfig = {
+    defaultOpen:
+      root.getAttribute('default-open') === 'true' || content?.dataset['state'] === 'open',
+    loop: root.getAttribute('loop') !== 'false',
+    avoidCollisions: root.getAttribute('avoid-collisions') !== 'false',
+  };
+
+  const { memory, dispatch } = createBehavior(contextMenu, config);
+  const request = (action: keyof ContextMenuActions, payload?: { x: number; y: number }): boolean =>
+    dispatch(
+      action,
+      config,
+      ...((payload === undefined ? [] : [payload]) as [{ x: number; y: number }]),
+    );
+
+  // ids READ from the server/author markup, never generated.
+  const ids = {} as PartIds<ContextMenuPart>;
+  for (const part of Object.keys(contextMenu.parts) as ContextMenuPart[])
+    ids[part] = getPart(part)?.id ?? '';
+
+  const trigger = getPart('trigger');
+
+  // Bind the top-level submenus (each recurses). Selecting a submenu item
+  // collapses the whole menu via the parent's close.
+  const subs: SubMenuBinding[] = content
+    ? directSubMenus(content).map((el) =>
+        bindContextSubMenu(el, { onSelect: () => request('close') }),
+      )
+    : [];
+
+  let stopEffects: (() => void) | null = null;
+  let prevOpen = isContextMenuOpen(memory.get(), config);
+
+  const render = () => {
+    const state = memory.get();
+    const open = isContextMenuOpen(state, config);
+    const projection = contextMenu.aria(state, config, ids);
+    for (const part of Object.keys(projection) as ContextMenuPart[]) {
+      const attrs = projection[part];
+      const el = getPart(part);
+      if (el && attrs) applyProjection(el, attrs);
+    }
+    if (content) {
+      if (open) {
+        positionContextMenuContent(content, { x: state.x, y: state.y }, config);
+        if (!stopEffects) {
+          stopEffects = startContextMenuEffects({
+            content,
+            loop: config.loop ?? true,
+            onDismiss: () => request('close'),
+          });
+        }
+        // One-shot on the closed->open edge: move focus into the menu.
+        if (!prevOpen) focusFirstItem(content);
+      } else {
+        stopEffects?.();
+        stopEffects = null;
+        // Collapse any open submenu with the parent, and restore focus to the
+        // trigger on the open->close edge.
+        if (prevOpen) {
+          for (const sub of subs) sub.close();
+          trigger?.focus();
+        }
+      }
+    }
+    prevOpen = open;
+  };
+  const unsubscribe = memory.subscribe(render); // fires immediately: first paint
+
+  // Right-click summons the menu at the pointer point. preventDefault suppresses
+  // the native browser context menu.
+  const onContextMenu = (event: MouseEvent) => {
+    event.preventDefault();
+    request('openAt', { x: event.clientX, y: event.clientY });
+  };
+  trigger?.addEventListener('contextmenu', onContextMenu);
+
+  // Escape dismisses through the score's keymap; Enter/Space activates a focused
+  // item (native <div> items do not emit a click), and the click path
+  // selects-and-closes.
+  const onKeydown = (event: KeyboardEvent) => {
+    const action = contextMenu.keymap(
+      {
+        key: event.key,
+        shiftKey: event.shiftKey,
+        ctrlKey: event.ctrlKey,
+        altKey: event.altKey,
+        metaKey: event.metaKey,
+      },
+      memory.get(),
+      'content',
+      config,
+    );
+    if (action === 'close' && isContextMenuOpen(memory.get(), config)) {
+      event.preventDefault();
+      request('close');
+      return;
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      const item = (event.target as HTMLElement).closest<HTMLElement>(MENU_ITEM_SELECTOR);
+      if (item && content?.contains(item)) {
+        event.preventDefault();
+        item.click();
+      }
+    }
+  };
+  content?.addEventListener('keydown', onKeydown);
+
+  // Selecting any item closes the menu (the menu-collection contract).
+  const onClick = (event: MouseEvent) => {
+    const item = (event.target as HTMLElement).closest<HTMLElement>(MENU_ITEM_SELECTOR);
+    if (item && content?.contains(item)) request('close');
+  };
+  content?.addEventListener('click', onClick);
+
+  return () => {
+    unsubscribe();
+    stopEffects?.();
+    stopEffects = null;
+    for (const sub of subs) sub.teardown();
+    trigger?.removeEventListener('contextmenu', onContextMenu);
+    content?.removeEventListener('keydown', onKeydown);
+    content?.removeEventListener('click', onClick);
+  };
+}

--- a/packages/ui/src/components/context-menu/context-menu.behavior.ts
+++ b/packages/ui/src/components/context-menu/context-menu.behavior.ts
@@ -479,7 +479,14 @@ export function bindContextSubMenu(
   subContent.addEventListener('click', onContentClick);
 
   return {
-    close: () => void request('close'),
+    // Collapse the whole subtree: close nested children BEFORE this level, so a
+    // grandchild is never orphaned open when an ancestor closes (the parent's
+    // cascade and the select-an-item path both call this). React is exempt --
+    // its ContextMenuSubContent unmounts the nested subtree via usePresence.
+    close: () => {
+      for (const child of nested) child.close();
+      request('close');
+    },
     teardown: () => {
       clearTimers();
       unsubscribe();

--- a/packages/ui/src/components/context-menu/context-menu.classes.ts
+++ b/packages/ui/src/components/context-menu/context-menu.classes.ts
@@ -1,0 +1,92 @@
+import type { ContextMenuConfig, ContextMenuState } from './context-menu.behavior';
+
+/**
+ * The view for context-menu: class strings only, no logic. Motion rides the
+ * semantic motion tokens (Spec 05): the content enters on `motion-dropdown-in`
+ * (fade + zoom, the dropdown tier), and item highlight rides `motion-focus`.
+ * No raw numeric durations or hand-picked easings -- the tokens encode timing,
+ * curve, and the prefers-reduced-motion degradation. Fill, not background:
+ * bg-popover/text-popover-foreground are the popover surface tokens; the depth
+ * token (z-depth-dropdown) replaces a raw z-index.
+ *
+ * Exit motion (`motion-dropdown-out`) is intentionally NOT declared: the content
+ * toggles `hidden` when closed, so the exiting node leaves the box model before
+ * an out transition can play. A played exit awaits the Presence layer (Spec 04);
+ * declaring it now would be a silent no-op.
+ */
+export interface ContextMenuClassSet {
+  trigger: string;
+  content: string;
+  item: string;
+  checkboxItem: string;
+  radioItem: string;
+  subTrigger: string;
+  subTriggerChevron: string;
+  itemIndicator: string;
+  checkIcon: string;
+  radioDot: string;
+  label: string;
+  separator: string;
+  shortcut: string;
+  group: string;
+}
+
+const trigger = 'inline-block';
+
+const content =
+  'z-depth-dropdown min-w-32 overflow-hidden rounded-md border bg-popover p-1 ' +
+  'text-popover-foreground shadow-lg outline-none ' +
+  'motion-dropdown-in opacity-0 scale-95 data-[state=open]:opacity-100 data-[state=open]:scale-100';
+
+const itemBase =
+  'relative flex cursor-default select-none items-center rounded-sm text-body-small outline-none ' +
+  'motion-focus focus:bg-accent focus:text-accent-foreground ' +
+  'data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
+
+const item = `${itemBase} gap-2 px-2 py-1.5`;
+
+const checkboxItem = `${itemBase} py-1.5 pl-8 pr-2`;
+
+const radioItem = `${itemBase} py-1.5 pl-8 pr-2`;
+
+// The sub-trigger is a menuitem that also stays highlighted while its submenu is
+// open (data-[state=open]).
+const subTrigger = `${itemBase} gap-2 px-2 py-1.5 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground`;
+
+const subTriggerChevron = 'ml-auto h-4 w-4';
+
+const itemIndicator = 'absolute left-2 flex h-3.5 w-3.5 items-center justify-center';
+
+const checkIcon = 'h-4 w-4';
+
+const radioDot = 'h-2 w-2 rounded-full bg-current';
+
+const label = 'px-2 py-1.5 text-label-medium';
+
+const separator = '-mx-1 my-1 h-px border-0 bg-muted';
+
+const shortcut = 'ml-auto text-shortcut opacity-60';
+
+const group = '';
+
+export function contextMenuClasses(
+  _config: ContextMenuConfig,
+  _state: ContextMenuState,
+): ContextMenuClassSet {
+  return {
+    trigger,
+    content,
+    item,
+    checkboxItem,
+    radioItem,
+    subTrigger,
+    subTriggerChevron,
+    itemIndicator,
+    checkIcon,
+    radioDot,
+    label,
+    separator,
+    shortcut,
+    group,
+  };
+}

--- a/packages/ui/src/components/context-menu/context-menu.element.ts
+++ b/packages/ui/src/components/context-menu/context-menu.element.ts
@@ -1,0 +1,29 @@
+/**
+ * WC performance for context-menu: the thinnest wrapper. All behavior --
+ * including the DOM binding -- lives in context-menu.behavior.ts, shared with
+ * the Astro performance. This file only adapts that binding to the
+ * custom-element lifecycle. The host is a light-DOM enhancer: the bind reads
+ * real document DOM (trigger, content, items) for the primitives it composes.
+ */
+import { bindContextMenu } from './context-menu.behavior';
+
+export class RaftersContextMenu extends HTMLElement {
+  private teardown: (() => void) | null = null;
+
+  connectedCallback(): void {
+    // connectedCallback can fire before the light-DOM children are parsed
+    // (upgrade order), so bind on the next microtask when the parts exist.
+    queueMicrotask(() => {
+      if (this.isConnected && !this.teardown) this.teardown = bindContextMenu(this);
+    });
+  }
+
+  disconnectedCallback(): void {
+    this.teardown?.();
+    this.teardown = null;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-context-menu')) {
+  customElements.define('rafters-context-menu', RaftersContextMenu);
+}

--- a/packages/ui/src/components/context-menu/context-menu.tsx
+++ b/packages/ui/src/components/context-menu/context-menu.tsx
@@ -1,0 +1,841 @@
+/**
+ * Context menu: the right-click contextual action popup. A role="menu" surface
+ * summoned at the pointer point, with roving focus, typeahead, and dismissal.
+ *
+ * @cognitive-load 4/10 - Five dimensions: decision-count moderate (a scannable
+ *   action list, Miller's Law caps it at 7 plus/minus 2); visual-complexity low
+ *   (flat rows, separators, optional check/radio marks); interaction-cost low
+ *   (one right-click summons, one click selects); memory-burden low (nothing to
+ *   recall -- the actions are the current selection's own verbs); novelty low
+ *   (the universally learned right-click gesture).
+ * @attention-economics Contextual and on-demand: it costs zero attention until
+ *   summoned, then presents exactly the actions relevant to what was clicked,
+ *   grouped with separators so related verbs read as a unit.
+ * @trust-building Predictable summon-at-cursor placement, keyboard parity
+ *   (arrows, typeahead, Enter/Escape), and clear focus/disabled affordances make
+ *   the menu feel reliable rather than surprising.
+ * @accessibility role="menu" with aria-orientation=vertical; items are
+ *   menuitem/menuitemcheckbox/menuitemradio; roving tabindex moves focus, Escape
+ *   dismisses and restores focus to the trigger, an outside pointerdown closes,
+ *   and disabled items are skipped by navigation.
+ *
+ * The React performance decorates the context-menu score
+ * (context-menu.behavior.ts) with the view (context-menu.classes.ts) and the
+ * framework wiring only: the roving/typeahead/dismiss trio via
+ * startContextMenuEffects and cursor placement via positionContextMenuContent.
+ * Every decision -- reducers, aria, keymap -- stays in the score.
+ *
+ * @example
+ * ```tsx
+ * <ContextMenu>
+ *   <ContextMenu.Trigger>
+ *     <div>Right-click me</div>
+ *   </ContextMenu.Trigger>
+ *   <ContextMenu.Content>
+ *     <ContextMenu.Item onSelect={edit}>Edit</ContextMenu.Item>
+ *     <ContextMenu.Separator />
+ *     <ContextMenu.Item onSelect={remove}>Delete</ContextMenu.Item>
+ *   </ContextMenu.Content>
+ * </ContextMenu>
+ * ```
+ */
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import { keyInputOf } from '../../hooks/key-input';
+import { useMemory } from '../../hooks/use-memory';
+import { usePresence } from '../../hooks/use-presence';
+import { createBehavior, type AriaAttrs, type PartIds, type PayloadArgs } from '../../lib/contract';
+import { getPortalContainer } from '../../primitives/portal';
+import classy from '../../primitives/classy';
+import { mergeProps } from '../../primitives/slot';
+import {
+  contextMenu,
+  contextSubMenu,
+  isContextMenuOpen,
+  isSubMenuOpen,
+  MENU_ITEM_SELECTOR,
+  positionContextMenuContent,
+  positionSubContent,
+  startContextMenuEffects,
+  startContextSubMenuEffects,
+  SUB_MENU_HOVER_DELAY,
+  type ContextMenuActions,
+  type ContextMenuConfig,
+  type ContextMenuPart,
+  type ContextMenuState,
+  type ContextSubMenuActions,
+  type ContextSubMenuConfig,
+  type ContextSubMenuPart,
+  type ContextSubMenuState,
+} from './context-menu.behavior';
+import { contextMenuClasses, type ContextMenuClassSet } from './context-menu.classes';
+
+interface ContextMenuContextValue {
+  state: ContextMenuState;
+  ids: PartIds<ContextMenuPart>;
+  aria: Partial<Record<ContextMenuPart, AriaAttrs>>;
+  request: <K extends keyof ContextMenuActions>(
+    action: K,
+    ...payload: PayloadArgs<ContextMenuActions[K]>
+  ) => boolean;
+  getPart: (part: string) => HTMLElement | null;
+  config: ContextMenuConfig;
+  effectiveOpen: boolean;
+  classes: ContextMenuClassSet;
+}
+
+const ContextMenuCtx = React.createContext<ContextMenuContextValue | null>(null);
+
+function useContextMenuCtx(component: string): ContextMenuContextValue {
+  const context = React.useContext(ContextMenuCtx);
+  if (!context) {
+    throw new Error(`${component} must be used within <ContextMenu>`);
+  }
+  return context;
+}
+
+/** Radio-group scope: the selected value and the change callback. */
+interface RadioGroupContextValue {
+  value: string;
+  onValueChange: (value: string) => void;
+}
+
+const RadioGroupCtx = React.createContext<RadioGroupContextValue | null>(null);
+
+export interface ContextMenuProps {
+  children: React.ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  loop?: boolean;
+  avoidCollisions?: boolean;
+}
+
+export function ContextMenu({
+  children,
+  open,
+  defaultOpen = false,
+  onOpenChange,
+  loop = true,
+  avoidCollisions = true,
+}: ContextMenuProps) {
+  const config: ContextMenuConfig = { open, defaultOpen, loop, avoidCollisions };
+
+  // The controller composes the score with the substrate -- no useBehavior.
+  const { memory, dispatch } = React.useMemo(() => createBehavior(contextMenu, config), []);
+  const state = useMemory(memory);
+  const effectiveOpen = isContextMenuOpen(state, config);
+
+  const uid = React.useId();
+  const ids = React.useMemo(() => {
+    const out = {} as PartIds<ContextMenuPart>;
+    for (const part of Object.keys(contextMenu.parts) as ContextMenuPart[]) {
+      out[part] = `${uid}-${part}`;
+    }
+    return out;
+  }, [uid]);
+
+  // Content portals to document.body with a stable id, so getPart resolves by
+  // id -- the roving/typeahead/dismiss trio and the positioner find it there.
+  const getPart = React.useCallback(
+    (part: string): HTMLElement | null =>
+      typeof document === 'undefined' ? null : document.getElementById(`${uid}-${part}`),
+    [uid],
+  );
+
+  const latest = React.useRef({ config, onOpenChange });
+  latest.current = { config, onOpenChange };
+  const request = React.useCallback(
+    <K extends keyof ContextMenuActions>(
+      action: K,
+      ...payload: PayloadArgs<ContextMenuActions[K]>
+    ): boolean => {
+      const { config: cfg, onOpenChange: cb } = latest.current;
+      if (!dispatch(action, cfg, ...payload)) return false;
+      cb?.(action === 'openAt');
+      return true;
+    },
+    [dispatch],
+  );
+
+  // The roving/typeahead/dismiss trio, composed directly on the open transition
+  // (replacing the effects runner). Level-triggered via the dependency array;
+  // the closed->open edge also moves focus into the menu.
+  React.useEffect(() => {
+    if (!effectiveOpen) return;
+    const content = getPart('content');
+    if (!content) return;
+    const stop = startContextMenuEffects({
+      content,
+      loop,
+      onDismiss: () => request('close'),
+    });
+    content.querySelector<HTMLElement>(MENU_ITEM_SELECTOR)?.focus();
+    return stop;
+  }, [effectiveOpen, loop, getPart, request]);
+
+  // Place the menu at the cursor point whenever it opens or the point moves.
+  // Depends on the primitive avoidCollisions, not the per-render config object,
+  // so it re-runs only when the point (or that flag) actually changes.
+  React.useEffect(() => {
+    if (!effectiveOpen) return;
+    const content = getPart('content');
+    if (content)
+      positionContextMenuContent(content, { x: state.x, y: state.y }, { avoidCollisions });
+  }, [effectiveOpen, state.x, state.y, getPart, avoidCollisions]);
+
+  // Restore focus to the trigger on the open->close edge.
+  const wasOpen = React.useRef(effectiveOpen);
+  React.useEffect(() => {
+    if (wasOpen.current && !effectiveOpen) getPart('trigger')?.focus();
+    wasOpen.current = effectiveOpen;
+  }, [effectiveOpen, getPart]);
+
+  const aria = contextMenu.aria(state, config, ids);
+
+  const contextValue: ContextMenuContextValue = {
+    state,
+    ids,
+    aria,
+    request,
+    getPart,
+    config,
+    effectiveOpen,
+    classes: contextMenuClasses(config, state),
+  };
+
+  return <ContextMenuCtx.Provider value={contextValue}>{children}</ContextMenuCtx.Provider>;
+}
+
+export interface ContextMenuTriggerProps extends React.HTMLAttributes<HTMLSpanElement> {
+  asChild?: boolean;
+  disabled?: boolean;
+}
+
+export function ContextMenuTrigger({
+  asChild,
+  disabled,
+  onContextMenu,
+  className,
+  children,
+  ...props
+}: ContextMenuTriggerProps) {
+  const { ids, aria, request, classes } = useContextMenuCtx('ContextMenuTrigger');
+
+  const handleContextMenu = (event: React.MouseEvent<HTMLSpanElement>) => {
+    onContextMenu?.(event);
+    if (disabled || event.defaultPrevented) return;
+    event.preventDefault();
+    request('openAt', { x: event.clientX, y: event.clientY });
+  };
+
+  const partProps = {
+    'data-part': 'trigger',
+    id: ids.trigger,
+    // Focusable only programmatically (-1): Escape/select restores focus here
+    // when the menu closes, without adding the region to the Tab sequence.
+    tabIndex: -1,
+    className: classy(classes.trigger, className),
+    'data-disabled': disabled ? '' : undefined,
+    ...aria.trigger,
+    onContextMenu: handleContextMenu,
+  };
+
+  if (asChild && React.isValidElement(children)) {
+    const childProps = children.props as Record<string, unknown>;
+    return React.cloneElement(children, mergeProps(partProps, childProps) as React.Attributes);
+  }
+
+  // biome-ignore lint/a11y/noStaticElementInteractions: a context-menu trigger requires onContextMenu, a pointer gesture with no keyboard equivalent by design.
+  return React.createElement('span', { ...partProps, ...props }, children);
+}
+
+export interface ContextMenuPortalProps {
+  children: React.ReactNode;
+  container?: HTMLElement | null;
+  forceMount?: boolean;
+}
+
+/** Passthrough for Radix-style composition. Content already brings its own
+ *  portal, so this simply renders its children in place. */
+export function ContextMenuPortal({ children }: ContextMenuPortalProps) {
+  return <>{children}</>;
+}
+
+export interface ContextMenuContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  forceMount?: boolean;
+  container?: HTMLElement | null;
+  onEscapeKeyDown?: (event: KeyboardEvent) => void;
+}
+
+export function ContextMenuContent({
+  forceMount,
+  container,
+  onEscapeKeyDown,
+  className,
+  children,
+  onKeyDown,
+  ...props
+}: ContextMenuContentProps) {
+  const { config, state, effectiveOpen, ids, aria, classes, request } =
+    useContextMenuCtx('ContextMenuContent');
+  // Presence (wave 0-B): keep the content mounted through its exit animation.
+  // With no exit animation it releases immediately, so behavior is unchanged.
+  const { present, ref: presenceRef } = usePresence(effectiveOpen);
+
+  if (!(forceMount || present)) return null;
+  if (typeof document === 'undefined') return null;
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    onKeyDown?.(event);
+    if (event.defaultPrevented) return;
+    const action = contextMenu.keymap(keyInputOf(event), state, 'content', config);
+    if (action !== 'close') return;
+    onEscapeKeyDown?.(event.nativeEvent);
+    if (event.nativeEvent.defaultPrevented) return;
+    event.preventDefault();
+    request('close');
+  };
+
+  const content = (
+    <div
+      data-part="content"
+      id={ids.content}
+      ref={presenceRef}
+      role="menu"
+      tabIndex={-1}
+      className={classy(classes.content, className)}
+      {...aria.content}
+      onKeyDown={handleKeyDown}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+
+  const target = getPortalContainer(
+    container !== undefined ? { container, enabled: true } : { enabled: true },
+  );
+  if (!target) return content;
+  return createPortal(content, target);
+}
+
+export type ContextMenuGroupProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function ContextMenuGroup({ className, ...props }: ContextMenuGroupProps) {
+  const { classes } = useContextMenuCtx('ContextMenuGroup');
+  // biome-ignore lint/a11y/useSemanticElements: role="group" is the WAI-ARIA menu grouping element.
+  return <div role="group" className={classy(classes.group, className)} {...props} />;
+}
+
+export interface ContextMenuLabelProps extends React.HTMLAttributes<HTMLDivElement> {
+  inset?: boolean;
+}
+
+export function ContextMenuLabel({ className, inset, ...props }: ContextMenuLabelProps) {
+  const { classes } = useContextMenuCtx('ContextMenuLabel');
+  return <div className={classy(classes.label, inset ? 'pl-8' : '', className)} {...props} />;
+}
+
+/** Shared select-and-close for every item variant. Runs the consumer's select
+ *  hook first; unless vetoed, applies the variant's extra effect and closes the
+ *  menu (the menu-collection contract). */
+function useItemSelect(disabled: boolean | undefined, onSelect?: (event: Event) => void) {
+  const { request } = useContextMenuCtx('ContextMenuItem');
+  return React.useCallback(
+    (extra?: () => void): void => {
+      if (disabled) return;
+      const event = new Event('select', { cancelable: true });
+      onSelect?.(event);
+      if (event.defaultPrevented) return;
+      extra?.();
+      request('close');
+    },
+    [disabled, onSelect, request],
+  );
+}
+
+/** The absolute-positioned check/dot slot. className is pre-declared in a props
+ *  object so the span carries no literal className attribute. */
+function ItemIndicator({ children }: { children?: React.ReactNode }) {
+  const { classes } = useContextMenuCtx('ContextMenuItemIndicator');
+  const spanProps = { className: classes.itemIndicator };
+  return React.createElement('span', spanProps, children);
+}
+
+export interface ContextMenuItemProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'onSelect'
+> {
+  inset?: boolean;
+  disabled?: boolean;
+  onSelect?: (event: Event) => void;
+}
+
+export function ContextMenuItem({
+  className,
+  inset,
+  disabled,
+  onSelect,
+  onClick,
+  onKeyDown,
+  ...props
+}: ContextMenuItemProps) {
+  const { classes } = useContextMenuCtx('ContextMenuItem');
+  const select = useItemSelect(disabled, onSelect);
+
+  return (
+    <div
+      // biome-ignore lint/a11y/useSemanticElements: role="menuitem" is the WAI-ARIA menu item, not a native element.
+      role="menuitem"
+      tabIndex={disabled ? undefined : -1}
+      aria-disabled={disabled || undefined}
+      data-disabled={disabled ? '' : undefined}
+      className={classy(classes.item, inset ? 'pl-8' : '', className)}
+      onClick={(event: React.MouseEvent<HTMLDivElement>) => {
+        onClick?.(event);
+        select();
+      }}
+      onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
+        onKeyDown?.(event);
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          select();
+        }
+      }}
+      {...props}
+    />
+  );
+}
+
+export interface ContextMenuCheckboxItemProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'onSelect'
+> {
+  checked?: boolean;
+  disabled?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+  onSelect?: (event: Event) => void;
+}
+
+export function ContextMenuCheckboxItem({
+  className,
+  checked = false,
+  disabled,
+  onCheckedChange,
+  onSelect,
+  onClick,
+  onKeyDown,
+  children,
+  ...props
+}: ContextMenuCheckboxItemProps) {
+  const { classes } = useContextMenuCtx('ContextMenuCheckboxItem');
+  const select = useItemSelect(disabled, onSelect);
+  const toggle = () => select(() => onCheckedChange?.(!checked));
+
+  return (
+    <div
+      // biome-ignore lint/a11y/useSemanticElements: role="menuitemcheckbox" is the WAI-ARIA menu checkbox item.
+      role="menuitemcheckbox"
+      aria-checked={checked}
+      tabIndex={disabled ? undefined : -1}
+      aria-disabled={disabled || undefined}
+      data-disabled={disabled ? '' : undefined}
+      data-state={checked ? 'checked' : 'unchecked'}
+      className={classy(classes.checkboxItem, className)}
+      onClick={(event: React.MouseEvent<HTMLDivElement>) => {
+        onClick?.(event);
+        toggle();
+      }}
+      onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
+        onKeyDown?.(event);
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          toggle();
+        }
+      }}
+      {...props}
+    >
+      <ItemIndicator>
+        {checked ? (
+          <svg
+            className={classes.checkIcon}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        ) : null}
+      </ItemIndicator>
+      {children}
+    </div>
+  );
+}
+
+export interface ContextMenuRadioGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+  value?: string;
+  onValueChange?: (value: string) => void;
+}
+
+export function ContextMenuRadioGroup({
+  value = '',
+  onValueChange,
+  className,
+  ...props
+}: ContextMenuRadioGroupProps) {
+  const { classes } = useContextMenuCtx('ContextMenuRadioGroup');
+  const contextValue = React.useMemo<RadioGroupContextValue>(
+    () => ({ value, onValueChange: (next: string) => onValueChange?.(next) }),
+    [value, onValueChange],
+  );
+  return (
+    <RadioGroupCtx.Provider value={contextValue}>
+      {/* biome-ignore lint/a11y/useSemanticElements: role="group" is the WAI-ARIA menu radio grouping element. */}
+      <div role="group" className={classy(classes.group, className)} {...props} />
+    </RadioGroupCtx.Provider>
+  );
+}
+
+export interface ContextMenuRadioItemProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'onSelect'
+> {
+  value: string;
+  disabled?: boolean;
+  onSelect?: (event: Event) => void;
+}
+
+export function ContextMenuRadioItem({
+  className,
+  value,
+  disabled,
+  onSelect,
+  onClick,
+  onKeyDown,
+  children,
+  ...props
+}: ContextMenuRadioItemProps) {
+  const { classes } = useContextMenuCtx('ContextMenuRadioItem');
+  const group = React.useContext(RadioGroupCtx);
+  if (!group) {
+    throw new Error('ContextMenuRadioItem must be used within <ContextMenu.RadioGroup>');
+  }
+  const checked = group.value === value;
+  const select = useItemSelect(disabled, onSelect);
+  const pick = () => select(() => group.onValueChange(value));
+
+  const dotProps = { className: classes.radioDot, 'aria-hidden': 'true' as const };
+
+  return (
+    <div
+      // biome-ignore lint/a11y/useSemanticElements: role="menuitemradio" is the WAI-ARIA menu radio item.
+      role="menuitemradio"
+      aria-checked={checked}
+      tabIndex={disabled ? undefined : -1}
+      aria-disabled={disabled || undefined}
+      data-disabled={disabled ? '' : undefined}
+      data-state={checked ? 'checked' : 'unchecked'}
+      className={classy(classes.radioItem, className)}
+      onClick={(event: React.MouseEvent<HTMLDivElement>) => {
+        onClick?.(event);
+        pick();
+      }}
+      onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
+        onKeyDown?.(event);
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          pick();
+        }
+      }}
+      {...props}
+    >
+      <ItemIndicator>{checked ? React.createElement('span', dotProps) : null}</ItemIndicator>
+      {children}
+    </div>
+  );
+}
+
+export type ContextMenuSeparatorProps = React.HTMLAttributes<HTMLHRElement>;
+
+export function ContextMenuSeparator({ className, ...props }: ContextMenuSeparatorProps) {
+  const { classes } = useContextMenuCtx('ContextMenuSeparator');
+  return <hr className={classy(classes.separator, className)} {...props} />;
+}
+
+export type ContextMenuShortcutProps = React.HTMLAttributes<HTMLSpanElement>;
+
+export function ContextMenuShortcut({ className, ...props }: ContextMenuShortcutProps) {
+  const { classes } = useContextMenuCtx('ContextMenuShortcut');
+  const spanProps = { className: classy(classes.shortcut, className), ...props };
+  return React.createElement('span', spanProps);
+}
+
+// ==================== Submenu ====================
+
+interface SubMenuContextValue {
+  state: ContextSubMenuState;
+  config: ContextSubMenuConfig;
+  ids: PartIds<ContextSubMenuPart>;
+  aria: Partial<Record<ContextSubMenuPart, AriaAttrs>>;
+  request: (action: keyof ContextSubMenuActions) => boolean;
+  effectiveOpen: boolean;
+  openViaHover: () => void;
+  closeViaHover: () => void;
+  cancelHover: () => void;
+}
+
+const SubMenuCtx = React.createContext<SubMenuContextValue | null>(null);
+
+function useSubMenuCtx(component: string): SubMenuContextValue {
+  const context = React.useContext(SubMenuCtx);
+  if (!context) {
+    throw new Error(`${component} must be used within <ContextMenu.Sub>`);
+  }
+  return context;
+}
+
+export interface ContextMenuSubProps {
+  children: React.ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  loop?: boolean;
+  avoidCollisions?: boolean;
+}
+
+export function ContextMenuSub({
+  children,
+  open,
+  defaultOpen = false,
+  onOpenChange,
+  loop = true,
+  avoidCollisions = true,
+}: ContextMenuSubProps) {
+  const config: ContextSubMenuConfig = { open, defaultOpen, loop, avoidCollisions };
+
+  const { memory, dispatch } = React.useMemo(() => createBehavior(contextSubMenu, config), []);
+  const state = useMemory(memory);
+  const effectiveOpen = isSubMenuOpen(state, config);
+
+  const uid = React.useId();
+  const ids = React.useMemo(
+    () => ({ subTrigger: `${uid}-sub-trigger`, subContent: `${uid}-sub-content` }),
+    [uid],
+  );
+  const getPart = React.useCallback(
+    (part: string): HTMLElement | null =>
+      typeof document === 'undefined' ? null : document.getElementById(`${uid}-${part}`),
+    [uid],
+  );
+
+  const openTimer = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const closeTimer = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const clearTimers = React.useCallback(() => {
+    if (openTimer.current) clearTimeout(openTimer.current);
+    if (closeTimer.current) clearTimeout(closeTimer.current);
+  }, []);
+
+  const latest = React.useRef({ config, onOpenChange });
+  latest.current = { config, onOpenChange };
+  const request = React.useCallback(
+    (action: keyof ContextSubMenuActions): boolean => {
+      const { config: cfg, onOpenChange: cb } = latest.current;
+      if (!dispatch(action, cfg)) return false;
+      cb?.(action === 'open');
+      return true;
+    },
+    [dispatch],
+  );
+
+  const openViaHover = React.useCallback(() => {
+    clearTimers();
+    openTimer.current = setTimeout(() => request('open'), SUB_MENU_HOVER_DELAY);
+  }, [clearTimers, request]);
+  const closeViaHover = React.useCallback(() => {
+    clearTimers();
+    closeTimer.current = setTimeout(() => request('close'), SUB_MENU_HOVER_DELAY);
+  }, [clearTimers, request]);
+  React.useEffect(() => () => clearTimers(), [clearTimers]);
+
+  // Position + roving/typeahead + focus-first on the open transition. The
+  // sub-content portals to body, so the parent's roving never sees its items.
+  React.useEffect(() => {
+    if (!effectiveOpen) return;
+    const subContent = getPart('sub-content');
+    if (!subContent) return;
+    const subTrigger = getPart('sub-trigger');
+    if (subTrigger) positionSubContent(subTrigger, subContent, { avoidCollisions });
+    const stop = startContextSubMenuEffects(subContent, loop);
+    subContent.querySelector<HTMLElement>(MENU_ITEM_SELECTOR)?.focus();
+    return stop;
+  }, [effectiveOpen, loop, avoidCollisions, getPart]);
+
+  // Restore focus to the sub-trigger on the open->close edge.
+  const wasOpen = React.useRef(effectiveOpen);
+  React.useEffect(() => {
+    if (wasOpen.current && !effectiveOpen) getPart('sub-trigger')?.focus();
+    wasOpen.current = effectiveOpen;
+  }, [effectiveOpen, getPart]);
+
+  const aria = contextSubMenu.aria(state, config, ids);
+  const value: SubMenuContextValue = {
+    state,
+    config,
+    ids,
+    aria,
+    request,
+    effectiveOpen,
+    openViaHover,
+    closeViaHover,
+    cancelHover: clearTimers,
+  };
+
+  return <SubMenuCtx.Provider value={value}>{children}</SubMenuCtx.Provider>;
+}
+
+export interface ContextMenuSubTriggerProps extends React.HTMLAttributes<HTMLDivElement> {
+  inset?: boolean;
+  disabled?: boolean;
+}
+
+export function ContextMenuSubTrigger({
+  className,
+  inset,
+  disabled,
+  onPointerEnter,
+  onPointerLeave,
+  onKeyDown,
+  onClick,
+  children,
+  ...props
+}: ContextMenuSubTriggerProps) {
+  const { classes } = useContextMenuCtx('ContextMenuSubTrigger');
+  const sub = useSubMenuCtx('ContextMenuSubTrigger');
+
+  return (
+    <div
+      // biome-ignore lint/a11y/useSemanticElements: role="menuitem" is the WAI-ARIA menu item that discloses a submenu.
+      role="menuitem"
+      data-part="sub-trigger"
+      id={sub.ids.subTrigger}
+      tabIndex={disabled ? undefined : -1}
+      aria-disabled={disabled || undefined}
+      data-disabled={disabled ? '' : undefined}
+      className={classy(classes.subTrigger, inset ? 'pl-8' : '', className)}
+      {...sub.aria.subTrigger}
+      onPointerEnter={(event: React.PointerEvent<HTMLDivElement>) => {
+        onPointerEnter?.(event);
+        if (!disabled) sub.openViaHover();
+      }}
+      onPointerLeave={(event: React.PointerEvent<HTMLDivElement>) => {
+        onPointerLeave?.(event);
+        sub.closeViaHover();
+      }}
+      onClick={(event: React.MouseEvent<HTMLDivElement>) => {
+        onClick?.(event);
+        if (!disabled) sub.request('open');
+      }}
+      onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
+        onKeyDown?.(event);
+        if (disabled) return;
+        const action = contextSubMenu.keymap(
+          keyInputOf(event),
+          sub.state,
+          'subTrigger',
+          sub.config,
+        );
+        if (action === 'open') {
+          event.preventDefault();
+          sub.request('open');
+        }
+      }}
+      {...props}
+    >
+      {children}
+      <svg
+        className={classes.subTriggerChevron}
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+        aria-hidden="true"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+      </svg>
+    </div>
+  );
+}
+
+export interface ContextMenuSubContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  forceMount?: boolean;
+  container?: HTMLElement | null;
+}
+
+export function ContextMenuSubContent({
+  forceMount,
+  container,
+  className,
+  children,
+  onKeyDown,
+  ...props
+}: ContextMenuSubContentProps) {
+  const { classes } = useContextMenuCtx('ContextMenuSubContent');
+  const sub = useSubMenuCtx('ContextMenuSubContent');
+  const { present, ref: presenceRef } = usePresence(sub.effectiveOpen);
+
+  if (!(forceMount || present)) return null;
+  if (typeof document === 'undefined') return null;
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    onKeyDown?.(event);
+    if (event.defaultPrevented) return;
+    const action = contextSubMenu.keymap(keyInputOf(event), sub.state, 'subContent', sub.config);
+    if (action !== 'close') return;
+    event.preventDefault();
+    sub.request('close');
+  };
+
+  const content = (
+    <div
+      data-part="sub-content"
+      id={sub.ids.subContent}
+      ref={presenceRef}
+      role="menu"
+      tabIndex={-1}
+      className={classy(classes.content, className)}
+      {...sub.aria.subContent}
+      onPointerEnter={() => sub.cancelHover()}
+      onPointerLeave={() => sub.closeViaHover()}
+      onKeyDown={handleKeyDown}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+
+  const target = getPortalContainer(
+    container !== undefined ? { container, enabled: true } : { enabled: true },
+  );
+  if (!target) return content;
+  return createPortal(content, target);
+}
+
+ContextMenu.Trigger = ContextMenuTrigger;
+ContextMenu.Portal = ContextMenuPortal;
+ContextMenu.Content = ContextMenuContent;
+ContextMenu.Group = ContextMenuGroup;
+ContextMenu.Label = ContextMenuLabel;
+ContextMenu.Item = ContextMenuItem;
+ContextMenu.CheckboxItem = ContextMenuCheckboxItem;
+ContextMenu.RadioGroup = ContextMenuRadioGroup;
+ContextMenu.RadioItem = ContextMenuRadioItem;
+ContextMenu.Separator = ContextMenuSeparator;
+ContextMenu.Shortcut = ContextMenuShortcut;
+ContextMenu.Sub = ContextMenuSub;
+ContextMenu.SubTrigger = ContextMenuSubTrigger;
+ContextMenu.SubContent = ContextMenuSubContent;
+
+export { ContextMenu as ContextMenuRoot };

--- a/packages/ui/test/components/context-menu/context-menu.astro.conformance.test.ts
+++ b/packages/ui/test/components/context-menu/context-menu.astro.conformance.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Astro performance of the context-menu score, driven end to end. AstroContainer
+ * renders the SSR markup with the initial (closed) projection already applied,
+ * but does NOT run the <script>, so the test calls bindContextMenu directly --
+ * that IS the script's job -- then drives the same score the React and WC
+ * performances drive. The SSR markup is wrapped in a <main> landmark so axe's
+ * best-practice region rule holds for the menu.
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import ContextMenu from '../../../src/components/context-menu/context-menu.astro';
+import {
+  bindContextMenu,
+  contextMenu,
+} from '../../../src/components/context-menu/context-menu.behavior';
+import { assertAxeClean, assertContractFulfillment } from '../../harness/conformance';
+
+const items = [
+  { label: 'Cut' },
+  { label: 'Copy' },
+  { type: 'separator' as const },
+  { label: 'Paste', disabled: true },
+  { label: 'Delete', shortcut: 'Del' },
+];
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+async function mount(): Promise<HTMLElement> {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(ContextMenu, {
+    props: { id: 'cm', triggerLabel: 'Right-click here', items },
+  });
+  document.body.innerHTML = `<main>${html}</main>`;
+  const root = document.body.querySelector('[data-context-menu-root]') as HTMLElement;
+  bindContextMenu(root); // the <script> does this per instance on the real page
+  return root;
+}
+
+const itemsWithSub = [
+  { label: 'Cut' },
+  {
+    type: 'sub' as const,
+    label: 'More',
+    subItems: [{ label: 'Deep' }, { label: 'Deeper' }],
+  },
+];
+
+async function mountWithSub(): Promise<HTMLElement> {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(ContextMenu, {
+    props: { id: 'cm', triggerLabel: 'Right-click here', items: itemsWithSub },
+  });
+  document.body.innerHTML = `<main>${html}</main>`;
+  const root = document.body.querySelector('[data-context-menu-root]') as HTMLElement;
+  bindContextMenu(root);
+  return root;
+}
+
+const subTrigger = () =>
+  document.body.querySelector<HTMLElement>('[data-part="sub-trigger"]') as HTMLElement;
+const subContent = () =>
+  document.body.querySelector<HTMLElement>('[data-part="sub-content"]') as HTMLElement;
+
+const trigger = () =>
+  document.body.querySelector<HTMLElement>('[data-part="trigger"]') as HTMLElement;
+const content = () =>
+  document.body.querySelector<HTMLElement>('[data-part="content"]') as HTMLElement;
+const itemByText = (text: string): HTMLElement => {
+  const match = Array.from(document.body.querySelectorAll<HTMLElement>('[role="menuitem"]')).find(
+    (element) => element.textContent?.trim().startsWith(text),
+  );
+  if (!match) throw new Error(`no item ${text}`);
+  return match;
+};
+
+describe('context-menu conformance [astro]', () => {
+  it('SSR closed: content present-but-hidden, items in the DOM, axe-clean', async () => {
+    await mount();
+    expect(content().hidden).toBe(true);
+    expect(content().getAttribute('data-state')).toBe('closed');
+    expect(content().querySelectorAll('[role="menuitem"]').length).toBe(4);
+    await assertAxeClean(document.body);
+  });
+
+  it('per-part ARIA equals the score projection, closed (SSR) and open', async () => {
+    await mount();
+    assertContractFulfillment(
+      contextMenu,
+      document.body,
+      { open: false, x: 0, y: 0 },
+      { loop: true, avoidCollisions: true },
+      ['trigger', 'content'],
+    );
+    fireEvent.contextMenu(trigger(), { clientX: 12, clientY: 22 });
+    assertContractFulfillment(
+      contextMenu,
+      document.body,
+      { open: true, x: 12, y: 22 },
+      { loop: true, avoidCollisions: true },
+      ['trigger', 'content'],
+    );
+  });
+
+  it('right-click opens at the pointer point and focuses the first item', async () => {
+    await mount();
+    fireEvent.contextMenu(trigger(), { clientX: 12, clientY: 22 });
+    expect(content().hidden).toBe(false);
+    expect(content().style.left).toBe('12px');
+    expect(content().style.top).toBe('22px');
+    expect(document.activeElement).toBe(itemByText('Cut'));
+    await assertAxeClean(document.body);
+  });
+
+  it('Escape closes and restores focus to the trigger', async () => {
+    const user = userEvent.setup();
+    await mount();
+    fireEvent.contextMenu(trigger(), { clientX: 12, clientY: 22 });
+    expect(content().hidden).toBe(false);
+    await user.keyboard('{Escape}');
+    expect(content().hidden).toBe(true);
+    expect(document.activeElement).toBe(trigger());
+  });
+
+  it('selecting an item closes the menu', async () => {
+    const user = userEvent.setup();
+    await mount();
+    fireEvent.contextMenu(trigger(), { clientX: 12, clientY: 22 });
+    await user.click(itemByText('Copy'));
+    expect(content().hidden).toBe(true);
+  });
+
+  it('a SSR submenu opens on ArrowRight and closes on ArrowLeft', async () => {
+    const user = userEvent.setup();
+    await mountWithSub();
+    fireEvent.contextMenu(trigger(), { clientX: 12, clientY: 22 });
+    expect(subContent().hidden).toBe(true);
+    subTrigger().focus();
+    await user.keyboard('{ArrowRight}');
+    expect(subContent().hidden).toBe(false);
+    expect(subTrigger().getAttribute('aria-expanded')).toBe('true');
+    expect(document.activeElement).toBe(itemByText('Deep'));
+    await user.keyboard('{ArrowLeft}');
+    expect(subContent().hidden).toBe(true);
+    expect(document.activeElement).toBe(subTrigger());
+  });
+});

--- a/packages/ui/test/components/context-menu/context-menu.astro.conformance.test.ts
+++ b/packages/ui/test/components/context-menu/context-menu.astro.conformance.test.ts
@@ -45,7 +45,10 @@ const itemsWithSub = [
   {
     type: 'sub' as const,
     label: 'More',
-    subItems: [{ label: 'Deep' }, { label: 'Deeper' }],
+    subItems: [
+      { label: 'Deep' },
+      { type: 'sub' as const, label: 'Even more', subItems: [{ label: 'Grandchild' }] },
+    ],
   },
 ];
 
@@ -64,6 +67,17 @@ const subTrigger = () =>
   document.body.querySelector<HTMLElement>('[data-part="sub-trigger"]') as HTMLElement;
 const subContent = () =>
   document.body.querySelector<HTMLElement>('[data-part="sub-content"]') as HTMLElement;
+const subTriggerByText = (text: string): HTMLElement => {
+  const match = Array.from(
+    document.body.querySelectorAll<HTMLElement>('[data-part="sub-trigger"]'),
+  ).find((element) => element.textContent?.trim().startsWith(text));
+  if (!match) throw new Error(`no sub-trigger ${text}`);
+  return match;
+};
+const grandchildContent = () =>
+  document.body.querySelector<HTMLElement>(
+    '[data-part="sub-content"][aria-label="Even more"]',
+  ) as HTMLElement;
 
 const trigger = () =>
   document.body.querySelector<HTMLElement>('[data-part="trigger"]') as HTMLElement;
@@ -146,5 +160,37 @@ describe('context-menu conformance [astro]', () => {
     await user.keyboard('{ArrowLeft}');
     expect(subContent().hidden).toBe(true);
     expect(document.activeElement).toBe(subTrigger());
+  });
+
+  // Open the level-1 (More) and level-2 (Even more) submenus from SSR markup.
+  async function openTwoLevels(user: ReturnType<typeof userEvent.setup>): Promise<HTMLElement> {
+    fireEvent.contextMenu(trigger(), { clientX: 12, clientY: 22 });
+    subTriggerByText('More').focus();
+    await user.keyboard('{ArrowRight}');
+    subTriggerByText('Even more').focus();
+    await user.keyboard('{ArrowRight}');
+    const grandchild = grandchildContent();
+    expect(grandchild.hidden).toBe(false);
+    return grandchild;
+  }
+
+  it('dismissing the whole menu collapses a NESTED (grandchild) submenu in the SSR path', async () => {
+    const user = userEvent.setup();
+    await mountWithSub();
+    const grandchild = await openTwoLevels(user);
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    fireEvent.pointerDown(outside);
+    expect(content().hidden).toBe(true);
+    expect(grandchild.hidden).toBe(true);
+  });
+
+  it('selecting a top-level item while a nested submenu is open collapses the grandchild', async () => {
+    const user = userEvent.setup();
+    await mountWithSub();
+    const grandchild = await openTwoLevels(user);
+    await user.click(itemByText('Cut'));
+    expect(content().hidden).toBe(true);
+    expect(grandchild.hidden).toBe(true);
   });
 });

--- a/packages/ui/test/components/context-menu/context-menu.behavior.test.ts
+++ b/packages/ui/test/components/context-menu/context-menu.behavior.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createBehavior } from '../../../src/lib/contract';
+import {
+  contextMenu,
+  contextSubMenu,
+  directSubMenus,
+  isContextMenuOpen,
+  isSubMenuOpen,
+  positionContextMenuContent,
+  startContextMenuEffects,
+  type ContextMenuConfig,
+  type ContextMenuState,
+  type ContextSubMenuState,
+} from '../../../src/components/context-menu/context-menu.behavior';
+
+const base: ContextMenuConfig = {};
+
+describe('context-menu parts', () => {
+  it('declares the trigger region and the menu content', () => {
+    expect(Object.keys(contextMenu.parts).sort()).toEqual(['content', 'trigger']);
+    // The menu surface carries the WAI-ARIA menu role.
+    expect(contextMenu.parts.content.role).toBe('menu');
+    expect(contextMenu.parts.content.optional).toBe(true);
+    // The trigger is a plain pointer region -- no role.
+    expect(contextMenu.parts.trigger.role).toBeUndefined();
+  });
+});
+
+describe('context-menu state', () => {
+  it('seeds closed at the origin, or open from defaultOpen', () => {
+    expect(contextMenu.initialState(base)).toEqual({ open: false, x: 0, y: 0 });
+    expect(contextMenu.initialState({ defaultOpen: true }).open).toBe(true);
+    expect(contextMenu.initialState({ open: true }).open).toBe(true);
+  });
+
+  it('controlled open shadows intrinsic state', () => {
+    const closed: ContextMenuState = { open: false, x: 0, y: 0 };
+    expect(isContextMenuOpen(closed, { open: true })).toBe(true);
+    expect(isContextMenuOpen({ open: true, x: 0, y: 0 }, { open: false })).toBe(false);
+    expect(isContextMenuOpen(closed, {})).toBe(false);
+  });
+});
+
+describe('context-menu actions', () => {
+  it('openAt opens and records the pointer point', () => {
+    const { memory, dispatch } = createBehavior(contextMenu, base);
+    expect(dispatch('openAt', base, { x: 120, y: 40 })).toBe(true);
+    expect(memory.get()).toEqual({ open: true, x: 120, y: 40 });
+  });
+
+  it('a second openAt repositions the menu', () => {
+    const { memory, dispatch } = createBehavior(contextMenu, base);
+    dispatch('openAt', base, { x: 10, y: 10 });
+    expect(dispatch('openAt', base, { x: 200, y: 300 })).toBe(true);
+    expect(memory.get()).toEqual({ open: true, x: 200, y: 300 });
+  });
+
+  it('close closes; it is rejected when already closed', () => {
+    const { memory, dispatch } = createBehavior(contextMenu, base);
+    expect(dispatch('close', base)).toBe(false);
+    dispatch('openAt', base, { x: 5, y: 5 });
+    expect(dispatch('close', base)).toBe(true);
+    expect(memory.get().open).toBe(false);
+  });
+
+  it('close is rejected against a controlled-closed menu, allowed against controlled-open', () => {
+    const { dispatch } = createBehavior(contextMenu, base);
+    expect(dispatch('close', { open: false })).toBe(false);
+    expect(dispatch('close', { open: true })).toBe(true);
+  });
+});
+
+describe('context-menu keymap', () => {
+  const state: ContextMenuState = { open: true, x: 0, y: 0 };
+  it('Escape closes; navigation/printable keys are left to the primitives', () => {
+    expect(contextMenu.keymap({ key: 'Escape' }, state, 'content', base)).toBe('close');
+    expect(contextMenu.keymap({ key: 'ArrowDown' }, state, 'content', base)).toBeNull();
+    expect(contextMenu.keymap({ key: 'a' }, state, 'content', base)).toBeNull();
+    expect(contextMenu.keymap({ key: 'Enter' }, state, 'content', base)).toBeNull();
+  });
+});
+
+describe('context-menu aria', () => {
+  const ids = { trigger: 't', content: 'c' };
+
+  it('closed: content carries the vertical menu orientation and is hidden', () => {
+    const aria = contextMenu.aria({ open: false, x: 0, y: 0 }, base, ids);
+    expect(aria.trigger?.['data-state']).toBe('closed');
+    expect(aria.content).toEqual({
+      'aria-orientation': 'vertical',
+      'data-state': 'closed',
+      hidden: true,
+    });
+  });
+
+  it('open: content is shown (hidden projected undefined)', () => {
+    const aria = contextMenu.aria({ open: true, x: 10, y: 10 }, base, ids);
+    expect(aria.content?.['data-state']).toBe('open');
+    expect(aria.content?.['hidden']).toBeUndefined();
+  });
+
+  it('a controlled-open projection tracks the config value', () => {
+    const aria = contextMenu.aria({ open: false, x: 0, y: 0 }, { open: true }, ids);
+    expect(aria.content?.['data-state']).toBe('open');
+    expect(aria.content?.['hidden']).toBeUndefined();
+  });
+});
+
+describe('context-menu positioning', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('places the menu top-left corner at the pointer point (fixed)', () => {
+    const content = document.createElement('div');
+    document.body.appendChild(content);
+    positionContextMenuContent(content, { x: 15, y: 25 }, {});
+    expect(content.style.position).toBe('fixed');
+    expect(content.style.left).toBe('15px');
+    expect(content.style.top).toBe('25px');
+  });
+});
+
+describe('context-menu effects composition', () => {
+  const stops: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const stop of stops.splice(0)) stop();
+    document.body.innerHTML = '';
+  });
+
+  function mountContent(): HTMLElement {
+    document.body.innerHTML = `
+      <div data-part="content" role="menu">
+        <div role="menuitem">Cut</div>
+        <div role="menuitem">Copy</div>
+        <div role="menuitem" data-disabled>Paste</div>
+      </div>`;
+    return document.body.querySelector('[data-part="content"]') as HTMLElement;
+  }
+
+  it('roving tabindex initializes across the enabled items', () => {
+    const content = mountContent();
+    const stop = startContextMenuEffects({ content, loop: true, onDismiss: () => {} });
+    stops.push(stop);
+    const items = content.querySelectorAll<HTMLElement>('[role="menuitem"]');
+    expect(items[0]?.getAttribute('tabindex')).toBe('0');
+    expect(items[1]?.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('outside pointerdown dismisses; cleanup detaches every listener', () => {
+    const content = mountContent();
+    const onDismiss = vi.fn();
+    const stop = startContextMenuEffects({ content, loop: true, onDismiss });
+    stops.push(stop);
+
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    outside.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+
+    stop();
+    outside.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('a pointerdown inside the menu does not dismiss', () => {
+    const content = mountContent();
+    const onDismiss = vi.fn();
+    const stop = startContextMenuEffects({ content, loop: true, onDismiss });
+    stops.push(stop);
+    const item = content.querySelector<HTMLElement>('[role="menuitem"]');
+    item?.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+});
+
+describe('context-sub-menu score', () => {
+  const base = {};
+  const open: ContextSubMenuState = { open: true };
+  const closed: ContextSubMenuState = { open: false };
+
+  it('declares the sub-trigger menuitem and the sub-content menu', () => {
+    expect(Object.keys(contextSubMenu.parts).sort()).toEqual(['subContent', 'subTrigger']);
+    expect(contextSubMenu.parts.subTrigger.role).toBe('menuitem');
+    expect(contextSubMenu.parts.subContent.role).toBe('menu');
+  });
+
+  it('controlled open shadows intrinsic state; close/open gate on the effective value', () => {
+    expect(isSubMenuOpen(closed, { open: true })).toBe(true);
+    expect(contextSubMenu.canDispatch(closed, 'close', base)).toBe(false);
+    expect(contextSubMenu.canDispatch(closed, 'open', base)).toBe(true);
+    expect(contextSubMenu.canDispatch(open, 'open', base)).toBe(false);
+    expect(contextSubMenu.canDispatch(open, 'close', base)).toBe(true);
+  });
+
+  it('keymap: ArrowRight/Enter/Space open from the trigger, ArrowLeft/Escape close from the content', () => {
+    for (const key of ['ArrowRight', 'Enter', ' ']) {
+      expect(contextSubMenu.keymap({ key }, closed, 'subTrigger', base)).toBe('open');
+    }
+    for (const key of ['ArrowLeft', 'Escape']) {
+      expect(contextSubMenu.keymap({ key }, open, 'subContent', base)).toBe('close');
+    }
+    // Cross-part keys do not fire (ArrowLeft on the trigger, ArrowRight in content).
+    expect(contextSubMenu.keymap({ key: 'ArrowLeft' }, closed, 'subTrigger', base)).toBeNull();
+    expect(contextSubMenu.keymap({ key: 'ArrowRight' }, open, 'subContent', base)).toBeNull();
+  });
+
+  it('aria: trigger advertises the popup, content is a hidden vertical menu when closed', () => {
+    const ids = { subTrigger: 'st', subContent: 'sc' };
+    const closedAria = contextSubMenu.aria(closed, base, ids);
+    expect(closedAria.subTrigger).toEqual({
+      'aria-haspopup': 'menu',
+      'aria-expanded': 'false',
+      'aria-controls': undefined,
+      'data-state': 'closed',
+    });
+    expect(closedAria.subContent?.['hidden']).toBe(true);
+    const openAria = contextSubMenu.aria(open, base, ids);
+    expect(openAria.subTrigger?.['aria-expanded']).toBe('true');
+    expect(openAria.subTrigger?.['aria-controls']).toBe('sc');
+    expect(openAria.subContent?.['hidden']).toBeUndefined();
+  });
+});
+
+describe('directSubMenus', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('returns only the submenus directly inside the container, not nested ones', () => {
+    document.body.innerHTML = `
+      <div data-part="content" role="menu">
+        <div data-part="sub" id="s1">
+          <div data-part="sub-trigger" role="menuitem">More</div>
+          <div data-part="sub-content" role="menu">
+            <div data-part="sub" id="s2">
+              <div data-part="sub-trigger" role="menuitem">Even more</div>
+              <div data-part="sub-content" role="menu"></div>
+            </div>
+          </div>
+        </div>
+      </div>`;
+    const content = document.body.querySelector('[data-part="content"]') as HTMLElement;
+    const direct = directSubMenus(content).map((el) => el.id);
+    expect(direct).toEqual(['s1']);
+  });
+});

--- a/packages/ui/test/components/context-menu/context-menu.classes.test.ts
+++ b/packages/ui/test/components/context-menu/context-menu.classes.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { contextMenu } from '../../../src/components/context-menu/context-menu.behavior';
+import { contextMenuClasses } from '../../../src/components/context-menu/context-menu.classes';
+
+const config = {};
+const classes = contextMenuClasses(config, contextMenu.initialState(config));
+
+describe('context-menu classes', () => {
+  it('content sits on the dropdown depth and popover surface tokens', () => {
+    expect(classes.content).toContain('z-depth-dropdown');
+    expect(classes.content).toContain('bg-popover');
+    expect(classes.content).toContain('text-popover-foreground');
+  });
+
+  it('content enters on the semantic dropdown motion token, driven by data-state', () => {
+    expect(classes.content).toContain('motion-dropdown-in');
+    expect(classes.content).toContain('opacity-0');
+    expect(classes.content).toContain('scale-95');
+    expect(classes.content).toContain('data-[state=open]:opacity-100');
+    expect(classes.content).toContain('data-[state=open]:scale-100');
+  });
+
+  it('items highlight on the semantic focus motion token', () => {
+    expect(classes.item).toContain('motion-focus');
+    expect(classes.item).toContain('focus:bg-accent');
+    expect(classes.item).toContain('data-[disabled]:pointer-events-none');
+    expect(classes.item).toContain('data-[disabled]:opacity-50');
+  });
+
+  it('checkbox and radio items reserve the indicator gutter', () => {
+    expect(classes.checkboxItem).toContain('pl-8');
+    expect(classes.radioItem).toContain('pl-8');
+    expect(classes.itemIndicator).toContain('absolute');
+    expect(classes.radioDot).toContain('rounded-full');
+  });
+
+  it('the sub-trigger highlights while its submenu is open', () => {
+    expect(classes.subTrigger).toContain('motion-focus');
+    expect(classes.subTrigger).toContain('data-[state=open]:bg-accent');
+    expect(classes.subTriggerChevron).toContain('ml-auto');
+  });
+
+  it('separator, label, and shortcut carry their chrome', () => {
+    expect(classes.separator).toContain('bg-muted');
+    expect(classes.label).toContain('text-label-medium');
+    expect(classes.shortcut).toContain('ml-auto');
+  });
+
+  it('declares no raw numeric durations or animate utilities (motion tokens only)', () => {
+    for (const value of [classes.content, classes.item, classes.checkboxItem, classes.radioItem]) {
+      expect(value).not.toMatch(/duration-\d/);
+      expect(value).not.toContain('animate-in');
+      expect(value).not.toContain('zoom-in');
+    }
+  });
+});

--- a/packages/ui/test/components/context-menu/context-menu.conformance.test.tsx
+++ b/packages/ui/test/components/context-menu/context-menu.conformance.test.tsx
@@ -1,0 +1,305 @@
+/**
+ * React performance of the context-menu score, driven end to end. Replaces the
+ * oracle's imperative effects: state moves only through dispatched actions;
+ * roving focus, typeahead, positioning, and dismissal are composed from the
+ * primitives on the open transition.
+ *
+ * The tree renders inside a <main> landmark and the menu portals into it, so
+ * axe's best-practice region rule is satisfied for the portaled popup (the same
+ * containment a real page's landmarks provide).
+ */
+import * as React from 'react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  ContextMenu,
+  ContextMenuCheckboxItem,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
+  ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuTrigger,
+} from '../../../src/components/context-menu/context-menu';
+import { contextMenu } from '../../../src/components/context-menu/context-menu.behavior';
+import { assertAxeClean, assertContractFulfillment } from '../../harness/conformance';
+
+interface SetupProps {
+  onSelectEdit?: () => void;
+  onOpenChange?: (open: boolean) => void;
+  open?: boolean;
+  container?: HTMLElement | null;
+  extraOutside?: boolean;
+}
+
+function TestMenu({ onSelectEdit, onOpenChange, open, container, extraOutside }: SetupProps) {
+  return (
+    <>
+      {extraOutside ? <button type="button">Elsewhere</button> : null}
+      <ContextMenu onOpenChange={onOpenChange} open={open}>
+        <ContextMenuTrigger>
+          <span>Right-click surface</span>
+        </ContextMenuTrigger>
+        <ContextMenuContent aria-label="Actions" container={container}>
+          <ContextMenuItem onSelect={() => onSelectEdit?.()}>Edit</ContextMenuItem>
+          <ContextMenuItem>Duplicate</ContextMenuItem>
+          <ContextMenuSeparator />
+          <ContextMenuItem disabled>Archive</ContextMenuItem>
+          <ContextMenuItem>Delete</ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+    </>
+  );
+}
+
+const body = () => document.body;
+const menu = () => body().querySelector<HTMLElement>('[data-part="content"]');
+const trigger = () => body().querySelector<HTMLElement>('[data-part="trigger"]') as HTMLElement;
+const itemByText = (text: string): HTMLElement => {
+  const match = Array.from(body().querySelectorAll<HTMLElement>('[role="menuitem"]')).find(
+    (element) => element.textContent === text,
+  );
+  if (!match) throw new Error(`no item ${text}`);
+  return match;
+};
+
+let region: HTMLElement;
+
+function setup(props: SetupProps = {}): void {
+  region = document.createElement('main');
+  document.body.appendChild(region);
+  render(<TestMenu {...props} container={region} />, { container: region });
+}
+
+function openMenu(x = 40, y = 60): void {
+  fireEvent.contextMenu(trigger(), { clientX: x, clientY: y });
+}
+
+afterEach(() => {
+  cleanup();
+  document.body.replaceChildren();
+});
+
+describe('context-menu conformance [react]', () => {
+  it('closed: the menu is not in the DOM', async () => {
+    setup();
+    expect(menu()).toBeNull();
+    expect(trigger().getAttribute('data-state')).toBe('closed');
+    await assertAxeClean(body());
+  });
+
+  it('right-click opens the menu at the pointer point, focus lands on the first item', async () => {
+    setup();
+    openMenu();
+    const content = menu();
+    expect(content).not.toBeNull();
+    expect(content?.getAttribute('role')).toBe('menu');
+    expect(content?.getAttribute('aria-orientation')).toBe('vertical');
+    expect(content?.getAttribute('data-state')).toBe('open');
+    expect(content?.style.position).toBe('fixed');
+    expect(content?.style.left).toBe('40px');
+    expect(content?.style.top).toBe('60px');
+    expect(document.activeElement).toBe(itemByText('Edit'));
+    await assertAxeClean(body());
+  });
+
+  it('the rendered ARIA equals the score projection when open', () => {
+    setup();
+    openMenu();
+    assertContractFulfillment(
+      contextMenu,
+      body(),
+      { open: true, x: 40, y: 60 },
+      { loop: true, avoidCollisions: true },
+      ['trigger', 'content'],
+    );
+  });
+
+  it('Escape closes and restores focus to the trigger', async () => {
+    const user = userEvent.setup();
+    setup();
+    openMenu();
+    expect(menu()).not.toBeNull();
+    await user.keyboard('{Escape}');
+    expect(menu()).toBeNull();
+    expect(document.activeElement).toBe(trigger());
+  });
+
+  it('pointerdown outside closes', async () => {
+    setup({ extraOutside: true });
+    openMenu();
+    expect(menu()).not.toBeNull();
+    fireEvent.pointerDown(region.querySelector('button') as HTMLElement);
+    expect(menu()).toBeNull();
+  });
+
+  it('selecting an item runs onSelect and closes', async () => {
+    const user = userEvent.setup();
+    const onSelectEdit = vi.fn();
+    setup({ onSelectEdit });
+    openMenu();
+    await user.click(itemByText('Edit'));
+    expect(onSelectEdit).toHaveBeenCalledTimes(1);
+    expect(menu()).toBeNull();
+  });
+
+  it('arrow keys rove focus down the enabled items, skipping the disabled one', async () => {
+    const user = userEvent.setup();
+    setup();
+    openMenu();
+    expect(document.activeElement).toBe(itemByText('Edit'));
+    await user.keyboard('{ArrowDown}');
+    expect(document.activeElement).toBe(itemByText('Duplicate'));
+    await user.keyboard('{ArrowDown}');
+    // Archive is disabled -- roving skips it and lands on Delete.
+    expect(document.activeElement).toBe(itemByText('Delete'));
+  });
+
+  it('typeahead focuses the item whose label starts with the typed key', async () => {
+    const user = userEvent.setup();
+    setup();
+    openMenu();
+    await user.keyboard('d');
+    expect(document.activeElement).toBe(itemByText('Duplicate'));
+  });
+
+  it('uncontrolled onOpenChange fires true on open and false on close', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    setup({ onOpenChange });
+    openMenu();
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    await user.keyboard('{Escape}');
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('checkbox and radio items toggle their state and close the menu', async () => {
+    const user = userEvent.setup();
+    const onCheckedChange = vi.fn();
+    const onValueChange = vi.fn();
+    region = document.createElement('main');
+    document.body.appendChild(region);
+    function Menu() {
+      return (
+        <ContextMenu>
+          <ContextMenuTrigger>
+            <span>Surface</span>
+          </ContextMenuTrigger>
+          <ContextMenuContent aria-label="Options" container={region}>
+            <ContextMenuCheckboxItem checked={false} onCheckedChange={onCheckedChange}>
+              Bold
+            </ContextMenuCheckboxItem>
+            <ContextMenuRadioGroup value="a" onValueChange={onValueChange}>
+              <ContextMenuRadioItem value="a">A</ContextMenuRadioItem>
+              <ContextMenuRadioItem value="b">B</ContextMenuRadioItem>
+            </ContextMenuRadioGroup>
+          </ContextMenuContent>
+        </ContextMenu>
+      );
+    }
+    render(<Menu />, { container: region });
+    fireEvent.contextMenu(trigger(), { clientX: 10, clientY: 10 });
+    const bold = body().querySelector<HTMLElement>('[role="menuitemcheckbox"]') as HTMLElement;
+    await user.click(bold);
+    expect(onCheckedChange).toHaveBeenCalledWith(true);
+    expect(menu()).toBeNull();
+
+    fireEvent.contextMenu(trigger(), { clientX: 10, clientY: 10 });
+    const optionB = Array.from(body().querySelectorAll<HTMLElement>('[role="menuitemradio"]')).find(
+      (element) => element.textContent === 'B',
+    ) as HTMLElement;
+    await user.click(optionB);
+    expect(onValueChange).toHaveBeenCalledWith('b');
+  });
+
+  it('controlled open renders the menu without a right-click', () => {
+    setup({ open: true });
+    expect(menu()).not.toBeNull();
+    expect(menu()?.getAttribute('data-state')).toBe('open');
+  });
+});
+
+const subContent = () => document.body.querySelector<HTMLElement>('[data-part="sub-content"]');
+const subTrigger = () =>
+  document.body.querySelector<HTMLElement>('[data-part="sub-trigger"]') as HTMLElement;
+
+function setupWithSub(onSelectDeep?: () => void): void {
+  region = document.createElement('main');
+  document.body.appendChild(region);
+  function Menu() {
+    return (
+      <ContextMenu>
+        <ContextMenuTrigger>
+          <span>Surface</span>
+        </ContextMenuTrigger>
+        <ContextMenuContent aria-label="Actions" container={region}>
+          <ContextMenuItem>Edit</ContextMenuItem>
+          <ContextMenuSub>
+            <ContextMenuSubTrigger>More</ContextMenuSubTrigger>
+            <ContextMenuSubContent aria-label="More actions" container={region}>
+              <ContextMenuItem onSelect={() => onSelectDeep?.()}>Deep</ContextMenuItem>
+              <ContextMenuItem>Deeper</ContextMenuItem>
+            </ContextMenuSubContent>
+          </ContextMenuSub>
+        </ContextMenuContent>
+      </ContextMenu>
+    );
+  }
+  render(<Menu />, { container: region });
+}
+
+describe('context-menu submenu [react]', () => {
+  it('the sub-trigger is a menuitem with a collapsed haspopup', () => {
+    setupWithSub();
+    openMenu();
+    expect(subTrigger().getAttribute('role')).toBe('menuitem');
+    expect(subTrigger().getAttribute('aria-haspopup')).toBe('menu');
+    expect(subTrigger().getAttribute('aria-expanded')).toBe('false');
+    expect(subContent()).toBeNull();
+  });
+
+  it('ArrowRight on the sub-trigger opens the submenu and focuses its first item', async () => {
+    const user = userEvent.setup();
+    setupWithSub();
+    openMenu();
+    await user.keyboard('{ArrowDown}'); // Edit -> More
+    expect(document.activeElement).toBe(subTrigger());
+    await user.keyboard('{ArrowRight}');
+    expect(subContent()).not.toBeNull();
+    expect(subTrigger().getAttribute('aria-expanded')).toBe('true');
+    expect(subTrigger().getAttribute('aria-controls')).toBe(subContent()?.id);
+    expect(document.activeElement?.textContent).toBe('Deep');
+    await assertAxeClean(body());
+  });
+
+  it('ArrowLeft closes the submenu and restores focus to the sub-trigger', async () => {
+    const user = userEvent.setup();
+    setupWithSub();
+    openMenu();
+    await user.keyboard('{ArrowDown}{ArrowRight}');
+    expect(subContent()).not.toBeNull();
+    await user.keyboard('{ArrowLeft}');
+    expect(subContent()).toBeNull();
+    expect(document.activeElement).toBe(subTrigger());
+  });
+
+  it('selecting a submenu item runs its onSelect and collapses the whole menu', async () => {
+    const user = userEvent.setup();
+    const onSelectDeep = vi.fn();
+    setupWithSub(onSelectDeep);
+    openMenu();
+    await user.keyboard('{ArrowDown}{ArrowRight}');
+    await user.click(
+      Array.from(body().querySelectorAll<HTMLElement>('[role="menuitem"]')).find(
+        (element) => element.textContent === 'Deep',
+      ) as HTMLElement,
+    );
+    expect(onSelectDeep).toHaveBeenCalledTimes(1);
+    expect(menu()).toBeNull();
+    expect(subContent()).toBeNull();
+  });
+});

--- a/packages/ui/test/components/context-menu/context-menu.element.conformance.test.ts
+++ b/packages/ui/test/components/context-menu/context-menu.element.conformance.test.ts
@@ -1,0 +1,172 @@
+/**
+ * WC performance of the context-menu score, driven end to end against light-DOM
+ * markup. Same score as the React conformance test -- the only difference is the
+ * controller applies the projection imperatively. The markup sits inside a
+ * <main> landmark so axe's best-practice region rule holds for the menu.
+ */
+import { cleanup, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { contextMenu } from '../../../src/components/context-menu/context-menu.behavior';
+import { RaftersContextMenu } from '../../../src/components/context-menu/context-menu.element';
+import { assertAxeClean, assertContractFulfillment } from '../../harness/conformance';
+
+beforeAll(() => {
+  if (!customElements.get('rafters-context-menu')) {
+    customElements.define('rafters-context-menu', RaftersContextMenu);
+  }
+});
+
+async function mount(): Promise<HTMLElement> {
+  document.body.innerHTML = `
+    <main>
+      <rafters-context-menu>
+        <span data-part="trigger" tabindex="-1" id="cm-trigger">Right-click here</span>
+        <div data-part="content" role="menu" aria-label="Actions" id="cm-content" data-state="closed" style="position: fixed; left: 0; top: 0;">
+          <div role="menuitem">Cut</div>
+          <div role="menuitem">Copy</div>
+          <div role="menuitem" data-disabled aria-disabled="true">Paste</div>
+          <div role="menuitem">Delete</div>
+          <div data-part="sub" id="cm-sub">
+            <div data-part="sub-trigger" role="menuitem" tabindex="-1" id="cm-sub-trigger">More</div>
+            <div data-part="sub-content" role="menu" aria-label="More" id="cm-sub-content" data-state="closed" style="position: fixed; left: 0; top: 0;">
+              <div role="menuitem">Deep</div>
+              <div role="menuitem">Deeper</div>
+            </div>
+          </div>
+        </div>
+      </rafters-context-menu>
+    </main>`;
+  await Promise.resolve(); // let the element's deferred bind run
+  return document.body.querySelector('rafters-context-menu') as HTMLElement;
+}
+
+const trigger = () =>
+  document.body.querySelector<HTMLElement>('[data-part="trigger"]') as HTMLElement;
+const content = () =>
+  document.body.querySelector<HTMLElement>('[data-part="content"]') as HTMLElement;
+const itemByText = (text: string): HTMLElement => {
+  const match = Array.from(document.body.querySelectorAll<HTMLElement>('[role="menuitem"]')).find(
+    (element) => element.textContent === text,
+  );
+  if (!match) throw new Error(`no item ${text}`);
+  return match;
+};
+
+// The bind portals an open submenu's content to document.body (escaping the
+// parent overflow and roving scope). In happy-dom a `hidden` attribute is not
+// collapsed to display:none, so a closed sub-content there would trip axe's
+// best-practice region rule that a real browser skips. Scope axe to the <main>
+// landmark, which contains the menu; the portaled node sits outside it.
+const landmark = () => document.body.querySelector('main') as HTMLElement;
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+describe('context-menu conformance [wc]', () => {
+  it('closed: content hidden, trigger collapsed, axe-clean', async () => {
+    await mount();
+    expect(content().hidden).toBe(true);
+    expect(content().getAttribute('data-state')).toBe('closed');
+    expect(trigger().getAttribute('data-state')).toBe('closed');
+    await assertAxeClean(landmark());
+  });
+
+  it('right-click opens at the pointer point, focus lands on the first item', async () => {
+    await mount();
+    fireEvent.contextMenu(trigger(), { clientX: 30, clientY: 50 });
+    expect(content().hidden).toBe(false);
+    expect(content().getAttribute('data-state')).toBe('open');
+    expect(content().style.left).toBe('30px');
+    expect(content().style.top).toBe('50px');
+    expect(document.activeElement).toBe(itemByText('Cut'));
+    await assertAxeClean(landmark());
+  });
+
+  it('the rendered ARIA equals the score projection when open', async () => {
+    await mount();
+    fireEvent.contextMenu(trigger(), { clientX: 10, clientY: 10 });
+    assertContractFulfillment(
+      contextMenu,
+      document.body,
+      { open: true, x: 10, y: 10 },
+      { loop: true, avoidCollisions: true },
+      ['trigger', 'content'],
+    );
+  });
+
+  it('Escape closes and restores focus to the trigger', async () => {
+    const user = userEvent.setup();
+    await mount();
+    fireEvent.contextMenu(trigger(), { clientX: 10, clientY: 10 });
+    expect(content().hidden).toBe(false);
+    await user.keyboard('{Escape}');
+    expect(content().hidden).toBe(true);
+    expect(document.activeElement).toBe(trigger());
+  });
+
+  it('pointerdown outside closes', async () => {
+    await mount();
+    fireEvent.contextMenu(trigger(), { clientX: 10, clientY: 10 });
+    expect(content().hidden).toBe(false);
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    fireEvent.pointerDown(outside);
+    expect(content().hidden).toBe(true);
+  });
+
+  it('arrow keys rove focus, skipping the disabled item', async () => {
+    const user = userEvent.setup();
+    await mount();
+    fireEvent.contextMenu(trigger(), { clientX: 10, clientY: 10 });
+    expect(document.activeElement).toBe(itemByText('Cut'));
+    await user.keyboard('{ArrowDown}');
+    expect(document.activeElement).toBe(itemByText('Copy'));
+    await user.keyboard('{ArrowDown}');
+    // Paste is disabled -- roving skips it and lands on Delete.
+    expect(document.activeElement).toBe(itemByText('Delete'));
+  });
+
+  it('selecting an item closes the menu', async () => {
+    const user = userEvent.setup();
+    await mount();
+    fireEvent.contextMenu(trigger(), { clientX: 10, clientY: 10 });
+    await user.click(itemByText('Copy'));
+    expect(content().hidden).toBe(true);
+  });
+
+  it('ArrowRight opens a submenu and ArrowLeft closes it back to the sub-trigger', async () => {
+    const user = userEvent.setup();
+    await mount();
+    fireEvent.contextMenu(trigger(), { clientX: 10, clientY: 10 });
+    const st = document.body.querySelector<HTMLElement>('[data-part="sub-trigger"]') as HTMLElement;
+    const sc = document.body.querySelector<HTMLElement>('[data-part="sub-content"]') as HTMLElement;
+    expect(sc.hidden).toBe(true);
+    st.focus();
+    await user.keyboard('{ArrowRight}');
+    expect(sc.hidden).toBe(false);
+    expect(st.getAttribute('aria-expanded')).toBe('true');
+    expect(st.getAttribute('aria-controls')).toBe('cm-sub-content');
+    expect(document.activeElement).toBe(itemByText('Deep'));
+    await user.keyboard('{ArrowLeft}');
+    expect(sc.hidden).toBe(true);
+    expect(document.activeElement).toBe(st);
+  });
+
+  it('closing the whole menu collapses an open submenu', async () => {
+    const user = userEvent.setup();
+    await mount();
+    fireEvent.contextMenu(trigger(), { clientX: 10, clientY: 10 });
+    const st = document.body.querySelector<HTMLElement>('[data-part="sub-trigger"]') as HTMLElement;
+    const sc = document.body.querySelector<HTMLElement>('[data-part="sub-content"]') as HTMLElement;
+    st.focus();
+    await user.keyboard('{ArrowRight}');
+    expect(sc.hidden).toBe(false);
+    await user.keyboard('{Escape}');
+    // Escape in the submenu closes the submenu first, back to the sub-trigger.
+    expect(sc.hidden).toBe(true);
+    expect(document.activeElement).toBe(st);
+  });
+});

--- a/packages/ui/test/components/context-menu/context-menu.element.conformance.test.ts
+++ b/packages/ui/test/components/context-menu/context-menu.element.conformance.test.ts
@@ -31,7 +31,12 @@ async function mount(): Promise<HTMLElement> {
             <div data-part="sub-trigger" role="menuitem" tabindex="-1" id="cm-sub-trigger">More</div>
             <div data-part="sub-content" role="menu" aria-label="More" id="cm-sub-content" data-state="closed" style="position: fixed; left: 0; top: 0;">
               <div role="menuitem">Deep</div>
-              <div role="menuitem">Deeper</div>
+              <div data-part="sub" id="cm-sub2">
+                <div data-part="sub-trigger" role="menuitem" tabindex="-1" id="cm-sub2-trigger">Even more</div>
+                <div data-part="sub-content" role="menu" aria-label="Even more" id="cm-sub2-content" data-state="closed" style="position: fixed; left: 0; top: 0;">
+                  <div role="menuitem">Grandchild</div>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -159,8 +164,8 @@ describe('context-menu conformance [wc]', () => {
     const user = userEvent.setup();
     await mount();
     fireEvent.contextMenu(trigger(), { clientX: 10, clientY: 10 });
-    const st = document.body.querySelector<HTMLElement>('[data-part="sub-trigger"]') as HTMLElement;
-    const sc = document.body.querySelector<HTMLElement>('[data-part="sub-content"]') as HTMLElement;
+    const st = document.getElementById('cm-sub-trigger') as HTMLElement;
+    const sc = document.getElementById('cm-sub-content') as HTMLElement;
     st.focus();
     await user.keyboard('{ArrowRight}');
     expect(sc.hidden).toBe(false);
@@ -168,5 +173,39 @@ describe('context-menu conformance [wc]', () => {
     // Escape in the submenu closes the submenu first, back to the sub-trigger.
     expect(sc.hidden).toBe(true);
     expect(document.activeElement).toBe(st);
+  });
+
+  // Open the level-1 submenu (Sub A) and its nested level-2 submenu (Sub A.1).
+  async function openTwoLevels(user: ReturnType<typeof userEvent.setup>): Promise<HTMLElement> {
+    fireEvent.contextMenu(trigger(), { clientX: 10, clientY: 10 });
+    (document.getElementById('cm-sub-trigger') as HTMLElement).focus();
+    await user.keyboard('{ArrowRight}');
+    (document.getElementById('cm-sub2-trigger') as HTMLElement).focus();
+    await user.keyboard('{ArrowRight}');
+    const grandchild = document.getElementById('cm-sub2-content') as HTMLElement;
+    expect(grandchild.hidden).toBe(false);
+    return grandchild;
+  }
+
+  it('dismissing the whole menu collapses a NESTED (grandchild) submenu, not just one level', async () => {
+    const user = userEvent.setup();
+    await mount();
+    const grandchild = await openTwoLevels(user);
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    fireEvent.pointerDown(outside);
+    expect(content().hidden).toBe(true);
+    expect(grandchild.hidden).toBe(true);
+    expect(grandchild.getAttribute('data-state')).toBe('closed');
+  });
+
+  it('selecting a top-level item while a nested submenu is open collapses the grandchild', async () => {
+    const user = userEvent.setup();
+    await mount();
+    const grandchild = await openTwoLevels(user);
+    await user.click(itemByText('Cut'));
+    expect(content().hidden).toBe(true);
+    expect(grandchild.hidden).toBe(true);
+    expect(grandchild.getAttribute('data-state')).toBe('closed');
   });
 });


### PR DESCRIPTION
## Summary

Ports `context-menu` to the behavior layer as a menu-collection-popup: one score
(`context-menu.behavior.ts`) driving three thin decorators (React `.tsx`, Web
Component `.element.ts`, Astro `.astro`), all composing the SAME `bindContextMenu`
for the DOM-native clients.

- The score is a single custom slice with state `{ open, x, y }` and actions
  `openAt`/`close`. The pointer point lives in the score (a controlled/SSR client
  must project it); the highlighted item does not (roving-focus owns it).
- Impure work is composed DIRECTLY from primitives (effects-as-data retired):
  `collision-detector`'s `{x,y}` point anchor for cursor placement, `roving-focus`
  + `typeahead` for the item list, `outside-click` for dismissal, and Escape via
  the score's keymap.
- Submenus are a SECOND score (`contextSubMenu`) -- a nested disclosure with its
  own `createBehavior` instance (not a second cell folded into the parent),
  composed from the same primitives with a plain-timeout hover-intent. Bound in
  all three frameworks, supporting arbitrary nesting. `Sub`/`SubTrigger`/
  `SubContent` preserve shadcn parity.
- Motion rides the semantic `motion-dropdown-in` token; no raw numeric durations.
- No shared files touched (components.jsonl deleted; no CHANGELOG/exports per the
  wave-4 rules).

## Acceptance criteria mapping

### Component doc written

`docs/spec/components/context-menu.md` follows the dialog.md register: composition,
config/state/actions, the parts + ARIA table (including sub-trigger/sub-content),
keyboard, the oracle-disposition table, and the WCAG obligations.
Evidence: packages/ui/docs/spec/components/context-menu.md:1

### JSDoc intelligence tags present

The React file's leading JSDoc carries all four tags the registry parses, with a
genuine five-dimension breakdown on `@cognitive-load` plus attention-economics,
trust-building, and accessibility notes specific to a right-click menu.
Evidence: packages/ui/src/components/context-menu/context-menu.tsx:5

### Behavior test (pure, no DOM)

The behavior suite exercises the score's laws directly -- parts, controlled
shadowing, action gates, keymap, aria, and both the main and submenu scores --
without rendering any framework, plus the pure `directSubMenus` helper.
Evidence: packages/ui/test/components/context-menu/context-menu.behavior.test.ts:34

### Classes parity test

The classes test pins the surface tokens and asserts motion rides the semantic
`motion-dropdown-in`/`motion-focus` tokens, with a regression guard that no raw
numeric duration or `animate-*` utility leaked back in.
Evidence: packages/ui/test/components/context-menu/context-menu.classes.test.ts:39

### Conformance test via the shared harness (aria + keymap against rendered DOM)

Three conformance suites drive the one score through `assertContractFulfillment`
and `assertAxeClean`, checking the projected ARIA and every keymap key (Escape,
arrows, typeahead, submenu Arrow Right/Left) against real rendered DOM in React,
the Web Component, and Astro SSR.
Evidence: packages/ui/test/components/context-menu/context-menu.conformance.test.tsx:107

### shadcn drop-in parity where the component exists in shadcn

The full compound surface is preserved -- Trigger/Content/Item/CheckboxItem/
RadioGroup/RadioItem/Separator/Label/Group/Shortcut/Portal AND the nested
Sub/SubTrigger/SubContent -- so a shadcn context-menu consumer's imports and props
(`onSelect`, `checked`/`onCheckedChange`, radio `onValueChange`, `asChild`) resolve
unchanged.
Evidence: packages/ui/src/components/context-menu/context-menu.tsx:801

### `pnpm --filter @rafters/ui test:unit` green, `pnpm preflight` green

Both configs of `test:unit` (57 context-menu tests among them) and the full
workspace `preflight` (lint, format, typecheck, build) exit zero locally; the
lefthook pre-commit ran the same gates on commit.
Evidence: packages/ui/test/components/context-menu/context-menu.element.conformance.test.ts:60

## Not done

- No shared-file edits (components matrix, CHANGELOG, package.json exports) -- the
  wave-4 rules place distribution in the registry (#1896), so a port PR touches
  only its own component folder and tests.
- `alignOffset` on Content is intentionally dropped (recorded in the doc's
  disposition table): cursor placement uses side='bottom' align='start' at the
  point, and no oracle test exercised a non-zero offset.
- Exit motion (`motion-dropdown-out`) is declared as intent only, not played: the
  content toggles `hidden` when closed, so a played exit awaits the Presence layer
  (Spec 04). The token exists; only the presence plumbing does not.
- No Vue performance (out of scope; the matrix keeps Vue missing).

Closes #1768
