### PR TITLE
chore(release): 0.0.73

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # rafters
 
+## 0.0.73
+
+### Features
+
+- feat(design-tokens, cli, studio): documentation CSS export (#1931). New `exports.documentation` flag produces `rafters.documentation.css` -- the complete utility surface derived from the token graph at base + state variants (hover/focus-visible/focus/active/dark), compiled via Tailwind with no component scanning. The output is the sheet veneer adopts whole for live previews and treeshakes at bake.
+
+### Bug Fixes
+
+- fix(studio): vite-plugin default export fallback now matches `DEFAULT_EXPORTS` (`typescript` was incorrectly `false`).
+- fix(studio): vite-plugin watcher re-resolves content source dirs on config change so a newly added component path is picked up without a dev server restart.
+
 ## 0.0.72
 
 ### Features

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "description": "Design Intelligence CLI. Scaffold tokens, import existing shadcn/Tailwind v4 sources, add components, and serve an MCP server so AI agents read decisions instead of guessing.",
   "homepage": "https://rafters.studio",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Version bump to 0.0.73 for the documentation CSS export and studio hot-reload fixes landed via #1932 (closes #1931).

## Acceptance criteria mapping

### 1. `ExportConfig` and `OutputExports` include `documentation: boolean`

Shipped in #1932. Both interfaces carry the new field, mirroring each other by design.

Evidence: exports.ts:9, outputs.ts:28.

### 2. `DEFAULT_EXPORTS.documentation` is `false`

Shipped in #1932. The `DEFAULT_EXPORTS` constant sets `documentation: false` so the documentation sheet is not generated by default -- it is an opt-in export, gated the same way `compiled` and `dtcg` are. A fresh `rafters init` without explicit export selection produces no `rafters.documentation.css`. Veneer sets the flag when installed.

Evidence: exports.ts:12-17 (`DEFAULT_EXPORTS` object).

### 3. `regenerateOutputs` writes `rafters.documentation.css` when `exports.documentation` is true

Shipped in #1932. New conditional branch calls `registryToDocumentation` and writes the file.

Evidence: outputs.ts:153-157.

### 4. `registryToDocumentation` derives candidates from the theme CSS and compiles without content sources

Shipped in #1932. `deriveCandidates` parses `@theme` custom properties and maps them to utility classes, crosses with state variants. Compiled via Tailwind CLI with `source(none)` and a generated candidate file.

Evidence: tailwind.ts:1283-1395.

### 5. The documentation sheet contains utilities no component references (e.g. `.bg-panel`)

Verified by toy spike before implementation. The sheet contains `.bg-panel` which standalone.css misses because no component references it.

Evidence: toy spike output confirmed `.bg-panel: true`.

### 6. The documentation sheet contains state variants (`hover:bg-*`, `dark:bg-*`)

Shipped in #1932. `STATE_VARIANTS` defines five prefixes; `deriveCandidates` crosses every base candidate with every variant.

Evidence: tailwind.ts:1269, tailwind.ts:1329-1334.

### 7. Studio vite-plugin default fallback matches `DEFAULT_EXPORTS` (typescript: true)

Shipped in #1932. The `regenerate` closure in the vite plugin falls back to a hardcoded exports object when `config.exports` is null (no config file). The `typescript` field was `false`, which meant a project without a persisted config would silently skip TypeScript output regeneration during studio dev. Corrected to `true` to match `DEFAULT_EXPORTS`. The fallback object also now includes `documentation: false`.

Evidence: vite-plugin.ts:648-655 (the fallback object in `regenerate`).

### 8. Studio watcher re-resolves content source dirs on config file change

Shipped in #1932. `syncWatchTargets` tracks dirs in a `Set` and adds newly-discovered dirs on config change.

Evidence: vite-plugin.ts:703-716.

### 9. `pnpm preflight` green

Full preflight pipeline verified on the `release/v0.0.73` branch: typecheck (astro check + tsc across 12 workspace projects), oxlint, oxfmt format check, unit tests (all packages including the integration test that was fixed for the new `documentation` field in #1932), a11y tests, and CLI build -- all passed with exit 0. No warnings or errors introduced by the version bump.

Evidence: preflight run on `release/v0.0.73`, exit code 0, all 12 workspace projects clean.

## Not done

- No code changes in this PR -- version string and changelog text only.
- All code shipped in #1932.

Closes #1931