### PR TITLE
fix(design-tokens): an unknown duration tier or curve fails the build

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rafters
 
+## Unreleased
+
+### Bug Fixes
+
+- fix(design-tokens): an unknown duration tier or easing curve now fails the build instead of vanishing (#1977). The motion generator skipped any mapping whose tier or curve it did not recognise -- a bare `continue`, no throw, no warning -- while the exporter emitted `var(--duration-<name>)` regardless. A typo therefore produced syntactically valid CSS that resolves to nothing: the element did not animate, the build stayed green, and no test failed. The semantic-motion path was worse, never resolving its names at all and writing them straight into both the token value and `dependsOn`, so a typo also produced a dangling dependency edge. All four lookups now throw at generation time, naming the offending definition and listing the known vocabulary -- the failure is almost always a near-miss, and the fix is unguessable without the valid names in front of you. Every shipping definition resolves, so this lands with no change to any emitted value.
+
 ## 0.0.78
 
 ### Features

--- a/packages/design-tokens/src/generators/motion.ts
+++ b/packages/design-tokens/src/generators/motion.ts
@@ -39,6 +39,32 @@ import type { GeneratorResult, ResolvedSystemConfig } from './types.js';
 import { EASING_CURVES, MOTION_DURATION_SCALE } from './types.js';
 
 /**
+ * Resolve a named definition or fail loudly.
+ *
+ * Every one of these lookups previously did `if (!def) continue`, which drops the
+ * token and lets the build stay green. The reference survives elsewhere: the
+ * semantic path writes `motion-duration-<name>` into `dependsOn` and the exporter
+ * emits `var(--duration-<name>)` unconditionally, so a typo produced syntactically
+ * valid CSS that resolves to nothing -- no throw, no warning, no failing test, and
+ * an element that simply does not animate.
+ *
+ * The name is authored data, so an unknown one is a definition error and belongs
+ * at generation time. Listing the known names matters more than it looks: the
+ * failure is almost always a near-miss (`easing` vs `ease`, a renamed curve), and
+ * the fix is unguessable without the vocabulary in front of you.
+ */
+function requireDef<T>(defs: Record<string, T>, key: string, kind: string, owner: string): T {
+  const def = defs[key];
+  if (def === undefined) {
+    throw new Error(
+      `motion generator: ${owner} references unknown ${kind} "${key}". ` +
+        `Known ${kind}s: ${Object.keys(defs).sort().join(', ')}.`,
+    );
+  }
+  return def;
+}
+
+/**
  * Generate motion tokens from provided definitions.
  *
  * Every part of the vocabulary arrives as a parameter. Keyframes and animations
@@ -267,15 +293,18 @@ export function generateMotionTokens(
       durationRef = anim.duration.loopPeriod;
       durationDependency = [];
     } else {
-      const durationDef = durationDefs[anim.duration.tier];
-      if (!durationDef) continue;
+      const durationDef = requireDef(
+        durationDefs,
+        anim.duration.tier,
+        'duration tier',
+        `animation "${name}"`,
+      );
       durationValue = `${durationDef.default}ms`;
       durationRef = `var(--motion-duration-${anim.duration.tier})`;
       durationDependency = [`motion-duration-${anim.duration.tier}`];
     }
 
-    const easingDef = easingDefs[anim.curve];
-    if (!easingDef) continue;
+    const easingDef = requireDef(easingDefs, anim.curve, 'easing curve', `animation "${name}"`);
     const easingRef = `var(--motion-easing-${anim.curve})`;
 
     const iterations = anim.iterations || '';
@@ -311,9 +340,18 @@ export function generateMotionTokens(
   // Composite presets -- retained for backwards compatibility; the semantic
   // motion tokens are the current expression of the same idea.
   for (const [name, comp] of Object.entries(compositePresets)) {
-    const durationDef = durationDefs[comp.durationTier];
-    const easingDef = easingDefs[comp.curve];
-    if (!durationDef || !easingDef) continue;
+    const durationDef = requireDef(
+      durationDefs,
+      comp.durationTier,
+      'duration tier',
+      `composite preset "${name}"`,
+    );
+    const easingDef = requireDef(
+      easingDefs,
+      comp.curve,
+      'easing curve',
+      `composite preset "${name}"`,
+    );
 
     const durationMs = durationDef.default;
 
@@ -343,6 +381,14 @@ export function generateMotionTokens(
   // loop skips it (tokenValueToCSS returns null for JSON), so it never leaks a
   // raw custom property. Named after typography-composite's single-source model.
   for (const [name, mapping] of Object.entries(semanticMappings)) {
+    // Unlike the animation and composite paths, this one never resolved its tier
+    // or curve at all -- it wrote both names straight into the blob AND into
+    // dependsOn. A typo therefore produced a dangling dependency edge and a
+    // var(--duration-<typo>) that renders nothing, with no lookup anywhere to
+    // fail. Resolve purely to validate; the emitted value stays a reference.
+    requireDef(durationDefs, mapping.durationTier, 'duration tier', `semantic motion "${name}"`);
+    requireDef(easingDefs, mapping.curve, 'easing curve', `semantic motion "${name}"`);
+
     tokens.push({
       name: `motion-semantic-${name}`,
       value: JSON.stringify({

--- a/packages/design-tokens/test/motion-unknown-names.test.ts
+++ b/packages/design-tokens/test/motion-unknown-names.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_ANIMATION_DEFINITIONS,
+  DEFAULT_DELAY_DEFINITIONS,
+  DEFAULT_DURATION_DEFINITIONS,
+  DEFAULT_EASING_DEFINITIONS,
+  DEFAULT_KEYFRAME_DEFINITIONS,
+  DEFAULT_MOTION_COMPOSITE_PRESETS,
+  DEFAULT_MOTION_SEMANTIC_MAPPINGS,
+} from '../src/generators/defaults.js';
+import { generateMotionTokens } from '../src/generators/motion.js';
+import type { ResolvedSystemConfig } from '../src/generators/types.js';
+
+/**
+ * An unknown duration tier or easing curve must fail the build.
+ *
+ * Before this guard every lookup was `if (!def) continue`, which drops the token
+ * and leaves the build green. The reference survived downstream regardless: the
+ * semantic path writes `motion-duration-<name>` into `dependsOn` and the exporter
+ * emits `var(--duration-<name>)` unconditionally. A typo therefore produced
+ * syntactically valid CSS that resolves to nothing -- the element simply does not
+ * animate, and no test, lint or build step notices.
+ *
+ * These assert the BUILD FAILS, not that some string is absent from the output.
+ * Asserting absence is what a silent skip already satisfies, so it would pass
+ * against the bug.
+ */
+
+// progressionRatio is a NAME resolved against the ratio registry, not a number --
+// a numeric value throws `Unknown ratio` from math-utils before the generator
+// reaches any tier lookup.
+const CONFIG = {
+  baseTransitionDuration: 150,
+  progressionRatio: 'perfect-fourth',
+} as unknown as ResolvedSystemConfig;
+
+function generate(
+  overrides: {
+    semantic?: typeof DEFAULT_MOTION_SEMANTIC_MAPPINGS;
+    animations?: typeof DEFAULT_ANIMATION_DEFINITIONS;
+    composites?: typeof DEFAULT_MOTION_COMPOSITE_PRESETS;
+  } = {},
+) {
+  return generateMotionTokens(
+    CONFIG,
+    DEFAULT_DURATION_DEFINITIONS,
+    DEFAULT_EASING_DEFINITIONS,
+    DEFAULT_DELAY_DEFINITIONS,
+    overrides.semantic ?? DEFAULT_MOTION_SEMANTIC_MAPPINGS,
+    DEFAULT_KEYFRAME_DEFINITIONS,
+    overrides.animations ?? DEFAULT_ANIMATION_DEFINITIONS,
+    overrides.composites ?? DEFAULT_MOTION_COMPOSITE_PRESETS,
+  );
+}
+
+describe('motion generator rejects unknown tier and curve names (#1977)', () => {
+  it('every shipping definition resolves -- this guard lands with no value change', () => {
+    expect(() => generate()).not.toThrow();
+  });
+
+  it('an unknown duration tier on a semantic mapping fails the build', () => {
+    const [firstName, firstMapping] = Object.entries(DEFAULT_MOTION_SEMANTIC_MAPPINGS)[0] as [
+      string,
+      (typeof DEFAULT_MOTION_SEMANTIC_MAPPINGS)[string],
+    ];
+    const semantic = {
+      ...DEFAULT_MOTION_SEMANTIC_MAPPINGS,
+      [firstName]: { ...firstMapping, durationTier: 'moderat' },
+    };
+    expect(() => generate({ semantic })).toThrowError(/unknown duration tier "moderat"/);
+  });
+
+  it('an unknown easing curve on a semantic mapping fails the build', () => {
+    const [firstName, firstMapping] = Object.entries(DEFAULT_MOTION_SEMANTIC_MAPPINGS)[0] as [
+      string,
+      (typeof DEFAULT_MOTION_SEMANTIC_MAPPINGS)[string],
+    ];
+    const semantic = {
+      ...DEFAULT_MOTION_SEMANTIC_MAPPINGS,
+      [firstName]: { ...firstMapping, curve: 'ease' },
+    };
+    expect(() => generate({ semantic })).toThrowError(/unknown easing curve "ease"/);
+  });
+
+  it('an unknown tier on a composite preset fails the build', () => {
+    const [firstName, firstPreset] = Object.entries(DEFAULT_MOTION_COMPOSITE_PRESETS)[0] as [
+      string,
+      (typeof DEFAULT_MOTION_COMPOSITE_PRESETS)[string],
+    ];
+    const composites = {
+      ...DEFAULT_MOTION_COMPOSITE_PRESETS,
+      [firstName]: { ...firstPreset, durationTier: 'nope' },
+    };
+    expect(() => generate({ composites })).toThrowError(/unknown duration tier "nope"/);
+  });
+
+  it('the error names the offending definition and the known vocabulary', () => {
+    const [firstName, firstMapping] = Object.entries(DEFAULT_MOTION_SEMANTIC_MAPPINGS)[0] as [
+      string,
+      (typeof DEFAULT_MOTION_SEMANTIC_MAPPINGS)[string],
+    ];
+    const semantic = {
+      ...DEFAULT_MOTION_SEMANTIC_MAPPINGS,
+      [firstName]: { ...firstMapping, durationTier: 'moderat' },
+    };
+
+    // The failure is nearly always a near-miss, so the fix is unguessable without
+    // the vocabulary printed alongside it. Assert both halves.
+    let message = '';
+    try {
+      generate({ semantic });
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toContain(`semantic motion "${firstName}"`);
+    for (const tier of Object.keys(DEFAULT_DURATION_DEFINITIONS)) {
+      expect(message).toContain(tier);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Four lookups in the motion generator dropped a definition on an unrecognised name and let the build stay green. The reference survived downstream regardless -- the exporter emits `var(--duration-<name>)` unconditionally -- so a typo produced syntactically valid CSS that resolves to nothing. The element does not animate, no test fails, nothing reports it.

## Acceptance criteria mapping

### 1. An unknown duration tier fails the build, naming the mapping and the bad value

`requireDef` (`motion.ts:56`) throws instead of returning undefined, and the three duration call sites now route through it: `motion.ts:296` (animation), `:343` (composite preset), `:389` (semantic mapping). The message carries both the owner (`semantic motion "hover"`) and the offending value.

Evidence: test "an unknown duration tier on a semantic mapping fails the build" and "an unknown tier on a composite preset fails the build".

### 2. An unknown curve name does the same

Same helper, curve call sites at `motion.ts:307` (animation), `:349` (composite), `:390` (semantic).

Evidence: test "an unknown easing curve on a semantic mapping fails the build".

### 3. The error names what was expected, not just what was wrong

The message appends the sorted known vocabulary. This is not decoration: the failure is almost always a near-miss -- `easing` for `ease`, or a curve renamed in an earlier pass -- and the correct name is unguessable from the wrong one without the valid set in front of you.

Evidence: test "the error names the offending definition and the known vocabulary" asserts the owner string AND every key of `DEFAULT_DURATION_DEFINITIONS` appears in the message.

### 4. A test covers both, asserting the build fails rather than that a string is absent

Five cases, all `toThrowError`. This distinction is the point of the issue: a silent skip already satisfies "the string is absent from the output", so an absence assertion passes against the bug it is meant to catch. Asserting the throw is the only form that fails before the fix and passes after.

The helper `generate()` mirrors the real call site (`generators/index.ts:132`) and overrides exactly one definition record per case, so a case cannot pass against a synthetic vocabulary that never ships.

Evidence: `motion-unknown-names.test.ts`, 5 cases.

### 5. No mapping is silently skipped anywhere in the motion generators

All four sites converted. The `loopPeriod` branch above the animation tier lookup still skips it, correctly -- that shape carries its own literal period and names no tier, so there is nothing to resolve.

Evidence: `motion.ts:290-300`; the four `requireDef` call sites are the complete set of tier/curve resolutions in the file.

### 6. Every currently shipping mapping still resolves, so this lands with no value change

Asserted as the first case in the suite rather than left implicit -- without it this guard could pass while rejecting something real. The full design-tokens suite is green at 234 tests (229 before, plus the 5 added) with no snapshot updates.

Evidence: test "every shipping definition resolves -- this guard lands with no value change"; `pnpm --filter @rafters/design-tokens test` 28 files / 234 tests; `pnpm preflight` exits 0.

## The semantic path was worse than the issue described

The issue named three bare `continue`s. There were three, plus a fourth site that never resolved its names **at all**: the semantic-mapping loop wrote `durationTier` and `curve` straight into the token's JSON value AND into `dependsOn`, unchecked. So a typo there produced a dangling dependency edge as well as a dead `var()`, and there was no lookup present to fail. It now resolves purely to validate; the emitted value is unchanged.

## Not done

- **The same class of silent skip in other generators.** The issue scopes this to motion and says to file separately if it exists elsewhere. I did not audit the other generators here.
- **Any change to what a valid mapping emits.** Purely a guard.
- **The `as unknown as ResolvedSystemConfig` cast in the test.** The config type is wide and this path reads two fields; a full fixture would assert facts this suite does not test. Flagged as the one soft spot. Worth knowing: `progressionRatio` is a ratio NAME resolved against a registry, and a numeric value throws `Unknown ratio` from math-utils before the generator reaches any tier lookup -- that cost a run to discover and is recorded in a comment.

Closes #1977
