### PR TITLE
feat(design-tokens, cli, studio): documentation CSS export + hot-reload fixes

### DIFF
--- a/packages/cli/src/utils/exports.ts
+++ b/packages/cli/src/utils/exports.ts
@@ -7,6 +7,7 @@ export interface ExportConfig {
   typescript: boolean;
   dtcg: boolean;
   compiled: boolean;
+  documentation: boolean;
 }
 
 export const DEFAULT_EXPORTS: ExportConfig = {
@@ -14,6 +15,7 @@ export const DEFAULT_EXPORTS: ExportConfig = {
   typescript: true,
   dtcg: false,
   compiled: false,
+  documentation: false,
 };
 
 export interface ExportChoice {
@@ -44,6 +46,11 @@ export const EXPORT_CHOICES: ExportChoice[] = [
     value: 'compiled',
     checked: false,
   },
+  {
+    name: 'Documentation CSS (complete utility surface for docs/previews)',
+    value: 'documentation',
+    checked: false,
+  },
 ];
 
 // Future exports - shown as disabled
@@ -71,6 +78,7 @@ export function selectionsToConfig(selections: string[]): ExportConfig {
     typescript: selections.includes('typescript'),
     dtcg: selections.includes('dtcg'),
     compiled: selections.includes('compiled'),
+    documentation: selections.includes('documentation'),
   };
 }
 
@@ -83,5 +91,6 @@ export function configToSelections(config: ExportConfig): string[] {
   if (config.typescript) selections.push('typescript');
   if (config.dtcg) selections.push('dtcg');
   if (config.compiled) selections.push('compiled');
+  if (config.documentation) selections.push('documentation');
   return selections;
 }

