### PR TITLE
fix(ui): port select onto the semantic motion layer

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rafters
 
+## Unreleased
+
+### Bug Fixes
+
+- fix(ui): select now actually animates (#1956). Its listbox declared six tailwindcss-animate utilities -- `animate-in`, `animate-out`, `fade-in-0`/`fade-out-0`, `zoom-in-95`/`zoom-out-95` -- and that package is a dependency of no workspace, so none resolved and the listbox opened and closed with no transition. It now enters on `motion-dropdown-in` and exits on `motion-dropdown-out`, with both opacity and scale endpoints stated, because the semantic utilities are transitions rather than animations and a transition has no implicit start frame. The zoom the dead classes intended is restored rather than dropped: nothing writes an inline `style.transform` to this element, so transform is free here. The trigger's `transition-shadow duration-100` becomes `motion-focus` and the chevron's `transition-transform duration-200` becomes `motion-toggle`, so no raw millisecond value remains. Reduced motion is now decided per element by the utility applied to it -- the trigger keeps its guard because `motion-focus` has no `prefers-reduced-motion` block, the chevron drops it because `motion-toggle` does.
+
 ## 0.0.78
 
 ### Features

--- a/packages/ui/src/components/select/select.classes.ts
+++ b/packages/ui/src/components/select/select.classes.ts
@@ -18,10 +18,15 @@ export interface SelectClassSet {
 
 // Touch floor at h-11, scaling down via the container query (repo CQ
 // convention) rather than the viewport. Fill, not background.
+// The shadow move goes through motion-focus, which is box-shadow + outline-color
+// over --duration-micro on a linear curve -- the same property and the same 100ms
+// the raw pair spelled out, now owned by the token layer. motion-focus carries no
+// prefers-reduced-motion block of its own, so unlike the chevron below this
+// element still needs its guard; nothing else would disable the transition.
 const triggerClasses =
   'group flex h-11 @md:h-9 w-full items-center justify-between gap-2 rounded-md ' +
   'border border-input bg-background px-3 py-2 text-body-small shadow-sm ring-offset-background ' +
-  'transition-shadow duration-100 motion-reduce:transition-none ' +
+  'motion-focus motion-reduce:transition-none ' +
   'hover:border-input-hover ' +
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ' +
   'disabled:cursor-not-allowed disabled:opacity-50 ' +
@@ -31,16 +36,35 @@ const triggerClasses =
 // toggled by the binding when nothing is selected.
 const valueClasses = 'pointer-events-none truncate text-left data-[empty]:text-muted-foreground';
 
+// The 180-degree flip is a toggle, so it takes motion-toggle -- transform on the
+// spring-snappy curve. No guard here, deliberately: motion-toggle has its own
+// prefers-reduced-motion block that drops transform while keeping the colour
+// transition, and motion-reduce:transition-none would override that with nothing
+// rather than reinforce it. Which layer owns reduced motion is decided per
+// element by the utility applied to it.
 const chevronClasses =
-  'size-4 shrink-0 opacity-50 transition-transform duration-200 motion-reduce:transition-none ' +
-  'group-data-[state=open]:rotate-180';
+  'size-4 shrink-0 opacity-50 motion-toggle ' + 'group-data-[state=open]:rotate-180';
 
+// Enter and exit through the semantic layer. These are transitions rather than
+// animations, so both endpoints are stated -- an animation brings its own start
+// frame and a transition does not.
+//
+// Scale is available here, unlike on popover: nothing writes an inline
+// style.transform to this element, so the zoom the old dead classes intended can
+// actually run. motion-dropdown-in already transitions transform alongside
+// opacity, so the endpoints below need no extra declaration to move.
+//
+// `starting:` supplies the from-value. SelectContent keeps the listbox mounted
+// and toggles `hidden` (select.tsx:367), so it comes back out of display:none
+// with the open state already applied and nothing to interpolate from; the
+// @starting-style block is what gives the first frame something to leave.
 const contentClasses =
   'z-depth-dropdown max-h-96 min-w-32 overflow-hidden rounded-md border bg-popover ' +
   'text-popover-foreground shadow-md ' +
-  'data-[state=open]:animate-in data-[state=closed]:animate-out ' +
-  'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 ' +
-  'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95';
+  'data-[state=open]:motion-dropdown-in data-[state=closed]:motion-dropdown-out ' +
+  'starting:opacity-0 starting:scale-95 ' +
+  'data-[state=open]:opacity-100 data-[state=closed]:opacity-0 ' +
+  'data-[state=open]:scale-100 data-[state=closed]:scale-95';
 
 const viewportClasses = 'p-1';
 

--- a/packages/ui/test/components/select/select.classes.test.ts
+++ b/packages/ui/test/components/select/select.classes.test.ts
@@ -18,7 +18,7 @@ describe('select classes', () => {
 
   it('state-dependent looks key off projected attributes', () => {
     expect(classes.chevron).toContain('group-data-[state=open]:rotate-180');
-    expect(classes.content).toContain('data-[state=open]:animate-in');
+    expect(classes.content).toContain('data-[state=open]:motion-dropdown-in');
     expect(classes.item).toContain('data-[highlighted]:bg-accent');
     expect(classes.value).toContain('data-[empty]:text-muted-foreground');
   });
@@ -29,9 +29,49 @@ describe('select classes', () => {
     expect(classes.item).toContain('data-[disabled]:pointer-events-none');
   });
 
-  it('motion respects reduced-motion everywhere it animates', () => {
-    for (const value of [classes.trigger, classes.chevron]) {
-      expect(value).toContain('motion-reduce:transition-none');
+  it('enter and exit run through the semantic motion layer', () => {
+    expect(classes.content).toContain('data-[state=open]:motion-dropdown-in');
+    expect(classes.content).toContain('data-[state=closed]:motion-dropdown-out');
+    expect(classes.trigger).toContain('motion-focus');
+    expect(classes.chevron).toContain('motion-toggle');
+  });
+
+  it('states both transition endpoints, including the start frame', () => {
+    // A transition has no implicit start. The listbox is present-but-hidden and
+    // comes back out of display:none with the open state already applied, so
+    // without @starting-style there is nothing to interpolate from.
+    expect(classes.content).toContain('starting:opacity-0');
+    expect(classes.content).toContain('starting:scale-95');
+    expect(classes.content).toContain('data-[state=open]:opacity-100');
+    expect(classes.content).toContain('data-[state=closed]:opacity-0');
+    expect(classes.content).toContain('data-[state=open]:scale-100');
+  });
+
+  it('references no animation utility this system does not define', () => {
+    for (const dead of [
+      'animate-in',
+      'animate-out',
+      'fade-in-0',
+      'fade-out-0',
+      'zoom-in-95',
+      'zoom-out-95',
+    ]) {
+      expect(classes.content).not.toContain(dead);
     }
+  });
+
+  it('writes no raw duration anywhere', () => {
+    for (const value of Object.values(classes)) {
+      expect(value).not.toMatch(/duration-\d/);
+      expect(value).not.toMatch(/duration-\[\d/);
+    }
+  });
+
+  it('leaves reduced motion to whichever layer owns each element', () => {
+    // motion-focus carries no prefers-reduced-motion block, so the trigger still
+    // needs the guard. motion-toggle carries one that drops transform while
+    // keeping colour, so a guard on the chevron would override it with nothing.
+    expect(classes.trigger).toContain('motion-reduce:transition-none');
+    expect(classes.chevron).not.toContain('motion-reduce:transition-none');
   });
 });


### PR DESCRIPTION
## Summary

Select's listbox declared six tailwindcss-animate utilities that resolve to nothing in this
system, so it opened and closed with no transition while appearing to specify a full
enter/exit. This ports all three of its motion sites onto the semantic layer. Second component
of #1951.

## Acceptance criteria mapping

### 1. No undefined utility remains

All six went out with the old `contentClasses`: `animate-in`, `animate-out`, `fade-in-0`,
`fade-out-0`, `zoom-in-95`, `zoom-out-95`. They were tailwindcss-animate utilities and that
package is a dependency of no workspace, so none resolved to a keyframe, an `@utility` block
or an `--animate-*` alias. Removing them changes no rendered output, because they rendered
nothing; what changes is that the file now declares only classes the sheet defines.

Evidence: `select.classes.ts:57`; test "references no animation utility this system does not
define" iterates all six and asserts `not.toContain`.

### 2. Enter and exit use the semantic utilities on data-state

`data-[state=open]:motion-dropdown-in` and `data-[state=closed]:motion-dropdown-out`. The
state selector is the mechanism the old code already used, so the behavior layer is untouched
-- nothing in `select.behavior.ts` changed, and no `.tsx`, `.astro` or `.element.ts` file is in
this diff.

Evidence: `select.classes.ts:57`; test "enter and exit run through the semantic motion layer".

### 3. Both opacity and scale endpoints, restoring the zoom

This is where select differs from popover, and the difference is worth stating because it
looks like an inconsistency otherwise. Popover had to go opacity-only: `positionPopover`
writes placement as an inline `style.transform`, which outranks any class-declared transform.
Nothing writes an inline transform to select's listbox, so transform is unclaimed here and the
scale endpoints actually move. `motion-dropdown-in` already transitions `transform` alongside
`opacity`, so the endpoints need no extra declaration. Same token, two different ceilings,
decided by what else touches the element.

Evidence: `select.classes.ts:57`; no `style.transform` assignment anywhere in
`select.behavior.ts` or `select.tsx`, unlike `positionPopover`.

### 4. A start frame, so the enter actually runs

`starting:opacity-0` and `starting:scale-95`. `SelectContent` keeps the listbox mounted and
toggles `hidden` (`select.tsx:367`), so it returns from `display: none` with the open state
already applied and nothing to interpolate away from -- the transition would paint straight to
the open values. `@starting-style` is what supplies the from-value. Popover needed the same
thing for a different reason (it mounts rather than unhides), which suggests this will recur
across the epic wherever a component is not permanently rendered.

Evidence: `select.classes.ts:57`; test "states both transition endpoints, including the start
frame".

### 5. Trigger and chevron take exact semantic fits; no raw millisecond remains

Neither needed a tier fallback. `transition-shadow duration-100` became `motion-focus`, which
is `box-shadow, outline-color` over `--duration-micro` on `--ease-linear` -- the same property
and the same 100ms, now owned by the token layer rather than restated. `transition-transform
duration-200` became `motion-toggle`, whose `transform` on `--ease-spring-snappy` is what a
180-degree chevron flip is for.

Evidence: `select.classes.ts:26` and `:43`; test "writes no raw duration anywhere" iterates
`Object.values(classes)` -- all thirteen sets, not only the two edited -- asserting neither a
bare `duration-150` nor an arbitrary literal `duration-[150ms]` appears.

### 6. Reduced motion retained on the trigger, removed from the chevron

Decided per element by which utility owns it. `motion-focus` carries no
`prefers-reduced-motion` block, so the trigger keeps `motion-reduce:transition-none` --
nothing else would disable its transition. `motion-toggle` carries one that drops `transform`
while keeping the colour transition, so the guard came off the chevron: it would have
overridden that with nothing rather than reinforced it.

I replaced the old test loop that asserted the guard on both elements, because that loop
encoded the wrong invariant -- it assumed reduced motion is handled uniformly, which is the
assumption this change disproves.

Evidence: `select.classes.ts:26` and `:43`; test "leaves reduced motion to whichever layer owns
each element" asserts both directions.

### 7. The chevron still rotates

`group-data-[state=open]:rotate-180` is untouched. Only the transition changed hands; the
rotation itself, and the `group` mechanism that drives it from the trigger's state, are the
same.

Evidence: `select.classes.ts:43`; the pre-existing test "state-dependent looks key off
projected attributes" still asserts it and still passes unmodified.

### 8. preflight exits 0

Run on this HEAD, after `pnpm format` -- worth noting because a newly written file that has
not been through oxfmt fails `format:check` while `pnpm lint` passes, which reads as a
confusing unrelated red.

Evidence: `pnpm preflight; echo $?` prints 0; select suite 4 files / 47 tests green.

## Not done

- **Converting to bare tier utilities.** Not needed: every site here had an exact semantic
  fit, so this branch depends on nothing from #1955.
- **The remaining ~40 components.** Tracked under #1951.
- **Visual confirmation.** Compilation and class presence are verified; whether the fade and
  scale read correctly on screen needs the app running, which I do not start.

Closes #1956
