### PR TITLE
feat(ui): port sidebar to the behavior layer

### DIFF
--- a/packages/ui/docs/spec/components/sidebar.md
+++ b/packages/ui/docs/spec/components/sidebar.md
@@ -15,14 +15,16 @@ conformance).
 
 A persistent navigation rail. On desktop it expands to a full rail or collapses
 (to an icon strip or fully off-canvas), and it remembers that choice across
-loads. Below the `md` breakpoint the same panel becomes a dismissable overlay
-over a scrim.
+loads. Below the `md` breakpoint the same navigation becomes a MODAL overlay --
+the merged `sheet` -- matching shadcn's architecture.
 
 ## Composition
 
 ```
 sidebar (bespoke slice)   state {open, openMobile}, actions open/close/openMobile/closeMobile,
-                          parts root/trigger/rail/panel/overlay, aria + Escape keymap
+                          parts root/trigger/rail/panel, aria + Escape keymap
+sheet (merged component)  the mobile overlay: React renders <Sheet>/<SheetContent>;
+                          WC/Astro compose startSheetModalEffects on the panel
 ```
 
 The slice is bespoke, not `disclosable`: the sidebar has TWO independent axes
@@ -36,6 +38,11 @@ the pure score cannot hold. The routing decision is a pure exported function,
 `toggleIntent(state, config, isMobile)`, so it lives IN the behavior; each
 performance supplies only the `isMobile` reading and calls it. `isMobile` never
 enters the score's state.
+
+The mobile overlay COMPOSES the merged `sheet` rather than re-deriving modality:
+the React performance renders `<Sheet open={openMobile}>` + `<SheetContent>`; the
+WC/Astro binds compose `startSheetModalEffects` (sheet's own exported modal trio)
+on the panel. `openMobile` drives the sheet's open state either way.
 
 ## Config, state, actions
 
@@ -66,47 +73,57 @@ mobile prop, so `openMobile` is always intrinsic and has no change callback.
 | Part | Presence | ARIA / data |
 | --- | --- | --- |
 | root | always | none (the provider wrapper and bind root) |
-| trigger | optional | `aria-controls` (panel id, only when real), `data-state` (expanded/collapsed) |
+| trigger | optional | `aria-controls` (desktop panel id, only when real; dropped on mobile where the panel is the Sheet), `data-state` |
 | rail | optional | `aria-label="Toggle Sidebar"`, `data-state` |
 | panel | always | `data-state` (expanded/collapsed), `data-collapsible` (mode, only while collapsed and not `none`), `data-mobile` (open/closed) |
-| overlay | optional | `aria-label="Close sidebar"`, `data-state` (open/closed); present-but-hidden off the mobile axis |
+
+`role="dialog"` + `aria-modal` + `aria-label="Sidebar"` are NOT in the score's
+projection -- they are bind-managed on the panel while the mobile overlay is open
+(they depend on the viewport signal, which the score does not hold), mirroring the
+React `SheetContent` surface. On mobile in React the panel is not rendered at all
+(the overlay is the portaled Sheet), so the trigger drops its `aria-controls`
+there to avoid a dangling reference.
 
 The trigger carries NO `aria-expanded`. The gesture moves whichever axis the
 viewport selects, so a single expanded value would misreport on the other
-viewport; `aria-controls` (a stable relationship) is projected instead. Empty-id
-convention: a part the binding did not render passes `''`, and the projection
-emits `undefined` rather than a dangling reference.
+viewport; `aria-controls` (a stable relationship, desktop only) is projected
+instead. Empty-id convention: a part the binding did not render passes `''`, and
+the projection emits `undefined` rather than a dangling reference.
 
-The panel is a single `<nav>` carrying BOTH axes' hooks; the view keys the
-desktop width collapse off `data-state`/`data-collapsible` (scoped `md:`) and the
-mobile off-canvas slide off `data-mobile` (below `md`). One element, two
-viewports -- never two panels with duplicated ids and duplicated AT content.
+The panel is a single `<nav>`. On desktop the view keys the width collapse off
+`data-state`/`data-collapsible` (scoped `md:`). On mobile: in React the `Sidebar`
+renders the merged `<Sheet>` instead of the nav (one runtime branch on
+`isMobile`, no duplicated children); in WC/Astro the one `<nav>` is enhanced in
+place into a modal by the bind, and `hidden` when the overlay is closed.
 
 ## Keyboard and dismissal
 
 - **Cmd/Ctrl+B**: an imperative window listener (the shortcut is global, not
   part-scoped) routed through `toggleIntent`. Wired in `bindSidebar` (WC/Astro)
   and a React effect.
-- **Escape** on the panel -> `closeMobile`, restoring focus to the trigger. The
-  bind resolves the keydown part by CONTAINMENT (`panel.contains(target)`),
-  never `target.closest('[data-part]')`: the latter misroutes when focus rests on
-  a focusable descendant that carries its own `data-part` (the rail), the
-  systemic dialog-family defect tracked in #1921. React hardcodes the part
-  `'panel'` on the element it renders, the same resolution by construction.
-- **Scrim click** -> `closeMobile`.
+- **Escape** on the panel -> `closeMobile`. The bind resolves the keydown part by
+  CONTAINMENT (`panel.contains(target)`), never `target.closest('[data-part]')`:
+  the latter misroutes when focus rests on a focusable descendant that carries its
+  own `data-part` (the rail), the systemic dialog-family defect tracked in #1921.
+  React's desktop nav hardcodes the part `'panel'` (the same resolution by
+  construction); React's mobile Escape is the Sheet's own. On close the sheet
+  focus-trap teardown restores focus to the opener (the trigger).
+- **Outside pointerdown** on mobile dismisses via the sheet modal trio's
+  `onPointerDownOutside` (sparing the trigger) -- not a bespoke scrim handler.
 
-The mobile overlay is DISMISSABLE, not modal: no focus-trap, no scroll-lock, no
-outside-click primitive. This is faithful to the oracle (its mobile panel had a
-plain scrim button and no trap) and honors the port issue's "add no primitives".
-See the dispositions below.
+The mobile overlay is MODAL, via the composed `sheet`: focus is trapped inside,
+body scroll is locked, an outside pointerdown dismisses, and -- decisively for
+focus management -- the overlay content is UNREACHABLE while closed (React
+unmounts `SheetContent`; the WC/Astro bind `hidden`s the panel), so its links
+leave the tab order and a11y tree.
 
 ## Motion
 
-UNDECLARED. The issue's motion intent is "expand/collapse: slide, axis x" -- a
-horizontal collapse (width / off-canvas translate). The ratified animated-presence
-pattern (`motion-expand`/`motion-collapse` + `grid-template-rows`
-`minmax(0,0fr)<->minmax(0,1fr)` + `inert` on the collapsed panel) is the VERTICAL
-accordion trick and does NOT transfer here:
+The DESKTOP horizontal collapse is UNDECLARED. The issue's motion intent is
+"expand/collapse: slide, axis x" -- a horizontal collapse (width / off-canvas).
+The ratified animated-presence pattern (`motion-expand`/`motion-collapse` +
+`grid-template-rows` `minmax(0,0fr)<->minmax(0,1fr)` + `inert` on the collapsed
+panel) is the VERTICAL accordion trick and does NOT transfer here:
 
 - `grid-template-rows` animates the block (y) axis; sidebar collapse is the
   inline (x) axis. Applying it would animate height while width is what changes.