--- a/packages/cli/test/integration/init.integration.test.ts
+++ b/packages/cli/test/integration/init.integration.test.ts
@@ -43,6 +43,7 @@ describe('rafters init - fresh initialization', () => {
       typescript: true,
       dtcg: false,
       compiled: false,
+      documentation: false,
     });
     expect(config.installed).toEqual({
       components: [],

--- a/packages/design-tokens/src/exporters/index.ts
+++ b/packages/design-tokens/src/exporters/index.ts
@@ -11,6 +11,7 @@ export { type ToDTCGOptions, toDTCG } from './dtcg.js';
 export {
   type CompiledCssOptions,
   registryToCompiled,
+  registryToDocumentation,
   registryToTailwind,
   registryToTailwindStatic,
   type TailwindExportOptions,

--- a/packages/design-tokens/src/exporters/tailwind.ts
+++ b/packages/design-tokens/src/exporters/tailwind.ts
@@ -1212,3 +1212,176 @@ export async function registryToCompiled(
     rmSync(tempDir, { recursive: true, force: true });
   }
 }
+
+const COLOR_UTILITIES = [
+  'bg',
+  'text',
+  'border',
+  'ring',
+  'outline',
+  'fill',
+  'stroke',
+  'accent',
+  'caret',
+  'decoration',
+  'divide',
+  'shadow',
+  'placeholder',
+] as const;
+
+const SPACING_UTILITIES = [
+  'p',
+  'px',
+  'py',
+  'pt',
+  'pr',
+  'pb',
+  'pl',
+  'm',
+  'mx',
+  'my',
+  'mt',
+  'mr',
+  'mb',
+  'ml',
+  'gap',
+  'gap-x',
+  'gap-y',
+  'w',
+  'h',
+  'size',
+  'inset',
+  'top',
+  'right',
+  'bottom',
+  'left',
+  'space-x',
+  'space-y',
+] as const;
+
+const RADIUS_UTILITIES = [
+  'rounded',
+  'rounded-t',
+  'rounded-r',
+  'rounded-b',
+  'rounded-l',
+  'rounded-tl',
+  'rounded-tr',
+  'rounded-br',
+  'rounded-bl',
+] as const;
+
+const STATE_VARIANTS = ['hover', 'focus-visible', 'focus', 'active', 'dark'] as const;
+
+/**
+ * Derive the complete set of Tailwind utility candidates from theme custom
+ * properties. Each --color-<slug> becomes bg-<slug>, text-<slug>, etc.; each
+ * --spacing-<slug> becomes p-<slug>, m-<slug>, gap-<slug>, etc. The result is
+ * the exhaustive base utility surface the token graph can produce -- no
+ * component scanning required.
+ */
+function deriveCandidates(themeCSS: string): string[] {
+  const themeVarNames: string[] = [];
+  const themeBlockRe = /@theme\s*(?:inline\s*)?\{([^}]*)\}/gs;
+  let blockMatch: RegExpExecArray | null;
+  while ((blockMatch = themeBlockRe.exec(themeCSS)) !== null) {
+    const block = blockMatch[1] ?? '';
+    const varRe = /--([a-z][a-z0-9-]*)\s*:/g;
+    let varMatch: RegExpExecArray | null;
+    while ((varMatch = varRe.exec(block)) !== null) {
+      if (varMatch[1]) themeVarNames.push(varMatch[1]);
+    }
+  }
+
+  const candidates = new Set<string>();
+
+  for (const name of themeVarNames) {
+    if (name.startsWith('color-')) {
+      const slug = name.slice(6);
+      for (const p of COLOR_UTILITIES) candidates.add(`${p}-${slug}`);
+    } else if (name.startsWith('spacing-')) {
+      const slug = name.slice(8);
+      for (const p of SPACING_UTILITIES) candidates.add(`${p}-${slug}`);
+    } else if (name.startsWith('radius-')) {
+      const slug = name.slice(7);
+      for (const p of RADIUS_UTILITIES) candidates.add(`${p}-${slug}`);
+    } else if (name.startsWith('shadow-') && !/-(blur|spread|offset|color|inset)/.test(name)) {
+      candidates.add(`shadow-${name.slice(7)}`);
+    } else if (name.startsWith('font-size-')) {
+      candidates.add(`text-${name.slice(10)}`);
+    } else if (name.startsWith('font-weight-')) {
+      candidates.add(`font-${name.slice(12)}`);
+    } else if (name.startsWith('ease-')) {
+      candidates.add(name);
+    } else if (name.startsWith('animate-')) {
+      candidates.add(name);
+    }
+  }
+
+  const base = [...candidates];
+  for (const variant of STATE_VARIANTS) {
+    for (const c of base) {
+      candidates.add(`${variant}:${c}`);
+    }
+  }
+
+  return [...candidates];
+}
+
+/**
+ * Produce the complete documentation stylesheet -- every utility the token
+ * graph can emit at base + state variants, compiled via Tailwind with no
+ * component scanning. Veneer treeshakes the result at bake time; during dev
+ * it is adopted whole via constructable stylesheets.
+ */
+export async function registryToDocumentation(
+  registry: TokenRegistry,
+  options: { minify?: boolean } = {},
+): Promise<string> {
+  const { minify = true } = options;
+  const themeBody = registryToTailwind(registry, { includeImport: false });
+  const candidates = deriveCandidates(themeBody);
+
+  const { mkdtempSync, writeFileSync, rmSync } = await import('node:fs');
+  const { join, dirname } = await import('node:path');
+  const { createRequire } = await import('node:module');
+
+  const require = createRequire(import.meta.url);
+  let pkgDir: string;
+  try {
+    const pkgJsonPath = require.resolve('@tailwindcss/cli/package.json');
+    pkgDir = dirname(pkgJsonPath);
+  } catch {
+    throw new Error(
+      'Failed to resolve @tailwindcss/cli -- install it to generate documentation CSS',
+    );
+  }
+
+  const tempDir = mkdtempSync(join(pkgDir, '.tmp-doc-compile-'));
+  const candidateFile = join(tempDir, 'candidates.txt');
+  writeFileSync(candidateFile, candidates.join('\n'));
+
+  const sourceDirective = `@source "${candidateFile}";`;
+  const input = `@import "tailwindcss" source(none);\n${sourceDirective}\n${themeBody}`;
+
+  const tempInput = join(tempDir, 'input.css');
+  const tempOutput = join(tempDir, 'output.css');
+
+  try {
+    writeFileSync(tempInput, input);
+
+    const { execFileSync } = await import('node:child_process');
+    const binPath = join(pkgDir, 'dist', 'index.mjs');
+    const args = [binPath, '-i', tempInput, '-o', tempOutput];
+    if (minify) args.push('--minify');
+    execFileSync('node', args, { stdio: 'pipe', timeout: 60_000, cwd: pkgDir });
+
+    const { readFileSync } = await import('node:fs');
+    return readFileSync(tempOutput, 'utf-8');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to compile documentation CSS: ${message}`);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}

--- a/packages/design-tokens/src/outputs.ts
+++ b/packages/design-tokens/src/outputs.ts
@@ -5,7 +5,8 @@
  * Every trigger (CLI init, CLI add/update, studio token mutation, the file
  * watch) funnels through {@link regenerateOutputs}. There is exactly one
  * function that writes `rafters.css` / `rafters.ts` / `rafters.json` /
- * `rafters.standalone.css` and fires the HMR notification, so the emitted set
+ * `rafters.standalone.css` / `rafters.documentation.css` and fires the HMR
+ * notification, so the emitted set
  * can never drift between callers and there is no second regen/HMR mechanism.
  *
  * Token persistence (saveRegistryToDir) stays the caller's concern -- it is a
@@ -16,7 +17,11 @@ import { existsSync, realpathSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { isAbsolute, join, resolve } from 'node:path';
 import { toDTCG } from './exporters/dtcg.js';
-import { registryToCompiled, registryToTailwind } from './exporters/tailwind.js';
+import {
+  registryToCompiled,
+  registryToDocumentation,
+  registryToTailwind,
+} from './exporters/tailwind.js';
 import { registryToTypeScript } from './exporters/typescript.js';
 import type { TokenRegistry } from './registry.js';
 
@@ -26,6 +31,7 @@ export interface OutputExports {
   typescript: boolean;
   dtcg: boolean;
   compiled: boolean;
+  documentation: boolean;
 }
 
 export interface RegenerateOutputsInput {
@@ -148,6 +154,12 @@ export async function regenerateOutputs(
     const compiled = await registryToCompiled(registry, { contentSources });
     await writeFile(join(outputDir, 'rafters.standalone.css'), compiled);
     written.push('rafters.standalone.css');
+  }
+
+  if (exports.documentation) {
+    const doc = await registryToDocumentation(registry);
+    await writeFile(join(outputDir, 'rafters.documentation.css'), doc);
+    written.push('rafters.documentation.css');
   }
 
   hooks.notify?.();

--- a/packages/studio/src/api/vite-plugin.ts
+++ b/packages/studio/src/api/vite-plugin.ts
@@ -81,7 +81,13 @@ const configPath = join(projectPath, '.rafters', 'config.rafters.json');
  * a changed config (e.g. a newly added namespace) is honored.
  */
 interface StudioConfig {
-  exports?: { tailwind: boolean; typescript: boolean; dtcg: boolean; compiled: boolean };
+  exports?: {
+    tailwind: boolean;
+    typescript: boolean;
+    dtcg: boolean;
+    compiled: boolean;
+    documentation: boolean;
+  };
   componentsPath?: string | Array<string | { path: string }>;
   primitivesPath?: string | Array<string | { path: string }>;
   compositesPath?: string | Array<string | { path: string }>;
@@ -642,9 +648,10 @@ export function studioApiPlugin(): Plugin {
         const config = await loadStudioConfig();
         const exports = config?.exports ?? {
           tailwind: true,
-          typescript: false,
+          typescript: true,
           dtcg: false,
           compiled: false,
+          documentation: false,
         };
         await regenerateOutputs(
           registry,
@@ -694,14 +701,21 @@ export function studioApiPlugin(): Plugin {
       };
 
       {
-        const watchConfig = await loadStudioConfig();
-        const classDirs = watchConfig ? resolveContentSources(projectPath, watchConfig) : [];
-        const watchTargets = [
-          join(tokensDir, '*.rafters.json'),
-          configPath,
-          ...classDirs.map((dir) => join(dir, '**/*.classes.ts')),
-        ];
-        server.watcher.add(watchTargets);
+        const trackedClassDirs = new Set<string>();
+
+        const syncWatchTargets = async (): Promise<void> => {
+          const watchConfig = await loadStudioConfig();
+          const classDirs = watchConfig ? resolveContentSources(projectPath, watchConfig) : [];
+          const newDirs = classDirs.filter((d) => !trackedClassDirs.has(d));
+          if (newDirs.length > 0) {
+            server.watcher.add(newDirs.map((dir) => join(dir, '**/*.classes.ts')));
+            for (const d of newDirs) trackedClassDirs.add(d);
+          }
+        };
+
+        server.watcher.add([join(tokensDir, '*.rafters.json'), configPath]);
+        await syncWatchTargets();
+
         let debounce: ReturnType<typeof setTimeout> | null = null;
         const onChange = (changed: string): void => {
           const watched =
@@ -711,7 +725,11 @@ export function studioApiPlugin(): Plugin {
           if (!watched) return;
           if (debounce) clearTimeout(debounce);
           debounce = setTimeout(() => {
-            void reloadAndRegenerate();
+            const isConfigChange = changed === configPath;
+            const run = isConfigChange
+              ? syncWatchTargets().then(reloadAndRegenerate)
+              : reloadAndRegenerate();
+            void run;
           }, 150);
         };
         server.watcher.on('change', onChange);


### PR DESCRIPTION
## Summary

New `documentation` export produces `rafters.documentation.css` -- the complete utility surface derived from the token graph. Plus two hot-reload fixes in the studio vite plugin.

## Acceptance criteria mapping

### 1. `ExportConfig` and `OutputExports` include `documentation: boolean`

`ExportConfig` at exports.ts:9 and `OutputExports` at outputs.ts:28 both carry the new field. The two interfaces mirror each other by design (the doc comment on `OutputExports` says "Mirrors the CLI's ExportConfig").

Evidence: exports.ts:5-10 (`ExportConfig`), outputs.ts:24-29 (`OutputExports`).

### 2. `DEFAULT_EXPORTS.documentation` is `false`

Set at exports.ts:16. Documentation CSS is opt-in -- veneer sets it when installed.

Evidence: exports.ts:12-17.

### 3. `regenerateOutputs` writes `rafters.documentation.css` when `exports.documentation` is true

New branch at outputs.ts:153-157 follows the same gate-call-write-push pattern as the four existing exports. Calls `registryToDocumentation(registry)` and writes to `join(outputDir, 'rafters.documentation.css')`.

Evidence: outputs.ts:153-157.

### 4. `registryToDocumentation` derives candidates from the theme CSS and compiles without content sources

`deriveCandidates` (tailwind.ts:1283) parses `@theme` blocks for custom property names, maps them to Tailwind utility classes (color -> bg/text/border/ring/etc, spacing -> p/m/gap/w/h/etc, radius -> rounded-*, shadow, font-size, font-weight, ease, animate), then crosses with state variants. `registryToDocumentation` (tailwind.ts:1343) writes candidates to a temp file and compiles via `@source "<candidateFile>"` with `source(none)` -- zero component scanning.

Evidence: tailwind.ts:1283-1395, the `deriveCandidates` and `registryToDocumentation` functions.

### 5. The documentation sheet contains utilities no component references (e.g. `.bg-panel`)

Verified by toy spike before implementation: loaded the lab token registry, generated candidates, compiled. Output contained `.bg-panel` (which standalone.css misses because no component references it), `.bg-surface`, and all state variants.

Evidence: toy spike output -- `.bg-panel: true`, `hover:bg-*: true`, `dark:bg-*: true`.

### 6. The documentation sheet contains state variants (`hover:bg-*`, `dark:bg-*`)

`STATE_VARIANTS` at tailwind.ts:1269 defines the five variant prefixes (hover, focus-visible, focus, active, dark). `deriveCandidates` crosses every base candidate with every variant.

Evidence: tailwind.ts:1269, tailwind.ts:1329-1334.

### 7. Studio vite-plugin default fallback matches `DEFAULT_EXPORTS` (typescript: true)

Fixed at vite-plugin.ts:650. Was `typescript: false`, now `typescript: true`. Also includes the new `documentation: false` field.

Evidence: vite-plugin.ts:648-655.

### 8. Studio watcher re-resolves content source dirs on config file change

`syncWatchTargets` (vite-plugin.ts:705) tracks known class dirs in a `Set<string>` and adds newly-discovered dirs via `server.watcher.add`. The `onChange` handler (vite-plugin.ts:721) calls `syncWatchTargets()` before `reloadAndRegenerate()` when the changed file is `configPath`.

Evidence: vite-plugin.ts:703-716 (`syncWatchTargets`), vite-plugin.ts:726-729 (config-change branch in `onChange`).

### 9. `pnpm preflight` green

Full preflight (typecheck, lint, format, unit tests, a11y tests, build) passed with exit 0 on this branch.

Evidence: preflight run on `feat/documentation-css-export`, exit 0.

## Not done

- No veneer install/configure flow -- blocked on unratified specs (FR-VEN-033/034)
- No responsive variant cross-product (breakpoints/containers explode the sheet to 14-18MB)
- No changes to the registry app, CLI add command, or component serving
- The `registryToCompiled` / `registryToDocumentation` Tailwind CLI boilerplate is not extracted to a shared helper -- two call sites with different input assembly, timeout, and temp dir naming; extraction costs more than the duplication saves

Closes #1931