### PR TITLE
feat(ui): port resizable to the behavior layer

### DIFF
--- a/packages/ui/docs/spec/components/resizable.md
+++ b/packages/ui/docs/spec/components/resizable.md
@@ -1,0 +1,128 @@
+# Component Spec — Resizable
+
+Status: PORTED (wave 5). Compound archetype; the split-panel control.
+
+Files (`src/components/resizable/`):
+
+```
+resizable.classes.ts   resizable.behavior.ts   resizable.tsx
+resizable.element.ts    resizable.astro
+```
+
+Tests mirror into `test/components/resizable/` (behavior, classes, and
+conformance across React + WC + Astro via the shared harness).
+
+## Composition
+
+```
+resizable (slice)   state {sizes}, action setSizes, parts root/panel/handle
+resizeSizes (pure)  the clamp/redistribute math a reducer cannot hold (needs config)
+interactive         the mouse/touch pointer surface on the group root
+keyboard-handler    arrow/Home/End resize on the focused handle
+```
+
+The score's only state axis is `sizes` (percent per panel). Which handle is
+being dragged and the `data-dragging` flag the CSS reads are ephemeral
+(bind-local closure), never score state -- the same split slider draws between
+its `values` and the active-thumb closure. Uncontrolled only:
+react-resizable-panels reports layout through `onLayout` rather than shadowing an
+external `sizes` prop, so there is no controlled boundary to cross.
+
+The pointer axis is COMPOSED onto `interactive`, not hand-rolled: `interactive`
+owns the mouse/touch surface and document-level drag tracking on the group root,
+and a separate `pointerdown` gate honours a press only when it lands on a handle
+(a 1px handle has no meaningful rect of its own, so the surface is the group).
+The percent math lives in the pure `resizeSizes` helper because a reducer gets no
+config and the constraint math needs each panel's min/max.
+
+## Config, state, actions
+
+```ts
+interface ResizablePanelConfig { defaultSize: number; minSize: number; maxSize: number }
+interface ResizableConfig {
+  direction: 'horizontal' | 'vertical';
+  panels: ResizablePanelConfig[]; // one per panel, DOM order
+  disabled?: boolean;             // gates every resize
+}
+interface ResizableState { sizes: number[] } // percent per panel
+type ResizableActions = { setSizes: { sizes: number[] } };
+```
+
+One `setSizes` action: the pure `resizeSizes` helper computes the clamped,
+redistributed array (both the pointer path and the keyboard path call it), and
+the reducer replaces wholesale. `canDispatch` rejects `setSizes` while disabled,
+so `onLayout` never fires for a move the control would refuse.
+
+## Parts and ARIA
+
+| Part | Presence | ARIA |
+| --- | --- | --- |
+| root | always | `data-orientation`, `data-disabled` (only when disabled) |
+| panel | one per panel | none (geometry); `flex-basis` carries its size percent |
+| handle | one fewer than panels | `role="separator"`, `aria-orientation`, `aria-valuenow`/`min`/`max`, `aria-disabled` (when disabled), accessible name (decorator), `tabindex` |
+
+`aria-valuenow` is the size of the panel BEFORE the handle, rounded, bounded by
+that panel's `minSize`/`maxSize`. Per-instance ARIA rides the score's
+`instanceAria` (`resizableHandleAria`) keyed by the handle's `data-value` (= its
+index), so the conformance harness drives it generically. The accessible name is
+a decorator concern (a separator has no intrinsic text) -- each decorator applies
+`aria-label` (default "Resize"), not projected by the score.
+
+`aria-orientation` follows the WAI-ARIA Window Splitter pattern: the separator
+line is perpendicular to the group axis, so a horizontally-arranged group (panels
+side by side) has a **vertical** separator and a vertical group a horizontal one.
+
+## Keyboard
+
+- `keymap`: on a `handle`, the along-axis arrows plus `Home`/`End` -> `setSizes`.
+  Horizontal claims `ArrowLeft`/`ArrowRight`; vertical claims
+  `ArrowUp`/`ArrowDown`. The bind resolves WHICH handle (the focused one) and the
+  delta via `keyDelta`.
+- `keyDelta`: Right/Down grow the leading panel, Left/Up shrink it (the visible
+  drag direction); step 1, or 10 with Shift. `Home` shrinks the leading panel to
+  its min, `End` grows it to its max.
+
+## Motion
+
+None. The oracle carried `transition-shadow duration-100` on the handle; the raw
+numeric duration is prohibited (Spec 05) and no semantic `motion-*` token yet
+fits a separator hover/focus transition (the motion-token layer is being rebuilt,
+#1899/#1902). Motion is left **undeclared** rather than hardcoded -- the focus
+ring and the `data-dragging` colour swap apply instantly. Reinstate a
+`motion-hover`/`motion-focus` token here when one lands.
+
+## Oracle dispositions (src/old/ui/resizable.tsx)
+
+| Oracle feature | Disposition |
+| --- | --- |
+| PanelGroup / Panel / Handle compositional surface (direction, defaultSize, minSize, maxSize, withHandle, handle disabled) | contract |
+| drag-to-resize with min/max redistribution (`resizePanels`) | contract -- ported verbatim into the pure `resizeSizes`; the mouse `movementX` mechanism is reframed onto the `interactive` primitive (composed, not reimplemented) |
+| arrow-key resize, Shift x10 | contract; `Home`/`End` to the leading panel's bounds added (WAI-ARIA Window Splitter) |
+| `onLayout(sizes)` | contract |
+| per-instance `aria-valuenow`/`min`/`max` | contract (now the score's `instanceAria`) |
+| `data-dragging` styling | contract -- now per-handle (only the dragged separator flags), not a group flag |
+| `withHandle` grip affordance | contract (decorative chip) |
+| `role="slider"` on the handle | defect-do-not-port -- a focusable window splitter is `role="separator"` (WAI-ARIA Window Splitter), replaced |
+| `aria-orientation = horizontal for a horizontal group` | defect-do-not-port -- inverted vs the splitter pattern (the separator line is perpendicular to the group axis); replaced with `separatorOrientation` |
+| `transition-shadow duration-100` on the handle | defect-do-not-port -- raw numeric duration (Spec 05); motion left undeclared |
+| collapse/expand (`collapsible`, `collapsedSize`, `onCollapse`, `onExpand`, `collapsePanel`/`expandPanel`) | dropped -- outside the drag-resize contract the issue enumerates (`States: sizes, dragging`); the unwired props are not accepted in the API |
+| `autoSaveId` localStorage persistence (+ `sizesEqual` dedup export) | dropped -- persistence is a consumer concern and a localStorage side effect has no place in the pure score; the `autoSaveId` prop is not accepted |
+| runtime panel/handle registration via a second `createMemory` cell | dropped -- the behavior owns the single `sizes` cell; React derives indices from its children (cloneElement), the DOM-native binds read them from `data-index`/`data-value` |
+
+## Astro content limitation
+
+Astro forbids a dynamic `slot name`, so per-panel content rides the `panels`
+prop data (`content?: string`), the same shape `navigation-menu.astro` uses for
+its structured items -- not N named slots. The React performance keeps the full
+compositional children API; the WC is a light-DOM enhancer over author markup.
+
+## WCAG 2.1 AA obligations
+
+- 1.3.1 / 4.1.2: `role="separator"` with `aria-orientation` and
+  `aria-valuenow`/`min`/`max`, asserted against real DOM by the harness; each
+  handle carries an accessible name.
+- 2.1.1 Keyboard (Level A): every handle is a tab stop and resizes by arrow keys;
+  `Home`/`End` reach the leading panel's bounds. Disabled removes the handles
+  from the tab order and gates all movement.
+- 2.4.7 Focus Visible: token focus ring (`focus-visible:ring-ring`) on the
+  handle.

--- a/packages/ui/src/components/resizable/resizable.astro
+++ b/packages/ui/src/components/resizable/resizable.astro
@@ -1,0 +1,143 @@
+---
+/**
+ * Astro performance (controller) for resizable.
+ *
+ * Server-renders the full LIGHT-DOM group -- panels interleaved with
+ * role=separator handles -- with classes, the score's initial projection
+ * (data-orientation / aria-valuenow/min/max / aria-orientation) and each panel's
+ * flex-basis already applied, so the split is correct and accessible before any
+ * JS. Each panel carries its data-panel-min/max/default so bindResizable can
+ * rebuild the config from the DOM. The <script> then hands each server-rendered
+ * root to bindResizable -- the SAME DOM-native controller the Web Component uses.
+ * One score, three performances, zero drift.
+ *
+ * A separator has no intrinsic text, so each handle gets an accessible name
+ * (defaulting to "Resize"); per-panel content rides the named slot `panel-{i}`.
+ */
+import {
+  resizableBehavior,
+  resizableHandleAria,
+  type ResizableConfig,
+  type ResizableDirection,
+  type ResizablePanelConfig,
+  type ResizablePart,
+} from './resizable.behavior';
+import { resizableClasses } from './resizable.classes';
+import type { PartIds } from '../../lib/contract';
+
+interface PanelProp {
+  defaultSize?: number;
+  minSize?: number;
+  maxSize?: number;
+  /** Panel content. Astro forbids a dynamic `slot name`, so per-panel content
+   *  rides the data (like nav-menu.astro's structured items), not N slots. */
+  content?: string;
+}
+
+interface Props {
+  id: string;
+  direction?: ResizableDirection;
+  panels: PanelProp[];
+  withHandle?: boolean;
+  disabled?: boolean;
+  handleLabel?: string;
+}
+
+const {
+  id,
+  direction = 'horizontal',
+  panels,
+  withHandle = false,
+  disabled = false,
+  handleLabel = 'Resize',
+} = Astro.props;
+
+const share = panels.length > 0 ? 100 / panels.length : 100;
+const panelConfigs: ResizablePanelConfig[] = panels.map((panel) => ({
+  defaultSize: panel.defaultSize ?? share,
+  minSize: panel.minSize ?? 0,
+  maxSize: panel.maxSize ?? 100,
+}));
+
+const config: ResizableConfig = { direction, panels: panelConfigs, disabled };
+const state = resizableBehavior.initialState(config);
+const classes = resizableClasses(config, state);
+
+const ids = {} as PartIds<ResizablePart>;
+for (const part of Object.keys(resizableBehavior.parts) as ResizablePart[]) {
+  ids[part] = `${id}-${part}`;
+}
+const aria = resizableBehavior.aria(state, config, ids);
+---
+
+<div
+  data-part="root"
+  id={ids.root}
+  data-direction={direction}
+  class={classes.root}
+  {...aria.root}
+>
+  {
+    panelConfigs.map((panel, index) => (
+      <>
+        <div
+          data-part="panel"
+          data-index={index}
+          data-panel-default={panel.defaultSize}
+          data-panel-min={panel.minSize}
+          data-panel-max={panel.maxSize}
+          class={classes.panel}
+          style={`flex-basis:${state.sizes[index]}%`}
+        >
+          {panels[index]?.content}
+        </div>
+        {index < panelConfigs.length - 1 && (
+          <div
+            role="separator"
+            data-part="handle"
+            data-index={index}
+            data-value={index}
+            data-disabled={disabled ? 'true' : undefined}
+            tabindex={disabled ? -1 : 0}
+            aria-label={handleLabel}
+            class={classes.handle}
+            {...resizableHandleAria(String(index), state, config)}
+          >
+            {withHandle && (
+              <div class={classes.grip}>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class={classes.gripIcon}
+                  aria-hidden="true"
+                >
+                  <title>Drag handle</title>
+                  <circle cx="12" cy="5" r="1" />
+                  <circle cx="12" cy="12" r="1" />
+                  <circle cx="12" cy="19" r="1" />
+                </svg>
+              </div>
+            )}
+          </div>
+        )}
+      </>
+    ))
+  }
+</div>
+
+<script>
+  import { bindResizable } from './resizable.behavior';
+
+  // The <script> is bundled and runs once per page; bind every instance's
+  // server-rendered root. Same controller as the Web Component.
+  for (const root of document.querySelectorAll<HTMLElement>('div[data-part="root"][data-direction]')) {
+    if (root.dataset['bound'] === 'true') continue;
+    root.dataset['bound'] = 'true';
+    bindResizable(root);
+  }
+</script>

--- a/packages/ui/src/components/resizable/resizable.behavior.ts
+++ b/packages/ui/src/components/resizable/resizable.behavior.ts
@@ -1,0 +1,450 @@
+import { compose, type Slice } from '../../lib/compose';
+import {
+  createBehavior,
+  type AriaAttrs,
+  type BehaviorSpec,
+  type PartIds,
+} from '../../lib/contract';
+import { updateAriaAttribute } from '../../primitives/aria-manager';
+import { createInteractive } from '../../primitives/interactive';
+import { createKeyboardHandler } from '../../primitives/keyboard-handler';
+import type { InteractiveMode, NormalizedPoint } from '../../primitives/types';
+
+/**
+ * Resizable: split panels whose adjacent sizes are moved by dragging a handle or
+ * pressing arrow keys. The shadcn/react-resizable-panels surface is a
+ * `PanelGroup` of `Panel`s separated by resize `Handle`s; the score's only state
+ * axis is the panel `sizes` (percent per panel). Which handle is being dragged
+ * and the `data-dragging` flag the CSS reads are ephemeral (bind-local closure,
+ * like slider tracks the active thumb), never score state.
+ *
+ * Composition (Spec 05, "compose the primitive, never reimplement it"):
+ * - pointer drag rides the `interactive` primitive -- it owns the mouse/touch
+ *   surface and the document-level drag tracking and hands back a normalized
+ *   {left, top}. The surface is the GROUP root, not a handle (a 1px handle has no
+ *   meaningful rect); a press is only honoured when it lands on a handle (the
+ *   `active` gate below, mirroring slider's `pickPending`). The percent math that
+ *   turns the point into new sizes is component-internal pure state -- the
+ *   exported `resizeSizes` helper -- never inside a reducer (a reducer gets no
+ *   config, and the constraint math needs each panel's min/max).
+ * - keyboard resize rides `keyboard-handler` (`createKeyboardHandler`); the
+ *   keymap projection is the pure claim record (Spec 01) and the bind computes
+ *   the delta via `keyDelta`.
+ *
+ * Uncontrolled only: react-resizable-panels reports layout via `onLayout` rather
+ * than shadowing an external `sizes` prop, so there is no controlled boundary to
+ * cross -- the intrinsic `sizes` are always the effective sizes.
+ */
+export type ResizableDirection = 'horizontal' | 'vertical';
+
+/** Per-panel sizing metadata. All values are percentages of the group. */
+export interface ResizablePanelConfig {
+  /** Initial size (percent). Seeds the intrinsic `sizes`. */
+  defaultSize: number;
+  /** Floor the panel is clamped to while a neighbour pushes against it. */
+  minSize: number;
+  /** Ceiling the panel is clamped to. */
+  maxSize: number;
+}
+
+export interface ResizableConfig {
+  /** Axis the panels are laid along: horizontal = side by side. */
+  direction: ResizableDirection;
+  /** One entry per panel, in DOM order. Length defines the panel count. */
+  panels: ResizablePanelConfig[];
+  /** No drag or key movement while disabled (gates the reducer too). */
+  disabled?: boolean | undefined;
+}
+
+export interface ResizableState {
+  /** Percent per panel, in DOM order. A resize keeps the sum constant. */
+  sizes: number[];
+}
+
+export type ResizableActions = {
+  /** Replace every panel size at once (the pure helper owns the clamp math). */
+  setSizes: { sizes: number[] };
+};
+
+export type ResizablePart = 'root' | 'panel' | 'handle';
+
+/** Clamp a value into an inclusive range. */
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * The new size array after moving the handle between panel `handleIndex` and its
+ * successor by `delta` percent. Faithful port of the oracle's `resizePanels`:
+ * the delta is added to the panel before the handle and removed from the panel
+ * after, then each is clamped to its min (redistributing the shortfall to the
+ * neighbour) and its max. Pure over (sizes, panels) so it is unit-tested with no
+ * DOM and shared by the pointer path (delta from the drag origin) and the
+ * keyboard path (delta from a key).
+ */
+export function resizeSizes(
+  sizes: number[],
+  handleIndex: number,
+  delta: number,
+  panels: ResizablePanelConfig[],
+): number[] {
+  const before = panels[handleIndex];
+  const after = panels[handleIndex + 1];
+  const sizeBefore = sizes[handleIndex];
+  const sizeAfter = sizes[handleIndex + 1];
+  if (!before || !after || sizeBefore === undefined || sizeAfter === undefined) return sizes;
+
+  let newBefore = sizeBefore + delta;
+  let newAfter = sizeAfter - delta;
+
+  if (newBefore < before.minSize) {
+    const shortfall = before.minSize - newBefore;
+    newBefore = before.minSize;
+    newAfter -= shortfall;
+  }
+  if (newAfter < after.minSize) {
+    const shortfall = after.minSize - newAfter;
+    newAfter = after.minSize;
+    newBefore -= shortfall;
+  }
+  newBefore = clamp(newBefore, before.minSize, before.maxSize);
+  newAfter = clamp(newAfter, after.minSize, after.maxSize);
+
+  return sizes.map((size, index) => {
+    if (index === handleIndex) return newBefore;
+    if (index === handleIndex + 1) return newAfter;
+    return size;
+  });
+}
+
+const ARROW_STEP = 1;
+const SHIFT_STEP = 10;
+
+/**
+ * The resize delta a key targets from the current sizes, or `null` when the key
+ * is not a resize key for this direction. Arrows step by 1 (10 with Shift);
+ * Home shrinks the leading panel to its min, End grows it to its max. Right/Down
+ * grow the leading panel, Left/Up shrink it (the visible drag direction).
+ */
+export function keyDelta(
+  key: string,
+  shiftKey: boolean,
+  config: ResizableConfig,
+  sizes: number[],
+  handleIndex: number,
+): number | null {
+  const step = shiftKey ? SHIFT_STEP : ARROW_STEP;
+  const panel = config.panels[handleIndex];
+  const current = sizes[handleIndex];
+  const horizontal = config.direction === 'horizontal';
+  switch (key) {
+    case 'ArrowRight':
+      return horizontal ? step : null;
+    case 'ArrowLeft':
+      return horizontal ? -step : null;
+    case 'ArrowDown':
+      return horizontal ? null : step;
+    case 'ArrowUp':
+      return horizontal ? null : -step;
+    case 'Home':
+      return panel && current !== undefined ? panel.minSize - current : null;
+    case 'End':
+      return panel && current !== undefined ? panel.maxSize - current : null;
+    default:
+      return null;
+  }
+}
+
+/** Keys that resize for a given direction -- the keymap's claim set. */
+function resizeKeysFor(direction: ResizableDirection): ReadonlyArray<string> {
+  return direction === 'horizontal'
+    ? ['ArrowLeft', 'ArrowRight', 'Home', 'End']
+    : ['ArrowUp', 'ArrowDown', 'Home', 'End'];
+}
+
+/**
+ * The separator orientation follows the WAI-ARIA Window Splitter pattern: the
+ * separator line is perpendicular to the group axis, so a horizontally-arranged
+ * group (panels side by side) has a VERTICAL separator, and a vertical group has
+ * a horizontal one.
+ */
+function separatorOrientation(direction: ResizableDirection): 'horizontal' | 'vertical' {
+  return direction === 'horizontal' ? 'vertical' : 'horizontal';
+}
+
+const resizable: Slice<ResizableConfig, ResizableState, ResizableActions, ResizablePart> = {
+  name: 'resizable',
+  parts: {
+    // The group root carries no widget role (it is a plain container); the
+    // handles are the role=separator widgets. Panels are geometry.
+    root: {},
+    panel: { many: true },
+    handle: { many: true, role: 'separator' },
+  },
+  initialState: (config) => ({ sizes: config.panels.map((panel) => panel.defaultSize) }),
+  actions: {
+    // The sizes arrive already clamped/redistributed (resizeSizes owns the math,
+    // since a reducer gets no config). Replacing wholesale keeps the sum stable.
+    setSizes: (_state, { sizes }) => ({ sizes }),
+  },
+  // The gate: a disabled group rejects every resize, so a consumer's onLayout
+  // never fires for a move it would refuse.
+  canDispatch: (_state, action, config) => (action === 'setSizes' ? !config.disabled : true),
+  aria: (_state, config) => ({
+    root: {
+      'data-orientation': config.direction,
+      'data-disabled': config.disabled ? 'true' : undefined,
+    },
+  }),
+  // The pure claim record (Spec 01): these keys resize. The bind computes WHICH
+  // handle (the focused one) and the delta via keyDelta.
+  keymap: (event, _state, part, config) =>
+    part === 'handle' && resizeKeysFor(config.direction).includes(event.key) ? 'setSizes' : null,
+};
+
+/**
+ * Per-instance ARIA for the `handle` many-part (Spec 01: instanceAria). `aria()`
+ * projects one AriaAttrs per part NAME; a handle occurs once per boundary, so its
+ * projection takes the instance value -- the handle index -- and reads the size
+ * of the panel BEFORE it as aria-valuenow (bounded by that panel's min/max). The
+ * handle's data-value equals its index, so the harness's data-value-keyed driver
+ * and this projection agree by construction. The accessible name is a decorator
+ * concern (a separator has no intrinsic text), not projected here.
+ */
+export function resizableHandleAria(
+  value: string,
+  state: ResizableState,
+  config: ResizableConfig,
+): AriaAttrs {
+  const index = Number(value);
+  const panel = config.panels[index];
+  const size = state.sizes[index] ?? panel?.defaultSize ?? 0;
+  return {
+    'aria-orientation': separatorOrientation(config.direction),
+    'aria-valuenow': String(Math.round(size)),
+    'aria-valuemin': String(panel?.minSize ?? 0),
+    'aria-valuemax': String(panel?.maxSize ?? 100),
+    'aria-disabled': config.disabled ? 'true' : undefined,
+  };
+}
+
+// First-class the handle's per-instance projection on the spec (Spec 05's open
+// gap): the harness's generic `assertInstanceAriaFulfillment` reads
+// `spec.instanceAria`, and `compose` does not carry it, so it is attached here.
+export const resizableBehavior: BehaviorSpec<
+  ResizableConfig,
+  ResizableState,
+  ResizableActions,
+  ResizablePart
+> = {
+  ...compose('resizable', resizable),
+  instanceAria: (part, value, state, config) =>
+    part === 'handle' ? resizableHandleAria(value, state, config) : {},
+};
+
+/** The interactive mode for a direction (1D, single axis). */
+function interactiveMode(config: ResizableConfig): InteractiveMode {
+  return config.direction === 'vertical' ? '1d-vertical' : '1d-horizontal';
+}
+
+const HANDLE_SELECTOR = '[data-part="handle"]';
+
+/** The focused handle's index from the DOM, or null. Shared by bind and React. */
+export function focusedHandleIndex(root: HTMLElement): number | null {
+  const activeEl = (root.getRootNode() as Document | ShadowRoot)
+    .activeElement as HTMLElement | null;
+  const handle = activeEl?.closest<HTMLElement>(HANDLE_SELECTOR) ?? null;
+  if (!handle || !root.contains(handle)) return null;
+  const index = Number(handle.dataset['index']);
+  return Number.isInteger(index) ? index : null;
+}
+
+/** Whether the handle at `index` is individually disabled (data-disabled). */
+function handleDisabled(root: HTMLElement, index: number): boolean {
+  const handle = root.querySelector<HTMLElement>(`${HANDLE_SELECTOR}[data-index="${index}"]`);
+  return handle?.dataset['disabled'] === 'true';
+}
+
+/** Strip the role/tabindex the interactive primitive stamps on its surface. The
+ *  surface here is the group root, not a widget, so the stamp is removed after
+ *  create -- the same wipe slider applies. */
+function neutralizeInteractiveAria(surface: HTMLElement): void {
+  surface.removeAttribute('role');
+  surface.removeAttribute('tabindex');
+  surface.removeAttribute('aria-disabled');
+}
+
+export interface ResizableInteractionOptions {
+  /** The interactive surface AND the keyboard host -- the group root. */
+  root: HTMLElement;
+  getConfig: () => ResizableConfig;
+  /** Intrinsic sizes at call time. */
+  getSizes: () => number[];
+  /** Commit a new size array (already clamped by resizeSizes). */
+  commit: (sizes: number[]) => void;
+}
+
+/**
+ * Compose the impure pointer + keyboard surface. Shared verbatim by
+ * `bindResizable` (WC + Astro) and the React controller's effect -- one
+ * composition, three performances, so the drag/keyboard rules can never drift.
+ */
+export function composeResizableInteractions(options: ResizableInteractionOptions): () => void {
+  const { root, getConfig, getSizes, commit } = options;
+
+  let active: number | null = null;
+  // The sizes and pointer fraction at the drag origin: every move applies the
+  // cumulative delta to THIS snapshot (absolute-follow, no accumulation drift).
+  let snapshot: number[] | null = null;
+  let startFraction: number | null = null;
+
+  const setDragging = (index: number | null, on: boolean): void => {
+    if (index === null) return;
+    const handle = root.querySelector<HTMLElement>(`${HANDLE_SELECTOR}[data-index="${index}"]`);
+    if (!handle) return;
+    if (on) handle.setAttribute('data-dragging', 'true');
+    else handle.removeAttribute('data-dragging');
+  };
+
+  const onPointerDown = (event: PointerEvent): void => {
+    if (getConfig().disabled) return;
+    const handle = (event.target as HTMLElement).closest<HTMLElement>(HANDLE_SELECTOR);
+    if (!handle || !root.contains(handle)) return;
+    const index = Number(handle.dataset['index']);
+    if (!Number.isInteger(index) || handleDisabled(root, index)) return;
+    active = index;
+    snapshot = [...getSizes()];
+    startFraction = null;
+    setDragging(index, true);
+  };
+  root.addEventListener('pointerdown', onPointerDown);
+
+  const cleanupInteractive = createInteractive(root, {
+    mode: interactiveMode(getConfig()),
+    disabled: getConfig().disabled ?? false,
+    onMove: (point: NormalizedPoint) => {
+      if (active === null || snapshot === null) return;
+      const fraction = getConfig().direction === 'vertical' ? point.top : point.left;
+      // The press point anchors the drag: the first move records it (no jump),
+      // later moves apply the delta from it.
+      if (startFraction === null) {
+        startFraction = fraction;
+        return;
+      }
+      const delta = (fraction - startFraction) * 100;
+      commit(resizeSizes(snapshot, active, delta, getConfig().panels));
+    },
+  });
+  neutralizeInteractiveAria(root);
+
+  const endDrag = (): void => {
+    setDragging(active, false);
+    active = null;
+    snapshot = null;
+    startFraction = null;
+  };
+  window.addEventListener('pointerup', endDrag);
+  window.addEventListener('pointercancel', endDrag);
+
+  // Keyboard rides the keyboard-handler primitive, on the root so a focused
+  // handle's keydown bubbles up; the handler resolves the focused handle from
+  // the DOM (like slider resolves the focused thumb) and computes the delta.
+  const cleanupKeyboard = createKeyboardHandler(root, {
+    key: ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End'],
+    preventDefault: true,
+    handler: (event) => {
+      const config = getConfig();
+      if (config.disabled) return;
+      const index = focusedHandleIndex(root);
+      if (index === null || handleDisabled(root, index)) return;
+      const delta = keyDelta(event.key, event.shiftKey, config, getSizes(), index);
+      if (delta === null || delta === 0) return;
+      commit(resizeSizes(getSizes(), index, delta, config.panels));
+    },
+  });
+
+  return () => {
+    root.removeEventListener('pointerdown', onPointerDown);
+    window.removeEventListener('pointerup', endDrag);
+    window.removeEventListener('pointercancel', endDrag);
+    cleanupInteractive();
+    cleanupKeyboard();
+  };
+}
+
+/** Read the panel configs the author/server rendered onto the DOM. */
+function readPanels(root: HTMLElement): ResizablePanelConfig[] {
+  return Array.from(root.querySelectorAll<HTMLElement>('[data-part="panel"]')).map((panel) => ({
+    defaultSize: Number(panel.dataset['panelDefault'] ?? panel.dataset['panelSize'] ?? 0),
+    minSize: Number(panel.dataset['panelMin'] ?? 0),
+    maxSize: Number(panel.dataset['panelMax'] ?? 100),
+  }));
+}
+
+/**
+ * The DOM-native binding of the resizable score -- the client the Web Component
+ * and the Astro <script> both import. React (retained-mode) reads the
+ * projections declaratively instead, but composes the SAME
+ * `composeResizableInteractions`.
+ */
+export function bindResizable(root: HTMLElement): () => void {
+  const config: ResizableConfig = {
+    direction: root.dataset['direction'] === 'vertical' ? 'vertical' : 'horizontal',
+    disabled: root.dataset['disabled'] === 'true',
+    panels: readPanels(root),
+  };
+
+  const getPart = (part: string): HTMLElement | null =>
+    part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
+
+  const { memory, dispatch } = createBehavior(resizableBehavior, config);
+
+  const ids = {} as PartIds<ResizablePart>;
+  for (const part of Object.keys(resizableBehavior.parts) as ResizablePart[]) {
+    ids[part] = getPart(part)?.id ?? '';
+  }
+
+  const applyProjection = (el: HTMLElement, attrs: AriaAttrs) => {
+    for (const [name, value] of Object.entries(attrs)) {
+      updateAriaAttribute(el, name as never, value as never, { validate: false });
+    }
+  };
+
+  const render = () => {
+    const state = memory.get();
+    const projection = resizableBehavior.aria(state, config, ids);
+    const rootAttrs = projection.root;
+    if (rootAttrs) applyProjection(root, rootAttrs);
+
+    // Paint each panel's flex-basis and each handle's per-instance ARIA.
+    const panels = Array.from(root.querySelectorAll<HTMLElement>('[data-part="panel"]'));
+    for (const [index, el] of panels.entries()) {
+      const size = state.sizes[index];
+      if (size === undefined) continue;
+      el.style.flexBasis = `${size}%`;
+    }
+    for (const handle of root.querySelectorAll<HTMLElement>(HANDLE_SELECTOR)) {
+      const value = handle.dataset['value'];
+      if (value === undefined) continue;
+      applyProjection(handle, resizableHandleAria(value, state, config));
+    }
+  };
+  const unsubscribe = memory.subscribe(render); // fires immediately: first paint
+
+  const commit = (sizes: number[]): void => {
+    if (!dispatch('setSizes', config, { sizes })) return;
+    root.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+  };
+
+  const stopInteractions = composeResizableInteractions({
+    root,
+    getConfig: () => config,
+    getSizes: () => memory.get().sizes,
+    commit,
+  });
+
+  return () => {
+    unsubscribe();
+    stopInteractions();
+  };
+}

--- a/packages/ui/src/components/resizable/resizable.classes.ts
+++ b/packages/ui/src/components/resizable/resizable.classes.ts
@@ -1,0 +1,64 @@
+import type { ResizableConfig, ResizableDirection, ResizableState } from './resizable.behavior';
+
+export interface ResizableClassSet {
+  root: string;
+  panel: string;
+  handle: string;
+  grip: string;
+  gripIcon: string;
+}
+
+// The group is a flex container; the axis maps directly to flex-direction.
+const baseRootClasses = 'flex h-full w-full';
+
+const rootDirectionClasses: Record<ResizableDirection, string> = {
+  horizontal: 'flex-row',
+  vertical: 'flex-col',
+};
+
+// Panels do not grow/shrink; their flex-basis carries the percent the score
+// paints. `overflow-hidden` keeps content from spilling past a shrunk panel.
+const basePanelClasses = 'relative grow-0 shrink-0 overflow-hidden';
+
+// The handle presentation rides the projected data-attributes (data-disabled,
+// data-dragging), not swapped strings: one class set covers every state and the
+// CSS reads the flags -- so light-DOM markup, the WC, and React look identical.
+// Motion is left undeclared: no semantic motion token exists yet for a
+// separator hover/focus transition (the raw duration the oracle used is
+// prohibited), so the focus ring and drag colour swap apply instantly.
+const baseHandleClasses =
+  'relative flex items-center justify-center bg-border ' +
+  'after:absolute after:inset-y-0 after:left-1/2 after:-translate-x-1/2 ' +
+  'hover:bg-muted ' +
+  'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 ' +
+  'data-[dragging]:bg-primary ' +
+  'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50';
+
+const handleDirectionClasses: Record<ResizableDirection, string> = {
+  horizontal: 'w-px cursor-col-resize after:w-1',
+  vertical: 'h-px cursor-row-resize after:h-1',
+};
+
+// The optional grip affordance (withHandle) -- a small draggable-looking chip.
+const baseGripClasses = 'z-10 flex items-center justify-center rounded-sm border bg-border';
+
+const gripDirectionClasses: Record<ResizableDirection, string> = {
+  horizontal: 'h-4 w-3',
+  vertical: 'h-3 w-4',
+};
+
+const baseGripIconClasses = 'size-2.5';
+
+export function resizableClasses(
+  config: ResizableConfig,
+  _state?: ResizableState,
+): ResizableClassSet {
+  const { direction } = config;
+  return {
+    root: `${baseRootClasses} ${rootDirectionClasses[direction]}`,
+    panel: basePanelClasses,
+    handle: `${baseHandleClasses} ${handleDirectionClasses[direction]}`,
+    grip: `${baseGripClasses} ${gripDirectionClasses[direction]}`,
+    gripIcon: direction === 'horizontal' ? `${baseGripIconClasses} rotate-90` : baseGripIconClasses,
+  };
+}

--- a/packages/ui/src/components/resizable/resizable.element.ts
+++ b/packages/ui/src/components/resizable/resizable.element.ts
@@ -1,0 +1,35 @@
+/**
+ * WC performance for resizable: the thinnest wrapper. The score AND the
+ * DOM-native binding (bindResizable) live in resizable.behavior.ts, shared with
+ * the Astro performance. This file only adapts that binding to the
+ * custom-element lifecycle.
+ *
+ * A light-DOM enhancer: the author (or Astro) provides the real group with its
+ * panel/handle children -- each panel carrying its data-panel-min/max/default
+ * and each handle its role=separator + aria-valuenow -- so the pointer surface
+ * and the separators exist before any JS; the WC never renders a shadow tree of
+ * its own. The bind is deferred one microtask because connectedCallback can fire
+ * before the light-DOM children are parsed (upgrade order).
+ */
+import { bindResizable } from './resizable.behavior';
+
+export class RaftersResizable extends HTMLElement {
+  private teardown: (() => void) | null = null;
+
+  connectedCallback(): void {
+    queueMicrotask(() => {
+      if (!this.isConnected || this.teardown) return;
+      const root = this.querySelector<HTMLElement>('[data-part="root"]');
+      if (root) this.teardown = bindResizable(root);
+    });
+  }
+
+  disconnectedCallback(): void {
+    this.teardown?.();
+    this.teardown = null;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-resizable')) {
+  customElements.define('rafters-resizable', RaftersResizable);
+}

--- a/packages/ui/src/components/resizable/resizable.tsx
+++ b/packages/ui/src/components/resizable/resizable.tsx
@@ -1,0 +1,281 @@
+import * as React from 'react';
+import { createBehavior, type PartIds } from '../../lib/contract';
+import { useMemory } from '../../hooks/use-memory';
+import classy from '../../primitives/classy';
+import {
+  composeResizableInteractions,
+  resizableBehavior,
+  resizableHandleAria,
+  type ResizableConfig,
+  type ResizableDirection,
+  type ResizablePanelConfig,
+  type ResizablePart,
+  type ResizableState,
+} from './resizable.behavior';
+import { resizableClasses, type ResizableClassSet } from './resizable.classes';
+
+export type { ResizableDirection };
+
+/**
+ * Resizable -- the React performance of the resizable score, a compound in the
+ * shadcn/react-resizable-panels shape: `ResizablePanelGroup` provides the
+ * context, `ResizablePanel`s hold arbitrary content, and `ResizableHandle`s sit
+ * between them. The group reads its panels' sizing from their props to seed the
+ * score, assigns each panel/handle its positional index, and composes the ONE
+ * pointer/keyboard surface (`composeResizableInteractions`) -- the same
+ * composition the WC/Astro bind runs. Uncontrolled: layout is reported through
+ * `onLayout`, never shadowed by an external prop.
+ *
+ * @cognitive-load 3/10 - decision 1, information 1, interaction 1, disruption 0,
+ * learning 0. One spatial trade-off along a shared edge; the panel sizes are the
+ * only information to read. A universally learned grab/arrow affordance, no
+ * workflow disruption, nothing to learn.
+ * @attention-economics Near-zero standing cost: both panels stay visible and the
+ * edge only draws attention on hover or focus. The control communicates the
+ * current allocation continuously without competing for the eye; best when the
+ * user, not the layout, should own the space trade-off.
+ * @trust-building Immediate, reversible feedback -- the boundary tracks the
+ * pointer and every arrow key in real time, min/max clamps keep a panel from
+ * vanishing, and the disabled gate freezes an unavailable split while keeping it
+ * discoverable.
+ * @accessibility Each handle is a role="separator" with aria-valuenow/min/max and
+ * aria-orientation, wired to real DOM by the harness (WAI-ARIA Window Splitter).
+ * Arrow keys along the group axis resize (Shift x10), Home/End reach the leading
+ * panel's bounds; every handle is a tab stop and carries an accessible name.
+ * Disabled removes the handles from the tab order and gates all movement.
+ */
+
+interface ResizableContextValue {
+  direction: ResizableDirection;
+  disabled: boolean;
+  state: ResizableState;
+  config: ResizableConfig;
+  classes: ResizableClassSet;
+}
+
+const ResizableContext = React.createContext<ResizableContextValue | null>(null);
+
+function useResizableContext(component: string): ResizableContextValue {
+  const context = React.useContext(ResizableContext);
+  if (!context) {
+    throw new Error(`${component} must be used within <ResizablePanelGroup>`);
+  }
+  return context;
+}
+
+/** Internal: the positional index the group injects into each child. */
+interface InjectedIndex {
+  __resizableIndex?: number;
+}
+
+export interface ResizablePanelProps extends React.HTMLAttributes<HTMLDivElement>, InjectedIndex {
+  /** Initial size (percent). Defaults to an equal share of the group. */
+  defaultSize?: number;
+  /** Floor (percent) the panel is clamped to. */
+  minSize?: number;
+  /** Ceiling (percent) the panel is clamped to. */
+  maxSize?: number;
+}
+
+export function ResizablePanel({
+  defaultSize,
+  minSize,
+  maxSize,
+  __resizableIndex = 0,
+  className,
+  children,
+  style,
+  ...rest
+}: ResizablePanelProps) {
+  const { state, config, classes } = useResizableContext('ResizablePanel');
+  const size = state.sizes[__resizableIndex] ?? config.panels[__resizableIndex]?.defaultSize ?? 0;
+  return (
+    <div
+      data-part="panel"
+      data-index={__resizableIndex}
+      className={classy(classes.panel, className)}
+      style={{ flexBasis: `${size}%`, ...style }}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}
+
+export interface ResizableHandleProps extends React.HTMLAttributes<HTMLDivElement>, InjectedIndex {
+  /** Render the grip affordance (a draggable-looking chip). */
+  withHandle?: boolean;
+  /** Individually disable this handle (in addition to a disabled group). */
+  disabled?: boolean;
+}
+
+export function ResizableHandle({
+  withHandle = false,
+  disabled = false,
+  __resizableIndex = 0,
+  className,
+  'aria-label': ariaLabel = 'Resize',
+  ...rest
+}: ResizableHandleProps) {
+  const {
+    disabled: groupDisabled,
+    state,
+    config,
+    classes,
+  } = useResizableContext('ResizableHandle');
+  const effectiveDisabled = disabled || groupDisabled;
+  const aria = resizableHandleAria(String(__resizableIndex), state, config);
+  return (
+    <div
+      role="separator"
+      data-part="handle"
+      data-index={__resizableIndex}
+      data-value={__resizableIndex}
+      data-disabled={effectiveDisabled || undefined}
+      tabIndex={effectiveDisabled ? -1 : 0}
+      aria-label={ariaLabel}
+      className={classy(classes.handle, className)}
+      {...aria}
+      {...rest}
+    >
+      {withHandle && (
+        <div className={classes.grip}>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={classes.gripIcon}
+            aria-hidden="true"
+          >
+            <title>Drag handle</title>
+            <circle cx="12" cy="5" r="1" />
+            <circle cx="12" cy="12" r="1" />
+            <circle cx="12" cy="19" r="1" />
+          </svg>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export interface ResizablePanelGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+  direction?: ResizableDirection;
+  /** Fires on every committed resize with the sizes the layout now holds. */
+  onLayout?: (sizes: number[]) => void;
+  disabled?: boolean;
+}
+
+/** Panel sizing configs read from the group's Panel children, in DOM order. */
+function readPanelConfigs(children: React.ReactNode): ResizablePanelConfig[] {
+  const panels = React.Children.toArray(children).filter(
+    (child): child is React.ReactElement<ResizablePanelProps> =>
+      React.isValidElement(child) && child.type === ResizablePanel,
+  );
+  const share = panels.length > 0 ? 100 / panels.length : 100;
+  return panels.map((panel) => ({
+    defaultSize: panel.props.defaultSize ?? share,
+    minSize: panel.props.minSize ?? 0,
+    maxSize: panel.props.maxSize ?? 100,
+  }));
+}
+
+export function ResizablePanelGroup({
+  direction = 'horizontal',
+  onLayout,
+  disabled = false,
+  className,
+  children,
+  ...rest
+}: ResizablePanelGroupProps) {
+  const panelConfigs = readPanelConfigs(children);
+  const config: ResizableConfig = { direction, panels: panelConfigs, disabled };
+
+  const { memory, dispatch } = React.useMemo(() => createBehavior(resizableBehavior, config), []);
+  const state = useMemory(memory);
+
+  const rootRef = React.useRef<HTMLDivElement | null>(null);
+
+  // Effect-composed interactions must read the CURRENT config and callback, so
+  // those ride in a ref rather than being captured stale.
+  const latest = React.useRef({ config, onLayout });
+  latest.current = { config, onLayout };
+
+  const commit = React.useCallback(
+    (sizes: number[]) => {
+      if (!dispatch('setSizes', latest.current.config, { sizes })) return;
+      latest.current.onLayout?.(sizes);
+    },
+    [dispatch],
+  );
+
+  // Compose the ONE pointer/keyboard surface -- the same composition the bind
+  // runs. Re-created only when direction/disabled change (interactive fixes its
+  // mode at create; panels are read live via getConfig).
+  React.useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    return composeResizableInteractions({
+      root,
+      getConfig: () => latest.current.config,
+      getSizes: () => memory.get().sizes,
+      commit,
+    });
+  }, [direction, disabled, commit, memory]);
+
+  const uid = React.useId();
+  const ids = {} as PartIds<ResizablePart>;
+  for (const part of Object.keys(resizableBehavior.parts) as ResizablePart[])
+    ids[part] = `${uid}-${part}`;
+  const aria = resizableBehavior.aria(state, config, ids);
+  const classes = resizableClasses(config, state);
+
+  const contextValue: ResizableContextValue = {
+    direction,
+    disabled,
+    state,
+    config,
+    classes,
+  };
+
+  // Assign each panel/handle its positional index by cloning the direct
+  // children -- deterministic (children render in order) and pure (derived from
+  // the children prop), no runtime registration.
+  let panelIndex = 0;
+  let handleIndex = 0;
+  const decorated = React.Children.map(children, (child) => {
+    if (!React.isValidElement(child)) return child;
+    if (child.type === ResizablePanel) {
+      return React.cloneElement(child as React.ReactElement<InjectedIndex>, {
+        __resizableIndex: panelIndex++,
+      });
+    }
+    if (child.type === ResizableHandle) {
+      return React.cloneElement(child as React.ReactElement<InjectedIndex>, {
+        __resizableIndex: handleIndex++,
+      });
+    }
+    return child;
+  });
+
+  return (
+    <ResizableContext.Provider value={contextValue}>
+      <div
+        ref={rootRef}
+        data-part="root"
+        id={ids.root}
+        data-direction={direction}
+        className={classy(classes.root, className)}
+        {...aria.root}
+        {...rest}
+      >
+        {decorated}
+      </div>
+    </ResizableContext.Provider>
+  );
+}
+
+export default ResizablePanelGroup;

--- a/packages/ui/test/components/resizable/conformance-suite.ts
+++ b/packages/ui/test/components/resizable/conformance-suite.ts
@@ -1,0 +1,222 @@
+/**
+ * Resizable conformance suite -- one suite, run per render adapter. The React
+ * and WC conformance tests are each their adapter plus a call into
+ * runResizableConformance. Astro drives the same score from its own file.
+ */
+import { describe, expect, it } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import {
+  resizableBehavior,
+  type ResizableConfig,
+  type ResizableDirection,
+} from '../../../src/components/resizable/resizable.behavior';
+import {
+  assertAxeClean,
+  assertContractFulfillment,
+  assertInstanceAriaFulfillment,
+  partElement,
+  partElements,
+  type RenderResult,
+} from '../../harness/conformance';
+
+export interface ScenarioPanel {
+  defaultSize: number;
+  minSize?: number;
+  maxSize?: number;
+}
+
+export interface ResizableScenarioProps {
+  direction?: ResizableDirection;
+  panels: ScenarioPanel[];
+  disabled?: boolean;
+  withHandle?: boolean;
+}
+
+export interface ResizableAdapter {
+  name: string;
+  /** Every scenario carries an accessible name applied to each handle (a
+   *  separator has no intrinsic text). */
+  render(props: ResizableScenarioProps, label: string): RenderResult | Promise<RenderResult>;
+}
+
+interface Scenario {
+  name: string;
+  props: ResizableScenarioProps;
+}
+
+const SCENARIOS: ReadonlyArray<Scenario> = [
+  { name: 'two panels horizontal', props: { panels: [{ defaultSize: 50 }, { defaultSize: 50 }] } },
+  {
+    name: 'three panels with a grip',
+    props: {
+      withHandle: true,
+      panels: [{ defaultSize: 25 }, { defaultSize: 50 }, { defaultSize: 25 }],
+    },
+  },
+  {
+    name: 'vertical split',
+    props: { direction: 'vertical', panels: [{ defaultSize: 40 }, { defaultSize: 60 }] },
+  },
+  {
+    name: 'bounded panels',
+    props: {
+      panels: [
+        { defaultSize: 30, minSize: 20, maxSize: 60 },
+        { defaultSize: 70, minSize: 40, maxSize: 80 },
+      ],
+    },
+  },
+  {
+    name: 'disabled',
+    props: { disabled: true, panels: [{ defaultSize: 50 }, { defaultSize: 50 }] },
+  },
+];
+
+const EXPECTED_PARTS = ['root', 'panel', 'handle'] as const;
+
+export function configFor(props: ResizableScenarioProps): ResizableConfig {
+  const share = props.panels.length > 0 ? 100 / props.panels.length : 100;
+  return {
+    direction: props.direction ?? 'horizontal',
+    disabled: props.disabled ?? false,
+    panels: props.panels.map((panel) => ({
+      defaultSize: panel.defaultSize ?? share,
+      minSize: panel.minSize ?? 0,
+      maxSize: panel.maxSize ?? 100,
+    })),
+  };
+}
+
+export function runResizableConformance(adapter: ResizableAdapter): void {
+  describe(`resizable conformance [${adapter.name}]`, () => {
+    for (const scenario of SCENARIOS) {
+      it(`${scenario.name}: parts and aria match the behavior projection`, async () => {
+        const result = await adapter.render(scenario.props, 'Resize section');
+        try {
+          const config = configFor(scenario.props);
+          const state = resizableBehavior.initialState(config);
+          assertContractFulfillment(resizableBehavior, result.root, state, config, EXPECTED_PARTS);
+          assertInstanceAriaFulfillment(resizableBehavior, result.root, state, config);
+        } finally {
+          result.cleanup();
+        }
+      });
+
+      it(`${scenario.name}: one fewer separator than panels, each role=separator`, async () => {
+        const result = await adapter.render(scenario.props, 'Resize section');
+        try {
+          const panels = partElements(result.root, 'panel');
+          const handles = partElements(result.root, 'handle');
+          expect(panels.length).toBe(scenario.props.panels.length);
+          expect(handles.length).toBe(scenario.props.panels.length - 1);
+          for (const handle of handles) {
+            expect(handle.getAttribute('role')).toBe('separator');
+            // The genuine per-instance ARIA is exercised (not skipped): a
+            // focusable separator must carry a numeric aria-valuenow.
+            expect(Number(handle.getAttribute('aria-valuenow'))).not.toBeNaN();
+            expect(handle.getAttribute('aria-valuemin')).not.toBeNull();
+            expect(handle.getAttribute('aria-valuemax')).not.toBeNull();
+          }
+        } finally {
+          result.cleanup();
+        }
+      });
+
+      it(`${scenario.name}: axe clean`, async () => {
+        const result = await adapter.render(scenario.props, 'Resize section');
+        try {
+          await assertAxeClean(result.host);
+        } finally {
+          result.cleanup();
+        }
+      });
+    }
+
+    it('the first handle reports the leading panel size as aria-valuenow', async () => {
+      const result = await adapter.render(
+        { panels: [{ defaultSize: 30 }, { defaultSize: 70 }] },
+        'Resize section',
+      );
+      try {
+        const handle = partElement(result.root, 'handle');
+        expect(handle?.getAttribute('aria-valuenow')).toBe('30');
+      } finally {
+        result.cleanup();
+      }
+    });
+
+    it('ArrowRight grows the leading panel, ArrowLeft shrinks it', async () => {
+      const result = await adapter.render(
+        { panels: [{ defaultSize: 50 }, { defaultSize: 50 }] },
+        'Resize section',
+      );
+      try {
+        const handle = partElement(result.root, 'handle');
+        expect(handle?.getAttribute('aria-valuenow')).toBe('50');
+        const user = userEvent.setup();
+        handle?.focus();
+        await user.keyboard('{ArrowRight}');
+        expect(handle?.getAttribute('aria-valuenow')).toBe('51');
+        await user.keyboard('{ArrowLeft}');
+        expect(handle?.getAttribute('aria-valuenow')).toBe('50');
+      } finally {
+        result.cleanup();
+      }
+    });
+
+    it('Shift+Arrow moves ten, Home/End reach the leading panel bounds', async () => {
+      const result = await adapter.render(
+        { panels: [{ defaultSize: 50, minSize: 10, maxSize: 90 }, { defaultSize: 50 }] },
+        'Resize section',
+      );
+      try {
+        const handle = partElement(result.root, 'handle');
+        const user = userEvent.setup();
+        handle?.focus();
+        await user.keyboard('{Shift>}{ArrowRight}{/Shift}');
+        expect(handle?.getAttribute('aria-valuenow')).toBe('60');
+        await user.keyboard('{Home}');
+        expect(handle?.getAttribute('aria-valuenow')).toBe('10');
+        await user.keyboard('{End}');
+        expect(handle?.getAttribute('aria-valuenow')).toBe('90');
+      } finally {
+        result.cleanup();
+      }
+    });
+
+    it('vertical: ArrowDown grows the leading panel', async () => {
+      const result = await adapter.render(
+        { direction: 'vertical', panels: [{ defaultSize: 40 }, { defaultSize: 60 }] },
+        'Resize section',
+      );
+      try {
+        const handle = partElement(result.root, 'handle');
+        expect(handle?.getAttribute('aria-orientation')).toBe('horizontal');
+        const user = userEvent.setup();
+        handle?.focus();
+        await user.keyboard('{ArrowDown}');
+        expect(handle?.getAttribute('aria-valuenow')).toBe('41');
+      } finally {
+        result.cleanup();
+      }
+    });
+
+    it('disabled: separators leave the tab order and keys do not resize', async () => {
+      const result = await adapter.render(
+        { disabled: true, panels: [{ defaultSize: 50 }, { defaultSize: 50 }] },
+        'Resize section',
+      );
+      try {
+        const handle = partElement(result.root, 'handle');
+        expect(handle?.getAttribute('tabindex')).toBe('-1');
+        expect(handle?.getAttribute('aria-disabled')).toBe('true');
+        const user = userEvent.setup();
+        handle?.focus();
+        await user.keyboard('{ArrowRight}');
+        expect(handle?.getAttribute('aria-valuenow')).toBe('50');
+      } finally {
+        result.cleanup();
+      }
+    });
+  });
+}

--- a/packages/ui/test/components/resizable/resizable.astro.conformance.test.ts
+++ b/packages/ui/test/components/resizable/resizable.astro.conformance.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Astro render adapter + the shared resizable conformance suite. AstroContainer
+ * renders the SSR markup with the score's initial projection + flex geometry
+ * already applied, but does NOT run the <script>, so the adapter calls
+ * bindResizable directly -- that IS the script's job -- then drives the same
+ * score the React and WC performances drive. One score, three performances.
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { afterEach } from 'vitest';
+import Resizable from '../../../src/components/resizable/resizable.astro';
+import { bindResizable } from '../../../src/components/resizable/resizable.behavior';
+import type { RenderResult } from '../../harness/conformance';
+import {
+  runResizableConformance,
+  type ResizableAdapter,
+  type ResizableScenarioProps,
+} from './conformance-suite';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const astroAdapter: ResizableAdapter = {
+  name: 'astro',
+  async render(props: ResizableScenarioProps, label): Promise<RenderResult> {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(Resizable, {
+      props: {
+        id: 'r',
+        direction: props.direction,
+        panels: props.panels,
+        withHandle: props.withHandle,
+        disabled: props.disabled,
+        handleLabel: label,
+      },
+    });
+    // Scope the host to a wrapper (like the React/WC adapters) rather than
+    // document.body, so axe's page-level `region` landmark rule -- irrelevant to
+    // a resizable fragment -- does not fire on the detached SSR markup.
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = html;
+    document.body.appendChild(wrapper);
+    const root = wrapper.querySelector<HTMLElement>('[data-part="root"]');
+    if (!root) throw new Error('astro adapter: no root');
+    bindResizable(root); // the <script> does this per instance on the real page
+    return {
+      host: wrapper,
+      root,
+      cleanup: () => {
+        wrapper.remove();
+      },
+    };
+  },
+};
+
+runResizableConformance(astroAdapter);

--- a/packages/ui/test/components/resizable/resizable.behavior.test.ts
+++ b/packages/ui/test/components/resizable/resizable.behavior.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Pure score tests for resizable -- no DOM. Exercises the reducer, the clamp
+ * math (resizeSizes), the key-to-delta projection (keyDelta), the aria/keymap
+ * projections, and the disabled gate.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  keyDelta,
+  resizableBehavior,
+  resizableHandleAria,
+  resizeSizes,
+  type ResizableConfig,
+  type ResizablePanelConfig,
+} from '../../../src/components/resizable/resizable.behavior';
+
+const PANELS: ResizablePanelConfig[] = [
+  { defaultSize: 50, minSize: 10, maxSize: 90 },
+  { defaultSize: 50, minSize: 10, maxSize: 90 },
+];
+
+function configFor(overrides: Partial<ResizableConfig> = {}): ResizableConfig {
+  return { direction: 'horizontal', panels: PANELS, disabled: false, ...overrides };
+}
+
+describe('resizable initialState', () => {
+  it('seeds sizes from each panel defaultSize', () => {
+    const state = resizableBehavior.initialState(configFor());
+    expect(state.sizes).toEqual([50, 50]);
+  });
+
+  it('seeds an arbitrary panel count', () => {
+    const panels: ResizablePanelConfig[] = [
+      { defaultSize: 20, minSize: 0, maxSize: 100 },
+      { defaultSize: 30, minSize: 0, maxSize: 100 },
+      { defaultSize: 50, minSize: 0, maxSize: 100 },
+    ];
+    expect(resizableBehavior.initialState(configFor({ panels })).sizes).toEqual([20, 30, 50]);
+  });
+});
+
+describe('resizeSizes', () => {
+  it('moves the boundary: delta grows the leading panel, shrinks the next', () => {
+    expect(resizeSizes([50, 50], 0, 10, PANELS)).toEqual([60, 40]);
+  });
+
+  it('keeps the sum constant', () => {
+    const next = resizeSizes([50, 50], 0, 7.5, PANELS);
+    expect((next[0] ?? 0) + (next[1] ?? 0)).toBeCloseTo(100);
+  });
+
+  it('clamps the leading panel to its min and redistributes the shortfall', () => {
+    // -45 would take panel 0 to 5, below min 10: it stops at 10 and panel 1
+    // only receives the honoured 40.
+    expect(resizeSizes([50, 50], 0, -45, PANELS)).toEqual([10, 90]);
+  });
+
+  it('clamps the trailing panel to its min', () => {
+    expect(resizeSizes([50, 50], 0, 45, PANELS)).toEqual([90, 10]);
+  });
+
+  it('caps the leading panel at its maxSize (the oracle does not redistribute the excess)', () => {
+    const capped: ResizablePanelConfig[] = [
+      { defaultSize: 50, minSize: 0, maxSize: 60 },
+      { defaultSize: 50, minSize: 0, maxSize: 100 },
+    ];
+    // +30 would take panel 0 to 80; it stops at its max 60 while panel 1 still
+    // gives up the full 30 -- a faithful port of the oracle's one-sided max clamp.
+    expect(resizeSizes([50, 50], 0, 30, capped)).toEqual([60, 20]);
+  });
+
+  it('only touches the two panels around the handle', () => {
+    const three: ResizablePanelConfig[] = [
+      { defaultSize: 30, minSize: 0, maxSize: 100 },
+      { defaultSize: 40, minSize: 0, maxSize: 100 },
+      { defaultSize: 30, minSize: 0, maxSize: 100 },
+    ];
+    expect(resizeSizes([30, 40, 30], 1, 10, three)).toEqual([30, 50, 20]);
+  });
+
+  it('is a no-op for an out-of-range handle index', () => {
+    expect(resizeSizes([50, 50], 5, 10, PANELS)).toEqual([50, 50]);
+  });
+});
+
+describe('keyDelta', () => {
+  it('horizontal: Right grows, Left shrinks the leading panel', () => {
+    const config = configFor();
+    expect(keyDelta('ArrowRight', false, config, [50, 50], 0)).toBe(1);
+    expect(keyDelta('ArrowLeft', false, config, [50, 50], 0)).toBe(-1);
+  });
+
+  it('horizontal: vertical arrows do not resize', () => {
+    const config = configFor();
+    expect(keyDelta('ArrowUp', false, config, [50, 50], 0)).toBeNull();
+    expect(keyDelta('ArrowDown', false, config, [50, 50], 0)).toBeNull();
+  });
+
+  it('vertical: Down grows, Up shrinks; horizontal arrows do not resize', () => {
+    const config = configFor({ direction: 'vertical' });
+    expect(keyDelta('ArrowDown', false, config, [50, 50], 0)).toBe(1);
+    expect(keyDelta('ArrowUp', false, config, [50, 50], 0)).toBe(-1);
+    expect(keyDelta('ArrowRight', false, config, [50, 50], 0)).toBeNull();
+  });
+
+  it('Shift multiplies the step to ten', () => {
+    expect(keyDelta('ArrowRight', true, configFor(), [50, 50], 0)).toBe(10);
+  });
+
+  it('Home targets the leading panel min, End its max (as a delta)', () => {
+    const config = configFor();
+    expect(keyDelta('Home', false, config, [50, 50], 0)).toBe(-40); // 10 - 50
+    expect(keyDelta('End', false, config, [50, 50], 0)).toBe(40); // 90 - 50
+  });
+
+  it('returns null for a non-resize key', () => {
+    expect(keyDelta('Enter', false, configFor(), [50, 50], 0)).toBeNull();
+  });
+});
+
+describe('keymap', () => {
+  it('claims the horizontal-axis keys on a handle', () => {
+    const config = configFor();
+    const state = resizableBehavior.initialState(config);
+    for (const key of ['ArrowLeft', 'ArrowRight', 'Home', 'End']) {
+      expect(resizableBehavior.keymap({ key }, state, 'handle', config)).toBe('setSizes');
+    }
+    expect(resizableBehavior.keymap({ key: 'ArrowUp' }, state, 'handle', config)).toBeNull();
+  });
+
+  it('claims the vertical-axis keys when the group is vertical', () => {
+    const config = configFor({ direction: 'vertical' });
+    const state = resizableBehavior.initialState(config);
+    expect(resizableBehavior.keymap({ key: 'ArrowDown' }, state, 'handle', config)).toBe(
+      'setSizes',
+    );
+    expect(resizableBehavior.keymap({ key: 'ArrowLeft' }, state, 'handle', config)).toBeNull();
+  });
+
+  it('never claims a key off a handle', () => {
+    const config = configFor();
+    const state = resizableBehavior.initialState(config);
+    expect(resizableBehavior.keymap({ key: 'ArrowRight' }, state, 'root', config)).toBeNull();
+    expect(resizableBehavior.keymap({ key: 'ArrowRight' }, state, 'panel', config)).toBeNull();
+  });
+});
+
+describe('aria projection', () => {
+  it('projects orientation and no disabled flag by default', () => {
+    const config = configFor();
+    const state = resizableBehavior.initialState(config);
+    const aria = resizableBehavior.aria(state, config, { root: 'r', panel: 'p', handle: 'h' });
+    expect(aria.root).toEqual({ 'data-orientation': 'horizontal', 'data-disabled': undefined });
+  });
+
+  it('projects the disabled flag when disabled', () => {
+    const config = configFor({ disabled: true });
+    const state = resizableBehavior.initialState(config);
+    const aria = resizableBehavior.aria(state, config, { root: 'r', panel: 'p', handle: 'h' });
+    expect(aria.root?.['data-disabled']).toBe('true');
+  });
+});
+
+describe('resizableHandleAria (instanceAria)', () => {
+  it('reads the leading panel size as aria-valuenow, bounded by its min/max', () => {
+    const config = configFor();
+    const state = { sizes: [60, 40] };
+    expect(resizableHandleAria('0', state, config)).toEqual({
+      'aria-orientation': 'vertical',
+      'aria-valuenow': '60',
+      'aria-valuemin': '10',
+      'aria-valuemax': '90',
+      'aria-disabled': undefined,
+    });
+  });
+
+  it('flips the separator orientation for a vertical group', () => {
+    const config = configFor({ direction: 'vertical' });
+    const state = resizableBehavior.initialState(config);
+    expect(resizableHandleAria('0', state, config)['aria-orientation']).toBe('horizontal');
+  });
+
+  it('rounds a fractional size', () => {
+    expect(resizableHandleAria('0', { sizes: [33.4, 66.6] }, configFor())['aria-valuenow']).toBe(
+      '33',
+    );
+  });
+
+  it('marks the separator disabled when the group is disabled', () => {
+    const config = configFor({ disabled: true });
+    expect(resizableHandleAria('0', { sizes: [50, 50] }, config)['aria-disabled']).toBe('true');
+  });
+});
+
+describe('canDispatch disabled gate', () => {
+  it('rejects setSizes while disabled', () => {
+    const config = configFor({ disabled: true });
+    const state = resizableBehavior.initialState(config);
+    expect(resizableBehavior.canDispatch(state, 'setSizes', config)).toBe(false);
+  });
+
+  it('allows setSizes while enabled', () => {
+    const config = configFor();
+    const state = resizableBehavior.initialState(config);
+    expect(resizableBehavior.canDispatch(state, 'setSizes', config)).toBe(true);
+  });
+});

--- a/packages/ui/test/components/resizable/resizable.classes.test.ts
+++ b/packages/ui/test/components/resizable/resizable.classes.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resizableBehavior,
+  type ResizableConfig,
+} from '../../../src/components/resizable/resizable.behavior';
+import { resizableClasses } from '../../../src/components/resizable/resizable.classes';
+
+const base: ResizableConfig = {
+  direction: 'horizontal',
+  panels: [
+    { defaultSize: 50, minSize: 10, maxSize: 90 },
+    { defaultSize: 50, minSize: 10, maxSize: 90 },
+  ],
+  disabled: false,
+};
+
+function classesFor(config: ResizableConfig) {
+  return resizableClasses(config, resizableBehavior.initialState(config));
+}
+
+describe('resizable classes', () => {
+  it('root is a flex container that follows the horizontal axis', () => {
+    const { root } = classesFor(base);
+    expect(root).toContain('flex');
+    expect(root).toContain('h-full');
+    expect(root).toContain('w-full');
+    expect(root).toContain('flex-row');
+  });
+
+  it('vertical root stacks the column', () => {
+    expect(classesFor({ ...base, direction: 'vertical' }).root).toContain('flex-col');
+  });
+
+  it('panel is a fixed-basis, clipped cell', () => {
+    const { panel } = classesFor(base);
+    expect(panel).toContain('grow-0');
+    expect(panel).toContain('shrink-0');
+    expect(panel).toContain('overflow-hidden');
+  });
+
+  it('handle carries the border rail, focus ring, and data-driven state styling', () => {
+    const { handle } = classesFor(base);
+    expect(handle).toContain('bg-border');
+    expect(handle).toContain('focus-visible:ring-ring');
+    expect(handle).toContain('data-[dragging]:bg-primary');
+    expect(handle).toContain('data-[disabled]:opacity-50');
+    expect(handle).toContain('cursor-col-resize');
+  });
+
+  it('vertical handle uses the row-resize cursor and horizontal rail', () => {
+    const { handle } = classesFor({ ...base, direction: 'vertical' });
+    expect(handle).toContain('cursor-row-resize');
+    expect(handle).toContain('h-px');
+  });
+
+  it('declares no raw duration or easing literal (motion undeclared)', () => {
+    const { handle, root, panel } = classesFor(base);
+    for (const cls of [handle, root, panel]) {
+      expect(cls).not.toMatch(/duration-\d/);
+      expect(cls).not.toMatch(/duration-\[/);
+      expect(cls).not.toMatch(/ease-\[/);
+    }
+  });
+
+  it('grip icon rotates only in the horizontal axis', () => {
+    expect(classesFor(base).gripIcon).toContain('rotate-90');
+    expect(classesFor({ ...base, direction: 'vertical' }).gripIcon).not.toContain('rotate-90');
+  });
+});

--- a/packages/ui/test/components/resizable/resizable.conformance.test.tsx
+++ b/packages/ui/test/components/resizable/resizable.conformance.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * React render adapter + the shared resizable conformance suite, plus the
+ * compound-only onLayout proof.
+ */
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from '../../../src/components/resizable/resizable';
+import type { RenderResult } from '../../harness/conformance';
+import {
+  runResizableConformance,
+  type ResizableAdapter,
+  type ResizableScenarioProps,
+} from './conformance-suite';
+
+function tree(props: ResizableScenarioProps, label: string): React.ReactElement {
+  const children: React.ReactNode[] = [];
+  for (const [index, panel] of props.panels.entries()) {
+    children.push(
+      <ResizablePanel
+        key={`panel-${index}`}
+        defaultSize={panel.defaultSize}
+        minSize={panel.minSize}
+        maxSize={panel.maxSize}
+      />,
+    );
+    if (index < props.panels.length - 1) {
+      children.push(
+        <ResizableHandle
+          key={`handle-${index}`}
+          withHandle={props.withHandle}
+          aria-label={label}
+        />,
+      );
+    }
+  }
+  return (
+    <ResizablePanelGroup direction={props.direction} disabled={props.disabled}>
+      {children}
+    </ResizablePanelGroup>
+  );
+}
+
+const reactAdapter: ResizableAdapter = {
+  name: 'react',
+  render(props, label): RenderResult {
+    const utils = render(tree(props, label));
+    const root = utils.container.querySelector<HTMLElement>('[data-part="root"]');
+    if (!root) throw new Error('react adapter: no [data-part="root"] rendered');
+    return { host: utils.container, root, cleanup: () => utils.unmount() };
+  },
+};
+
+runResizableConformance(reactAdapter);
+
+describe('resizable onLayout [react]', () => {
+  it('reports the new sizes on every committed resize', async () => {
+    const layouts: number[][] = [];
+    const { container } = render(
+      <ResizablePanelGroup onLayout={(sizes) => layouts.push(sizes)}>
+        <ResizablePanel defaultSize={50} minSize={10} maxSize={90} />
+        <ResizableHandle aria-label="Resize" />
+        <ResizablePanel defaultSize={50} minSize={10} maxSize={90} />
+      </ResizablePanelGroup>,
+    );
+    const handle = container.querySelector<HTMLElement>('[data-part="handle"]');
+    if (!handle) throw new Error('no handle');
+    const user = userEvent.setup();
+    handle.focus();
+    await user.keyboard('{ArrowRight}');
+    expect(layouts.at(-1)).toEqual([51, 49]);
+    await user.keyboard('{Shift>}{ArrowRight}{/Shift}');
+    expect(layouts.at(-1)).toEqual([61, 39]);
+  });
+
+  it('does not fire onLayout while disabled', async () => {
+    const layouts: number[][] = [];
+    const { container } = render(
+      <ResizablePanelGroup disabled onLayout={(sizes) => layouts.push(sizes)}>
+        <ResizablePanel defaultSize={50} />
+        <ResizableHandle aria-label="Resize" />
+        <ResizablePanel defaultSize={50} />
+      </ResizablePanelGroup>,
+    );
+    const handle = container.querySelector<HTMLElement>('[data-part="handle"]');
+    const user = userEvent.setup();
+    handle?.focus();
+    await user.keyboard('{ArrowRight}');
+    expect(layouts).toEqual([]);
+  });
+});

--- a/packages/ui/test/components/resizable/resizable.element.conformance.test.ts
+++ b/packages/ui/test/components/resizable/resizable.element.conformance.test.ts
@@ -1,0 +1,111 @@
+/**
+ * WC render adapter + the shared resizable conformance suite.
+ *
+ * The Web Component is a light-DOM enhancer: the author provides the real group
+ * with its panel/handle children so the pointer surface and the role=separator
+ * handles exist before JS. This adapter server-renders that markup with the
+ * score's initial projection + flex geometry already applied -- what Astro emits
+ * -- then lets RaftersResizable hand the root to bindResizable (the SAME
+ * controller the React binding composes).
+ */
+import { beforeAll } from 'vitest';
+import {
+  resizableBehavior,
+  resizableHandleAria,
+  type ResizableConfig,
+} from '../../../src/components/resizable/resizable.behavior';
+import { resizableClasses } from '../../../src/components/resizable/resizable.classes';
+import { RaftersResizable } from '../../../src/components/resizable/resizable.element';
+import type { RenderResult } from '../../harness/conformance';
+import {
+  configFor,
+  runResizableConformance,
+  type ResizableAdapter,
+  type ResizableScenarioProps,
+} from './conformance-suite';
+
+beforeAll(() => {
+  if (!customElements.get('rafters-resizable')) {
+    customElements.define('rafters-resizable', RaftersResizable);
+  }
+});
+
+function applyAria(
+  element: HTMLElement,
+  attrs: Record<string, string | boolean | undefined>,
+): void {
+  for (const [name, value] of Object.entries(attrs)) {
+    if (value === undefined) continue;
+    element.setAttribute(name, String(value));
+  }
+}
+
+function buildRoot(config: ResizableConfig, label: string, withHandle: boolean): HTMLElement {
+  const state = resizableBehavior.initialState(config);
+  const classes = resizableClasses(config, state);
+  const aria = resizableBehavior.aria(state, config, { root: '', panel: '', handle: '' });
+
+  const root = document.createElement('div');
+  root.dataset['part'] = 'root';
+  root.id = 'wc-root';
+  root.dataset['direction'] = config.direction;
+  root.className = classes.root;
+  if (aria.root) applyAria(root, aria.root);
+
+  for (const [index, panel] of config.panels.entries()) {
+    const panelEl = document.createElement('div');
+    panelEl.dataset['part'] = 'panel';
+    panelEl.dataset['index'] = String(index);
+    panelEl.dataset['panelDefault'] = String(panel.defaultSize);
+    panelEl.dataset['panelMin'] = String(panel.minSize);
+    panelEl.dataset['panelMax'] = String(panel.maxSize);
+    panelEl.className = classes.panel;
+    panelEl.style.flexBasis = `${state.sizes[index]}%`;
+    root.appendChild(panelEl);
+
+    if (index < config.panels.length - 1) {
+      const handle = document.createElement('div');
+      handle.setAttribute('role', 'separator');
+      handle.dataset['part'] = 'handle';
+      handle.dataset['index'] = String(index);
+      handle.dataset['value'] = String(index);
+      if (config.disabled) handle.dataset['disabled'] = 'true';
+      handle.tabIndex = config.disabled ? -1 : 0;
+      handle.setAttribute('aria-label', label);
+      handle.className = classes.handle;
+      applyAria(handle, resizableHandleAria(String(index), state, config));
+      if (withHandle) {
+        const grip = document.createElement('div');
+        grip.className = classes.grip;
+        handle.appendChild(grip);
+      }
+      root.appendChild(handle);
+    }
+  }
+
+  return root;
+}
+
+const wcAdapter: ResizableAdapter = {
+  name: 'wc',
+  async render(props: ResizableScenarioProps, label): Promise<RenderResult> {
+    const config = configFor(props);
+    const hostEl = document.createElement('rafters-resizable');
+    hostEl.appendChild(buildRoot(config, label, props.withHandle ?? false));
+    document.body.appendChild(hostEl);
+    // connectedCallback defers the bind one microtask (upgrade order); wait for it.
+    await Promise.resolve();
+
+    const root = hostEl.querySelector<HTMLElement>('[data-part="root"]');
+    if (!root) throw new Error('wc adapter: no root');
+    return {
+      host: hostEl,
+      root,
+      cleanup: () => {
+        hostEl.remove();
+      },
+    };
+  },
+};
+
+runResizableConformance(wcAdapter);


### PR DESCRIPTION
## Summary

Ports `resizable` to the behavior layer as one score and three decorators. The
score's only state axis is `sizes` (percent per panel); dragging is ephemeral
bind-local state, exactly the split slider draws. Pointer drag composes the
`interactive` primitive on the group root (gated so only a press that lands on a
handle resizes, since a 1px handle has no meaningful rect), and keyboard resize
composes `keyboard-handler` on the focused handle -- both feed the single pure
`resizeSizes` clamp/redistribute helper, faithfully ported from the oracle's
`resizePanels`. Handles are `role="separator"` with
aria-valuenow/min/max/orientation per the WAI-ARIA Window Splitter pattern,
replacing the oracle's `role="slider"` and its inverted aria-orientation. React
is a compound (context + children in the shadcn PanelGroup/Panel/Handle shape);
the WC and Astro performances drive the shared `bindResizable`.

The drag/pointer primitive fit: the drag-drop primitive (`createDraggable`) is
the wrong shape (it stamps role=button/aria-grabbed/draggable + dropzone
semantics); `interactive` is the right follow-pointer surface but stamps
role=slider, so its stamp is neutralized on the group root exactly as slider
does, and its normalized point is converted to a boundary delta from the drag
origin.

## Acceptance criteria mapping

### Component doc written

`docs/spec/components/resizable.md` is modeled on dialog.md and describes THIS
component row by row: composition, config/state/actions, a parts+ARIA table, the
keyboard map, the oracle-disposition table (contract / defect-do-not-port /
dropped labelled against the actual code), and the WCAG obligations.
Evidence: packages/ui/docs/spec/components/resizable.md:1

### JSDoc intelligence tags present

The React performance carries all four registry-parsed tags -- `@cognitive-load`
with the five-dimension breakdown, `@attention-economics`, `@trust-building`,
and `@accessibility` -- on the component's leading JSDoc block.
Evidence: packages/ui/src/components/resizable/resizable.tsx:29

### Behavior test (pure, no DOM)

`resizable.behavior.test.ts` exercises the score with no DOM: `resizeSizes`
clamp/redistribute cases, `keyDelta` per direction and modifier, the keymap
claims, the aria and `resizableHandleAria` projections, and the disabled gate.
Evidence: packages/ui/test/components/resizable/resizable.behavior.test.ts:41

### Classes parity test

`resizable.classes.test.ts` asserts the class projection: the flex root and
direction variants, the fixed-basis panel, the data-attr-driven handle state
styling, and an explicit assertion that no raw duration/easing literal is emitted.
Evidence: packages/ui/test/components/resizable/resizable.classes.test.ts:48

### Conformance test via the shared harness (aria + keymap against rendered DOM)

One `conformance-suite.ts` runs `assertContractFulfillment` +
`assertInstanceAriaFulfillment` and drives arrow/Home/End keydowns against
rendered DOM, inherited by React, WC, and Astro adapters -- so the separator ARIA
and keymap are checked against real markup in all three frameworks.
Evidence: packages/ui/test/components/resizable/conformance-suite.ts:66

### shadcn drop-in parity where the component exists in shadcn

The React API keeps the shadcn names and props -- `ResizablePanelGroup`
(direction, onLayout), `ResizablePanel` (defaultSize/minSize/maxSize),
`ResizableHandle` (withHandle, disabled) -- as a compositional context+children
tree; unwired oracle-only features (collapse, autoSaveId) are dropped, not faked.
Evidence: packages/ui/src/components/resizable/resizable.tsx:186

### `pnpm --filter @rafters/ui test:unit` green, `pnpm preflight` green

The full unit suite passes (main config 445 files / 6907 tests, astro config 52
files / 300 tests, exit 0) and `pnpm preflight` completes exit 0 across
typecheck, lint, format:check, test:unit, test:a11y, and build.
Evidence: packages/ui/test/components/resizable/resizable.conformance.test.tsx:1

## Not done

- Collapse/expand (`collapsible`, `collapsedSize`, `onCollapse`, `onExpand`) is
  dropped and labelled `dropped` in the disposition table: it is outside the
  drag-resize contract the issue enumerates (`States: sizes, dragging`), and the
  unwired props are deliberately not accepted in the API.
- `autoSaveId` localStorage persistence (and its `sizesEqual` dedup export) is
  dropped: a localStorage side effect has no place in the pure score, and
  persistence is a consumer concern.
- Motion is left undeclared: no semantic `motion-*` token yet fits a separator
  hover/focus transition, and the oracle's raw `duration-100` is prohibited. To
  be reinstated when the motion-token layer lands (#1899/#1902).
- Astro per-panel content rides `panels[i].content` data rather than N named
  slots, because Astro forbids a dynamic `slot name`.
- No shared-file edits (components.jsonl is deleted, no CHANGELOG/components.md)
  and no package.json export entries, per the issue's parallel-safe port rules.

Closes #1788