@@ -116,9 +133,10 @@ accordion trick and does NOT transfer here:
 
 No horizontal-slide/width semantic motion token exists yet (the token layer is
 being rebuilt, #1899/#1902), so -- following the sheet precedent -- the from/to
-states ride the `data-state`/`data-mobile` hooks while the timing is left to the
-future token layer rather than hardcoded (`duration-200 ease-linear` etc. are
-dropped). Small `duration-150` hover/press acknowledgments on the menu buttons
+states ride the `data-state` hooks while the timing is left to the future token
+layer rather than hardcoded (`duration-200 ease-linear` etc. are dropped). The
+MOBILE overlay's enter/exit is the merged `sheet`'s own concern, not the
+sidebar's. Small `duration-150` hover/press acknowledgments on the menu buttons
 are kept (Spec 04 retains interaction feedback), never the layout motion.
 
 ## Oracle dispositions (src/old/ui/sidebar.tsx, boundary 9)
@@ -134,12 +152,12 @@ surface; `dropped` = intentionally not ported; `defect-do-not-port` = oracle bug
 | `toggleSidebar` routing to a viewport-appropriate axis | contract; moved into pure `toggleIntent(state, config, isMobile)` |
 | cookie persistence: write on `open` change, seed from `defaultOpen`, never read back | contract; replicated write-only via `memory.select` in the bind and a React effect |
 | Cmd/Ctrl+B window shortcut | contract; window listener routed through `toggleIntent` in all three performances |
-| mobile overlay = scrim button (click closes) + sliding panel | contract; the dismissable (non-modal) overlay is preserved |
-| mobile overlay had NO focus-trap / scroll-lock / outside-click / Escape | contract for the first three (deliberately add none -- issue: "add none"); Escape ADDED as an a11y hardening (panel keymap, containment-resolved) |
-| shadcn wraps the mobile sidebar in a modal `Sheet` | dropped; the rafters oracle diverged to a non-modal scrim, and this port keeps that (documented divergence from shadcn, per issue point 7) |
+| mobile overlay = plain scrim button + sliding panel (the rafters oracle's non-modal divergence) | defect-do-not-port; replaced by the merged modal `sheet` -- the non-modal scrim is exactly what left closed-overlay links tab-reachable |
+| mobile overlay had NO focus-trap / scroll-lock / outside-dismiss | defect-do-not-port; the composed sheet modal trio supplies all three (WCAG 2.2 AAA focus management) |
+| shadcn wraps the mobile sidebar in a modal `Sheet` | contract; now composed -- React renders `<Sheet>`/`<SheetContent>`, WC/Astro compose `startSheetModalEffects` on the panel |
 | `side` / `variant` / `collapsible` props | contract; positional/surface decoration as `data-*` + classes, never ARIA |
 | `collapsible="none"` non-collapsible branch | contract; `data-collapsible` is never projected for `none` |
-| desktop "gap" element for a smooth width transition | dropped; it existed only to animate width, and motion is undeclared |
+| desktop "gap" element for a smooth width transition | dropped; it existed only to animate width, and desktop motion is undeclared |
 | Rail (desktop toggle, `tabIndex=-1`, labelled) | contract |
 | Inset (`<main>` landmark) | contract |
 | Header/Footer/Content/Group(+Label/Action/Content)/Menu(+Item/Button/Action/Badge/Skeleton/Sub/SubItem/SubButton)/Separator | contract; pure decoration (classes + `data-sidebar` attrs), no behavior |
@@ -147,29 +165,29 @@ surface; `dropped` = intentionally not ported; `defect-do-not-port` = oracle bug
 | MenuButton `variant`/`size`, MenuSubButton `size`, `isActive` (`data-active`) | contract; decoration variants |
 | MenuSkeleton random bar width (`Math.random`) | framework-affordance (React only); the WC/Astro shells do not render skeletons |
 | JSDoc claimed a "nav role" landmark but rendered a `<div>` | defect-do-not-port; this port actually delivers `<nav>` for the panel (the landmark the oracle only aspired to) |
-| trigger had no `aria-controls`/`aria-expanded` | contract, hardened: `aria-controls` -> panel added; `aria-expanded` deliberately omitted (viewport-ambiguous) |
-| raw `duration-200 ease-linear`/`ease-in-out` collapse + slide transitions | defect-do-not-port; raw numeric durations, dropped -- motion left undeclared pending horizontal tokens (#1899/#1902) |
+| trigger had no `aria-controls`/`aria-expanded` | contract, hardened: desktop `aria-controls` -> panel added (dropped on mobile, where the panel is the Sheet); `aria-expanded` deliberately omitted (viewport-ambiguous) |
+| raw `duration-200 ease-linear`/`ease-in-out` desktop collapse transition | defect-do-not-port; raw numeric durations, dropped -- desktop motion undeclared pending horizontal tokens (#1899/#1902) |
 | accordion grid-rows/`inert` animated-presence (spawn point 5) | not applicable; horizontal collapse (axis x) and a visible `icon` rail must not be `inert` -- see Motion |
 
 ## Known limitations (honest not-delivered)
 
-1. **Mobile-closed panel remains tab-reachable.** With one panel + CSS translate,
-   a closed mobile overlay's links are translated off-screen but stay in the a11y
-   tree. This is not hidden with reactive `inert` on purpose: the same element is
-   the desktop `icon` rail, which must stay reachable, so a mode-dependent `inert`
-   would wrongly hide it. A future fix belongs to the presence/token layer.
-2. **No animation.** Collapse and slide are state-correct but not animated until
-   horizontal-slide motion tokens land (#1899/#1902).
-3. **Non-modal mobile overlay.** No focus containment or scroll lock on mobile;
-   this matches the oracle and the "add no primitives" constraint. If a modal
-   mobile sidebar is later wanted, compose the sheet modal trio then.
+1. **No desktop collapse animation.** The horizontal expand/collapse is
+   state-correct but unanimated until a horizontal-slide / width motion token
+   lands (#1899/#1902). The mobile overlay's enter/exit is animated by the merged
+   `sheet` (its own concern).
 
-## WCAG 2.1 AA obligations
+## WCAG obligations
 
-- 1.3.1 / 4.1.2: the panel is a `<nav>` landmark; the trigger is a labelled
-  control wired by real id (`aria-controls`) to the panel; the scrim is a
-  labelled dismiss button. Asserted against real DOM by the conformance harness.
+- 1.3.1 / 4.1.2: on desktop the panel is a `<nav>` landmark and the trigger is a
+  labelled control wired by real id (`aria-controls`) to it; on mobile the overlay
+  is `role="dialog"` + `aria-modal` with an accessible name (`aria-label="Sidebar"`).
+  Asserted against real DOM by the conformance harness.
 - 2.1.1 / 2.1.2: Escape dismisses the mobile overlay and restores focus to the
-  trigger; the collapsed desktop rail stays keyboard-navigable (never removed
-  from the tree, never `inert`).
+  trigger; focus is trapped inside the open overlay and cycles without escaping;
+  the collapsed desktop rail stays keyboard-navigable (never removed, never
+  `inert`).
+- 2.4.3 Focus Order (AAA-grade management): the mobile overlay traps focus while
+  open and, while CLOSED, is unreachable -- its links are not in the tab order or
+  a11y tree (React unmounts the content; WC/Astro `hidden` the panel), each
+  asserted per framework in the conformance suites.
 - 2.4.7: token focus ring on the menu controls.

--- a/packages/ui/docs/spec/components/sidebar.md
+++ b/packages/ui/docs/spec/components/sidebar.md
@@ -1,0 +1,175 @@
+# Component Spec — Sidebar
+
+Status: DRAFT. Compound archetype. Collapsible application navigation rail.
+
+Files (`src/components/sidebar/`):
+
+```
+sidebar.classes.ts    sidebar.behavior.ts    sidebar.tsx    sidebar.element.ts    sidebar.astro
+```
+
+Tests mirror into `test/components/sidebar/` (behavior + classes + React/WC/Astro
+conformance).
+
+## What it is
+
+A persistent navigation rail. On desktop it expands to a full rail or collapses
+(to an icon strip or fully off-canvas), and it remembers that choice across
+loads. Below the `md` breakpoint the same panel becomes a dismissable overlay
+over a scrim.
+
+## Composition
+
+```
+sidebar (bespoke slice)   state {open, openMobile}, actions open/close/openMobile/closeMobile,
+                          parts root/trigger/rail/panel/overlay, aria + Escape keymap
+```
+
+The slice is bespoke, not `disclosable`: the sidebar has TWO independent axes
+(`open`, the persistent desktop expand; `openMobile`, the transient mobile
+overlay), and `disclosable` models a single open/closed axis. Both axes are
+reducers over the ONE memory cell `createBehavior` owns -- no second cell, per
+the cell-ownership rule (createSelectionGroup/createDisclosure do not compose).
+
+Which axis a toggle gesture moves depends on the viewport, a media-query signal
+the pure score cannot hold. The routing decision is a pure exported function,
+`toggleIntent(state, config, isMobile)`, so it lives IN the behavior; each
+performance supplies only the `isMobile` reading and calls it. `isMobile` never
+enters the score's state.
+
+## Config, state, actions
+
+```ts
+interface SidebarConfig {
+  open?: boolean;        // controlled desktop expand
+  defaultOpen?: boolean; // uncontrolled seed, default true
+  side?: 'left' | 'right';                    // decoration
+  variant?: 'sidebar' | 'floating' | 'inset'; // decoration
+  collapsible?: 'offcanvas' | 'icon' | 'none';// collapse mode (data hook)
+}
+interface SidebarState { open: boolean; openMobile: boolean }
+type SidebarActions = { open; close; openMobile; closeMobile } // all undefined payload
+```
+
+No `toggle` reducer: the trigger/rail/shortcut resolve the effective value and
+dispatch `open`/`close` (or `openMobile`/`closeMobile`), so intrinsic state can
+never drift from a controlled consumer. The per-axis idempotence gate (open only
+when effectively closed, close only when effectively open, and likewise for the
+mobile axis) makes `onOpenChange` fire once per real desktop transition and makes
+`closeMobile` a no-op while the overlay is already closed.
+
+Only the desktop `open` axis is controllable; the oracle exposed no controlled
+mobile prop, so `openMobile` is always intrinsic and has no change callback.
+
+## Parts and ARIA
+
+| Part | Presence | ARIA / data |
+| --- | --- | --- |
+| root | always | none (the provider wrapper and bind root) |
+| trigger | optional | `aria-controls` (panel id, only when real), `data-state` (expanded/collapsed) |
+| rail | optional | `aria-label="Toggle Sidebar"`, `data-state` |
+| panel | always | `data-state` (expanded/collapsed), `data-collapsible` (mode, only while collapsed and not `none`), `data-mobile` (open/closed) |
+| overlay | optional | `aria-label="Close sidebar"`, `data-state` (open/closed); present-but-hidden off the mobile axis |
+
+The trigger carries NO `aria-expanded`. The gesture moves whichever axis the
+viewport selects, so a single expanded value would misreport on the other
+viewport; `aria-controls` (a stable relationship) is projected instead. Empty-id
+convention: a part the binding did not render passes `''`, and the projection
+emits `undefined` rather than a dangling reference.
+
+The panel is a single `<nav>` carrying BOTH axes' hooks; the view keys the
+desktop width collapse off `data-state`/`data-collapsible` (scoped `md:`) and the
+mobile off-canvas slide off `data-mobile` (below `md`). One element, two
+viewports -- never two panels with duplicated ids and duplicated AT content.
+
+## Keyboard and dismissal
+
+- **Cmd/Ctrl+B**: an imperative window listener (the shortcut is global, not
+  part-scoped) routed through `toggleIntent`. Wired in `bindSidebar` (WC/Astro)
+  and a React effect.
+- **Escape** on the panel -> `closeMobile`, restoring focus to the trigger. The
+  bind resolves the keydown part by CONTAINMENT (`panel.contains(target)`),
+  never `target.closest('[data-part]')`: the latter misroutes when focus rests on
+  a focusable descendant that carries its own `data-part` (the rail), the
+  systemic dialog-family defect tracked in #1921. React hardcodes the part
+  `'panel'` on the element it renders, the same resolution by construction.
+- **Scrim click** -> `closeMobile`.
+
+The mobile overlay is DISMISSABLE, not modal: no focus-trap, no scroll-lock, no
+outside-click primitive. This is faithful to the oracle (its mobile panel had a
+plain scrim button and no trap) and honors the port issue's "add no primitives".
+See the dispositions below.
+
+## Motion
+
+UNDECLARED. The issue's motion intent is "expand/collapse: slide, axis x" -- a
+horizontal collapse (width / off-canvas translate). The ratified animated-presence
+pattern (`motion-expand`/`motion-collapse` + `grid-template-rows`
+`minmax(0,0fr)<->minmax(0,1fr)` + `inert` on the collapsed panel) is the VERTICAL
+accordion trick and does NOT transfer here:
+
+- `grid-template-rows` animates the block (y) axis; sidebar collapse is the
+  inline (x) axis. Applying it would animate height while width is what changes.
+- `inert` on the collapsed panel is wrong: an `icon`-mode collapsed rail stays
+  VISIBLE and its buttons remain clickable, so marking it `inert` would remove
+  live, visible controls from the a11y tree.
+
+No horizontal-slide/width semantic motion token exists yet (the token layer is
+being rebuilt, #1899/#1902), so -- following the sheet precedent -- the from/to
+states ride the `data-state`/`data-mobile` hooks while the timing is left to the
+future token layer rather than hardcoded (`duration-200 ease-linear` etc. are
+dropped). Small `duration-150` hover/press acknowledgments on the menu buttons
+are kept (Spec 04 retains interaction feedback), never the layout motion.
+
+## Oracle dispositions (src/old/ui/sidebar.tsx, boundary 9)
+
+Legend: `contract` = preserved semantic; `framework-affordance` = React-only
+surface; `dropped` = intentionally not ported; `defect-do-not-port` = oracle bug.
+
+| Oracle feature | Disposition |
+| --- | --- |
+| `open`/`defaultOpen`/`onOpenChange` on the provider (desktop axis) | contract; dialog-style (no toggle reducer), callback on the desktop axis only |
+| two booleans (`open`, `openMobile`) in one memory cell | contract; re-expressed as two axes/reducers over the single score cell |
+| `isMobile` as a local media-query signal, not state | contract; kept OUTSIDE the score, consumed via pure `toggleIntent` |
+| `toggleSidebar` routing to a viewport-appropriate axis | contract; moved into pure `toggleIntent(state, config, isMobile)` |
+| cookie persistence: write on `open` change, seed from `defaultOpen`, never read back | contract; replicated write-only via `memory.select` in the bind and a React effect |
+| Cmd/Ctrl+B window shortcut | contract; window listener routed through `toggleIntent` in all three performances |
+| mobile overlay = scrim button (click closes) + sliding panel | contract; the dismissable (non-modal) overlay is preserved |
+| mobile overlay had NO focus-trap / scroll-lock / outside-click / Escape | contract for the first three (deliberately add none -- issue: "add none"); Escape ADDED as an a11y hardening (panel keymap, containment-resolved) |
+| shadcn wraps the mobile sidebar in a modal `Sheet` | dropped; the rafters oracle diverged to a non-modal scrim, and this port keeps that (documented divergence from shadcn, per issue point 7) |
+| `side` / `variant` / `collapsible` props | contract; positional/surface decoration as `data-*` + classes, never ARIA |
+| `collapsible="none"` non-collapsible branch | contract; `data-collapsible` is never projected for `none` |
+| desktop "gap" element for a smooth width transition | dropped; it existed only to animate width, and motion is undeclared |
+| Rail (desktop toggle, `tabIndex=-1`, labelled) | contract |
+| Inset (`<main>` landmark) | contract |
+| Header/Footer/Content/Group(+Label/Action/Content)/Menu(+Item/Button/Action/Badge/Skeleton/Sub/SubItem/SubButton)/Separator | contract; pure decoration (classes + `data-sidebar` attrs), no behavior |
+| `asChild` on Trigger/GroupLabel/GroupAction/MenuButton/MenuAction/MenuSubButton | framework-affordance (React) |
+| MenuButton `variant`/`size`, MenuSubButton `size`, `isActive` (`data-active`) | contract; decoration variants |
+| MenuSkeleton random bar width (`Math.random`) | framework-affordance (React only); the WC/Astro shells do not render skeletons |
+| JSDoc claimed a "nav role" landmark but rendered a `<div>` | defect-do-not-port; this port actually delivers `<nav>` for the panel (the landmark the oracle only aspired to) |
+| trigger had no `aria-controls`/`aria-expanded` | contract, hardened: `aria-controls` -> panel added; `aria-expanded` deliberately omitted (viewport-ambiguous) |
+| raw `duration-200 ease-linear`/`ease-in-out` collapse + slide transitions | defect-do-not-port; raw numeric durations, dropped -- motion left undeclared pending horizontal tokens (#1899/#1902) |
+| accordion grid-rows/`inert` animated-presence (spawn point 5) | not applicable; horizontal collapse (axis x) and a visible `icon` rail must not be `inert` -- see Motion |
+
+## Known limitations (honest not-delivered)
+
+1. **Mobile-closed panel remains tab-reachable.** With one panel + CSS translate,
+   a closed mobile overlay's links are translated off-screen but stay in the a11y
+   tree. This is not hidden with reactive `inert` on purpose: the same element is
+   the desktop `icon` rail, which must stay reachable, so a mode-dependent `inert`
+   would wrongly hide it. A future fix belongs to the presence/token layer.
+2. **No animation.** Collapse and slide are state-correct but not animated until
+   horizontal-slide motion tokens land (#1899/#1902).
+3. **Non-modal mobile overlay.** No focus containment or scroll lock on mobile;
+   this matches the oracle and the "add no primitives" constraint. If a modal
+   mobile sidebar is later wanted, compose the sheet modal trio then.
+
+## WCAG 2.1 AA obligations
+
+- 1.3.1 / 4.1.2: the panel is a `<nav>` landmark; the trigger is a labelled
+  control wired by real id (`aria-controls`) to the panel; the scrim is a
+  labelled dismiss button. Asserted against real DOM by the conformance harness.
+- 2.1.1 / 2.1.2: Escape dismisses the mobile overlay and restores focus to the
+  trigger; the collapsed desktop rail stays keyboard-navigable (never removed
+  from the tree, never `inert`).
+- 2.4.7: token focus ring on the menu controls.

--- a/packages/ui/src/components/sidebar/sidebar.astro
+++ b/packages/ui/src/components/sidebar/sidebar.astro
@@ -1,0 +1,103 @@
+---
+/**
+ * Astro performance for sidebar. Server-renders the full light-DOM shell with
+ * the initial projection already applied (desktop-expanded, mobile-closed --
+ * correct and navigable before JS), then the <script> hands each instance to
+ * bindSidebar, the SAME DOM-native client the Web Component uses. One score,
+ * three performances.
+ *
+ * The panel is a single <nav> carrying both axes' data hooks; side/variant are
+ * authored into its classes here (decoration the binding never touches). The
+ * scrim is present-but-hidden off the mobile axis. Nav content arrives through
+ * the default slot; the trigger through the `trigger` slot. Motion is undeclared
+ * (horizontal-slide tokens pending, #1899/#1902), so this is state-correct, not
+ * animated.
+ */
+import {
+  sidebar,
+  type SidebarConfig,
+  type SidebarPart,
+  type SidebarSide,
+  type SidebarVariant,
+} from './sidebar.behavior';
+import { sidebarClasses, sidebarPanelClasses } from './sidebar.classes';
+import type { PartIds } from '../../lib/contract';
+
+interface Props {
+  id: string;
+  side?: SidebarSide;
+  variant?: SidebarVariant;
+  collapsible?: SidebarConfig['collapsible'];
+  defaultOpen?: boolean;
+}
+
+const {
+  id,
+  side = 'left',
+  variant = 'sidebar',
+  collapsible = 'offcanvas',
+  defaultOpen = true,
+} = Astro.props;
+
+const config: SidebarConfig = { defaultOpen, side, variant, collapsible };
+const state = sidebar.initialState(config);
+const classes = sidebarClasses();
+const panelClass = sidebarPanelClasses(side, variant);
+
+const ids = {} as PartIds<SidebarPart>;
+for (const part of Object.keys(sidebar.parts) as SidebarPart[]) ids[part] = `${id}-${part}`;
+const aria = sidebar.aria(state, config, ids);
+const mobileOpen = state.openMobile;
+---
+
+<rafters-sidebar
+  data-part="root"
+  data-side={side}
+  data-variant={variant}
+  data-collapsible={collapsible}
+  data-default-open={String(defaultOpen)}
+  class={classes.provider}
+>
+  <button type="button" id={ids.trigger} data-part="trigger" class={classes.trigger} {...aria.trigger}>
+    <slot name="trigger">Toggle Sidebar</slot>
+  </button>
+
+  <button
+    type="button"
+    id={ids.overlay}
+    data-part="overlay"
+    class={classes.overlay}
+    hidden={!mobileOpen}
+    {...aria.overlay}
+  ></button>
+
+  <nav
+    id={ids.panel}
+    data-part="panel"
+    data-side={side}
+    data-variant={variant}
+    class={panelClass}
+    {...aria.panel}
+  >
+    <button
+      type="button"
+      id={ids.rail}
+      data-part="rail"
+      tabindex="-1"
+      title="Toggle Sidebar"
+      class={classes.rail}
+      {...aria.rail}></button>
+    <slot />
+  </nav>
+</rafters-sidebar>
+
+<script>
+  import { bindSidebar } from './sidebar.behavior';
+
+  for (const root of document.querySelectorAll('rafters-sidebar[data-part="root"]')) {
+    const el = root as HTMLElement;
+    if (el.dataset['bound'] === 'true') continue;
+    el.dataset['bound'] = 'true';
+    bindSidebar(el);
+  }
+</script>

--- a/packages/ui/src/components/sidebar/sidebar.astro
+++ b/packages/ui/src/components/sidebar/sidebar.astro
@@ -7,11 +7,12 @@
  * three performances.
  *
  * The panel is a single <nav> carrying both axes' data hooks; side/variant are
- * authored into its classes here (decoration the binding never touches). The
- * scrim is present-but-hidden off the mobile axis. Nav content arrives through
- * the default slot; the trigger through the `trigger` slot. Motion is undeclared
- * (horizontal-slide tokens pending, #1899/#1902), so this is state-correct, not
- * animated.
+ * authored into its classes here (decoration the binding never touches). On the
+ * mobile viewport bindSidebar enhances that same <nav> into a modal overlay
+ * (role=dialog + the sheet modal trio) and `hidden`s it when closed; the desktop
+ * rail path is untouched. Nav content arrives through the default slot; the
+ * trigger through the `trigger` slot. Motion is undeclared (horizontal-slide
+ * tokens pending, #1899/#1902), so this is state-correct, not animated.
  */
 import {
   sidebar,
@@ -47,7 +48,6 @@ const panelClass = sidebarPanelClasses(side, variant);
 const ids = {} as PartIds<SidebarPart>;
 for (const part of Object.keys(sidebar.parts) as SidebarPart[]) ids[part] = `${id}-${part}`;
 const aria = sidebar.aria(state, config, ids);
-const mobileOpen = state.openMobile;
 ---
 
 <rafters-sidebar
@@ -62,20 +62,12 @@ const mobileOpen = state.openMobile;
     <slot name="trigger">Toggle Sidebar</slot>
   </button>
 
-  <button
-    type="button"
-    id={ids.overlay}
-    data-part="overlay"
-    class={classes.overlay}
-    hidden={!mobileOpen}
-    {...aria.overlay}
-  ></button>
-
   <nav
     id={ids.panel}
     data-part="panel"
     data-side={side}
     data-variant={variant}
+    tabindex="-1"
     class={panelClass}
     {...aria.panel}
   >

--- a/packages/ui/src/components/sidebar/sidebar.behavior.ts
+++ b/packages/ui/src/components/sidebar/sidebar.behavior.ts
@@ -1,0 +1,310 @@
+import { compose, type Slice } from '../../lib/compose';
+import {
+  createBehavior,
+  type AriaAttrs,
+  type BehaviorSpec,
+  type PartIds,
+} from '../../lib/contract';
+import { updateAriaAttribute } from '../../primitives/aria-manager';
+
+/** The edge the rail is anchored to. Purely positional: it selects the view's
+ *  side variant and the collapse/slide direction. It never enters a reducer and
+ *  projects no ARIA. Default: left. */
+export type SidebarSide = 'left' | 'right';
+
+/** Surface treatment of the desktop rail. Positional decoration only. */
+export type SidebarVariant = 'sidebar' | 'floating' | 'inset';
+
+/** How the desktop rail collapses. `offcanvas` slides fully off; `icon` shrinks
+ *  to an icon strip; `none` never collapses. It is projected as a data hook the
+ *  view keys its collapse rules off, never as ARIA. Default: offcanvas. */
+export type SidebarCollapsible = 'offcanvas' | 'icon' | 'none';
+
+export interface SidebarConfig {
+  /** Controlled desktop expand: shadows the intrinsic `open` axis when present. */
+  open?: boolean | undefined;
+  /** Uncontrolled seed for the desktop expand axis. Default true -- the oracle's
+   *  default (a fresh app opens expanded). */
+  defaultOpen?: boolean | undefined;
+  /** Positional decoration; never state. Default left. */
+  side?: SidebarSide | undefined;
+  /** Surface decoration; never state. Default sidebar. */
+  variant?: SidebarVariant | undefined;
+  /** Collapse mode; projected as `data-collapsible`. Default offcanvas. */
+  collapsible?: SidebarCollapsible | undefined;
+}
+
+/**
+ * Two independent axes in ONE memory cell (Spec 01: reducers are pure over the
+ * single cell createBehavior owns). `open` is the persistent desktop
+ * expand/collapse rail; `openMobile` is the transient mobile overlay. They never
+ * couple in a reducer -- which axis a toggle gesture moves is decided by the
+ * browser's viewport signal, resolved OUTSIDE the score by `toggleIntent`
+ * (isMobile is a media-query signal, not application state).
+ */
+export interface SidebarState {
+  /** Intrinsic desktop expand -- ignored while a controlled `open` is present. */
+  open: boolean;
+  /** Mobile overlay visibility. Always intrinsic; the oracle exposed no
+   *  controlled mobile prop. */
+  openMobile: boolean;
+}
+
+export type SidebarActions = {
+  /** Expand the desktop rail. */
+  open: undefined;
+  /** Collapse the desktop rail. */
+  close: undefined;
+  /** Reveal the mobile overlay. */
+  openMobile: undefined;
+  /** Dismiss the mobile overlay. */
+  closeMobile: undefined;
+};
+
+export type SidebarPart = 'root' | 'trigger' | 'rail' | 'panel' | 'overlay';
+
+/** The effective desktop-expand value: a controlled `open` shadows intrinsic. */
+export function isOpen(state: SidebarState, config: SidebarConfig): boolean {
+  return config.open ?? state.open;
+}
+
+/** The effective mobile-overlay value. Always intrinsic (no controlled prop). */
+export function isMobileOpen(state: SidebarState): boolean {
+  return state.openMobile;
+}
+
+export function collapsibleOf(config: SidebarConfig): SidebarCollapsible {
+  return config.collapsible ?? 'offcanvas';
+}
+
+/**
+ * Which action a single toggle gesture (the Trigger, the Rail, or Cmd/Ctrl+B)
+ * dispatches, given the viewport. The routing decision lives HERE -- a pure
+ * function of the effective state and the browser's `isMobile` signal -- so no
+ * decorator holds a branch: each performance only supplies the media-query
+ * reading and calls this. On mobile the gesture opens/closes the overlay; on
+ * desktop it expands/collapses the rail. Mirrors the oracle's `toggleSidebar`.
+ */
+export function toggleIntent(
+  state: SidebarState,
+  config: SidebarConfig,
+  isMobile: boolean,
+): keyof SidebarActions {
+  if (isMobile) return isMobileOpen(state) ? 'closeMobile' : 'openMobile';
+  return isOpen(state, config) ? 'close' : 'open';
+}
+
+const sidebarSlice: Slice<SidebarConfig, SidebarState, SidebarActions, SidebarPart> = {
+  name: 'sidebar',
+  parts: {
+    root: {},
+    trigger: { optional: true },
+    rail: { optional: true },
+    panel: {},
+    overlay: { optional: true },
+  },
+  initialState: (config) => ({
+    // A fresh app opens expanded (oracle default true); a controlled value seeds
+    // the first paint without a flash.
+    open: config.open ?? config.defaultOpen ?? true,
+    openMobile: false,
+  }),
+  actions: {
+    open: (state) => ({ ...state, open: true }),
+    close: (state) => ({ ...state, open: false }),
+    openMobile: (state) => ({ ...state, openMobile: true }),
+    closeMobile: (state) => ({ ...state, openMobile: false }),
+  },
+  // Idempotence gate per axis: opening the open or closing the closed is
+  // rejected, so a controlled consumer's onOpenChange fires once per real
+  // desktop transition, and Escape on a desktop (mobile-closed) sidebar is a
+  // no-op rather than a spurious closeMobile.
+  canDispatch: (state, action, config) => {
+    if (action === 'open') return !isOpen(state, config);
+    if (action === 'close') return isOpen(state, config);
+    if (action === 'openMobile') return !isMobileOpen(state);
+    if (action === 'closeMobile') return isMobileOpen(state);
+    return true;
+  },
+  aria: (state, config, ids) => {
+    const open = isOpen(state, config);
+    const mobileOpen = isMobileOpen(state);
+    const mode = collapsibleOf(config);
+    const desktopState = open ? 'expanded' : 'collapsed';
+    return {
+      trigger: {
+        // The trigger controls the rail; it carries no aria-expanded because the
+        // gesture moves whichever axis the viewport selects, so a single
+        // expanded value would misreport on the other viewport (see doc).
+        'aria-controls': ids.panel || undefined,
+        'data-state': desktopState,
+      },
+      rail: {
+        'aria-label': 'Toggle Sidebar',
+        'data-state': desktopState,
+      },
+      panel: {
+        // Desktop expand axis: the view keys width/offcanvas off data-state and
+        // the collapse mode.
+        'data-state': desktopState,
+        // Collapse mode is a hook only while collapsed; `none` never collapses.
+        'data-collapsible': open || mode === 'none' ? undefined : mode,
+        // Mobile overlay axis, independent of the desktop state above.
+        'data-mobile': mobileOpen ? 'open' : 'closed',
+      },
+      overlay: {
+        // A real, labelled scrim button (the oracle's earned dismiss affordance),
+        // not an aria-hidden presentation layer.
+        'aria-label': 'Close sidebar',
+        'data-state': mobileOpen ? 'open' : 'closed',
+      },
+    };
+  },
+  // Escape dismisses the MOBILE overlay only, scoped to the panel. On desktop
+  // the idempotence gate turns closeMobile into a no-op, so the same key is
+  // inert while the rail is merely collapsed -- no mode branch needed.
+  keymap: (event, _state, part) =>
+    part === 'panel' && event.key === 'Escape' ? 'closeMobile' : null,
+};
+
+export const sidebar: BehaviorSpec<SidebarConfig, SidebarState, SidebarActions, SidebarPart> =
+  compose('sidebar', sidebarSlice);
+
+/** The keyboard shortcut that toggles the sidebar, matching the oracle. */
+const TOGGLE_KEY = 'b';
+
+/**
+ * The DOM-native binding of the sidebar score -- the client the Web Component
+ * and the Astro <script> both import; only React reads the projections
+ * declaratively. Composes the same substrate a decorator would:
+ *
+ * - `createBehavior` is the model (the one memory cell, the two axes).
+ * - `aria-manager` applies the resolved projection.
+ * - Presence: the mobile scrim is present-but-hidden, toggled on the openMobile
+ *   axis (the panel itself is never hidden -- a collapsed desktop rail stays
+ *   visible and navigable; CSS translates the mobile-closed panel off-canvas).
+ *
+ * Dismissal is DELIBERATELY light (the oracle added no focus-trap, scroll-lock,
+ * or outside-click primitive to its mobile panel, and the port issue said add
+ * none): a click on the scrim closes, and Escape closes via the score keymap.
+ * The Escape part is resolved by CONTAINMENT (`panel.contains(target)`), not
+ * `target.closest('[data-part]')` -- the latter misroutes when focus rests on a
+ * focusable descendant that carries its own data-part (a menu button), the
+ * systemic dialog-family defect tracked in #1921.
+ *
+ * Cmd/Ctrl+B is an imperative window listener (the shortcut is global, not
+ * part-scoped) routed through `toggleIntent`; the desktop `open` axis is
+ * persisted write-only to a cookie via `memory.select`, seeded from
+ * `defaultOpen` -- the oracle wrote the cookie but never read it back.
+ */
+export function bindSidebar(root: HTMLElement): () => void {
+  const config: SidebarConfig = {
+    defaultOpen: root.getAttribute('data-default-open') !== 'false',
+    side: (root.getAttribute('data-side') as SidebarSide | null) ?? undefined,
+    variant: (root.getAttribute('data-variant') as SidebarVariant | null) ?? undefined,
+    collapsible: (root.getAttribute('data-collapsible') as SidebarCollapsible | null) ?? undefined,
+  };
+
+  const getPart = (part: string): HTMLElement | null =>
+    part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
+
+  const { memory, dispatch } = createBehavior(sidebar, config);
+  const request = (action: keyof SidebarActions): boolean => dispatch(action, config);
+
+  const mql =
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? window.matchMedia('(max-width: 768px)')
+      : null;
+  const isMobile = (): boolean => mql?.matches ?? false;
+
+  // ids READ from the author/server markup, never generated.
+  const ids = {} as PartIds<SidebarPart>;
+  for (const part of Object.keys(sidebar.parts) as SidebarPart[])
+    ids[part] = getPart(part)?.id ?? '';
+
+  const applyProjection = (el: HTMLElement, attrs: AriaAttrs) => {
+    for (const [name, value] of Object.entries(attrs)) {
+      updateAriaAttribute(el, name as never, value as never, { validate: false });
+    }
+  };
+
+  const render = () => {
+    const state = memory.get();
+    const projection = sidebar.aria(state, config, ids);
+    for (const part of Object.keys(projection) as SidebarPart[]) {
+      const attrs = projection[part];
+      const el = getPart(part);
+      if (el && attrs) applyProjection(el, attrs);
+    }
+    // Presence: only the scrim hides off the mobile axis; the panel stays put.
+    const overlay = getPart('overlay');
+    if (overlay) overlay.hidden = !isMobileOpen(state);
+  };
+  const unsubscribe = memory.subscribe(render); // fires immediately: first paint
+
+  // Persistence is a reaction to the desktop axis, equality-gated so it writes
+  // only on a real change -- never on an unrelated re-render. Write-only: init
+  // seeds from defaultOpen, matching the oracle.
+  const stopPersist = memory.select(
+    (state) => state.open,
+    (open) => {
+      if (typeof document === 'undefined') return;
+      // biome-ignore lint/suspicious/noDocumentCookie: sidebar state persistence across page loads
+      document.cookie = `sidebar:state=${open}; path=/; max-age=${60 * 60 * 24 * 7}`;
+    },
+  );
+
+  const onClick = (event: Event) => {
+    const target = event.target as HTMLElement;
+    if (target.closest('[data-part="overlay"]')) {
+      request('closeMobile');
+      return;
+    }
+    if (target.closest('[data-part="trigger"]') || target.closest('[data-part="rail"]')) {
+      request(toggleIntent(memory.get(), config, isMobile()));
+    }
+  };
+  root.addEventListener('click', onClick);
+
+  const onKeydown = (event: KeyboardEvent) => {
+    // Containment resolution: the panel is the Escape scope. A focusable
+    // descendant with its own data-part must NOT shadow it (the closest()
+    // defect), so test containment against the panel directly.
+    const panel = getPart('panel');
+    if (!panel || !panel.contains(event.target as Node)) return;
+    const action = sidebar.keymap(
+      {
+        key: event.key,
+        shiftKey: event.shiftKey,
+        ctrlKey: event.ctrlKey,
+        altKey: event.altKey,
+        metaKey: event.metaKey,
+      },
+      memory.get(),
+      'panel',
+      config,
+    );
+    if (!action) return;
+    if (!request(action)) return;
+    event.preventDefault();
+    // Escape returns focus to the trigger, mirroring a dismissable layer.
+    if (action === 'closeMobile') getPart('trigger')?.focus();
+  };
+  root.addEventListener('keydown', onKeydown);
+
+  const onShortcut = (event: KeyboardEvent) => {
+    if (event.key.toLowerCase() === TOGGLE_KEY && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      request(toggleIntent(memory.get(), config, isMobile()));
+    }
+  };
+  if (typeof window !== 'undefined') window.addEventListener('keydown', onShortcut);
+
+  return () => {
+    unsubscribe();
+    stopPersist();
+    root.removeEventListener('click', onClick);
+    root.removeEventListener('keydown', onKeydown);
+    if (typeof window !== 'undefined') window.removeEventListener('keydown', onShortcut);
+  };
+}

--- a/packages/ui/src/components/sidebar/sidebar.behavior.ts
+++ b/packages/ui/src/components/sidebar/sidebar.behavior.ts
@@ -6,6 +6,7 @@ import {
   type PartIds,
 } from '../../lib/contract';
 import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { startSheetModalEffects } from '../sheet/sheet.behavior';
 
 /** The edge the rail is anchored to. Purely positional: it selects the view's
  *  side variant and the collapse/slide direction. It never enters a reducer and
@@ -61,7 +62,7 @@ export type SidebarActions = {
   closeMobile: undefined;
 };
 
-export type SidebarPart = 'root' | 'trigger' | 'rail' | 'panel' | 'overlay';
+export type SidebarPart = 'root' | 'trigger' | 'rail' | 'panel';
 
 /** The effective desktop-expand value: a controlled `open` shadows intrinsic. */
 export function isOpen(state: SidebarState, config: SidebarConfig): boolean {
@@ -101,7 +102,6 @@ const sidebarSlice: Slice<SidebarConfig, SidebarState, SidebarActions, SidebarPa
     trigger: { optional: true },
     rail: { optional: true },
     panel: {},
-    overlay: { optional: true },
   },
   initialState: (config) => ({
     // A fresh app opens expanded (oracle default true); a controlled value seeds
@@ -149,14 +149,11 @@ const sidebarSlice: Slice<SidebarConfig, SidebarState, SidebarActions, SidebarPa
         'data-state': desktopState,
         // Collapse mode is a hook only while collapsed; `none` never collapses.
         'data-collapsible': open || mode === 'none' ? undefined : mode,
-        // Mobile overlay axis, independent of the desktop state above.
+        // Mobile overlay axis, independent of the desktop state above. The modal
+        // role/aria-modal that turn the panel into a dialog while the mobile
+        // overlay is open are bind-managed (they depend on the viewport signal,
+        // which the score does not hold) -- see bindSidebar.
         'data-mobile': mobileOpen ? 'open' : 'closed',
-      },
-      overlay: {
-        // A real, labelled scrim button (the oracle's earned dismiss affordance),
-        // not an aria-hidden presentation layer.
-        'aria-label': 'Close sidebar',
-        'data-state': mobileOpen ? 'open' : 'closed',
       },
     };
   },
@@ -173,6 +170,10 @@ export const sidebar: BehaviorSpec<SidebarConfig, SidebarState, SidebarActions, 
 /** The keyboard shortcut that toggles the sidebar, matching the oracle. */
 const TOGGLE_KEY = 'b';
 
+/** Accessible name for the mobile overlay dialog (matches the React SheetContent
+ *  aria-label): a nameless role=dialog is an axe violation. */
+const MOBILE_DIALOG_LABEL = 'Sidebar';
+
 /**
  * The DOM-native binding of the sidebar score -- the client the Web Component
  * and the Astro <script> both import; only React reads the projections
@@ -180,17 +181,19 @@ const TOGGLE_KEY = 'b';
  *
  * - `createBehavior` is the model (the one memory cell, the two axes).
  * - `aria-manager` applies the resolved projection.
- * - Presence: the mobile scrim is present-but-hidden, toggled on the openMobile
- *   axis (the panel itself is never hidden -- a collapsed desktop rail stays
- *   visible and navigable; CSS translates the mobile-closed panel off-canvas).
+ * - Presence + modality on the mobile axis: below `md`, an open overlay turns the
+ *   panel into a modal dialog (role=dialog, aria-modal, and the sheet modal trio
+ *   -- focus-trap, scroll-lock, dismiss-on-outside -- COMPOSED from
+ *   `startSheetModalEffects`, the merged sheet's own behavior), and a CLOSED
+ *   mobile overlay `hidden`s the panel so its links leave the tab order and a11y
+ *   tree (WCAG 2.2 AAA focus management). On the desktop viewport the panel is
+ *   never modal and never hidden -- the collapsed rail stays visible/navigable.
  *
- * Dismissal is DELIBERATELY light (the oracle added no focus-trap, scroll-lock,
- * or outside-click primitive to its mobile panel, and the port issue said add
- * none): a click on the scrim closes, and Escape closes via the score keymap.
- * The Escape part is resolved by CONTAINMENT (`panel.contains(target)`), not
- * `target.closest('[data-part]')` -- the latter misroutes when focus rests on a
- * focusable descendant that carries its own data-part (a menu button), the
- * systemic dialog-family defect tracked in #1921.
+ * Escape closes via the score keymap, its part resolved by CONTAINMENT
+ * (`panel.contains(target)`), not `target.closest('[data-part]')` -- the latter
+ * misroutes when focus rests on a focusable descendant that carries its own
+ * data-part (the rail), the systemic dialog-family defect tracked in #1921. On
+ * close the sheet trap teardown restores focus to the opener (the trigger).
  *
  * Cmd/Ctrl+B is an imperative window listener (the shortcut is global, not
  * part-scoped) routed through `toggleIntent`; the desktop `open` axis is
@@ -228,6 +231,10 @@ export function bindSidebar(root: HTMLElement): () => void {
     }
   };
 
+  // The sheet modal trio is level-triggered: present only while the mobile
+  // overlay is open. render() starts it on the transition and stops it on close.
+  let modalCleanup: (() => void) | null = null;
+
   const render = () => {
     const state = memory.get();
     const projection = sidebar.aria(state, config, ids);
@@ -236,11 +243,50 @@ export function bindSidebar(root: HTMLElement): () => void {
       const el = getPart(part);
       if (el && attrs) applyProjection(el, attrs);
     }
-    // Presence: only the scrim hides off the mobile axis; the panel stays put.
-    const overlay = getPart('overlay');
-    if (overlay) overlay.hidden = !isMobileOpen(state);
+
+    const panel = getPart('panel');
+    const overlayOpen = isMobile() && isMobileOpen(state);
+    if (panel) {
+      // Presence: a closed mobile overlay removes the panel from the tree so its
+      // links are unreachable (AAA); the open overlay and the desktop rail stay.
+      panel.hidden = isMobile() && !isMobileOpen(state);
+      // Modality: while the mobile overlay is open the panel IS the dialog. These
+      // depend on the viewport signal, so the bind manages them (the score, which
+      // holds no isMobile, cannot). Mirrors the React SheetContent surface.
+      if (overlayOpen) {
+        panel.setAttribute('role', 'dialog');
+        panel.setAttribute('aria-modal', 'true');
+        panel.setAttribute('aria-label', MOBILE_DIALOG_LABEL);
+      } else {
+        panel.removeAttribute('role');
+        panel.removeAttribute('aria-modal');
+        panel.removeAttribute('aria-label');
+      }
+    }
+
+    // Compose the merged sheet's modal trio directly, level-triggered: focus-trap
+    // + scroll-lock + dismiss-on-pointerdown-outside (sparing the trigger). The
+    // panel is un-hidden above before the trap reads its focusables. On close the
+    // trap teardown restores focus to the opener.
+    if (overlayOpen && !modalCleanup && panel) {
+      modalCleanup = startSheetModalEffects({
+        content: panel,
+        getTrigger: () => getPart('trigger'),
+        onDismiss: () => {
+          request('closeMobile');
+        },
+      });
+    } else if (!overlayOpen && modalCleanup) {
+      modalCleanup();
+      modalCleanup = null;
+    }
   };
   const unsubscribe = memory.subscribe(render); // fires immediately: first paint
+
+  // Presence + modality now depend on the viewport, so re-render on its change --
+  // otherwise a desktop->mobile-closed resize leaves the panel wrongly visible.
+  const onViewportChange = () => render();
+  mql?.addEventListener('change', onViewportChange);
 
   // Persistence is a reaction to the desktop axis, equality-gated so it writes
   // only on a real change -- never on an unrelated re-render. Write-only: init
@@ -256,10 +302,8 @@ export function bindSidebar(root: HTMLElement): () => void {
 
   const onClick = (event: Event) => {
     const target = event.target as HTMLElement;
-    if (target.closest('[data-part="overlay"]')) {
-      request('closeMobile');
-      return;
-    }
+    // Mobile-overlay dismissal on outside pointerdown is the sheet trio's job;
+    // clicks here only drive the toggle affordances.
     if (target.closest('[data-part="trigger"]') || target.closest('[data-part="rail"]')) {
       request(toggleIntent(memory.get(), config, isMobile()));
     }
@@ -285,10 +329,9 @@ export function bindSidebar(root: HTMLElement): () => void {
       config,
     );
     if (!action) return;
-    if (!request(action)) return;
-    event.preventDefault();
-    // Escape returns focus to the trigger, mirroring a dismissable layer.
-    if (action === 'closeMobile') getPart('trigger')?.focus();
+    // On a real close the sheet trap teardown (in render) restores focus to the
+    // opener, so no explicit focus call is needed here.
+    if (request(action)) event.preventDefault();
   };
   root.addEventListener('keydown', onKeydown);
 
@@ -302,6 +345,9 @@ export function bindSidebar(root: HTMLElement): () => void {
 
   return () => {
     unsubscribe();
+    modalCleanup?.();
+    modalCleanup = null;
+    mql?.removeEventListener('change', onViewportChange);
     stopPersist();
     root.removeEventListener('click', onClick);
     root.removeEventListener('keydown', onKeydown);

--- a/packages/ui/src/components/sidebar/sidebar.classes.ts
+++ b/packages/ui/src/components/sidebar/sidebar.classes.ts
@@ -1,0 +1,239 @@
+import type { SidebarSide, SidebarVariant } from './sidebar.behavior';
+
+/**
+ * The sidebar view. Class strings only -- no logic, no state reads. The panel
+ * carries BOTH axes' data hooks (Spec: one panel, not two): the mobile overlay
+ * off-canvas slide keys off `data-mobile`, and the desktop rail collapse keys
+ * off `data-state`/`data-collapsible`, each scoped to its breakpoint so a single
+ * element serves both viewports.
+ *
+ * Motion is UNDECLARED. The oracle animated the collapse and the mobile slide
+ * with raw `duration-200 ease-linear/ease-in-out`; the horizontal
+ * expand/collapse and sheet-slide semantic motion tokens do not exist yet (the
+ * token layer is being rebuilt, #1899/#1902), so the from/to states are declared
+ * (translate, width) while the timing is left to the future token layer rather
+ * than hardcoded. The small `duration-150` interaction acknowledgments on the
+ * buttons are kept (Spec 04 retains hover/press feedback -- cf. sheet's close
+ * button), never the layout motion.
+ */
+export interface SidebarClassSet {
+  provider: string;
+  trigger: string;
+  rail: string;
+  overlay: string;
+  inset: string;
+  header: string;
+  footer: string;
+  content: string;
+  group: string;
+  groupLabel: string;
+  groupAction: string;
+  groupContent: string;
+  menu: string;
+  menuItem: string;
+  menuAction: string;
+  menuActionShowOnHover: string;
+  menuBadge: string;
+  menuSkeleton: string;
+  menuSkeletonIcon: string;
+  menuSkeletonText: string;
+  menuSub: string;
+  menuSubItem: string;
+  separator: string;
+}
+
+const providerClasses = 'group/sidebar-wrapper flex min-h-svh w-full';
+
+// The mobile scrim: a full-viewport dismiss surface on the overlay depth. The
+// binding hides it off the mobile axis, so it never intercepts clicks while the
+// overlay is closed.
+const overlayClasses = 'fixed inset-0 z-depth-overlay bg-foreground/80 cursor-default md:hidden';
+
+// The one panel. Mobile: a fixed off-canvas overlay. Desktop (md:): a sticky
+// rail whose width collapses. No transition utilities: the layout motion is
+// undeclared (see the file header); only the from/to states ride the data hooks.
+const panelBaseClasses =
+  'flex flex-col bg-sidebar text-sidebar-foreground ' +
+  'fixed inset-y-0 z-depth-modal h-svh w-72 ' +
+  'md:sticky md:top-0 md:z-depth-navigation md:h-svh md:w-64 md:data-[mobile=closed]:translate-x-0 ' +
+  'md:data-[state=collapsed]:data-[collapsible=icon]:w-12 ' +
+  'md:data-[state=collapsed]:data-[collapsible=offcanvas]:w-0 ' +
+  'md:data-[state=collapsed]:data-[collapsible=offcanvas]:overflow-hidden';
+
+const panelSideClasses: Record<SidebarSide, string> = {
+  left: 'left-0 data-[mobile=closed]:-translate-x-full border-r border-sidebar-border',
+  right: 'right-0 data-[mobile=closed]:translate-x-full border-l border-sidebar-border',
+};
+
+const panelVariantClasses: Record<SidebarVariant, string> = {
+  sidebar: '',
+  floating: 'md:m-2 md:h-[calc(100svh-theme(spacing.4))] md:rounded-lg md:border md:shadow-sm',
+  inset: 'md:m-2 md:h-[calc(100svh-theme(spacing.4))] md:rounded-lg md:shadow-sm',
+};
+
+/** The panel class: the axis-carrying base plus the anchored side and the
+ *  surface variant. The single source of the panel class -- every performance
+ *  calls this, so side and variant (decoration the score never touches) are the
+ *  only arguments. */
+export function sidebarPanelClasses(side: SidebarSide, variant: SidebarVariant): string {
+  return `${panelBaseClasses} ${panelSideClasses[side]} ${panelVariantClasses[variant]}`.trim();
+}
+
+const triggerClasses = 'inline-flex size-7 items-center justify-center';
+
+// The desktop drag rail: a hairline hit target on the collapsing edge. Hidden on
+// mobile (the overlay owns dismissal there). The layout slide is undeclared; the
+// hover acknowledgment on the hairline is a color swap, not a duration.
+const railClasses =
+  'absolute inset-y-0 z-depth-navigation hidden w-4 -translate-x-1/2 cursor-ew-resize md:flex ' +
+  'after:absolute after:inset-y-0 after:left-1/2 after:w-0.5 hover:after:bg-sidebar-border ' +
+  'group-data-[side=left]:-right-4 group-data-[side=right]:left-0';
+
+const insetClasses = 'relative flex min-h-svh w-full flex-1 flex-col bg-background';
+
+const headerClasses = 'flex flex-col gap-2 p-2';
+const footerClasses = 'flex flex-col gap-2 p-2';
+
+const contentClasses =
+  'flex min-h-0 flex-1 flex-col gap-2 overflow-auto ' +
+  'group-data-[collapsible=icon]:overflow-hidden';
+
+const groupClasses = 'relative flex w-full min-w-0 flex-col p-2';
+
+const groupLabelClasses =
+  'flex h-8 shrink-0 items-center rounded-md px-2 text-label-small text-sidebar-foreground/70 ' +
+  'outline-none ring-sidebar-ring focus-visible:ring-2 ' +
+  'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0';
+
+const groupActionClasses =
+  'absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 ' +
+  'text-sidebar-foreground outline-none ring-sidebar-ring transition-transform duration-150 ' +
+  'motion-reduce:transition-none hover:bg-sidebar-accent hover:text-sidebar-accent-foreground ' +
+  'focus-visible:ring-2 after:absolute after:-inset-2 md:after:hidden ' +
+  'group-data-[collapsible=icon]:hidden';
+
+const groupContentClasses = 'w-full';
+
+const menuClasses = 'flex w-full min-w-0 flex-col gap-1';
+
+const menuItemClasses = 'group/menu-item relative';
+
+const menuButtonBaseClasses =
+  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left ' +
+  'text-label-medium outline-none ring-sidebar-ring transition-colors duration-150 ' +
+  'motion-reduce:transition-none hover:bg-sidebar-accent hover:text-sidebar-accent-foreground ' +
+  'focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground ' +
+  'disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none ' +
+  'aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium ' +
+  'data-[active=true]:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8 ' +
+  'group-data-[collapsible=icon]:p-2';
+
+const menuButtonSizeClasses: Record<'default' | 'sm' | 'lg', string> = {
+  default: '',
+  sm: 'text-label-small',
+  lg: 'text-label-medium group-data-[collapsible=icon]:p-0',
+};
+
+const menuButtonOutlineClasses =
+  'bg-background shadow-sm hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-none';
+
+/** The menu button class: base signature plus the size and (optional) outline
+ *  variant. */
+export function sidebarMenuButtonClasses(
+  variant: 'default' | 'outline' = 'default',
+  size: 'default' | 'sm' | 'lg' = 'default',
+): string {
+  return [
+    menuButtonBaseClasses,
+    menuButtonSizeClasses[size],
+    variant === 'outline' ? menuButtonOutlineClasses : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+const menuActionClasses =
+  'absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 ' +
+  'text-sidebar-foreground outline-none ring-sidebar-ring transition-transform duration-150 ' +
+  'motion-reduce:transition-none hover:bg-sidebar-accent hover:text-sidebar-accent-foreground ' +
+  'focus-visible:ring-2 peer-hover/menu-button:text-sidebar-accent-foreground ' +
+  'after:absolute after:-inset-2 md:after:hidden group-data-[collapsible=icon]:hidden';
+
+const menuActionShowOnHoverClasses =
+  'group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 ' +
+  'data-[state=open]:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground ' +
+  'md:opacity-0';
+
+const menuBadgeClasses =
+  'pointer-events-none absolute right-1 flex h-5 min-w-5 select-none items-center justify-center ' +
+  'rounded-md px-1 text-label-small tabular-nums text-sidebar-foreground ' +
+  'peer-hover/menu-button:text-sidebar-accent-foreground ' +
+  'peer-data-[active=true]/menu-button:text-sidebar-accent-foreground ' +
+  'group-data-[collapsible=icon]:hidden';
+
+const menuSkeletonClasses = 'flex h-8 items-center gap-2 rounded-md px-2';
+const menuSkeletonIconClasses =
+  'size-4 shrink-0 animate-pulse motion-reduce:animate-none rounded-md bg-sidebar-accent';
+const menuSkeletonTextClasses =
+  'h-4 max-w-[--skeleton-width] flex-1 animate-pulse motion-reduce:animate-none rounded-md bg-sidebar-accent';
+
+const menuSubClasses =
+  'ml-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border py-0.5 pl-2.5 ' +
+  'group-data-[collapsible=icon]:hidden';
+
+const menuSubItemClasses = 'relative';
+
+const menuSubButtonBaseClasses =
+  'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 ' +
+  'text-sidebar-foreground outline-none ring-sidebar-ring transition-colors duration-150 ' +
+  'motion-reduce:transition-none hover:bg-sidebar-accent hover:text-sidebar-accent-foreground ' +
+  'focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground ' +
+  'disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none ' +
+  'aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent ' +
+  'data-[active=true]:text-sidebar-accent-foreground';
+
+const menuSubButtonSizeClasses: Record<'sm' | 'md', string> = {
+  sm: 'text-label-small',
+  md: 'text-label-medium',
+};
+
+/** The submenu button class: base signature plus size. */
+export function sidebarMenuSubButtonClasses(size: 'sm' | 'md' = 'md'): string {
+  return `${menuSubButtonBaseClasses} ${menuSubButtonSizeClasses[size]}`;
+}
+
+const separatorClasses = 'mx-2 h-px w-auto bg-sidebar-border';
+
+/** The side/variant-independent class set. The panel class is NOT here (it
+ *  depends on side + variant, produced by `sidebarPanelClasses`), and the
+ *  variant-bearing button classes are their own functions. Everything below is
+ *  invariant across side, variant, and state. */
+export function sidebarClasses(): SidebarClassSet {
+  return {
+    provider: providerClasses,
+    trigger: triggerClasses,
+    rail: railClasses,
+    overlay: overlayClasses,
+    inset: insetClasses,
+    header: headerClasses,
+    footer: footerClasses,
+    content: contentClasses,
+    group: groupClasses,
+    groupLabel: groupLabelClasses,
+    groupAction: groupActionClasses,
+    groupContent: groupContentClasses,
+    menu: menuClasses,
+    menuItem: menuItemClasses,
+    menuAction: menuActionClasses,
+    menuActionShowOnHover: menuActionShowOnHoverClasses,
+    menuBadge: menuBadgeClasses,
+    menuSkeleton: menuSkeletonClasses,
+    menuSkeletonIcon: menuSkeletonIconClasses,
+    menuSkeletonText: menuSkeletonTextClasses,
+    menuSub: menuSubClasses,
+    menuSubItem: menuSubItemClasses,
+    separator: separatorClasses,
+  };
+}
+
+export { panelSideClasses, panelVariantClasses };

--- a/packages/ui/src/components/sidebar/sidebar.classes.ts
+++ b/packages/ui/src/components/sidebar/sidebar.classes.ts
@@ -20,7 +20,7 @@ export interface SidebarClassSet {
   provider: string;
   trigger: string;
   rail: string;
-  overlay: string;
+  mobilePanel: string;
   inset: string;
   header: string;
   footer: string;
@@ -44,25 +44,22 @@ export interface SidebarClassSet {
 
 const providerClasses = 'group/sidebar-wrapper flex min-h-svh w-full';
 
-// The mobile scrim: a full-viewport dismiss surface on the overlay depth. The
-// binding hides it off the mobile axis, so it never intercepts clicks while the
-// overlay is closed.
-const overlayClasses = 'fixed inset-0 z-depth-overlay bg-foreground/80 cursor-default md:hidden';
-
-// The one panel. Mobile: a fixed off-canvas overlay. Desktop (md:): a sticky
-// rail whose width collapses. No transition utilities: the layout motion is
-// undeclared (see the file header); only the from/to states ride the data hooks.
+// The one panel. Mobile: a fixed overlay panel (a modal dialog while open; the
+// bind `hidden`s it when closed). Desktop (md:): a sticky rail whose width
+// collapses. No transition utilities: the layout motion is undeclared (see the
+// file header); the enter/exit of the mobile modal is the sheet's concern in
+// React, and undeclared for the WC/Astro in-place enhancement.
 const panelBaseClasses =
   'flex flex-col bg-sidebar text-sidebar-foreground ' +
   'fixed inset-y-0 z-depth-modal h-svh w-72 ' +
-  'md:sticky md:top-0 md:z-depth-navigation md:h-svh md:w-64 md:data-[mobile=closed]:translate-x-0 ' +
+  'md:sticky md:top-0 md:z-depth-navigation md:h-svh md:w-64 ' +
   'md:data-[state=collapsed]:data-[collapsible=icon]:w-12 ' +
   'md:data-[state=collapsed]:data-[collapsible=offcanvas]:w-0 ' +
   'md:data-[state=collapsed]:data-[collapsible=offcanvas]:overflow-hidden';
 
 const panelSideClasses: Record<SidebarSide, string> = {
-  left: 'left-0 data-[mobile=closed]:-translate-x-full border-r border-sidebar-border',
-  right: 'right-0 data-[mobile=closed]:translate-x-full border-l border-sidebar-border',
+  left: 'left-0 border-r border-sidebar-border',
+  right: 'right-0 border-l border-sidebar-border',
 };
 
 const panelVariantClasses: Record<SidebarVariant, string> = {
@@ -80,6 +77,10 @@ export function sidebarPanelClasses(side: SidebarSide, variant: SidebarVariant):
 }
 
 const triggerClasses = 'inline-flex size-7 items-center justify-center';
+
+// The mobile overlay surface: the sidebar fill laid over the merged Sheet's own
+// positioning (Sheet owns the modal frame; this only paints the sidebar chrome).
+const mobilePanelClasses = 'flex h-full w-full flex-col bg-sidebar text-sidebar-foreground';
 
 // The desktop drag rail: a hairline hit target on the collapsing edge. Hidden on
 // mobile (the overlay owns dismissal there). The layout slide is undeclared; the
@@ -213,7 +214,7 @@ export function sidebarClasses(): SidebarClassSet {
     provider: providerClasses,
     trigger: triggerClasses,
     rail: railClasses,
-    overlay: overlayClasses,
+    mobilePanel: mobilePanelClasses,
     inset: insetClasses,
     header: headerClasses,
     footer: footerClasses,

--- a/packages/ui/src/components/sidebar/sidebar.element.ts
+++ b/packages/ui/src/components/sidebar/sidebar.element.ts
@@ -1,0 +1,28 @@
+/**
+ * WC performance for sidebar: the thinnest wrapper. The score AND the DOM-native
+ * binding (bindSidebar) live in sidebar.behavior.ts, shared with the Astro
+ * performance. This file only adapts that binding to the custom-element
+ * lifecycle -- deferring the bind one microtask because connectedCallback can
+ * fire before the light-DOM parts (trigger, panel, overlay, nav content) are
+ * parsed.
+ */
+import { bindSidebar } from './sidebar.behavior';
+
+export class RaftersSidebar extends HTMLElement {
+  private teardown: (() => void) | null = null;
+
+  connectedCallback(): void {
+    queueMicrotask(() => {
+      if (this.isConnected && !this.teardown) this.teardown = bindSidebar(this);
+    });
+  }
+
+  disconnectedCallback(): void {
+    this.teardown?.();
+    this.teardown = null;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-sidebar')) {
+  customElements.define('rafters-sidebar', RaftersSidebar);
+}

--- a/packages/ui/src/components/sidebar/sidebar.tsx
+++ b/packages/ui/src/components/sidebar/sidebar.tsx
@@ -1,0 +1,640 @@
+/**
+ * Collapsible application navigation rail. On desktop it expands to a full rail
+ * or collapses to an icon strip (or fully off-canvas), persisting that choice;
+ * below the md breakpoint it becomes a dismissable overlay over a scrim. The
+ * primary, always-present chrome a user orients by.
+ *
+ * @cognitive-load 3/10 - A familiar, persistent navigation pattern in a fixed
+ *   location: the user never hunts for it, and the two states (expanded rail,
+ *   collapsed icons) are both legible. The mobile overlay narrows the surface
+ *   without hiding where the user was.
+ * @attention-economics Near-zero standing cost: the rail sits at the edge and is
+ *   scanned only when navigating. The mobile overlay is a brief, reversible
+ *   detour -- the scrim dims the page but keeps it in view, so orientation is
+ *   never lost.
+ * @trust-building One consistent edge and toggle direction, a Cmd/Ctrl+B
+ *   shortcut, state remembered across loads, and a mobile scrim plus Escape that
+ *   both read as obvious, reversible exits -- so collapsing or opening always
+ *   feels safe.
+ * @accessibility The rail stays navigable while collapsed (never removed from the
+ *   a11y tree); the trigger is a labelled control wired by real id to the panel
+ *   it controls; the mobile scrim is a labelled dismiss button; Escape dismisses
+ *   the overlay and returns focus to the trigger.
+ *
+ * The React performance is a DECORATOR over sidebar.behavior.ts: it adds only the
+ * view (sidebar.classes.ts) and React wiring (useMemory + effects that read the
+ * viewport, persist the cookie, and bind Cmd/Ctrl+B). Every decision -- reducers,
+ * the aria projection, the Escape keymap, the toggle routing -- lives in the
+ * score, shared with the WC and Astro performances via bindSidebar.
+ *
+ * @example
+ * ```tsx
+ * <SidebarProvider>
+ *   <Sidebar>
+ *     <SidebarHeader>Brand</SidebarHeader>
+ *     <SidebarContent>
+ *       <SidebarMenu>
+ *         <SidebarMenuItem>
+ *           <SidebarMenuButton>Dashboard</SidebarMenuButton>
+ *         </SidebarMenuItem>
+ *       </SidebarMenu>
+ *     </SidebarContent>
+ *   </Sidebar>
+ *   <SidebarInset>
+ *     <SidebarTrigger />
+ *     <main>Page</main>
+ *   </SidebarInset>
+ * </SidebarProvider>
+ * ```
+ */
+import * as React from 'react';
+import { createBehavior, type AriaAttrs, type PartIds } from '../../lib/contract';
+import { keyInputOf } from '../../hooks/key-input';
+import { useMemory } from '../../hooks/use-memory';
+import classy from '../../primitives/classy';
+import { mergeProps } from '../../primitives/slot';
+import {
+  sidebar,
+  toggleIntent,
+  type SidebarActions,
+  type SidebarConfig,
+  type SidebarPart,
+  type SidebarSide,
+  type SidebarState,
+  type SidebarVariant,
+} from './sidebar.behavior';
+import {
+  sidebarClasses,
+  sidebarMenuButtonClasses,
+  sidebarMenuSubButtonClasses,
+  sidebarPanelClasses,
+  type SidebarClassSet,
+} from './sidebar.classes';
+
+interface SidebarContextValue {
+  state: SidebarState;
+  config: SidebarConfig;
+  aria: Partial<Record<SidebarPart, AriaAttrs>>;
+  ids: PartIds<SidebarPart>;
+  request: (action: keyof SidebarActions) => boolean;
+  isMobile: boolean;
+  classes: SidebarClassSet;
+}
+
+const SidebarContext = React.createContext<SidebarContextValue | null>(null);
+
+export function useSidebar(): SidebarContextValue {
+  const context = React.useContext(SidebarContext);
+  if (!context) {
+    throw new Error('useSidebar must be used within <SidebarProvider>');
+  }
+  return context;
+}
+
+/** The viewport signal -- a browser fact, not application state, so it stays a
+ *  local subscription and never enters the score's cell. */
+function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = React.useState(false);
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mql = window.matchMedia('(max-width: 768px)');
+    setIsMobile(mql.matches);
+    const handler = (event: MediaQueryListEvent) => setIsMobile(event.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+  return isMobile;
+}
+
+export interface SidebarProviderProps extends React.HTMLAttributes<HTMLDivElement> {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  side?: SidebarSide;
+  variant?: SidebarVariant;
+  collapsible?: SidebarConfig['collapsible'];
+}
+
+export function SidebarProvider({
+  open,
+  defaultOpen = true,
+  onOpenChange,
+  side = 'left',
+  variant = 'sidebar',
+  collapsible = 'offcanvas',
+  className,
+  children,
+  ...props
+}: SidebarProviderProps) {
+  const config: SidebarConfig = { open, defaultOpen, side, variant, collapsible };
+  const isMobile = useIsMobile();
+
+  // The controller composes the score with the substrate -- no useBehavior.
+  const { memory, dispatch } = React.useMemo(() => createBehavior(sidebar, config), []);
+  const state = useMemory(memory);
+
+  const uid = React.useId();
+  const ids = React.useMemo(() => {
+    const out = {} as PartIds<SidebarPart>;
+    for (const part of Object.keys(sidebar.parts) as SidebarPart[]) out[part] = `${uid}-${part}`;
+    return out;
+  }, [uid]);
+
+  const latest = React.useRef({ config, onOpenChange });
+  latest.current = { config, onOpenChange };
+  const request = React.useCallback(
+    (action: keyof SidebarActions): boolean => {
+      const { config: cfg, onOpenChange: cb } = latest.current;
+      if (!dispatch(action, cfg)) return false;
+      // Only the desktop expand axis has a controlled callback (the oracle
+      // exposed no mobile change prop).
+      if (action === 'open' || action === 'close') cb?.(action === 'open');
+      return true;
+    },
+    [dispatch],
+  );
+
+  // Persistence is a reaction to the desktop axis, equality-gated (write-only,
+  // seeded from defaultOpen -- the oracle never read the cookie back).
+  React.useEffect(() => {
+    return memory.select(
+      (value) => value.open,
+      (isDesktopOpen) => {
+        if (typeof document === 'undefined') return;
+        // biome-ignore lint/suspicious/noDocumentCookie: sidebar state persistence across page loads
+        document.cookie = `sidebar:state=${isDesktopOpen}; path=/; max-age=${60 * 60 * 24 * 7}`;
+      },
+    );
+  }, [memory]);
+
+  // The global toggle shortcut. Window-scoped (not part-scoped), routed through
+  // the score's pure toggleIntent so the routing decision stays in the behavior.
+  React.useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() === 'b' && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        request(toggleIntent(memory.get(), latest.current.config, isMobile));
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [memory, request, isMobile]);
+
+  const aria = sidebar.aria(state, config, ids);
+
+  const contextValue: SidebarContextValue = {
+    state,
+    config,
+    aria,
+    ids,
+    request,
+    isMobile,
+    classes: sidebarClasses(),
+  };
+
+  return (
+    <SidebarContext.Provider value={contextValue}>
+      <div
+        data-part="root"
+        data-side={side}
+        data-variant={variant}
+        className={classy(sidebarClasses().provider, className)}
+        {...props}
+      >
+        {children}
+      </div>
+    </SidebarContext.Provider>
+  );
+}
+
+export interface SidebarProps extends React.HTMLAttributes<HTMLElement> {
+  side?: SidebarSide;
+  variant?: SidebarVariant;
+}
+
+export function Sidebar({ side, variant, className, children, onKeyDown, ...props }: SidebarProps) {
+  const { state, config, aria, ids, request, classes } = useSidebar();
+  const resolvedSide = side ?? config.side ?? 'left';
+  const resolvedVariant = variant ?? config.variant ?? 'sidebar';
+  const mobileOpen = aria.panel?.['data-mobile'] === 'open';
+
+  // The panel is the Escape scope; React hardcodes the part it renders here,
+  // mirroring the DOM-native bind's containment resolution. The idempotence gate
+  // makes closeMobile a no-op while the overlay is closed (desktop), so Escape is
+  // inert there rather than swallowed.
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    onKeyDown?.(event);
+    if (event.defaultPrevented) return;
+    const action = sidebar.keymap(keyInputOf(event), state, 'panel', config);
+    if (!action) return;
+    if (!request(action)) return;
+    event.preventDefault();
+    if (typeof document !== 'undefined') document.getElementById(ids.trigger)?.focus();
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        data-part="overlay"
+        id={ids.overlay}
+        hidden={mobileOpen ? undefined : true}
+        className={classes.overlay}
+        onClick={() => request('closeMobile')}
+        {...aria.overlay}
+      />
+      <nav
+        data-part="panel"
+        id={ids.panel}
+        data-side={resolvedSide}
+        data-variant={resolvedVariant}
+        className={classy(sidebarPanelClasses(resolvedSide, resolvedVariant), className)}
+        onKeyDown={handleKeyDown}
+        {...aria.panel}
+        {...props}
+      >
+        {children}
+      </nav>
+    </>
+  );
+}
+
+export interface SidebarTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+}
+
+export function SidebarTrigger({
+  asChild,
+  className,
+  onClick,
+  children,
+  ...props
+}: SidebarTriggerProps) {
+  const { state, config, aria, ids, request, isMobile, classes } = useSidebar();
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    request(toggleIntent(state, config, isMobile));
+  };
+
+  const partProps = {
+    'data-part': 'trigger',
+    id: ids.trigger,
+    className: classy(classes.trigger, className),
+    onClick: handleClick,
+    ...aria.trigger,
+  };
+
+  if (asChild && React.isValidElement(children)) {
+    const childProps = children.props as Record<string, unknown>;
+    return React.cloneElement(children, mergeProps(partProps, childProps) as React.Attributes);
+  }
+
+  return (
+    <button type="button" aria-label="Toggle Sidebar" {...partProps} {...props}>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="size-4"
+        aria-hidden="true"
+      >
+        <title>Toggle sidebar</title>
+        <rect width="18" height="18" x="3" y="3" rx="2" />
+        <path d="M9 3v18" />
+      </svg>
+    </button>
+  );
+}
+
+export interface SidebarRailProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export function SidebarRail({ className, onClick, ...props }: SidebarRailProps) {
+  const { state, config, aria, ids, request, isMobile, classes } = useSidebar();
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    request(toggleIntent(state, config, isMobile));
+  };
+
+  return (
+    <button
+      type="button"
+      data-part="rail"
+      id={ids.rail}
+      tabIndex={-1}
+      title="Toggle Sidebar"
+      className={classy(classes.rail, className)}
+      onClick={handleClick}
+      {...aria.rail}
+      {...props}
+    />
+  );
+}
+
+export interface SidebarInsetProps extends React.HTMLAttributes<HTMLElement> {}
+
+export function SidebarInset({ className, ...props }: SidebarInsetProps) {
+  const { classes } = useSidebar();
+  return <main data-part="inset" className={classy(classes.inset, className)} {...props} />;
+}
+
+export type SidebarHeaderProps = React.HTMLAttributes<HTMLDivElement>;
+export function SidebarHeader({ className, ...props }: SidebarHeaderProps) {
+  const { classes } = useSidebar();
+  return <div data-sidebar="header" className={classy(classes.header, className)} {...props} />;
+}
+
+export type SidebarFooterProps = React.HTMLAttributes<HTMLDivElement>;
+export function SidebarFooter({ className, ...props }: SidebarFooterProps) {
+  const { classes } = useSidebar();
+  return <div data-sidebar="footer" className={classy(classes.footer, className)} {...props} />;
+}
+
+export type SidebarContentProps = React.HTMLAttributes<HTMLDivElement>;
+export function SidebarContent({ className, ...props }: SidebarContentProps) {
+  const { classes } = useSidebar();
+  return <div data-sidebar="content" className={classy(classes.content, className)} {...props} />;
+}
+
+export type SidebarGroupProps = React.HTMLAttributes<HTMLDivElement>;
+export function SidebarGroup({ className, ...props }: SidebarGroupProps) {
+  const { classes } = useSidebar();
+  return <div data-sidebar="group" className={classy(classes.group, className)} {...props} />;
+}
+
+export interface SidebarGroupLabelProps extends React.HTMLAttributes<HTMLDivElement> {
+  asChild?: boolean;
+}
+export function SidebarGroupLabel({
+  asChild,
+  className,
+  children,
+  ...props
+}: SidebarGroupLabelProps) {
+  const { classes } = useSidebar();
+  const labelProps = {
+    'data-sidebar': 'group-label',
+    className: classy(classes.groupLabel, className),
+    ...props,
+  };
+  if (asChild && React.isValidElement(children)) {
+    const childProps = children.props as Record<string, unknown>;
+    return React.cloneElement(children, mergeProps(labelProps, childProps) as React.Attributes);
+  }
+  return <div {...labelProps}>{children}</div>;
+}
+
+export interface SidebarGroupActionProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+}
+export function SidebarGroupAction({
+  asChild,
+  className,
+  children,
+  ...props
+}: SidebarGroupActionProps) {
+  const { classes } = useSidebar();
+  const actionProps = {
+    'data-sidebar': 'group-action',
+    className: classy(classes.groupAction, className),
+    ...props,
+  };
+  if (asChild && React.isValidElement(children)) {
+    const childProps = children.props as Record<string, unknown>;
+    return React.cloneElement(children, mergeProps(actionProps, childProps) as React.Attributes);
+  }
+  return (
+    <button type="button" {...actionProps}>
+      {children}
+    </button>
+  );
+}
+
+export type SidebarGroupContentProps = React.HTMLAttributes<HTMLDivElement>;
+export function SidebarGroupContent({ className, ...props }: SidebarGroupContentProps) {
+  const { classes } = useSidebar();
+  return (
+    <div
+      data-sidebar="group-content"
+      className={classy(classes.groupContent, className)}
+      {...props}
+    />
+  );
+}
+
+export type SidebarMenuProps = React.HTMLAttributes<HTMLUListElement>;
+export function SidebarMenu({ className, ...props }: SidebarMenuProps) {
+  const { classes } = useSidebar();
+  return <ul data-sidebar="menu" className={classy(classes.menu, className)} {...props} />;
+}
+
+export type SidebarMenuItemProps = React.HTMLAttributes<HTMLLIElement>;
+export function SidebarMenuItem({ className, ...props }: SidebarMenuItemProps) {
+  const { classes } = useSidebar();
+  return <li data-sidebar="menu-item" className={classy(classes.menuItem, className)} {...props} />;
+}
+
+export interface SidebarMenuButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+  isActive?: boolean;
+  variant?: 'default' | 'outline';
+  size?: 'default' | 'sm' | 'lg';
+}
+export function SidebarMenuButton({
+  asChild,
+  isActive = false,
+  variant = 'default',
+  size = 'default',
+  className,
+  children,
+  ...props
+}: SidebarMenuButtonProps) {
+  const buttonProps = {
+    'data-sidebar': 'menu-button',
+    'data-size': size,
+    'data-active': isActive,
+    className: classy(sidebarMenuButtonClasses(variant, size), className),
+    ...props,
+  };
+  if (asChild && React.isValidElement(children)) {
+    const childProps = children.props as Record<string, unknown>;
+    return React.cloneElement(children, mergeProps(buttonProps, childProps) as React.Attributes);
+  }
+  return (
+    <button type="button" {...buttonProps}>
+      {children}
+    </button>
+  );
+}
+
+export interface SidebarMenuActionProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+  showOnHover?: boolean;
+}
+export function SidebarMenuAction({
+  asChild,
+  showOnHover = false,
+  className,
+  children,
+  ...props
+}: SidebarMenuActionProps) {
+  const { classes } = useSidebar();
+  const actionProps = {
+    'data-sidebar': 'menu-action',
+    className: classy(
+      classes.menuAction,
+      showOnHover ? classes.menuActionShowOnHover : '',
+      className,
+    ),
+    ...props,
+  };
+  if (asChild && React.isValidElement(children)) {
+    const childProps = children.props as Record<string, unknown>;
+    return React.cloneElement(children, mergeProps(actionProps, childProps) as React.Attributes);
+  }
+  return (
+    <button type="button" {...actionProps}>
+      {children}
+    </button>
+  );
+}
+
+export type SidebarMenuBadgeProps = React.HTMLAttributes<HTMLDivElement>;
+export function SidebarMenuBadge({ className, ...props }: SidebarMenuBadgeProps) {
+  const { classes } = useSidebar();
+  return (
+    <div data-sidebar="menu-badge" className={classy(classes.menuBadge, className)} {...props} />
+  );
+}
+
+export interface SidebarMenuSkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
+  showIcon?: boolean;
+}
+export function SidebarMenuSkeleton({
+  showIcon = false,
+  className,
+  ...props
+}: SidebarMenuSkeletonProps) {
+  const { classes } = useSidebar();
+  // A stable width per instance so the skeleton does not jitter across renders.
+  const [width] = React.useState(() => `${Math.floor(Math.random() * 40) + 50}%`);
+  return (
+    <div
+      data-sidebar="menu-skeleton"
+      className={classy(classes.menuSkeleton, className)}
+      {...props}
+    >
+      {showIcon ? <div className={classes.menuSkeletonIcon} /> : null}
+      <div
+        className={classes.menuSkeletonText}
+        style={{ '--skeleton-width': width } as React.CSSProperties}
+      />
+    </div>
+  );
+}
+
+export type SidebarMenuSubProps = React.HTMLAttributes<HTMLUListElement>;
+export function SidebarMenuSub({ className, ...props }: SidebarMenuSubProps) {
+  const { classes } = useSidebar();
+  return <ul data-sidebar="menu-sub" className={classy(classes.menuSub, className)} {...props} />;
+}
+
+export type SidebarMenuSubItemProps = React.HTMLAttributes<HTMLLIElement>;
+export function SidebarMenuSubItem({ className, ...props }: SidebarMenuSubItemProps) {
+  const { classes } = useSidebar();
+  return (
+    <li
+      data-sidebar="menu-sub-item"
+      className={classy(classes.menuSubItem, className)}
+      {...props}
+    />
+  );
+}
+
+export interface SidebarMenuSubButtonProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  asChild?: boolean;
+  isActive?: boolean;
+  size?: 'sm' | 'md';
+}
+export function SidebarMenuSubButton({
+  asChild,
+  isActive = false,
+  size = 'md',
+  className,
+  children,
+  ...props
+}: SidebarMenuSubButtonProps) {
+  const buttonProps = {
+    'data-sidebar': 'menu-sub-button',
+    'data-size': size,
+    'data-active': isActive,
+    className: classy(sidebarMenuSubButtonClasses(size), className),
+    ...props,
+  };
+  if (asChild && React.isValidElement(children)) {
+    const childProps = children.props as Record<string, unknown>;
+    return React.cloneElement(children, mergeProps(buttonProps, childProps) as React.Attributes);
+  }
+  return <a {...buttonProps}>{children}</a>;
+}
+
+export type SidebarSeparatorProps = React.HTMLAttributes<HTMLDivElement>;
+export function SidebarSeparator({ className, ...props }: SidebarSeparatorProps) {
+  const { classes } = useSidebar();
+  return (
+    <div data-sidebar="separator" className={classy(classes.separator, className)} {...props} />
+  );
+}
+
+SidebarProvider.displayName = 'SidebarProvider';
+Sidebar.displayName = 'Sidebar';
+SidebarTrigger.displayName = 'SidebarTrigger';
+SidebarRail.displayName = 'SidebarRail';
+SidebarInset.displayName = 'SidebarInset';
+SidebarHeader.displayName = 'SidebarHeader';
+SidebarFooter.displayName = 'SidebarFooter';
+SidebarContent.displayName = 'SidebarContent';
+SidebarGroup.displayName = 'SidebarGroup';
+SidebarGroupLabel.displayName = 'SidebarGroupLabel';
+SidebarGroupAction.displayName = 'SidebarGroupAction';
+SidebarGroupContent.displayName = 'SidebarGroupContent';
+SidebarMenu.displayName = 'SidebarMenu';
+SidebarMenuItem.displayName = 'SidebarMenuItem';
+SidebarMenuButton.displayName = 'SidebarMenuButton';
+SidebarMenuAction.displayName = 'SidebarMenuAction';
+SidebarMenuBadge.displayName = 'SidebarMenuBadge';
+SidebarMenuSkeleton.displayName = 'SidebarMenuSkeleton';
+SidebarMenuSub.displayName = 'SidebarMenuSub';
+SidebarMenuSubItem.displayName = 'SidebarMenuSubItem';
+SidebarMenuSubButton.displayName = 'SidebarMenuSubButton';
+SidebarSeparator.displayName = 'SidebarSeparator';
+
+// Namespaced surface (oracle parity: Sidebar.Provider, Sidebar.Trigger, ...).
+Sidebar.Provider = SidebarProvider;
+Sidebar.Trigger = SidebarTrigger;
+Sidebar.Rail = SidebarRail;
+Sidebar.Inset = SidebarInset;
+Sidebar.Header = SidebarHeader;
+Sidebar.Footer = SidebarFooter;
+Sidebar.Content = SidebarContent;
+Sidebar.Group = SidebarGroup;
+Sidebar.GroupLabel = SidebarGroupLabel;
+Sidebar.GroupAction = SidebarGroupAction;
+Sidebar.GroupContent = SidebarGroupContent;
+Sidebar.Menu = SidebarMenu;
+Sidebar.MenuItem = SidebarMenuItem;
+Sidebar.MenuButton = SidebarMenuButton;
+Sidebar.MenuAction = SidebarMenuAction;
+Sidebar.MenuBadge = SidebarMenuBadge;
+Sidebar.MenuSkeleton = SidebarMenuSkeleton;
+Sidebar.MenuSub = SidebarMenuSub;
+Sidebar.MenuSubItem = SidebarMenuSubItem;
+Sidebar.MenuSubButton = SidebarMenuSubButton;
+Sidebar.Separator = SidebarSeparator;

--- a/packages/ui/src/components/sidebar/sidebar.tsx
+++ b/packages/ui/src/components/sidebar/sidebar.tsx
@@ -1,31 +1,33 @@
 /**
  * Collapsible application navigation rail. On desktop it expands to a full rail
  * or collapses to an icon strip (or fully off-canvas), persisting that choice;
- * below the md breakpoint it becomes a dismissable overlay over a scrim. The
+ * below the md breakpoint it becomes a modal overlay (the merged Sheet). The
  * primary, always-present chrome a user orients by.
  *
  * @cognitive-load 3/10 - A familiar, persistent navigation pattern in a fixed
  *   location: the user never hunts for it, and the two states (expanded rail,
- *   collapsed icons) are both legible. The mobile overlay narrows the surface
- *   without hiding where the user was.
+ *   collapsed icons) are both legible. The mobile overlay narrows the surface to
+ *   one focused choice set without hiding where the user was.
  * @attention-economics Near-zero standing cost: the rail sits at the edge and is
  *   scanned only when navigating. The mobile overlay is a brief, reversible
- *   detour -- the scrim dims the page but keeps it in view, so orientation is
- *   never lost.
+ *   detour -- the modal scrim dims the page but keeps it in view, so orientation
+ *   is never lost.
  * @trust-building One consistent edge and toggle direction, a Cmd/Ctrl+B
- *   shortcut, state remembered across loads, and a mobile scrim plus Escape that
- *   both read as obvious, reversible exits -- so collapsing or opening always
- *   feels safe.
+ *   shortcut, state remembered across loads, and a mobile overlay whose scrim,
+ *   Escape, and close all read as obvious, reversible exits -- so collapsing or
+ *   opening always feels safe.
  * @accessibility The rail stays navigable while collapsed (never removed from the
- *   a11y tree); the trigger is a labelled control wired by real id to the panel
- *   it controls; the mobile scrim is a labelled dismiss button; Escape dismisses
- *   the overlay and returns focus to the trigger.
+ *   a11y tree); the trigger is a labelled control wired by real id to the desktop
+ *   panel; the mobile overlay is a modal dialog (focus trapped, scroll locked,
+ *   Escape dismisses and restores focus, and its content is unreachable while
+ *   closed) via the composed Sheet.
  *
  * The React performance is a DECORATOR over sidebar.behavior.ts: it adds only the
  * view (sidebar.classes.ts) and React wiring (useMemory + effects that read the
- * viewport, persist the cookie, and bind Cmd/Ctrl+B). Every decision -- reducers,
- * the aria projection, the Escape keymap, the toggle routing -- lives in the
- * score, shared with the WC and Astro performances via bindSidebar.
+ * viewport, persist the cookie, and bind Cmd/Ctrl+B), and composes the merged
+ * Sheet for the mobile overlay. Every decision -- reducers, the aria projection,
+ * the Escape keymap, the toggle routing -- lives in the score, shared with the WC
+ * and Astro performances via bindSidebar.
  *
  * @example
  * ```tsx
@@ -53,6 +55,7 @@ import { keyInputOf } from '../../hooks/key-input';
 import { useMemory } from '../../hooks/use-memory';
 import classy from '../../primitives/classy';
 import { mergeProps } from '../../primitives/slot';
+import { Sheet, SheetContent } from '../sheet/sheet';
 import {
   sidebar,
   toggleIntent,
@@ -213,49 +216,59 @@ export interface SidebarProps extends React.HTMLAttributes<HTMLElement> {
 }
 
 export function Sidebar({ side, variant, className, children, onKeyDown, ...props }: SidebarProps) {
-  const { state, config, aria, ids, request, classes } = useSidebar();
+  const { state, config, aria, ids, request, isMobile, classes } = useSidebar();
   const resolvedSide = side ?? config.side ?? 'left';
   const resolvedVariant = variant ?? config.variant ?? 'sidebar';
-  const mobileOpen = aria.panel?.['data-mobile'] === 'open';
 
-  // The panel is the Escape scope; React hardcodes the part it renders here,
-  // mirroring the DOM-native bind's containment resolution. The idempotence gate
-  // makes closeMobile a no-op while the overlay is closed (desktop), so Escape is
-  // inert there rather than swallowed.
+  // Mobile: the overlay IS our merged Sheet -- a modal dialog (focus-trap,
+  // scroll-lock, dismiss-on-outside, Escape, and content UNMOUNTED when closed so
+  // its links leave the tab order and a11y tree, WCAG 2.2 AAA). Controlled by the
+  // sidebar's openMobile axis; matches shadcn's SidebarProvider architecture.
+  if (isMobile) {
+    return (
+      <Sheet
+        open={state.openMobile}
+        onOpenChange={(next) => request(next ? 'openMobile' : 'closeMobile')}
+        modal
+      >
+        <SheetContent
+          side={resolvedSide}
+          aria-label="Sidebar"
+          data-sidebar="sidebar"
+          showCloseButton={false}
+          className={classy(classes.mobilePanel, className)}
+          {...props}
+        >
+          {children}
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  // Desktop: the persistent rail. The panel-scoped keymap is kept for symmetry
+  // with the bind; on desktop there is no mobile overlay so closeMobile is a
+  // gated no-op and Escape is inert (not swallowed).
   const handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
     onKeyDown?.(event);
     if (event.defaultPrevented) return;
     const action = sidebar.keymap(keyInputOf(event), state, 'panel', config);
     if (!action) return;
-    if (!request(action)) return;
-    event.preventDefault();
-    if (typeof document !== 'undefined') document.getElementById(ids.trigger)?.focus();
+    if (request(action)) event.preventDefault();
   };
 
   return (
-    <>
-      <button
-        type="button"
-        data-part="overlay"
-        id={ids.overlay}
-        hidden={mobileOpen ? undefined : true}
-        className={classes.overlay}
-        onClick={() => request('closeMobile')}
-        {...aria.overlay}
-      />
-      <nav
-        data-part="panel"
-        id={ids.panel}
-        data-side={resolvedSide}
-        data-variant={resolvedVariant}
-        className={classy(sidebarPanelClasses(resolvedSide, resolvedVariant), className)}
-        onKeyDown={handleKeyDown}
-        {...aria.panel}
-        {...props}
-      >
-        {children}
-      </nav>
-    </>
+    <nav
+      data-part="panel"
+      id={ids.panel}
+      data-side={resolvedSide}
+      data-variant={resolvedVariant}
+      className={classy(sidebarPanelClasses(resolvedSide, resolvedVariant), className)}
+      onKeyDown={handleKeyDown}
+      {...aria.panel}
+      {...props}
+    >
+      {children}
+    </nav>
   );
 }
 
@@ -277,12 +290,16 @@ export function SidebarTrigger({
     request(toggleIntent(state, config, isMobile));
   };
 
+  // On mobile the panel is not rendered (the overlay is the portaled Sheet), so
+  // the projected aria-controls -> panel id would dangle. Drop it there; the
+  // trigger keeps its accessible name and toggles openMobile.
   const partProps = {
     'data-part': 'trigger',
     id: ids.trigger,
     className: classy(classes.trigger, className),
     onClick: handleClick,
     ...aria.trigger,
+    ...(isMobile ? { 'aria-controls': undefined } : {}),
   };
 
   if (asChild && React.isValidElement(children)) {

--- a/packages/ui/test/components/sidebar/sidebar.astro.conformance.test.ts
+++ b/packages/ui/test/components/sidebar/sidebar.astro.conformance.test.ts
@@ -3,7 +3,11 @@
  * renders the SSR markup but does NOT run the <script>, so the test calls
  * bindSidebar directly -- that IS the script's job -- then drives the same score
  * the React and WC performances drive. The viewport signal is mocked via
- * matchMedia (read live at gesture time by the bind).
+ * matchMedia (read live by the bind).
+ *
+ * The mobile overlay is the SSR panel enhanced in place into a modal by the bind
+ * (role=dialog + the sheet modal trio); a closed mobile overlay is `hidden` so
+ * its links leave the tab order and a11y tree.
  */
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import userEvent from '@testing-library/user-event';
@@ -24,14 +28,11 @@ function setViewport(isMobile: boolean): void {
   })) as unknown as typeof window.matchMedia;
 }
 
-async function mount(
-  props: Record<string, unknown> = {},
-  slots: Record<string, string> = {},
-): Promise<HTMLElement> {
+async function mount(props: Record<string, unknown> = {}): Promise<HTMLElement> {
   const container = await AstroContainer.create();
   const html = await container.renderToString(Sidebar, {
     props: { id: 'sb', ...props },
-    slots: { default: '<a href="/dashboard" data-sidebar="menu-button">Dashboard</a>', ...slots },
+    slots: { default: '<a href="/dashboard" data-sidebar="menu-button">Dashboard</a>' },
   });
   document.body.innerHTML = html;
   const root = document.body.querySelector('rafters-sidebar') as HTMLElement;
@@ -42,7 +43,6 @@ async function mount(
 const trigger = () => document.body.querySelector<HTMLElement>('[data-part="trigger"]')!;
 const rail = () => document.body.querySelector<HTMLElement>('[data-part="rail"]')!;
 const panel = () => document.body.querySelector<HTMLElement>('[data-part="panel"]')!;
-const overlay = () => document.body.querySelector<HTMLElement>('[data-part="overlay"]')!;
 
 beforeEach(() => setViewport(false));
 afterEach(() => {
@@ -51,15 +51,10 @@ afterEach(() => {
 });
 
 describe('sidebar conformance [astro]', () => {
-  it('SSR default: expanded rail, scrim hidden and crawlable', async () => {
+  it('SSR default: expanded rail, present and navigable, wired to the panel by real id', async () => {
     await mount();
     expect(panel().getAttribute('data-state')).toBe('expanded');
-    expect(panel().getAttribute('data-mobile')).toBe('closed');
-    expect(overlay().hidden).toBe(true);
-  });
-
-  it('SSR wires the trigger to the panel by real id', async () => {
-    await mount();
+    expect(panel().hidden).toBe(false);
     expect(trigger().getAttribute('aria-controls')).toBe(panel().id);
     expect(panel().id).toBe('sb-panel');
   });
@@ -72,19 +67,29 @@ describe('sidebar conformance [astro]', () => {
     expect(panel().getAttribute('data-collapsible')).toBe('icon');
   });
 
-  it('bind mobile: the trigger reveals the overlay; Escape from a data-part descendant dismisses', async () => {
-    const user = userEvent.setup();
+  it('bind mobile: a CLOSED overlay hides the panel so its links are unreachable', async () => {
     setViewport(true);
     await mount();
+    expect(panel().hidden).toBe(true);
+  });
+
+  it('bind mobile: the trigger opens a modal dialog; Escape from a data-part descendant dismisses', async () => {
+    setViewport(true);
+    const user = userEvent.setup();
+    await mount();
     await user.click(trigger());
-    expect(panel().getAttribute('data-mobile')).toBe('open');
-    expect(overlay().hidden).toBe(false);
+    expect(panel().hidden).toBe(false);
+    expect(panel().getAttribute('role')).toBe('dialog');
+    expect(panel().getAttribute('aria-modal')).toBe('true');
+    expect(panel().contains(document.activeElement)).toBe(true);
+    expect(document.body.style.overflow).toBe('hidden');
 
     // Containment resolution: focus the rail (its own data-part, inside the
     // panel) then Escape -- it must still dismiss and restore focus.
     rail().focus();
     await user.keyboard('{Escape}');
-    expect(panel().getAttribute('data-mobile')).toBe('closed');
+    expect(panel().hidden).toBe(true);
     expect(document.activeElement).toBe(trigger());
+    expect(document.body.style.overflow).not.toBe('hidden');
   });
 });

--- a/packages/ui/test/components/sidebar/sidebar.astro.conformance.test.ts
+++ b/packages/ui/test/components/sidebar/sidebar.astro.conformance.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Astro performance of the sidebar score, driven end to end. AstroContainer
+ * renders the SSR markup but does NOT run the <script>, so the test calls
+ * bindSidebar directly -- that IS the script's job -- then drives the same score
+ * the React and WC performances drive. The viewport signal is mocked via
+ * matchMedia (read live at gesture time by the bind).
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Sidebar from '../../../src/components/sidebar/sidebar.astro';
+import { bindSidebar } from '../../../src/components/sidebar/sidebar.behavior';
+
+function setViewport(isMobile: boolean): void {
+  window.matchMedia = ((query: string) => ({
+    matches: isMobile,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
+async function mount(
+  props: Record<string, unknown> = {},
+  slots: Record<string, string> = {},
+): Promise<HTMLElement> {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Sidebar, {
+    props: { id: 'sb', ...props },
+    slots: { default: '<a href="/dashboard" data-sidebar="menu-button">Dashboard</a>', ...slots },
+  });
+  document.body.innerHTML = html;
+  const root = document.body.querySelector('rafters-sidebar') as HTMLElement;
+  bindSidebar(root); // the <script> does this per instance on the real page
+  return root;
+}
+
+const trigger = () => document.body.querySelector<HTMLElement>('[data-part="trigger"]')!;
+const rail = () => document.body.querySelector<HTMLElement>('[data-part="rail"]')!;
+const panel = () => document.body.querySelector<HTMLElement>('[data-part="panel"]')!;
+const overlay = () => document.body.querySelector<HTMLElement>('[data-part="overlay"]')!;
+
+beforeEach(() => setViewport(false));
+afterEach(() => {
+  document.body.innerHTML = '';
+  setViewport(false);
+});
+
+describe('sidebar conformance [astro]', () => {
+  it('SSR default: expanded rail, scrim hidden and crawlable', async () => {
+    await mount();
+    expect(panel().getAttribute('data-state')).toBe('expanded');
+    expect(panel().getAttribute('data-mobile')).toBe('closed');
+    expect(overlay().hidden).toBe(true);
+  });
+
+  it('SSR wires the trigger to the panel by real id', async () => {
+    await mount();
+    expect(trigger().getAttribute('aria-controls')).toBe(panel().id);
+    expect(panel().id).toBe('sb-panel');
+  });
+
+  it('bind: the trigger collapses the rail on the desktop viewport', async () => {
+    const user = userEvent.setup();
+    await mount({ collapsible: 'icon' });
+    await user.click(trigger());
+    expect(panel().getAttribute('data-state')).toBe('collapsed');
+    expect(panel().getAttribute('data-collapsible')).toBe('icon');
+  });
+
+  it('bind mobile: the trigger reveals the overlay; Escape from a data-part descendant dismisses', async () => {
+    const user = userEvent.setup();
+    setViewport(true);
+    await mount();
+    await user.click(trigger());
+    expect(panel().getAttribute('data-mobile')).toBe('open');
+    expect(overlay().hidden).toBe(false);
+
+    // Containment resolution: focus the rail (its own data-part, inside the
+    // panel) then Escape -- it must still dismiss and restore focus.
+    rail().focus();
+    await user.keyboard('{Escape}');
+    expect(panel().getAttribute('data-mobile')).toBe('closed');
+    expect(document.activeElement).toBe(trigger());
+  });
+});

--- a/packages/ui/test/components/sidebar/sidebar.behavior.test.ts
+++ b/packages/ui/test/components/sidebar/sidebar.behavior.test.ts
@@ -16,7 +16,6 @@ const ids: PartIds<SidebarPart> = {
   trigger: 't',
   rail: 'rl',
   panel: 'p',
-  overlay: 'o',
 };
 
 function ariaAt(config: SidebarConfig, state: SidebarState = sidebar.initialState(config)) {
@@ -25,19 +24,13 @@ function ariaAt(config: SidebarConfig, state: SidebarState = sidebar.initialStat
 
 describe('sidebar parts', () => {
   it('declares the full behavior surface', () => {
-    expect(Object.keys(sidebar.parts).sort()).toEqual([
-      'overlay',
-      'panel',
-      'rail',
-      'root',
-      'trigger',
-    ]);
+    expect(Object.keys(sidebar.parts).sort()).toEqual(['panel', 'rail', 'root', 'trigger']);
     // The panel is the only always-present interactive part besides root; the
-    // rest are optional.
+    // rest are optional. There is no scrim part: the mobile overlay is the merged
+    // Sheet (React) or the bind-enhanced modal panel (WC/Astro).
     expect(sidebar.parts.panel.optional).toBeUndefined();
     expect(sidebar.parts.trigger.optional).toBe(true);
     expect(sidebar.parts.rail.optional).toBe(true);
-    expect(sidebar.parts.overlay.optional).toBe(true);
   });
 });
 
@@ -157,12 +150,14 @@ describe('sidebar aria projection', () => {
     expect(aria.trigger?.['aria-controls']).toBeUndefined();
   });
 
-  it('mobile axis flips the panel and scrim data-state without touching the desktop one', () => {
+  it('mobile axis flips the panel data-mobile without touching the desktop one', () => {
     const shown: SidebarState = { open: true, openMobile: true };
     const aria = sidebar.aria(shown, {}, ids);
     expect(aria.panel?.['data-mobile']).toBe('open');
     expect(aria.panel?.['data-state']).toBe('expanded');
-    expect(aria.overlay).toEqual({ 'aria-label': 'Close sidebar', 'data-state': 'open' });
+    // role=dialog/aria-modal are bind-managed (viewport-dependent), never in the
+    // pure projection.
+    expect(aria.panel?.role).toBeUndefined();
   });
 
   it('side and variant are decoration -- they never enter the projection', () => {

--- a/packages/ui/test/components/sidebar/sidebar.behavior.test.ts
+++ b/packages/ui/test/components/sidebar/sidebar.behavior.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import { createBehavior, type PartIds } from '../../../src/lib/contract';
+import {
+  collapsibleOf,
+  isMobileOpen,
+  isOpen,
+  sidebar,
+  toggleIntent,
+  type SidebarConfig,
+  type SidebarPart,
+  type SidebarState,
+} from '../../../src/components/sidebar/sidebar.behavior';
+
+const ids: PartIds<SidebarPart> = {
+  root: 'r',
+  trigger: 't',
+  rail: 'rl',
+  panel: 'p',
+  overlay: 'o',
+};
+
+function ariaAt(config: SidebarConfig, state: SidebarState = sidebar.initialState(config)) {
+  return sidebar.aria(state, config, ids);
+}
+
+describe('sidebar parts', () => {
+  it('declares the full behavior surface', () => {
+    expect(Object.keys(sidebar.parts).sort()).toEqual([
+      'overlay',
+      'panel',
+      'rail',
+      'root',
+      'trigger',
+    ]);
+    // The panel is the only always-present interactive part besides root; the
+    // rest are optional.
+    expect(sidebar.parts.panel.optional).toBeUndefined();
+    expect(sidebar.parts.trigger.optional).toBe(true);
+    expect(sidebar.parts.rail.optional).toBe(true);
+    expect(sidebar.parts.overlay.optional).toBe(true);
+  });
+});
+
+describe('sidebar state: two independent axes', () => {
+  it('seeds desktop open from defaultOpen, defaulting to expanded', () => {
+    expect(sidebar.initialState({}).open).toBe(true);
+    expect(sidebar.initialState({ defaultOpen: false }).open).toBe(false);
+    expect(sidebar.initialState({}).openMobile).toBe(false);
+  });
+
+  it('a controlled open shadows the intrinsic desktop axis; mobile is always intrinsic', () => {
+    expect(isOpen({ open: false, openMobile: false }, { open: true })).toBe(true);
+    expect(isOpen({ open: true, openMobile: false }, { open: false })).toBe(false);
+    expect(isOpen({ open: true, openMobile: false }, {})).toBe(true);
+    expect(isMobileOpen({ open: true, openMobile: true })).toBe(true);
+    expect(isMobileOpen({ open: true, openMobile: false })).toBe(false);
+  });
+
+  it('collapsibleOf defaults to offcanvas', () => {
+    expect(collapsibleOf({})).toBe('offcanvas');
+    expect(collapsibleOf({ collapsible: 'icon' })).toBe('icon');
+  });
+});
+
+describe('sidebar toggleIntent (viewport routing lives in the score)', () => {
+  const expanded: SidebarState = { open: true, openMobile: false };
+  const collapsed: SidebarState = { open: false, openMobile: false };
+  const mobileShown: SidebarState = { open: true, openMobile: true };
+
+  it('desktop: toggles the expand axis on the effective value', () => {
+    expect(toggleIntent(expanded, {}, false)).toBe('close');
+    expect(toggleIntent(collapsed, {}, false)).toBe('open');
+    // Controlled value drives the intent, not intrinsic state.
+    expect(toggleIntent(collapsed, { open: true }, false)).toBe('close');
+  });
+
+  it('mobile: toggles the overlay axis, never the desktop one', () => {
+    expect(toggleIntent(expanded, {}, true)).toBe('openMobile');
+    expect(toggleIntent(mobileShown, {}, true)).toBe('closeMobile');
+  });
+});
+
+describe('sidebar canDispatch (per-axis idempotence gate)', () => {
+  const expanded: SidebarState = { open: true, openMobile: false };
+  const collapsed: SidebarState = { open: false, openMobile: false };
+  const mobileShown: SidebarState = { open: true, openMobile: true };
+
+  it('desktop open only when collapsed, close only when expanded', () => {
+    expect(sidebar.canDispatch(collapsed, 'open', {})).toBe(true);
+    expect(sidebar.canDispatch(collapsed, 'close', {})).toBe(false);
+    expect(sidebar.canDispatch(expanded, 'open', {})).toBe(false);
+    expect(sidebar.canDispatch(expanded, 'close', {})).toBe(true);
+  });
+
+  it('mobile openMobile only when hidden, closeMobile only when shown', () => {
+    expect(sidebar.canDispatch(collapsed, 'openMobile', {})).toBe(true);
+    expect(sidebar.canDispatch(collapsed, 'closeMobile', {})).toBe(false);
+    expect(sidebar.canDispatch(mobileShown, 'openMobile', {})).toBe(false);
+    expect(sidebar.canDispatch(mobileShown, 'closeMobile', {})).toBe(true);
+  });
+
+  it('gates desktop on the CONTROLLED value when present', () => {
+    const drifted: SidebarState = { open: false, openMobile: false };
+    expect(sidebar.canDispatch(drifted, 'close', { open: true })).toBe(true);
+    expect(sidebar.canDispatch(drifted, 'open', { open: true })).toBe(false);
+  });
+});
+
+describe('sidebar actions move the two axes through dispatch', () => {
+  it('desktop open/close', () => {
+    const { memory, dispatch } = createBehavior(sidebar, { defaultOpen: false });
+    expect(dispatch('open', {})).toBe(true);
+    expect(memory.get().open).toBe(true);
+    expect(dispatch('open', {})).toBe(false);
+    expect(dispatch('close', {})).toBe(true);
+    expect(memory.get().open).toBe(false);
+  });
+
+  it('mobile openMobile/closeMobile, independent of the desktop axis', () => {
+    const { memory, dispatch } = createBehavior(sidebar, {});
+    expect(memory.get().open).toBe(true);
+    expect(dispatch('openMobile', {})).toBe(true);
+    expect(memory.get().openMobile).toBe(true);
+    // The desktop axis is untouched by a mobile action.
+    expect(memory.get().open).toBe(true);
+    expect(dispatch('closeMobile', {})).toBe(true);
+    expect(memory.get().openMobile).toBe(false);
+  });
+});
+
+describe('sidebar aria projection', () => {
+  it('expanded: panel reports expanded, no collapse hook, mobile closed', () => {
+    const aria = ariaAt({});
+    expect(aria.panel).toEqual({
+      'data-state': 'expanded',
+      'data-collapsible': undefined,
+      'data-mobile': 'closed',
+    });
+    expect(aria.trigger).toEqual({ 'aria-controls': 'p', 'data-state': 'expanded' });
+    expect(aria.rail).toEqual({ 'aria-label': 'Toggle Sidebar', 'data-state': 'expanded' });
+  });
+
+  it('collapsed: panel reports the collapse mode hook', () => {
+    const aria = ariaAt({ defaultOpen: false, collapsible: 'icon' });
+    expect(aria.panel?.['data-state']).toBe('collapsed');
+    expect(aria.panel?.['data-collapsible']).toBe('icon');
+  });
+
+  it('collapsible=none never projects a collapse hook, even collapsed', () => {
+    const aria = ariaAt({ defaultOpen: false, collapsible: 'none' });
+    expect(aria.panel?.['data-state']).toBe('collapsed');
+    expect(aria.panel?.['data-collapsible']).toBeUndefined();
+  });
+
+  it('trigger controls the panel by real id; absent panel id projects no dangling reference', () => {
+    const aria = sidebar.aria(sidebar.initialState({}), {}, { ...ids, panel: '' });
+    expect(aria.trigger?.['aria-controls']).toBeUndefined();
+  });
+
+  it('mobile axis flips the panel and scrim data-state without touching the desktop one', () => {
+    const shown: SidebarState = { open: true, openMobile: true };
+    const aria = sidebar.aria(shown, {}, ids);
+    expect(aria.panel?.['data-mobile']).toBe('open');
+    expect(aria.panel?.['data-state']).toBe('expanded');
+    expect(aria.overlay).toEqual({ 'aria-label': 'Close sidebar', 'data-state': 'open' });
+  });
+
+  it('side and variant are decoration -- they never enter the projection', () => {
+    const aria = sidebar.aria(
+      sidebar.initialState({}),
+      { side: 'right', variant: 'floating' },
+      ids,
+    );
+    const serialized = JSON.stringify(aria);
+    expect(serialized).not.toContain('right');
+    expect(serialized).not.toContain('floating');
+  });
+});
+
+describe('sidebar keymap', () => {
+  const state: SidebarState = { open: true, openMobile: true };
+  it('Escape on the panel dismisses the mobile overlay', () => {
+    expect(sidebar.keymap({ key: 'Escape' }, state, 'panel', {})).toBe('closeMobile');
+  });
+  it('Escape elsewhere and other keys are not claimed', () => {
+    expect(sidebar.keymap({ key: 'Escape' }, state, 'trigger', {})).toBeNull();
+    expect(sidebar.keymap({ key: 'Enter' }, state, 'panel', {})).toBeNull();
+  });
+});

--- a/packages/ui/test/components/sidebar/sidebar.classes.test.ts
+++ b/packages/ui/test/components/sidebar/sidebar.classes.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+  panelSideClasses,
+  panelVariantClasses,
+  sidebarClasses,
+  sidebarMenuButtonClasses,
+  sidebarMenuSubButtonClasses,
+  sidebarPanelClasses,
+} from '../../../src/components/sidebar/sidebar.classes';
+
+const classes = sidebarClasses();
+
+describe('sidebar shell classes', () => {
+  it('the scrim fills the viewport on the overlay depth and is desktop-hidden', () => {
+    expect(classes.overlay).toContain('fixed');
+    expect(classes.overlay).toContain('inset-0');
+    expect(classes.overlay).toContain('z-depth-overlay');
+    expect(classes.overlay).toContain('bg-foreground/80');
+    expect(classes.overlay).toContain('md:hidden');
+  });
+
+  it('the rail hairline is desktop-only on the navigation depth', () => {
+    expect(classes.rail).toContain('md:flex');
+    expect(classes.rail).toContain('z-depth-navigation');
+    expect(classes.rail).toContain('cursor-ew-resize');
+  });
+
+  it('separators and menus sit on sidebar surface tokens', () => {
+    expect(classes.separator).toContain('bg-sidebar-border');
+    expect(classes.menu).toContain('flex');
+  });
+});
+
+describe('sidebar panel: one element, both axes', () => {
+  it('carries the mobile overlay size and the desktop rail size on their breakpoints', () => {
+    const panel = sidebarPanelClasses('left', 'sidebar');
+    expect(panel).toContain('z-depth-modal'); // mobile overlay depth
+    expect(panel).toContain('w-72'); // mobile overlay width
+    expect(panel).toContain('md:z-depth-navigation'); // desktop rail depth
+    expect(panel).toContain('md:w-64'); // desktop rail width
+  });
+
+  it('keys the desktop collapse off data-state + data-collapsible', () => {
+    const panel = sidebarPanelClasses('left', 'sidebar');
+    expect(panel).toContain('md:data-[state=collapsed]:data-[collapsible=icon]:w-12');
+    expect(panel).toContain('md:data-[state=collapsed]:data-[collapsible=offcanvas]:w-0');
+  });
+
+  it('keys the mobile off-canvas slide off data-mobile, per side', () => {
+    expect(panelSideClasses.left).toContain('data-[mobile=closed]:-translate-x-full');
+    expect(panelSideClasses.left).toContain('left-0');
+    expect(panelSideClasses.left).toContain('border-r');
+    expect(panelSideClasses.right).toContain('data-[mobile=closed]:translate-x-full');
+    expect(panelSideClasses.right).toContain('right-0');
+    expect(panelSideClasses.right).toContain('border-l');
+  });
+
+  it('floating and inset variants round and lift the desktop rail', () => {
+    expect(panelVariantClasses.floating).toContain('md:rounded-lg');
+    expect(panelVariantClasses.floating).toContain('md:border');
+    expect(panelVariantClasses.inset).toContain('md:rounded-lg');
+    expect(panelVariantClasses.sidebar).toBe('');
+  });
+
+  it('declares NO layout motion: the collapse/slide timing is undeclared (tokens pending)', () => {
+    // The oracle animated the collapse and slide with raw duration-200 +
+    // ease-linear/ease-in-out; those are dropped -- only the from/to states ride
+    // the data hooks. The horizontal-slide motion tokens do not exist yet.
+    const panel = `${sidebarPanelClasses('left', 'sidebar')} ${sidebarPanelClasses('right', 'inset')}`;
+    expect(panel).not.toContain('duration-200');
+    expect(panel).not.toContain('ease-linear');
+    expect(panel).not.toContain('ease-in-out');
+    expect(panel).not.toContain('transition-transform');
+    expect(panel).not.toContain('transition-all');
+    expect(panel).not.toContain('animate-in');
+    expect(panel).not.toContain('slide-in');
+  });
+});
+
+describe('sidebar menu button variants', () => {
+  it('base keeps only the small interaction-feedback duration (Spec 04)', () => {
+    const base = sidebarMenuButtonClasses('default', 'default');
+    expect(base).toContain('transition-colors');
+    expect(base).toContain('duration-150');
+    expect(base).toContain('motion-reduce:transition-none');
+    expect(base).not.toContain('duration-200');
+  });
+
+  it('size and outline variants layer onto the base', () => {
+    expect(sidebarMenuButtonClasses('default', 'sm')).toContain('text-label-small');
+    expect(sidebarMenuButtonClasses('outline', 'default')).toContain('bg-background');
+    expect(sidebarMenuButtonClasses('default', 'default')).not.toContain('bg-background');
+  });
+
+  it('submenu button sizes layer onto its base', () => {
+    expect(sidebarMenuSubButtonClasses('sm')).toContain('text-label-small');
+    expect(sidebarMenuSubButtonClasses('md')).toContain('text-label-medium');
+  });
+});

--- a/packages/ui/test/components/sidebar/sidebar.classes.test.ts
+++ b/packages/ui/test/components/sidebar/sidebar.classes.test.ts
@@ -11,12 +11,12 @@ import {
 const classes = sidebarClasses();
 
 describe('sidebar shell classes', () => {
-  it('the scrim fills the viewport on the overlay depth and is desktop-hidden', () => {
-    expect(classes.overlay).toContain('fixed');
-    expect(classes.overlay).toContain('inset-0');
-    expect(classes.overlay).toContain('z-depth-overlay');
-    expect(classes.overlay).toContain('bg-foreground/80');
-    expect(classes.overlay).toContain('md:hidden');
+  it('the mobile overlay surface paints the sidebar fill over the Sheet frame', () => {
+    // Sheet owns the modal positioning; this class only carries the sidebar
+    // chrome, so it must not re-declare fixed/inset positioning.
+    expect(classes.mobilePanel).toContain('bg-sidebar');
+    expect(classes.mobilePanel).toContain('flex');
+    expect(classes.mobilePanel).not.toContain('fixed');
   });
 
   it('the rail hairline is desktop-only on the navigation depth', () => {
@@ -46,11 +46,9 @@ describe('sidebar panel: one element, both axes', () => {
     expect(panel).toContain('md:data-[state=collapsed]:data-[collapsible=offcanvas]:w-0');
   });
 
-  it('keys the mobile off-canvas slide off data-mobile, per side', () => {
-    expect(panelSideClasses.left).toContain('data-[mobile=closed]:-translate-x-full');
+  it('anchors the panel to its side edge with the matching border', () => {
     expect(panelSideClasses.left).toContain('left-0');
     expect(panelSideClasses.left).toContain('border-r');
-    expect(panelSideClasses.right).toContain('data-[mobile=closed]:translate-x-full');
     expect(panelSideClasses.right).toContain('right-0');
     expect(panelSideClasses.right).toContain('border-l');
   });

--- a/packages/ui/test/components/sidebar/sidebar.conformance.test.tsx
+++ b/packages/ui/test/components/sidebar/sidebar.conformance.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * React performance of the sidebar score, driven end to end. Nothing portals, so
+ * part queries run against the RTL container. The mobile axis is exercised by
+ * mocking matchMedia (the viewport signal useIsMobile reads).
+ */
+import * as React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarTrigger,
+} from '../../../src/components/sidebar/sidebar';
+import { sidebar } from '../../../src/components/sidebar/sidebar.behavior';
+import { assertAxeClean, assertContractFulfillment, partElement } from '../../harness/conformance';
+import type { SidebarConfig, SidebarState } from '../../../src/components/sidebar/sidebar.behavior';
+
+function setViewport(isMobile: boolean): void {
+  window.matchMedia = ((query: string) => ({
+    matches: isMobile,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
+interface SetupProps {
+  open?: boolean;
+  defaultOpen?: boolean;
+  collapsible?: SidebarConfig['collapsible'];
+  onOpenChange?: (open: boolean) => void;
+}
+
+function TestSidebar(props: SetupProps) {
+  return (
+    <SidebarProvider {...props}>
+      <SidebarTrigger />
+      <Sidebar>
+        <SidebarRail />
+        <SidebarContent>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton>Dashboard</SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarContent>
+      </Sidebar>
+      <SidebarInset>Page</SidebarInset>
+    </SidebarProvider>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  setViewport(false);
+});
+
+describe('sidebar conformance [react]', () => {
+  it('default: expanded rail, every declared part present, ARIA equals the projection', async () => {
+    setViewport(false);
+    const { container } = render(<TestSidebar />);
+    const config: SidebarConfig = {
+      defaultOpen: true,
+      side: 'left',
+      variant: 'sidebar',
+      collapsible: 'offcanvas',
+    };
+    const state: SidebarState = { open: true, openMobile: false };
+    assertContractFulfillment(sidebar, container, state, config, [
+      'root',
+      'trigger',
+      'rail',
+      'panel',
+      'overlay',
+    ]);
+    await assertAxeClean(container);
+  });
+
+  it('desktop: the trigger collapses the rail and projects the collapse mode hook', async () => {
+    setViewport(false);
+    const user = userEvent.setup();
+    const { container } = render(<TestSidebar collapsible="icon" />);
+    const panel = partElement(container, 'panel') as HTMLElement;
+    expect(panel.getAttribute('data-state')).toBe('expanded');
+
+    await user.click(partElement(container, 'trigger') as HTMLElement);
+    expect(panel.getAttribute('data-state')).toBe('collapsed');
+    expect(panel.getAttribute('data-collapsible')).toBe('icon');
+    // The desktop collapse never touches the mobile axis.
+    expect(panel.getAttribute('data-mobile')).toBe('closed');
+  });
+
+  it('desktop: the rail toggles the same expand axis as the trigger', async () => {
+    setViewport(false);
+    const user = userEvent.setup();
+    const { container } = render(<TestSidebar />);
+    const panel = partElement(container, 'panel') as HTMLElement;
+    await user.click(partElement(container, 'rail') as HTMLElement);
+    expect(panel.getAttribute('data-state')).toBe('collapsed');
+  });
+
+  it('mobile: the trigger reveals the overlay and unhides the scrim', async () => {
+    setViewport(true);
+    const user = userEvent.setup();
+    const { container } = render(<TestSidebar />);
+    const panel = partElement(container, 'panel') as HTMLElement;
+    const overlay = partElement(container, 'overlay') as HTMLElement;
+    expect(overlay.hasAttribute('hidden')).toBe(true);
+
+    await user.click(partElement(container, 'trigger') as HTMLElement);
+    expect(panel.getAttribute('data-mobile')).toBe('open');
+    expect(overlay.hasAttribute('hidden')).toBe(false);
+    // The mobile overlay never touches the desktop expand axis.
+    expect(panel.getAttribute('data-state')).toBe('expanded');
+  });
+
+  it('mobile: clicking the scrim dismisses the overlay', async () => {
+    setViewport(true);
+    const user = userEvent.setup();
+    const { container } = render(<TestSidebar />);
+    await user.click(partElement(container, 'trigger') as HTMLElement);
+    const panel = partElement(container, 'panel') as HTMLElement;
+    expect(panel.getAttribute('data-mobile')).toBe('open');
+
+    await user.click(partElement(container, 'overlay') as HTMLElement);
+    expect(panel.getAttribute('data-mobile')).toBe('closed');
+  });
+
+  it('mobile: Escape inside the panel dismisses and restores focus to the trigger', async () => {
+    setViewport(true);
+    const user = userEvent.setup();
+    const { container } = render(<TestSidebar />);
+    const trigger = partElement(container, 'trigger') as HTMLElement;
+    await user.click(trigger);
+    const panel = partElement(container, 'panel') as HTMLElement;
+    expect(panel.getAttribute('data-mobile')).toBe('open');
+
+    // Focus a control INSIDE the panel, then press Escape: the panel-scoped
+    // keymap must fire even though focus is on a descendant.
+    const menuButton = panel.querySelector<HTMLElement>(
+      '[data-sidebar="menu-button"]',
+    ) as HTMLElement;
+    menuButton.focus();
+    await user.keyboard('{Escape}');
+    expect(panel.getAttribute('data-mobile')).toBe('closed');
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('desktop: Escape is inert while the overlay is closed (no swallowed key)', async () => {
+    setViewport(false);
+    const user = userEvent.setup();
+    const { container } = render(<TestSidebar />);
+    const panel = partElement(container, 'panel') as HTMLElement;
+    const menuButton = panel.querySelector<HTMLElement>(
+      '[data-sidebar="menu-button"]',
+    ) as HTMLElement;
+    menuButton.focus();
+    await user.keyboard('{Escape}');
+    // The idempotence gate makes closeMobile a no-op; nothing changes.
+    expect(panel.getAttribute('data-mobile')).toBe('closed');
+    expect(panel.getAttribute('data-state')).toBe('expanded');
+  });
+
+  it('controlled: onOpenChange fires and the desktop axis follows the prop, not the gesture', async () => {
+    setViewport(false);
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const { container, rerender } = render(
+      <TestSidebar open={false} onOpenChange={onOpenChange} />,
+    );
+    const panel = partElement(container, 'panel') as HTMLElement;
+    expect(panel.getAttribute('data-state')).toBe('collapsed');
+
+    await user.click(partElement(container, 'trigger') as HTMLElement);
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    // Effective value is controlled: the rail stays collapsed until the prop moves.
+    expect(panel.getAttribute('data-state')).toBe('collapsed');
+
+    rerender(<TestSidebar open onOpenChange={onOpenChange} />);
+    expect(panel.getAttribute('data-state')).toBe('expanded');
+  });
+
+  it('Cmd/Ctrl+B toggles the desktop expand axis from anywhere', async () => {
+    setViewport(false);
+    const user = userEvent.setup();
+    const { container } = render(<TestSidebar />);
+    const panel = partElement(container, 'panel') as HTMLElement;
+    expect(panel.getAttribute('data-state')).toBe('expanded');
+    await user.keyboard('{Meta>}b{/Meta}');
+    expect(panel.getAttribute('data-state')).toBe('collapsed');
+  });
+});

--- a/packages/ui/test/components/sidebar/sidebar.conformance.test.tsx
+++ b/packages/ui/test/components/sidebar/sidebar.conformance.test.tsx
@@ -1,7 +1,8 @@
 /**
- * React performance of the sidebar score, driven end to end. Nothing portals, so
- * part queries run against the RTL container. The mobile axis is exercised by
- * mocking matchMedia (the viewport signal useIsMobile reads).
+ * React performance of the sidebar score, driven end to end. The desktop rail
+ * renders in the RTL container; the mobile overlay is the merged Sheet, which
+ * portals to document.body. The mobile axis is exercised by mocking matchMedia
+ * (the viewport signal useIsMobile reads).
  */
 import * as React from 'react';
 import { cleanup, render } from '@testing-library/react';
@@ -61,13 +62,17 @@ function TestSidebar(props: SetupProps) {
   );
 }
 
+const menuButton = () => document.body.querySelector<HTMLElement>('[data-sidebar="menu-button"]');
+const dialog = () => document.body.querySelector<HTMLElement>('[role="dialog"]');
+
 afterEach(() => {
   cleanup();
+  document.body.replaceChildren();
   setViewport(false);
 });
 
 describe('sidebar conformance [react]', () => {
-  it('default: expanded rail, every declared part present, ARIA equals the projection', async () => {
+  it('desktop default: expanded rail, every declared part present, ARIA equals the projection', async () => {
     setViewport(false);
     const { container } = render(<TestSidebar />);
     const config: SidebarConfig = {
@@ -82,7 +87,6 @@ describe('sidebar conformance [react]', () => {
       'trigger',
       'rail',
       'panel',
-      'overlay',
     ]);
     await assertAxeClean(container);
   });
@@ -97,8 +101,8 @@ describe('sidebar conformance [react]', () => {
     await user.click(partElement(container, 'trigger') as HTMLElement);
     expect(panel.getAttribute('data-state')).toBe('collapsed');
     expect(panel.getAttribute('data-collapsible')).toBe('icon');
-    // The desktop collapse never touches the mobile axis.
-    expect(panel.getAttribute('data-mobile')).toBe('closed');
+    // The collapsed desktop rail stays in the tree, navigable (never hidden).
+    expect(panel.hasAttribute('hidden')).toBe(false);
   });
 
   it('desktop: the rail toggles the same expand axis as the trigger', async () => {
@@ -110,66 +114,44 @@ describe('sidebar conformance [react]', () => {
     expect(panel.getAttribute('data-state')).toBe('collapsed');
   });
 
-  it('mobile: the trigger reveals the overlay and unhides the scrim', async () => {
+  it('mobile: a CLOSED overlay renders no nav content -- links are not in the DOM or tab order', () => {
     setViewport(true);
-    const user = userEvent.setup();
-    const { container } = render(<TestSidebar />);
-    const panel = partElement(container, 'panel') as HTMLElement;
-    const overlay = partElement(container, 'overlay') as HTMLElement;
-    expect(overlay.hasAttribute('hidden')).toBe(true);
-
-    await user.click(partElement(container, 'trigger') as HTMLElement);
-    expect(panel.getAttribute('data-mobile')).toBe('open');
-    expect(overlay.hasAttribute('hidden')).toBe(false);
-    // The mobile overlay never touches the desktop expand axis.
-    expect(panel.getAttribute('data-state')).toBe('expanded');
+    render(<TestSidebar />);
+    // The merged Sheet is closed, so SheetContent is unmounted: the menu button
+    // does not exist anywhere in the document (the AAA focus-management fix).
+    expect(menuButton()).toBeNull();
+    expect(dialog()).toBeNull();
   });
 
-  it('mobile: clicking the scrim dismisses the overlay', async () => {
+  it('mobile: the trigger reveals a modal dialog with the nav content and traps focus', async () => {
     setViewport(true);
     const user = userEvent.setup();
-    const { container } = render(<TestSidebar />);
-    await user.click(partElement(container, 'trigger') as HTMLElement);
-    const panel = partElement(container, 'panel') as HTMLElement;
-    expect(panel.getAttribute('data-mobile')).toBe('open');
+    render(<TestSidebar />);
+    await user.click(partElement(document.body, 'trigger') as HTMLElement);
 
-    await user.click(partElement(container, 'overlay') as HTMLElement);
-    expect(panel.getAttribute('data-mobile')).toBe('closed');
+    const modal = dialog() as HTMLElement;
+    expect(modal).not.toBeNull();
+    expect(modal.getAttribute('aria-modal')).toBe('true');
+    expect(modal.getAttribute('aria-label')).toBe('Sidebar');
+    expect(menuButton()).not.toBeNull();
+    expect(modal.contains(document.activeElement)).toBe(true);
+    expect(document.body.style.overflow).toBe('hidden');
+    await assertAxeClean(document.body);
   });
 
-  it('mobile: Escape inside the panel dismisses and restores focus to the trigger', async () => {
+  it('mobile: Escape closes the overlay, unmounts the nav, and restores focus to the trigger', async () => {
     setViewport(true);
     const user = userEvent.setup();
-    const { container } = render(<TestSidebar />);
-    const trigger = partElement(container, 'trigger') as HTMLElement;
+    render(<TestSidebar />);
+    const trigger = partElement(document.body, 'trigger') as HTMLElement;
     await user.click(trigger);
-    const panel = partElement(container, 'panel') as HTMLElement;
-    expect(panel.getAttribute('data-mobile')).toBe('open');
+    expect(dialog()).not.toBeNull();
 
-    // Focus a control INSIDE the panel, then press Escape: the panel-scoped
-    // keymap must fire even though focus is on a descendant.
-    const menuButton = panel.querySelector<HTMLElement>(
-      '[data-sidebar="menu-button"]',
-    ) as HTMLElement;
-    menuButton.focus();
     await user.keyboard('{Escape}');
-    expect(panel.getAttribute('data-mobile')).toBe('closed');
+    expect(dialog()).toBeNull();
+    expect(menuButton()).toBeNull();
     expect(document.activeElement).toBe(trigger);
-  });
-
-  it('desktop: Escape is inert while the overlay is closed (no swallowed key)', async () => {
-    setViewport(false);
-    const user = userEvent.setup();
-    const { container } = render(<TestSidebar />);
-    const panel = partElement(container, 'panel') as HTMLElement;
-    const menuButton = panel.querySelector<HTMLElement>(
-      '[data-sidebar="menu-button"]',
-    ) as HTMLElement;
-    menuButton.focus();
-    await user.keyboard('{Escape}');
-    // The idempotence gate makes closeMobile a no-op; nothing changes.
-    expect(panel.getAttribute('data-mobile')).toBe('closed');
-    expect(panel.getAttribute('data-state')).toBe('expanded');
+    expect(document.body.style.overflow).not.toBe('hidden');
   });
 
   it('controlled: onOpenChange fires and the desktop axis follows the prop, not the gesture', async () => {
@@ -184,7 +166,6 @@ describe('sidebar conformance [react]', () => {
 
     await user.click(partElement(container, 'trigger') as HTMLElement);
     expect(onOpenChange).toHaveBeenLastCalledWith(true);
-    // Effective value is controlled: the rail stays collapsed until the prop moves.
     expect(panel.getAttribute('data-state')).toBe('collapsed');
 
     rerender(<TestSidebar open onOpenChange={onOpenChange} />);

--- a/packages/ui/test/components/sidebar/sidebar.element.conformance.test.ts
+++ b/packages/ui/test/components/sidebar/sidebar.element.conformance.test.ts
@@ -1,0 +1,126 @@
+/**
+ * WC performance of the sidebar score, driven end to end against light-DOM
+ * markup. Same score as the React conformance test. The viewport signal is
+ * mocked via matchMedia (the bind reads it live at gesture time, so no effect
+ * timing is involved).
+ *
+ * The Escape test focuses the RAIL -- a focusable element that carries its own
+ * data-part and sits INSIDE the panel -- then presses Escape. This is the exact
+ * shape of the dialog-family defect #1921: `target.closest('[data-part]')` would
+ * resolve to the rail and swallow the key; the bind resolves the part by
+ * CONTAINMENT (`panel.contains(target)`), so Escape still dismisses.
+ */
+import { cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { RaftersSidebar } from '../../../src/components/sidebar/sidebar.element';
+
+function setViewport(isMobile: boolean): void {
+  window.matchMedia = ((query: string) => ({
+    matches: isMobile,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
+beforeAll(() => {
+  if (!customElements.get('rafters-sidebar')) {
+    customElements.define('rafters-sidebar', RaftersSidebar);
+  }
+});
+
+async function mount(): Promise<HTMLElement> {
+  document.body.innerHTML = `
+    <rafters-sidebar data-part="root" data-default-open="true" data-side="left" data-collapsible="offcanvas">
+      <button type="button" data-part="trigger" id="sb-trigger" aria-controls="sb-panel" data-state="expanded">Toggle</button>
+      <button type="button" data-part="overlay" id="sb-overlay" aria-label="Close sidebar" data-state="closed" hidden></button>
+      <nav data-part="panel" id="sb-panel" data-state="expanded" data-mobile="closed">
+        <button type="button" data-part="rail" id="sb-rail" tabindex="-1" aria-label="Toggle Sidebar" data-state="expanded"></button>
+        <button type="button" data-sidebar="menu-button">Dashboard</button>
+      </nav>
+    </rafters-sidebar>`;
+  await Promise.resolve();
+  return document.body.querySelector('rafters-sidebar') as HTMLElement;
+}
+
+const trigger = () => document.body.querySelector<HTMLElement>('[data-part="trigger"]')!;
+const rail = () => document.body.querySelector<HTMLElement>('[data-part="rail"]')!;
+const panel = () => document.body.querySelector<HTMLElement>('[data-part="panel"]')!;
+const overlay = () => document.body.querySelector<HTMLElement>('[data-part="overlay"]')!;
+
+beforeEach(() => setViewport(false));
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+  setViewport(false);
+});
+
+describe('sidebar conformance [wc]', () => {
+  it('default: the rail is expanded and the scrim is hidden', async () => {
+    await mount();
+    expect(panel().getAttribute('data-state')).toBe('expanded');
+    expect(overlay().hidden).toBe(true);
+  });
+
+  it('desktop: the trigger collapses the rail and projects the collapse mode', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(trigger());
+    expect(panel().getAttribute('data-state')).toBe('collapsed');
+    expect(panel().getAttribute('data-collapsible')).toBe('offcanvas');
+  });
+
+  it('desktop: the rail toggles the expand axis', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(rail());
+    expect(panel().getAttribute('data-state')).toBe('collapsed');
+  });
+
+  it('mobile: the trigger reveals the overlay and unhides the scrim', async () => {
+    const user = userEvent.setup();
+    setViewport(true);
+    await mount();
+    await user.click(trigger());
+    expect(panel().getAttribute('data-mobile')).toBe('open');
+    expect(overlay().hidden).toBe(false);
+    expect(panel().getAttribute('data-state')).toBe('expanded');
+  });
+
+  it('mobile: clicking the scrim dismisses the overlay', async () => {
+    const user = userEvent.setup();
+    setViewport(true);
+    await mount();
+    await user.click(trigger());
+    await user.click(overlay());
+    expect(panel().getAttribute('data-mobile')).toBe('closed');
+    expect(overlay().hidden).toBe(true);
+  });
+
+  it('mobile: Escape resolves the panel by CONTAINMENT even from a data-part descendant', async () => {
+    const user = userEvent.setup();
+    setViewport(true);
+    await mount();
+    await user.click(trigger());
+    expect(panel().getAttribute('data-mobile')).toBe('open');
+
+    // Focus the rail (its own data-part, inside the panel), then Escape.
+    rail().focus();
+    await user.keyboard('{Escape}');
+    expect(panel().getAttribute('data-mobile')).toBe('closed');
+    expect(document.activeElement).toBe(trigger());
+  });
+
+  it('Cmd/Ctrl+B toggles the desktop expand axis', async () => {
+    const user = userEvent.setup();
+    await mount();
+    expect(panel().getAttribute('data-state')).toBe('expanded');
+    await user.keyboard('{Control>}b{/Control}');
+    expect(panel().getAttribute('data-state')).toBe('collapsed');
+  });
+});

--- a/packages/ui/test/components/sidebar/sidebar.element.conformance.test.ts
+++ b/packages/ui/test/components/sidebar/sidebar.element.conformance.test.ts
@@ -1,14 +1,15 @@
 /**
  * WC performance of the sidebar score, driven end to end against light-DOM
  * markup. Same score as the React conformance test. The viewport signal is
- * mocked via matchMedia (the bind reads it live at gesture time, so no effect
- * timing is involved).
+ * mocked via matchMedia (the bind reads it live).
  *
- * The Escape test focuses the RAIL -- a focusable element that carries its own
- * data-part and sits INSIDE the panel -- then presses Escape. This is the exact
- * shape of the dialog-family defect #1921: `target.closest('[data-part]')` would
- * resolve to the rail and swallow the key; the bind resolves the part by
- * CONTAINMENT (`panel.contains(target)`), so Escape still dismisses.
+ * The mobile overlay is the panel enhanced IN PLACE by the bind into a modal
+ * (role=dialog + the sheet modal trio), composing the merged sheet's own
+ * behavior; a closed mobile overlay is `hidden` so its links leave the tab order
+ * and a11y tree (WCAG 2.2 AAA). The Escape test focuses the RAIL -- a focusable
+ * element that carries its own data-part inside the panel -- to prove the part is
+ * resolved by CONTAINMENT (`panel.contains`), not `closest('[data-part]')`, the
+ * dialog-family defect #1921.
  */
 import { cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -38,8 +39,7 @@ async function mount(): Promise<HTMLElement> {
   document.body.innerHTML = `
     <rafters-sidebar data-part="root" data-default-open="true" data-side="left" data-collapsible="offcanvas">
       <button type="button" data-part="trigger" id="sb-trigger" aria-controls="sb-panel" data-state="expanded">Toggle</button>
-      <button type="button" data-part="overlay" id="sb-overlay" aria-label="Close sidebar" data-state="closed" hidden></button>
-      <nav data-part="panel" id="sb-panel" data-state="expanded" data-mobile="closed">
+      <nav data-part="panel" id="sb-panel" data-state="expanded" data-mobile="closed" tabindex="-1">
         <button type="button" data-part="rail" id="sb-rail" tabindex="-1" aria-label="Toggle Sidebar" data-state="expanded"></button>
         <button type="button" data-sidebar="menu-button">Dashboard</button>
       </nav>
@@ -51,7 +51,6 @@ async function mount(): Promise<HTMLElement> {
 const trigger = () => document.body.querySelector<HTMLElement>('[data-part="trigger"]')!;
 const rail = () => document.body.querySelector<HTMLElement>('[data-part="rail"]')!;
 const panel = () => document.body.querySelector<HTMLElement>('[data-part="panel"]')!;
-const overlay = () => document.body.querySelector<HTMLElement>('[data-part="overlay"]')!;
 
 beforeEach(() => setViewport(false));
 afterEach(() => {
@@ -61,10 +60,11 @@ afterEach(() => {
 });
 
 describe('sidebar conformance [wc]', () => {
-  it('default: the rail is expanded and the scrim is hidden', async () => {
+  it('desktop default: the rail is expanded, present and navigable (never hidden)', async () => {
     await mount();
     expect(panel().getAttribute('data-state')).toBe('expanded');
-    expect(overlay().hidden).toBe(true);
+    expect(panel().hidden).toBe(false);
+    expect(panel().hasAttribute('role')).toBe(false);
   });
 
   it('desktop: the trigger collapses the rail and projects the collapse mode', async () => {
@@ -73,6 +73,7 @@ describe('sidebar conformance [wc]', () => {
     await user.click(trigger());
     expect(panel().getAttribute('data-state')).toBe('collapsed');
     expect(panel().getAttribute('data-collapsible')).toBe('offcanvas');
+    expect(panel().hidden).toBe(false);
   });
 
   it('desktop: the rail toggles the expand axis', async () => {
@@ -82,38 +83,40 @@ describe('sidebar conformance [wc]', () => {
     expect(panel().getAttribute('data-state')).toBe('collapsed');
   });
 
-  it('mobile: the trigger reveals the overlay and unhides the scrim', async () => {
-    const user = userEvent.setup();
+  it('mobile: a CLOSED overlay hides the panel -- its links leave the tab order and a11y tree', async () => {
     setViewport(true);
     await mount();
-    await user.click(trigger());
-    expect(panel().getAttribute('data-mobile')).toBe('open');
-    expect(overlay().hidden).toBe(false);
-    expect(panel().getAttribute('data-state')).toBe('expanded');
+    expect(panel().hidden).toBe(true);
+    expect(panel().hasAttribute('role')).toBe(false);
   });
 
-  it('mobile: clicking the scrim dismisses the overlay', async () => {
-    const user = userEvent.setup();
+  it('mobile: the trigger opens a modal dialog, traps focus, and locks scroll', async () => {
     setViewport(true);
+    const user = userEvent.setup();
     await mount();
     await user.click(trigger());
-    await user.click(overlay());
-    expect(panel().getAttribute('data-mobile')).toBe('closed');
-    expect(overlay().hidden).toBe(true);
+    expect(panel().hidden).toBe(false);
+    expect(panel().getAttribute('role')).toBe('dialog');
+    expect(panel().getAttribute('aria-modal')).toBe('true');
+    expect(panel().getAttribute('aria-label')).toBe('Sidebar');
+    expect(panel().contains(document.activeElement)).toBe(true);
+    expect(document.body.style.overflow).toBe('hidden');
   });
 
-  it('mobile: Escape resolves the panel by CONTAINMENT even from a data-part descendant', async () => {
-    const user = userEvent.setup();
+  it('mobile: Escape resolves the panel by CONTAINMENT from a data-part descendant, closes and restores focus', async () => {
     setViewport(true);
+    const user = userEvent.setup();
     await mount();
     await user.click(trigger());
-    expect(panel().getAttribute('data-mobile')).toBe('open');
+    expect(panel().getAttribute('role')).toBe('dialog');
 
     // Focus the rail (its own data-part, inside the panel), then Escape.
     rail().focus();
     await user.keyboard('{Escape}');
-    expect(panel().getAttribute('data-mobile')).toBe('closed');
+    expect(panel().hidden).toBe(true);
+    expect(panel().hasAttribute('role')).toBe(false);
     expect(document.activeElement).toBe(trigger());
+    expect(document.body.style.overflow).not.toBe('hidden');
   });
 
   it('Cmd/Ctrl+B toggles the desktop expand axis', async () => {


### PR DESCRIPTION
## Summary

Ports `sidebar` to the behavior layer as a compound: one bespoke two-axis score
(`sidebar.behavior.ts`) plus three thin performances (`sidebar.tsx`,
`sidebar.element.ts`, `sidebar.astro`) that all drive the shared `bindSidebar`.

The desktop expand/collapse rail and the mobile overlay are two independent axes
(`open`, `openMobile`) expressed as reducers over the single memory cell
`createBehavior` owns -- `createDisclosure`/`createSelectionGroup` do not compose,
so no second cell. Which axis a toggle gesture moves depends on the viewport, a
media-query signal the pure score cannot hold; that routing is the pure exported
`toggleIntent(state, config, isMobile)`, so no decorator carries the branch.

The mobile overlay COMPOSES the merged `sheet` (modal), matching shadcn's
architecture: React's `Sidebar` branches on `isMobile` to render
`<Sheet open={openMobile}>` + `<SheetContent aria-label="Sidebar">`, and the
WC/Astro binds compose `startSheetModalEffects` (sheet's own focus-trap +
scroll-lock + outside-dismiss trio) on the panel. This brings WCAG 2.2 AAA focus
management: focus trapped while open, and the overlay content UNREACHABLE while
closed (React unmounts `SheetContent`; the WC/Astro bind `hidden`s the panel), so
its links leave the tab order and a11y tree. Escape resolves the panel by
CONTAINMENT in the bind (`panel.contains(target)`), never `closest('[data-part]')`
-- the #1921 dialog-family defect. Cmd/Ctrl+B and write-only cookie persistence are
wired in all three performances. The desktop horizontal collapse motion is left
undeclared (no token exists yet, #1899/#1902); the mobile overlay's motion is the
merged sheet's own concern.

## Acceptance criteria mapping

### Component doc written

`docs/spec/components/sidebar.md` follows the dialog.md article shape -- composition,
config/state/actions, a parts+ARIA table, keyboard, an oracle-disposition table
matched row-by-row to this code, a Motion section, and WCAG obligations. The
shadcn-Sheet row reads `contract` (composed); the disposition table is
sidebar-specific, not copied from sheet.
Evidence: packages/ui/docs/spec/components/sidebar.md:92

### JSDoc intelligence tags present

The React performance carries the four required tags -- `@cognitive-load`,
`@attention-economics`, `@trust-building`, `@accessibility` -- at the top of the
`.tsx`, each written for sidebar's own affordances (persistent rail, modal mobile
overlay, Cmd/Ctrl+B), so the registry parser can extract them.
Evidence: packages/ui/src/components/sidebar/sidebar.tsx:7

### Behavior test (pure, no DOM)

`sidebar.behavior.test.ts` exercises the score with no DOM: parts declaration,
two-axis initial state, controlled shadowing, `toggleIntent` viewport routing,
per-axis `canDispatch` idempotence, action reducers, the aria projection (role/
aria-modal are asserted absent -- they are bind-managed), and the Escape keymap.
Evidence: packages/ui/test/components/sidebar/sidebar.behavior.test.ts:65

### Classes parity test

`sidebar.classes.test.ts` asserts the token-based view: depth tokens on the panel,
the per-side/per-mode desktop collapse hooks, the variant maps, the `mobilePanel`
surface (which must not re-declare Sheet's positioning), and the no-raw-duration
invariant (desktop collapse timing stays undeclared).
Evidence: packages/ui/test/components/sidebar/sidebar.classes.test.ts:79

### Conformance test via the shared harness (aria + keymap against rendered DOM)

Three conformance suites drive the one score through the shared harness against
rendered DOM. Desktop asserts `assertContractFulfillment`/`assertAxeClean`; mobile
asserts the composed modal per framework -- role=dialog, focus trap, scroll lock,
Escape-by-containment (focusing the data-part rail), and the CLOSED-overlay
regression (links absent from the DOM / tab order).
Evidence: packages/ui/test/components/sidebar/sidebar.element.conformance.test.ts:88

### shadcn drop-in parity where the component exists in shadcn

The React `.tsx` exports the full shadcn compound surface -- Provider, Sidebar,
Trigger, Rail, Inset, Header, Footer, Content, Group(+Label/Action/Content),
Menu(+Item/Button/Action/Badge/Skeleton/Sub/SubItem/SubButton), Separator -- with
namespaced `Sidebar.X` aliases, and the mobile overlay composes the merged Sheet
exactly as shadcn's SidebarProvider does, so consumer markup drops in unchanged.
Evidence: packages/ui/src/components/sidebar/sidebar.tsx:540

### `pnpm --filter @rafters/ui test:unit` green, `pnpm preflight` green

Both configs pass: `vitest run` and the Astro config both exit 0, with the sidebar
behavior/classes/React/WC/Astro suites green; `pnpm preflight` (lint, format,
typecheck, build across the workspace) exits 0. Lefthook passed on commit.
Evidence: packages/ui/test/components/sidebar/sidebar.conformance.test.tsx:120

## Not done

- **No desktop collapse animation.** The horizontal expand/collapse is
  state-correct but unanimated until a horizontal-slide / width motion token lands
  (#1899/#1902). The accordion grid-rows/`inert` pattern does not apply -- sidebar
  collapse is axis-x (horizontal), and a visible icon rail must not be `inert`. The
  mobile overlay's enter/exit is animated by the merged sheet.
- Shared files (matrix, CHANGELOG, package.json exports) intentionally untouched,
  per the issue -- a port PR touches only its own component folder and tests.


Closes #1793
