### PR TITLE
feat(design-tokens): override provenance -- baseline | preset | designer

### DIFF
--- a/packages/design-tokens/src/graph.ts
+++ b/packages/design-tokens/src/graph.ts
@@ -1,3 +1,4 @@
+import { type OverrideKind, OverrideKindSchema } from '@rafters/shared';
 import { z } from 'zod';
 
 export type Plugin = {
@@ -12,6 +13,9 @@ export const UserOverrideSchema = z.object({
   previousValue: z.unknown(),
   reason: z.string(),
   context: z.string().optional(),
+  // Provenance. Optional by design: absent means unknown, which is what every
+  // override written before this field existed actually is.
+  kind: OverrideKindSchema.optional(),
 });
 
 export type UserOverride = z.infer<typeof UserOverrideSchema>;
@@ -35,6 +39,7 @@ export type Node = z.infer<typeof NodeSchema>;
 export type SetOptions = {
   reason: string;
   context?: string;
+  kind?: OverrideKind;
 };
 
 export class CircularDependencyError extends Error {
@@ -74,6 +79,7 @@ export class TokenGraph {
         previousValue: existing?.value,
         reason: options.reason,
         ...(options.context ? { context: options.context } : {}),
+        ...(options.kind ? { kind: options.kind } : {}),
       },
       ...(existing?.binding ? { binding: existing.binding } : {}),
     };

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -46,6 +46,13 @@ export {
   saveRegistryToDir,
 } from './persistence.js';
 export type { PluginSpec } from './plugin.js';
+export {
+  type ApplyPresetOptions,
+  type ApplyPresetResult,
+  applyPreset,
+  isDesignerAttributed,
+  type PresetValueSet,
+} from './preset.js';
 export { definePlugin } from './plugin.js';
 export {
   calcPlugin,

--- a/packages/design-tokens/src/preset.ts
+++ b/packages/design-tokens/src/preset.ts
@@ -1,0 +1,71 @@
+import type { Token } from '@rafters/shared';
+import type { TokenRegistry } from './registry.js';
+
+// A preset is a value-set over system tokens: token name -> value.
+export type PresetValueSet = Readonly<Record<string, string>>;
+
+export type ApplyPresetOptions = {
+  // Human-facing reason recorded on every token the preset writes.
+  reason: string;
+  context?: string;
+};
+
+export type ApplyPresetResult = {
+  // Tokens the preset wrote, each now carrying kind: 'preset'.
+  applied: readonly string[];
+  // Tokens left alone because a designer had attributed the current value.
+  skipped: readonly string[];
+  // Tokens in the value-set that the registry does not know about.
+  unknown: readonly string[];
+};
+
+/**
+ * Apply a preset value-set without destroying designer decisions.
+ *
+ * A naive apply -- set() every token in the value-set -- silently clobbers a
+ * designer's pin: no error is raised, and the pinned value survives only as
+ * previousValue under the PRESET's reason, so the designer attribution is
+ * gone. A second apply erases even that. This helper is the shipped answer:
+ * it skips any token whose current override is attributed to a designer, and
+ * records kind: 'preset' on everything it does write.
+ *
+ * Provenance is what it branches on, never the free-text reason string. An
+ * override with no kind is NOT treated as a designer pin -- absent provenance
+ * means unknown, and the preset overwrites it. That is the honest status quo
+ * for overrides written before the kind field existed; Studio should backfill
+ * kind rather than have this helper guess.
+ */
+export function applyPreset(
+  registry: TokenRegistry,
+  valueSet: PresetValueSet,
+  options: ApplyPresetOptions,
+): ApplyPresetResult {
+  const applied: string[] = [];
+  const skipped: string[] = [];
+  const unknown: string[] = [];
+
+  for (const [name, value] of Object.entries(valueSet)) {
+    const token = registry.get(name);
+    if (!token) {
+      unknown.push(name);
+      continue;
+    }
+    if (isDesignerAttributed(token)) {
+      skipped.push(name);
+      continue;
+    }
+    registry.set(name, value, {
+      reason: options.reason,
+      ...(options.context ? { context: options.context } : {}),
+      kind: 'preset',
+    });
+    applied.push(name);
+  }
+
+  return { applied, skipped, unknown };
+}
+
+/** True when the token's current value is a designer decision. */
+export function isDesignerAttributed(token: Token): boolean {
+  return token.userOverride?.kind === 'designer';
+}

--- a/packages/design-tokens/src/registry.ts
+++ b/packages/design-tokens/src/registry.ts
@@ -1,6 +1,6 @@
 import { type Token, TokenSchema } from '@rafters/shared';
 import type { z } from 'zod';
-import { type Node, type Plugin, type SetOptions, TokenGraph } from './graph.js';
+import { type Node, type Plugin, type SetOptions, TokenGraph, type UserOverride } from './graph.js';
 
 type TokenValue = z.infer<typeof TokenSchema>['value'];
 type UserOverrideField = NonNullable<z.infer<typeof TokenSchema>['userOverride']>;
@@ -34,13 +34,7 @@ export class TokenRegistry {
     // rebinds, but the override anchor blocks pass 2 from re-running the
     // transform now.
     for (const t of parsed) {
-      const override = t.userOverride
-        ? {
-            previousValue: t.userOverride.previousValue,
-            reason: t.userOverride.reason,
-            ...(t.userOverride.context ? { context: t.userOverride.context } : {}),
-          }
-        : undefined;
+      const override = toNodeOverride(t.userOverride);
       if (t.binding && !override) continue;
       this.graph.seed(t.name, t.value, {
         ...(override ? { userOverride: override } : {}),
@@ -68,13 +62,7 @@ export class TokenRegistry {
     }
     const t = result.data;
     this.metadata.set(t.name, t);
-    const override = t.userOverride
-      ? {
-          previousValue: t.userOverride.previousValue,
-          reason: t.userOverride.reason,
-          ...(t.userOverride.context ? { context: t.userOverride.context } : {}),
-        }
-      : undefined;
+    const override = toNodeOverride(t.userOverride);
     if (t.binding && !override) {
       this.graph.bind(t.name, t.binding.plugin, t.binding.input);
     } else {
@@ -167,6 +155,20 @@ export class TokenParseError extends Error {
   }
 }
 
+// Token schema shape -> graph node shape. One copy site so a newly added
+// override field cannot be dropped on the way in.
+function toNodeOverride(field: Token['userOverride']): UserOverride | undefined {
+  if (!field) return undefined;
+  return {
+    previousValue: field.previousValue,
+    reason: field.reason,
+    ...(field.context ? { context: field.context } : {}),
+    ...(field.kind ? { kind: field.kind } : {}),
+  };
+}
+
+// Graph node shape -> token schema shape. This is what persistence writes:
+// saveRegistryToDir serialises registry.list(), which routes through here.
 function toUserOverrideField(
   override: NonNullable<Node['userOverride']>,
   baseValue: TokenValue,
@@ -177,5 +179,6 @@ function toUserOverrideField(
     reason: override.reason,
   };
   if (override.context) result.context = override.context;
+  if (override.kind) result.kind = override.kind;
   return result;
 }

--- a/packages/design-tokens/test/preset-override.test.ts
+++ b/packages/design-tokens/test/preset-override.test.ts
@@ -1,0 +1,202 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  applyPreset,
+  loadRegistryFromDir,
+  saveRegistryToDir,
+  TokenParseError,
+  TokenRegistry,
+} from '../src/index.js';
+
+const EFFICIENT: Record<string, string> = {
+  'rafters-duration-fast': '150ms',
+  'rafters-duration-moderate': '250ms',
+  'rafters-duration-normal': '350ms',
+  'rafters-duration-slow': '500ms',
+};
+
+// Values are deliberately fake and obviously so. The mechanics are under test,
+// not the numbers -- there is no measured row for any intent preset yet.
+const FAKE_PRESET: Record<string, string> = {
+  'rafters-duration-fast': '999ms',
+  'rafters-duration-moderate': '999ms',
+  'rafters-duration-normal': '999ms',
+  'rafters-duration-slow': '999ms',
+};
+
+const leaf = (name: string, value: string) => ({
+  name,
+  value,
+  category: 'motion',
+  namespace: 'motion',
+  userOverride: null,
+});
+
+const freshRegistry = (): TokenRegistry =>
+  new TokenRegistry(
+    Object.entries(EFFICIENT).map(([n, v]) => leaf(n, v)),
+    [],
+  );
+
+const pinModerate = (registry: TokenRegistry): void => {
+  registry.set('rafters-duration-moderate', '220ms', {
+    reason: 'brand sits low in the band',
+    kind: 'designer',
+  });
+};
+
+describe('naive preset apply (documented failure mode)', () => {
+  it('clobbers a designer pin and destroys its attribution', () => {
+    const registry = freshRegistry();
+    pinModerate(registry);
+
+    // The naive apply Studio must NOT ship: set() every token in the value-set.
+    for (const [name, value] of Object.entries(FAKE_PRESET)) {
+      registry.set(name, value, { reason: 'apply preset', kind: 'preset' });
+    }
+
+    const moderate = registry.get('rafters-duration-moderate');
+    expect(moderate?.value).toBe('999ms');
+    // The pin survives only as previousValue, filed under the PRESET's reason
+    // and the PRESET's provenance. Nothing on the token says a designer chose
+    // 220ms -- that attribution is gone.
+    expect(moderate?.userOverride?.previousValue).toBe('220ms');
+    expect(moderate?.userOverride?.reason).toBe('apply preset');
+    expect(moderate?.userOverride?.kind).toBe('preset');
+  });
+
+  it('erases even the one step of history on a second apply', () => {
+    const registry = freshRegistry();
+    pinModerate(registry);
+    for (let pass = 0; pass < 2; pass++) {
+      for (const [name, value] of Object.entries(FAKE_PRESET)) {
+        registry.set(name, value, { reason: 'apply preset', kind: 'preset' });
+      }
+    }
+    const moderate = registry.get('rafters-duration-moderate');
+    expect(moderate?.userOverride?.previousValue).toBe('999ms');
+  });
+});
+
+describe('applyPreset', () => {
+  it('preserves the designer pin and moves everything else', () => {
+    const registry = freshRegistry();
+    pinModerate(registry);
+
+    const result = applyPreset(registry, FAKE_PRESET, { reason: 'apply preset' });
+
+    expect(result.skipped).toEqual(['rafters-duration-moderate']);
+    expect(result.applied).toEqual([
+      'rafters-duration-fast',
+      'rafters-duration-normal',
+      'rafters-duration-slow',
+    ]);
+    expect(result.unknown).toEqual([]);
+
+    const moderate = registry.get('rafters-duration-moderate');
+    expect(moderate?.value).toBe('220ms');
+    expect(moderate?.userOverride?.kind).toBe('designer');
+    expect(moderate?.userOverride?.reason).toBe('brand sits low in the band');
+
+    for (const name of result.applied) {
+      const token = registry.get(name);
+      expect(token?.value).toBe('999ms');
+      expect(token?.userOverride?.kind).toBe('preset');
+    }
+  });
+
+  it('is idempotent for the pin across repeated applies', () => {
+    const registry = freshRegistry();
+    pinModerate(registry);
+    applyPreset(registry, FAKE_PRESET, { reason: 'apply preset' });
+    applyPreset(registry, FAKE_PRESET, { reason: 'apply preset again' });
+    expect(registry.get('rafters-duration-moderate')?.value).toBe('220ms');
+  });
+
+  it('treats a legacy override without kind as unattributed and overwrites it', () => {
+    // Absent provenance means unknown, not designer. Overrides written before
+    // the kind field existed carry no claim on the value, and this helper does
+    // not sniff the reason string for a "designer:" prefix.
+    const registry = freshRegistry();
+    registry.set('rafters-duration-moderate', '220ms', { reason: 'designer: brand tune' });
+
+    const result = applyPreset(registry, FAKE_PRESET, { reason: 'apply preset' });
+
+    expect(result.skipped).toEqual([]);
+    expect(registry.get('rafters-duration-moderate')?.value).toBe('999ms');
+  });
+
+  it('reports value-set entries the registry does not know', () => {
+    const registry = freshRegistry();
+    const result = applyPreset(
+      registry,
+      { 'rafters-duration-fast': '10ms', 'rafters-duration-nonexistent': '10ms' },
+      { reason: 'apply preset' },
+    );
+    expect(result.unknown).toEqual(['rafters-duration-nonexistent']);
+    expect(result.applied).toEqual(['rafters-duration-fast']);
+  });
+});
+
+describe('override provenance persistence', () => {
+  const TEST_TMP_ROOT = join(import.meta.dirname, '..', 'node_modules', '.test-tmp');
+  let tmpDir: string;
+
+  beforeEach(() => {
+    mkdirSync(TEST_TMP_ROOT, { recursive: true });
+    tmpDir = mkdtempSync(join(TEST_TMP_ROOT, 'provenance-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('survives the save -> disk -> load roundtrip', () => {
+    const registry = freshRegistry();
+    pinModerate(registry);
+    applyPreset(registry, FAKE_PRESET, { reason: 'apply preset' });
+    saveRegistryToDir(tmpDir, registry);
+
+    const reloaded = loadRegistryFromDir(tmpDir);
+    const moderate = reloaded.get('rafters-duration-moderate');
+    expect(moderate?.value).toBe('220ms');
+    expect(moderate?.userOverride?.kind).toBe('designer');
+    expect(reloaded.get('rafters-duration-fast')?.userOverride?.kind).toBe('preset');
+  });
+
+  it('still skips the reloaded designer pin on a later apply', () => {
+    const registry = freshRegistry();
+    pinModerate(registry);
+    saveRegistryToDir(tmpDir, registry);
+
+    const reloaded = loadRegistryFromDir(tmpDir);
+    const result = applyPreset(reloaded, FAKE_PRESET, { reason: 'apply preset' });
+    expect(result.skipped).toEqual(['rafters-duration-moderate']);
+    expect(reloaded.get('rafters-duration-moderate')?.value).toBe('220ms');
+  });
+
+  it('rejects an unknown provenance kind at schema level', () => {
+    expect(
+      () =>
+        new TokenRegistry([
+          {
+            ...leaf('rafters-duration-fast', '150ms'),
+            userOverride: { previousValue: '150ms', reason: 'whatever', kind: 'nonsense' },
+          },
+        ]),
+    ).toThrow(TokenParseError);
+  });
+
+  it('loads a legacy override with no kind unchanged', () => {
+    const registry = new TokenRegistry([
+      {
+        ...leaf('rafters-duration-fast', '111ms'),
+        userOverride: { previousValue: '150ms', reason: 'legacy tweak' },
+      },
+    ]);
+    const token = registry.get('rafters-duration-fast');
+    expect(token?.value).toBe('111ms');
+    expect(token?.userOverride?.kind).toBeUndefined();
+  });
+});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -455,6 +455,16 @@ export const BindingSchema = z.object({
 });
 export type Binding = z.infer<typeof BindingSchema>;
 
+// Override provenance: WHO put the value there, as a machine-readable kind
+// rather than a free-text convention on the reason string.
+//   baseline -- the generated system value, restated as an explicit override
+//   preset   -- written by applying a Studio value-set
+//   designer -- a human decision; preset application must not clobber it
+// Extension point: 'measured' / 'tuned' can join the enum later.
+export const OVERRIDE_KINDS = ['baseline', 'preset', 'designer'] as const;
+export const OverrideKindSchema = z.enum(OVERRIDE_KINDS);
+export type OverrideKind = z.infer<typeof OverrideKindSchema>;
+
 // Comprehensive Design Token Schema - Single Source of Truth
 export const TokenSchema = z.object({
   // Core token data
@@ -497,6 +507,12 @@ export const TokenSchema = z.object({
       reason: z.string(),
       // Additional context (e.g. "Q1 marketing campaign", "accessibility audit")
       context: z.string().optional(),
+      // Who attributed the value. The reason string is for humans; kind is what
+      // machines branch on (preset application skips kind === 'designer').
+      // Optional and never defaulted: absent means the provenance is unknown,
+      // which is the honest state of every override written before this field
+      // existed.
+      kind: OverrideKindSchema.optional(),
     })
     .nullable(),
 


### PR DESCRIPTION
## Summary

Override attribution stops being a free-text convention. `userOverride` gains an optional
`kind` field -- `baseline | preset | designer`, with room for `measured`/`tuned` later -- so
the knobs-won numbers and someone's Tuesday accident are distinguishable at rest without any
code sniffing a `designer:` prefix off the reason string. The reason string stays exactly as
it is, for humans; `kind` is what machines branch on. On top of that field, `applyPreset()`
promotes toy 11's respectful apply to a shipped code path: it skips designer-attributed
tokens, records `kind: 'preset'` on everything it writes, and returns `{applied, skipped,
unknown}` so Studio can tell the designer what it did and did not touch. The change is
additive end to end -- every existing `set()` caller compiles and behaves identically.

## Acceptance criteria mapping

### 1. The toy 11 collision reproduced as a test: naive apply clobbers (documented failure mode), provenance-aware apply preserves the pin and moves everything else

Both halves live in one test file so the defect and its fix read together. The naive half
reproduces exactly what the toy did -- loop `registry.set()` over every entry in the
value-set -- and asserts the failure the way it actually hurts, which is attribution loss
rather than a changed number. After the apply the pinned token reads the preset's `999ms`,
and the designer's `220ms` survives only as `previousValue`, now filed under the preset's
`reason` AND the preset's `kind`. Nothing left on that token says a human chose it. A second
test runs the naive loop twice to show that `previousValue` is then overwritten with `999ms`
too: one step of history is storage, not provenance, which is the whole argument for the
field. The provenance-aware half calls `applyPreset()`, which reads each token's current
override and skips it when `kind === 'designer'` -- so the pin survives at `220ms` with its
designer attribution and its original reason intact, while the other three tokens move to the
preset value and come back carrying `kind: 'preset'`. The returned `skipped` array names the
pin, which is what makes the skip observable to Studio rather than silent.

Evidence: `packages/design-tokens/test/preset-override.test.ts` -- `clobbers a designer pin and
destroys its attribution`, `erases even the one step of history on a second apply`, and
`preserves the designer pin and moves everything else`. Implementation at
`packages/design-tokens/src/preset.ts:41` (`applyPreset`).

### 2. kind survives the persistence roundtrip; schema validates

Persistence has one chokepoint and the field had to be threaded through it. `saveRegistryToDir`
serialises `registry.list()`, which routes every token through `toUserOverrideField`
(`registry.ts:172`) on the way out; loading comes back the other direction through
`toNodeOverride` (`registry.ts:160`), which also absorbs the two hand-copied override spreads
that previously sat in the constructor and in `define`. Both directions now carry `kind`, so a
pin written in memory is the same pin after save -> disk -> load. Validation is real rather
than nominal: `OverrideKindSchema` is a `z.enum` declared once in `@rafters/shared` and imported
by the graph's `UserOverrideSchema`, so `TokenSchema.safeParse` in the registry constructor
rejects an unknown kind at load time with `TokenParseError` -- an on-disk `kind: "nonsense"`
never becomes a live token.

Evidence: `packages/design-tokens/test/preset-override.test.ts` -- `survives the save -> disk ->
load roundtrip`, `still skips the reloaded designer pin on a later apply`, and `rejects an
unknown provenance kind at schema level`. Schema at `packages/shared/src/types.ts:462`.

### 3. No behavior change for existing override users beyond the new optional field

`kind` is `.optional()` on both schemas and is never given a `.default()`, and `SetOptions.kind`
is optional too, so every existing `set(name, value, {reason})` call site compiles unchanged and
writes exactly the override it wrote before. The deliberate consequence is that an override with
no kind is not treated as a designer pin -- absent provenance means unknown, and a preset
overwrites it. That is the honest status quo for data written before the field existed, and it
is the only reading that avoids a silent behavior change in the other direction: a schema-level
`.default('designer')` would retroactively make every legacy override un-overwritable by every
future preset. The reason-string prefix check the toy used as a stand-in is deliberately not
reintroduced anywhere in the shipped code, since that convention is what this issue replaces.
`graph.ts:164`, where a `userOverride` hard-stops the cascade, is untouched -- provenance does
not participate in cascade decisions at all.

Evidence: `packages/design-tokens/test/preset-override.test.ts` -- `treats a legacy override
without kind as unattributed and overwrites it` and `loads a legacy override with no kind
unchanged`. Full design-tokens suite 268 pass, shared 129 pass, `pnpm preflight` exit 0.

## Not done

No backfill of `kind` onto existing on-disk overrides -- deciding whether a given legacy
override was a designer decision is a human call, and a migration that guesses would manufacture
exactly the false attribution this field exists to prevent. No undo semantics for preset
application: `TokenGraph`'s snapshot is single-slot, so `undo()` after an N-token preset rolls
back one token rather than the preset. That is pre-existing and out of scope here, and no test
in this PR implies otherwise. No `measured`/`tuned` kinds yet -- the enum is the extension point,
but inventing values before there is measured data to attach them to is the forbidden move. No
CHANGELOG entry, since no CLI behavior changed.

Closes #1994
