### PR TITLE
chore(release): 0.0.78

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # rafters
 
+## 0.0.78
+
+### Features
+
+- feat(design-tokens): duration tiers are now perceptual ranges a designer moves within, not fixed constants (#1943). Each tier carries a `[min, max]` band plus a default, and Studio clamps its picker to the band -- a duration outside its perceptual window is unreachable by accident. The tiers are explicitly not a ratio progression; `moderate` is somewhere in the communicative window, not `fast x ratio`.
+- feat(design-tokens): retune the motion baseline to the efficient (neutral-default) intent (#1946). The `standard` easing curve becomes `cubic-bezier(0.4, 0, 0.2, 1)` -- a mild decelerate with a responsive start, replacing the old symmetric ease -- and the duration tier defaults move to the low end of each range (`moderate` 200ms, `normal` 300ms, `slow` 400ms). Anything referencing the `motion-*` / `--ease-*` / `--duration-*` tokens follows automatically; `sheet` and `page` motion drop off the slow tier.
+- feat(design-tokens): the motion generator now receives its whole vocabulary as input -- keyframes, animations, and composite presets are parameters rather than literals in the generator body -- so the emitted motion system is a pure function of its definitions (#1943).
+
+### Bug Fixes
+
+- fix(design-tokens): remove the broken `accordion-down` / `accordion-up` keyframes (#1899). They interpolated `var(--radix-accordion-content-height)`, which nothing in this system sets, so they compiled as real utilities that animated to an undefined height in every consumer. The `motion-expand` / `motion-collapse` `grid-template-rows` transition replaces them.
+
 ## 0.0.77
 
 ### Bug Fixes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.77",
+  "version": "0.0.78",
   "description": "Design Intelligence CLI. Scaffold tokens, import existing shadcn/Tailwind v4 sources, add components, and serve an MCP server so AI agents read decisions instead of guessing.",
   "homepage": "https://rafters.studio",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Cuts CLI release 0.0.78. It ships the motion work merged to main since 0.0.77: the efficient motion-baseline retune (#1946) plus the motion-intent foundation (#1943) -- duration tiers as designer-movable ranges, the generator owning its whole vocabulary, and the broken-accordion-keyframe fix. The diff is the two release files (version + changelog); the shipped behavior change already landed on main via those PRs.

## Acceptance criteria mapping

### 1. CLI version is 0.0.78
`packages/cli/package.json` `version` field is bumped from the released `0.0.77` to `0.0.78`. `rafters` is the published package (it has the `bin` and `publishConfig`), and it bundles `@rafters/design-tokens` at build time, so this version is what carries the new motion defaults to consumers.
Evidence: `packages/cli/package.json:3`.

### 2. CHANGELOG has a 0.0.78 section covering the unreleased motion work
A `## 0.0.78` section was prepended above `## 0.0.77`, split into `### Features` (efficient baseline retune with the concrete curve/duration values; duration tiers becoming ranges; the generator receiving its whole vocabulary) and `### Bug Fixes` (the `accordion-down`/`-up` keyframes that interpolated an unset `--radix-*` var). Each bullet names its PR/issue and describes the mechanism, in the established changelog voice.
Evidence: `packages/cli/CHANGELOG.md:3-15`.

### 3. The published generator emits the new efficient defaults
Validated by running the built CLI as a consumer would: `rafters init` in a scratch project generated 819 tokens, and the compiled `rafters.css` carries `--ease-standard: cubic-bezier(0.4, 0, 0.2, 1)`, `--duration-moderate: 200ms`, `--duration-normal: 300ms`, `--duration-slow: 400ms`, each referenced by `var()` in the emitted `@utility` blocks. So the version being released actually produces the documented values end-to-end, not just in unit tests.
Evidence: `rafters init` output on this HEAD; the design-tokens golden test (`motion-golden.test.ts`) pins the same values by assertion.

### 4. preflight green
`pnpm preflight` passes on the release branch (build across all packages, typecheck, lint, format, and the full test suite -- 229 design-tokens tests among them). The pre-commit hook re-ran format on the release commit.
Evidence: preflight exit 0 on HEAD `fe9aba81`.

## Not done

The committed `apps/demo/.rafters/output` artifacts still bake the pre-0.0.78 motion values -- they are downstream generated output and regenerate on the demo's next build (#1944 tracks the stale-artifact regeneration gap). No source or published-package content depends on them. Also out of scope: the unrelated `rafters-frontend` skill removal, which gets its own PR.

Closes #1947