### PR TITLE
chore(release): 0.0.75

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rafters
 
+## 0.0.75
+
+### Bug Fixes
+
+- fix(cli): install `.behavior.ts` files with components. The behavior score is the source of truth every framework variant imports -- without it the installed component is non-functional. `SHARED_EXTENSIONS` was missing `.behavior.ts`. Also removed dead `.types.ts` and `.constants.ts` entries (no component uses either suffix).
+
 ## 0.0.74
 
 ### Bug Fixes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "description": "Design Intelligence CLI. Scaffold tokens, import existing shadcn/Tailwind v4 sources, add components, and serve an MCP server so AI agents read decisions instead of guessing.",
   "homepage": "https://rafters.studio",
   "license": "MIT",

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -151,7 +151,7 @@ function getComponentTarget(config: RaftersConfig | null): ComponentTarget {
  * Shared file extensions that should always be included regardless of framework target.
  * These are auxiliary files (class maps, types, constants) used by framework-specific components.
  */
-const SHARED_EXTENSIONS = new Set(['.classes.ts', '.types.ts', '.constants.ts']);
+const SHARED_EXTENSIONS = new Set(['.behavior.ts', '.classes.ts']);
 
 /**
  * Check if a file path is a shared auxiliary file.


### PR DESCRIPTION
## Summary

Install .behavior.ts files with components and remove dead shared extension entries.

## Acceptance criteria mapping

### 1. `../name/name` collapses to `@/components/ui/name`

Shipped in v0.0.74 (PR #1937, already merged). The collapse regex at add.ts:450-454 handles this.

Evidence: add.ts:450-454, add.test.ts:168-172.

### 2. `../name/name.suffix` collapses to `@/components/ui/name.suffix`

Shipped in v0.0.74 (PR #1937, already merged). Same regex handles suffixed variants.

Evidence: add.test.ts:174-178.

### 3. .behavior.ts installs with components

`SHARED_EXTENSIONS` at add.ts:154 now includes `.behavior.ts`. The behavior score is the source of truth every framework variant (.tsx, .element.ts, .astro) imports via `./name.behavior` -- without it installed components fail at runtime with an unresolved import. Verified: `rafters add sidebar --overwrite` now installs `sidebar.tsx`, `sidebar.behavior.ts`, `sidebar.classes.ts` (was missing `sidebar.behavior.ts`). A full install of all 54 components produced 55 behavior files on disk.

Evidence: add.ts:154 (`SHARED_EXTENSIONS` set), install output showing `.behavior.ts` in files array for every component.

### 4. Affected components install with correct imports and behavior files

Verified by reinstalling all 54 components in the fresh demo app with `--overwrite`. Container's `container.classes.ts` now imports `@/components/ui/grid.classes` (flat, correct). Sidebar installs `sidebar.behavior.ts` alongside `sidebar.tsx` and `sidebar.classes.ts`. All 82 items (54 components + 28 deps) install with no missing files.

Evidence: `rafters add --overwrite` output shows `.behavior.ts` in every component's files array; container.classes.ts verified with correct flat import path.

### 5. Dead .types.ts and .constants.ts removed

Verified via `ls packages/ui/src/components/*/*.types.ts` and `*.constants.ts` -- zero files exist with either suffix across all 54 component directories. These were vestigial entries from a prior architecture that never materialized. Removing them tightens the shared-file filter to only the two suffixes that exist in the real component tree.

Evidence: filesystem check returns "no matches found" for both suffixes under `packages/ui/src/components/`.

### 3. pnpm preflight green

Full preflight passed on this branch. All CLI unit tests pass (259 passed, 12 skipped), typecheck clean across 12 workspace projects, lint 0 errors, format clean, build succeeds.

Evidence: lefthook pre-commit all green, exit 0.

## Not done

- No registry-side changes.
- No new tests added -- the existing `selectFilesForFramework` tests cover the shared-file inclusion path; `.behavior.ts` follows the same code path as `.classes.ts`.

Closes #1936