### PR TITLE
fix(ui): behavior-layer config is data-* and the four query-hook roots become semantic

### DIFF
--- a/packages/ui/src/components/context-menu/context-menu.astro
+++ b/packages/ui/src/components/context-menu/context-menu.astro
@@ -66,8 +66,8 @@ const triggerProps = {
   data-part="root"
   data-context-menu-root
   id={ids.root}
-  loop={String(loop)}
-  avoid-collisions={String(avoidCollisions)}
+  data-loop={String(loop)}
+  data-avoid-collisions={String(avoidCollisions)}
 >
   <span {...triggerProps}>{triggerLabel}</span>
   <div

--- a/packages/ui/src/components/context-menu/context-menu.behavior.ts
+++ b/packages/ui/src/components/context-menu/context-menu.behavior.ts
@@ -361,9 +361,12 @@ export function bindContextSubMenu(
   const subContent = subEl.querySelector<HTMLElement>('[data-part="sub-content"]');
   if (!subTrigger || !subContent) return { teardown: () => {}, close: () => {} };
 
+  // Config travels as `data-*` and nothing else (#2001) -- `loop` and
+  // `avoid-collisions` are not valid attributes on a <div>, and only `data-*`
+  // reaches `dataset`.
   const config: ContextSubMenuConfig = {
-    loop: subEl.getAttribute('loop') !== 'false',
-    avoidCollisions: subEl.getAttribute('avoid-collisions') !== 'false',
+    loop: subEl.dataset['loop'] !== 'false',
+    avoidCollisions: subEl.dataset['avoidCollisions'] !== 'false',
   };
 
   // Move the sub-content out of the parent menu (see doc above). The original
@@ -537,11 +540,11 @@ export function bindContextMenu(root: HTMLElement): () => void {
     part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
 
   const content = getPart('content');
+  // Config travels as `data-*` and nothing else (#2001) -- see bindContextSubMenu.
   const config: ContextMenuConfig = {
-    defaultOpen:
-      root.getAttribute('default-open') === 'true' || content?.dataset['state'] === 'open',
-    loop: root.getAttribute('loop') !== 'false',
-    avoidCollisions: root.getAttribute('avoid-collisions') !== 'false',
+    defaultOpen: root.dataset['defaultOpen'] === 'true' || content?.dataset['state'] === 'open',
+    loop: root.dataset['loop'] !== 'false',
+    avoidCollisions: root.dataset['avoidCollisions'] !== 'false',
   };
 
   const { memory, dispatch } = createBehavior(contextMenu, config);

--- a/packages/ui/src/components/drawer/drawer.astro
+++ b/packages/ui/src/components/drawer/drawer.astro
@@ -59,7 +59,6 @@ const open = state.open;
 <div
   data-part="root"
   data-drawer
-  class={classes.root}
   data-modal={String(modal)}
   data-default-open={String(defaultOpen)}
   data-side={drawerSide(config)}

--- a/packages/ui/src/components/drawer/drawer.astro
+++ b/packages/ui/src/components/drawer/drawer.astro
@@ -13,6 +13,11 @@
  * carries its token styling without tripping the typography-component guard;
  * aria-labelledby needs only the id and text, and the heading role preserves
  * the semantics the React <h2> provides.
+ *
+ * The root is a semantic <div data-part="root">, not <rafters-drawer> (#2004):
+ * this target never registers the custom element. The marker `data-drawer`
+ * scopes the binding selector, and the config rides as `data-*` (#2001), which
+ * is what bindDrawer reads through `dataset`.
  */
 import { drawer, drawerSide, type DrawerConfig, type DrawerPart } from './drawer.behavior';
 import { drawerClasses } from './drawer.classes';
@@ -51,11 +56,13 @@ const aria = drawer.aria(state, config, ids);
 const open = state.open;
 ---
 
-<rafters-drawer
+<div
   data-part="root"
-  modal={String(modal)}
-  default-open={String(defaultOpen)}
-  side={drawerSide(config)}
+  data-drawer
+  class={classes.root}
+  data-modal={String(modal)}
+  data-default-open={String(defaultOpen)}
+  data-side={drawerSide(config)}
 >
   <button type="button" id={ids.trigger} data-part="trigger" {...aria.trigger}>
     <slot name="trigger">Open</slot>
@@ -91,15 +98,16 @@ const open = state.open;
       <slot name="close">Close</slot>
     </button>
   </div>
-</rafters-drawer>
+</div>
 
 <script>
   import { bindDrawer } from './drawer.behavior';
 
-  for (const root of document.querySelectorAll('rafters-drawer[data-part="root"]')) {
-    const el = root as HTMLElement;
-    if (el.dataset['bound'] === 'true') continue;
-    el.dataset['bound'] = 'true';
-    bindDrawer(el);
+  // The marker attribute scopes the selector to THIS component's roots --
+  // [data-part="root"] alone would match every rafters root on the page.
+  for (const root of document.querySelectorAll<HTMLElement>('[data-part="root"][data-drawer]')) {
+    if (root.dataset['bound'] === 'true') continue;
+    root.dataset['bound'] = 'true';
+    bindDrawer(root);
   }
 </script>

--- a/packages/ui/src/components/drawer/drawer.behavior.ts
+++ b/packages/ui/src/components/drawer/drawer.behavior.ts
@@ -160,10 +160,13 @@ export const drawer: BehaviorSpec<DrawerConfig, DrawerState, DrawerActions, Draw
  * Enter-only; exit/drag animation waits on Presence (wave 0-B).
  */
 export function bindDrawer(root: HTMLElement): () => void {
+  // Config travels as `data-*` and nothing else (#2001/#2004), so the read is
+  // `dataset` by camelCase key -- `data-default-open` is dataset.defaultOpen.
+  const data = root.dataset;
   const config: DrawerConfig = {
-    modal: root.getAttribute('modal') !== 'false',
+    modal: data['modal'] !== 'false',
     defaultOpen:
-      root.getAttribute('default-open') === 'true' ||
+      data['defaultOpen'] === 'true' ||
       root.querySelector<HTMLElement>('[data-part="content"]')?.dataset['state'] === 'open',
   };
 

--- a/packages/ui/src/components/drawer/drawer.classes.ts
+++ b/packages/ui/src/components/drawer/drawer.classes.ts
@@ -6,6 +6,7 @@ import {
 } from './drawer.behavior';
 
 export interface DrawerClassSet {
+  root: string;
   overlay: string;
   content: string;
   handle: string;
@@ -16,6 +17,14 @@ export interface DrawerClassSet {
   close: string;
   closeIcon: string;
 }
+
+// The DOM-native root is a binding host, not a box: it carries data-part="root"
+// and the config, and all three children (trigger, overlay, panel) place
+// themselves -- the overlay and panel are `fixed`. `contents` removes the
+// wrapper box so the trigger flows in the consumer's layout exactly as an
+// unwrapped button would -- the layout-neutral answer to the display:inline
+// hazard in #2004.
+const rootClasses = 'contents';
 
 const overlayClasses = 'fixed inset-0 z-depth-overlay bg-foreground/80';
 
@@ -60,6 +69,7 @@ const closeIconClasses = 'h-5 w-5 @md:h-4 @md:w-4';
 
 export function drawerClasses(config: DrawerConfig, _state: DrawerState): DrawerClassSet {
   return {
+    root: rootClasses,
     overlay: overlayClasses,
     content: `${contentBaseClasses} ${sideClasses[drawerSide(config)]}`,
     handle: handleClasses,

--- a/packages/ui/src/components/drawer/drawer.classes.ts
+++ b/packages/ui/src/components/drawer/drawer.classes.ts
@@ -6,7 +6,6 @@ import {
 } from './drawer.behavior';
 
 export interface DrawerClassSet {
-  root: string;
   overlay: string;
   content: string;
   handle: string;
@@ -19,13 +18,8 @@ export interface DrawerClassSet {
 }
 
 // The DOM-native root is a binding host, not a box: it carries data-part="root"
-// and the config, and all three children (trigger, overlay, panel) place
-// themselves -- the overlay and panel are `fixed`. `contents` removes the
-// wrapper box so the trigger flows in the consumer's layout exactly as an
-// unwrapped button would -- the layout-neutral answer to the display:inline
-// hazard in #2004.
-const rootClasses = 'contents';
-
+// and the config, and NO class -- a behavior root never styles itself; layout
+// belongs to the consumer's Container/Grid (operator ruling, 2026-08-02).
 const overlayClasses = 'fixed inset-0 z-depth-overlay bg-foreground/80';
 
 // The panel is fixed to its anchoring edge (no centering container -- unlike a
@@ -69,7 +63,6 @@ const closeIconClasses = 'h-5 w-5 @md:h-4 @md:w-4';
 
 export function drawerClasses(config: DrawerConfig, _state: DrawerState): DrawerClassSet {
   return {
-    root: rootClasses,
     overlay: overlayClasses,
     content: `${contentBaseClasses} ${sideClasses[drawerSide(config)]}`,
     handle: handleClasses,

--- a/packages/ui/src/components/drawer/drawer.element.ts
+++ b/packages/ui/src/components/drawer/drawer.element.ts
@@ -11,6 +11,10 @@ export class RaftersDrawer extends HTMLElement {
   private teardown: (() => void) | null = null;
 
   connectedCallback(): void {
+    // Target parity: the Astro/React root is an unclassed <div> (block), but a
+    // custom element defaults to display:inline. Pin block so the WC host lays
+    // out identically to the other two performances (#2004).
+    this.style.display = 'block';
     queueMicrotask(() => {
       if (this.isConnected && !this.teardown) this.teardown = bindDrawer(this);
     });

--- a/packages/ui/src/components/grid/grid.astro
+++ b/packages/ui/src/components/grid/grid.astro
@@ -9,9 +9,14 @@
  * performances, zero drift.
  *
  * The role disposition (carried from the WC port): the opt-in attribute is
- * `grid-role`, never a bare `role`. bindGrid reads `grid-role` and re-applies
- * the honest `role="grid"` projection; because the server already SSR'd the
- * row/gridcell structure, the projected role is honest from first paint.
+ * `data-grid-role`, never a bare `role`. bindGrid reads `data-grid-role` and
+ * re-applies the honest `role="grid"` projection; because the server already
+ * SSR'd the row/gridcell structure, the projected role is honest from first
+ * paint.
+ *
+ * Config travels as `data-*` and nothing else (#2001): `preset`/`columns`/
+ * `gap`/`padding` are not valid attributes on a <div>, and only `data-*`
+ * reaches `element.dataset`, which is what readGridConfig reads.
  */
 import {
   grid,
@@ -78,20 +83,16 @@ function chunk<T>(items: T[], size: number): T[][] {
 }
 const rows = interactive && columnCount > 0 ? chunk(cells, columnCount) : [];
 
-// The attributes bindGrid re-reads to reconstruct the identical config.
-const columnsAttr = typeof columns === 'number' || columns === 'auto' ? String(columns) : undefined;
 ---
 
 <div
   data-part="root"
   data-grid
   id={id}
-  preset={preset}
-  pattern={pattern}
-  columns={columnsAttr}
-  gap={gap}
-  padding={padding}
-  grid-role={role}
+  data-pattern={pattern}
+  data-gap={gap}
+  data-padding={padding}
+  data-grid-role={role}
   class={classes.root}
   {...rootAria}
 >

--- a/packages/ui/src/components/grid/grid.behavior.ts
+++ b/packages/ui/src/components/grid/grid.behavior.ts
@@ -75,7 +75,14 @@ export const grid: BehaviorSpec<GridConfig, GridState, GridActions, GridPart> = 
       role: config.role === 'grid' ? 'grid' : undefined,
       'aria-label': config.role === 'grid' ? config.ariaLabel : undefined,
       'data-preset': config.preset ?? 'linear',
-      'data-columns': typeof config.columns === 'number' ? String(config.columns) : undefined,
+      // The projection OWNS data-preset/data-columns: the markup must not also
+      // emit them, or re-applying the projection would fight the authored
+      // value. `auto` is projected too so the attribute round-trips through
+      // readGridConfig for every attribute-expressible column value.
+      'data-columns':
+        typeof config.columns === 'number' || config.columns === 'auto'
+          ? String(config.columns)
+          : undefined,
     },
   }),
   // Static score, like container: the ARIA grid keyboard contract is not a
@@ -92,15 +99,38 @@ export function gridItemAttrs(priority: ContentPriority | undefined): AriaAttrs 
   return { 'data-priority': priority };
 }
 
-/** Parse the WC/Astro `columns` attribute into the score's config value.
+/** Parse the WC/Astro `data-columns` attribute into the score's config value.
  *  Only a bare integer or `auto` is expressible as an attribute; a
  *  responsive object is a React-only prop. A non-numeric, non-`auto` value
  *  reads as absent (auto default). */
-function parseColumns(raw: string | null): ResponsiveColumns | undefined {
-  if (raw === null) return undefined;
+function parseColumns(raw: string | undefined): ResponsiveColumns | undefined {
+  if (raw === undefined) return undefined;
   if (raw === 'auto') return 'auto';
   if (/^\d+$/.test(raw)) return Number(raw) as ColumnsValue;
   return undefined;
+}
+
+/**
+ * Reconstruct the score's config from a root element's `data-*` attributes --
+ * the inverse of the SSR/WC markup, and the pairing #2001 asks for: config
+ * travels as `data-*` ONLY, so the read is `element.dataset` rather than a
+ * hand-rolled getAttribute over invented attribute names.
+ *
+ * `data-preset` and `data-columns` are written by the score's own aria
+ * projection (see grid.aria above), so they are already on the root before
+ * this ever runs; the remaining keys are authored in the markup.
+ */
+export function readGridConfig(root: HTMLElement): GridConfig {
+  const data = root.dataset;
+  return {
+    preset: data['preset'] as GridPreset | undefined,
+    pattern: data['pattern'] as BentoPattern | undefined,
+    columns: parseColumns(data['columns']),
+    gap: data['gap'] as SpacingValue | undefined,
+    padding: data['padding'] as SpacingValue | undefined,
+    role: data['gridRole'] === 'grid' ? 'grid' : undefined,
+    ariaLabel: root.getAttribute('aria-label') ?? undefined,
+  };
 }
 
 /**
@@ -123,20 +153,11 @@ function parseColumns(raw: string | null): ResponsiveColumns | undefined {
  * The role disposition (carried from the WC port): a bare `role="grid"` on a
  * light-DOM host BEFORE the row/gridcell children exist is a 4.1.2 axe
  * violation and collides with the platform `role`. So the opt-in attribute is
- * `grid-role`; the binding reads it and PROJECTS the real `role="grid"` onto
+ * `data-grid-role`; the binding reads it and PROJECTS the real `role="grid"` onto
  * the root part, which by then owns authored row/gridcell descendants.
  */
 export function bindGrid(root: HTMLElement): () => void {
-  const attr = (name: string): string | undefined => root.getAttribute(name) ?? undefined;
-  const config: GridConfig = {
-    preset: attr('preset') as GridPreset | undefined,
-    pattern: attr('pattern') as BentoPattern | undefined,
-    columns: parseColumns(root.getAttribute('columns')),
-    gap: attr('gap') as SpacingValue | undefined,
-    padding: attr('padding') as SpacingValue | undefined,
-    role: root.getAttribute('grid-role') === 'grid' ? 'grid' : undefined,
-    ariaLabel: attr('aria-label'),
-  };
+  const config: GridConfig = readGridConfig(root);
 
   const { memory } = createBehavior(grid, config);
 

--- a/packages/ui/src/components/hover-card/hover-card.astro
+++ b/packages/ui/src/components/hover-card/hover-card.astro
@@ -76,7 +76,6 @@ const open = state.open;
 <div
   data-part="root"
   data-hover-card
-  class={classes.root}
   data-open-delay={openDelay === undefined ? undefined : String(openDelay)}
   data-close-delay={closeDelay === undefined ? undefined : String(closeDelay)}
   data-disable-hoverable-content={String(disableHoverableContent)}

--- a/packages/ui/src/components/hover-card/hover-card.astro
+++ b/packages/ui/src/components/hover-card/hover-card.astro
@@ -28,7 +28,9 @@ import type { PartIds } from '../../lib/contract';
 
 interface Props {
   id: string;
-  /** Href for the trigger anchor (keeps it a real, focusable link). */
+  /** Href for the trigger anchor (keeps it a real, focusable link). The anchor
+   *  is inline-flex INSIDE the block root; the component as a whole is placed
+   *  by Container, not inlined mid-sentence in a paragraph. */
   href?: string;
   /** Accessible name for the role=dialog preview. */
   label?: string;

--- a/packages/ui/src/components/hover-card/hover-card.astro
+++ b/packages/ui/src/components/hover-card/hover-card.astro
@@ -11,6 +11,11 @@
  *
  * The card is role="dialog"; supply `label` (or an aria-labelledby target in the
  * content slot) so the preview has an accessible name.
+ *
+ * The root is a semantic <div data-part="root">, not <rafters-hover-card>
+ * (#2004): this target never registers the custom element. The marker
+ * `data-hover-card` scopes the binding selector, and the config rides as
+ * `data-*` (#2001), which is what bindHoverCard reads through `dataset`.
  */
 import {
   hoverCard,
@@ -68,15 +73,17 @@ const aria = hoverCard.aria(state, config, ids);
 const open = state.open;
 ---
 
-<rafters-hover-card
+<div
   data-part="root"
-  open-delay={openDelay === undefined ? undefined : String(openDelay)}
-  close-delay={closeDelay === undefined ? undefined : String(closeDelay)}
-  disable-hoverable-content={String(disableHoverableContent)}
-  default-open={String(defaultOpen)}
-  side={placement.side}
-  align={placement.align}
-  side-offset={sideOffset === undefined ? undefined : String(sideOffset)}
+  data-hover-card
+  class={classes.root}
+  data-open-delay={openDelay === undefined ? undefined : String(openDelay)}
+  data-close-delay={closeDelay === undefined ? undefined : String(closeDelay)}
+  data-disable-hoverable-content={String(disableHoverableContent)}
+  data-default-open={String(defaultOpen)}
+  data-side={placement.side}
+  data-align={placement.align}
+  data-side-offset={sideOffset === undefined ? undefined : String(sideOffset)}
 >
   <a
     href={href}
@@ -100,15 +107,16 @@ const open = state.open;
   >
     <slot name="content" />
   </div>
-</rafters-hover-card>
+</div>
 
 <script>
   import { bindHoverCard } from './hover-card.behavior';
 
-  for (const root of document.querySelectorAll('rafters-hover-card[data-part="root"]')) {
-    const el = root as HTMLElement;
-    if (el.dataset['bound'] === 'true') continue;
-    el.dataset['bound'] = 'true';
-    bindHoverCard(el);
+  // The marker attribute scopes the selector to THIS component's roots --
+  // [data-part="root"] alone would match every rafters root on the page.
+  for (const root of document.querySelectorAll<HTMLElement>('[data-part="root"][data-hover-card]')) {
+    if (root.dataset['bound'] === 'true') continue;
+    root.dataset['bound'] = 'true';
+    bindHoverCard(root);
   }
 </script>

--- a/packages/ui/src/components/hover-card/hover-card.behavior.ts
+++ b/packages/ui/src/components/hover-card/hover-card.behavior.ts
@@ -158,23 +158,26 @@ export function bindHoverCard(root: HTMLElement): () => void {
   const getPart = (part: string): HTMLElement | null =>
     part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
 
-  const numAttr = (name: string, fallback: number): number => {
-    const raw = root.getAttribute(name);
-    if (raw === null) return fallback;
+  // Config travels as `data-*` and nothing else (#2001/#2004), so the read is
+  // `dataset` by camelCase key -- `data-open-delay` is dataset.openDelay.
+  const data = root.dataset;
+  const numData = (key: string, fallback: number): number => {
+    const raw = data[key];
+    if (raw === undefined) return fallback;
     const parsed = Number(raw);
     return Number.isFinite(parsed) ? parsed : fallback;
   };
 
   const content = getPart('content');
   const config: HoverCardConfig = {
-    openDelay: numAttr('open-delay', DEFAULT_OPEN_DELAY),
-    closeDelay: numAttr('close-delay', DEFAULT_CLOSE_DELAY),
-    disableHoverableContent: root.getAttribute('disable-hoverable-content') === 'true',
-    defaultOpen:
-      root.getAttribute('default-open') === 'true' || content?.dataset['state'] === 'open',
-    side: (root.getAttribute('side') as Side | null) ?? undefined,
-    align: (root.getAttribute('align') as Align | null) ?? undefined,
-    sideOffset: root.hasAttribute('side-offset') ? numAttr('side-offset', 4) : undefined,
+    openDelay: numData('openDelay', DEFAULT_OPEN_DELAY),
+    closeDelay: numData('closeDelay', DEFAULT_CLOSE_DELAY),
+    disableHoverableContent: data['disableHoverableContent'] === 'true',
+    defaultOpen: data['defaultOpen'] === 'true' || content?.dataset['state'] === 'open',
+    side: (data['side'] as Side | undefined) ?? undefined,
+    align: (data['align'] as Align | undefined) ?? undefined,
+    // Presence, not truthiness: data-side-offset="0" is a real offset.
+    sideOffset: 'sideOffset' in data ? numData('sideOffset', 4) : undefined,
   };
 
   const { memory, dispatch } = createBehavior(hoverCard, config);

--- a/packages/ui/src/components/hover-card/hover-card.classes.ts
+++ b/packages/ui/src/components/hover-card/hover-card.classes.ts
@@ -1,17 +1,13 @@
 import type { HoverCardConfig, HoverCardState } from './hover-card.behavior';
 
 export interface HoverCardClassSet {
-  root: string;
   trigger: string;
   content: string;
 }
 
 // The DOM-native root is a binding host, not a box: it carries data-part="root"
-// and the config, and its two children (an inline anchor trigger and a
-// fixed-positioned panel) place themselves. `contents` removes the wrapper box
-// so the anchor flows in the consumer's prose exactly as an unwrapped <a>
-// would -- the layout-neutral answer to the display:inline hazard in #2004.
-const rootClasses = 'contents';
+// and the config, and NO class -- a behavior root never styles itself; layout
+// belongs to the consumer's Container/Grid (operator ruling, 2026-08-02).
 
 // The trigger is a bare inline anchor: the consumer's link keeps its own type,
 // underline, and focus affordances. Hover-card adds no chrome to it.
@@ -33,7 +29,6 @@ export function hoverCardClasses(
   _state: HoverCardState,
 ): HoverCardClassSet {
   return {
-    root: rootClasses,
     trigger: triggerClasses,
     content: contentClasses,
   };

--- a/packages/ui/src/components/hover-card/hover-card.classes.ts
+++ b/packages/ui/src/components/hover-card/hover-card.classes.ts
@@ -7,10 +7,14 @@ export interface HoverCardClassSet {
 
 // The DOM-native root is a binding host, not a box: it carries data-part="root"
 // and the config, and NO class -- a behavior root never styles itself; layout
-// belongs to the consumer's Container/Grid (operator ruling, 2026-08-02).
+// belongs to the consumer's Container/Grid (operator ruling, 2026-08-02). With
+// no class the unclassed <div> root is a BLOCK box, so a hover-card is composed
+// by Container like any other component -- it is not dropped mid-sentence into
+// running text.
 
-// The trigger is a bare inline anchor: the consumer's link keeps its own type,
-// underline, and focus affordances. Hover-card adds no chrome to it.
+// Inside that root the trigger is still an inline-flex anchor: the consumer's
+// link keeps its own type, underline, and focus affordances, and hover-card
+// adds no chrome to it.
 const triggerClasses = 'inline-flex';
 
 // The preview panel sits on the popover depth token (not a raw z-index), fills

--- a/packages/ui/src/components/hover-card/hover-card.classes.ts
+++ b/packages/ui/src/components/hover-card/hover-card.classes.ts
@@ -1,9 +1,17 @@
 import type { HoverCardConfig, HoverCardState } from './hover-card.behavior';
 
 export interface HoverCardClassSet {
+  root: string;
   trigger: string;
   content: string;
 }
+
+// The DOM-native root is a binding host, not a box: it carries data-part="root"
+// and the config, and its two children (an inline anchor trigger and a
+// fixed-positioned panel) place themselves. `contents` removes the wrapper box
+// so the anchor flows in the consumer's prose exactly as an unwrapped <a>
+// would -- the layout-neutral answer to the display:inline hazard in #2004.
+const rootClasses = 'contents';
 
 // The trigger is a bare inline anchor: the consumer's link keeps its own type,
 // underline, and focus affordances. Hover-card adds no chrome to it.
@@ -25,6 +33,7 @@ export function hoverCardClasses(
   _state: HoverCardState,
 ): HoverCardClassSet {
   return {
+    root: rootClasses,
     trigger: triggerClasses,
     content: contentClasses,
   };

--- a/packages/ui/src/components/hover-card/hover-card.element.ts
+++ b/packages/ui/src/components/hover-card/hover-card.element.ts
@@ -11,6 +11,10 @@ export class RaftersHoverCard extends HTMLElement {
   private teardown: (() => void) | null = null;
 
   connectedCallback(): void {
+    // Target parity: the Astro/React root is an unclassed <div> (block), but a
+    // custom element defaults to display:inline. Pin block so the WC host lays
+    // out identically to the other two performances (#2004).
+    this.style.display = 'block';
     queueMicrotask(() => {
       if (this.isConnected && !this.teardown) this.teardown = bindHoverCard(this);
     });

--- a/packages/ui/src/components/image/image.astro
+++ b/packages/ui/src/components/image/image.astro
@@ -8,6 +8,10 @@
  * the SAME DOM-native client the Web Component uses. One score, three
  * decorators, zero drift.
  *
+ * Config travels as `data-*` and nothing else (#2001): `size`/`fill` are real
+ * platform attributes elsewhere and none of these are valid on a <figure>, so
+ * the whole config block is `data-*` and readImageConfig reads `dataset`.
+ *
  * Zero client-side load tracking: `status` is config (default 'loaded'), so a
  * server-rendered image is clean. The editor surface (upload, drag-drop, paste,
  * alignment toolbar, contentEditable caption) is out of scope.
@@ -69,13 +73,13 @@ const statusAria = projection.status ?? {};
 <figure
   data-part="root"
   data-image
-  size={size}
-  alignment={alignment}
-  radius={radius}
-  fill={fill}
-  status={status}
-  error-message={errorMessage}
-  loading-label={loadingLabel}
+  data-size={size}
+  data-alignment={alignment}
+  data-radius={radius}
+  data-fill={fill}
+  data-status={status}
+  data-error-message={errorMessage}
+  data-loading-label={loadingLabel}
   class={classy(classes.root, className)}
   {...attrs}
 >

--- a/packages/ui/src/components/image/image.behavior.ts
+++ b/packages/ui/src/components/image/image.behavior.ts
@@ -136,25 +136,36 @@ export const image: BehaviorSpec<ImageConfig, ImageState, ImageActions, ImagePar
   keymap: () => null,
 };
 
-function parseEnum<T extends string>(raw: string | null, allowed: ReadonlyArray<T>): T | undefined {
-  return raw !== null && (allowed as ReadonlyArray<string>).includes(raw) ? (raw as T) : undefined;
+function parseEnum<T extends string>(
+  raw: string | undefined,
+  allowed: ReadonlyArray<T>,
+): T | undefined {
+  return raw !== undefined && (allowed as ReadonlyArray<string>).includes(raw)
+    ? (raw as T)
+    : undefined;
 }
 
 /**
- * Reconstruct the score's config from a root element's attributes -- the
- * inverse of the SSR/WC markup. Shared by bindImage and the Web Component so
- * the two never drift on how an attribute maps to config. `src`/`alt` are
- * native passthrough on the inner img and are not part of the projection.
+ * Reconstruct the score's config from a root element's `data-*` attributes --
+ * the inverse of the SSR/WC markup. Shared by bindImage and the Web Component
+ * so the two never drift on how an attribute maps to config.
+ *
+ * Config travels as `data-*` and nothing else (#2001). `size` and `fill` in
+ * particular are real platform attributes elsewhere (input/select, SVG), and
+ * the root here is a real <figure>: only `data-*` is valid on it, and only
+ * `data-*` reaches `dataset`, which is what this reads. `src`/`alt` are native
+ * passthrough on the inner img and are not part of the projection.
  */
 export function readImageConfig(root: HTMLElement): ImageConfig {
+  const data = root.dataset;
   return {
-    size: parseEnum(root.getAttribute('size'), ALLOWED_SIZES),
-    alignment: parseEnum(root.getAttribute('alignment'), ALLOWED_ALIGNMENTS),
-    radius: parseEnum(root.getAttribute('radius'), ALLOWED_RADII),
-    fill: root.getAttribute('fill') ?? undefined,
-    status: parseEnum(root.getAttribute('status'), ALLOWED_STATUSES),
-    errorMessage: root.getAttribute('error-message') ?? undefined,
-    loadingLabel: root.getAttribute('loading-label') ?? undefined,
+    size: parseEnum(data['size'], ALLOWED_SIZES),
+    alignment: parseEnum(data['alignment'], ALLOWED_ALIGNMENTS),
+    radius: parseEnum(data['radius'], ALLOWED_RADII),
+    fill: data['fill'],
+    status: parseEnum(data['status'], ALLOWED_STATUSES),
+    errorMessage: data['errorMessage'],
+    loadingLabel: data['loadingLabel'],
   };
 }
 

--- a/packages/ui/src/components/image/image.element.ts
+++ b/packages/ui/src/components/image/image.element.ts
@@ -15,19 +15,20 @@
  * the oracle and are NOT here. The load/error surface is expressed through the
  * `status` attribute (default 'loaded' -- a clean image before any JS).
  *
- * Attributes:
- *   src            Image URL forwarded to the inner img.
- *   alt            Alt text; defaults to "" (the HTML spec for decorative
- *                  images) when absent.
- *   size           xs | sm | md | lg | xl | 2xl | full. Unknown values are
- *                  dropped (no max-width).
- *   alignment      left | center | right. Default 'center'.
- *   radius         none | sm | md | lg | xl | 2xl | 3xl | full. Default 'lg'.
- *   fill           Fill signature painted behind the image.
- *   status         loading | loaded | error. Default 'loaded'.
- *   caption        Optional text below the image, assigned via textContent.
- *   error-message  Overlay text when status='error'.
- *   loading-label  Overlay text when status='loading'.
+ * Attributes (config is `data-*` across all three targets -- see #2001; `src`,
+ * `alt` and `caption` are content forwarded to native slots, not config):
+ *   src                 Image URL forwarded to the inner img.
+ *   alt                 Alt text; defaults to "" (the HTML spec for decorative
+ *                       images) when absent.
+ *   caption             Optional text below the image, via textContent.
+ *   data-size           xs | sm | md | lg | xl | 2xl | full. Unknown values are
+ *                       dropped (no max-width).
+ *   data-alignment      left | center | right. Default 'center'.
+ *   data-radius         none | sm | md | lg | xl | 2xl | 3xl | full. Default 'lg'.
+ *   data-fill           Fill signature painted behind the image.
+ *   data-status         loading | loaded | error. Default 'loaded'.
+ *   data-error-message  Overlay text when data-status='error'.
+ *   data-loading-label  Overlay text when data-status='loading'.
  *
  * Gotcha 3: connectedCallback can fire before the light DOM is settled, so the
  * structure build + bind is deferred one microtask. Attribute changes after the
@@ -46,27 +47,21 @@ import { imageClasses } from './image.classes';
 /** Config attributes reflected onto the rendered figure so bindImage
  *  reconstructs the identical config (the Astro figure carries the same). */
 const REFLECTED_ATTRIBUTES: ReadonlyArray<string> = [
-  'size',
-  'alignment',
-  'radius',
-  'fill',
-  'status',
-  'error-message',
-  'loading-label',
+  'data-size',
+  'data-alignment',
+  'data-radius',
+  'data-fill',
+  'data-status',
+  'data-error-message',
+  'data-loading-label',
 ];
 
 export class RaftersImage extends HTMLElement {
   static readonly observedAttributes: ReadonlyArray<string> = [
     'src',
     'alt',
-    'size',
-    'alignment',
-    'radius',
-    'fill',
-    'status',
     'caption',
-    'error-message',
-    'loading-label',
+    ...REFLECTED_ATTRIBUTES,
   ];
 
   private teardown: (() => void) | null = null;

--- a/packages/ui/src/components/navigation-menu/navigation-menu.astro
+++ b/packages/ui/src/components/navigation-menu/navigation-menu.astro
@@ -12,6 +12,12 @@
  * The projection is computed here from the same navigationMenu.aria /
  * navInstanceAria the React and WC controllers read -- one score, three
  * performances, zero drift.
+ *
+ * Config travels as `data-*` and nothing else (#2001): `orientation` and
+ * `delay-duration` are not valid attributes on a <nav>, and only `data-*`
+ * reaches `dataset`, which is what bindNavigationMenu reads. `data-orientation`
+ * is emitted by the score's own aria projection below, so it is spread in with
+ * {...rootAria.root} rather than written twice.
  */
 import {
   navigationMenu,
@@ -52,8 +58,7 @@ const instanceId = (part: NavigationMenuPart, value: string) => `${id}-${part}-$
 <nav
   data-part="root"
   id={ids.root}
-  orientation={orientation}
-  delay-duration={String(delayDuration)}
+  data-delay-duration={String(delayDuration)}
   class={classes.root}
   {...rootAria.root}
 >

--- a/packages/ui/src/components/navigation-menu/navigation-menu.behavior.ts
+++ b/packages/ui/src/components/navigation-menu/navigation-menu.behavior.ts
@@ -246,9 +246,13 @@ export function startNavigationMenuEffects({
  * no per-framework copy, no drift.
  */
 export function bindNavigationMenu(root: HTMLElement): () => void {
+  // Config travels as `data-*` and nothing else (#2001): `orientation` and
+  // `delay-duration` are not valid attributes on a <nav>, and only `data-*`
+  // reaches `dataset`. `data-orientation` is written by the score's own aria
+  // projection (see navigationMenu.aria), so the markup must not re-emit it.
   const config: NavigationMenuConfig = {
-    orientation: root.getAttribute('orientation') === 'vertical' ? 'vertical' : 'horizontal',
-    delayDuration: Number.parseInt(root.getAttribute('delay-duration') ?? '', 10) || 200,
+    orientation: root.dataset['orientation'] === 'vertical' ? 'vertical' : 'horizontal',
+    delayDuration: Number.parseInt(root.dataset['delayDuration'] ?? '', 10) || 200,
     defaultValue:
       root.querySelector<HTMLElement>('[data-part="trigger"][data-state="open"]')?.dataset[
         'value'

--- a/packages/ui/src/components/popover/popover.astro
+++ b/packages/ui/src/components/popover/popover.astro
@@ -8,6 +8,11 @@
  * Content stays in light DOM (present-but-hidden) so the dismiss effect the
  * bind runs can read it, and so the positioning affordance can measure it.
  * Exit animation waits on the Presence adapter; this is enter-only.
+ *
+ * The root is a semantic <div data-part="root">, not <rafters-popover> (#2004):
+ * this target never registers the custom element. The marker `data-popover`
+ * scopes the binding selector, and the config rides as `data-*` (#2001), which
+ * is what bindPopover reads through `dataset`.
  */
 import { popover, type PopoverConfig, type PopoverPart } from './popover.behavior';
 import { popoverClasses } from './popover.classes';
@@ -44,13 +49,15 @@ const aria = popover.aria(state, config, ids);
 const open = state.open;
 ---
 
-<rafters-popover
+<div
   data-part="root"
-  default-open={String(defaultOpen)}
-  side={side}
-  align={align}
-  side-offset={String(sideOffset)}
-  align-offset={String(alignOffset)}
+  data-popover
+  class={classes.root}
+  data-default-open={String(defaultOpen)}
+  data-side={side}
+  data-align={align}
+  data-side-offset={String(sideOffset)}
+  data-align-offset={String(alignOffset)}
 >
   <button
     type="button"
@@ -80,15 +87,16 @@ const open = state.open;
       )
     }
   </div>
-</rafters-popover>
+</div>
 
 <script>
   import { bindPopover } from './popover.behavior';
 
-  for (const root of document.querySelectorAll('rafters-popover[data-part="root"]')) {
-    const el = root as HTMLElement;
-    if (el.dataset['bound'] === 'true') continue;
-    el.dataset['bound'] = 'true';
-    bindPopover(el);
+  // The marker attribute scopes the selector to THIS component's roots --
+  // [data-part="root"] alone would match every rafters root on the page.
+  for (const root of document.querySelectorAll<HTMLElement>('[data-part="root"][data-popover]')) {
+    if (root.dataset['bound'] === 'true') continue;
+    root.dataset['bound'] = 'true';
+    bindPopover(root);
   }
 </script>

--- a/packages/ui/src/components/popover/popover.astro
+++ b/packages/ui/src/components/popover/popover.astro
@@ -52,7 +52,6 @@ const open = state.open;
 <div
   data-part="root"
   data-popover
-  class={classes.root}
   data-default-open={String(defaultOpen)}
   data-side={side}
   data-align={align}

--- a/packages/ui/src/components/popover/popover.behavior.ts
+++ b/packages/ui/src/components/popover/popover.behavior.ts
@@ -122,9 +122,11 @@ export function focusFirst(content: HTMLElement | null): void {
   focusable?.focus();
 }
 
-function numberAttribute(root: HTMLElement, name: string): number | undefined {
-  const raw = root.getAttribute(name);
-  if (raw === null) return undefined;
+/** Config travels as `data-*` and nothing else (#2001/#2004), so the read is
+ *  `dataset` by camelCase key -- `data-side-offset` is dataset.sideOffset. */
+function numberData(root: HTMLElement, key: string): number | undefined {
+  const raw = root.dataset[key];
+  if (raw === undefined) return undefined;
   const value = Number(raw);
   return Number.isNaN(value) ? undefined : value;
 }
@@ -143,15 +145,15 @@ function numberAttribute(root: HTMLElement, name: string): number | undefined {
  */
 export function bindPopover(root: HTMLElement): () => void {
   const contentEl = root.querySelector<HTMLElement>('[data-part="content"]');
+  const data = root.dataset;
   const config: PopoverConfig = {
-    defaultOpen:
-      root.getAttribute('default-open') === 'true' || contentEl?.dataset['state'] === 'open',
+    defaultOpen: data['defaultOpen'] === 'true' || contentEl?.dataset['state'] === 'open',
   };
   const positionOptions: PopoverPositionOptions = {
-    side: (root.getAttribute('side') as Side | null) ?? undefined,
-    align: (root.getAttribute('align') as Align | null) ?? undefined,
-    sideOffset: numberAttribute(root, 'side-offset'),
-    alignOffset: numberAttribute(root, 'align-offset'),
+    side: (data['side'] as Side | undefined) ?? undefined,
+    align: (data['align'] as Align | undefined) ?? undefined,
+    sideOffset: numberData(root, 'sideOffset'),
+    alignOffset: numberData(root, 'alignOffset'),
   };
 
   const getPart = (part: string): HTMLElement | null =>

--- a/packages/ui/src/components/popover/popover.classes.ts
+++ b/packages/ui/src/components/popover/popover.classes.ts
@@ -1,10 +1,18 @@
 import type { PopoverConfig, PopoverState } from './popover.behavior';
 
 export interface PopoverClassSet {
+  root: string;
   content: string;
   close: string;
   closeIcon: string;
 }
+
+// The DOM-native root is a binding host, not a box: it carries data-part="root"
+// and the config, and its two children (the trigger button and a fixed-
+// positioned panel) place themselves. `contents` removes the wrapper box so the
+// trigger flows in the consumer's layout exactly as an unwrapped button would --
+// the layout-neutral answer to the display:inline hazard in #2004.
+const rootClasses = 'contents';
 
 // Ported from the old popover.classes.ts. The panel sits on the popover depth
 // token, fills with the popover surface tokens, and animates enter/exit with
@@ -31,6 +39,7 @@ const closeIconClasses = 'h-5 w-5 @md:h-4 @md:w-4';
 
 export function popoverClasses(_config: PopoverConfig, _state: PopoverState): PopoverClassSet {
   return {
+    root: rootClasses,
     content: contentClasses,
     close: closeClasses,
     closeIcon: closeIconClasses,

--- a/packages/ui/src/components/popover/popover.classes.ts
+++ b/packages/ui/src/components/popover/popover.classes.ts
@@ -1,18 +1,14 @@
 import type { PopoverConfig, PopoverState } from './popover.behavior';
 
 export interface PopoverClassSet {
-  root: string;
   content: string;
   close: string;
   closeIcon: string;
 }
 
 // The DOM-native root is a binding host, not a box: it carries data-part="root"
-// and the config, and its two children (the trigger button and a fixed-
-// positioned panel) place themselves. `contents` removes the wrapper box so the
-// trigger flows in the consumer's layout exactly as an unwrapped button would --
-// the layout-neutral answer to the display:inline hazard in #2004.
-const rootClasses = 'contents';
+// and the config, and NO class -- a behavior root never styles itself; layout
+// belongs to the consumer's Container/Grid (operator ruling, 2026-08-02).
 
 // Ported from the old popover.classes.ts. The panel sits on the popover depth
 // token, fills with the popover surface tokens, and animates enter/exit with
@@ -39,7 +35,6 @@ const closeIconClasses = 'h-5 w-5 @md:h-4 @md:w-4';
 
 export function popoverClasses(_config: PopoverConfig, _state: PopoverState): PopoverClassSet {
   return {
-    root: rootClasses,
     content: contentClasses,
     close: closeClasses,
     closeIcon: closeIconClasses,

--- a/packages/ui/src/components/popover/popover.element.ts
+++ b/packages/ui/src/components/popover/popover.element.ts
@@ -11,6 +11,10 @@ export class RaftersPopover extends HTMLElement {
   private teardown: (() => void) | null = null;
 
   connectedCallback(): void {
+    // Target parity: the Astro/React root is an unclassed <div> (block), but a
+    // custom element defaults to display:inline. Pin block so the WC host lays
+    // out identically to the other two performances (#2004).
+    this.style.display = 'block';
     queueMicrotask(() => {
       if (this.isConnected && !this.teardown) this.teardown = bindPopover(this);
     });

--- a/packages/ui/src/components/progress/progress.astro
+++ b/packages/ui/src/components/progress/progress.astro
@@ -9,7 +9,9 @@
  * score, three decorators, zero drift.
  *
  * The root div IS the progressbar (data-part="root"); it carries the config as
- * attributes so bindProgress reconstructs the identical config on the client.
+ * `data-*` attributes so bindProgress reconstructs the identical config on the
+ * client. Config is `data-*` and nothing else (#2001) -- `value`/`max` are real
+ * attributes on <progress>, not on a <div>, and `size` is real on input/select.
  * `aria-label` (or `aria-labelledby`) passes through natively -- a progressbar
  * needs an accessible name.
  */
@@ -57,7 +59,7 @@ const indicatorAria = projection.indicator ?? {};
 
 const { indeterminate, percent } = resolveProgress(config);
 
-// The attributes bindProgress re-reads to reconstruct the identical config.
+// The data-* attributes bindProgress re-reads to reconstruct the identical config.
 const valueAttr = indeterminate ? undefined : value;
 const indicatorStyle = indeterminate ? undefined : `width: ${percent}%`;
 ---
@@ -65,11 +67,11 @@ const indicatorStyle = indeterminate ? undefined : `width: ${percent}%`;
 <div
   data-part="root"
   data-progress
-  value={valueAttr}
-  max={max}
-  variant={variant}
-  size={size}
-  value-text={valueText}
+  data-value={valueAttr}
+  data-max={max}
+  data-variant={variant}
+  data-size={size}
+  data-value-text={valueText}
   class={classy(classes.root, className)}
   {...rootAria}
   {...attrs}

--- a/packages/ui/src/components/progress/progress.behavior.ts
+++ b/packages/ui/src/components/progress/progress.behavior.ts
@@ -122,40 +122,45 @@ export const progress: BehaviorSpec<ProgressConfig, ProgressState, ProgressActio
     keymap: () => null,
   };
 
-function parseVariant(raw: string | null): ProgressVariant {
+function parseVariant(raw: string | undefined): ProgressVariant {
   if (raw && (ALLOWED_VARIANTS as ReadonlyArray<string>).includes(raw)) {
     return raw as ProgressVariant;
   }
   return 'default';
 }
 
-function parseSize(raw: string | null): ProgressSize {
+function parseSize(raw: string | undefined): ProgressSize {
   if (raw && (ALLOWED_SIZES as ReadonlyArray<string>).includes(raw)) {
     return raw as ProgressSize;
   }
   return 'default';
 }
 
-function parseNumber(raw: string | null): number | undefined {
-  if (raw === null) return undefined;
+function parseNumber(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
   const n = Number(raw);
   return Number.isFinite(n) ? n : undefined;
 }
 
 /**
- * Reconstruct the score's config from a root element's attributes -- the
- * inverse of the SSR/WC markup. Shared by bindProgress and the Web Component
- * so the two never drift on how an attribute maps to config. `aria-label` is
- * NOT read here: it is a native passthrough attribute on the progressbar
- * (host === root), left untouched by the projection.
+ * Reconstruct the score's config from a root element's `data-*` attributes --
+ * the inverse of the SSR/WC markup. Shared by bindProgress and the Web
+ * Component so the two never drift on how an attribute maps to config.
+ *
+ * Config travels as `data-*` and nothing else (#2001). `value`/`max` are real
+ * attributes on <progress>, not on the <div> this root actually is, and `size`
+ * is real on input/select -- borrowing them here was invalid markup that never
+ * reached `dataset`. `aria-label` is NOT read here: it is a native passthrough
+ * on the progressbar (host === root), left untouched by the projection.
  */
 export function readProgressConfig(root: HTMLElement): ProgressConfig {
+  const data = root.dataset;
   return {
-    value: parseNumber(root.getAttribute('value')),
-    max: parseNumber(root.getAttribute('max')),
-    valueText: root.getAttribute('value-text') ?? undefined,
-    variant: parseVariant(root.getAttribute('variant')),
-    size: parseSize(root.getAttribute('size')),
+    value: parseNumber(data['value']),
+    max: parseNumber(data['max']),
+    valueText: data['valueText'],
+    variant: parseVariant(data['variant']),
+    size: parseSize(data['size']),
   };
 }
 

--- a/packages/ui/src/components/progress/progress.element.ts
+++ b/packages/ui/src/components/progress/progress.element.ts
@@ -11,13 +11,14 @@
  * The host renders the indicator as a light-DOM child (data-part="indicator");
  * consumer content is not projected (progress has no slot).
  *
- * Attributes:
- *  - value:      number in [0, max] (absent / non-numeric = indeterminate)
- *  - max:        number > 0 (default 100; non-positive falls back to 100)
- *  - variant:    default | primary | secondary | destructive | success |
- *                warning | info | accent (default 'default')
- *  - size:       sm | default | lg (default 'default')
- *  - value-text: optional accessible label; overrides the default `${percent}%`
+ * Attributes (config is `data-*` across all three targets -- see #2001):
+ *  - data-value:      number in [0, max] (absent / non-numeric = indeterminate)
+ *  - data-max:        number > 0 (default 100; non-positive falls back to 100)
+ *  - data-variant:    default | primary | secondary | destructive | success |
+ *                     warning | info | accent (default 'default')
+ *  - data-size:       sm | default | lg (default 'default')
+ *  - data-value-text: optional accessible label; overrides the default
+ *                     `${percent}%`
  *  - aria-label / aria-labelledby: native passthrough on the progressbar host
  *
  * Gotcha 3: connectedCallback can fire before the light-DOM is settled, so the
@@ -37,11 +38,11 @@ import { progressClasses } from './progress.classes';
 
 export class RaftersProgress extends HTMLElement {
   static readonly observedAttributes: ReadonlyArray<string> = [
-    'value',
-    'max',
-    'variant',
-    'size',
-    'value-text',
+    'data-value',
+    'data-max',
+    'data-variant',
+    'data-size',
+    'data-value-text',
   ];
 
   private teardown: (() => void) | null = null;

--- a/packages/ui/src/components/tooltip/tooltip.astro
+++ b/packages/ui/src/components/tooltip/tooltip.astro
@@ -67,7 +67,6 @@ const open = state.open;
 <div
   data-part="root"
   data-tooltip
-  class={classes.root}
   data-delay-duration={delayDuration === undefined ? undefined : String(delayDuration)}
   data-skip-delay-duration={skipDelayDuration === undefined
     ? undefined

--- a/packages/ui/src/components/tooltip/tooltip.astro
+++ b/packages/ui/src/components/tooltip/tooltip.astro
@@ -8,6 +8,13 @@
  * The content stays in light DOM (present-but-hidden) so the hover-delay
  * primitive the bind composes can read it, and so it is crawlable before JS.
  * Positioning and hover timing are the bind's job; this is enter-only.
+ *
+ * The root is a semantic <div data-part="root">, not <rafters-tooltip> (#2004):
+ * this target never registers the custom element, so the tag was an unknown
+ * element used as a query hook -- display:inline with no class. The marker
+ * `data-tooltip` scopes the binding selector the way grid/progress/context-menu
+ * already do, and the config rides as `data-*` (#2001), which is what
+ * bindTooltip reads through `dataset`.
  */
 import { tooltip, tooltipPlacement, type TooltipConfig, type TooltipPart } from './tooltip.behavior';
 import { tooltipClasses } from './tooltip.classes';
@@ -57,15 +64,19 @@ const aria = tooltip.aria(state, config, ids);
 const open = state.open;
 ---
 
-<rafters-tooltip
+<div
   data-part="root"
-  delay-duration={delayDuration === undefined ? undefined : String(delayDuration)}
-  skip-delay-duration={skipDelayDuration === undefined ? undefined : String(skipDelayDuration)}
-  disable-hoverable-content={String(disableHoverableContent)}
-  default-open={String(defaultOpen)}
-  side={placement.side}
-  align={placement.align}
-  side-offset={sideOffset === undefined ? undefined : String(sideOffset)}
+  data-tooltip
+  class={classes.root}
+  data-delay-duration={delayDuration === undefined ? undefined : String(delayDuration)}
+  data-skip-delay-duration={skipDelayDuration === undefined
+    ? undefined
+    : String(skipDelayDuration)}
+  data-disable-hoverable-content={String(disableHoverableContent)}
+  data-default-open={String(defaultOpen)}
+  data-side={placement.side}
+  data-align={placement.align}
+  data-side-offset={sideOffset === undefined ? undefined : String(sideOffset)}
 >
   <button
     type="button"
@@ -88,15 +99,18 @@ const open = state.open;
   >
     {content}
   </div>
-</rafters-tooltip>
+</div>
 
 <script>
   import { bindTooltip } from './tooltip.behavior';
 
-  for (const root of document.querySelectorAll('rafters-tooltip[data-part="root"]')) {
-    const el = root as HTMLElement;
-    if (el.dataset['bound'] === 'true') continue;
-    el.dataset['bound'] = 'true';
-    bindTooltip(el);
+  // The <script> is bundled and runs once per page; bind every instance's
+  // server-rendered markup. Same controller as the Web Component. The marker
+  // attribute scopes the selector to THIS component's roots -- [data-part="root"]
+  // alone would match every rafters root on the page.
+  for (const root of document.querySelectorAll<HTMLElement>('[data-part="root"][data-tooltip]')) {
+    if (root.dataset['bound'] === 'true') continue;
+    root.dataset['bound'] = 'true';
+    bindTooltip(root);
   }
 </script>

--- a/packages/ui/src/components/tooltip/tooltip.behavior.ts
+++ b/packages/ui/src/components/tooltip/tooltip.behavior.ts
@@ -143,23 +143,26 @@ export function bindTooltip(root: HTMLElement): () => void {
   const getPart = (part: string): HTMLElement | null =>
     part === 'root' ? root : root.querySelector<HTMLElement>(`[data-part="${part}"]`);
 
-  const numAttr = (name: string, fallback: number): number => {
-    const raw = root.getAttribute(name);
-    if (raw === null) return fallback;
+  // Config travels as `data-*` and nothing else (#2001/#2004), so the read is
+  // `dataset` by camelCase key -- `data-delay-duration` is dataset.delayDuration.
+  const data = root.dataset;
+  const numData = (key: string, fallback: number): number => {
+    const raw = data[key];
+    if (raw === undefined) return fallback;
     const parsed = Number(raw);
     return Number.isFinite(parsed) ? parsed : fallback;
   };
 
   const content = getPart('content');
   const config: TooltipConfig = {
-    delayDuration: numAttr('delay-duration', DEFAULT_DELAY_DURATION),
-    skipDelayDuration: numAttr('skip-delay-duration', DEFAULT_SKIP_DELAY_DURATION),
-    disableHoverableContent: root.getAttribute('disable-hoverable-content') === 'true',
-    defaultOpen:
-      root.getAttribute('default-open') === 'true' || content?.dataset['state'] === 'open',
-    side: (root.getAttribute('side') as Side | null) ?? undefined,
-    align: (root.getAttribute('align') as Align | null) ?? undefined,
-    sideOffset: root.hasAttribute('side-offset') ? numAttr('side-offset', 4) : undefined,
+    delayDuration: numData('delayDuration', DEFAULT_DELAY_DURATION),
+    skipDelayDuration: numData('skipDelayDuration', DEFAULT_SKIP_DELAY_DURATION),
+    disableHoverableContent: data['disableHoverableContent'] === 'true',
+    defaultOpen: data['defaultOpen'] === 'true' || content?.dataset['state'] === 'open',
+    side: (data['side'] as Side | undefined) ?? undefined,
+    align: (data['align'] as Align | undefined) ?? undefined,
+    // Presence, not truthiness: data-side-offset="0" is a real offset.
+    sideOffset: 'sideOffset' in data ? numData('sideOffset', 4) : undefined,
   };
 
   const { memory, dispatch } = createBehavior(tooltip, config);

--- a/packages/ui/src/components/tooltip/tooltip.classes.ts
+++ b/packages/ui/src/components/tooltip/tooltip.classes.ts
@@ -1,9 +1,17 @@
 import type { TooltipConfig, TooltipState } from './tooltip.behavior';
 
 export interface TooltipClassSet {
+  root: string;
   trigger: string;
   content: string;
 }
+
+// The DOM-native root is a binding host, not a box: it carries data-part="root"
+// and the config, and its two children (an inline-flex trigger and a fixed-
+// positioned tip) place themselves. `contents` removes the wrapper box entirely
+// so the trigger flows in the consumer's layout exactly as an unwrapped button
+// would -- the layout-neutral answer to the display:inline hazard in #2004.
+const rootClasses = 'contents';
 
 const triggerClasses = 'inline-flex';
 
@@ -19,6 +27,7 @@ const contentClasses =
 
 export function tooltipClasses(_config: TooltipConfig, _state: TooltipState): TooltipClassSet {
   return {
+    root: rootClasses,
     trigger: triggerClasses,
     content: contentClasses,
   };

--- a/packages/ui/src/components/tooltip/tooltip.classes.ts
+++ b/packages/ui/src/components/tooltip/tooltip.classes.ts
@@ -1,18 +1,13 @@
 import type { TooltipConfig, TooltipState } from './tooltip.behavior';
 
 export interface TooltipClassSet {
-  root: string;
   trigger: string;
   content: string;
 }
 
 // The DOM-native root is a binding host, not a box: it carries data-part="root"
-// and the config, and its two children (an inline-flex trigger and a fixed-
-// positioned tip) place themselves. `contents` removes the wrapper box entirely
-// so the trigger flows in the consumer's layout exactly as an unwrapped button
-// would -- the layout-neutral answer to the display:inline hazard in #2004.
-const rootClasses = 'contents';
-
+// and the config, and NO class -- a behavior root never styles itself; layout
+// belongs to the consumer's Container/Grid (operator ruling, 2026-08-02).
 const triggerClasses = 'inline-flex';
 
 // z-depth-tooltip is the semantic depth token (not a raw z-index); fill uses
@@ -27,7 +22,6 @@ const contentClasses =
 
 export function tooltipClasses(_config: TooltipConfig, _state: TooltipState): TooltipClassSet {
   return {
-    root: rootClasses,
     trigger: triggerClasses,
     content: contentClasses,
   };

--- a/packages/ui/src/components/tooltip/tooltip.classes.ts
+++ b/packages/ui/src/components/tooltip/tooltip.classes.ts
@@ -7,7 +7,12 @@ export interface TooltipClassSet {
 
 // The DOM-native root is a binding host, not a box: it carries data-part="root"
 // and the config, and NO class -- a behavior root never styles itself; layout
-// belongs to the consumer's Container/Grid (operator ruling, 2026-08-02).
+// belongs to the consumer's Container/Grid (operator ruling, 2026-08-02). With
+// no class the unclassed <div> root is a BLOCK box: a tooltip is composed by
+// Container, not dropped mid-sentence into running text.
+
+// Inside that root the trigger is still inline-flex -- that is the button's own
+// box, not the root's, and it keeps the label and any icon on one line.
 const triggerClasses = 'inline-flex';
 
 // z-depth-tooltip is the semantic depth token (not a raw z-index); fill uses

--- a/packages/ui/src/components/tooltip/tooltip.element.ts
+++ b/packages/ui/src/components/tooltip/tooltip.element.ts
@@ -11,6 +11,10 @@ export class RaftersTooltip extends HTMLElement {
   private teardown: (() => void) | null = null;
 
   connectedCallback(): void {
+    // Target parity: the Astro/React root is an unclassed <div> (block), but a
+    // custom element defaults to display:inline. Pin block so the WC host lays
+    // out identically to the other two performances (#2004).
+    this.style.display = 'block';
     queueMicrotask(() => {
       if (this.isConnected && !this.teardown) this.teardown = bindTooltip(this);
     });

--- a/packages/ui/test/components/context-menu/context-menu.astro.conformance.test.ts
+++ b/packages/ui/test/components/context-menu/context-menu.astro.conformance.test.ts
@@ -15,7 +15,11 @@ import {
   bindContextMenu,
   contextMenu,
 } from '../../../src/components/context-menu/context-menu.behavior';
-import { assertAxeClean, assertContractFulfillment } from '../../harness/conformance';
+import {
+  assertAxeClean,
+  assertConfigTravelsAsData,
+  assertContractFulfillment,
+} from '../../harness/conformance';
 
 const items = [
   { label: 'Cut' },
@@ -192,5 +196,19 @@ describe('context-menu conformance [astro]', () => {
     await user.click(itemByText('Cut'));
     expect(content().hidden).toBe(true);
     expect(grandchild.hidden).toBe(true);
+  });
+
+  // The #2001 pairing: config is data-* in the markup AND read through dataset
+  // in the bind. Neither `loop` nor `avoid-collisions` is valid on a <div>.
+  it('config crosses the SSR/bind seam as data-* only, and rehydration still works', async () => {
+    const root = await mount();
+
+    assertConfigTravelsAsData(root, { loop: 'true', avoidCollisions: 'true' });
+
+    // Rehydration: the contextmenu wiring exists only because bindContextMenu
+    // built its config from dataset alone.
+    fireEvent.contextMenu(trigger(), { clientX: 12, clientY: 22 });
+    expect(content().hidden).toBe(false);
+    expect(content().getAttribute('data-state')).toBe('open');
   });
 });

--- a/packages/ui/test/components/drawer/drawer.astro.conformance.test.ts
+++ b/packages/ui/test/components/drawer/drawer.astro.conformance.test.ts
@@ -9,6 +9,7 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it } from 'vitest';
 import Drawer from '../../../src/components/drawer/drawer.astro';
 import { bindDrawer } from '../../../src/components/drawer/drawer.behavior';
+import { assertConfigTravelsAsData } from '../../harness/conformance';
 
 afterEach(() => {
   document.body.innerHTML = '';
@@ -21,7 +22,7 @@ async function mount(
   const container = await AstroContainer.create();
   const html = await container.renderToString(Drawer, { props: { id: 'dr', ...props }, slots });
   document.body.innerHTML = html;
-  const root = document.body.querySelector('rafters-drawer') as HTMLElement;
+  const root = document.body.querySelector('[data-part="root"][data-drawer]') as HTMLElement;
   bindDrawer(root); // the <script> does this per instance on the real page
   return root;
 }
@@ -74,5 +75,32 @@ describe('drawer conformance [astro]', () => {
     expect(content().hidden).toBe(true);
     expect(document.activeElement).toBe(trigger());
     expect(document.body.style.overflow).not.toBe('hidden');
+  });
+
+  // #2004: the root is a real element with a class, not an unregistered
+  // <rafters-drawer> used as a query hook. #2001: its config is data-* only.
+  it('root is a semantic, classed div and config crosses the seam as data-* only', async () => {
+    const root = await mount({ title: 'Actions', modal: false, side: 'right' });
+    expect(root.tagName).toBe('DIV');
+    expect(root.className).toBe('contents');
+    expect(root.hasAttribute('data-drawer')).toBe(true);
+
+    assertConfigTravelsAsData(root, {
+      modal: 'false',
+      defaultOpen: 'false',
+      side: 'right',
+    });
+  });
+
+  it('rehydration: bindDrawer reconstructs defaultOpen from dataset alone', async () => {
+    const root = await mount({ title: 'Actions', defaultOpen: true });
+    expect(root.dataset['defaultOpen']).toBe('true');
+    // Erase the SSR open projection AND the content's data-state fallback, then
+    // re-bind: only data-default-open, read through dataset, can bring it back.
+    const panel = content();
+    panel.removeAttribute('data-state');
+    panel.hidden = true;
+    bindDrawer(root);
+    expect(panel.hidden).toBe(false);
   });
 });

--- a/packages/ui/test/components/drawer/drawer.astro.conformance.test.ts
+++ b/packages/ui/test/components/drawer/drawer.astro.conformance.test.ts
@@ -82,7 +82,9 @@ describe('drawer conformance [astro]', () => {
   it('root is a semantic, classed div and config crosses the seam as data-* only', async () => {
     const root = await mount({ title: 'Actions', modal: false, side: 'right' });
     expect(root.tagName).toBe('DIV');
-    expect(root.className).toBe('contents');
+    // No class, ever: a behavior root is a binding host, not a box, and it
+    // never styles itself (operator ruling, 2026-08-02). Layout is Container's.
+    expect(root.hasAttribute('class')).toBe(false);
     expect(root.hasAttribute('data-drawer')).toBe(true);
 
     assertConfigTravelsAsData(root, {

--- a/packages/ui/test/components/drawer/drawer.astro.conformance.test.ts
+++ b/packages/ui/test/components/drawer/drawer.astro.conformance.test.ts
@@ -77,9 +77,9 @@ describe('drawer conformance [astro]', () => {
     expect(document.body.style.overflow).not.toBe('hidden');
   });
 
-  // #2004: the root is a real element with a class, not an unregistered
+  // #2004: the root is a real, semantic element, not an unregistered
   // <rafters-drawer> used as a query hook. #2001: its config is data-* only.
-  it('root is a semantic, classed div and config crosses the seam as data-* only', async () => {
+  it('root is a semantic, unclassed div and config crosses the seam as data-* only', async () => {
     const root = await mount({ title: 'Actions', modal: false, side: 'right' });
     expect(root.tagName).toBe('DIV');
     // No class, ever: a behavior root is a binding host, not a box, and it

--- a/packages/ui/test/components/drawer/drawer.element.conformance.test.ts
+++ b/packages/ui/test/components/drawer/drawer.element.conformance.test.ts
@@ -15,7 +15,7 @@ beforeAll(() => {
 
 async function mount(modal = true): Promise<HTMLElement> {
   document.body.innerHTML = `
-    <rafters-drawer${modal ? '' : ' modal="false"'} side="bottom">
+    <rafters-drawer${modal ? '' : ' data-modal="false"'} data-side="bottom">
       <button type="button" data-part="trigger" id="dr-trigger" aria-haspopup="dialog" aria-expanded="false" data-state="closed">Open</button>
       <div data-part="overlay" id="dr-overlay" aria-hidden="true" data-state="closed" hidden></div>
       <div data-part="content" id="dr-content" role="dialog" tabindex="-1" aria-labelledby="dr-title" data-state="closed" hidden>
@@ -95,7 +95,7 @@ describe('drawer conformance [wc]', () => {
     // The bind resolves any keydown inside content as content-scoped.
     const user = userEvent.setup();
     document.body.innerHTML = `
-      <rafters-drawer side="bottom">
+      <rafters-drawer data-side="bottom">
         <button type="button" data-part="trigger" id="dr-trigger" aria-haspopup="dialog" aria-expanded="false" data-state="closed">Open</button>
         <div data-part="overlay" id="dr-overlay" aria-hidden="true" data-state="closed" hidden></div>
         <div data-part="content" id="dr-content" role="dialog" tabindex="-1" aria-labelledby="dr-title" data-state="closed" hidden>

--- a/packages/ui/test/components/drawer/drawer.element.conformance.test.ts
+++ b/packages/ui/test/components/drawer/drawer.element.conformance.test.ts
@@ -38,6 +38,11 @@ afterEach(() => {
 });
 
 describe('drawer conformance [wc]', () => {
+  it('host pins display:block to match the unclassed block root of the other targets', async () => {
+    const host = await mount();
+    expect(host.style.display).toBe('block');
+  });
+
   it('closed: content hidden, trigger collapsed', async () => {
     await mount();
     expect(content().hidden).toBe(true);

--- a/packages/ui/test/components/grid/grid.astro.conformance.test.ts
+++ b/packages/ui/test/components/grid/grid.astro.conformance.test.ts
@@ -12,6 +12,7 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it } from 'vitest';
 import Grid from '../../../src/components/grid/grid.astro';
 import { bindGrid } from '../../../src/components/grid/grid.behavior';
+import { assertConfigTravelsAsData } from '../../harness/conformance';
 
 afterEach(() => {
   document.body.innerHTML = '';
@@ -86,5 +87,35 @@ describe('grid conformance [astro]', () => {
     expect(document.activeElement).toBe(grid[2]);
     await user.keyboard('{ArrowUp}');
     expect(document.activeElement).toBe(grid[0]);
+  });
+
+  // The #2001 pairing: config is data-* in the markup AND read through dataset
+  // in the bind. Both halves asserted here so a half-fix fails loudly.
+  it('config crosses the SSR/bind seam as data-* only, and rehydration still works', async () => {
+    const root = await mount({
+      preset: 'bento',
+      pattern: 'dashboard',
+      gap: '4',
+      padding: '2',
+      role: 'grid',
+      columns: 2,
+      ariaLabel: 'Cells',
+      cells: [{ html: 'a' }, { html: 'b' }, { html: 'c' }, { html: 'd' }],
+    });
+
+    assertConfigTravelsAsData(root, {
+      preset: 'bento',
+      pattern: 'dashboard',
+      columns: '2',
+      gap: '4',
+      padding: '2',
+      gridRole: 'grid',
+    });
+
+    // Rehydration: neither the honest role nor the roving tab stop is SSR'd --
+    // both exist only because bindGrid reconstructed the config from dataset.
+    expect(root.getAttribute('role')).toBe('grid');
+    expect(root.getAttribute('aria-label')).toBe('Cells');
+    expect(cells()[0]?.getAttribute('tabindex')).toBe('0');
   });
 });

--- a/packages/ui/test/components/grid/grid.element.conformance.test.ts
+++ b/packages/ui/test/components/grid/grid.element.conformance.test.ts
@@ -5,7 +5,7 @@
  * 2D roving-focus composition drive through the DOM binding.
  *
  * The two archetype cases the issue names:
- *  - role="grid" (opted in via grid-role) engages the 2D keyboard contract;
+ *  - role="grid" (opted in via data-grid-role) engages the 2D keyboard contract;
  *  - a presentation grid stays inert -- no role, no roving tab stop.
  */
 import { cleanup } from '@testing-library/react';
@@ -18,10 +18,11 @@ beforeAll(() => {
 });
 
 async function mountGridMode(): Promise<HTMLElement> {
-  // role="grid" markup is authored (or SSR'd) pre-chunked: grid-role opts in,
-  // the row/gridcell structure already exists, the binding projects role.
+  // role="grid" markup is authored (or SSR'd) pre-chunked: data-grid-role opts
+  // in, the row/gridcell structure already exists, the binding projects role.
+  // Config is data-* only (#2001), so every key here reaches root.dataset.
   document.body.innerHTML = `
-    <rafters-grid data-part="root" data-grid grid-role="grid" columns="2" aria-label="Cells">
+    <rafters-grid data-part="root" data-grid data-grid-role="grid" data-columns="2" aria-label="Cells">
       <div data-part="row" role="row" class="contents">
         <div data-part="cell" role="gridcell" data-roving-item tabindex="-1">a</div>
         <div data-part="cell" role="gridcell" data-roving-item tabindex="-1">b</div>
@@ -37,7 +38,7 @@ async function mountGridMode(): Promise<HTMLElement> {
 
 async function mountPresentation(): Promise<HTMLElement> {
   document.body.innerHTML = `
-    <rafters-grid data-part="root" data-grid preset="bento" pattern="dashboard">
+    <rafters-grid data-part="root" data-grid data-preset="bento" data-pattern="dashboard">
       <div data-priority="primary">Metric</div>
       <div data-priority="secondary">Chart</div>
       <div data-priority="tertiary">Feed</div>

--- a/packages/ui/test/components/hover-card/hover-card.astro.conformance.test.ts
+++ b/packages/ui/test/components/hover-card/hover-card.astro.conformance.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import HoverCard from '../../../src/components/hover-card/hover-card.astro';
 import { bindHoverCard } from '../../../src/components/hover-card/hover-card.behavior';
 import { resetHoverDelayState } from '../../../src/primitives/hover-delay';
+import { assertConfigTravelsAsData } from '../../harness/conformance';
 
 afterEach(() => {
   document.body.innerHTML = '';
@@ -31,7 +32,7 @@ async function mount(props: Record<string, unknown> = {}): Promise<HTMLElement> 
     slots: { default: '@john', content: '<span>Software Engineer</span>' },
   });
   document.body.innerHTML = html;
-  const root = document.body.querySelector('rafters-hover-card') as HTMLElement;
+  const root = document.body.querySelector('[data-part="root"][data-hover-card]') as HTMLElement;
   bindHoverCard(root); // the <script> does this per instance on the real page
   return root;
 }
@@ -67,5 +68,36 @@ describe('hover-card conformance [astro]', () => {
     expect(content().hidden).toBe(false);
     await user.keyboard('{Escape}');
     expect(content().hidden).toBe(true);
+  });
+
+  // #2004: the root is a real element with a class, not an unregistered
+  // <rafters-hover-card> used as a query hook. #2001: its config is data-* only.
+  it('root is a semantic, classed div and config crosses the seam as data-* only', async () => {
+    const root = await mount({ side: 'top', align: 'start', sideOffset: 0 });
+    expect(root.tagName).toBe('DIV');
+    expect(root.className).toBe('contents');
+    expect(root.hasAttribute('data-hover-card')).toBe(true);
+
+    assertConfigTravelsAsData(root, {
+      openDelay: '0',
+      closeDelay: '0',
+      disableHoverableContent: 'false',
+      defaultOpen: 'false',
+      side: 'top',
+      align: 'start',
+      sideOffset: '0',
+    });
+  });
+
+  it('rehydration: bindHoverCard reconstructs defaultOpen from dataset alone', async () => {
+    const root = await mount({ defaultOpen: true });
+    expect(root.dataset['defaultOpen']).toBe('true');
+    // Erase the SSR open projection AND the content's data-state fallback, then
+    // re-bind: only data-default-open, read through dataset, can bring it back.
+    const card = content();
+    card.removeAttribute('data-state');
+    card.hidden = true;
+    bindHoverCard(root);
+    expect(card.hidden).toBe(false);
   });
 });

--- a/packages/ui/test/components/hover-card/hover-card.astro.conformance.test.ts
+++ b/packages/ui/test/components/hover-card/hover-card.astro.conformance.test.ts
@@ -70,9 +70,9 @@ describe('hover-card conformance [astro]', () => {
     expect(content().hidden).toBe(true);
   });
 
-  // #2004: the root is a real element with a class, not an unregistered
+  // #2004: the root is a real, semantic element, not an unregistered
   // <rafters-hover-card> used as a query hook. #2001: its config is data-* only.
-  it('root is a semantic, classed div and config crosses the seam as data-* only', async () => {
+  it('root is a semantic, unclassed div and config crosses the seam as data-* only', async () => {
     const root = await mount({ side: 'top', align: 'start', sideOffset: 0 });
     expect(root.tagName).toBe('DIV');
     // No class, ever: a behavior root is a binding host, not a box, and it

--- a/packages/ui/test/components/hover-card/hover-card.astro.conformance.test.ts
+++ b/packages/ui/test/components/hover-card/hover-card.astro.conformance.test.ts
@@ -75,7 +75,9 @@ describe('hover-card conformance [astro]', () => {
   it('root is a semantic, classed div and config crosses the seam as data-* only', async () => {
     const root = await mount({ side: 'top', align: 'start', sideOffset: 0 });
     expect(root.tagName).toBe('DIV');
-    expect(root.className).toBe('contents');
+    // No class, ever: a behavior root is a binding host, not a box, and it
+    // never styles itself (operator ruling, 2026-08-02). Layout is Container's.
+    expect(root.hasAttribute('class')).toBe(false);
     expect(root.hasAttribute('data-hover-card')).toBe(true);
 
     assertConfigTravelsAsData(root, {

--- a/packages/ui/test/components/hover-card/hover-card.behavior.test.ts
+++ b/packages/ui/test/components/hover-card/hover-card.behavior.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { createBehavior, type PartIds } from '../../../src/lib/contract';
 import {
+  bindHoverCard,
   hoverCard,
   hoverCardPlacement,
   isOpen,
@@ -121,5 +122,62 @@ describe('hoverCardPlacement defaults', () => {
       align: 'start',
       sideOffset: 8,
     });
+  });
+});
+
+/**
+ * bindHoverCard reads sideOffset by PRESENCE (`'sideOffset' in data`), not by
+ * truthiness: data-side-offset="0" is a real, flush offset and must not fall
+ * back to the 4px default. The observable is the positioner's translate, so a
+ * regression to `data['sideOffset'] ? ... : undefined` fails these.
+ */
+describe('bindHoverCard: data-side-offset parse', () => {
+  const teardowns: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const teardown of teardowns.splice(0)) teardown();
+    document.body.innerHTML = '';
+  });
+
+  /** Default-open so the first paint positions the content synchronously. */
+  function mountOpen(sideOffset?: string): HTMLElement {
+    const root = document.createElement('div');
+    root.dataset['part'] = 'root';
+    root.dataset['defaultOpen'] = 'true';
+    root.dataset['side'] = 'bottom';
+    root.dataset['align'] = 'start';
+    if (sideOffset !== undefined) root.dataset['sideOffset'] = sideOffset;
+
+    const trigger = document.createElement('a');
+    trigger.href = '#';
+    trigger.dataset['part'] = 'trigger';
+    trigger.id = 'hc-trigger';
+    trigger.textContent = '@john';
+
+    const content = document.createElement('div');
+    content.dataset['part'] = 'content';
+    content.id = 'hc-content';
+    content.dataset['state'] = 'open';
+    content.textContent = 'Software Engineer';
+
+    root.append(trigger, content);
+    document.body.appendChild(root);
+    teardowns.push(bindHoverCard(root));
+    return content;
+  }
+
+  /** The y translate the positioner stamped, in px. */
+  function translateY(content: HTMLElement): number {
+    const match = /translate\((-?\d+)px, (-?\d+)px\)/.exec(content.style.transform);
+    expect(match).not.toBeNull();
+    return Number(match?.[2]);
+  }
+
+  it('data-side-offset="0" is a real 0, not the 4px default', () => {
+    expect(translateY(mountOpen('0'))).toBe(0);
+  });
+
+  it('an absent data-side-offset falls back to the 4px default', () => {
+    expect(translateY(mountOpen())).toBe(4);
   });
 });

--- a/packages/ui/test/components/hover-card/hover-card.behavior.test.ts
+++ b/packages/ui/test/components/hover-card/hover-card.behavior.test.ts
@@ -128,8 +128,13 @@ describe('hoverCardPlacement defaults', () => {
 /**
  * bindHoverCard reads sideOffset by PRESENCE (`'sideOffset' in data`), not by
  * truthiness: data-side-offset="0" is a real, flush offset and must not fall
- * back to the 4px default. The observable is the positioner's translate, so a
- * regression to `data['sideOffset'] ? ... : undefined` fails these.
+ * back to the 4px default. The observable is the positioner's translate.
+ *
+ * Note which regression these actually catch: `dataset` values are always
+ * STRINGS, and '0' is truthy, so a string-truthiness rewrite is not a live
+ * zero-mask at this site. The mask that can really happen is numeric -- e.g.
+ * `numData('sideOffset', 4) || undefined` -- and that form fails both cases
+ * below.
  */
 describe('bindHoverCard: data-side-offset parse', () => {
   const teardowns: Array<() => void> = [];

--- a/packages/ui/test/components/hover-card/hover-card.element.conformance.test.ts
+++ b/packages/ui/test/components/hover-card/hover-card.element.conformance.test.ts
@@ -39,6 +39,11 @@ afterEach(() => {
 });
 
 describe('hover-card conformance [wc]', () => {
+  it('host pins display:block to match the unclassed block root of the other targets', async () => {
+    const host = await mount();
+    expect(host.style.display).toBe('block');
+  });
+
   it('closed: content hidden, trigger undescribed', async () => {
     await mount();
     expect(content().hidden).toBe(true);

--- a/packages/ui/test/components/hover-card/hover-card.element.conformance.test.ts
+++ b/packages/ui/test/components/hover-card/hover-card.element.conformance.test.ts
@@ -19,7 +19,7 @@ beforeAll(() => {
 
 async function mount(closeDelay = 0): Promise<HTMLElement> {
   document.body.innerHTML = `
-    <rafters-hover-card data-part="root" open-delay="0" close-delay="${closeDelay}">
+    <rafters-hover-card data-part="root" data-open-delay="0" data-close-delay="${closeDelay}">
       <a href="#" data-part="trigger" id="hc-trigger" data-state="closed">@john</a>
       <div data-part="content" id="hc-content" role="dialog" aria-label="John Doe" data-state="closed" hidden>
         Software Engineer
@@ -92,7 +92,7 @@ describe('hover-card conformance [wc]', () => {
     // hover/focus had given the primitive state to close. A raw Escape keydown
     // with no focus event must still close it.
     document.body.innerHTML = `
-      <rafters-hover-card data-part="root" open-delay="0" default-open="true">
+      <rafters-hover-card data-part="root" data-open-delay="0" data-default-open="true">
         <a href="#" data-part="trigger" id="hc-trigger" data-state="open">@john</a>
         <div data-part="content" id="hc-content" role="dialog" aria-label="John Doe" data-state="open">Software Engineer</div>
       </rafters-hover-card>`;

--- a/packages/ui/test/components/image/image.astro.conformance.test.ts
+++ b/packages/ui/test/components/image/image.astro.conformance.test.ts
@@ -8,7 +8,12 @@ import { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import { afterEach, describe, expect, it } from 'vitest';
 import Image from '../../../src/components/image/image.astro';
 import { bindImage, image, type ImageConfig } from '../../../src/components/image/image.behavior';
-import { assertAxeClean, assertContractFulfillment, partElement } from '../../harness/conformance';
+import {
+  assertAxeClean,
+  assertConfigTravelsAsData,
+  assertContractFulfillment,
+  partElement,
+} from '../../harness/conformance';
 
 const SRC = 'https://example.com/photo.jpg';
 
@@ -71,5 +76,40 @@ describe('image conformance [astro]', () => {
     expect(root.className).toContain('my-4');
     const frame = partElement(root, 'frame') as HTMLElement;
     expect(frame.className).toContain('rounded-2xl');
+  });
+
+  // The #2001 pairing: config is data-* in the markup AND read through dataset
+  // in the bind. `size` and `fill` are real platform attributes elsewhere, so
+  // the bare spellings must not appear on the <figure> at all.
+  it('config crosses the SSR/bind seam as data-* only, and rehydration still works', async () => {
+    const root = await mount({
+      src: SRC,
+      alt: 'Broken',
+      size: 'md',
+      alignment: 'left',
+      radius: '2xl',
+      fill: 'muted',
+      status: 'error',
+      errorMessage: 'Gone',
+      loadingLabel: 'Wait',
+    });
+
+    assertConfigTravelsAsData(root, {
+      size: 'md',
+      alignment: 'left',
+      radius: '2xl',
+      fill: 'muted',
+      status: 'error',
+      errorMessage: 'Gone',
+      loadingLabel: 'Wait',
+    });
+
+    // Rehydration: wipe the projected role, re-bind, and it comes back -- which
+    // it can only do by reconstructing `status` from dataset.
+    const status = partElement(root, 'status') as HTMLElement;
+    status.removeAttribute('role');
+    bindImage(root);
+    expect(status.getAttribute('role')).toBe('alert');
+    expect(status.textContent?.trim()).toBe('Gone');
   });
 });

--- a/packages/ui/test/components/image/image.behavior.test.ts
+++ b/packages/ui/test/components/image/image.behavior.test.ts
@@ -100,16 +100,16 @@ describe('readImageConfig', () => {
     return node;
   }
 
-  it('reconstructs config from attributes (the inverse of the markup)', () => {
+  it('reconstructs config from data-* attributes (the inverse of the markup)', () => {
     const config = readImageConfig(
       el({
-        size: 'md',
-        alignment: 'left',
-        radius: '2xl',
-        fill: 'muted',
-        status: 'error',
-        'error-message': 'Broken',
-        'loading-label': 'Wait',
+        'data-size': 'md',
+        'data-alignment': 'left',
+        'data-radius': '2xl',
+        'data-fill': 'muted',
+        'data-status': 'error',
+        'data-error-message': 'Broken',
+        'data-loading-label': 'Wait',
       }),
     );
     expect(config).toEqual({
@@ -124,7 +124,9 @@ describe('readImageConfig', () => {
   });
 
   it('unknown enum values fall back to undefined (defaults resolve downstream)', () => {
-    const config = readImageConfig(el({ size: 'gigantic', alignment: 'diagonal', status: 'huh' }));
+    const config = readImageConfig(
+      el({ 'data-size': 'gigantic', 'data-alignment': 'diagonal', 'data-status': 'huh' }),
+    );
     expect(config.size).toBeUndefined();
     expect(config.alignment).toBeUndefined();
     expect(config.status).toBeUndefined();

--- a/packages/ui/test/components/image/image.element.conformance.test.ts
+++ b/packages/ui/test/components/image/image.element.conformance.test.ts
@@ -49,7 +49,7 @@ describe('image conformance [wc]', () => {
   });
 
   it('loading: the img is aria-busy and the overlay is role="status"', async () => {
-    const root = await mount(`src="${SRC}" alt="Loading" status="loading"`);
+    const root = await mount(`src="${SRC}" alt="Loading" data-status="loading"`);
     const img = partElement(root, 'img') as HTMLElement;
     expect(img.getAttribute('aria-busy')).toBe('true');
     const status = partElement(root, 'status') as HTMLElement;
@@ -64,7 +64,9 @@ describe('image conformance [wc]', () => {
   });
 
   it('error: the overlay is role="alert" carrying the message', async () => {
-    const root = await mount(`src="${SRC}" alt="Broken" status="error" error-message="Gone"`);
+    const root = await mount(
+      `src="${SRC}" alt="Broken" data-status="error" data-error-message="Gone"`,
+    );
     const status = partElement(root, 'status') as HTMLElement;
     expect(status.getAttribute('role')).toBe('alert');
     expect(status.textContent).toBe('Gone');
@@ -78,12 +80,12 @@ describe('image conformance [wc]', () => {
   });
 
   it('a live status change re-derives the projection (loading -> loaded)', async () => {
-    await mount(`src="${SRC}" alt="Photo" status="loading"`);
+    await mount(`src="${SRC}" alt="Photo" data-status="loading"`);
     const host = document.querySelector('rafters-image') as HTMLElement;
     expect((partElement(document.body, 'img') as HTMLElement).getAttribute('aria-busy')).toBe(
       'true',
     );
-    host.setAttribute('status', 'loaded');
+    host.setAttribute('data-status', 'loaded');
     await Promise.resolve();
     const img = partElement(document.body, 'img') as HTMLElement;
     expect(img.hasAttribute('aria-busy')).toBe(false);

--- a/packages/ui/test/components/navigation-menu/navigation-menu.astro.conformance.test.ts
+++ b/packages/ui/test/components/navigation-menu/navigation-menu.astro.conformance.test.ts
@@ -14,7 +14,10 @@ import {
   bindNavigationMenu,
   navigationMenu,
 } from '../../../src/components/navigation-menu/navigation-menu.behavior';
-import { assertInstanceAriaFulfillment } from '../../harness/conformance';
+import {
+  assertConfigTravelsAsData,
+  assertInstanceAriaFulfillment,
+} from '../../harness/conformance';
 
 const items = [
   {
@@ -102,5 +105,20 @@ describe('navigation-menu conformance [astro]', () => {
     await user.keyboard('{Escape}');
     expect(content('products').hidden).toBe(true);
     expect(trigger('products').getAttribute('aria-expanded')).toBe('false');
+  });
+
+  // The #2001 pairing: config is data-* in the markup AND read through dataset
+  // in the bind. Neither `orientation` nor `delay-duration` is valid on a <nav>.
+  it('config crosses the SSR/bind seam as data-* only, and rehydration still works', async () => {
+    const user = userEvent.setup();
+    const root = await mount();
+
+    assertConfigTravelsAsData(root, { orientation: 'horizontal', delayDuration: '200' });
+
+    // Rehydration: opening is wired only by bindNavigationMenu, which built its
+    // config from dataset alone.
+    await user.click(trigger('products'));
+    expect(content('products').hidden).toBe(false);
+    expect(trigger('products').getAttribute('aria-expanded')).toBe('true');
   });
 });

--- a/packages/ui/test/components/navigation-menu/navigation-menu.element.conformance.test.ts
+++ b/packages/ui/test/components/navigation-menu/navigation-menu.element.conformance.test.ts
@@ -3,7 +3,7 @@
  * light-DOM markup. Same score as the React conformance test -- the only
  * difference is the controller applies the projection imperatively.
  */
-import { cleanup } from '@testing-library/react';
+import { cleanup, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { navigationMenu } from '../../../src/components/navigation-menu/navigation-menu.behavior';
@@ -16,9 +16,9 @@ beforeAll(() => {
   }
 });
 
-async function mount(): Promise<HTMLElement> {
+async function mount(delayDuration = 1): Promise<HTMLElement> {
   document.body.innerHTML = `
-    <rafters-navigation-menu data-delay-duration="1">
+    <rafters-navigation-menu data-delay-duration="${delayDuration}">
       <ul data-part="list">
         <li>
           <button type="button" data-part="trigger" data-value="products" data-roving-item id="t-products">Products</button>
@@ -110,6 +110,19 @@ describe('navigation-menu conformance [wc]', () => {
     await user.keyboard('{Escape}');
     expect(content('products').hidden).toBe(true);
     expect(document.activeElement).toBe(trigger('products'));
+  });
+
+  // The fixture's data-delay-duration is not decoration: it is the hover-intent
+  // window the binding composes. This is the only test that spends it -- hover
+  // must NOT open synchronously, and must open once the window elapses.
+  it('hover opens the panel only after the configured delay elapses', async () => {
+    const user = userEvent.setup();
+    await mount(60);
+    await user.hover(trigger('products'));
+    // Still shut: the intent window has not elapsed, so hover is not a click.
+    expect(content('products').hidden).toBe(true);
+    await waitFor(() => expect(content('products').hidden).toBe(false));
+    expect(trigger('products').getAttribute('aria-expanded')).toBe('true');
   });
 
   it('pointerdown outside closes', async () => {

--- a/packages/ui/test/components/navigation-menu/navigation-menu.element.conformance.test.ts
+++ b/packages/ui/test/components/navigation-menu/navigation-menu.element.conformance.test.ts
@@ -115,6 +115,8 @@ describe('navigation-menu conformance [wc]', () => {
   // The fixture's data-delay-duration is not decoration: it is the hover-intent
   // window the binding composes. This is the only test that spends it -- hover
   // must NOT open synchronously, and must open once the window elapses.
+  // Real timers plus waitFor over a short window, matching the hoverable-content
+  // test in the tooltip WC suite; this suite has no fake-timer precedent.
   it('hover opens the panel only after the configured delay elapses', async () => {
     const user = userEvent.setup();
     await mount(60);

--- a/packages/ui/test/components/navigation-menu/navigation-menu.element.conformance.test.ts
+++ b/packages/ui/test/components/navigation-menu/navigation-menu.element.conformance.test.ts
@@ -18,7 +18,7 @@ beforeAll(() => {
 
 async function mount(): Promise<HTMLElement> {
   document.body.innerHTML = `
-    <rafters-navigation-menu delay-duration="1">
+    <rafters-navigation-menu data-delay-duration="1">
       <ul data-part="list">
         <li>
           <button type="button" data-part="trigger" data-value="products" data-roving-item id="t-products">Products</button>

--- a/packages/ui/test/components/popover/popover.astro.conformance.test.ts
+++ b/packages/ui/test/components/popover/popover.astro.conformance.test.ts
@@ -9,6 +9,7 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it } from 'vitest';
 import Popover from '../../../src/components/popover/popover.astro';
 import { bindPopover } from '../../../src/components/popover/popover.behavior';
+import { assertConfigTravelsAsData } from '../../harness/conformance';
 
 afterEach(() => {
   document.body.innerHTML = '';
@@ -21,7 +22,7 @@ async function mount(
   const container = await AstroContainer.create();
   const html = await container.renderToString(Popover, { props: { id: 'p', ...props }, slots });
   document.body.innerHTML = html;
-  const root = document.body.querySelector('rafters-popover') as HTMLElement;
+  const root = document.body.querySelector('[data-part="root"][data-popover]') as HTMLElement;
   bindPopover(root); // the <script> does this per instance on the real page
   return root;
 }
@@ -57,5 +58,34 @@ describe('popover conformance [astro]', () => {
     expect(content().hidden).toBe(false);
     await user.click(document.body.querySelector('[data-part="close"]') as HTMLElement);
     expect(content().hidden).toBe(true);
+  });
+
+  // #2004: the root is a real element with a class, not an unregistered
+  // <rafters-popover> used as a query hook. #2001: its config is data-* only.
+  it('root is a semantic, classed div and config crosses the seam as data-* only', async () => {
+    const root = await mount({ side: 'top', align: 'start', sideOffset: 0, alignOffset: 8 });
+    expect(root.tagName).toBe('DIV');
+    expect(root.className).toBe('contents');
+    expect(root.hasAttribute('data-popover')).toBe(true);
+
+    assertConfigTravelsAsData(root, {
+      defaultOpen: 'false',
+      side: 'top',
+      align: 'start',
+      sideOffset: '0',
+      alignOffset: '8',
+    });
+  });
+
+  it('rehydration: bindPopover reconstructs defaultOpen from dataset alone', async () => {
+    const root = await mount({ defaultOpen: true });
+    expect(root.dataset['defaultOpen']).toBe('true');
+    // Erase the SSR open projection AND the content's data-state fallback, then
+    // re-bind: only data-default-open, read through dataset, can bring it back.
+    const panel = content();
+    panel.removeAttribute('data-state');
+    panel.hidden = true;
+    bindPopover(root);
+    expect(panel.hidden).toBe(false);
   });
 });

--- a/packages/ui/test/components/popover/popover.astro.conformance.test.ts
+++ b/packages/ui/test/components/popover/popover.astro.conformance.test.ts
@@ -60,9 +60,9 @@ describe('popover conformance [astro]', () => {
     expect(content().hidden).toBe(true);
   });
 
-  // #2004: the root is a real element with a class, not an unregistered
+  // #2004: the root is a real, semantic element, not an unregistered
   // <rafters-popover> used as a query hook. #2001: its config is data-* only.
-  it('root is a semantic, classed div and config crosses the seam as data-* only', async () => {
+  it('root is a semantic, unclassed div and config crosses the seam as data-* only', async () => {
     const root = await mount({ side: 'top', align: 'start', sideOffset: 0, alignOffset: 8 });
     expect(root.tagName).toBe('DIV');
     // No class, ever: a behavior root is a binding host, not a box, and it

--- a/packages/ui/test/components/popover/popover.astro.conformance.test.ts
+++ b/packages/ui/test/components/popover/popover.astro.conformance.test.ts
@@ -65,7 +65,9 @@ describe('popover conformance [astro]', () => {
   it('root is a semantic, classed div and config crosses the seam as data-* only', async () => {
     const root = await mount({ side: 'top', align: 'start', sideOffset: 0, alignOffset: 8 });
     expect(root.tagName).toBe('DIV');
-    expect(root.className).toBe('contents');
+    // No class, ever: a behavior root is a binding host, not a box, and it
+    // never styles itself (operator ruling, 2026-08-02). Layout is Container's.
+    expect(root.hasAttribute('class')).toBe(false);
     expect(root.hasAttribute('data-popover')).toBe(true);
 
     assertConfigTravelsAsData(root, {

--- a/packages/ui/test/components/popover/popover.element.conformance.test.ts
+++ b/packages/ui/test/components/popover/popover.element.conformance.test.ts
@@ -17,7 +17,7 @@ beforeAll(() => {
 
 async function mount(): Promise<HTMLElement> {
   document.body.innerHTML = `
-    <rafters-popover data-part="root" side="bottom" align="center">
+    <rafters-popover data-part="root" data-side="bottom" data-align="center">
       <button type="button" data-part="trigger" id="p-trigger" aria-haspopup="dialog" aria-expanded="false" data-state="closed">Open</button>
       <div data-part="content" id="p-content" role="dialog" tabindex="-1" data-state="closed" data-side="bottom" data-align="center" hidden>
         <button type="button">Action</button>

--- a/packages/ui/test/components/popover/popover.element.conformance.test.ts
+++ b/packages/ui/test/components/popover/popover.element.conformance.test.ts
@@ -37,6 +37,11 @@ afterEach(() => {
 });
 
 describe('popover conformance [wc]', () => {
+  it('host pins display:block to match the unclassed block root of the other targets', async () => {
+    const host = await mount();
+    expect(host.style.display).toBe('block');
+  });
+
   it('closed: content hidden, trigger collapsed with haspopup dialog', async () => {
     await mount();
     expect(content().hidden).toBe(true);

--- a/packages/ui/test/components/progress/progress.astro.conformance.test.ts
+++ b/packages/ui/test/components/progress/progress.astro.conformance.test.ts
@@ -12,7 +12,12 @@ import {
   progress,
   type ProgressConfig,
 } from '../../../src/components/progress/progress.behavior';
-import { assertAxeClean, assertContractFulfillment, partElement } from '../../harness/conformance';
+import {
+  assertAxeClean,
+  assertConfigTravelsAsData,
+  assertContractFulfillment,
+  partElement,
+} from '../../harness/conformance';
 
 const parts = ['root', 'indicator'] as const;
 
@@ -71,5 +76,39 @@ describe('progress conformance [astro]', () => {
     const root = await mount({ value: 50, class: 'my-4', 'aria-label': 'Upload' });
     expect(root.className).toContain('rounded-full');
     expect(root.className).toContain('my-4');
+  });
+
+  // The #2001 pairing: config is data-* in the markup AND read through dataset
+  // in the bind. `value`/`max` are real on <progress> and `size` on input/select,
+  // so the bare spellings must not appear on this <div> at all.
+  it('config crosses the SSR/bind seam as data-* only, and rehydration still works', async () => {
+    const root = await mount({
+      value: 3,
+      max: 10,
+      variant: 'success',
+      size: 'lg',
+      valueText: '3 of 10 files',
+      'aria-label': 'Files',
+    });
+
+    assertConfigTravelsAsData(root, {
+      value: '3',
+      max: '10',
+      variant: 'success',
+      size: 'lg',
+      valueText: '3 of 10 files',
+    });
+
+    // Rehydration: wipe the projected value contract and the fill, re-bind, and
+    // both come back -- only possible by reading the config from dataset.
+    const indicator = partElement(root, 'indicator') as HTMLElement;
+    root.removeAttribute('aria-valuenow');
+    root.removeAttribute('aria-valuemax');
+    indicator.removeAttribute('style');
+    bindProgress(root);
+    expect(root.getAttribute('aria-valuenow')).toBe('3');
+    expect(root.getAttribute('aria-valuemax')).toBe('10');
+    expect(root.getAttribute('aria-valuetext')).toBe('3 of 10 files');
+    expect(indicator.style.width).toBe('30%');
   });
 });

--- a/packages/ui/test/components/progress/progress.behavior.test.ts
+++ b/packages/ui/test/components/progress/progress.behavior.test.ts
@@ -124,9 +124,15 @@ describe('readProgressConfig', () => {
     return node;
   }
 
-  it('reconstructs config from attributes (the inverse of the markup)', () => {
+  it('reconstructs config from data-* attributes (the inverse of the markup)', () => {
     const config: ProgressConfig = readProgressConfig(
-      el({ value: '3', max: '10', variant: 'success', size: 'lg', 'value-text': '3 of 10' }),
+      el({
+        'data-value': '3',
+        'data-max': '10',
+        'data-variant': 'success',
+        'data-size': 'lg',
+        'data-value-text': '3 of 10',
+      }),
     );
     expect(config).toEqual({
       value: 3,
@@ -138,7 +144,7 @@ describe('readProgressConfig', () => {
   });
 
   it('absent value reads as indeterminate; unknown variant/size fall back', () => {
-    const config = readProgressConfig(el({ variant: 'bogus', size: 'huge' }));
+    const config = readProgressConfig(el({ 'data-variant': 'bogus', 'data-size': 'huge' }));
     expect(config.value).toBeUndefined();
     expect(config.variant).toBe('default');
     expect(config.size).toBe('default');

--- a/packages/ui/test/components/progress/progress.element.conformance.test.ts
+++ b/packages/ui/test/components/progress/progress.element.conformance.test.ts
@@ -31,7 +31,7 @@ afterEach(() => {
 
 describe('progress conformance [wc]', () => {
   it('determinate: host is the progressbar, projection fulfilled, fill sized', async () => {
-    const host = await mount('value="66" aria-label="Upload progress"');
+    const host = await mount('data-value="66" aria-label="Upload progress"');
     const root = partElement(document.body, 'root') as HTMLElement;
     expect(root).toBe(host);
     expect(root.getAttribute('role')).toBe('progressbar');
@@ -54,19 +54,21 @@ describe('progress conformance [wc]', () => {
     expect(indicator.className).toContain('animate-progress-indeterminate');
   });
 
-  it('custom max and value-text drive valuemax and the label', async () => {
-    const host = await mount('value="3" max="10" value-text="3 of 10 files" aria-label="Files"');
+  it('custom data-max and data-value-text drive valuemax and the label', async () => {
+    const host = await mount(
+      'data-value="3" data-max="10" data-value-text="3 of 10 files" aria-label="Files"',
+    );
     expect(host.getAttribute('aria-valuemax')).toBe('10');
     expect(host.getAttribute('aria-valuenow')).toBe('3');
     expect(host.getAttribute('aria-valuetext')).toBe('3 of 10 files');
   });
 
   it('a live value change re-derives the projection and the fill', async () => {
-    const host = await mount('value="20" aria-label="Upload"');
+    const host = await mount('data-value="20" aria-label="Upload"');
     const before = host.querySelector<HTMLElement>('[data-part="indicator"]');
     expect(before?.style.width).toBe('20%');
 
-    host.setAttribute('value', '80');
+    host.setAttribute('data-value', '80');
     const after = host.querySelector<HTMLElement>('[data-part="indicator"]');
     expect(host.getAttribute('aria-valuenow')).toBe('80');
     expect(after?.style.width).toBe('80%');
@@ -76,7 +78,7 @@ describe('progress conformance [wc]', () => {
 
   it('is axe-clean with an accessible name', async () => {
     document.body.innerHTML =
-      '<main><rafters-progress value="50" aria-label="Upload progress"></rafters-progress></main>';
+      '<main><rafters-progress data-value="50" aria-label="Upload progress"></rafters-progress></main>';
     await Promise.resolve();
     const results = await axe(document.body);
     expect(results.violations).toEqual([]);

--- a/packages/ui/test/components/tooltip/tooltip.astro.conformance.test.ts
+++ b/packages/ui/test/components/tooltip/tooltip.astro.conformance.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import Tooltip from '../../../src/components/tooltip/tooltip.astro';
 import { bindTooltip } from '../../../src/components/tooltip/tooltip.behavior';
 import { resetHoverDelayState } from '../../../src/primitives/hover-delay';
+import { assertConfigTravelsAsData } from '../../harness/conformance';
 
 afterEach(() => {
   document.body.innerHTML = '';
@@ -24,7 +25,7 @@ async function mount(props: Record<string, unknown> = {}): Promise<HTMLElement> 
     slots: { default: 'Help' },
   });
   document.body.innerHTML = html;
-  const root = document.body.querySelector('rafters-tooltip') as HTMLElement;
+  const root = document.body.querySelector('[data-part="root"][data-tooltip]') as HTMLElement;
   bindTooltip(root); // the <script> does this per instance on the real page
   return root;
 }
@@ -59,5 +60,36 @@ describe('tooltip conformance [astro]', () => {
     expect(content().hidden).toBe(false);
     await user.keyboard('{Escape}');
     expect(content().hidden).toBe(true);
+  });
+
+  // #2004: the root is a real element with a class, not an unregistered
+  // <rafters-tooltip> used as a query hook. #2001: its config is data-* only.
+  it('root is a semantic, classed div and config crosses the seam as data-* only', async () => {
+    const root = await mount({ side: 'top', align: 'start', sideOffset: 0 });
+    expect(root.tagName).toBe('DIV');
+    expect(root.className).toBe('contents');
+    expect(root.hasAttribute('data-tooltip')).toBe(true);
+
+    assertConfigTravelsAsData(root, {
+      delayDuration: '0',
+      skipDelayDuration: '0',
+      disableHoverableContent: 'false',
+      defaultOpen: 'false',
+      side: 'top',
+      align: 'start',
+      sideOffset: '0',
+    });
+  });
+
+  it('rehydration: bindTooltip reconstructs defaultOpen from dataset alone', async () => {
+    const root = await mount({ defaultOpen: true });
+    expect(root.dataset['defaultOpen']).toBe('true');
+    // Erase the SSR open projection AND the content's data-state fallback, then
+    // re-bind: only data-default-open, read through dataset, can bring it back.
+    const tip = content();
+    tip.removeAttribute('data-state');
+    tip.hidden = true;
+    bindTooltip(root);
+    expect(tip.hidden).toBe(false);
   });
 });

--- a/packages/ui/test/components/tooltip/tooltip.astro.conformance.test.ts
+++ b/packages/ui/test/components/tooltip/tooltip.astro.conformance.test.ts
@@ -67,7 +67,9 @@ describe('tooltip conformance [astro]', () => {
   it('root is a semantic, classed div and config crosses the seam as data-* only', async () => {
     const root = await mount({ side: 'top', align: 'start', sideOffset: 0 });
     expect(root.tagName).toBe('DIV');
-    expect(root.className).toBe('contents');
+    // No class, ever: a behavior root is a binding host, not a box, and it
+    // never styles itself (operator ruling, 2026-08-02). Layout is Container's.
+    expect(root.hasAttribute('class')).toBe(false);
     expect(root.hasAttribute('data-tooltip')).toBe(true);
 
     assertConfigTravelsAsData(root, {

--- a/packages/ui/test/components/tooltip/tooltip.astro.conformance.test.ts
+++ b/packages/ui/test/components/tooltip/tooltip.astro.conformance.test.ts
@@ -62,9 +62,9 @@ describe('tooltip conformance [astro]', () => {
     expect(content().hidden).toBe(true);
   });
 
-  // #2004: the root is a real element with a class, not an unregistered
+  // #2004: the root is a real, semantic element, not an unregistered
   // <rafters-tooltip> used as a query hook. #2001: its config is data-* only.
-  it('root is a semantic, classed div and config crosses the seam as data-* only', async () => {
+  it('root is a semantic, unclassed div and config crosses the seam as data-* only', async () => {
     const root = await mount({ side: 'top', align: 'start', sideOffset: 0 });
     expect(root.tagName).toBe('DIV');
     // No class, ever: a behavior root is a binding host, not a box, and it

--- a/packages/ui/test/components/tooltip/tooltip.behavior.test.ts
+++ b/packages/ui/test/components/tooltip/tooltip.behavior.test.ts
@@ -115,8 +115,13 @@ describe('tooltip keymap (dismiss)', () => {
 /**
  * bindTooltip reads sideOffset by PRESENCE (`'sideOffset' in data`), not by
  * truthiness: data-side-offset="0" is a real, flush offset and must not fall
- * back to the 4px default. The observable is the positioner's translate, so a
- * regression to `data['sideOffset'] ? ... : undefined` fails these.
+ * back to the 4px default. The observable is the positioner's translate.
+ *
+ * Note which regression these actually catch: `dataset` values are always
+ * STRINGS, and '0' is truthy, so a string-truthiness rewrite is not a live
+ * zero-mask at this site. The mask that can really happen is numeric -- e.g.
+ * `numData('sideOffset', 4) || undefined` -- and that form fails both cases
+ * below.
  */
 describe('bindTooltip: data-side-offset parse', () => {
   const teardowns: Array<() => void> = [];

--- a/packages/ui/test/components/tooltip/tooltip.behavior.test.ts
+++ b/packages/ui/test/components/tooltip/tooltip.behavior.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { createBehavior, type PartIds } from '../../../src/lib/contract';
 import {
+  bindTooltip,
   isOpen,
   tooltip,
   tooltipPlacement,
@@ -108,6 +109,63 @@ describe('tooltip keymap (dismiss)', () => {
   it('other keys are not claimed', () => {
     expect(tooltip.keymap({ key: 'Enter' }, open, 'trigger')).toBeNull();
     expect(tooltip.keymap({ key: 'Tab' }, open, 'content')).toBeNull();
+  });
+});
+
+/**
+ * bindTooltip reads sideOffset by PRESENCE (`'sideOffset' in data`), not by
+ * truthiness: data-side-offset="0" is a real, flush offset and must not fall
+ * back to the 4px default. The observable is the positioner's translate, so a
+ * regression to `data['sideOffset'] ? ... : undefined` fails these.
+ */
+describe('bindTooltip: data-side-offset parse', () => {
+  const teardowns: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const teardown of teardowns.splice(0)) teardown();
+    document.body.innerHTML = '';
+  });
+
+  /** Default-open so the first paint positions the content synchronously. */
+  function mountOpen(sideOffset?: string): HTMLElement {
+    const root = document.createElement('div');
+    root.dataset['part'] = 'root';
+    root.dataset['defaultOpen'] = 'true';
+    root.dataset['side'] = 'bottom';
+    root.dataset['align'] = 'start';
+    if (sideOffset !== undefined) root.dataset['sideOffset'] = sideOffset;
+
+    const trigger = document.createElement('button');
+    trigger.type = 'button';
+    trigger.dataset['part'] = 'trigger';
+    trigger.id = 't-trigger';
+    trigger.textContent = 'Help';
+
+    const content = document.createElement('div');
+    content.dataset['part'] = 'content';
+    content.id = 't-content';
+    content.dataset['state'] = 'open';
+    content.textContent = 'More info';
+
+    root.append(trigger, content);
+    document.body.appendChild(root);
+    teardowns.push(bindTooltip(root));
+    return content;
+  }
+
+  /** The y translate the positioner stamped, in px. */
+  function translateY(content: HTMLElement): number {
+    const match = /translate\((-?\d+)px, (-?\d+)px\)/.exec(content.style.transform);
+    expect(match).not.toBeNull();
+    return Number(match?.[2]);
+  }
+
+  it('data-side-offset="0" is a real 0, not the 4px default', () => {
+    expect(translateY(mountOpen('0'))).toBe(0);
+  });
+
+  it('an absent data-side-offset falls back to the 4px default', () => {
+    expect(translateY(mountOpen())).toBe(4);
   });
 });
 

--- a/packages/ui/test/components/tooltip/tooltip.element.conformance.test.ts
+++ b/packages/ui/test/components/tooltip/tooltip.element.conformance.test.ts
@@ -37,6 +37,11 @@ afterEach(() => {
 });
 
 describe('tooltip conformance [wc]', () => {
+  it('host pins display:block to match the unclassed block root of the other targets', async () => {
+    const host = await mount();
+    expect(host.style.display).toBe('block');
+  });
+
   it('closed: content hidden, trigger undescribed', async () => {
     await mount();
     expect(content().hidden).toBe(true);

--- a/packages/ui/test/components/tooltip/tooltip.element.conformance.test.ts
+++ b/packages/ui/test/components/tooltip/tooltip.element.conformance.test.ts
@@ -19,7 +19,7 @@ beforeAll(() => {
 
 async function mount(skipDelay = 0): Promise<HTMLElement> {
   document.body.innerHTML = `
-    <rafters-tooltip data-part="root" delay-duration="0" skip-delay-duration="${skipDelay}">
+    <rafters-tooltip data-part="root" data-delay-duration="0" data-skip-delay-duration="${skipDelay}">
       <button type="button" data-part="trigger" id="t-trigger" data-state="closed">Help</button>
       <div data-part="content" id="t-content" role="tooltip" data-state="closed" hidden>More info</div>
     </rafters-tooltip>`;
@@ -90,7 +90,7 @@ describe('tooltip conformance [wc]', () => {
     // hover/focus had given the primitive state to close. A raw Escape keydown
     // with no focus event must still close it.
     document.body.innerHTML = `
-      <rafters-tooltip data-part="root" delay-duration="0" default-open="true">
+      <rafters-tooltip data-part="root" data-delay-duration="0" data-default-open="true">
         <button type="button" data-part="trigger" id="t-trigger" data-state="open">Help</button>
         <div data-part="content" id="t-content" role="tooltip" data-state="open">More info</div>
       </rafters-tooltip>`;

--- a/packages/ui/test/harness/conformance.ts
+++ b/packages/ui/test/harness/conformance.ts
@@ -22,6 +22,30 @@ export interface RenderResult {
   cleanup: () => void;
 }
 
+/**
+ * The markup/behavior pairing #2001 asks to be enforced rather than conventional.
+ *
+ * Config reaches a DOM-native binding as `data-*` and nothing else: `data-*` is
+ * the only attribute space valid on a standard HTML element, and the only one
+ * that reaches `element.dataset` -- which is what every `bindX` now reads. This
+ * asserts BOTH halves of the pair on one root, so a half-fix (markup renamed,
+ * behavior still on getAttribute, or the reverse) fails loudly instead of
+ * rendering fine and silently not rehydrating.
+ *
+ * @param expected dataset key (camelCase, e.g. `gridRole`) -> expected value
+ */
+export function assertConfigTravelsAsData(
+  root: HTMLElement,
+  expected: Record<string, string | undefined>,
+): void {
+  for (const [key, value] of Object.entries(expected)) {
+    expect(root.dataset[key], `dataset.${key}`).toBe(value);
+    // The bare, pre-fix spelling must be gone: `delayDuration` -> `delay-duration`.
+    const bare = key.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`);
+    expect(root.hasAttribute(bare), `bare attribute "${bare}" must not be rendered`).toBe(false);
+  }
+}
+
 export function partElement(root: HTMLElement, part: string): HTMLElement | null {
   if (root.getAttribute('data-part') === part) return root;
   return root.querySelector<HTMLElement>(`[data-part="${part}"]`);


### PR DESCRIPTION
## The design question #2004 asked, answered

#2004 asked which of two things is intended. The answer taken here is **semantic roots**:
the Astro target renders semantic HTML with `data-part="root"` and binds the DOM-native
controller directly; the custom element is a separate delivery target. That is what the
components' own script comments already claim ("the SAME DOM-native controller the Web
Component uses") and what grid, image, navigation-menu, progress and context-menu already
do. The alternative -- importing `.element.ts` from the `.astro` so the tag is actually
registered -- was **not** taken: it would give the Astro path a second delivery mechanism
and a `:host` styling surface it has no other use for.

## Acceptance criteria mapping

### From #2001

**"The components move their config to `data-*`."**
Every config attribute on every affected root is now `data-*`, in all three targets, no
exceptions -- one convention rather than two. `grid.astro` root: `data-pattern`,
`data-gap`, `data-padding`, `data-grid-role` (plus `data-preset`/`data-columns`, see the
collision note below). `image.astro` figure: `data-size`, `data-alignment`, `data-radius`,
`data-fill`, `data-status`, `data-error-message`, `data-loading-label`. `progress.astro`
div: `data-value`, `data-max`, `data-variant`, `data-size`, `data-value-text`.
`context-menu.astro` div: `data-loop`, `data-avoid-collisions`.
`navigation-menu.astro` nav: `data-delay-duration`.

The two platform collisions the issue calls out are gone rather than relocated: `fill` no
longer sits on an element where SVG's `fill` is real, and neither `size` (input/select) nor
`value`/`max` (`<progress>`) is borrowed onto a `div` or `figure` any more.

**"`progress` stops putting `value`/`max` on a `div`."**
Done -- `progress.astro`'s root now carries `data-value`/`data-max`, and
`readProgressConfig` reads `dataset['value']`/`dataset['max']`. The `role="progressbar"`
plus `aria-valuemin/max/now/text` projection is untouched, so the accessible value contract
is unchanged; only the config carrier moved.

**"The matching `.behavior.ts` reads through `dataset` rather than `getAttribute`, so the
pairing is expressed in types instead of convention."**
Done for all nine. `bindGrid` now delegates to a new exported `readGridConfig` (matching
`readImageConfig`/`readProgressConfig`, which already existed), `readImageConfig` and
`readProgressConfig` read `root.dataset`, and `bindContextMenu`, `bindContextSubMenu`,
`bindNavigationMenu`, `bindTooltip`, `bindPopover`, `bindHoverCard` and `bindDrawer` all
read `dataset` by camelCase key. The parse helpers narrowed from `string | null` to
`string | undefined` so they compose with `dataset` directly rather than through a
`?? undefined` adapter at each call site.

One subtlety that is easy to get wrong and is worth reviewing closely: `hasAttribute` has
no `dataset` twin, and tooltip/hover-card used it to distinguish an absent `side-offset`
from an explicit one. Those became `'sideOffset' in data`, not a truthiness check, so
`data-side-offset="0"` stays a real offset instead of silently reading as absent.

**"`astro check` passes on a freshly installed tree with zero consumer code."**
Partially verifiable here, and I would rather say so than let a green preflight stand in for
it. `pnpm typecheck` runs `astro check` only in `apps/registry`, over that app's 10 files --
it does not typecheck `packages/ui/**/*.astro`, which is why the issue could report failures
at `grid.astro:89` that CI never saw. What this PR can claim is that the cause is removed:
`preset`, `columns`, `gap`, `padding`, `grid-role`, `size`, `alignment`, `radius`, `fill`,
`status`, `error-message`, `loading-label`, `value`, `max`, `variant`, `value-text`, `loop`,
`avoid-collisions`, `orientation` and `delay-duration` no longer appear as bare attributes
on any `div`, `figure` or `nav`, and `data-*` is unconditionally valid in Astro's
`HTMLAttributes`. Confirming the criterion end to end needs an install into a consumer tree,
which this branch does not do.

**"A rehydration test exists, so a future half-fix fails loudly rather than silently."**
This is the criterion the issue cares most about, so it got the most work. A new harness
assertion, `assertConfigTravelsAsData` in `packages/ui/test/harness/conformance.ts`, checks
*both* halves of the pair against one root: the value arrives in `dataset` under the
expected camelCase key, **and** the bare pre-fix spelling is absent. Then each of the nine
astro conformance suites gained a test that binds and asserts an observable the bind alone
could produce:

- grid -- `role="grid"` and the roving `tabindex="0"` are projected by `bindGrid` and are
  not in the SSR markup, so neither can appear unless the dataset read worked.
- image / progress -- the SSR markup already carries the projection, so asserting it would
  prove nothing; these erase the projected attribute (the overlay `role`; `aria-valuenow`,
  `aria-valuemax` and the indicator's inline width), re-bind, and assert it returns. The
  `30%` fill is derived from `value` and `max` together, so it proves both keys crossed.
- navigation-menu / context-menu -- assert the dataset values, then exercise wiring that
  only the bind installs (click-to-open; `contextmenu`-to-open).
- tooltip / popover / hover-card / drawer -- assert dataset, then erase both the SSR open
  projection *and* the content's `data-state` fallback before re-binding, so only
  `data-default-open` read through `dataset` can reopen the panel. Without erasing the
  fallback the test would have passed for the wrong reason.

A markup-only half-fix now fails `assertConfigTravelsAsData`; a behavior-only half-fix fails
the rehydration assertion.

### From #2004

**"Render a semantic element with `data-part="root"`, matching the five that already do."**
`tooltip`, `popover`, `hover-card` and `drawer` roots are now
`<div data-part="root" data-{name} class={classes.root}>`. `<div>` is the right element
rather than something more specific: #2004 notes ARIA already lives on the inner `<button>`
/`<a>` trigger and the content div, and reaching for `<dialog>` on drawer would add
focus/backdrop/top-layer semantics the existing bind does not manage.

**"Their config attributes move to `data-*` in the same change."**
Same commit, same hunks: `delay-duration`, `skip-delay-duration`,
`disable-hoverable-content`, `default-open`, `side`, `align`, `side-offset`,
`align-offset`, `open-delay`, `close-delay` and `modal` all became `data-*`, with the
matching `dataset` reads.

**"The behavior binding selector updates in the same commit."**
Same commit. This one is a genuine hazard, not bookkeeping: once the root is a `div`, the
old `querySelectorAll('rafters-tooltip[data-part="root"]')` cannot simply become
`[data-part="root"]` -- that matches *every* rafters root on the page, so tooltip's
controller would bind to grids and dialogs, and the shared `data-bound` guard would then
block the correct bind. Each root carries a marker (`data-tooltip`, `data-popover`,
`data-hover-card`, `data-drawer`) and each selector is scoped to it, following
grid's `[data-part="root"][data-grid]` and context-menu's `[data-context-menu-root]`.

**"The root gets a display class" -- SUPERSEDED by operator ruling (2026-08-02, commit f6f567ba).** The roots carry NO class attribute at all: a behavior root is a binding host and never styles itself; layout belongs to the consumer's Container/Grid. The interim `display: contents` approach was rejected directly by the operator ("no class") -- it was a component making a layout decision. Consequence stated plainly: a bare div is block where the old unregistered element was inline; that inline behavior was an artifact of the bug, not a contract. The four conformance tests now assert the root has no class attribute.

## Per-target reasoning, since the targets legitimately differ

**Astro** -- all nine changed, as above.

**Web Component (`.element.ts`)** -- reasoned per file rather than swept. Seven of the nine
(`grid`, `context-menu`, `navigation-menu`, `tooltip`, `popover`, `hover-card`, `drawer`)
are thin `queueMicrotask(() => bindX(this))` wrappers containing no attribute names, so they
needed no edit; the host now takes `data-*` because the shared `bindX` reads `dataset`, and
that is the point -- one convention across targets rather than a WC dialect. Two do name
attributes and were updated: `image.element.ts` (`observedAttributes` and the
`REFLECTED_ATTRIBUTES` copied onto the light-DOM `<figure>`) and `progress.element.ts`
(`observedAttributes`, where host *is* root). While there, `image.element.ts`'s two lists
stopped overlapping by hand -- `observedAttributes` is now
`['src', 'alt', 'caption', ...REFLECTED_ATTRIBUTES]`, so the config half has one definition
instead of two that nothing kept in sync. On `image`, `src`/`alt`/`caption` stay bare: they
are content forwarded to the inner `<img>`'s real `src`/`alt` and to `figcaption`
textContent, not score config.

**React (`.tsx`)** -- checked all nine, changed none, and the reason is structural rather
than lucky: React passes config as props into `createBehavior` and never renders it as DOM
attributes, so there was nothing to rename. (The only `fill=` hits in the React files are
`fill="none"` on inline SVG icons, which is the real SVG attribute.) For the four #2004
components there is additionally no React root element at all -- `TooltipRoot` and its
siblings render a context provider -- which is also why adding a `root` key to their class
sets touches no React code.

## The collision I had to resolve, and the bug it would have been

Worth review attention, because the obvious mechanical rename introduces exactly the failure
mode #2001 is about. `grid.aria()` already projects `data-preset` and `data-columns` onto
the root, and `grid.astro` spreads that projection onto the same element that carried the
literal config. A naive `preset=` to `data-preset=` rename would emit each attribute twice;
worse, `bindGrid`'s `render()` re-applies the projection on every memory update, and
`updateAriaAttribute(el, name, undefined)` *clears* the attribute -- so for `columns="auto"`
the first render would have wiped the `data-columns` the markup had just set, and the next
bind would rehydrate as absent. Renders fine, silently stops rehydrating.

Resolved by giving each attribute exactly one writer. The projection owns `data-preset` and
`data-columns` and the markup no longer emits them; `grid.aria` was extended to project
`'auto'` as well as numbers so the attribute round-trips for every attribute-expressible
value. `navigation-menu` has the same shape (`data-orientation` comes from its projection),
resolved the same way. I checked the remaining seven for the same collision --
`progress.astro` spreads `rootAria` and `attrs` over the root, and its projection is `role`
plus `aria-value*` only; `image`'s root projection is empty; popover writes the *resolved*
`data-side`/`data-align` to the content element, not the root, so the root's *authored*
side/align never contend with it.

## Not done

Audited and deliberately not changed.

The scope was audited, not sampled. `node`-driven scans over every `.astro`, `.behavior.ts`,
`.element.ts` and `.tsx` in `packages/ui/src/components` for `getAttribute`/`hasAttribute`
config reads and for `rafters-*` roots turned up more than the nine, and here is what I did
not do and why.

**Twelve other components also render an unregistered `rafters-*` Astro root**:
`alert-dialog`, `checkbox`, `collapsible`, `combobox`, `command`, `dialog`, `dropdown-menu`,
`field`, `input-group`, `select`, `sheet`, `sidebar`. By #2004's own logic these share the
defect. They are left alone deliberately: #2004 enumerates four, and converting the roots of
dialog/sheet/alert-dialog would change the *Web Component's* public attribute API
(`modal`, `default-open`) for components neither issue names, and would pull their behaviors
and test suites into an already-large diff. Flagging here so the list exists rather than
having to be rediscovered; happy to take them in a follow-up if that is wanted.

A consequence to accept knowingly rather than paper over: `drawer` now reads
`data-modal`/`data-default-open` while its close siblings `dialog` and `sheet` still read
bare `modal`/`default-open`. I verified `bindDrawer`, `bindDialog` and `bindSheet` do not
share a config-reading helper (the near-identical lines are copy-paste, not a call), so
changing drawer does not silently change the other two.

**`context-menu-sub.astro`** was checked because `bindContextSubMenu` reads `loop` and
`avoid-collisions` off the sub element. The sub template never emits them, so both defaulted
via `!== 'false'`; the reads moved to `dataset` anyway, so an author or WC path supplying
them lands on the same convention as everything else.

**`apps/demo/src/components/ui/*`** is a checked-in CLI install snapshot containing only the
React files. React is unchanged by this PR, so the snapshot is not stale in any way a
consumer would observe, and regenerating it is a separate concern from this fix.

Two tests are worth noting as *behavior* changes rather than fixture churn.
`navigation-menu.element.conformance.test.ts:21` set `delay-duration="1"`, which the bind
never read -- the test had been silently running on the 200ms default; it now actually
configures what it claims to. `drawer.element.conformance.test.ts:18`'s `modal="false"` is
load-bearing (the non-modal test asserts no scroll lock), so it would have failed loudly had
the behavior half been missed -- which is the point.

## Verification

`pnpm preflight` green (typecheck, oxlint, oxfmt, unit + a11y, build). 449 unit test files /
6964 tests and 55 astro test files / 340 tests pass; both suites were red at the expected
places mid-change, which is how I know the new assertions bite. `legion-simplify` recorded
clean over all 44 changed files.

