### PR TITLE
feat(design-tokens): derive motion duration and curve from travel and intent

### DIFF
--- a/packages/design-tokens/src/generators/motion-derivation.ts
+++ b/packages/design-tokens/src/generators/motion-derivation.ts
@@ -1,0 +1,216 @@
+/**
+ * Motion derivation: duration and curve are COMPUTED, not authored.
+ *
+ * The model, established by the #1975 spike:
+ *
+ *   band     = f(travel, category)   perception -- how far it moves, and whether
+ *                                    it is arriving or leaving
+ *   position = g(intent)             character  -- where inside that band it sits
+ *   curve    = h(category, intent)   character
+ *
+ * The six duration tiers are NOT a ratio progression and are not retuned here.
+ * They are perceptual facts (`defaults.ts`: "the window is a fact about
+ * perception rather than a step on a curve"), so they act as OUTPUT BANDS. What
+ * this module removes is authors CHOOSING one.
+ *
+ * WHY TRAVEL IS ORDINAL RATHER THAN METRIC. The output is discrete -- six bands,
+ * selected by a step function. Travel therefore needs exactly enough resolution
+ * to pick among them, and a millimetre-or-spacing-step metric would be false
+ * precision fitted to an answer we already have. The research corpus names this
+ * trap directly ("fit is not derivation"), so the scale stops at the resolution
+ * the decision actually consumes.
+ */
+
+import type { DurationDef } from './defaults.js';
+
+/**
+ * How far the animated thing moves. Ordinal, ordered, and read off the
+ * `sizeReasoning` prose each mapping already carried:
+ *
+ *   none    "Colour only, no movement"                    (hover)
+ *   short   "small and travels a short distance"          (dropdown)
+ *   medium  "larger and travels farther than a dropdown"  (modal)
+ *   large   "a large spatial movement"                    (sheet, page)
+ */
+export type MotionTravel = 'none' | 'short' | 'medium' | 'large';
+
+/**
+ * The five intents. `efficient` is the neutral baseline and owns no signature --
+ * that is what qualifies it as the default rather than a gap in the data.
+ */
+export type MotionIntent = 'efficient' | 'elegant' | 'friendly' | 'technical' | 'editorial';
+
+/** Ordered so "one band shorter" is an index step rather than a lookup table. */
+export const BAND_ORDER = ['instant', 'micro', 'fast', 'moderate', 'normal', 'slow'] as const;
+export type MotionBand = (typeof BAND_ORDER)[number];
+
+/**
+ * Travel selects the band for anything that moves through space.
+ *
+ * Reproduces the shipped enter tiers exactly: dropdown (short) -> moderate,
+ * modal (medium) -> normal. `large` maps to `slow`, whose own definition names
+ * sheets in its contexts -- see LARGE_TRAVEL_DISAGREEMENT below, because the
+ * shipped value for sheet and page is `normal`, not `slow`.
+ */
+const TRAVEL_BAND: Record<MotionTravel, MotionBand> = {
+  none: 'fast',
+  short: 'moderate',
+  medium: 'normal',
+  large: 'slow',
+};
+
+/**
+ * `sheet-in` and `page` declare "large spatial movement" and the `slow` tier
+ * lists `sheets` and `page-transitions` in its own contexts -- yet both ship at
+ * `normal`. That is a deliberate human call (`b864de01`), not drift.
+ *
+ * The derivation therefore does NOT silently overwrite it. Naming the exception
+ * here keeps it a visible, arguable decision instead of a number nobody can
+ * trace, which is the whole point of deriving rather than typing.
+ */
+export const LARGE_TRAVEL_DISAGREEMENT = {
+  derived: 'slow' as MotionBand,
+  shipped: 'normal' as MotionBand,
+  reason:
+    'b864de01 places the sheet pair at normal deliberately -- the one pair without a shortened exit. Unresolved: either the model needs a term that justifies normal, or these move to slow.',
+};
+
+/** Honour the shipped call while the disagreement stands. */
+function applyLargeTravelException(band: MotionBand, travel: MotionTravel): MotionBand {
+  return travel === 'large' ? LARGE_TRAVEL_DISAGREEMENT.shipped : band;
+}
+
+/**
+ * Exit is one band shorter than its enter -- greet warmly, leave quietly.
+ *
+ * Holds for three of the four shipped pairs (dropdown moderate->fast, modal
+ * normal->moderate, expand normal->moderate). The sheet pair is the documented
+ * exception and is handled by the large-travel rule above, which lands both
+ * halves on `normal`.
+ */
+function shortenForExit(band: MotionBand): MotionBand {
+  const i = BAND_ORDER.indexOf(band);
+  return BAND_ORDER[Math.max(0, i - 1)] as MotionBand;
+}
+
+/**
+ * Where inside its band an intent sits, as a 0..1 position.
+ *
+ * Only two intents have measured data. `efficient` sits at the LOW end of every
+ * band -- that is what ships today and what `motion-duration-ranges.test.ts`
+ * documents ("efficient runs fast, so its pick is the LOW end of each range").
+ * `elegant` is the measured peak for motion-duration in the 30-site study.
+ *
+ * The remaining three are NOT yet researched. They inherit the neutral position
+ * rather than receiving an invented one -- a guessed number here would be
+ * indistinguishable from data at the call site, which is exactly how the last
+ * hand-typed table came to look derived.
+ */
+const INTENT_POSITION: Record<MotionIntent, number> = {
+  efficient: 0,
+  elegant: 1,
+  friendly: 0,
+  technical: 0,
+  editorial: 0,
+};
+
+/** Intents whose position is measured rather than inherited from neutral. */
+export const RESEARCHED_INTENTS: ReadonlySet<MotionIntent> = new Set(['efficient', 'elegant']);
+
+/**
+ * Duration in ms: the band supplies the window, the intent picks a point in it.
+ *
+ * The band is the clamp. An intent can push `moderate` from 200 to 300 but never
+ * to 400, because 400 is no longer the communicative window. Perception bounds
+ * character, which is why the tiers are ranges rather than constants and why no
+ * separate clamping step is needed.
+ */
+/**
+ * Bands whose default is a PERCEPTUAL LANDMARK rather than a position.
+ *
+ * `micro` ships 100ms inside a [50,120] band because 100ms is the Nielsen
+ * instantaneous threshold; `fast` ships 150ms inside [120,200] to match a cursor
+ * already on target. Neither is "the low end of its range" -- they are fixed
+ * points that happen to lie in one, so intent has nothing to position.
+ *
+ * Applying the interpolation here would move `micro` from 100ms to 50ms and
+ * `fast` from 150ms to 120ms, silently changing every focus ring, press and
+ * hover in the system. These bands take their default verbatim.
+ */
+const LANDMARK_BANDS: ReadonlySet<MotionBand> = new Set(['instant', 'micro', 'fast']);
+
+export function deriveDuration(
+  band: MotionBand,
+  intent: MotionIntent,
+  durationDefs: Record<string, DurationDef>,
+): number {
+  const def = durationDefs[band];
+  if (def === undefined) {
+    throw new Error(
+      `motion derivation: unknown band "${band}". Known bands: ${BAND_ORDER.join(', ')}.`,
+    );
+  }
+  if (LANDMARK_BANDS.has(band)) return def.default;
+
+  const [min, max] = def.range;
+  const position = INTENT_POSITION[intent];
+  return Math.round(min + (max - min) * position);
+}
+
+/**
+ * Which band a mapping lands in.
+ *
+ * `interaction` tokens are handed their band directly: hover, focus, press and
+ * toggle do not move through space, so travel cannot select for them. Their
+ * bands separate by FEEDBACK KIND instead -- focus and press sit at `micro`
+ * (acknowledging that input landed) while hover sits at `fast` (matching a
+ * cursor already on target). Forcing a spatial rule onto them would be fitting.
+ */
+export function deriveBand(
+  category: 'interaction' | 'enter' | 'exit',
+  travel: MotionTravel,
+  declaredBand: MotionBand | undefined,
+): MotionBand {
+  if (category === 'interaction') {
+    if (declaredBand === undefined) {
+      throw new Error(
+        'motion derivation: an interaction mapping must declare its band -- it has no travel to derive from.',
+      );
+    }
+    return declaredBand;
+  }
+
+  const base = applyLargeTravelException(TRAVEL_BAND[travel], travel);
+
+  // Large travel is "the one pair without a shortened exit" (b864de01): a tracked
+  // spatial surface moves in and out at one pace, because the user is following
+  // it both ways. So the exit rule does not apply -- and that is a second,
+  // independent reason the sheet pair sits where it does, distinct from the band
+  // disagreement above.
+  if (category === 'exit' && travel !== 'large') return shortenForExit(base);
+  return base;
+}
+
+/**
+ * Curve by category, per intent.
+ *
+ * `exit` is perfectly regular in the shipped set -- all four exits use the exit
+ * curve. `enter` is regular except the two large-travel cases, which use a
+ * smooth spring because the user must track the surface into place; that is a
+ * travel-driven refinement, not an exception.
+ *
+ * Only `efficient` has a locked curve vocabulary. Other intents fall back to it
+ * for the same reason their position does: an invented curve would read as
+ * researched.
+ */
+export function deriveCurve(
+  category: 'interaction' | 'enter' | 'exit',
+  travel: MotionTravel,
+  _intent: MotionIntent,
+  declaredCurve: string | undefined,
+): string {
+  if (category === 'exit') return 'exit';
+  if (category === 'enter') return travel === 'large' ? 'spring-smooth' : 'enter';
+  // interaction: feedback character is per-token, not per-category.
+  return declaredCurve ?? 'standard';
+}

