### PR TITLE
chore(release): 0.0.77

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rafters
 
+## 0.0.77
+
+### Bug Fixes
+
+- fix(design-tokens): documentation CSS now includes `@container` rules. The `@theme` block parser used `[^}]*` which truncated at nested braces, missing `--container-*` vars. Replaced with brace-depth parser (`extractThemeBlocks`). Container-prefixed layout candidates (`@sm:`, `@md:`, `@lg:`, `@xl:`) are now generated for spacing, grid, flex, and sizing utilities.
+
 ## 0.0.76
 
 ### Features

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.76",
+  "version": "0.0.77",
   "description": "Design Intelligence CLI. Scaffold tokens, import existing shadcn/Tailwind v4 sources, add components, and serve an MCP server so AI agents read decisions instead of guessing.",
   "homepage": "https://rafters.studio",
   "license": "MIT",

--- a/packages/design-tokens/src/exporters/tailwind.ts
+++ b/packages/design-tokens/src/exporters/tailwind.ts
@@ -1273,6 +1273,39 @@ const RADIUS_UTILITIES = [
 
 const STATE_VARIANTS = ['hover', 'focus-visible', 'focus', 'active', 'dark'] as const;
 
+const CONTAINER_LAYOUT_UTILITIES = [
+  'grid-cols',
+  'gap',
+  'p',
+  'px',
+  'py',
+  'pt',
+  'pr',
+  'pb',
+  'pl',
+  'h',
+  'w',
+  'max-w',
+  'flex-row',
+  'flex-col',
+  'flex-col-reverse',
+  'flex-wrap',
+  'items-center',
+  'justify-end',
+  'justify-center',
+  'justify-between',
+  'text-left',
+  'text-center',
+  'text-right',
+  'space-x',
+  'space-y',
+  'mt',
+  'rounded',
+  'rounded-sm',
+  'rounded-md',
+  'rounded-lg',
+] as const;
+
 /**
  * Derive the complete set of Tailwind utility candidates from theme custom
  * properties. Each --color-<slug> becomes bg-<slug>, text-<slug>, etc.; each
@@ -1280,12 +1313,30 @@ const STATE_VARIANTS = ['hover', 'focus-visible', 'focus', 'active', 'dark'] as 
  * the exhaustive base utility surface the token graph can produce -- no
  * component scanning required.
  */
+function extractThemeBlocks(css: string): string[] {
+  const blocks: string[] = [];
+  const re = /@theme\s*(?:inline\s*)?\{/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(css)) !== null) {
+    let depth = 1;
+    const start = match.index + match[0].length;
+    for (let i = start; i < css.length; i++) {
+      if (css[i] === '{') depth++;
+      if (css[i] === '}') {
+        depth--;
+        if (depth === 0) {
+          blocks.push(css.slice(start, i));
+          break;
+        }
+      }
+    }
+  }
+  return blocks;
+}
+
 function deriveCandidates(themeCSS: string): string[] {
   const themeVarNames: string[] = [];
-  const themeBlockRe = /@theme\s*(?:inline\s*)?\{([^}]*)\}/gs;
-  let blockMatch: RegExpExecArray | null;
-  while ((blockMatch = themeBlockRe.exec(themeCSS)) !== null) {
-    const block = blockMatch[1] ?? '';
+  for (const block of extractThemeBlocks(themeCSS)) {
     const varRe = /--([a-z][a-z0-9-]*)\s*:/g;
     let varMatch: RegExpExecArray | null;
     while ((varMatch = varRe.exec(block)) !== null) {
@@ -1322,6 +1373,21 @@ function deriveCandidates(themeCSS: string): string[] {
   for (const variant of STATE_VARIANTS) {
     for (const c of base) {
       candidates.add(`${variant}:${c}`);
+    }
+  }
+
+  // Container query variants for layout utilities. Only layout-shaped
+  // utilities get container prefixes -- crossing the full color/shadow
+  // surface with 13 container sizes would produce ~18MB.
+  const containerSizes = themeVarNames
+    .filter((n) => n.startsWith('container-'))
+    .map((n) => n.slice(10));
+  const layoutCandidates = base.filter((c) =>
+    CONTAINER_LAYOUT_UTILITIES.some((u) => c === u || c.startsWith(`${u}-`)),
+  );
+  for (const size of containerSizes) {
+    for (const c of layoutCandidates) {
+      candidates.add(`@${size}:${c}`);
     }
   }
 


### PR DESCRIPTION
Fix documentation CSS container queries -- theme block parser truncated at nested braces, missing container size vars. Container-prefixed layout candidates now generated. Bump to 0.0.77.