### PR TITLE
feat(design-tokens): duration and easing resolve through --rafters-*, like the rest of the system

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rafters
 
+## Unreleased
+
+### Features
+
+- feat(design-tokens): duration and easing tokens resolve through the `--rafters-*` layer like the rest of the system (#1974). `--duration-moderate` held the literal `200ms`; it now holds `var(--rafters-motion-duration-moderate)`, with the value on the `--rafters-*` declaration. This is the same split shadow already uses for its decomposed parts and radius uses for its corners. Motion was the last composite family whose Tailwind-facing token carried a value rather than a reference, which is why changing a duration tier meant regenerating the sheet while changing `primary` is a var re-point -- colour emits `--color-primary: var(--primary)`. Computed output is unchanged: every consumer resolves to the same duration and curve, and the semantic `motion-*` utilities needed no edit because they were already written as `var(--duration-<tier>)`.
+
 ## 0.0.78
 
 ### Features

--- a/packages/design-tokens/src/exporters/tailwind.ts
+++ b/packages/design-tokens/src/exporters/tailwind.ts
@@ -386,21 +386,25 @@ function generateThemeBlock(groups: GroupedTokens): string {
     lines.push('');
   }
 
-  // Motion duration tokens -- Tailwind reads --duration-* (no transition-duration utility, but available as var())
+  // Motion duration/easing tokens -- Tailwind reads --duration-* and --ease-*.
+  // The literal value lands on --rafters-<token name>; the Tailwind-facing token
+  // holds a var() reference to it. Same split shadow uses for its decomposed
+  // parts above (:353) and radius uses at :336 -- the --rafters-* layer is where
+  // a unique value lives, so re-pointing it moves every consumer without a
+  // regenerate. Emitting the literal here instead is what made a duration tier
+  // the one composite family Studio could not change the way it changes primary.
   if (groups.motion.length > 0) {
     for (const token of groups.motion) {
-      if (token.name.startsWith('motion-duration-') && token.name !== 'motion-duration-base') {
-        const key = token.name.replace('motion-duration-', '');
-        const value = tokenValueToCSS(token);
-        if (value === null) continue;
-        lines.push(`  --duration-${key}: ${value};`);
-      }
-      if (token.name.startsWith('motion-easing-')) {
-        const key = token.name.replace('motion-easing-', '');
-        const value = tokenValueToCSS(token);
-        if (value === null) continue;
-        lines.push(`  --ease-${key}: ${value};`);
-      }
+      const isDuration =
+        token.name.startsWith('motion-duration-') && token.name !== 'motion-duration-base';
+      const isEasing = token.name.startsWith('motion-easing-');
+      if (!isDuration && !isEasing) continue;
+      const value = tokenValueToCSS(token);
+      if (value === null) continue;
+      const namespace = isDuration ? 'duration' : 'ease';
+      const key = token.name.replace(isDuration ? 'motion-duration-' : 'motion-easing-', '');
+      lines.push(`  --rafters-${token.name}: ${value};`);
+      lines.push(`  --${namespace}-${key}: var(--rafters-${token.name});`);
     }
     lines.push('');
   }

--- a/packages/design-tokens/test/exporters/motion-utilities.test.ts
+++ b/packages/design-tokens/test/exporters/motion-utilities.test.ts
@@ -67,9 +67,16 @@ describe('semantic motion utilities compile (#1902/#1903/#1904)', () => {
     // expand/collapse transition grid-template-rows, never height.
     expect(css).toContain('transition-property: grid-template-rows, opacity;');
     expect(css).not.toContain('transition-property: height');
-    // The referenced theme vars carry the perceptual value and the named curve.
-    expect(css).toContain('--duration-normal: 300ms;');
-    expect(css).toContain('--ease-enter: cubic-bezier(0, 0, 0.2, 1);');
+    // The literal lands on the --rafters-* layer; the Tailwind-facing token holds
+    // a var() reference to it. This is the split that lets Studio re-point a tier
+    // without regenerating, and it is the same shape shadow and radius use.
+    expect(css).toContain('--rafters-motion-duration-normal: 300ms;');
+    expect(css).toContain('--duration-normal: var(--rafters-motion-duration-normal);');
+    expect(css).toContain('--rafters-motion-easing-enter: cubic-bezier(0, 0, 0.2, 1);');
+    expect(css).toContain('--ease-enter: var(--rafters-motion-easing-enter);');
+    // The Tailwind-facing token must never carry the literal -- that regression is
+    // exactly what makes a tier unchangeable at runtime.
+    expect(css).not.toContain('--duration-normal: 300ms;');
   });
 
   it('compiles a token-named motion class to a real rule, reduced-motion block intact', async () => {
@@ -79,8 +86,16 @@ describe('semantic motion utilities compile (#1902/#1903/#1904)', () => {
     expect(css).toContain('.motion-hover');
     // The nested @media survived compile + minify -- the blueprint-risk-#1 shape.
     expect(css, 'reduced-motion block dropped').toContain('prefers-reduced-motion');
-    // The referenced duration theme var resolved into the sheet (Tailwind minifies
-    // 300ms -> .3s), proving the class is not a dangling var() reference.
-    expect(css, 'duration var tree-shaken').toMatch(/--duration-normal:\s*(300ms|\.3s)/);
+    // Both links of the indirection survived compile + minify, proving the class is
+    // not a dangling var(). Tailwind minifies 300ms -> .3s, and the reference itself
+    // must still point at a var that is actually declared in the emitted sheet --
+    // a surviving reference to a tree-shaken var would compile and resolve to
+    // nothing, which is the failure this asserts against.
+    expect(css, 'rafters duration var tree-shaken').toMatch(
+      /--rafters-motion-duration-normal:\s*(300ms|\.3s)/,
+    );
+    expect(css, 'duration token lost its reference').toMatch(
+      /--duration-normal:\s*var\(--rafters-motion-duration-normal\)/,
+    );
   });
 });


### PR DESCRIPTION
## Summary

`--duration-moderate` held the literal `200ms`. It now holds `var(--rafters-motion-duration-moderate)`, with the value on the `--rafters-*` declaration. Same for `--ease-*`. This is the split shadow already uses for its decomposed parts (`tailwind.ts:353`) and radius uses for its corners (`:336`).

Motion was the last composite family whose Tailwind-facing token carried a value rather than a reference. That is why changing a duration tier meant regenerating the sheet, while changing `primary` is a var re-point: colour emits `--color-primary: var(--primary)`, motion emitted `--duration-moderate: 200ms`. Computed output is unchanged.

Delivers epic #1973's first requirement: change a global setting like `duration-fast` and have it cascade.

## Acceptance criteria mapping

### 1. Every `--duration-*` and `--ease-*` declaration is a var() reference, none carries a literal

The motion duration/easing emitter now pushes two lines per token instead of one: the literal onto `--rafters-<token name>`, then the Tailwind-facing token holding a reference to it. The emitted form is `--duration-normal: var(--rafters-motion-duration-normal)`, structurally what the sheet already does for `--color-primary: var(--primary)`.

I also collapsed the two near-identical `if` arms (one per namespace) into one parametrised pass, because adding a second push to each would have produced four near-duplicate blocks.

Evidence: `motion-utilities.test.ts`, case "emits a motion-* @utility longhand", asserts all four declarations.

### 2. The literal lands on `--rafters-<full token name>`

`--rafters-${token.name}` verbatim -- the same expression the shadow branch uses. So `motion-duration-moderate` becomes `--rafters-motion-duration-moderate`.

Evidence: the emitter line; assertions in the same test case.

### 3. A test asserts BOTH links in the COMPILED output

This is the criterion that matters, because the failure mode here is silent. `--rafters-*` is not a Tailwind theme namespace and neither is `--duration-*`. If Tailwind tree-shook the `--rafters-*` declaration, the surviving reference would be syntactically perfect CSS computing to nothing -- exactly how a class that compiled to nothing failed before.

Asserting only the reference passes on that bug. So the compiled case asserts the `--rafters-*` declaration survives compile and minify AND that the Tailwind token still references it. Verified by probe when this was first written: `--rafters-motion-duration-normal:.3s` retained, `.motion-modal-in` still a real rule, and every emitted `var(--rafters-motion-*)` had a matching declaration in the compiled sheet.

Evidence: `motion-utilities.test.ts`, case "compiles a token-named motion class", two `toMatch` assertions against the compiled output.

### 4. A negative assertion pins the regression direction

`expect(css).not.toContain('--duration-normal: 300ms;')`. A regression back to the literal fails rather than passing quietly -- which is what the original assertions did, since they asserted the literal was present.

Evidence: same test case.

### 5. `motion-duration-base` stays excluded

The exclusion condition is unchanged: the `isDuration` predicate carries the same `!== 'motion-duration-base'` clause the previous code had, so `base` still falls through to the raw-value block above.

Evidence: the predicate in the emitter.

### 6. The semantic motion utilities need no edit

They already said `var(--duration-<tier>)`, so the extra hop is invisible to them and no line changed in the utility generator. This was the criterion most likely to be wrong, and it held.

Evidence: the test still asserts `transition-duration: var(--duration-normal);` unchanged, and the compiled case still finds `.motion-modal-in`.

### 7. Computed output is identical -- pure indirection

No token value changed; only where the literal is written. Every consumer resolves to the same duration and curve.

Evidence: full design-tokens suite green with no snapshot updates -- 27 files, 229 tests.

### 8. Tests and typecheck green

`pnpm --filter @rafters/design-tokens test`: 27 files, 229 tests passing. `tsc --noEmit` clean in that package. `pnpm preflight` exits 0.

## Provenance

This change was written and verified once before as PR #1971, then reverted in #1972 along with four other merges so `main` would return to one known state rather than a partial one. This is that commit recovered by cherry-pick onto current `main`, re-tested, with the CHANGELOG entry and issue reference updated. The diff is unchanged.

## Not done

- **No automated runtime re-point test.** Epic #1973 wants "re-point one declaration, every consumer follows with no regeneration" proven. That needs computed-style resolution in a DOM; this package's suite asserts CSS text. The reference chain is verified post-compile instead. Worth its own issue if a DOM-level token harness is wanted.
- **No other namespace.** `focus`, `typography-composite`, `depth` and `breakpoint` still emit literals where they emit at all. Out of scope by design.
- **No value change.** No tier or curve is retuned. #1965's recorded divergences are untouched and still unruled.
- **No component edit.** Components are #1976, and they depend on #1975 first.

Closes #1974