--- a/packages/design-tokens/test/motion-derivation.test.ts
+++ b/packages/design-tokens/test/motion-derivation.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_DURATION_DEFINITIONS } from '../src/generators/defaults.js';
+import {
+  BAND_ORDER,
+  deriveBand,
+  deriveCurve,
+  deriveDuration,
+  LARGE_TRAVEL_DISAGREEMENT,
+  type MotionTravel,
+} from '../src/generators/motion-derivation.js';
+
+/**
+ * The derivation must reproduce what ships, or the disagreement must be named.
+ *
+ * A derivation that quietly changes shipped values is indistinguishable from a
+ * bug; one that reproduces them proves the model describes the decisions a human
+ * already made. Where the model and the shipped value genuinely differ, the
+ * difference is asserted explicitly rather than smoothed over.
+ */
+
+/** Shipped enter/exit mappings, with the travel each declares in prose. */
+const SPATIAL: Array<{
+  name: string;
+  travel: MotionTravel;
+  category: 'enter' | 'exit';
+  ships: string;
+}> = [
+  { name: 'dropdown-in', travel: 'short', category: 'enter', ships: 'moderate' },
+  { name: 'dropdown-out', travel: 'short', category: 'exit', ships: 'fast' },
+  { name: 'modal-in', travel: 'medium', category: 'enter', ships: 'normal' },
+  { name: 'modal-out', travel: 'medium', category: 'exit', ships: 'moderate' },
+  { name: 'sheet-in', travel: 'large', category: 'enter', ships: 'normal' },
+  { name: 'sheet-out', travel: 'large', category: 'exit', ships: 'normal' },
+];
+
+describe('band derives from travel and category', () => {
+  for (const { name, travel, category, ships } of SPATIAL) {
+    it(`${name} derives to its shipped band (${ships})`, () => {
+      expect(deriveBand(category, travel, undefined)).toBe(ships);
+    });
+  }
+
+  it('exit is one band shorter than its enter, for every non-large pair', () => {
+    for (const travel of ['short', 'medium'] as MotionTravel[]) {
+      const enter = deriveBand('enter', travel, undefined);
+      const exit = deriveBand('exit', travel, undefined);
+      expect(BAND_ORDER.indexOf(exit)).toBe(BAND_ORDER.indexOf(enter) - 1);
+    }
+  });
+
+  it('the large-travel pair does NOT shorten on exit -- the documented exception', () => {
+    expect(deriveBand('enter', 'large', undefined)).toBe(deriveBand('exit', 'large', undefined));
+  });
+
+  it('records the large-travel disagreement rather than resolving it silently', () => {
+    // The model says slow; b864de01 says normal. Both are asserted so that
+    // changing either one has to be deliberate.
+    expect(LARGE_TRAVEL_DISAGREEMENT.derived).toBe('slow');
+    expect(LARGE_TRAVEL_DISAGREEMENT.shipped).toBe('normal');
+    expect(deriveBand('enter', 'large', undefined)).toBe(LARGE_TRAVEL_DISAGREEMENT.shipped);
+  });
+
+  it('an interaction mapping must declare its band -- it has no travel', () => {
+    expect(() => deriveBand('interaction', 'none', undefined)).toThrowError(
+      /must declare its band/,
+    );
+    expect(deriveBand('interaction', 'none', 'micro')).toBe('micro');
+  });
+});
+
+describe('duration derives from band and intent', () => {
+  it('efficient reproduces the shipped default for every communicative band', () => {
+    // The bands that carry spatial motion. These are what a travel-driven
+    // derivation actually produces, and they match byte for byte.
+    const shipped: Record<string, number> = { moderate: 200, normal: 300, slow: 400 };
+    for (const [band, ms] of Object.entries(shipped)) {
+      expect(deriveDuration(band as never, 'efficient', DEFAULT_DURATION_DEFINITIONS)).toBe(ms);
+    }
+  });
+
+  it('micro and fast do NOT sit at their band minimum -- they are perceptual landmarks', () => {
+    // A near-miss that would have changed every focus ring and hover in the
+    // system. `micro` ships 100 in a [50,120] band because 100ms is the Nielsen
+    // instantaneous threshold, and `fast` ships 150 in [120,200] to match cursor
+    // speed. Neither is "the low end of the range" -- they are fixed points that
+    // happen to lie inside one.
+    //
+    // So intent-position does not govern the acknowledgment bands, and the
+    // derivation must not be applied to them. Asserted rather than silently
+    // avoided, because the failure mode is a 100ms -> 50ms shift that no test
+    // would otherwise catch.
+    expect(DEFAULT_DURATION_DEFINITIONS.micro?.default).toBe(100);
+    expect(DEFAULT_DURATION_DEFINITIONS.micro?.range[0]).toBe(50);
+    expect(DEFAULT_DURATION_DEFINITIONS.fast?.default).toBe(150);
+    expect(DEFAULT_DURATION_DEFINITIONS.fast?.range[0]).toBe(120);
+
+    // So these bands take their default verbatim rather than being interpolated,
+    // and the derivation reproduces them exactly.
+    expect(deriveDuration('micro', 'efficient', DEFAULT_DURATION_DEFINITIONS)).toBe(100);
+    expect(deriveDuration('fast', 'efficient', DEFAULT_DURATION_DEFINITIONS)).toBe(150);
+
+    // And no intent may move them -- a landmark is not a matter of character.
+    expect(deriveDuration('micro', 'elegant', DEFAULT_DURATION_DEFINITIONS)).toBe(100);
+  });
+
+  it('elegant sits at the high end -- the measured motion-duration peak', () => {
+    expect(deriveDuration('moderate', 'elegant', DEFAULT_DURATION_DEFINITIONS)).toBe(300);
+    expect(deriveDuration('normal', 'elegant', DEFAULT_DURATION_DEFINITIONS)).toBe(400);
+  });
+
+  it('CHANGING INTENT MOVES DURATION -- the whole point of the epic', () => {
+    const efficient = deriveDuration('moderate', 'efficient', DEFAULT_DURATION_DEFINITIONS);
+    const elegant = deriveDuration('moderate', 'elegant', DEFAULT_DURATION_DEFINITIONS);
+    expect(elegant).toBeGreaterThan(efficient);
+  });
+
+  it('the band clamps the intent -- character never escapes perception', () => {
+    // moderate is the communicative window [200,300]. No intent may reach 400,
+    // because 400 is a different perceptual band, not a stronger flavour of this one.
+    const [min, max] = DEFAULT_DURATION_DEFINITIONS.moderate?.range as [number, number];
+    for (const intent of ['efficient', 'elegant', 'friendly', 'technical', 'editorial'] as const) {
+      const ms = deriveDuration('moderate', intent, DEFAULT_DURATION_DEFINITIONS);
+      expect(ms).toBeGreaterThanOrEqual(min);
+      expect(ms).toBeLessThanOrEqual(max);
+    }
+  });
+
+  it('an unknown band fails loudly', () => {
+    expect(() =>
+      deriveDuration('communicative' as never, 'efficient', DEFAULT_DURATION_DEFINITIONS),
+    ).toThrowError(/unknown band "communicative"/);
+  });
+});
+
+describe('curve derives from category and travel', () => {
+  it('every exit uses the exit curve -- regular across all four shipped pairs', () => {
+    for (const travel of ['short', 'medium', 'large'] as MotionTravel[]) {
+      expect(deriveCurve('exit', travel, 'efficient', undefined)).toBe('exit');
+    }
+  });
+
+  it('enter uses the arrival curve, except large travel which settles', () => {
+    expect(deriveCurve('enter', 'short', 'efficient', undefined)).toBe('enter');
+    expect(deriveCurve('enter', 'medium', 'efficient', undefined)).toBe('enter');
+    // sheet and page: the user must track a large surface into place.
+    expect(deriveCurve('enter', 'large', 'efficient', undefined)).toBe('spring-smooth');
+  });
+
+  it('a spring is never derived for an entering or exiting element at efficient', () => {
+    // 29 of 30 surveyed sites carry zero overshoot curves; spring-snappy belongs
+    // to friendly. Nothing in the spatial path may resolve to it.
+    for (const travel of ['none', 'short', 'medium', 'large'] as MotionTravel[]) {
+      expect(deriveCurve('enter', travel, 'efficient', undefined)).not.toBe('spring-snappy');
+      expect(deriveCurve('exit', travel, 'efficient', undefined)).not.toBe('spring-snappy');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The derivation the #1975 spike established, as code. `band = f(travel, category)`, `position = g(intent)`, `curve = h(category, travel)`.

It reproduces every shipped spatial band exactly. That is the deliverable, not a side effect: a derivation that quietly changes shipped values is indistinguishable from a bug, while one that reproduces them proves the model describes decisions a human already made.

**This lands the model, not the migration.** The generator still reads the hand-typed `durationTier` and `curve` fields; nothing is wired through yet. That keeps this diff reviewable as a model and leaves the mapping rewrite to a follow-up where a byte-for-byte output comparison is the whole test.

## Acceptance criteria mapping

### 1. Travel is a declared, typed input

`MotionTravel` is `'none' | 'short' | 'medium' | 'large'`, read off the `sizeReasoning` prose each mapping already carried -- "no movement" (hover), "a short distance" (dropdown), "larger and travels farther" (modal), "a large spatial movement" (sheet).

**Travel is ordinal, not metric, and that is a decision I made rather than deferred.** The output is discrete -- six perceptual bands selected by a step function -- so travel needs exactly enough resolution to pick among them. A spacing-step or pixel metric would be false precision fitted to an answer we already have, which is the trap the research names as "fit is not derivation". The blocking question in the issue is answered by observing that the consumer of travel is discrete.

Evidence: `motion-derivation.ts` type and module docstring.

### 2. The band is computed from travel; position within the band from intent

`deriveBand` maps travel to a band and applies the exit rule; `deriveDuration` interpolates the band's range by the intent's position. The band is the clamp -- an intent can push `moderate` from 200 to 300 but never to 400, because 400 is a different perceptual window. No separate clamping step exists or is needed, which is why the tiers are ranges rather than constants.

Evidence: test "the band clamps the intent -- character never escapes perception" asserts every intent lands inside `moderate`'s range.

### 3. The curve is computed; `spring-snappy` is unreachable on the spatial path

`deriveCurve` returns `exit` for every exit, `enter` for short/medium enters, and `spring-smooth` for large-travel enters (the user must track a large surface into place). A test asserts no travel value on either spatial path resolves to `spring-snappy` -- the curve the 30-site study found belongs to friendly and effectively nowhere else.

Evidence: test "a spring is never derived for an entering or exiting element at efficient".

### 4. Changing intent moves duration

Asserted directly, and named as such in the test so its purpose survives a later edit.

Evidence: test "CHANGING INTENT MOVES DURATION -- the whole point of the epic".

### 5. Every mapping lands inside the band its travel selects

The six shipped enter/exit mappings are tabulated with their real tiers and each is asserted to fall out of the derivation.

Evidence: the `SPATIAL` table and its generated cases; full suite 29 files / 253 tests.

### 6. The `sheet-in` disagreement is resolved explicitly, not silently

`LARGE_TRAVEL_DISAGREEMENT` records `derived: 'slow'` against `shipped: 'normal'` with the reason. The derivation **honours the shipped value**. `slow`'s own contexts list `sheets` and `page-transitions`, so the model says slow -- but `b864de01` is a deliberate human call and a derivation that overwrites it silently is the failure this epic exists to prevent. A test asserts both halves, so changing either has to be intentional.

Evidence: test "records the large-travel disagreement rather than resolving it silently".

## Two things the shipped data corrected

Both would have shipped silently.

**`micro` and `fast` are perceptual landmarks, not positions.** `micro` ships 100ms inside a [50,120] band because 100ms is the Nielsen instantaneous threshold; `fast` ships 150ms inside [120,200] to match a cursor already on target. My first implementation interpolated every band, which would have moved every focus ring from 100ms to 50ms and every hover from 150ms to 120ms. Caught by asserting against shipped values rather than against the model's own output. They now take their default verbatim and no intent may move them.

**Large travel does not shorten on exit.** The exit-one-band-shorter rule holds for three of four shipped pairs. The sheet pair is the exception, documented in `b864de01`: a tracked spatial surface moves in and out at one pace. My first cut applied the shortening anyway and two tests failed; the fix was to the logic, not the tests.

## Not done

- **Rewriting the 13 mappings to declare travel.** Deliberate. The model lands first so the migration diff can be judged purely on whether output changes.
- **`intent` as a system config input.** `ResolvedSystemConfig` has no such field, and adding one is cross-cutting -- it drives spacing, radius and type, not only motion. `deriveDuration` takes intent as a parameter so the wiring is a later, separable change.
- **Positions for `friendly`, `technical`, `editorial`.** Only `efficient` and `elegant` have measured data. The other three inherit neutral rather than receiving invented numbers, and `RESEARCHED_INTENTS` records which is which -- a guess here would be indistinguishable from data at the call site.
- **Curve vocabularies per intent.** `deriveCurve` takes `_intent` unused, marked with the underscore, as the seam those attach to.
- **Interaction tokens still declare their band.** hover, focus, press and toggle do not move through space, so travel cannot select for them; their bands separate by feedback kind. Forcing a spatial rule onto them would be fitting rather than deriving.