### PR TITLE
feat(design-tokens): motion tiers and curves derive; mappings declare travel

### DIFF
--- a/packages/design-tokens/src/generators/defaults.ts
+++ b/packages/design-tokens/src/generators/defaults.ts
@@ -18,6 +18,9 @@
  */
 
 import type { OKLCH } from '@rafters/shared';
+// Type-only both ways -- motion-derivation imports DurationDef from here. Both
+// sides are erased at compile, so this pair never forms a runtime cycle.
+import type { MotionBand, MotionTravel } from './motion-derivation.js';
 
 // =============================================================================
 // COLOR DEFAULTS
@@ -911,10 +914,31 @@ export const DEFAULT_MOTION_COMPOSITE_PRESETS: Record<string, MotionCompositePre
 export interface MotionSemanticMapping {
   /** CSS properties this transition animates (become `transition-property`). */
   properties: string[];
-  /** Duration tier name -- a key of DEFAULT_DURATION_DEFINITIONS. */
-  durationTier: string;
-  /** Easing curve name -- a key of DEFAULT_EASING_DEFINITIONS. */
-  curve: string;
+  /**
+   * How far the animated thing moves. THE input for anything spatial -- the
+   * duration band and the curve both derive from it, so neither is named here.
+   *
+   * Ordinal rather than metric because the output is discrete: six perceptual
+   * bands selected by a step function. A pixel or spacing-step figure would be
+   * precision the decision never consumes.
+   */
+  travel: MotionTravel;
+  /**
+   * Interaction-only. hover, focus, press and toggle do not move through space,
+   * so travel cannot select a band for them -- they separate by FEEDBACK KIND
+   * instead (`micro` acknowledges that input landed, `fast` matches a cursor
+   * already on target). Declared here rather than forced through a spatial rule
+   * that would be fitting rather than deriving.
+   *
+   * Must be absent for `enter`/`exit`, where the band is derived.
+   */
+  band?: MotionBand;
+  /**
+   * Interaction-only, for the same reason as `band`. Feedback character is
+   * per-token, not per-category. Absent for `enter`/`exit`, where the curve
+   * derives from category and travel.
+   */
+  curve?: string;
   /**
    * prefers-reduced-motion override. `null` = preserved unchanged (feedback that
    * must survive: hover colour, focus ring). Otherwise the reduced property set
@@ -944,7 +968,8 @@ export interface MotionSemanticMapping {
 export const DEFAULT_MOTION_SEMANTIC_MAPPINGS: Record<string, MotionSemanticMapping> = {
   hover: {
     properties: ['color', 'background-color', 'border-color'],
-    durationTier: 'fast',
+    travel: 'none',
+    band: 'fast',
     curve: 'standard',
     reducedMotion: null,
     category: 'interaction',
@@ -955,7 +980,8 @@ export const DEFAULT_MOTION_SEMANTIC_MAPPINGS: Record<string, MotionSemanticMapp
   },
   focus: {
     properties: ['box-shadow', 'outline-color'],
-    durationTier: 'micro',
+    travel: 'none',
+    band: 'micro',
     curve: 'linear',
     reducedMotion: null,
     category: 'interaction',
@@ -966,7 +992,8 @@ export const DEFAULT_MOTION_SEMANTIC_MAPPINGS: Record<string, MotionSemanticMapp
   },
   press: {
     properties: ['transform', 'color', 'background-color'],
-    durationTier: 'micro',
+    travel: 'none',
+    band: 'micro',
     curve: 'spring-snappy',
     reducedMotion: { properties: ['color', 'background-color'] },
     category: 'interaction',
@@ -977,7 +1004,8 @@ export const DEFAULT_MOTION_SEMANTIC_MAPPINGS: Record<string, MotionSemanticMapp
   },
   toggle: {
     properties: ['color', 'background-color', 'transform'],
-    durationTier: 'moderate',
+    travel: 'none',
+    band: 'moderate',
     curve: 'spring-snappy',
     reducedMotion: { properties: ['color', 'background-color'] },
     category: 'interaction',
@@ -988,8 +1016,7 @@ export const DEFAULT_MOTION_SEMANTIC_MAPPINGS: Record<string, MotionSemanticMapp
   },
   'dropdown-in': {
     properties: ['opacity', 'transform'],
-    durationTier: 'moderate',
-    curve: 'enter',
+    travel: 'short',
     reducedMotion: { properties: ['opacity'], ms: 100 },
     category: 'enter',
     sizeReasoning:
@@ -999,8 +1026,7 @@ export const DEFAULT_MOTION_SEMANTIC_MAPPINGS: Record<string, MotionSemanticMapp
   },
   'dropdown-out': {
     properties: ['opacity', 'transform'],
-    durationTier: 'fast',
-    curve: 'exit',
+    travel: 'short',
     reducedMotion: { properties: ['opacity'], ms: 100 },
     category: 'exit',
     sizeReasoning:
@@ -1010,8 +1036,7 @@ export const DEFAULT_MOTION_SEMANTIC_MAPPINGS: Record<string, MotionSemanticMapp
   },
   'modal-in': {
     properties: ['opacity', 'transform'],
-    durationTier: 'normal',
-    curve: 'enter',
+    travel: 'medium',
     reducedMotion: { properties: ['opacity'], ms: 150 },
     category: 'enter',
     sizeReasoning:
@@ -1021,8 +1046,7 @@ export const DEFAULT_MOTION_SEMANTIC_MAPPINGS: Record<string, MotionSemanticMapp
   },
   'modal-out': {
     properties: ['opacity', 'transform'],
-    durationTier: 'moderate',
-    curve: 'exit',
+    travel: 'medium',
     reducedMotion: { properties: ['opacity'], ms: 150 },
     category: 'exit',
     sizeReasoning:
@@ -1032,8 +1056,7 @@ export const DEFAULT_MOTION_SEMANTIC_MAPPINGS: Record<string, MotionSemanticMapp
   },
   'sheet-in': {
     properties: ['transform'],
-    durationTier: 'normal',
-    curve: 'spring-smooth',
+    travel: 'large',
     reducedMotion: { properties: ['opacity'], ms: 250 },
     category: 'enter',
     sizeReasoning:
@@ -1043,8 +1066,7 @@ export const DEFAULT_MOTION_SEMANTIC_MAPPINGS: Record<string, MotionSemanticMapp
   },
   'sheet-out': {
     properties: ['transform'],
-    durationTier: 'normal',
-    curve: 'exit',
+    travel: 'large',
     reducedMotion: { properties: ['opacity'], ms: 250 },
     category: 'exit',
     sizeReasoning:
@@ -1054,8 +1076,7 @@ export const DEFAULT_MOTION_SEMANTIC_MAPPINGS: Record<string, MotionSemanticMapp
   },
   expand: {
     properties: ['grid-template-rows', 'opacity'],
-    durationTier: 'normal',
-    curve: 'enter',
+    travel: 'medium',
     reducedMotion: { properties: ['opacity'] },
     category: 'enter',
     sizeReasoning:
@@ -1065,8 +1086,7 @@ export const DEFAULT_MOTION_SEMANTIC_MAPPINGS: Record<string, MotionSemanticMapp
   },
   collapse: {
     properties: ['grid-template-rows', 'opacity'],
-    durationTier: 'moderate',
-    curve: 'exit',
+    travel: 'medium',
     reducedMotion: { properties: ['opacity'] },
     category: 'exit',
     sizeReasoning:
@@ -1076,8 +1096,7 @@ export const DEFAULT_MOTION_SEMANTIC_MAPPINGS: Record<string, MotionSemanticMapp
   },
   page: {
     properties: ['opacity', 'transform'],
-    durationTier: 'normal',
-    curve: 'spring-smooth',
+    travel: 'large',
     reducedMotion: { properties: ['opacity'], ms: 200 },
     category: 'enter',
     sizeReasoning:

--- a/packages/design-tokens/src/generators/motion.ts
+++ b/packages/design-tokens/src/generators/motion.ts
@@ -35,6 +35,7 @@ import type {
   MotionCompositePreset,
   MotionSemanticMapping,
 } from './defaults.js';
+import { deriveBand, deriveCurve, deriveDuration, type MotionIntent } from './motion-derivation.js';
 import type { GeneratorResult, ResolvedSystemConfig } from './types.js';
 import { EASING_CURVES, MOTION_DURATION_SCALE } from './types.js';
 
@@ -89,6 +90,13 @@ export function generateMotionTokens(
   const timestamp = new Date().toISOString();
   const { baseTransitionDuration, progressionRatio } = config;
 
+  // The active intent. `ResolvedSystemConfig` has no `intent` field yet -- adding
+  // one is cross-cutting, since intent drives spacing, radius and type as well as
+  // motion, and widening the system config inside a motion change would be the
+  // wrong seam. Read optionally with the neutral default so the derivation is
+  // live now and the config work stays separable.
+  const intent: MotionIntent = (config as { intent?: MotionIntent }).intent ?? 'efficient';
+
   const ratio = resolveRatio(progressionRatio);
   const ratioVal = computeRatioValue(ratio);
   const computeStep = (base: number, step: number) => ratioStep(ratio, base, step);
@@ -130,7 +138,12 @@ export function generateMotionTokens(
     const def = durationDefs[scale];
     if (!def) continue;
     const scaleIndex = MOTION_DURATION_SCALE.indexOf(scale);
-    const durationMs = def.default;
+    // The band supplies the window; the intent picks a point inside it. This is
+    // the link that makes an intent change move motion -- without it the tier
+    // emits a constant and every downstream reference inherits the constant.
+    // At the neutral intent this returns each tier's shipped default, so the
+    // emitted system is unchanged until someone chooses a different intent.
+    const durationMs = deriveDuration(scale, intent, durationDefs);
     const [rangeMin, rangeMax] = def.range;
     const bandNote = def.band ? ` Band: ${def.band}.` : '';
     const rangeNote = rangeMin === rangeMax ? ' Fixed.' : ` Range: ${rangeMin}-${rangeMax}ms.`;
@@ -381,20 +394,25 @@ export function generateMotionTokens(
   // loop skips it (tokenValueToCSS returns null for JSON), so it never leaks a
   // raw custom property. Named after typography-composite's single-source model.
   for (const [name, mapping] of Object.entries(semanticMappings)) {
-    // Unlike the animation and composite paths, this one never resolved its tier
-    // or curve at all -- it wrote both names straight into the blob AND into
-    // dependsOn. A typo therefore produced a dangling dependency edge and a
-    // var(--duration-<typo>) that renders nothing, with no lookup anywhere to
-    // fail. Resolve purely to validate; the emitted value stays a reference.
-    requireDef(durationDefs, mapping.durationTier, 'duration tier', `semantic motion "${name}"`);
-    requireDef(easingDefs, mapping.curve, 'easing curve', `semantic motion "${name}"`);
+    // Tier and curve are DERIVED, not read. The mapping declares how far the
+    // thing travels; perception decides which band that lands in and character
+    // decides the curve. Nothing here names a tier, so there is no place left to
+    // bake a choice -- which is the whole point of the exercise.
+    const durationTier = deriveBand(mapping.category, mapping.travel, mapping.band);
+    const curve = deriveCurve(mapping.category, mapping.travel, intent, mapping.curve);
+
+    // Still validate, for the same reason as the other paths: the derived names
+    // flow into dependsOn and into a var() the exporter emits unconditionally, so
+    // a name that does not resolve would render nothing and fail nowhere.
+    requireDef(durationDefs, durationTier, 'duration tier', `semantic motion "${name}"`);
+    requireDef(easingDefs, curve, 'easing curve', `semantic motion "${name}"`);
 
     tokens.push({
       name: `motion-semantic-${name}`,
       value: JSON.stringify({
         properties: mapping.properties,
-        durationTier: mapping.durationTier,
-        curve: mapping.curve,
+        durationTier,
+        curve,
         reducedMotion: mapping.reducedMotion,
       }),
       category: 'motion',
@@ -408,8 +426,8 @@ export function generateMotionTokens(
             ? 'exit'
             : 'transition',
       generateUtilityClass: true,
-      dependsOn: [`motion-duration-${mapping.durationTier}`, `motion-easing-${mapping.curve}`],
-      description: `Semantic motion motion-${name}: ${mapping.properties.join(', ')} over ${mapping.durationTier} with ${mapping.curve}. ${mapping.sizeReasoning}`,
+      dependsOn: [`motion-duration-${durationTier}`, `motion-easing-${curve}`],
+      description: `Semantic motion motion-${name}: ${mapping.properties.join(', ')} over ${durationTier} with ${curve}. ${mapping.sizeReasoning}`,
       generatedAt: timestamp,
       containerQueryAware: false,
       reducedMotionAware: true,

--- a/packages/design-tokens/test/motion-derivation.test.ts
+++ b/packages/design-tokens/test/motion-derivation.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { DEFAULT_DURATION_DEFINITIONS } from '../src/generators/defaults.js';
+import {
+  DEFAULT_ANIMATION_DEFINITIONS,
+  DEFAULT_DELAY_DEFINITIONS,
+  DEFAULT_DURATION_DEFINITIONS,
+  DEFAULT_EASING_DEFINITIONS,
+  DEFAULT_KEYFRAME_DEFINITIONS,
+  DEFAULT_MOTION_COMPOSITE_PRESETS,
+  DEFAULT_MOTION_SEMANTIC_MAPPINGS,
+} from '../src/generators/defaults.js';
+import { generateMotionTokens } from '../src/generators/motion.js';
 import {
   BAND_ORDER,
   deriveBand,
@@ -153,5 +162,103 @@ describe('curve derives from category and travel', () => {
       expect(deriveCurve('enter', travel, 'efficient', undefined)).not.toBe('spring-snappy');
       expect(deriveCurve('exit', travel, 'efficient', undefined)).not.toBe('spring-snappy');
     }
+  });
+});
+
+describe('end to end: changing intent moves the emitted tokens (epic #1973)', () => {
+  function semanticFor(intent: string) {
+    const result = generateMotionTokens(
+      { baseTransitionDuration: 150, progressionRatio: 'perfect-fourth', intent } as never,
+      DEFAULT_DURATION_DEFINITIONS,
+      DEFAULT_EASING_DEFINITIONS,
+      DEFAULT_DELAY_DEFINITIONS,
+      DEFAULT_MOTION_SEMANTIC_MAPPINGS,
+      DEFAULT_KEYFRAME_DEFINITIONS,
+      DEFAULT_ANIMATION_DEFINITIONS,
+      DEFAULT_MOTION_COMPOSITE_PRESETS,
+    );
+    const out = new Map<string, string>();
+    for (const t of result.tokens) {
+      if (!t.name.startsWith('motion-semantic-')) continue;
+      const spec = JSON.parse(t.value as string) as { durationTier: string; curve: string };
+      out.set(t.name, `${spec.durationTier}/${spec.curve}`);
+    }
+    return out;
+  }
+
+  it('no mapping names a tier or a curve any more -- there is nowhere left to bake a choice', () => {
+    for (const [name, mapping] of Object.entries(DEFAULT_MOTION_SEMANTIC_MAPPINGS)) {
+      if (mapping.category === 'interaction') continue;
+      expect(mapping.band, `${name} still declares a band`).toBeUndefined();
+      expect(mapping.curve, `${name} still declares a curve`).toBeUndefined();
+    }
+  });
+
+  it('the derived output is identical to what shipped, for all 13', () => {
+    // The golden test guards the emitted CSS; this guards the token spec itself.
+    expect(semanticFor('efficient')).toMatchInlineSnapshot(`
+      Map {
+        "motion-semantic-hover" => "fast/standard",
+        "motion-semantic-focus" => "micro/linear",
+        "motion-semantic-press" => "micro/spring-snappy",
+        "motion-semantic-toggle" => "moderate/spring-snappy",
+        "motion-semantic-dropdown-in" => "moderate/enter",
+        "motion-semantic-dropdown-out" => "fast/exit",
+        "motion-semantic-modal-in" => "normal/enter",
+        "motion-semantic-modal-out" => "moderate/exit",
+        "motion-semantic-sheet-in" => "normal/spring-smooth",
+        "motion-semantic-sheet-out" => "normal/exit",
+        "motion-semantic-expand" => "normal/enter",
+        "motion-semantic-collapse" => "moderate/exit",
+        "motion-semantic-page" => "normal/spring-smooth",
+      }
+    `);
+  });
+});
+
+describe('the epic condition: a designer changes intent and motion moves', () => {
+  function durationsFor(intent: string) {
+    const result = generateMotionTokens(
+      { baseTransitionDuration: 150, progressionRatio: 'perfect-fourth', intent } as never,
+      DEFAULT_DURATION_DEFINITIONS,
+      DEFAULT_EASING_DEFINITIONS,
+      DEFAULT_DELAY_DEFINITIONS,
+      DEFAULT_MOTION_SEMANTIC_MAPPINGS,
+      DEFAULT_KEYFRAME_DEFINITIONS,
+      DEFAULT_ANIMATION_DEFINITIONS,
+      DEFAULT_MOTION_COMPOSITE_PRESETS,
+    );
+    const out: Record<string, string> = {};
+    for (const t of result.tokens) {
+      if (t.name.startsWith('motion-duration-')) out[t.name] = t.value as string;
+    }
+    return out;
+  }
+
+  it('efficient emits exactly the values that ship today', () => {
+    const d = durationsFor('efficient');
+    expect(d['motion-duration-micro']).toBe('100ms');
+    expect(d['motion-duration-fast']).toBe('150ms');
+    expect(d['motion-duration-moderate']).toBe('200ms');
+    expect(d['motion-duration-normal']).toBe('300ms');
+    expect(d['motion-duration-slow']).toBe('400ms');
+  });
+
+  it('elegant emits longer communicative durations -- WITHOUT ANY TABLE BEING EDITED', () => {
+    const efficient = durationsFor('efficient');
+    const elegant = durationsFor('elegant');
+
+    expect(elegant['motion-duration-moderate']).toBe('300ms');
+    expect(elegant['motion-duration-normal']).toBe('400ms');
+    expect(elegant['motion-duration-slow']).toBe('500ms');
+
+    expect(elegant['motion-duration-moderate']).not.toBe(efficient['motion-duration-moderate']);
+  });
+
+  it('the acknowledgment landmarks do not move -- perception is not a matter of taste', () => {
+    // micro is the Nielsen threshold and fast matches cursor speed. An intent
+    // may not restyle a perceptual constant.
+    expect(durationsFor('elegant')['motion-duration-micro']).toBe('100ms');
+    expect(durationsFor('elegant')['motion-duration-fast']).toBe('150ms');
   });
 });

--- a/packages/design-tokens/test/motion-unknown-names.test.ts
+++ b/packages/design-tokens/test/motion-unknown-names.test.ts
@@ -54,18 +54,22 @@ function generate(
 }
 
 describe('motion generator rejects unknown tier and curve names (#1977)', () => {
+  // Since #1982 the spatial mappings no longer NAME a tier or curve -- both derive
+  // from travel and intent -- so a spatial mapping cannot carry a bad name at all.
+  // What remains typo-able is the band and curve an INTERACTION mapping declares,
+  // because those have no travel to derive from. The first entry (hover) is one.
   it('every shipping definition resolves -- this guard lands with no value change', () => {
     expect(() => generate()).not.toThrow();
   });
 
-  it('an unknown duration tier on a semantic mapping fails the build', () => {
+  it('an unknown band on an interaction mapping fails the build', () => {
     const [firstName, firstMapping] = Object.entries(DEFAULT_MOTION_SEMANTIC_MAPPINGS)[0] as [
       string,
       (typeof DEFAULT_MOTION_SEMANTIC_MAPPINGS)[string],
     ];
     const semantic = {
       ...DEFAULT_MOTION_SEMANTIC_MAPPINGS,
-      [firstName]: { ...firstMapping, durationTier: 'moderat' },
+      [firstName]: { ...firstMapping, band: 'moderat' },
     };
     expect(() => generate({ semantic })).toThrowError(/unknown duration tier "moderat"/);
   });
@@ -101,7 +105,7 @@ describe('motion generator rejects unknown tier and curve names (#1977)', () => 
     ];
     const semantic = {
       ...DEFAULT_MOTION_SEMANTIC_MAPPINGS,
-      [firstName]: { ...firstMapping, durationTier: 'moderat' },
+      [firstName]: { ...firstMapping, band: 'moderat' },
     };
 
     // The failure is nearly always a near-miss, so the fix is unguessable without


### PR DESCRIPTION
## Summary

Semantic motion mappings no longer name a duration tier or a curve. They declare how far the thing travels; both fall out.

```
before   'dropdown-in': { durationTier: 'moderate', curve: 'enter', ... }
after    'dropdown-in': { travel: 'short', ... }
```

Completes epic #1973's condition: **a designer changes the intent and motion moves, without a table being edited.**

## Acceptance criteria mapping

### 1. Travel is a declared, typed input replacing the prose

All 13 mappings carry `travel: MotionTravel`, read off the `sizeReasoning` each already had. `sizeReasoning` stays as the human explanation; `travel` is now the machine-readable form of the same fact.

Evidence: `DEFAULT_MOTION_SEMANTIC_MAPPINGS`; test "no mapping names a tier or a curve any more".

### 2. `durationTier` and `curve` are removed -- no place left to bake a choice

Removed from every spatial mapping. Kept, renamed to `band`, on the four interaction mappings only, because hover/focus/press/toggle do not move through space and cannot derive a band from travel -- they separate by feedback kind. The interface makes both fields optional and documents them as interaction-only.

A test asserts no `enter`/`exit` mapping declares either field, so a regression that reintroduces one fails.

Evidence: test "no mapping names a tier or a curve any more -- there is nowhere left to bake a choice".

### 3. The band is computed from travel; position within the band from intent

`deriveBand(category, travel, band)` in the semantic loop; `deriveDuration(scale, intent, defs)` in the duration-token loop. The second is the load-bearing one -- without it a tier emits a constant and every downstream reference inherits the constant, so the intent would reach nothing.

Evidence: `motion.ts:151` and `:389`.

### 4. The curve is computed from category and travel

`deriveCurve` in the same loop. `motion-toggle` retains `spring-snappy` only because it is an interaction token declaring its own curve; no spatial token can resolve to a spring.

Evidence: `motion.ts:390`; the spring assertion in the derivation suite.

### 5. Changing intent moves emitted durations with no regeneration step

The criterion this epic exists for, asserted directly:

```
efficient   micro 100  fast 150  moderate 200  normal 300  slow 400
elegant     micro 100  fast 150  moderate 300  normal 400  slow 500
```

Nothing is edited between those two runs but the intent.

Evidence: tests "efficient emits exactly the values that ship today" and "elegant emits longer communicative durations -- WITHOUT ANY TABLE BEING EDITED".

### 6. Every mapping produces a duration inside the band its travel selects

An inline snapshot pins all 13 derived `tier/curve` pairs against what shipped. The motion golden test passes untouched. Together those make "output is unchanged" a checked claim rather than an assertion in a commit message.

Evidence: test "the derived output is identical to what shipped, for all 13"; `motion-golden.test.ts` unmodified and green.

### 7. Landmark bands are exempt from intent

`micro` stays 100ms and `fast` stays 150ms at every intent -- the Nielsen instantaneous threshold and cursor-matching speed are perceptual constants, not matters of taste. Interpolating them would have moved every focus ring from 100ms to 50ms.

Evidence: test "the acknowledgment landmarks do not move -- perception is not a matter of taste".

## Two #1977 tests changed, and the reason is this epic landing

They mutated `durationTier` on a semantic mapping to prove a typo throws. That field no longer exists there, so the mutation became a no-op and the assertions correctly failed.

**Coverage is not reduced -- the failure mode was removed.** A spatial mapping can no longer carry a bad tier at all, which is the outcome the epic wanted. The cases now target the `band` an interaction mapping declares, which is what remains typo-able.

## Not done

- **`intent` as a first-class `ResolvedSystemConfig` field.** Read via a cast with the neutral default (`motion.ts:103`). Adding the field is cross-cutting -- intent drives spacing, radius and type, not only motion -- so widening the system config inside a motion change would be the wrong seam. This is the weakest line in the diff and it is deliberate.
- **A discriminated union on `category`** so the compiler forbids `band`/`curve` on spatial mappings outright. The runtime guard throws and a test covers it; the type-level version restructures every entry and belongs in its own change.
- **`friendly`, `technical`, `editorial` positions.** Only efficient and elegant have measured data; the rest inherit neutral rather than receiving invented numbers.
- **Per-intent curve vocabularies.** `deriveCurve` takes intent unused, marked with an underscore, as the seam.
- **The `sheet` band disagreement.** Still recorded, still honouring the shipped `normal` over the derived `slow`. Unchanged by this PR.

Closes #1982
