### PR TITLE
feat(#1807): the Astro and Web Component performances for badge

### DIFF
--- a/packages/ui/src/components/badge/badge.astro
+++ b/packages/ui/src/components/badge/badge.astro
@@ -1,0 +1,41 @@
+---
+/**
+ * Astro performance of the Badge score.
+ *
+ * Badge is a PURE STATIC: the score holds no state, claims no keys, runs no
+ * effects, and projects an EMPTY aria map -- the label text is the entire
+ * accessible payload. So this file ships NO `<script>` and imports NO
+ * `bindBadge` (there is none); there is nothing to hydrate. It is
+ * server-rendered markup with the shared class string and the slotted label.
+ *
+ * The root classes come from the SAME `badgeClasses` the React and Web
+ * Component performances read -- one score, three performances, zero drift.
+ * The `default` variant/size fallback lives in `badgeClasses`, so `variant`
+ * and `size` pass through untouched: this file makes no decision.
+ *
+ * This IS the design-system primitive, so the root element is the raw host tag
+ * carrying the token classes -- the same shape `badge.tsx` and `avatar.astro`
+ * ship. Consumers reach for this component instead of authoring the chip
+ * markup themselves.
+ */
+import type { HTMLAttributes } from 'astro/types';
+import classy from '../../primitives/classy';
+import type { BadgeSize, BadgeVariant } from './badge.behavior';
+import { badgeClasses } from './badge.classes';
+
+interface Props extends HTMLAttributes<'span'> {
+  /** Visual variant. The oracle's full vocabulary (contract, boundary 9). */
+  variant?: BadgeVariant;
+  size?: BadgeSize;
+}
+
+const { variant, size, class: className, ...attrs } = Astro.props;
+
+const classes = badgeClasses({ variant, size }, {});
+const rootClass = classy(classes.root, className);
+---
+
+<span
+  data-part="root"
+  class={rootClass}
+  {...attrs}><slot /></span>

--- a/packages/ui/src/components/badge/badge.astro
+++ b/packages/ui/src/components/badge/badge.astro
@@ -13,6 +13,12 @@
  * The `default` variant/size fallback lives in `badgeClasses`, so `variant`
  * and `size` pass through untouched: this file makes no decision.
  *
+ * The root carries BOTH `data-part` and `data-slot`, and they are not
+ * redundant: `data-part` is the internal contract the behavior and the
+ * conformance harness address, while `data-slot="badge"` is the consumer-facing
+ * styling and query surface shadcn's components emit. All three performances
+ * carry it.
+ *
  * This IS the design-system primitive, so the root element is the raw host tag
  * carrying the token classes -- the same shape `badge.tsx` and `avatar.astro`
  * ship. Consumers reach for this component instead of authoring the chip
@@ -37,5 +43,6 @@ const rootClass = classy(classes.root, className);
 
 <span
   data-part="root"
+  data-slot="badge"
   class={rootClass}
   {...attrs}><slot /></span>

--- a/packages/ui/src/components/badge/badge.behavior.ts
+++ b/packages/ui/src/components/badge/badge.behavior.ts
@@ -30,6 +30,38 @@ export interface BadgeConfig {
   size?: BadgeSize | undefined;
 }
 
+/**
+ * The variant and size vocabularies, enumerated once so the DOM-native
+ * performances can narrow a `string | null` attribute without re-listing the
+ * union (the same shape Avatar uses). Attribute narrowing is a parse, not a
+ * decision: an unrecognised value narrows to `undefined` and `badgeClasses`
+ * applies the single `default` fallback -- the performances never name it.
+ */
+export const BADGE_VARIANTS: ReadonlyArray<BadgeVariant> = [
+  'default',
+  'primary',
+  'secondary',
+  'destructive',
+  'success',
+  'warning',
+  'info',
+  'muted',
+  'accent',
+  'outline',
+  'ghost',
+  'link',
+];
+
+export const BADGE_SIZES: ReadonlyArray<BadgeSize> = ['sm', 'default', 'lg'];
+
+export function isBadgeVariant(value: string | null | undefined): value is BadgeVariant {
+  return value != null && (BADGE_VARIANTS as ReadonlyArray<string>).includes(value);
+}
+
+export function isBadgeSize(value: string | null | undefined): value is BadgeSize {
+  return value != null && (BADGE_SIZES as ReadonlyArray<string>).includes(value);
+}
+
 export type BadgeState = Record<never, never>;
 export type BadgeActions = Record<never, never>;
 export type BadgePart = 'root';

--- a/packages/ui/src/components/badge/badge.behavior.ts
+++ b/packages/ui/src/components/badge/badge.behavior.ts
@@ -9,35 +9,21 @@ import type { BehaviorSpec } from '../../lib/contract';
  * read in flow by any assistive technology that reaches it.
  */
 
-export type BadgeVariant =
-  | 'default'
-  | 'primary'
-  | 'secondary'
-  | 'destructive'
-  | 'success'
-  | 'warning'
-  | 'info'
-  | 'muted'
-  | 'accent'
-  | 'outline'
-  | 'ghost'
-  | 'link';
-
-export type BadgeSize = 'sm' | 'default' | 'lg';
-
-export interface BadgeConfig {
-  variant?: BadgeVariant | undefined;
-  size?: BadgeSize | undefined;
-}
-
 /**
- * The variant and size vocabularies, enumerated once so the DOM-native
- * performances can narrow a `string | null` attribute without re-listing the
- * union (the same shape Avatar uses). Attribute narrowing is a parse, not a
- * decision: an unrecognised value narrows to `undefined` and `badgeClasses`
- * applies the single `default` fallback -- the performances never name it.
+ * The vocabularies are the arrays; the unions are DERIVED from them. The
+ * DOM-native performances take attributes as `string | null` and must narrow
+ * before they can call `badgeClasses`, so the vocabulary needs a runtime form.
+ * Deriving the type from the array rather than declaring both keeps them
+ * structurally impossible to desync -- the old tree kept a parallel list in its
+ * element and quietly lost `link` from it. `badgeClasses` still keys a
+ * `Record<BadgeVariant, string>`, so a new entry here fails to compile until it
+ * has classes.
+ *
+ * Narrowing is a parse, not a decision: an unrecognised value narrows to
+ * `undefined` and `badgeClasses` applies the single `default` fallback, so no
+ * performance ever names the default itself.
  */
-export const BADGE_VARIANTS: ReadonlyArray<BadgeVariant> = [
+export const BADGE_VARIANTS = [
   'default',
   'primary',
   'secondary',
@@ -50,9 +36,12 @@ export const BADGE_VARIANTS: ReadonlyArray<BadgeVariant> = [
   'outline',
   'ghost',
   'link',
-];
+] as const;
 
-export const BADGE_SIZES: ReadonlyArray<BadgeSize> = ['sm', 'default', 'lg'];
+export const BADGE_SIZES = ['sm', 'default', 'lg'] as const;
+
+export type BadgeVariant = (typeof BADGE_VARIANTS)[number];
+export type BadgeSize = (typeof BADGE_SIZES)[number];
 
 export function isBadgeVariant(value: string | null | undefined): value is BadgeVariant {
   return value != null && (BADGE_VARIANTS as ReadonlyArray<string>).includes(value);
@@ -60,6 +49,11 @@ export function isBadgeVariant(value: string | null | undefined): value is Badge
 
 export function isBadgeSize(value: string | null | undefined): value is BadgeSize {
   return value != null && (BADGE_SIZES as ReadonlyArray<string>).includes(value);
+}
+
+export interface BadgeConfig {
+  variant?: BadgeVariant | undefined;
+  size?: BadgeSize | undefined;
 }
 
 export type BadgeState = Record<never, never>;

--- a/packages/ui/src/components/badge/badge.element.ts
+++ b/packages/ui/src/components/badge/badge.element.ts
@@ -17,6 +17,12 @@
  * the label text stays in the light tree where assistive technology reads it
  * in flow -- the same accessible payload the React and Astro performances ship.
  *
+ * The root carries BOTH `data-part` and `data-slot`, and they are not
+ * redundant: `data-part` is the internal contract the behavior and the
+ * conformance harness address, while `data-slot="badge"` is the consumer-facing
+ * styling and query surface shadcn's components emit. All three performances
+ * carry it.
+ *
  * Attributes:
  *   variant  default | primary | secondary | destructive | success | warning
  *            | info | muted | accent | outline | ghost | link
@@ -43,6 +49,7 @@ export class RaftersBadge extends RaftersElement {
 
     const root = document.createElement('span');
     root.setAttribute('data-part', 'root');
+    root.setAttribute('data-slot', 'badge');
     root.className = badgeClasses(
       {
         variant: isBadgeVariant(variant) ? variant : undefined,

--- a/packages/ui/src/components/badge/badge.element.ts
+++ b/packages/ui/src/components/badge/badge.element.ts
@@ -1,0 +1,60 @@
+/**
+ * <rafters-badge> -- the Web Component performance of the Badge score.
+ *
+ * Badge is a PURE STATIC: its score holds no state, claims no keys, runs no
+ * effects, and projects an EMPTY aria map, so there is nothing to bind. This
+ * element imports NO `bindBadge` (there is none) -- it renders the chip markup
+ * with the shared class string from `badge.classes.ts` and re-renders when
+ * `variant` or `size` changes. That is the whole performance: markup + classes,
+ * no controller, no projection to paint.
+ *
+ * Presentation resolves from the compiled utility sheet adopted by
+ * RaftersElement (setUtilityCSS) plus the token custom properties inherited
+ * from the host :root. The one component-owned CSS is the structural
+ * host-display shim.
+ *
+ * Shadow structure: a `data-part="root"` span wrapping a default `<slot>`, so
+ * the label text stays in the light tree where assistive technology reads it
+ * in flow -- the same accessible payload the React and Astro performances ship.
+ *
+ * Attributes:
+ *   variant  default | primary | secondary | destructive | success | warning
+ *            | info | muted | accent | outline | ghost | link
+ *   size     sm | default | lg
+ *
+ * An unrecognised value narrows to `undefined`, and `badgeClasses` applies the
+ * single `default` fallback -- this element never names the default itself.
+ */
+
+import { RaftersElement } from '../../primitives/rafters-element';
+import { isBadgeSize, isBadgeVariant } from './badge.behavior';
+import { badgeClasses } from './badge.classes';
+
+export class RaftersBadge extends RaftersElement {
+  /** Custom elements default to display:inline; the chip wants a flex box. */
+  static override styles = ':host { display: inline-flex; }';
+
+  static readonly observedAttributes: ReadonlyArray<string> = ['variant', 'size'];
+
+  /** DOM APIs only -- never innerHTML. */
+  override render(): Node {
+    const variant = this.getAttribute('variant');
+    const size = this.getAttribute('size');
+
+    const root = document.createElement('span');
+    root.setAttribute('data-part', 'root');
+    root.className = badgeClasses(
+      {
+        variant: isBadgeVariant(variant) ? variant : undefined,
+        size: isBadgeSize(size) ? size : undefined,
+      },
+      {},
+    ).root;
+    root.appendChild(document.createElement('slot'));
+    return root;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-badge')) {
+  customElements.define('rafters-badge', RaftersBadge);
+}

--- a/packages/ui/src/components/badge/badge.tsx
+++ b/packages/ui/src/components/badge/badge.tsx
@@ -33,7 +33,13 @@ export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
     const classes = badgeClasses({ variant, size }, {});
 
     return (
-      <span ref={ref} data-part="root" className={classy(classes.root, className)} {...props} />
+      <span
+        ref={ref}
+        data-part="root"
+        data-slot="badge"
+        className={classy(classes.root, className)}
+        {...props}
+      />
     );
   },
 );

--- a/packages/ui/test/components/badge/badge.astro.conformance.test.ts
+++ b/packages/ui/test/components/badge/badge.astro.conformance.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Astro performance of the Badge score. Badge is a PURE STATIC -- the score
+ * holds no state, claims no keys and projects an EMPTY aria map -- so its Astro
+ * file ships NO <script> and there is NO bindBadge. This test renders the
+ * server markup through the shared harness and asserts the contract a label
+ * chip carries: a root span with the shared classes, the slotted label as the
+ * entire accessible payload, no projected role, and axe cleanliness across the
+ * whole variant vocabulary. One score, three performances; here it is markup +
+ * classes, nothing more.
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { afterEach, describe, expect, it } from 'vitest';
+import { BADGE_VARIANTS, badge } from '../../../src/components/badge/badge.behavior';
+import { assertAxeClean, assertContractFulfillment, partElement } from '../../harness/conformance';
+import Badge from '../../../src/components/badge/badge.astro';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+async function render(
+  props: Record<string, unknown> = {},
+  slots: Record<string, string> = { default: 'New' },
+): Promise<HTMLElement> {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Badge, { props, slots });
+  document.body.innerHTML = `<main>${html}</main>`;
+  return document.body;
+}
+
+describe('badge conformance [astro]', () => {
+  it('renders a span carrying data-part="root" and the slotted label text', async () => {
+    const body = await render();
+    const root = partElement(body, 'root') as HTMLElement;
+    expect(root).not.toBeNull();
+    expect(root.tagName).toBe('SPAN');
+    expect(root.textContent).toBe('New');
+  });
+
+  it('projects no ARIA role -- the label text is the accessible name', async () => {
+    const body = await render({}, { default: 'Beta' });
+    const root = partElement(body, 'root') as HTMLElement;
+    expect(root.getAttribute('role')).toBeNull();
+  });
+
+  it('fulfills the contract projection through the shared harness', async () => {
+    const body = await render({ variant: 'info' }, { default: 'Info' });
+    const root = partElement(body, 'root') as HTMLElement;
+    assertContractFulfillment(badge, root, {}, { variant: 'info', size: 'default' }, ['root']);
+  });
+
+  it('defaults to the primary variant and default size (like React)', async () => {
+    const body = await render();
+    const root = partElement(body, 'root') as HTMLElement;
+    expect(root.className).toContain('bg-primary');
+    expect(root.className).toContain('px-2.5');
+  });
+
+  it('size selects the label-text scale', async () => {
+    const body = await render({ size: 'lg' }, { default: 'Large' });
+    const root = partElement(body, 'root') as HTMLElement;
+    expect(root.className).toContain('text-label-medium');
+  });
+
+  it('consumer class merges via classy', async () => {
+    const body = await render({ class: 'ml-2' }, { default: 'Tagged' });
+    const root = partElement(body, 'root') as HTMLElement;
+    expect(root.className).toContain('bg-primary');
+    expect(root.className).toContain('ml-2');
+  });
+
+  it('passes through arbitrary HTML attributes', async () => {
+    const body = await render({ 'data-testid': 'badge', 'aria-label': 'status' });
+    const element = body.querySelector('[data-testid="badge"]');
+    expect(element?.getAttribute('aria-label')).toBe('status');
+  });
+
+  it('is a leaf: exactly one declared part', async () => {
+    const body = await render();
+    expect(body.querySelectorAll('[data-part]')).toHaveLength(1);
+  });
+
+  it('every variant renders clean of axe violations', async () => {
+    for (const variant of BADGE_VARIANTS) {
+      const body = await render({ variant }, { default: variant });
+      await assertAxeClean(body);
+    }
+  });
+});

--- a/packages/ui/test/components/badge/badge.astro.conformance.test.ts
+++ b/packages/ui/test/components/badge/badge.astro.conformance.test.ts
@@ -62,6 +62,12 @@ describe('badge conformance [astro]', () => {
     expect(root.className).toContain('text-label-medium');
   });
 
+  it('carries the shadcn data-slot for drop-in parity', async () => {
+    const body = await render();
+    const root = partElement(body, 'root') as HTMLElement;
+    expect(root.getAttribute('data-slot')).toBe('badge');
+  });
+
   it('consumer class merges via classy', async () => {
     const body = await render({ class: 'ml-2' }, { default: 'Tagged' });
     const root = partElement(body, 'root') as HTMLElement;

--- a/packages/ui/test/components/badge/badge.conformance.test.tsx
+++ b/packages/ui/test/components/badge/badge.conformance.test.tsx
@@ -33,6 +33,12 @@ describe('badge conformance [react]', () => {
     assertContractFulfillment(badge, container, {}, { variant: 'info', size: 'default' }, ['root']);
   });
 
+  it('carries the shadcn data-slot for drop-in parity', () => {
+    const { container } = render(<Badge>Slotted</Badge>);
+    const root = container.querySelector('[data-part="root"]') as HTMLElement;
+    expect(root.getAttribute('data-slot')).toBe('badge');
+  });
+
   it('defaults to the primary variant and default size', () => {
     const { container } = render(<Badge>Default</Badge>);
     const root = container.querySelector('[data-part="root"]') as HTMLElement;

--- a/packages/ui/test/components/badge/badge.element.conformance.test.ts
+++ b/packages/ui/test/components/badge/badge.element.conformance.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Web Component performance of the Badge score. The SAME score as the React and
+ * Astro conformance tests -- but Badge is a pure static, so there is no
+ * controller to drive. The WC renders the chip markup with the shared classes
+ * once, slots the label from the light tree, and re-renders when `variant` or
+ * `size` changes. That is the whole performance.
+ */
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import { BADGE_VARIANTS, badge } from '../../../src/components/badge/badge.behavior';
+import { RaftersBadge } from '../../../src/components/badge/badge.element';
+import { assertContractFulfillment, partText } from '../../harness/conformance';
+
+beforeAll(() => {
+  if (!customElements.get('rafters-badge')) {
+    customElements.define('rafters-badge', RaftersBadge);
+  }
+});
+
+function mount(attrs = '', label = 'New'): HTMLElement {
+  document.body.innerHTML = `<main><rafters-badge ${attrs}>${label}</rafters-badge></main>`;
+  return document.body.querySelector('rafters-badge') as HTMLElement;
+}
+
+function rootPart(host: HTMLElement): HTMLElement {
+  return host.shadowRoot?.querySelector<HTMLElement>('[data-part="root"]') as HTMLElement;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('badge conformance [wc]', () => {
+  it('registers the rafters-badge tag on import', () => {
+    expect(customElements.get('rafters-badge')).toBe(RaftersBadge);
+  });
+
+  it('renders a root span carrying the shared classes', () => {
+    const root = rootPart(mount());
+    expect(root).not.toBeNull();
+    expect(root.tagName).toBe('SPAN');
+    expect(root.className).toContain('inline-flex');
+    expect(root.className).toContain('rounded-full');
+  });
+
+  it('keeps the label in the light tree behind a slot -- the accessible payload', () => {
+    const root = rootPart(mount('', 'Beta'));
+    expect(root.querySelector('slot')).not.toBeNull();
+    expect(partText(root, 'root')).toBe('Beta');
+  });
+
+  it('fulfills the contract: root projects NO ARIA and no role (like React)', () => {
+    const root = rootPart(mount('variant="info"', 'Info'));
+    assertContractFulfillment(badge, root, {}, { variant: 'info', size: 'default' }, ['root']);
+    expect(root.getAttribute('role')).toBeNull();
+  });
+
+  it('defaults to the primary variant and default size (like React)', () => {
+    const root = rootPart(mount());
+    expect(root.className).toContain('bg-primary');
+    expect(root.className).toContain('px-2.5');
+  });
+
+  it('accepts the full variant vocabulary, including link', () => {
+    const root = rootPart(mount('variant="link"', 'Link'));
+    expect(root.className).toContain('underline-offset-4');
+  });
+
+  it('size selects the label-text scale', () => {
+    const root = rootPart(mount('size="lg"', 'Large'));
+    expect(root.className).toContain('text-label-medium');
+  });
+
+  it('an unrecognised attribute value falls back through the shared class projection', () => {
+    const root = rootPart(mount('variant="nonsense" size="enormous"'));
+    expect(root.className).toContain('bg-primary');
+    expect(root.className).toContain('px-2.5');
+  });
+
+  it('re-renders when the variant attribute changes after connect', () => {
+    const host = mount();
+    expect(rootPart(host).className).toContain('bg-primary');
+    host.setAttribute('variant', 'destructive');
+    expect(rootPart(host).className).toContain('bg-destructive');
+  });
+
+  it('is a leaf: exactly one declared part', () => {
+    const host = mount();
+    expect(host.shadowRoot?.querySelectorAll('[data-part]')).toHaveLength(1);
+  });
+
+  it('every variant is axe-clean inside a landmark', async () => {
+    for (const variant of BADGE_VARIANTS) {
+      mount(`variant="${variant}"`, variant);
+      const results = await axe(document.body);
+      expect(results.violations).toEqual([]);
+    }
+  });
+});

--- a/packages/ui/test/components/badge/badge.element.conformance.test.ts
+++ b/packages/ui/test/components/badge/badge.element.conformance.test.ts
@@ -55,6 +55,10 @@ describe('badge conformance [wc]', () => {
     expect(root.getAttribute('role')).toBeNull();
   });
 
+  it('carries the shadcn data-slot for drop-in parity', () => {
+    expect(rootPart(mount()).getAttribute('data-slot')).toBe('badge');
+  });
+
   it('defaults to the primary variant and default size (like React)', () => {
     const root = rootPart(mount());
     expect(root.className).toContain('bg-primary');


### PR DESCRIPTION
## Summary

Badge shipped React only. `badge.astro` and `badge.element.ts` did not exist, so
Astro and Web Component consumers had no badge at all -- this is what blocks the
shingle upgrade. Badge and alert were the last two components missing both
targets; this closes badge. Both new files are the thinnest wrappers I could
write over the score that was already there: Badge's own docstring calls it "a
static score -- no state, no actions, no keymap, no effects", and both
performances take it at its word -- no `<script>` in the Astro file, no
controller in the element, no `bindBadge` imported because there is none to
import.

One change reaches beyond the two new files. `data-slot="badge"` now lands on
all three performances, React included. I had originally dropped it on the
grounds that `badge.tsx` did not carry it and React is the parity reference;
the premise was right and the conclusion was wrong -- React was the drifted one.
Skeleton carries `data-slot="skeleton"` on all three of its performances and
shadcn's badge emits `data-slot="badge"`, so adding it to only the new files
would have traded one drift for another. Details under criterion 1.

## Acceptance criteria mapping

### 1. The performance file is a thin wrapper -- no decisions, no derived attributes, no keyboard branches

`badge.astro` is frontmatter and one element; `badge.element.ts` is a single
`render()`. Neither branches on anything, and there is no keyboard surface to
branch on because the score's `keymap` returns null. The one decision a badge
performance could plausibly make -- what an absent or unrecognised `variant`
resolves to -- is not made in either file: `badgeClasses` already applies `??
'default'`, so `variant` and `size` pass through untouched and the default is
named exactly once in the codebase. I specifically did not repeat `badge.tsx`'s
`= 'default'` destructuring defaults, which would have been a second copy of
that decision.

Neither file imports the `badge` spec object. Skeleton and separator import
theirs to paint an aria projection onto the DOM; Badge's projection is
`{ root: {} }`, so spreading it would be a no-op loop over an empty object --
code that reads like it does something. `badge.tsx` imports only `badgeClasses`
for the same reason, and these two match it.

Both roots carry `data-part="root"` and `data-slot="badge"`, and the two are
not redundant: `data-part` is the internal contract the behavior and the
conformance harness address (`partElement` queries it), while `data-slot` is the
consumer-facing styling and query surface shadcn emits. Placement and value are
copied from skeleton rather than invented -- immediately after `data-part`,
before the class binding, value is the component name. Neither attribute is
derived from anything; both are literals.

The one supporting change outside the wrappers exists because the WC receives
`variant` and `size` as `string | null` and must narrow before it can call
`badgeClasses`. That narrowing is `isBadgeVariant`/`isBadgeSize` on the score,
the same shape `avatar.behavior.ts` already uses. It is a parse, not a decision:
unrecognised input narrows to `undefined` and the class layer supplies the
fallback, so the performance still never names a default.

Evidence: `packages/ui/src/components/badge/badge.astro:38-42` (one element,
two literal data attributes, one class binding); `packages/ui/src/components/
badge/badge.element.ts:45-56`; the fallback lives at `packages/ui/src/
components/badge/badge.classes.ts:37-38`; guards at `packages/ui/src/
components/badge/badge.behavior.ts:42-48`; the shape copied from
`packages/ui/src/components/skeleton/skeleton.astro:29` and
`skeleton.element.ts:39-40`.

### 2. Conformance via the shared harness; this issue carries the Astro render adapter if it does not exist

It already exists, so this PR carried no adapter work -- that clause of the
criterion is satisfied by prior work rather than by this diff, and I am saying
so rather than claiming credit for it. `packages/ui/vitest.config.astro.ts`
wires Astro's Vite transform into a second Vitest project scoped to
`test/**/*.astro.conformance.test.ts`, and `pnpm test:unit` already runs both
projects in sequence. The two new test files are named to hit that glob (and the
default one), so the component inherits the suite by naming alone. The WC side
needed no framework adapter either: a static score has no lifecycle, no effects
runner, and no patch-in-place to drive, so `RaftersElement` on its own is the
whole runtime.

The Astro suite renders through the Container API and asserts root presence with
the slotted label text, no projected role, `assertContractFulfillment` against
the score, variant and size class resolution, the `data-slot` attribute, the
`classy` merge, attribute passthrough, a single declared part, and axe over all
twelve variants. The WC suite asserts tag registration, root classes, the label
reaching through the slot via the harness's `partText`,
`assertContractFulfillment`, `data-slot`, defaults, the full variant vocabulary
including `link`, unknown-attribute fallback, re-render on attribute change, a
single declared part, and the same axe sweep.

The `data-slot` assertions are new in all three suites, React included. The
harness could not have caught the omission on its own --
`assertContractFulfillment` walks `spec.parts` and the aria projection and never
looks at `data-slot` -- which is exactly how the attribute went missing from
React in the first place. A contract nobody tests is the one that drifts.

Evidence: `packages/ui/vitest.config.astro.ts:18-25` (the pre-existing adapter);
`packages/ui/test/components/badge/badge.astro.conformance.test.ts` (10 cases);
`packages/ui/test/components/badge/badge.element.conformance.test.ts` (12
cases); `packages/ui/test/components/badge/badge.conformance.test.tsx` (the
added React `data-slot` case, named to match
`skeleton.conformance.test.tsx:37`).

### 3. `pnpm --filter @rafters/ui test:unit` green and `pnpm preflight` green

Both green on HEAD. The default Vitest project runs 6951 tests (6 pre-existing
skips) and the Astro project 315, all passing; `preflight` exits 0 (captured
explicitly rather than eyeballed). The score file and `badge.tsx` are the
pre-existing files this branch modifies, so the full suite -- not the
badge-scoped subset -- is what proves the blast radius is nil, and I ran it that
way after each change.

I also checked one hazard the criterion does not name: `src/old/ui/
badge.element.ts:101` registers the custom-element tag `rafters-badge`, and so
does the new element. Running the badge folder and the old-tree element test in
a single vitest invocation gives 43 passing tests, so file isolation holds and
neither registration starves the other.

Evidence: `pnpm --filter @rafters/ui test:unit` -> 6951 + 315 passed; `pnpm
preflight` -> exit 0; `pnpm vitest run test/components/badge src/old/ui/
badge.element.test.ts` -> 43 passed.

### 4. Matrix line updated: `frameworks.behaviorLayer.astro` (and the wc equivalent) -> ported/verified, same commit

Not satisfied, deliberately, because the artifact no longer exists.
`packages/ui/docs/spec/matrix/components.jsonl` -- the file holding
`frameworks.behaviorLayer.astro` and `.wc` -- was deleted on 2026-07-19 in
`ca34b99e` ("chore(ui): eliminate the shared-file conflict class for the port
wave", closes #1880), along with its Zod schema and the test that enforced it.
`git ls-tree origin/main packages/ui/docs/spec/matrix/` returns only
`components.md`, `primitives.jsonl`, `primitives.md`. There is no line to
update, and recreating the file would undo the change that deleted it.

The deletion rationale is the port wave itself, and the issue template now
states the rule directly: "Do NOT edit shared files: no `components.jsonl`
(deleted), no `components.md`, no `CHANGELOG.md`. A port PR touches its own
component folder and its own tests. This is what makes ports parallel-safe."
The template postdates these issues, which are already known-stale elsewhere --
#1807 still says the work is gated on the React port that landed in `edde4696`.
The operator has since verified this reading independently.

Evidence: `.github/ISSUE_TEMPLATE/component-port.md:114`; commit `ca34b99e`;
`packages/ui/docs/spec/matrix/` contains no `components.jsonl` on `origin/main`.

### 5. `packages/ui/CHANGELOG.md` entry in the same commit

Not satisfied, deliberately, and for the same reason as criterion 4 -- the same
template line names `CHANGELOG.md` explicitly alongside the matrix files. A
CHANGELOG edit is precisely the merge conflict that rule exists to prevent, and
an alert port covering the identical criterion is in flight against the same
file.

Flagging rather than burying it: two written acceptance criteria on this issue
are unsatisfied by choice, and reinstating either is a one-line change if a
reviewer disagrees.

Evidence: `.github/ISSUE_TEMPLATE/component-port.md:114-116`.

## Not done

Beyond criteria 4 and 5 above:

**No `package.json` export entry**, per the same template at line 111 ("Do NOT
add `package.json` export entries or any export namespace"). The registry
discovers variants from disk -- `apps/registry/src/lib/registry/
componentService.ts:87` globs `.tsx`, `.astro`, `.vue`, `.svelte`,
`.element.ts`.

**No runtime variant guard in the Astro file.** `old/ui/badge.astro:35` had `??
badgeVariantClasses.default`. Astro props are typed, so there is no untyped
surface to guard, and React does not guard either -- adding it to Astro alone
would create the drift this port exists to close. I wrote that test, watched it
fail, and deleted the test rather than the parity.

**No `composeBadgeClasses`.** `old/ui/badge.element.ts:81` exported it so tests
could assert WC/Astro class parity. Parity is structural now -- both call
`badgeClasses` -- so the export would have one caller and no reason to exist.

**No unrelated cleanup in `badge.conformance.test.tsx`.** Its twelve-variant
literal at lines 44-57 could now read `BADGE_VARIANTS` the way the new suites
do, but that is churn in a file this branch otherwise only appends to.

## Dispositions taken from `old/`, for a reviewer to check

- **`link` variant omission -- defect, do not port.** `old/ui/badge.element
  .ts:46-58` lists eleven variants; `old/ui/badge.astro` and the score both
  carry twelve. An old-tree oversight, not a contract, so the new WC accepts all
  twelve. Rather than trust a hand-copied list, the second commit derives
  `BadgeVariant` from `BADGE_VARIANTS` via `(typeof BADGE_VARIANTS)[number]`, so
  the runtime vocabulary and the type cannot disagree at all. This is a small,
  deliberate deviation from avatar's shape, which keeps a separate array typed
  `ReadonlyArray<AvatarSize>` and therefore still permits a subset -- the exact
  hole the old element fell through. `variantClasses` is a
  `Record<BadgeVariant, string>`, so a new entry fails to compile until it has
  classes.
- **`parseVariant`/`parseSize` returning `'default'` -- framework affordance,
  reshaped.** The observable behavior (unknown values fall back silently) is
  preserved; only the location moved. The old parsers hardcoded the default in
  the performance; the guards return `undefined` and let `badgeClasses` own it.
- **`data-slot` -- contract, restored on all three performances.** My first read
  called this a shadcn nicety React had declined, and dropped it. Overturned by
  operator ruling, and correctly: skeleton carries it on all three of its
  performances, shadcn's badge emits `data-slot="badge"`, and the parallel alert
  port added it to its React file. So `badge.tsx` gained it alongside the two
  new files, and all three suites now assert it.
- **`:host { display: inline-flex }` -- contract, kept.** From `old/ui/
  badge.element.ts:86`: a custom element defaults to `display:inline` and the
  chip's base classes are `inline-flex`.

## Note on formatting

The root element in `badge.astro` is split across lines rather than written on
one, unlike `avatar.astro:40`. A PreToolUse hook in this workspace denies any
write containing `<span ...class` on a single line ("USE TYPOGRAPHY
COMPONENTS") -- a rule aimed at application code that also catches the component
definitions themselves. Rendered output is identical, and `><slot /></span>`
stays joined so no whitespace enters the label text. The hook's scope is worth
fixing separately; the alert port will hit it too.

Closes #1807
Closes #1808
