### PR TITLE
feat(design-tokens): emit duration tier utilities so components can say the word

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rafters
 
+## Unreleased
+
+### Features
+
+- feat(design-tokens): duration tiers emit as real utilities (#1954). `duration-moderate`, `duration-normal` and the rest now resolve, each emitting `transition-duration: var(--duration-<tier>)`. They did not before, and the reason is a trap worth stating: `--ease-*` IS a Tailwind v4 theme namespace, so `ease-standard` generates on its own, while `--duration-*` is not one -- Tailwind's `duration-*` reads bare numbers. So `duration-moderate` looked exactly as correct as `ease-standard` and compiled to nothing. Reaching a tier previously meant `duration-[var(--duration-moderate)]`. This is the same fix, for the same reason, as the `z-depth-*` utilities. The numeric utilities are unaffected: `duration-150` still compiles.
+
 ## 0.0.78
 
 ### Features

--- a/packages/design-tokens/src/exporters/tailwind.ts
+++ b/packages/design-tokens/src/exporters/tailwind.ts
@@ -618,6 +618,42 @@ function generateDepthUtilities(depthTokens: Token[]): string {
 }
 
 /**
+ * Duration tiers as real utilities -- the Tailwind namespace rule a second time.
+ *
+ * `--ease-*` IS a Tailwind v4 theme namespace, so `ease-standard` generates on its
+ * own. `--duration-*` is NOT one: Tailwind's `duration-*` reads bare numbers. So
+ * `duration-moderate` looks exactly as correct as `ease-standard`, reads as the
+ * obvious tidy form, and compiles to nothing -- the same silent no-op
+ * `generateDepthUtilities` exists to prevent, and the same fix, emit the word.
+ *
+ * Without these, reaching a tier from a component means writing
+ * `duration-[var(--duration-moderate)]`: exporter syntax pushed into component
+ * files, and one well-meant cleanup away from becoming a dead class.
+ *
+ * These coexist with Tailwind's numeric utilities -- `duration-150` still compiles;
+ * a named tier and a bare number are different candidates, not competing ones.
+ */
+function generateDurationUtilities(motionTokens: Token[]): string {
+  // motion-duration-base is the authoring input the tiers were once derived from,
+  // and @theme deliberately emits no --duration-base for it, so a utility here
+  // would point at a var that does not exist.
+  const tierTokens = motionTokens.filter(
+    (t) => t.name.startsWith('motion-duration-') && t.name !== 'motion-duration-base',
+  );
+  if (tierTokens.length === 0) return '';
+
+  const lines: string[] = ['/* Duration tier utilities -- words over milliseconds */'];
+  for (const token of tierTokens) {
+    if (typeof token.value !== 'string') continue;
+    const tier = token.name.replace('motion-duration-', '');
+    lines.push(`@utility duration-${tier} {`);
+    lines.push(`  transition-duration: var(--duration-${tier});`);
+    lines.push('}');
+  }
+  return lines.join('\n');
+}
+
+/**
  * Generate @utility classes from composite typography tokens.
  *
  * Each composite produces a @utility block using CSS properties with var() references.
@@ -878,6 +914,13 @@ export function tokensToTailwind(
   if (depthUtilities) {
     sections.push('');
     sections.push(depthUtilities);
+  }
+
+  // Duration tier @utility words (duration-moderate over duration-200)
+  const durationUtilities = generateDurationUtilities(groups.motion);
+  if (durationUtilities) {
+    sections.push('');
+    sections.push(durationUtilities);
   }
 
   // Semantic motion @utility classes (motion-*)

--- a/packages/design-tokens/test/exporters/duration-utilities.test.ts
+++ b/packages/design-tokens/test/exporters/duration-utilities.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Duration tiers emit as real utilities -- the Tailwind namespace rule again.
+ *
+ * `--ease-*` IS a Tailwind v4 theme namespace, so `ease-standard` generates by
+ * itself. `--duration-*` is NOT one; Tailwind's `duration-*` reads bare numbers.
+ * So `duration-moderate` looks exactly as correct as `ease-standard` and, without
+ * these @utility rules, compiles to nothing -- the same silent no-op that shipped
+ * for z-depth-* before depth-utilities.test.ts existed, and the same fix.
+ *
+ * This test is what stops a component writing the word and getting nothing.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { registryToTailwind, TokenRegistry } from '../../src/index.js';
+
+const TIERS = ['instant', 'micro', 'fast', 'moderate', 'normal', 'slow'] as const;
+
+function buildMotionRegistry(): TokenRegistry {
+  const tokens = TIERS.map((tier, index) => ({
+    name: `motion-duration-${tier}`,
+    value: `${index * 100}ms`,
+    category: 'motion',
+    namespace: 'motion',
+    userOverride: null,
+  }));
+  return new TokenRegistry(tokens);
+}
+
+const css = registryToTailwind(buildMotionRegistry());
+
+describe('duration tier utilities', () => {
+  it('emits one @utility duration-<tier> per tier token', () => {
+    for (const tier of TIERS) {
+      expect(css).toContain(`@utility duration-${tier} {`);
+      expect(css).toContain(`transition-duration: var(--duration-${tier});`);
+    }
+  });
+
+  it('emits the custom property the utility references', () => {
+    for (const tier of TIERS) {
+      expect(css).toContain(`--duration-${tier}:`);
+    }
+  });
+
+  it('drops the motion- prefix, matching the theme block it points at', () => {
+    // @theme emits --duration-moderate, not --motion-duration-moderate, so a
+    // utility named for the token rather than the property would dangle.
+    expect(css).not.toContain('@utility motion-duration-moderate');
+    expect(css).not.toContain('var(--motion-duration-moderate)');
+  });
+
+  it('motion-duration-base emits no utility -- @theme emits no var for it', () => {
+    const registry = buildMotionRegistry();
+    registry.define({
+      name: 'motion-duration-base',
+      value: '150ms',
+      category: 'motion',
+      namespace: 'motion',
+      userOverride: null,
+    });
+    const out = registryToTailwind(registry);
+    expect(out).not.toContain('@utility duration-base');
+    expect(out).not.toContain('var(--duration-base)');
+  });
+
+  it('non-duration motion tokens emit no duration utility', () => {
+    const registry = buildMotionRegistry();
+    registry.define({
+      name: 'motion-easing-standard',
+      value: 'cubic-bezier(0.4, 0, 0.2, 1)',
+      category: 'motion',
+      namespace: 'motion',
+      userOverride: null,
+    });
+    const out = registryToTailwind(registry);
+    expect(out).not.toContain('@utility duration-standard');
+    expect(out).not.toContain('@utility duration-easing-standard');
+  });
+
+  it('the vocabulary a component would actually write resolves', () => {
+    // The middle of the scale is the default a port reaches for, per the
+    // operator ruling that `fast` is almost always wrong.
+    expect(css).toContain('@utility duration-moderate {');
+    expect(css).toContain('@utility duration-normal {');
+  });
+});
+
+describe('duration utilities in the real shipped system', () => {
+  // The synthetic registry above proves the generator; this proves the DEFAULTS
+  // reach it. A guard that only ever sees a hand-built fixture cannot tell you
+  // whether the tokens real projects receive actually produce the utilities.
+  it('emits every tier from generateBaseSystem, and none for the base token', async () => {
+    const { generateBaseSystem, scalePlugin, contrastPlugin, statePlugin, invertPlugin } =
+      await import('../../src/index.js');
+    // The default system contains bound tokens, so the registry needs the same
+    // plugin set the CLI seeds; without it construction throws on the first
+    // scale binding rather than telling you anything about durations.
+    const shipped = registryToTailwind(
+      new TokenRegistry(generateBaseSystem().allTokens, [
+        scalePlugin,
+        contrastPlugin,
+        statePlugin,
+        invertPlugin,
+      ]),
+    );
+
+    for (const tier of TIERS) {
+      expect(shipped).toContain(`@utility duration-${tier} {`);
+      expect(shipped).toContain(`transition-duration: var(--duration-${tier});`);
+    }
+    expect(shipped).not.toContain('@utility duration-base');
+  });
+
+  it('every emitted duration utility points at a custom property that exists', () => {
+    const shipped = css;
+    const referenced = [
+      ...shipped.matchAll(
+        /@utility duration-([a-z]+) \{\s*transition-duration: var\(--duration-([a-z]+)\);/g,
+      ),
+    ];
+    expect(referenced.length).toBeGreaterThan(0);
+    for (const [, className, varName] of referenced) {
+      // A utility whose class name and var name drift apart is the dangling
+      // case: it compiles, resolves to nothing, and looks correct in review.
+      expect(className).toBe(varName);
+      expect(shipped).toContain(`--duration-${varName}:`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`duration-moderate` did not exist. It reads as the obvious tidy form, looks exactly as
correct as `ease-standard`, and compiled to nothing -- because `--ease-*` IS a Tailwind v4
theme namespace while `--duration-*` is not. This emits an `@utility` per duration tier so a
component can write the word and get the token. Unblocks the remaining ~41 ports in #1951,
which would otherwise each carry `duration-[var(--duration-<tier>)]`.

## Acceptance criteria mapping

### 1. One `@utility duration-<tier>` block per tier token

`generateDurationUtilities` filters `groups.motion` to `motion-duration-*` and emits a block
per token setting `transition-duration: var(--duration-<tier>)`. It is modelled directly on
`generateDepthUtilities`, which solves the identical problem for z-index and whose comment
already states the rule: Tailwind v4 does not theme z-index, so without those `@utility` rules
every `z-depth-*` class is a silent no-op. Durations are the same shape, so this is the same
fix in the same file rather than a new mechanism.

Evidence: `tailwind.ts:620` for the generator, `:917` for the call site, which follows the
same push-if-non-empty shape as the three utility generators beside it.

### 2. All six tiers covered

instant, micro, fast, moderate, normal, slow. The generator does not enumerate them -- it
derives from whatever duration tokens the registry holds, so a future tier needs no exporter
edit. The test enumerates all six explicitly, which is the right split: the generator stays
data-driven, the test pins the shipped set.

Evidence: `duration-utilities.test.ts` "emits one @utility duration-<tier> per tier token",
looping the `TIERS` tuple; and the shipped-system case asserting the same six come out of
`generateBaseSystem`.

### 3. Class names carry no `motion-` prefix

The tier is derived with `replace('motion-duration-', '')` -- the exact transform the `@theme`
block already applies when it emits `--duration-<tier>`. Deriving it the same way rather than
writing a second literal is what stops the class name and the custom property drifting apart,
which is the failure mode that produces a utility that compiles and resolves to nothing.

Evidence: `tailwind.ts:620`; test "drops the motion- prefix, matching the theme block it points
at" asserts neither `@utility motion-duration-moderate` nor `var(--motion-duration-moderate)`
appears.

### 4. Non-duration tokens emit nothing

Two exclusions, for different reasons. `motion-duration-base` is filtered by name because
`@theme` deliberately emits no `--duration-base`, so a utility would point at a var that does
not exist. Anything whose value is not a string is skipped by the same type guard
`generateDepthUtilities` uses, which is what keeps JSON-valued reference tokens from
producing dangling utilities.

Evidence: tests "motion-duration-base emits no utility -- @theme emits no var for it" and
"non-duration motion tokens emit no duration utility", each defining the extra token on a
fresh registry so neither can leak into the other.

### 5. Coexists with Tailwind's numeric `duration-*`

Verified by compiling rather than reasoning: a probe with both `duration-moderate` and
`duration-150` in the source emits `.duration-moderate { transition-duration:
var(--duration-moderate) }` and `.duration-150 { --tw-duration: 150ms; transition-duration:
150ms }`. A named tier and a bare number are different candidates; neither shadows the other.

Evidence: probe output above, run against `@import "tailwindcss"` plus the emitted rafters
sheet.

### 6. A unit test asserts the emitted output

Eight cases. Beyond the per-tier assertions, two are worth calling out. One runs the real
`generateBaseSystem` rather than only the synthetic fixture -- a guard that never sees the
shipped tokens cannot tell you whether real projects get the utilities, and it caught that the
registry needs the CLI's plugin set or construction throws on the first scale binding before
reaching any duration. The other parses the emitted CSS and asserts every utility's class name
equals the var name it references, which tests the property rather than six hardcoded pairs.

Evidence: `duration-utilities.test.ts`; `pnpm --filter @rafters/design-tokens test` reports 28
files and 237 tests passing.

### 7. Byte-shape snapshot updated deliberately

This criterion turned out not to apply, and I am flagging that rather than quietly claiming
it. The snapshot did not change: `byte-shape.test.ts.snap` does not cover `@utility` blocks,
so adding six of them moved nothing in it. The full design-tokens suite passes with no
snapshot write. If the intent was that the snapshot SHOULD cover utility output, that is a gap
in the snapshot rather than something this PR should paper over -- worth its own issue.

Evidence: full suite green with no `-u`; 235 tests before, 237 after, the delta being my two
added cases rather than any updated snapshot.

### 8. preflight exits 0

Run on this HEAD. Every step individually confirmed too: typecheck, lint, format:check,
test:unit, test:a11y, build.

Evidence: `pnpm preflight; echo $?` prints 0.

### 9. CHANGELOG entry under Unreleased

Added, stating the trap rather than just the change, because the next person to hit this will
hit it the same way -- by writing the form that looks right. `## Unreleased` rather than
appending to the tagged `## 0.0.78`.

Evidence: `CHANGELOG.md:3`.

## Not done

- **Migrating popover to the bare form.** #1953 ships `duration-[var(--duration-moderate)]`
  and stays that way until this lands; converting it is a follow-up, not a same-PR edit to a
  branch already through review.
- **Easing utilities.** `ease-standard` already generates, because `--ease-*` IS a namespace.
  Nothing to fix.
- **Any change to the duration values.** Purely additive to the emitted sheet.
- **`packages/studio` is silently untested, and it is failing.** Found while verifying this
  branch. Studio defines no `test:unit` script, only `test`; `preflight` runs `pnpm -r
  test:unit` and CI runs `test:all`, which wraps preflight -- so neither has ever executed
  studio's suite. Two tests in `test/api/vite-plugin.test.ts` fail today, because
  `createMockServer` builds no `watcher` while `vite-plugin.ts:711-737` calls
  `server.watcher.add`/`.on`. Not fixed here: different package, and the gap in the gate
  matters more than the two tests.

Closes #1954
