### PR TITLE
fix(registry): analyze shared file deps so behavior imports reach the primitives list

### DIFF
--- a/apps/registry/src/lib/registry/componentService.ts
+++ b/apps/registry/src/lib/registry/componentService.ts
@@ -99,10 +99,6 @@ const SHARED_SUFFIXES = ['.behavior.ts', '.classes.ts', '.types.ts', '.constants
 const IMPORT_REGEX =
   /import\s+(?:type\s+)?(?:(?:\{[^}]*\}|\*\s+as\s+\w+|\w+)\s+from\s+)?['"]([^'"]+)['"]/g;
 
-/** Same pattern but excludes "import type" to avoid treating type-only imports as deps */
-const VALUE_IMPORT_REGEX =
-  /import\s+(?:(?:\{[^}]*\}|\*\s+as\s+\w+|\w+)\s+from\s+)?['"]([^'"]+)['"]/g;
-
 /**
  * List all available component names.
  * `src/components` is NESTED: each component is a directory (`button/`) whose
@@ -712,8 +708,15 @@ export function loadComponent(name: string): RegistryItem | null {
     if (loadedPaths.has(sharedFilePath)) continue;
     try {
       const content = readFileSync(sharedPath, 'utf-8');
-      files.push({ path: sharedFilePath, content, dependencies: [], devDependencies: [] });
+      const analysis = analyzeSource(content, false);
+      files.push({
+        path: sharedFilePath,
+        content,
+        dependencies: analysis.allExternalDeps,
+        devDependencies: analysis.devDependencies,
+      });
       loadedPaths.add(sharedFilePath);
+      primitivesAll = [...new Set([...primitivesAll, ...analysis.primitiveDeps])];
     } catch {
       // No shared file -- skip
     }
@@ -729,8 +732,15 @@ export function loadComponent(name: string): RegistryItem | null {
         if (loadedPaths.has(filePath)) continue;
         try {
           const content = readFileSync(join(componentDir, `${sibling}.ts`), 'utf-8');
-          files.push({ path: filePath, content, dependencies: [], devDependencies: [] });
+          const analysis = analyzeSource(content, false);
+          files.push({
+            path: filePath,
+            content,
+            dependencies: analysis.allExternalDeps,
+            devDependencies: analysis.devDependencies,
+          });
           loadedPaths.add(filePath);
+          primitivesAll = [...new Set([...primitivesAll, ...analysis.primitiveDeps])];
         } catch {
           // Not found -- skip
         }
@@ -988,17 +998,14 @@ export function extractSiblingImports(content: string): string[] {
  * @param isPrimitive - If true, ./foo imports are treated as sibling primitives
  */
 function extractPrimitiveDependencies(content: string, isPrimitive = false): string[] {
-  const primitives: string[] = [];
+  const deps: string[] = [];
+  const substrateKinds = listSubstrateKinds();
 
-  // Uses VALUE_IMPORT_REGEX (excludes "import type") to avoid treating
-  // type-only shared files (like types.ts) as standalone primitive dependencies.
-  const matches = content.matchAll(VALUE_IMPORT_REGEX);
+  const matches = content.matchAll(IMPORT_REGEX);
 
   for (const match of matches) {
     const pkg = match[1];
 
-    // Check if it's a primitive import
-    // For primitives, ./foo (sibling import) is another primitive
     const isSiblingImport = isPrimitive && pkg.startsWith('./') && !pkg.slice(2).includes('/');
     const isPrimitiveImport =
       pkg.includes('/primitives/') ||
@@ -1006,13 +1013,18 @@ function extractPrimitiveDependencies(content: string, isPrimitive = false): str
       pkg.includes('../../primitives/') ||
       isSiblingImport;
 
-    if (isPrimitiveImport) {
-      const primitiveName = basename(pkg, '.ts');
-      if (!primitives.includes(primitiveName)) {
-        primitives.push(primitiveName);
+    const isSubstrateImport = substrateKinds.some(
+      (kind) =>
+        pkg.includes(`/${kind}/`) || pkg.includes(`../${kind}/`) || pkg.includes(`../../${kind}/`),
+    );
+
+    if (isPrimitiveImport || isSubstrateImport) {
+      const depName = basename(pkg, '.ts');
+      if (!deps.includes(depName)) {
+        deps.push(depName);
       }
     }
   }
 
-  return primitives;
+  return deps;
 }


### PR DESCRIPTION
## Summary

Fix the registry's shared-file dependency extraction so served components carry their complete primitives/substrate dependency list.

## Acceptance criteria mapping

### 1. `analyzeSource` runs on shared auxiliary files the same way it runs on framework variants

Shared file bundling at componentService.ts:709-720 and componentService.ts:731-738 now calls `analyzeSource` on each shared file and merges the extracted deps into `primitivesAll`. Previously pushed with `dependencies: []`.

Evidence: componentService.ts:714-720 (shared-by-name loop), componentService.ts:733-740 (sibling-shared loop).

### 2. `extractPrimitiveDependencies` recognizes substrate import paths

Extended at componentService.ts:1008-1036 to check against `listSubstrateKinds()` (filesystem-discovered). Import paths matching `../../lib/*`, `../../hooks/*`, or any future substrate dir are now captured alongside `/primitives/` paths. Switched to `IMPORT_REGEX` to capture type-only imports that still require the file installed for the consumer's TypeScript to compile -- matching `extractSubstrateDepNames` at componentService.ts:198 which already uses the same regex for the same reason.

Evidence: componentService.ts:1019-1022 (`isSubstrateImport` check using discovered substrate kinds).

### 3. `loadComponent('button')` includes substrate deps

Before the fix: `['classy', 'sr-announcer']` (only what the `.tsx` wrapper directly imports from `/primitives/`). After: `['contract', 'use-memory', 'classy', 'sr-announcer', 'compose', 'aria-manager', 'pressable']`. The five missing deps came from `button.behavior.ts` imports of `../../lib/compose`, `../../lib/contract`, `../../primitives/aria-manager`, and `../../lib/pressable`.

Evidence: verified via `pnpm tsx` loading `loadComponent('button')` from the registry app directory.

### 4. `loadComponent('dialog')` includes substrate deps

After the fix: `['contract', 'key-input', 'use-memory', 'use-presence', 'classy', 'slot', 'compose', 'aria-manager', 'focus-trap', 'outside-click', 'disclosable']` -- the full closure of primitives and substrate the dialog's behavior file composes.

Evidence: verified via `pnpm tsx` loading `loadComponent('dialog')` from the registry app directory.

### 5. Registry tests pass

All 17 registry tests pass including the closure-completeness guard (every served component's dependency graph resolves completely with no dangling imports) and the name-set disjointness guard (no name collisions across item types).

Evidence: `pnpm --filter @rafters/registry test` exit 0, 17 passed.

### 6. The unused `VALUE_IMPORT_REGEX` constant is removed

`extractPrimitiveDependencies` was the only consumer of `VALUE_IMPORT_REGEX`; it now uses `IMPORT_REGEX`. `extractSiblingImports` already used `IMPORT_REGEX`. The constant is removed to avoid dead code.

Evidence: componentService.ts no longer defines `VALUE_IMPORT_REGEX`.

## Not done

- No CLI-side changes -- `resolveDependencies` already walks `item.primitives` via `fetchItem` which tries all types including substrate
- No CLI version bump needed -- this is a registry-side data fix; existing CLI versions benefit on redeploy

Closes #1934