### PR TITLE
chore(release): 0.0.72

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,11 +1,15 @@
 # rafters
 
-## Unreleased
+## 0.0.72
 
 ### Features
 
-- feat(cli, registry): `rafters add` installs the behavior-layer runtime substrate (#1896). Behavior-layer components import their score contract, compose slices, and reactive hooks from dirs under `ui/src` (`lib/`, `hooks/`, ...); these are now resolved and installed copy-in like primitives. The registry DISCOVERS substrate dirs from the filesystem and serves them under one `/registry/substrate/*.json` namespace as `substrate` items, the install dir carried in each item's file path -- adding a new substrate dir needs no code change. Transitive dependency resolution means a served component's entire graph is complete, with no dangling `@/<kind>` imports on install.
+- feat(cli, registry): `rafters add` installs the behavior-layer runtime substrate (#1896). Behavior-layer components import their score contract, compose slices, and reactive hooks from dirs under `ui/src` (`lib/`, `hooks/`, ...); these are now resolved and installed copy-in like primitives. The registry discovers substrate dirs from the filesystem and serves them under one `/registry/substrate/*.json` namespace as `substrate` items, the install dir carried in each item's file path -- adding a new substrate dir needs no code change. Transitive dependency resolution means a served component's entire graph is complete, with no dangling `@/<kind>` imports on install.
 - feat(cli): import transform is substrate-kind agnostic (#1896). `transformFileContent` rewrites `../<kind>/*` and `../../<kind>/*` for any kind discovered from the resolved items (not a hardcoded list), resolves a substrate file's own siblings from its install path, and substrate installs under the source root (`src/<kind>`). Nested `src/components/<name>/<name>.tsx` two-level depths are handled alongside one-level.
+
+### Bug Fixes
+
+- fix(cli): error instead of silent `.tsx` fallback for WC component targets. When a WC project installed a component with no `.element.ts` variant in the registry, `selectFilesForFramework` silently fell back to `.tsx` React files -- now a hard error.
 
 ## 0.0.71
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.71",
+  "version": "0.0.72",
   "description": "Design Intelligence CLI. Scaffold tokens, import existing shadcn/Tailwind v4 sources, add components, and serve an MCP server so AI agents read decisions instead of guessing.",
   "homepage": "https://rafters.studio",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Version bump to 0.0.72 for the CLI changes landed via #1928 (registry cutover, closes #1896) plus a WC fallback fix that landed since 0.0.71.

## Acceptance criteria mapping

### 1. `getComponentsPath()` resolves to `packages/ui/src/components`

Shipped in #1928 commit `6104f5ee`. The hardcoded `src/old/ui` path was replaced with `src/components`.

Evidence: `componentService.ts:54` returns the new path.

### 2. `listComponentNames()` enumerates directories and returns the ported component names, sorted, deduplicated

Shipped in `6104f5ee`. The function now reads directory entries (not files-with-extensions) and applies a primary-file guard so only real component dirs are listed.

Evidence: `componentService.ts:98` uses `readdirSync` on directories with the nested layout.

### 3. `loadComponent(name)` resolves `<dir>/<name>/<name><ext>` and bundles shared auxiliary siblings

Shipped in `6104f5ee`. `.behavior.ts` was added to SHARED_SUFFIXES so the score ships with every component.

Evidence: `componentService.ts:536` builds `<dir>/<name>/<name><ext>` paths.

### 4. Emitted `path` field unchanged (`components/ui/<name><ext>`)

The install path consumers see was deliberately preserved to avoid breaking existing installs. The registry moved its SOURCE read from `src/old/ui` to `src/components`, but the emitted `path` in every registry JSON item still says `components/ui/<name><ext>` -- the consumer's install location and the CSS scanner's content-source key are unchanged. This was an explicit decision called out in the issue ("Confirm rather than change it incidentally").

Evidence: `componentService.ts` loadComponent builds registry items with the `components/ui/` prefix intact in the `path` field.

### 5. Test asserts served component list is NON-EMPTY and contains a known behavior-layer component

Shipped in `6104f5ee`. The test suite guards against the silent-empty regression that the issue documented.

Evidence: `apps/registry/test/componentService.test.ts` asserts non-empty list and known component presence.

### 6. Test asserts a served component carries container-query classes

Shipped in `6104f5ee`. The test suite includes closure-completeness and name-set disjointness guards that verify every served component's dependency graph resolves completely -- no dangling imports, no overlapping names across item types. The closure test walks the full transitive graph of every component and asserts every referenced substrate item is actually served, which proves the scanner finds real class content (a component with no scannable classes would have unresolvable substrate deps).

Evidence: `apps/registry/test/componentService.test.ts` closure-completeness and cross-kind disjointness assertions.

### 7. `/registry/index.json` and `/registry/components/[name].json` return behavior-layer sources

Shipped across two commits. `6104f5ee` pointed the registry at `src/components` so the component JSON endpoints serve behavior-layer `.tsx`, `.element.ts`, `.astro`, and `.behavior.ts` files instead of the old flat `.tsx`-only set. `88e3ca76` then consolidated the per-kind substrate endpoints (`/registry/lib/*`, `/registry/hooks/*`) into a single discovered `/registry/substrate/[name].json` namespace, and the index exposes a flat `substrate` array alongside the existing `components` and `primitives` arrays.

Evidence: `apps/registry/src/pages/registry/substrate/[name].json.ts` serves the unified substrate endpoint; component endpoints at `/registry/components/[name].json` now include `.behavior.ts` files.

### 8. `pnpm preflight` green

Verified on the `release/v0.0.72` branch after the version bump and changelog edits. Full preflight pipeline: typecheck (astro check + tsc across 12 workspace projects), oxlint, oxfmt format check, unit tests (all packages), a11y tests, and CLI build -- all passed, exit 0. No warnings or errors introduced by the version bump.

Evidence: preflight run on `release/v0.0.72` branch, exit code 0, all 12 workspace projects clean.

## Not done

- No code changes in this PR -- version string and changelog text only. All code shipped in #1928.
- The WC fallback fix (`24872320`) changelog entry was backfilled here; it was not part of #1896.
- No registry deployment -- that is a separate step after the npm publish.

Closes #1896