### PR TITLE
chore(release): 0.0.74

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rafters
 
+## 0.0.74
+
+### Bug Fixes
+
+- fix(cli): collapse nested cross-component imports to flat consumer layout. Components like container import sibling shared files via `../grid/grid.classes` (nested source layout); `transformFileContent` now collapses `../name/name.suffix` to `@/components/ui/name.suffix` (flat consumer layout). Affects container, field, sidebar, button-group.
+
 ## 0.0.73
 
 ### Features

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.73",
+  "version": "0.0.74",
   "description": "Design Intelligence CLI. Scaffold tokens, import existing shadcn/Tailwind v4 sources, add components, and serve an MCP server so AI agents read decisions instead of guessing.",
   "homepage": "https://rafters.studio",
   "license": "MIT",

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -447,6 +447,14 @@ export function transformFileContent(
     );
   }
 
+  // Cross-component sibling: ../name/name.suffix -> @/components/ui/name.suffix
+  // Source layout is nested (grid/grid.classes.ts); consumer layout is flat
+  // (grid.classes.ts next to grid.tsx). Collapse the repeated dir prefix.
+  transformed = transformed.replace(
+    /from\s+['"]\.\.\/([^/'"]+)\/\1([^'"]*)['"]/g,
+    `from '@/${aliasComponents}/$1$2'`,
+  );
+
   // Any remaining parent import is a sibling component -> componentsPath.
   transformed = transformed.replace(
     /from\s+['"]\.\.\/([^'"]+)['"]/g,

--- a/packages/cli/test/commands/add.test.ts
+++ b/packages/cli/test/commands/add.test.ts
@@ -165,12 +165,16 @@ describe('transformFileContent', () => {
     ).toBe(`import { createMemory } from '@/lib/primitives/memory';`);
   });
 
-  it('treats a ../<dir>/ import as a sibling component when the dir is not a known kind', () => {
-    // Kinds are data: without `lib` in substrateKinds it is not substrate, so it
-    // falls to the component path. Real installs always pass the discovered kinds.
+  it('collapses a cross-component ../name/name import to flat layout', () => {
     const input = `import { Card } from '../card/card';`;
     const result = transformFileContent(input, null);
-    expect(result).toBe(`import { Card } from '@/components/ui/card/card';`);
+    expect(result).toBe(`import { Card } from '@/components/ui/card';`);
+  });
+
+  it('collapses a cross-component ../name/name.suffix import to flat layout', () => {
+    const input = `import { gridClasses } from '../grid/grid.classes';`;
+    const result = transformFileContent(input, null);
+    expect(result).toBe(`import { gridClasses } from '@/components/ui/grid.classes';`);
   });
 
   it('handles multiple imports in one file', () => {


### PR DESCRIPTION
## Summary

Version bump to 0.0.74 for the cross-component import collapse fix.

## Acceptance criteria mapping

### 1. `../name/name` collapses to `@/components/ui/name`

New regex at add.ts:450-454 uses a backreference to match the repeated directory name pattern and collapse it. The generic `../` fallback at add.ts:457 only runs on imports the collapse regex did not match.

Evidence: add.ts:450-454 (collapse regex), test at add.test.ts:168-172 verifying `../card/card` -> `@/components/ui/card`.

### 2. `../name/name.suffix` collapses to `@/components/ui/name.suffix`

Same regex handles suffixed variants -- the backreference matches the dir name and the suffix passes through in capture group 2.

Evidence: add.test.ts:174-178 verifying `../grid/grid.classes` -> `@/components/ui/grid.classes`.

### 3. Affected components install with correct imports

Verified by reinstalling container in demo -- `container.classes.ts` now imports `from '@/components/ui/grid.classes'` (flat) instead of `@/components/ui/grid/grid.classes` (nested). All four affected components (container, field, sidebar, button-group) use the same `../name/name.suffix` pattern.

Evidence: `head -8 apps/demo/src/components/ui/container.classes.ts` shows `@/components/ui/grid.classes`.

### 4. Existing tests updated; new test for the `.suffix` variant

The old test expecting `@/components/ui/card/card` (nested passthrough) was updated to expect `@/components/ui/card` (flat collapse). A new test case covers `../grid/grid.classes` -> `@/components/ui/grid.classes`. All 259 CLI tests pass.

Evidence: add.test.ts:168-178, `pnpm --filter rafters test:unit` exit 0.

### 5. `pnpm preflight` green

Full preflight passed with exit 0 on this branch. Typecheck across 12 workspace projects clean, lint 0 errors, format clean, all unit tests pass, build succeeds.

Evidence: lefthook pre-commit and pre-push hooks all green.

## Not done

- No registry-side changes -- the registry serves the source-layout paths; the CLI transforms them on install.
- This is a CLI-only fix requiring a version bump.

Closes #1936