### PR TITLE
fix(design-tokens): motion-toggle uses the standard curve, not a spring

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## Unreleased
 
+### Features
+
+- feat(design-tokens): motion duration and curve are derived, not authored (#1982). A semantic motion mapping no longer names a duration tier or an easing curve -- it declares how far the thing travels, and both fall out. `band = f(travel, category)`, `position = g(intent)`, `curve = h(category, travel)`. The six duration tiers are unchanged and become output bands: they are perceptual facts, so they bound what any intent may express. The practical consequence is that changing the active intent moves motion with no table edited -- at `efficient` the communicative bands emit 200/300/400 as they always have, at `elegant` they emit 300/400/500. The acknowledgment bands do not move at any intent: `micro` stays 100ms (the Nielsen instantaneous threshold) and `fast` stays 150ms (cursor-matching speed), because perception is not a matter of taste. Emitted output is unchanged at the default intent, pinned by a snapshot of all 13 derived pairs plus the existing golden.
+
 ### Bug Fixes
 
+- fix(design-tokens): `motion-toggle` uses the standard curve, not a spring (#1965). It shipped `spring-snappy` against a recorded ruling that an efficient toggle is crisp. The 30-site intent study is the evidence: 29 of 30 surveyed sites carry zero overshoot curves, and the single exception is the friendly exemplar -- spring-snappy belongs to friendly and effectively nowhere else. Efficient is the shipped default intent and is characterised as zero-overshoot, so a spring contradicted the intent it shipped under. One line of emitted output changes.
 - fix(design-tokens): an unknown duration tier or easing curve now fails the build instead of vanishing (#1977). The motion generator skipped any mapping whose tier or curve it did not recognise -- a bare `continue`, no throw, no warning -- while the exporter emitted `var(--duration-<name>)` regardless. A typo therefore produced syntactically valid CSS that resolves to nothing: the element did not animate, the build stayed green, and no test failed. The semantic-motion path was worse, never resolving its names at all and writing them straight into both the token value and `dependsOn`, so a typo also produced a dangling dependency edge. All four lookups now throw at generation time, naming the offending definition and listing the known vocabulary -- the failure is almost always a near-miss, and the fix is unguessable without the valid names in front of you. Every shipping definition resolves, so this lands with no change to any emitted value.
 
 ## 0.0.78

--- a/packages/design-tokens/src/generators/defaults.ts
+++ b/packages/design-tokens/src/generators/defaults.ts
@@ -1006,11 +1006,18 @@ export const DEFAULT_MOTION_SEMANTIC_MAPPINGS: Record<string, MotionSemanticMapp
     properties: ['color', 'background-color', 'transform'],
     travel: 'none',
     band: 'moderate',
-    curve: 'spring-snappy',
+    // `standard`, not `spring-snappy`. The 30-site study found 29 of 30 sites
+    // carry zero overshoot curves, and the one that does is the friendly
+    // exemplar -- spring-snappy belongs to friendly and effectively nowhere
+    // else. Efficient is the shipped default intent and is characterised as
+    // zero-overshoot, so a spring here contradicts the intent it ships under.
+    // Matches the recorded ruling: an efficient toggle is crisp; friendly is
+    // the intent that springs a switch.
+    curve: 'standard',
     reducedMotion: { properties: ['color', 'background-color'] },
     category: 'interaction',
     sizeReasoning:
-      'A thumb travelling a track is a small, tracked movement -- moderate tier, snappy spring. Reduced motion drops the transform to a colour cross-fade.',
+      'A thumb travelling a track is a small, tracked movement -- moderate tier at the standard curve. Reduced motion drops the transform to a colour cross-fade.',
     meaning: 'Toggle/switch state change. Shows the new state.',
     contexts: ['switch', 'toggle', 'checkbox'],
   },

--- a/packages/design-tokens/test/__snapshots__/motion-golden.test.ts.snap
+++ b/packages/design-tokens/test/__snapshots__/motion-golden.test.ts.snap
@@ -144,7 +144,7 @@ exports[`motion generator: golden output > emits stable name -> value pairs 1`] 
   "motion-semantic-press = {"properties":["transform","color","background-color"],"durationTier":"micro","curve":"spring-snappy","reducedMotion":{"properties":["color","background-color"]}}",
   "motion-semantic-sheet-in = {"properties":["transform"],"durationTier":"normal","curve":"spring-smooth","reducedMotion":{"properties":["opacity"],"ms":250}}",
   "motion-semantic-sheet-out = {"properties":["transform"],"durationTier":"normal","curve":"exit","reducedMotion":{"properties":["opacity"],"ms":250}}",
-  "motion-semantic-toggle = {"properties":["color","background-color","transform"],"durationTier":"moderate","curve":"spring-snappy","reducedMotion":{"properties":["color","background-color"]}}",
+  "motion-semantic-toggle = {"properties":["color","background-color","transform"],"durationTier":"moderate","curve":"standard","reducedMotion":{"properties":["color","background-color"]}}",
   "motion-slide-in = 300ms cubic-bezier(0, 0, 0.2, 1)",
   "motion-slide-out = 150ms cubic-bezier(0.4, 0, 1, 1)",
 ]

--- a/packages/design-tokens/test/motion-derivation.test.ts
+++ b/packages/design-tokens/test/motion-derivation.test.ts
@@ -201,7 +201,7 @@ describe('end to end: changing intent moves the emitted tokens (epic #1973)', ()
         "motion-semantic-hover" => "fast/standard",
         "motion-semantic-focus" => "micro/linear",
         "motion-semantic-press" => "micro/spring-snappy",
-        "motion-semantic-toggle" => "moderate/spring-snappy",
+        "motion-semantic-toggle" => "moderate/standard",
         "motion-semantic-dropdown-in" => "moderate/enter",
         "motion-semantic-dropdown-out" => "fast/exit",
         "motion-semantic-modal-in" => "normal/enter",


### PR DESCRIPTION
## Summary

`motion-toggle` shipped `spring-snappy` against a recorded ruling that an efficient toggle is crisp. This changes it to `standard`.

## Acceptance criteria mapping

### 1. The shipped value matches the agreed baseline

`toggle.curve` becomes `'standard'`. The recorded ruling reads: "toggle at standard NOT spring-snappy -- efficient toggle is crisp; friendly is the intent that springs a switch."

Evidence: the `toggle` entry in `DEFAULT_MOTION_SEMANTIC_MAPPINGS`.

### 2. The change is evidenced, not preferred

The 30-site intent study is the strongest negative signal in the whole survey: **29 of 30 sites carry zero overshoot curves**, and the single exception is the friendly exemplar. spring-snappy belongs to friendly and effectively nowhere else. Efficient is the shipped default intent and is characterised as fast, decelerating and zero-overshoot -- so a spring contradicted the intent it shipped under rather than merely differing from taste.

Evidence: reflection `019f92f4`; the derivation suite already asserts no spatial token can resolve to a spring.

### 3. Blast radius is stated and bounded

One line of emitted output. The golden snapshot diff is a single `-`/`+` pair on `motion-semantic-toggle`, and within that JSON only `"curve"` moves. No other token, no ordering change.

Evidence: `git diff` on `motion-golden.test.ts.snap`; the inline snapshot of all 13 pairs changes one row.

### 4. The description does not drift from the value

`sizeReasoning` said "moderate tier, snappy spring". Left alone it would have described a spring on a token that no longer uses one -- the same blob/description desync this epic exists to remove. Corrected in the same change.

Evidence: the `sizeReasoning` edit.

## Honest correction to the epic

**#1973 predicted this issue would dissolve, and it did not.**

The epic argued that once curves derive from intent, a hardcoded choice would have nowhere to live. That is true for every spatial token -- no `enter` or `exit` mapping can name a curve any more, and a test asserts it. It is false for this one: `toggle` is an **interaction** token, and interaction tokens declare their own curve by design, because they have no travel to derive one from.

So this is a value fix, and the class of bug still exists for the four interaction tokens. I would rather record that than let the epic's prediction stand unexamined -- the prediction was mine.

## Not done

- **`press` also carries `spring-snappy`.** The recorded ruling names `toggle` only. Changing `press` would be extending an operator decision rather than applying one, so it stays and is flagged here.
- **Removing the two spring curves from the vocabulary.** The study found four of five intents will never touch them. That is a vocabulary decision, separate from this token.
- **Per-intent curve sets** that would make interaction curves derive too, which is what would actually dissolve this bug class.

Closes #1965