### PR TITLE
feat(ui): port carousel to the behavior layer

### DIFF
--- a/packages/ui/docs/spec/components/carousel.md
+++ b/packages/ui/docs/spec/components/carousel.md
@@ -1,0 +1,139 @@
+# Component Spec — Carousel
+
+Status: DRAFT. Compound archetype (imitates navigation-menu). Behavior-layer
+port of `src/old/ui/carousel.tsx`.
+
+Files (`src/components/carousel/`):
+
+```
+carousel.classes.ts   carousel.behavior.ts   carousel.tsx
+carousel.element.ts   carousel.astro
+```
+
+Tests mirror into `test/components/carousel/`: behavior (pure), classes, and
+conformance across React + WC + Astro via the shared harness.
+
+## Composition
+
+```
+carousel (slice)   state {index}, one action setIndex, region/slide/control aria,
+                   axis-arrow keymap
+keyboard-handler   createKeyboardHandler for the axis arrows, composed once by
+                   composeCarouselInteractions (shared by bindCarousel + React effect)
+```
+
+The single state axis is `index`. `canScrollPrev`/`canScrollNext`,
+`prevIndex`/`nextIndex`, and `clampIndex` are pure derivations against the slide
+`count` and the `loop` flag -- not stored state. A reducer receives no config
+(Spec 05), and prev/next/goto all need the count and loop flag to wrap or clamp,
+so that math lives in the exported helpers and the ONE `setIndex` reducer stores
+an already-resolved index -- the shape slider uses for `setThumb`.
+
+The slide count is the DOM, not a cell: `bindCarousel` counts rendered
+`[data-part="item"]` elements; the React `CarouselContent` counts its children
+and reports the count up. This replaces the oracle's ref registry
+(`itemIdsRef` + an `itemsVersion` bump cell).
+
+Controlled/uncontrolled per boundary 4: `config.value` is the consumer's
+controlled index, `state.index` is intrinsic, and every projection reads
+`activeIndex(state, config)`. The React `request` compares the effective index
+before against the intrinsic index after, so `onIndexChange` reports the target
+even when a controlled prop pins the effective view.
+
+## Config, state, actions
+
+```ts
+interface CarouselConfig {
+  orientation?: 'horizontal' | 'vertical'; // default horizontal
+  loop?: boolean;                          // wrap past the ends
+  count?: number;                          // total slides (the clamp bound)
+  label?: string;                          // region accessible name, default "Carousel"
+  value?: number;                          // controlled index
+  defaultValue?: number;                   // uncontrolled seed
+}
+interface CarouselState { index: number }  // intrinsic only
+type CarouselActions = { setIndex: number } // payload = an already-clamped index
+```
+
+`prev`/`next`/`goto` are not separate actions: each is `setIndex` fed the result
+of `prevIndex`/`nextIndex`/`clampIndex`, so the intrinsic index can never leave
+`[0, count-1]` and a controlled consumer's callback stays honest.
+
+## Parts and ARIA
+
+| Part | Presence | ARIA |
+| --- | --- | --- |
+| root | always | `role="region"`, `aria-roledescription="carousel"`, `aria-label`, `data-orientation` |
+| content | always | `data-orientation` (viewport; clips the track) |
+| track | always | none (structural; carries the inline translate offset) |
+| item | always (`many`) | `role="group"`, `aria-roledescription="slide"`, `aria-label="N of M"`, `data-state="active|inactive"` |
+| previous | always | `aria-label="Previous slide"`, `data-disabled` (only at the start), native `disabled` |
+| next | always | `aria-label="Next slide"`, `data-disabled` (only at the end), native `disabled` |
+| indicators | optional | `role="group"`, `aria-label="Choose slide to display"` |
+| indicator | optional (`many`) | `aria-label="Go to slide N"`, `aria-current="true"` (active only), `data-state` |
+
+The `item` and `indicator` per-instance projections come from
+`carouselInstanceAria(part, value, state, config)` (Spec 01
+`BehaviorSpec.instanceAria`), keyed by the slide index carried in each
+element's `data-value`; the harness's generic `assertInstanceAriaFulfillment`
+drives them.
+
+## Keyboard and motion
+
+- `keymap`: on the root, the axis arrows claim `setIndex` -- Left/Right when
+  horizontal, Up/Down when vertical. Only the axis's two keys are registered
+  with `keyboard-handler` (via `composeCarouselInteractions`), so
+  `preventDefault` never swallows the cross-axis scroll. The composed handler
+  resolves the target index with `indexForKey` and dispatches; the region itself
+  is NOT focusable, so arrows act while a carousel control (or slide content)
+  holds focus.
+- Motion (`slide-advance`, slide, axis x): **undeclared**. None of the thirteen
+  semantic `motion-*` tokens expresses a horizontal slide, and raw numeric
+  durations are prohibited (Spec 05). The track's translate offset
+  (`trackStyle`) is applied as pure layout data with NO transition, so the
+  active slide snaps into place; the animated transition lands when the slide
+  token ships (motion layer rebuild, #1899). This is why the oracle's
+  `transition-transform duration-300 ease-in-out` is not ported.
+
+## Oracle dispositions (src/old/ui/carousel.tsx, boundary 9)
+
+| Oracle feature | Disposition |
+| --- | --- |
+| orientation (horizontal/vertical), axis-mapped arrow keys | contract |
+| loop (wrap prev/next) | contract |
+| currentIndex + canScrollPrevious/canScrollNext | contract (index state; canScrollPrev/Next pure helpers) |
+| scrollPrevious / scrollNext / scrollTo | contract (prevIndex/nextIndex + setIndex; `goto` is setIndex(clampIndex)) |
+| Prev/Next: native `disabled`, aria-label, chevron default | contract; added `data-disabled` projection so CSS can style the bound without reading the DOM |
+| item role=group + aria-roledescription="slide" | contract; added `aria-label="N of M"` (WAI-ARIA APG slide labelling) |
+| useCarousel hook | contract (shadcn parity: activeIndex, count, canScrollPrev/Next, scrollPrev/scrollNext/scrollTo) |
+| item ref registry (registerItem/unregisterItem + itemsVersion bump cell) | re-expressed: the DOM is the registry (bind counts items; React counts children). No second cell -- a cell-owning registry does not compose (Spec 05) |
+| root `tabIndex={0}` on the region | dropped: a non-interactive focusable region is avoided; arrows act through the focusable controls instead |
+| autoPlay + autoPlayInterval | dropped: a timer whose interval is a raw numeric duration the motion layer forbids, and transient non-navigation behavior outside the index axis |
+| isPaused + hover/focus pause (mouseenter/leave/focus/blur) | dropped: only meaningful as autoplay's pause, and autoplay is dropped |
+| `transition-transform duration-300 ease-in-out` on the track | dropped: the slide-advance motion has no semantic token yet; ported as an undeclared, transition-free offset (see Motion) |
+| Indicators as `role="tablist"` / indicator `role="tab"` + `aria-selected` | defect-do-not-port: tablist/tab without tabpanel wiring is an ARIA misuse; re-expressed as a `role="group"` of slide-picker buttons with `aria-current` on the active dot |
+| JSDoc claim "ARIA live region for announcements" | defect-do-not-port: the oracle code never rendered a live region; the port does not claim one. Slides stay in the accessibility tree (not `aria-hidden`), faithful to the oracle's actual DOM |
+| touch/swipe gestures | dropped: the oracle JSDoc lists swipe but the code ships no touch handlers, and no primitive expresses carousel swipe without wrong ARIA -- `drag-drop` stamps `aria-grabbed`+`role=button`, `interactive` stamps `role=slider` on the surface |
+
+## Deltas from the oracle
+
+1. The region is not focusable (`tabIndex` removed); arrow navigation rides the
+   focusable prev/next controls and any focusable slide content, avoiding a
+   non-interactive tabindex.
+2. Slides are labelled `N of M` and offscreen slides are left in the
+   accessibility tree (the oracle's actual DOM behavior), not hidden.
+3. The slide offset is a data-driven inline transform with no transition until
+   the slide-advance motion token exists.
+
+## WCAG 2.1 AA obligations
+
+- 1.3.1 / 4.1.2: `role="region"` + `aria-roledescription="carousel"`, each slide
+  a labelled `role="group"`, and the prev/next/indicator names are asserted
+  against real DOM by the harness across all three performances.
+- 2.1.1 Keyboard: axis arrows advance the carousel while a control holds focus;
+  every control is a native `<button>`.
+- 2.4.7 Focus Visible: token focus ring on the controls
+  (`focus-visible:ring-ring`).
+- 4.1.2 Name, Role, Value: the current slide carries `data-state="active"` and
+  the current indicator `aria-current="true"`; disabled controls expose both
+  native `disabled` and `data-disabled` at the bounds.

--- a/packages/ui/src/components/carousel/carousel.astro
+++ b/packages/ui/src/components/carousel/carousel.astro
@@ -1,0 +1,124 @@
+---
+/**
+ * Astro performance (controller) for carousel.
+ *
+ * Server-renders the full LIGHT-DOM markup with the score's initial projection
+ * already applied, so the slides, controls, and current position are correct
+ * before any JS. The <script> then hands each instance to bindCarousel -- the
+ * SAME DOM-native controller the Web Component uses. The projection is computed
+ * here from the same carouselBehavior.aria / carouselInstanceAria the React and
+ * WC performances read -- one score, three performances, zero drift.
+ */
+import {
+  canScrollNext,
+  canScrollPrev,
+  carouselBehavior,
+  carouselInstanceAria,
+  trackStyle,
+  type CarouselConfig,
+  type CarouselPart,
+} from './carousel.behavior';
+import { carouselClasses } from './carousel.classes';
+import type { PartIds } from '../../lib/contract';
+
+interface Props {
+  id: string;
+  /** Slide bodies (HTML strings), rendered in order. */
+  slides: string[];
+  orientation?: 'horizontal' | 'vertical';
+  loop?: boolean;
+  label?: string;
+  /** Render the slide-picker indicator row. */
+  indicators?: boolean;
+}
+
+const { id, slides, orientation = 'horizontal', loop = false, label, indicators = false } =
+  Astro.props;
+
+const config: CarouselConfig = { orientation, loop, count: slides.length, label };
+const state = carouselBehavior.initialState(config);
+const classes = carouselClasses(config);
+
+const ids = {} as PartIds<CarouselPart>;
+for (const part of Object.keys(carouselBehavior.parts) as CarouselPart[]) {
+  ids[part] = `${id}-${part}`;
+}
+const aria = carouselBehavior.aria(state, config, ids);
+const trackTransform = `transform: ${trackStyle(state, config).transform}`;
+---
+
+<div
+  data-part="root"
+  data-carousel
+  id={ids.root}
+  role="region"
+  data-orientation={orientation}
+  data-loop={String(loop)}
+  class={classes.root}
+  {...aria.root}
+>
+  <button
+    type="button"
+    data-part="previous"
+    class={classes.previous}
+    disabled={!canScrollPrev(state, config)}
+    {...aria.previous}
+  >
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m15 18-6-6 6-6"></path></svg>
+  </button>
+
+  <div data-part="content" class={classes.content} {...aria.content}>
+    <div data-part="track" class={classes.track} style={trackTransform}>
+      {
+        slides.map((slide, index) => (
+          <div
+            role="group"
+            data-part="item"
+            data-value={index}
+            class={classes.item}
+            set:html={slide}
+            {...carouselInstanceAria('item', String(index), state, config)}
+          />
+        ))
+      }
+    </div>
+  </div>
+
+  <button
+    type="button"
+    data-part="next"
+    class={classes.next}
+    disabled={!canScrollNext(state, config)}
+    {...aria.next}
+  >
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m9 18 6-6-6-6"></path></svg>
+  </button>
+
+  {
+    indicators && (
+      <div data-part="indicators" role="group" class={classes.indicators} {...aria.indicators}>
+        {slides.map((_, index) => (
+          <button
+            type="button"
+            data-part="indicator"
+            data-value={index}
+            class={classes.indicator}
+            {...carouselInstanceAria('indicator', String(index), state, config)}
+          />
+        ))}
+      </div>
+    )
+  }
+</div>
+
+<script>
+  import { bindCarousel } from './carousel.behavior';
+
+  // The <script> is bundled and runs once per page; bind every instance's
+  // server-rendered markup. Same controller as the Web Component.
+  for (const root of document.querySelectorAll<HTMLElement>('div[data-part="root"][data-carousel]')) {
+    if (root.dataset['bound'] === 'true') continue;
+    root.dataset['bound'] = 'true';
+    bindCarousel(root);
+  }
+</script>

--- a/packages/ui/src/components/carousel/carousel.behavior.ts
+++ b/packages/ui/src/components/carousel/carousel.behavior.ts
@@ -1,0 +1,395 @@
+import { compose, type Slice } from '../../lib/compose';
+import {
+  createBehavior,
+  type AriaAttrs,
+  type BehaviorSpec,
+  type PartIds,
+} from '../../lib/contract';
+import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { createKeyboardHandler } from '../../primitives/keyboard-handler';
+
+/**
+ * Carousel: a sequence of slides advanced one at a time. The single state axis
+ * is the current slide `index`; `canScrollPrev`/`canScrollNext` are pure
+ * derivations of that index against the slide count and the loop flag, not
+ * stored state. Replaces the ref-registry controller in old/ui/carousel.tsx.
+ *
+ * Composition (Spec 05, "compose the primitive, never reimplement it"):
+ * - arrow-key navigation rides `keyboard-handler` (`createKeyboardHandler`),
+ *   composed once by `composeCarouselInteractions`, which BOTH the DOM-native
+ *   `bindCarousel` and the React controller call. The `keymap` projection is the
+ *   pure claim record (Spec 01); the composed handler computes the target index
+ *   via `indexForKey`, mirroring slider's `stepForKey`.
+ *
+ * A reducer receives no config (Spec 05), and prev/next/goto all need the count
+ * and loop flag to clamp or wrap. So the wrap/clamp math lives in the exported
+ * pure helpers (`prevIndex`/`nextIndex`/`clampIndex`) and the ONE `setIndex`
+ * reducer just stores an already-resolved index -- the exact shape slider uses
+ * for `setThumb`.
+ *
+ * Not ported (see carousel.md dispositions): auto-play (a timer whose interval
+ * is a raw numeric duration the motion-token layer forbids -- #1899) and touch
+ * swipe (the oracle never shipped it, and `drag-drop`/`interactive` both stamp
+ * ARIA that is wrong for a slide surface: `aria-grabbed`+`role=button` /
+ * `role=slider`). The animated slide transition itself is undeclared: no
+ * `motion-*` semantic token expresses a horizontal slide yet, so the track's
+ * position updates without a transition rather than with a hardcoded duration.
+ */
+export type CarouselOrientation = 'horizontal' | 'vertical';
+
+export interface CarouselConfig {
+  orientation?: CarouselOrientation | undefined;
+  /** Wrap from the last slide back to the first (and vice versa). */
+  loop?: boolean | undefined;
+  /** Total slide count -- the bound the index clamps against. */
+  count?: number | undefined;
+  /** Accessible name of the carousel region. */
+  label?: string | undefined;
+  /** Controlled index: shadows the intrinsic state when present. */
+  value?: number | undefined;
+  /** Uncontrolled seed for the intrinsic index. */
+  defaultValue?: number | undefined;
+}
+
+export interface CarouselState {
+  index: number;
+}
+
+export type CarouselActions = {
+  /** Move to an already-clamped/wrapped index (the pure helpers own the math). */
+  setIndex: number;
+};
+
+export type CarouselPart =
+  | 'root'
+  | 'content'
+  | 'track'
+  | 'item'
+  | 'previous'
+  | 'next'
+  | 'indicators'
+  | 'indicator';
+
+export function orientationOf(config: CarouselConfig): CarouselOrientation {
+  return config.orientation ?? 'horizontal';
+}
+
+export function countOf(config: CarouselConfig): number {
+  return Math.max(0, config.count ?? 0);
+}
+
+function labelOf(config: CarouselConfig): string {
+  return config.label ?? 'Carousel';
+}
+
+/** Clamp a raw index into [0, count - 1] (or 0 when there are no slides). */
+export function clampIndex(index: number, config: CarouselConfig): number {
+  const count = countOf(config);
+  if (count <= 0) return 0;
+  return Math.min(Math.max(index, 0), count - 1);
+}
+
+/** The effective index: a controlled `config.value` shadows intrinsic state. */
+export function activeIndex(state: CarouselState, config: CarouselConfig): number {
+  return clampIndex(config.value ?? state.index, config);
+}
+
+/** The index a "previous" step lands on: wraps under loop, else clamps at 0. */
+export function prevIndex(state: CarouselState, config: CarouselConfig): number {
+  const count = countOf(config);
+  if (count <= 0) return 0;
+  const current = activeIndex(state, config);
+  if (current > 0) return current - 1;
+  return config.loop ? count - 1 : 0;
+}
+
+/** The index a "next" step lands on: wraps under loop, else clamps at count-1. */
+export function nextIndex(state: CarouselState, config: CarouselConfig): number {
+  const count = countOf(config);
+  if (count <= 0) return 0;
+  const current = activeIndex(state, config);
+  if (current < count - 1) return current + 1;
+  return config.loop ? 0 : count - 1;
+}
+
+/** Whether a previous step would move: a slide exists and we are not pinned. */
+export function canScrollPrev(state: CarouselState, config: CarouselConfig): boolean {
+  return countOf(config) > 0 && (Boolean(config.loop) || activeIndex(state, config) > 0);
+}
+
+/** Whether a next step would move: a slide exists and we are not pinned. */
+export function canScrollNext(state: CarouselState, config: CarouselConfig): boolean {
+  return (
+    countOf(config) > 0 &&
+    (Boolean(config.loop) || activeIndex(state, config) < countOf(config) - 1)
+  );
+}
+
+/**
+ * The target index for a navigation key, or null when the key does not steer
+ * the carousel. Horizontal maps Left/Right to prev/next; vertical maps Up/Down.
+ * The bind and React effect feed this the current state and dispatch the result,
+ * mirroring slider's `stepForKey`.
+ */
+export function indexForKey(
+  key: string,
+  state: CarouselState,
+  config: CarouselConfig,
+): number | null {
+  const vertical = orientationOf(config) === 'vertical';
+  const prevKey = vertical ? 'ArrowUp' : 'ArrowLeft';
+  const nextKey = vertical ? 'ArrowDown' : 'ArrowRight';
+  if (key === prevKey) return prevIndex(state, config);
+  if (key === nextKey) return nextIndex(state, config);
+  return null;
+}
+
+/**
+ * The track's translate offset for the active index. Pure layout data -- NOT a
+ * motion declaration: the three decorators apply it as an inline style and the
+ * bind writes it in render(), exactly as slider paints its thumb geometry. The
+ * transition that would animate this offset is deliberately absent (no semantic
+ * slide token exists yet -- see the file header and carousel.md).
+ */
+export function trackStyle(state: CarouselState, config: CarouselConfig): { transform: string } {
+  const offset = activeIndex(state, config) * 100;
+  return {
+    transform:
+      orientationOf(config) === 'vertical' ? `translateY(-${offset}%)` : `translateX(-${offset}%)`,
+  };
+}
+
+const carousel: Slice<CarouselConfig, CarouselState, CarouselActions, CarouselPart> = {
+  name: 'carousel',
+  parts: {
+    root: { role: 'region' },
+    // The viewport clips the track; the track lays the slides in a row/column
+    // and translates. Both are structural, carrying no role.
+    content: {},
+    track: {},
+    item: { role: 'group', many: true },
+    previous: {},
+    next: {},
+    // The slide picker (goto UI) -- a group of buttons, one per slide.
+    indicators: { role: 'group', optional: true },
+    indicator: { many: true, optional: true },
+  },
+  initialState: (config) => ({
+    index: clampIndex(config.value ?? config.defaultValue ?? 0, config),
+  }),
+  actions: {
+    // The index arrives already clamped/wrapped from the pure helpers (a reducer
+    // gets no config, so it cannot bound the value itself).
+    setIndex: (state, index) => ({ ...state, index }),
+  },
+  canDispatch: () => true,
+  aria: (state, config) => ({
+    root: {
+      'aria-roledescription': 'carousel',
+      'aria-label': labelOf(config),
+      'data-orientation': orientationOf(config),
+    },
+    content: { 'data-orientation': orientationOf(config) },
+    previous: {
+      'aria-label': 'Previous slide',
+      'data-disabled': canScrollPrev(state, config) ? undefined : 'true',
+    },
+    next: {
+      'aria-label': 'Next slide',
+      'data-disabled': canScrollNext(state, config) ? undefined : 'true',
+    },
+    indicators: { 'aria-label': 'Choose slide to display' },
+  }),
+  // The pure claim record (Spec 01): these keys move the carousel. The composed
+  // keyboard-handler resolves the target index via indexForKey.
+  keymap: (event, _state, part, config) => {
+    if (part !== 'root') return null;
+    const vertical = orientationOf(config) === 'vertical';
+    const keys = vertical ? ['ArrowUp', 'ArrowDown'] : ['ArrowLeft', 'ArrowRight'];
+    return keys.includes(event.key) ? 'setIndex' : null;
+  },
+};
+
+/**
+ * Per-instance ARIA for the `many` parts (Spec 01: BehaviorSpec.instanceAria).
+ * `aria()` projects one AriaAttrs per part NAME; slides and indicators occur
+ * once per index, so their projection takes the instance value (the index as a
+ * string). The generic harness reads `carouselBehavior.instanceAria` and drives
+ * every rendered instance; the decorators call the concrete function directly.
+ */
+export function carouselInstanceAria(
+  part: CarouselPart,
+  value: string,
+  state: CarouselState,
+  config: CarouselConfig,
+): AriaAttrs {
+  const index = Number(value);
+  const current = activeIndex(state, config) === index;
+  if (part === 'item') {
+    return {
+      'aria-roledescription': 'slide',
+      'aria-label': `${index + 1} of ${countOf(config)}`,
+      'data-state': current ? 'active' : 'inactive',
+    };
+  }
+  if (part === 'indicator') {
+    return {
+      'aria-label': `Go to slide ${index + 1}`,
+      'aria-current': current ? 'true' : undefined,
+      'data-state': current ? 'active' : 'inactive',
+    };
+  }
+  return {};
+}
+
+export const carouselBehavior: BehaviorSpec<
+  CarouselConfig,
+  CarouselState,
+  CarouselActions,
+  CarouselPart
+> = {
+  ...compose('carousel', carousel),
+  instanceAria: (part, value, state, config) => carouselInstanceAria(part, value, state, config),
+};
+
+/** The root and the dispatch the arrow-key handler composes against. */
+export interface CarouselInteractionOptions {
+  /** The keyboard host -- the region root; a focused control's keydown bubbles up. */
+  root: HTMLElement;
+  getState: () => CarouselState;
+  getConfig: () => CarouselConfig;
+  /** Commit a move to an already-resolved index. */
+  request: (index: number) => void;
+}
+
+/**
+ * Compose the impure keyboard surface directly from `keyboard-handler`. Shared
+ * verbatim by `bindCarousel` (WC + Astro) and the React controller's effect --
+ * one composition, three performances, so the navigation rules cannot drift.
+ * Only the orientation's two arrow keys are registered, so preventDefault never
+ * swallows the cross-axis scroll.
+ */
+export function composeCarouselInteractions(options: CarouselInteractionOptions): () => void {
+  const { root, getState, getConfig, request } = options;
+  const vertical = orientationOf(getConfig()) === 'vertical';
+  const keys = vertical
+    ? (['ArrowUp', 'ArrowDown'] as const)
+    : (['ArrowLeft', 'ArrowRight'] as const);
+  return createKeyboardHandler(root, {
+    key: [...keys],
+    preventDefault: true,
+    handler: (event) => {
+      const config = getConfig();
+      const state = getState();
+      const target = indexForKey(event.key, state, config);
+      if (target === null) return;
+      if (target === activeIndex(state, config)) return;
+      request(target);
+    },
+  });
+}
+
+/**
+ * The DOM-native binding of the carousel score -- the client the Web Component
+ * and the Astro <script> both import. React (retained-mode) reads the
+ * projections declaratively instead, but composes the SAME
+ * `composeCarouselInteractions`. Uncontrolled: WC/Astro carry no reactive prop,
+ * so `config.value` is undefined and the effective index is the intrinsic state,
+ * seeded from `data-active-index`.
+ */
+export function bindCarousel(root: HTMLElement): () => void {
+  const items = root.querySelectorAll<HTMLElement>('[data-part="item"]');
+  const config: CarouselConfig = {
+    orientation: root.getAttribute('data-orientation') === 'vertical' ? 'vertical' : 'horizontal',
+    loop: root.getAttribute('data-loop') === 'true',
+    count: items.length,
+    label: root.getAttribute('aria-label') ?? undefined,
+    defaultValue: Number.parseInt(root.getAttribute('data-active-index') ?? '', 10) || 0,
+  };
+
+  const getPart = (part: string): HTMLElement | null =>
+    part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
+
+  const { memory, dispatch } = createBehavior(carouselBehavior, config);
+
+  const ids = {} as PartIds<CarouselPart>;
+  for (const part of Object.keys(carouselBehavior.parts) as CarouselPart[]) {
+    ids[part] = getPart(part)?.id ?? '';
+  }
+
+  const applyProjection = (el: HTMLElement, attrs: AriaAttrs) => {
+    for (const [name, value] of Object.entries(attrs)) {
+      updateAriaAttribute(el, name as never, value as never, { validate: false });
+    }
+  };
+
+  const manyParts = (Object.keys(carouselBehavior.parts) as CarouselPart[]).filter(
+    (part) => carouselBehavior.parts[part].many,
+  );
+
+  const projectInstances = (state: CarouselState) => {
+    for (const part of manyParts) {
+      for (const el of root.querySelectorAll<HTMLElement>(`[data-part="${part}"]`)) {
+        const value = el.dataset['value'];
+        if (value === undefined) continue;
+        applyProjection(el, carouselInstanceAria(part, value, state, config));
+      }
+    }
+  };
+
+  const render = () => {
+    const state = memory.get();
+    const projection = carouselBehavior.aria(state, config, ids);
+    for (const part of Object.keys(projection) as CarouselPart[]) {
+      const attrs = projection[part];
+      const el = getPart(part);
+      if (el && attrs) applyProjection(el, attrs);
+    }
+
+    const track = getPart('track');
+    if (track) track.style.transform = trackStyle(state, config).transform;
+
+    const previous = getPart('previous') as HTMLButtonElement | null;
+    if (previous) previous.disabled = !canScrollPrev(state, config);
+    const next = getPart('next') as HTMLButtonElement | null;
+    if (next) next.disabled = !canScrollNext(state, config);
+
+    projectInstances(state);
+  };
+  const unsubscribe = memory.subscribe(render); // fires immediately: first paint
+
+  const request = (index: number): void => {
+    dispatch('setIndex', config, clampIndex(index, config));
+  };
+
+  const onClick = (event: Event) => {
+    const target = event.target as HTMLElement;
+    if (target.closest('[data-part="previous"]')) {
+      request(prevIndex(memory.get(), config));
+      return;
+    }
+    if (target.closest('[data-part="next"]')) {
+      request(nextIndex(memory.get(), config));
+      return;
+    }
+    const indicator = target.closest<HTMLElement>('[data-part="indicator"]');
+    if (indicator && root.contains(indicator)) {
+      const value = indicator.dataset['value'];
+      if (value !== undefined) request(Number(value));
+    }
+  };
+  root.addEventListener('click', onClick);
+
+  const stopInteractions = composeCarouselInteractions({
+    root,
+    getState: () => memory.get(),
+    getConfig: () => config,
+    request,
+  });
+
+  return () => {
+    unsubscribe();
+    stopInteractions();
+    root.removeEventListener('click', onClick);
+  };
+}

--- a/packages/ui/src/components/carousel/carousel.classes.ts
+++ b/packages/ui/src/components/carousel/carousel.classes.ts
@@ -1,0 +1,59 @@
+import type { CarouselConfig } from './carousel.behavior';
+
+export interface CarouselClassSet {
+  root: string;
+  content: string;
+  track: string;
+  item: string;
+  previous: string;
+  next: string;
+  indicators: string;
+  indicator: string;
+}
+
+const rootClasses = 'relative';
+
+const contentClasses = 'overflow-hidden';
+
+// The track lays the slides along the orientation axis and translates to the
+// active slide. No transition class: the slide-advance motion has no semantic
+// motion-* token yet (see carousel.behavior.ts and carousel.md), so the offset
+// applies without a hardcoded duration.
+const trackHorizontal = 'flex flex-row';
+const trackVertical = 'flex flex-col';
+
+const itemClasses = 'min-w-0 shrink-0 grow-0 basis-full';
+
+// The prev/next controls share the round chrome; orientation only moves them.
+const controlBase =
+  'absolute inline-flex h-8 w-8 items-center justify-center rounded-full border ' +
+  'bg-background text-foreground shadow-sm transition-colors ' +
+  'hover:bg-accent hover:text-accent-foreground ' +
+  'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ' +
+  'disabled:pointer-events-none disabled:opacity-50';
+
+const previousHorizontal = 'left-2 top-1/2 -translate-y-1/2';
+const previousVertical = 'left-1/2 top-2 -translate-x-1/2 rotate-90';
+const nextHorizontal = 'right-2 top-1/2 -translate-y-1/2';
+const nextVertical = 'bottom-2 left-1/2 -translate-x-1/2 rotate-90';
+
+const indicatorsClasses = 'flex justify-center gap-2 py-2';
+
+const indicatorClasses =
+  'h-2 w-2 rounded-full bg-muted-foreground/30 transition-colors ' +
+  'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ' +
+  'data-[state=active]:bg-primary';
+
+export function carouselClasses(config: CarouselConfig): CarouselClassSet {
+  const vertical = config.orientation === 'vertical';
+  return {
+    root: rootClasses,
+    content: contentClasses,
+    track: vertical ? trackVertical : trackHorizontal,
+    item: itemClasses,
+    previous: `${controlBase} ${vertical ? previousVertical : previousHorizontal}`,
+    next: `${controlBase} ${vertical ? nextVertical : nextHorizontal}`,
+    indicators: indicatorsClasses,
+    indicator: indicatorClasses,
+  };
+}

--- a/packages/ui/src/components/carousel/carousel.element.ts
+++ b/packages/ui/src/components/carousel/carousel.element.ts
@@ -1,0 +1,32 @@
+/**
+ * WC performance for carousel: the thinnest wrapper. All behavior -- including
+ * the DOM binding -- lives in carousel.behavior.ts, shared with the Astro
+ * performance. This file only adapts that binding to the custom-element
+ * lifecycle.
+ */
+import { bindCarousel } from './carousel.behavior';
+
+export class RaftersCarousel extends HTMLElement {
+  private teardown: (() => void) | null = null;
+
+  connectedCallback(): void {
+    if (!this.hasAttribute('role')) this.setAttribute('role', 'region');
+    // The custom element IS the root part -- mark it so the DOM-native binding
+    // and the conformance harness resolve it without a wrapper element.
+    if (!this.hasAttribute('data-part')) this.setAttribute('data-part', 'root');
+    // connectedCallback can fire before the light-DOM children are parsed
+    // (upgrade order), so bind on the next microtask when the parts exist.
+    queueMicrotask(() => {
+      if (this.isConnected && !this.teardown) this.teardown = bindCarousel(this);
+    });
+  }
+
+  disconnectedCallback(): void {
+    this.teardown?.();
+    this.teardown = null;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-carousel')) {
+  customElements.define('rafters-carousel', RaftersCarousel);
+}

--- a/packages/ui/src/components/carousel/carousel.tsx
+++ b/packages/ui/src/components/carousel/carousel.tsx
@@ -1,0 +1,375 @@
+import * as React from 'react';
+import { createBehavior, type AriaAttrs, type PartIds, type PayloadArgs } from '../../lib/contract';
+import { useMemory } from '../../hooks/use-memory';
+import classy from '../../primitives/classy';
+import {
+  activeIndex,
+  canScrollNext,
+  canScrollPrev,
+  carouselBehavior,
+  carouselInstanceAria,
+  clampIndex,
+  composeCarouselInteractions,
+  nextIndex,
+  prevIndex,
+  trackStyle,
+  type CarouselActions,
+  type CarouselConfig,
+  type CarouselPart,
+  type CarouselState,
+} from './carousel.behavior';
+import { carouselClasses, type CarouselClassSet } from './carousel.classes';
+
+/**
+ * Carousel -- a slide sequence advanced one at a time by prev/next controls,
+ * arrow keys, or the indicator picker (goto).
+ *
+ * @cognitive-load
+ * - intrinsic: 3/10 -- a slideshow is a universally learned pattern.
+ * - extraneous: 2/10 -- two arrows and a row of dots, nothing to decode.
+ * - germane: 2/10 -- position ("N of M") is announced, not inferred.
+ * - working-memory: 2/10 -- one slide holds attention at a time.
+ * - overall: 3/10 -- familiar, low-friction navigation.
+ * @attention-economics Medium draw: content is the focus; the chrome recedes
+ * until a control is hovered or focused. No auto-advance steals attention.
+ * @trust-building Disabled arrows at the ends and a highlighted current dot make
+ * the sequence's bounds and position honest and predictable.
+ * @accessibility role=region + aria-roledescription="carousel"; each slide is a
+ * labelled group ("N of M"); prev/next carry names and disable at the bounds;
+ * arrow keys steer along the orientation axis; the current dot is aria-current.
+ */
+interface CarouselContextValue {
+  state: CarouselState;
+  config: CarouselConfig;
+  count: number;
+  setCount: (count: number) => void;
+  classes: CarouselClassSet;
+  aria: Partial<Record<string, AriaAttrs>>;
+  request: <K extends keyof CarouselActions>(
+    action: K,
+    ...payload: PayloadArgs<CarouselActions[K]>
+  ) => void;
+}
+
+const CarouselContext = React.createContext<CarouselContextValue | null>(null);
+
+function useCarouselContext(component: string): CarouselContextValue {
+  const context = React.useContext(CarouselContext);
+  if (!context) {
+    throw new Error(`${component} must be used within <Carousel>`);
+  }
+  return context;
+}
+
+const CarouselItemIndexContext = React.createContext<number>(0);
+
+export interface CarouselProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'defaultValue'> {
+  orientation?: 'horizontal' | 'vertical';
+  loop?: boolean;
+  /** Controlled active slide index. */
+  value?: number;
+  /** Uncontrolled seed for the active slide index. */
+  defaultValue?: number;
+  onIndexChange?: (index: number) => void;
+  /** Accessible name of the region (default "Carousel"). */
+  label?: string;
+}
+
+export function Carousel({
+  orientation = 'horizontal',
+  loop = false,
+  value,
+  defaultValue = 0,
+  onIndexChange,
+  label,
+  className,
+  children,
+  ...props
+}: CarouselProps) {
+  const [count, setCount] = React.useState(0);
+  const config: CarouselConfig = { orientation, loop, count, label, value, defaultValue };
+
+  // createBehavior is the model (memory + dispatch); useMemory subscribes React
+  // to it. The only React plumbing on top is the reported slide count and ids.
+  const { memory, dispatch } = React.useMemo(() => createBehavior(carouselBehavior, config), []);
+  const state = useMemory(memory);
+
+  const uid = React.useId();
+  const rootRef = React.useRef<HTMLDivElement>(null);
+
+  // ids are derived once from the root uid -- the projection never generates
+  // them (Spec 01), and no part cross-references another here.
+  const ids = React.useMemo(() => {
+    const out = {} as PartIds<CarouselPart>;
+    for (const part of Object.keys(carouselBehavior.parts) as CarouselPart[]) {
+      out[part] = `${uid}-${part}`;
+    }
+    return out;
+  }, [uid]);
+
+  // Effect-initiated moves (keyboard) must read the CURRENT config and callback,
+  // so those ride in a ref rather than being captured stale.
+  const latest = React.useRef({ config, onIndexChange });
+  latest.current = { config, onIndexChange };
+
+  const request = React.useCallback(
+    <K extends keyof CarouselActions>(
+      action: K,
+      ...payload: PayloadArgs<CarouselActions[K]>
+    ): void => {
+      const { config: cfg, onIndexChange: cb } = latest.current;
+      // Effective index before vs the INTRINSIC index after: a controlled
+      // carousel's effective index never moves (config.value shadows it), but
+      // the consumer callback must still report the index it should set next.
+      const before = activeIndex(memory.get(), cfg);
+      if (!dispatch(action, cfg, ...payload)) return;
+      const nextIntrinsic = clampIndex(memory.get().index, cfg);
+      if (nextIntrinsic !== before) cb?.(nextIntrinsic);
+    },
+    [memory, dispatch],
+  );
+
+  // Compose the arrow-key handler directly, rebuilt only when the orientation
+  // changes (it selects the axis's two keys). getConfig/getState read live.
+  React.useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    return composeCarouselInteractions({
+      root,
+      getState: () => memory.get(),
+      getConfig: () => latest.current.config,
+      request: (index) => request('setIndex', clampIndex(index, latest.current.config)),
+    });
+  }, [orientation, memory, request]);
+
+  const aria = carouselBehavior.aria(state, config, ids);
+
+  const contextValue: CarouselContextValue = {
+    state,
+    config,
+    count,
+    setCount,
+    classes: carouselClasses(config),
+    aria,
+    request,
+  };
+
+  return (
+    <CarouselContext.Provider value={contextValue}>
+      {/* biome-ignore lint/a11y/useSemanticElements: role="region" + aria-roledescription="carousel" is the WAI-ARIA carousel pattern */}
+      <div
+        ref={rootRef}
+        role="region"
+        data-part="root"
+        id={`${uid}-root`}
+        data-orientation={orientation}
+        className={classy(contextValue.classes.root, className)}
+        {...aria.root}
+        {...props}
+      >
+        {children}
+      </div>
+    </CarouselContext.Provider>
+  );
+}
+
+export type CarouselContentProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function CarouselContent({ className, children, ...props }: CarouselContentProps) {
+  const { state, config, classes, setCount } = useCarouselContext('CarouselContent');
+  const items = React.Children.toArray(children);
+
+  // The DOM (the rendered slides) is the registry; report the count up so the
+  // root can bound the index and disable the controls at the ends.
+  React.useEffect(() => {
+    setCount(items.length);
+  }, [items.length, setCount]);
+
+  return (
+    <div data-part="content" className={classes.content} data-orientation={config.orientation}>
+      <div
+        data-part="track"
+        className={classy(classes.track, className)}
+        style={trackStyle(state, config)}
+        {...props}
+      >
+        {items.map((child, index) => (
+          <CarouselItemIndexContext.Provider key={`slide-${index}`} value={index}>
+            {child}
+          </CarouselItemIndexContext.Provider>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export type CarouselItemProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function CarouselItem({ className, ...props }: CarouselItemProps) {
+  const { state, config, classes } = useCarouselContext('CarouselItem');
+  const index = React.useContext(CarouselItemIndexContext);
+  const aria = carouselInstanceAria('item', String(index), state, config);
+
+  return (
+    <div
+      role="group"
+      data-part="item"
+      data-value={index}
+      className={classy(classes.item, className)}
+      {...aria}
+      {...props}
+    />
+  );
+}
+
+export type CarouselPreviousProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export function CarouselPrevious({
+  className,
+  children,
+  onClick,
+  ...props
+}: CarouselPreviousProps) {
+  const { state, config, classes, aria, request } = useCarouselContext('CarouselPrevious');
+
+  return (
+    <button
+      type="button"
+      data-part="previous"
+      disabled={!canScrollPrev(state, config)}
+      className={classy(classes.previous, className)}
+      {...aria.previous}
+      onClick={(event) => {
+        onClick?.(event);
+        if (event.defaultPrevented) return;
+        request('setIndex', prevIndex(state, config));
+      }}
+      {...props}
+    >
+      {children ?? <ChevronPrevious />}
+    </button>
+  );
+}
+
+export type CarouselNextProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export function CarouselNext({ className, children, onClick, ...props }: CarouselNextProps) {
+  const { state, config, classes, aria, request } = useCarouselContext('CarouselNext');
+
+  return (
+    <button
+      type="button"
+      data-part="next"
+      disabled={!canScrollNext(state, config)}
+      className={classy(classes.next, className)}
+      {...aria.next}
+      onClick={(event) => {
+        onClick?.(event);
+        if (event.defaultPrevented) return;
+        request('setIndex', nextIndex(state, config));
+      }}
+      {...props}
+    >
+      {children ?? <ChevronNext />}
+    </button>
+  );
+}
+
+export type CarouselIndicatorsProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function CarouselIndicators({ className, ...props }: CarouselIndicatorsProps) {
+  const { state, config, count, classes, aria, request } = useCarouselContext('CarouselIndicators');
+
+  return (
+    <div
+      role="group"
+      data-part="indicators"
+      className={classy(classes.indicators, className)}
+      {...aria.indicators}
+      {...props}
+    >
+      {Array.from({ length: count }).map((_, index) => {
+        const instance = carouselInstanceAria('indicator', String(index), state, config);
+        return (
+          <button
+            key={`indicator-${index}`}
+            type="button"
+            data-part="indicator"
+            data-value={index}
+            className={classes.indicator}
+            {...instance}
+            onClick={() => request('setIndex', index)}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * The imperative slide controls, for consumers driving the carousel from outside
+ * a control (shadcn's `useCarousel` shape, minus the Embla instance).
+ */
+export function useCarousel() {
+  const { state, config, count, request } = useCarouselContext('useCarousel');
+  return {
+    activeIndex: activeIndex(state, config),
+    count,
+    canScrollPrev: canScrollPrev(state, config),
+    canScrollNext: canScrollNext(state, config),
+    scrollPrev: () => request('setIndex', prevIndex(state, config)),
+    scrollNext: () => request('setIndex', nextIndex(state, config)),
+    scrollTo: (index: number) => request('setIndex', clampIndex(index, config)),
+  };
+}
+
+function ChevronPrevious() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  );
+}
+
+function ChevronNext() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="m9 18 6-6-6-6" />
+    </svg>
+  );
+}
+
+Carousel.displayName = 'Carousel';
+CarouselContent.displayName = 'CarouselContent';
+CarouselItem.displayName = 'CarouselItem';
+CarouselPrevious.displayName = 'CarouselPrevious';
+CarouselNext.displayName = 'CarouselNext';
+CarouselIndicators.displayName = 'CarouselIndicators';
+
+Carousel.Content = CarouselContent;
+Carousel.Item = CarouselItem;
+Carousel.Previous = CarouselPrevious;
+Carousel.Next = CarouselNext;
+Carousel.Indicators = CarouselIndicators;

--- a/packages/ui/test/components/carousel/carousel.astro.conformance.test.ts
+++ b/packages/ui/test/components/carousel/carousel.astro.conformance.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Astro performance of the carousel score, driven end to end. AstroContainer
+ * renders the SSR markup with the initial projection already applied, but does
+ * NOT run the <script>, so the test calls bindCarousel directly -- that IS the
+ * script's job -- then drives the same score the React and WC performances
+ * drive. One score, three performances.
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import Carousel from '../../../src/components/carousel/carousel.astro';
+import { bindCarousel, carouselBehavior } from '../../../src/components/carousel/carousel.behavior';
+import {
+  assertContractFulfillment,
+  assertInstanceAriaFulfillment,
+} from '../../harness/conformance';
+
+const slides = ['Slide one', 'Slide two', 'Slide three'];
+const config = (over: Record<string, unknown> = {}) => ({
+  orientation: 'horizontal' as const,
+  loop: false,
+  count: 3,
+  label: undefined,
+  ...over,
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+async function mount(loop = false): Promise<HTMLElement> {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Carousel, {
+    props: { id: 'gallery', slides, indicators: true, loop },
+  });
+  document.body.innerHTML = html;
+  const root = document.body.querySelector('div[data-part="root"][data-carousel]') as HTMLElement;
+  bindCarousel(root); // the <script> does this per instance on the real page
+  return root;
+}
+
+const item = (index: number) =>
+  document.body.querySelector<HTMLElement>(`[data-part="item"][data-value="${index}"]`)!;
+const indicator = (index: number) =>
+  document.body.querySelector<HTMLElement>(`[data-part="indicator"][data-value="${index}"]`)!;
+const previous = () => document.body.querySelector<HTMLButtonElement>('[data-part="previous"]')!;
+const next = () => document.body.querySelector<HTMLButtonElement>('[data-part="next"]')!;
+
+describe('carousel conformance [astro]', () => {
+  it('SSR fulfills the contract: parts present, ARIA equals the projection', async () => {
+    const root = await mount();
+    assertContractFulfillment(carouselBehavior, root, { index: 0 }, config(), [
+      'root',
+      'content',
+      'track',
+      'item',
+      'previous',
+      'next',
+      'indicators',
+      'indicator',
+    ]);
+    assertInstanceAriaFulfillment(carouselBehavior, root, { index: 0 }, config());
+  });
+
+  it('SSR renders the slide bodies and marks the first slide active', async () => {
+    await mount();
+    expect(item(0).textContent).toContain('Slide one');
+    expect(item(0).getAttribute('data-state')).toBe('active');
+    expect(item(0).getAttribute('aria-label')).toBe('1 of 3');
+    expect(previous().disabled).toBe(true);
+    expect(next().disabled).toBe(false);
+  });
+
+  it('next advances the active slide after bind', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(next());
+    expect(item(1).getAttribute('data-state')).toBe('active');
+    expect(previous().disabled).toBe(false);
+  });
+
+  it('an indicator jumps directly to its slide', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(indicator(2));
+    expect(item(2).getAttribute('data-state')).toBe('active');
+    expect(indicator(2).getAttribute('aria-current')).toBe('true');
+  });
+
+  it('loop wraps past the start', async () => {
+    const user = userEvent.setup();
+    await mount(true);
+    await user.click(previous());
+    expect(item(2).getAttribute('data-state')).toBe('active');
+  });
+});

--- a/packages/ui/test/components/carousel/carousel.behavior.test.ts
+++ b/packages/ui/test/components/carousel/carousel.behavior.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createBehavior } from '../../../src/lib/contract';
+import {
+  activeIndex,
+  canScrollNext,
+  canScrollPrev,
+  carouselBehavior,
+  carouselInstanceAria,
+  clampIndex,
+  composeCarouselInteractions,
+  indexForKey,
+  nextIndex,
+  prevIndex,
+  trackStyle,
+  type CarouselConfig,
+} from '../../../src/components/carousel/carousel.behavior';
+
+const three: CarouselConfig = { count: 3 };
+const threeLoop: CarouselConfig = { count: 3, loop: true };
+
+describe('carousel parts', () => {
+  it('declares the structural parts and the two many-instance families', () => {
+    expect(Object.keys(carouselBehavior.parts).sort()).toEqual([
+      'content',
+      'indicator',
+      'indicators',
+      'item',
+      'next',
+      'previous',
+      'root',
+      'track',
+    ]);
+    expect(carouselBehavior.parts.item.many).toBe(true);
+    expect(carouselBehavior.parts.item.role).toBe('group');
+    expect(carouselBehavior.parts.indicator.many).toBe(true);
+    expect(carouselBehavior.parts.indicator.optional).toBe(true);
+    expect(carouselBehavior.parts.indicators.optional).toBe(true);
+    expect(carouselBehavior.parts.root.role).toBe('region');
+  });
+});
+
+describe('carousel state', () => {
+  it('seeds from value, else defaultValue, else 0 -- clamped to the count', () => {
+    expect(carouselBehavior.initialState(three).index).toBe(0);
+    expect(carouselBehavior.initialState({ count: 3, defaultValue: 2 }).index).toBe(2);
+    expect(carouselBehavior.initialState({ count: 3, defaultValue: 9 }).index).toBe(2);
+    expect(carouselBehavior.initialState({ count: 3, value: 1 }).index).toBe(1);
+  });
+
+  it('controlled value shadows intrinsic state and clamps', () => {
+    expect(activeIndex({ index: 1 }, three)).toBe(1);
+    expect(activeIndex({ index: 1 }, { count: 3, value: 2 })).toBe(2);
+    expect(activeIndex({ index: 1 }, { count: 3, value: 9 })).toBe(2);
+  });
+
+  it('clampIndex bounds into [0, count-1], or 0 with no slides', () => {
+    expect(clampIndex(5, three)).toBe(2);
+    expect(clampIndex(-1, three)).toBe(0);
+    expect(clampIndex(1, { count: 0 })).toBe(0);
+  });
+});
+
+describe('carousel navigation math', () => {
+  it('prev clamps at 0 without loop, wraps to the end with loop', () => {
+    expect(prevIndex({ index: 0 }, three)).toBe(0);
+    expect(prevIndex({ index: 0 }, threeLoop)).toBe(2);
+    expect(prevIndex({ index: 2 }, three)).toBe(1);
+  });
+
+  it('next clamps at the end without loop, wraps to 0 with loop', () => {
+    expect(nextIndex({ index: 2 }, three)).toBe(2);
+    expect(nextIndex({ index: 2 }, threeLoop)).toBe(0);
+    expect(nextIndex({ index: 0 }, three)).toBe(1);
+  });
+
+  it('canScrollPrev/Next reflect the bounds and the loop flag', () => {
+    expect(canScrollPrev({ index: 0 }, three)).toBe(false);
+    expect(canScrollPrev({ index: 0 }, threeLoop)).toBe(true);
+    expect(canScrollPrev({ index: 1 }, three)).toBe(true);
+    expect(canScrollNext({ index: 2 }, three)).toBe(false);
+    expect(canScrollNext({ index: 2 }, threeLoop)).toBe(true);
+    expect(canScrollNext({ index: 0 }, three)).toBe(true);
+    expect(canScrollPrev({ index: 0 }, { count: 0 })).toBe(false);
+  });
+});
+
+describe('carousel keymap and key targeting', () => {
+  it('horizontal steers with Left/Right; vertical with Up/Down', () => {
+    expect(indexForKey('ArrowRight', { index: 0 }, three)).toBe(1);
+    expect(indexForKey('ArrowLeft', { index: 1 }, three)).toBe(0);
+    expect(indexForKey('ArrowUp', { index: 1 }, three)).toBeNull();
+    expect(indexForKey('ArrowDown', { index: 0 }, { count: 3, orientation: 'vertical' })).toBe(1);
+    expect(
+      indexForKey('ArrowRight', { index: 0 }, { count: 3, orientation: 'vertical' }),
+    ).toBeNull();
+  });
+
+  it('keymap claims the axis arrows on the root only', () => {
+    expect(carouselBehavior.keymap({ key: 'ArrowRight' }, { index: 0 }, 'root', three)).toBe(
+      'setIndex',
+    );
+    expect(
+      carouselBehavior.keymap({ key: 'ArrowRight' }, { index: 0 }, 'previous', three),
+    ).toBeNull();
+    expect(carouselBehavior.keymap({ key: 'ArrowUp' }, { index: 0 }, 'root', three)).toBeNull();
+    expect(
+      carouselBehavior.keymap({ key: 'ArrowUp' }, { index: 0 }, 'root', {
+        count: 3,
+        orientation: 'vertical',
+      }),
+    ).toBe('setIndex');
+  });
+});
+
+describe('carousel setIndex reducer', () => {
+  it('moves the intrinsic index to the dispatched value', () => {
+    const { memory, dispatch } = createBehavior(carouselBehavior, three);
+    expect(memory.get().index).toBe(0);
+    expect(dispatch('setIndex', three, 2)).toBe(true);
+    expect(memory.get().index).toBe(2);
+  });
+});
+
+describe('carousel aria projection', () => {
+  const ids = {
+    root: 'r',
+    content: 'c',
+    track: 't',
+    item: '',
+    previous: 'p',
+    next: 'n',
+    indicators: 'is',
+    indicator: '',
+  };
+
+  it('root carries the carousel roledescription, label, and orientation', () => {
+    const aria = carouselBehavior.aria({ index: 0 }, three, ids);
+    expect(aria.root).toEqual({
+      'aria-roledescription': 'carousel',
+      'aria-label': 'Carousel',
+      'data-orientation': 'horizontal',
+    });
+    expect(
+      carouselBehavior.aria({ index: 0 }, { count: 3, label: 'Gallery' }, ids).root?.['aria-label'],
+    ).toBe('Gallery');
+  });
+
+  it('previous/next expose data-disabled exactly at the bounds', () => {
+    const atStart = carouselBehavior.aria({ index: 0 }, three, ids);
+    expect(atStart.previous?.['data-disabled']).toBe('true');
+    expect(atStart.next?.['data-disabled']).toBeUndefined();
+    const atEnd = carouselBehavior.aria({ index: 2 }, three, ids);
+    expect(atEnd.previous?.['data-disabled']).toBeUndefined();
+    expect(atEnd.next?.['data-disabled']).toBe('true');
+  });
+
+  it('instance ARIA: slides are labelled "N of M"; the current dot is aria-current', () => {
+    const item = carouselInstanceAria('item', '0', { index: 0 }, three);
+    expect(item).toEqual({
+      'aria-roledescription': 'slide',
+      'aria-label': '1 of 3',
+      'data-state': 'active',
+    });
+    expect(carouselInstanceAria('item', '1', { index: 0 }, three)['data-state']).toBe('inactive');
+    const dot = carouselInstanceAria('indicator', '0', { index: 0 }, three);
+    expect(dot).toEqual({
+      'aria-label': 'Go to slide 1',
+      'aria-current': 'true',
+      'data-state': 'active',
+    });
+    expect(
+      carouselInstanceAria('indicator', '1', { index: 0 }, three)['aria-current'],
+    ).toBeUndefined();
+  });
+});
+
+describe('carousel track geometry', () => {
+  it('translates by 100% per index along the orientation axis', () => {
+    expect(trackStyle({ index: 0 }, three).transform).toBe('translateX(-0%)');
+    expect(trackStyle({ index: 2 }, three).transform).toBe('translateX(-200%)');
+    expect(trackStyle({ index: 1 }, { count: 3, orientation: 'vertical' }).transform).toBe(
+      'translateY(-100%)',
+    );
+  });
+});
+
+describe('carousel interactions composition', () => {
+  const stops: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const stop of stops.splice(0)) stop();
+    document.body.innerHTML = '';
+  });
+
+  function mount(orientation: 'horizontal' | 'vertical' = 'horizontal'): HTMLElement {
+    document.body.innerHTML = `
+      <div data-part="root" data-orientation="${orientation}">
+        <div data-part="track">
+          <div data-part="item" data-value="0">A</div>
+          <div data-part="item" data-value="1">B</div>
+          <div data-part="item" data-value="2">C</div>
+        </div>
+      </div>`;
+    return document.body.querySelector('[data-part="root"]') as HTMLElement;
+  }
+
+  it('arrow keys on the axis request the resolved neighbour index', () => {
+    const root = mount('horizontal');
+    let index = 0;
+    const request = vi.fn((target: number) => {
+      index = target;
+    });
+    const stop = composeCarouselInteractions({
+      root,
+      getState: () => ({ index }),
+      getConfig: () => ({ count: 3, orientation: 'horizontal' }),
+      request,
+    });
+    stops.push(stop);
+
+    root.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(request).toHaveBeenLastCalledWith(1);
+    root.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(request).toHaveBeenLastCalledWith(2);
+    // Pinned at the end without loop: no further request.
+    root.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores the cross-axis arrows and detaches on cleanup', () => {
+    const root = mount('horizontal');
+    const request = vi.fn();
+    const stop = composeCarouselInteractions({
+      root,
+      getState: () => ({ index: 0 }),
+      getConfig: () => ({ count: 3, orientation: 'horizontal' }),
+      request,
+    });
+    root.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    expect(request).not.toHaveBeenCalled();
+    stop();
+    root.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/test/components/carousel/carousel.classes.test.ts
+++ b/packages/ui/test/components/carousel/carousel.classes.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { carouselClasses } from '../../../src/components/carousel/carousel.classes';
+
+describe('carousel classes', () => {
+  it('lays the track along the orientation axis', () => {
+    expect(carouselClasses({ orientation: 'horizontal' }).track).toContain('flex-row');
+    expect(carouselClasses({ orientation: 'vertical' }).track).toContain('flex-col');
+  });
+
+  it('slides are full-basis and non-shrinking so one fills the viewport', () => {
+    const classes = carouselClasses({});
+    expect(classes.item).toContain('basis-full');
+    expect(classes.item).toContain('shrink-0');
+    expect(classes.content).toContain('overflow-hidden');
+  });
+
+  it('the active indicator keys its fill off the projected data-state', () => {
+    expect(carouselClasses({}).indicator).toContain('data-[state=active]:bg-primary');
+  });
+
+  it('orientation only relocates the controls; the chrome is shared', () => {
+    const horizontal = carouselClasses({ orientation: 'horizontal' });
+    const vertical = carouselClasses({ orientation: 'vertical' });
+    expect(horizontal.previous).toContain('left-2');
+    expect(horizontal.next).toContain('right-2');
+    expect(vertical.previous).toContain('rotate-90');
+    expect(horizontal.previous).toContain('disabled:opacity-50');
+  });
+
+  it('declares no hardcoded slide-advance duration (no semantic token yet)', () => {
+    const classes = carouselClasses({});
+    for (const value of Object.values(classes)) {
+      expect(value).not.toMatch(/duration-\d/);
+    }
+  });
+});

--- a/packages/ui/test/components/carousel/carousel.conformance.test.tsx
+++ b/packages/ui/test/components/carousel/carousel.conformance.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * React performance of the carousel score, driven end to end. State moves only
+ * through the setIndex reducer; arrow-key navigation is the composed
+ * keyboard-handler primitive, shared verbatim with the DOM-native bind.
+ */
+import * as React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselIndicators,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from '../../../src/components/carousel/carousel';
+import { carouselBehavior } from '../../../src/components/carousel/carousel.behavior';
+import {
+  assertAxeClean,
+  assertContractFulfillment,
+  assertInstanceAriaFulfillment,
+  partElement,
+} from '../../harness/conformance';
+
+interface SetupProps {
+  orientation?: 'horizontal' | 'vertical';
+  loop?: boolean;
+  value?: number;
+  defaultValue?: number;
+  onIndexChange?: (index: number) => void;
+}
+
+function TestCarousel(props: SetupProps) {
+  return (
+    <Carousel {...props}>
+      <CarouselPrevious />
+      <CarouselContent>
+        <CarouselItem>Slide one</CarouselItem>
+        <CarouselItem>Slide two</CarouselItem>
+        <CarouselItem>Slide three</CarouselItem>
+      </CarouselContent>
+      <CarouselNext />
+      <CarouselIndicators />
+    </Carousel>
+  );
+}
+
+const body = () => document.body;
+const root = () => partElement(body(), 'root') as HTMLElement;
+const item = (index: number) =>
+  body().querySelector<HTMLElement>(`[data-part="item"][data-value="${index}"]`)!;
+const indicator = (index: number) =>
+  body().querySelector<HTMLElement>(`[data-part="indicator"][data-value="${index}"]`)!;
+const previous = () => body().querySelector<HTMLButtonElement>('[data-part="previous"]')!;
+const next = () => body().querySelector<HTMLButtonElement>('[data-part="next"]')!;
+const config = (over: Record<string, unknown> = {}) => ({
+  orientation: 'horizontal' as const,
+  loop: false,
+  count: 3,
+  label: undefined,
+  value: undefined,
+  defaultValue: 0,
+  ...over,
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('carousel conformance [react]', () => {
+  it('fulfills the contract: parts present, ARIA equals the projection', async () => {
+    render(<TestCarousel />);
+    assertContractFulfillment(carouselBehavior, root(), { index: 0 }, config(), [
+      'root',
+      'content',
+      'track',
+      'item',
+      'previous',
+      'next',
+      'indicators',
+      'indicator',
+    ]);
+    assertInstanceAriaFulfillment(carouselBehavior, root(), { index: 0 }, config());
+    await assertAxeClean(body());
+  });
+
+  it('opens on the first slide with previous disabled and next enabled', () => {
+    render(<TestCarousel />);
+    expect(root().getAttribute('aria-roledescription')).toBe('carousel');
+    expect(item(0).getAttribute('data-state')).toBe('active');
+    expect(item(0).getAttribute('aria-label')).toBe('1 of 3');
+    expect(previous().disabled).toBe(true);
+    expect(next().disabled).toBe(false);
+    expect(indicator(0).getAttribute('aria-current')).toBe('true');
+  });
+
+  it('next advances the active slide; prev/next disable at the bounds', async () => {
+    const user = userEvent.setup();
+    render(<TestCarousel />);
+    await user.click(next());
+    expect(item(1).getAttribute('data-state')).toBe('active');
+    expect(previous().disabled).toBe(false);
+    await user.click(next());
+    expect(item(2).getAttribute('data-state')).toBe('active');
+    expect(next().disabled).toBe(true);
+    assertInstanceAriaFulfillment(carouselBehavior, root(), { index: 2 }, config());
+  });
+
+  it('an indicator jumps directly to its slide (goto)', async () => {
+    const user = userEvent.setup();
+    render(<TestCarousel />);
+    await user.click(indicator(2));
+    expect(item(2).getAttribute('data-state')).toBe('active');
+    expect(indicator(2).getAttribute('aria-current')).toBe('true');
+    expect(indicator(0).hasAttribute('aria-current')).toBe(false);
+  });
+
+  it('arrow keys steer along the horizontal axis', async () => {
+    const user = userEvent.setup();
+    render(<TestCarousel />);
+    next().focus();
+    await user.keyboard('{ArrowRight}');
+    expect(item(1).getAttribute('data-state')).toBe('active');
+    await user.keyboard('{ArrowLeft}');
+    expect(item(0).getAttribute('data-state')).toBe('active');
+  });
+
+  it('loop wraps past the ends and keeps both controls enabled', async () => {
+    const user = userEvent.setup();
+    render(<TestCarousel loop />);
+    expect(previous().disabled).toBe(false);
+    await user.click(previous());
+    expect(item(2).getAttribute('data-state')).toBe('active');
+    await user.click(next());
+    expect(item(0).getAttribute('data-state')).toBe('active');
+  });
+
+  it('controlled: the callback reports the target, the prop drives the view', async () => {
+    const user = userEvent.setup();
+    const onIndexChange = vi.fn();
+    const { rerender } = render(<TestCarousel value={0} onIndexChange={onIndexChange} />);
+    await user.click(next());
+    expect(onIndexChange).toHaveBeenLastCalledWith(1);
+    // Effective index has not moved -- the prop owns it.
+    expect(item(0).getAttribute('data-state')).toBe('active');
+    rerender(<TestCarousel value={1} onIndexChange={onIndexChange} />);
+    expect(item(1).getAttribute('data-state')).toBe('active');
+  });
+});

--- a/packages/ui/test/components/carousel/carousel.element.conformance.test.ts
+++ b/packages/ui/test/components/carousel/carousel.element.conformance.test.ts
@@ -1,0 +1,126 @@
+/**
+ * WC performance of the carousel score, driven end to end against light-DOM
+ * markup. Same score as the React conformance test -- the only difference is the
+ * controller applies the projection imperatively.
+ */
+import { cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { carouselBehavior } from '../../../src/components/carousel/carousel.behavior';
+import { RaftersCarousel } from '../../../src/components/carousel/carousel.element';
+import {
+  assertAxeClean,
+  assertContractFulfillment,
+  assertInstanceAriaFulfillment,
+} from '../../harness/conformance';
+
+beforeAll(() => {
+  if (!customElements.get('rafters-carousel')) {
+    customElements.define('rafters-carousel', RaftersCarousel);
+  }
+});
+
+async function mount(loop = false): Promise<HTMLElement> {
+  document.body.innerHTML = `
+    <rafters-carousel data-loop="${loop}">
+      <button type="button" data-part="previous">prev</button>
+      <div data-part="content">
+        <div data-part="track">
+          <div role="group" data-part="item" data-value="0">Slide one</div>
+          <div role="group" data-part="item" data-value="1">Slide two</div>
+          <div role="group" data-part="item" data-value="2">Slide three</div>
+        </div>
+      </div>
+      <button type="button" data-part="next">next</button>
+      <div role="group" data-part="indicators">
+        <button type="button" data-part="indicator" data-value="0"></button>
+        <button type="button" data-part="indicator" data-value="1"></button>
+        <button type="button" data-part="indicator" data-value="2"></button>
+      </div>
+    </rafters-carousel>`;
+  await Promise.resolve(); // let the element's deferred bind run
+  return document.body.querySelector('rafters-carousel') as HTMLElement;
+}
+
+const item = (index: number) =>
+  document.body.querySelector<HTMLElement>(`[data-part="item"][data-value="${index}"]`)!;
+const indicator = (index: number) =>
+  document.body.querySelector<HTMLElement>(`[data-part="indicator"][data-value="${index}"]`)!;
+const previous = () => document.body.querySelector<HTMLButtonElement>('[data-part="previous"]')!;
+const next = () => document.body.querySelector<HTMLButtonElement>('[data-part="next"]')!;
+const config = (over: Record<string, unknown> = {}) => ({
+  orientation: 'horizontal' as const,
+  loop: false,
+  count: 3,
+  label: undefined,
+  defaultValue: 0,
+  ...over,
+});
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+describe('carousel conformance [wc]', () => {
+  it('fulfills the contract after the deferred bind', async () => {
+    const root = await mount();
+    assertContractFulfillment(carouselBehavior, root, { index: 0 }, config(), [
+      'root',
+      'content',
+      'track',
+      'item',
+      'previous',
+      'next',
+      'indicators',
+      'indicator',
+    ]);
+    assertInstanceAriaFulfillment(carouselBehavior, root, { index: 0 }, config());
+    await assertAxeClean(document.body);
+  });
+
+  it('first slide active, previous disabled, next enabled', async () => {
+    await mount();
+    expect(item(0).getAttribute('data-state')).toBe('active');
+    expect(item(0).getAttribute('aria-label')).toBe('1 of 3');
+    expect(previous().disabled).toBe(true);
+    expect(next().disabled).toBe(false);
+    expect(indicator(0).getAttribute('aria-current')).toBe('true');
+  });
+
+  it('next advances and disables at the last slide', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(next());
+    expect(item(1).getAttribute('data-state')).toBe('active');
+    await user.click(next());
+    expect(item(2).getAttribute('data-state')).toBe('active');
+    expect(next().disabled).toBe(true);
+  });
+
+  it('an indicator jumps directly to its slide', async () => {
+    const user = userEvent.setup();
+    await mount();
+    await user.click(indicator(2));
+    expect(item(2).getAttribute('data-state')).toBe('active');
+    expect(indicator(2).getAttribute('aria-current')).toBe('true');
+  });
+
+  it('arrow keys steer along the horizontal axis', async () => {
+    const user = userEvent.setup();
+    await mount();
+    next().focus();
+    await user.keyboard('{ArrowRight}');
+    expect(item(1).getAttribute('data-state')).toBe('active');
+    await user.keyboard('{ArrowLeft}');
+    expect(item(0).getAttribute('data-state')).toBe('active');
+  });
+
+  it('loop wraps past the ends', async () => {
+    const user = userEvent.setup();
+    await mount(true);
+    expect(previous().disabled).toBe(false);
+    await user.click(previous());
+    expect(item(2).getAttribute('data-state')).toBe('active');
+  });
+});


### PR DESCRIPTION
## Summary

Ports `carousel` (compound archetype) from `src/old/ui/carousel.tsx` to the behavior layer: one score, three decorators. The single state axis is the slide `index`; `canScrollPrev`/`canScrollNext`, `prevIndex`/`nextIndex` and `clampIndex` are pure derivations against the DOM-counted slide total and the loop flag, not stored state. A single `setIndex` reducer stores an already-resolved index (slider's `setThumb` shape, since a reducer receives no config), and arrow-key navigation rides the `keyboard-handler` primitive via a shared `composeCarouselInteractions` that both `bindCarousel` (WC + Astro) and the React effect call.

Dropped from the oracle and documented as such: auto-play (a raw-duration timer the motion layer forbids), the `isPaused` hover-pause (only meaningful with auto-play), the ref-registry cell (the DOM is the registry now), and touch swipe (no primitive expresses it without wrong ARIA -- `drag-drop` stamps `aria-grabbed`/`role=button`, `interactive` stamps `role=slider`). The indicators are re-expressed from the oracle's `tablist`/`tab` ARIA misuse to a group of slide-picker buttons with `aria-current`. The slide-advance motion is left undeclared: no semantic `motion-*` token expresses a horizontal slide yet, so the track offset applies with no transition rather than a hardcoded duration.

## Acceptance criteria mapping

### Component doc written

`docs/spec/components/carousel.md` is modeled on dialog.md and describes carousel's own composition, config/state/actions, parts+ARIA table, keyboard, motion, and a row-by-row oracle-disposition table written against the actual code (not copied), labelling every dropped oracle feature.
Evidence: packages/ui/docs/spec/components/carousel.md:60

### JSDoc intelligence tags present

The `Carousel` root in the React decorator carries all four registry-parsed tags -- `@cognitive-load` (five-dimension breakdown), `@attention-economics`, `@trust-building`, and `@accessibility` -- as a JSDoc block above the function.
Evidence: packages/ui/src/components/carousel/carousel.tsx:27

### Behavior test (pure, no DOM)

`carousel.behavior.test.ts` exercises the reducers, `activeIndex`/`clampIndex`, `prevIndex`/`nextIndex`, `canScroll*`, `indexForKey`, `keymap`, `aria`, `carouselInstanceAria`, and `trackStyle` as pure functions with no DOM; only the final interactions block mounts DOM to drive the composed keyboard handler.
Evidence: packages/ui/test/components/carousel/carousel.behavior.test.ts:63

### Classes parity test

`carousel.classes.test.ts` asserts the orientation branches (`flex-row`/`flex-col`, control positioning), the full-basis slide sizing, the `data-[state=active]` fill, and enforces that no class string carries a hardcoded `duration-N` utility.
Evidence: packages/ui/test/components/carousel/carousel.classes.test.ts:36

### Conformance test via the shared harness (aria + keymap against rendered DOM)

React, WC, and Astro conformance suites each call `assertContractFulfillment` and `assertInstanceAriaFulfillment` from the shared harness against rendered DOM, plus drive the arrow-key keymap and click paths (advance, goto, loop) and run axe on the React and WC trees.
Evidence: packages/ui/test/components/carousel/carousel.conformance.test.tsx:66

### shadcn drop-in parity where the component exists in shadcn

The React surface keeps the shadcn names -- `Carousel`, `CarouselContent`, `CarouselItem`, `CarouselPrevious`, `CarouselNext`, and a `useCarousel` hook exposing `scrollPrev`/`scrollNext`/`scrollTo` and `canScrollPrev`/`canScrollNext` -- alongside the rafters `CarouselIndicators` extension.
Evidence: packages/ui/src/components/carousel/carousel.tsx:322

### `pnpm --filter @rafters/ui test:unit` green, `pnpm preflight` green

The full carousel suite (39 tests across behavior, classes, and the three framework conformance files) passes, and `pnpm preflight` completed with exit code 0 (lint, format, typecheck, build, and the workspace test run).
Evidence: packages/ui/test/components/carousel/carousel.element.conformance.test.ts:60

## Not done

- Animated slide-advance transition: left undeclared pending a semantic slide `motion-*` token (motion layer rebuild, #1899); the offset snaps rather than using a hardcoded duration.
- Auto-play, hover-pause, and touch swipe: dropped, not ported (see the oracle-disposition table for the reasoning per feature).
- No Vue performance (out of scope for this wave), and no shared-file / registry / `package.json` export edits (distribution is the registry, #1896).

Closes #1763
