### PR TITLE
feat(design-tokens): radius and focus derive from spacing (#2035)

### DIFF
--- a/packages/design-tokens/src/exporters/tailwind.ts
+++ b/packages/design-tokens/src/exporters/tailwind.ts
@@ -393,13 +393,15 @@ function generateThemeBlock(groups: GroupedTokens): string {
   }
 
   // Radius tokens -- Tailwind v4 reads --radius-* for rounded-*
-  // Rewrite var(--rafters-radius-base) to var(--radius-base) for @theme context
+  // Rewrite internal var names to @theme names: radius-base derives from
+  // spacing-base (#2035), so the spacing reference must also be rewritten.
   if (groups.radius.length > 0) {
     for (const token of groups.radius) {
       const value = tokenValueToCSS(token);
       if (value === null) continue;
       const key = token.name.replace(/^radius-/, '');
       const themeValue = value
+        .replaceAll('var(--rafters-spacing-base)', 'var(--spacing-base)')
         .replaceAll('var(--rafters-radius-base)', 'var(--radius-base)')
         .replaceAll('var(--rafters-radius-tl)', 'var(--radius-tl)')
         .replaceAll('var(--rafters-radius-tr)', 'var(--radius-tr)')
@@ -481,12 +483,16 @@ function generateThemeBlock(groups: GroupedTokens): string {
     lines.push('');
   }
 
-  // Focus tokens
+  // Focus tokens -- focus-ring-width derives from spacing-base (#2035),
+  // and per-config tokens chain through focus-ring-width.
   if (groups.focus.length > 0) {
     for (const token of groups.focus) {
       const value = tokenValueToCSS(token);
       if (value === null) continue;
-      lines.push(`  --${token.name}: ${value};`);
+      const themeValue = value
+        .replaceAll('var(--rafters-spacing-base)', 'var(--spacing-base)')
+        .replaceAll('var(--rafters-focus-ring-width)', 'var(--focus-ring-width)');
+      lines.push(`  --${token.name}: ${themeValue};`);
     }
     lines.push('');
   }

--- a/packages/design-tokens/src/generators/focus.ts
+++ b/packages/design-tokens/src/generators/focus.ts
@@ -21,7 +21,9 @@ export function generateFocusTokens(
 
   // The divisor that anchors focus to spacing. `focusRingWidth` is already
   // `baseSpacingUnit / 2` from resolveConfig, so this is stable across bases.
-  const focusDivisor = baseSpacingUnit / focusRingWidth;
+  // Guard: a zero override would produce Infinity in the calc() string.
+  const focusDivisor =
+    focusRingWidth > 0 ? Math.round((baseSpacingUnit / focusRingWidth) * 1000) / 1000 : 2;
 
   const focusWidthValue = `calc(var(--rafters-spacing-base) / ${focusDivisor})`;
 

--- a/packages/design-tokens/src/generators/focus.ts
+++ b/packages/design-tokens/src/generators/focus.ts
@@ -1,27 +1,15 @@
 /**
  * Focus Generator
  *
- * Generates focus ring tokens for WCAG 2.2 compliance.
- * Focus indicators are critical for keyboard navigation and accessibility.
- *
- * This generator is a pure function - it receives focus configurations as input.
- * Default focus values are provided by the orchestrator from defaults.ts.
+ * Focus derives FROM spacing. `focus-ring-width` is
+ * `calc(var(--rafters-spacing-base) / 2)`, so changing the spacing base
+ * cascades into every focus token at runtime. WCAG 2.2 requires minimum 2px
+ * for visibility -- at base 4 the derivation produces exactly 2px.
  */
 
 import type { Token } from '@rafters/shared';
 import type { FocusConfig } from './defaults.js';
 import type { GeneratorResult, ResolvedSystemConfig } from './types.js';
-
-/**
- * Generate focus tokens from provided configurations
- */
-/**
- * Convert px value to rem string
- */
-function pxToRem(px: number): string {
-  const rem = Math.round((px / 16) * 1000) / 1000;
-  return `${rem}rem`;
-}
 
 export function generateFocusTokens(
   config: ResolvedSystemConfig,
@@ -29,21 +17,25 @@ export function generateFocusTokens(
 ): GeneratorResult {
   const tokens: Token[] = [];
   const timestamp = new Date().toISOString();
-  const { focusRingWidth } = config;
+  const { focusRingWidth, baseSpacingUnit } = config;
 
-  // Base focus width token - use rem
-  const focusRingWidthRem = pxToRem(focusRingWidth);
+  // The divisor that anchors focus to spacing. `focusRingWidth` is already
+  // `baseSpacingUnit / 2` from resolveConfig, so this is stable across bases.
+  const focusDivisor = baseSpacingUnit / focusRingWidth;
+
+  const focusWidthValue = `calc(var(--rafters-spacing-base) / ${focusDivisor})`;
 
   tokens.push({
     name: 'focus-ring-width',
-    value: focusRingWidthRem,
+    value: focusWidthValue,
     category: 'focus',
     namespace: 'focus',
-    semanticMeaning: 'Default focus ring width - WCAG 2.2 requires minimum 2px',
+    semanticMeaning: 'Default focus ring width - derives from spacing base',
     usageContext: ['focus-indicators', 'keyboard-navigation'],
     accessibilityLevel: 'AA',
-    focusRingWidth: focusRingWidthRem,
-    description: `Focus ring width ${focusRingWidthRem}. WCAG 2.2 requires minimum 2px for visibility.`,
+    focusRingWidth: focusWidthValue,
+    dependsOn: ['spacing-base'],
+    description: `Focus ring width = spacing-base / ${focusDivisor} (${focusRingWidth}px at base ${baseSpacingUnit}). WCAG 2.2 requires minimum 2px.`,
     generatedAt: timestamp,
     containerQueryAware: false,
     userOverride: null,
@@ -70,16 +62,28 @@ export function generateFocusTokens(
     userOverride: null,
   });
 
-  // Generate focus ring configuration tokens
+  // Each config's width and offset are expressed as multipliers of
+  // focus-ring-width, which itself derives from spacing-base. The build-time
+  // pixel number stays for the WCAG check; the emitted value is a calc().
+  const focusVar = 'var(--rafters-focus-ring-width)';
+
+  const focusCalc = (px: number): string => {
+    const mult = px / focusRingWidth;
+    if (mult === 0) return '0';
+    if (mult === 1) return focusVar;
+    if (mult === -1) return `calc(${focusVar} * -1)`;
+    return `calc(${focusVar} * ${mult})`;
+  };
+
   for (const [name, focusConfig] of Object.entries(focusConfigs)) {
-    const widthRem = pxToRem(focusConfig.width);
-    const offsetRem = pxToRem(focusConfig.offset);
+    const widthVal = focusCalc(focusConfig.width);
+    const offsetVal = focusCalc(focusConfig.offset);
 
     tokens.push({
       name: name === 'default' ? 'focus-ring' : `focus-ring-${name}`,
       value: JSON.stringify({
-        width: widthRem,
-        offset: offsetRem,
+        width: widthVal,
+        offset: offsetVal,
         style: focusConfig.style,
         color: 'var(--ring)',
       }),
@@ -87,13 +91,13 @@ export function generateFocusTokens(
       namespace: 'focus',
       semanticMeaning: focusConfig.meaning,
       usageContext: focusConfig.contexts,
-      focusRingWidth: widthRem,
+      focusRingWidth: widthVal,
       focusRingColor: 'var(--ring)',
-      focusRingOffset: offsetRem,
+      focusRingOffset: offsetVal,
       focusRingStyle: focusConfig.style,
       dependsOn: ['ring', 'focus-ring-width'],
       accessibilityLevel: focusConfig.width >= 2 ? 'AA' : undefined,
-      description: `${focusConfig.meaning}. Width: ${widthRem}, Offset: ${offsetRem}.`,
+      description: `${focusConfig.meaning}. Width: ${widthVal}, Offset: ${offsetVal}.`,
       generatedAt: timestamp,
       containerQueryAware: false,
       highContrastMode: 'Highlight',
@@ -114,8 +118,7 @@ export function generateFocusTokens(
       },
     });
 
-    // Also create CSS-ready outline shorthand
-    const outlineValue = `${widthRem} ${focusConfig.style} var(--ring)`;
+    const outlineValue = `${widthVal} ${focusConfig.style} var(--ring)`;
 
     tokens.push({
       name: name === 'default' ? 'focus-outline' : `focus-outline-${name}`,
@@ -124,8 +127,8 @@ export function generateFocusTokens(
       namespace: 'focus',
       semanticMeaning: `CSS outline shorthand for ${name} focus ring`,
       usageContext: ['css-outline-property'],
-      dependsOn: ['ring'],
-      description: `CSS outline value: ${outlineValue}. Use with outline-offset: ${offsetRem}.`,
+      dependsOn: ['ring', 'focus-ring-width'],
+      description: `CSS outline value: ${outlineValue}. Use with outline-offset: ${offsetVal}.`,
       generatedAt: timestamp,
       containerQueryAware: false,
       userOverride: null,
@@ -133,23 +136,23 @@ export function generateFocusTokens(
 
     tokens.push({
       name: name === 'default' ? 'focus-offset' : `focus-offset-${name}`,
-      value: offsetRem,
+      value: offsetVal,
       category: 'focus',
       namespace: 'focus',
       semanticMeaning: `Focus ring offset for ${name} style`,
-      focusRingOffset: offsetRem,
-      description: `Focus offset ${offsetRem} for ${name} focus style.`,
+      focusRingOffset: offsetVal,
+      dependsOn: ['focus-ring-width'],
+      description: `Focus offset ${offsetVal} for ${name} focus style.`,
       generatedAt: timestamp,
       containerQueryAware: false,
       userOverride: null,
     });
   }
 
-  // Focus-within variant for containers
   tokens.push({
     name: 'focus-within-ring',
     value: JSON.stringify({
-      width: focusRingWidthRem,
+      width: focusVar,
       offset: '0',
       style: 'solid',
       color: 'var(--ring)',
@@ -158,11 +161,11 @@ export function generateFocusTokens(
     namespace: 'focus',
     semanticMeaning: 'Focus ring for containers with focused descendants',
     usageContext: ['form-groups', 'card-actions', 'list-containers'],
-    focusRingWidth: focusRingWidthRem,
+    focusRingWidth: focusVar,
     focusRingColor: 'var(--ring)',
     focusRingOffset: '0',
     focusRingStyle: 'solid',
-    dependsOn: ['ring'],
+    dependsOn: ['ring', 'focus-ring-width'],
     description: 'Focus indicator for containers using :focus-within pseudo-class.',
     generatedAt: timestamp,
     containerQueryAware: false,
@@ -173,15 +176,14 @@ export function generateFocusTokens(
     },
   });
 
-  // High contrast mode overrides - derive from base focus ring width
-  // Width is scaled up for better visibility in high contrast
-  const highContrastWidth = focusRingWidth * 1.5; // 1.5x base width for high contrast visibility
-  const highContrastOffset = focusRingWidth; // Offset matches base width
+  // High contrast: 1.5x width, 1x offset -- both expressed through the var
+  const hcWidthVal = `calc(${focusVar} * 1.5)`;
+  const hcOffsetVal = focusVar;
   tokens.push({
     name: 'focus-high-contrast',
     value: JSON.stringify({
-      width: pxToRem(highContrastWidth),
-      offset: pxToRem(highContrastOffset),
+      width: hcWidthVal,
+      offset: hcOffsetVal,
       style: 'solid',
       color: 'Highlight',
     }),
@@ -189,10 +191,11 @@ export function generateFocusTokens(
     namespace: 'focus',
     semanticMeaning: 'Focus ring for Windows High Contrast Mode',
     usageContext: ['high-contrast-mode', 'forced-colors'],
-    focusRingWidth: pxToRem(highContrastWidth),
-    focusRingOffset: pxToRem(highContrastOffset),
+    focusRingWidth: hcWidthVal,
+    focusRingOffset: hcOffsetVal,
     focusRingStyle: 'solid',
     highContrastMode: 'Highlight',
+    dependsOn: ['focus-ring-width'],
     description: 'High contrast focus ring using system Highlight color.',
     generatedAt: timestamp,
     containerQueryAware: false,

--- a/packages/design-tokens/src/generators/radius.ts
+++ b/packages/design-tokens/src/generators/radius.ts
@@ -41,7 +41,8 @@ export function generateRadiusTokens(
   // The multiplier that anchors radius to spacing. `baseRadius` is already
   // `baseSpacingUnit * 1.5` from resolveConfig, so the multiplier is stable
   // across base changes. The CSS emission references the spacing var directly.
-  const radiusMultiplier = baseRadius / config.baseSpacingUnit;
+  // Rounded to 3 decimals, matching the convention at line 103.
+  const radiusMultiplier = Math.round((baseRadius / config.baseSpacingUnit) * 1000) / 1000;
 
   // Base radius token -- derives from spacing
   tokens.push({

--- a/packages/design-tokens/src/generators/radius.ts
+++ b/packages/design-tokens/src/generators/radius.ts
@@ -1,16 +1,11 @@
 /**
  * Border Radius Generator
  *
- * Generates border radius tokens using mathematical progressions from @rafters/math-utils.
- * Uses minor-third (1.2) ratio by default for harmonious radius scale.
- *
- * This generator uses step-based progression: value = base * ratio^step
- * - step 0 = base value
- * - step 1 = base * ratio (larger)
- * - step -1 = base / ratio (smaller)
- *
- * This generator is a pure function - it receives radius definitions as input.
- * Default radius values are provided by the orchestrator from defaults.ts.
+ * Radius derives FROM spacing. `radius-base` is
+ * `calc(var(--rafters-spacing-base) * 1.5)`, so changing the spacing base
+ * cascades into every radius token at runtime. The ratio steps on top of that
+ * anchor are radius's own -- step -1 exists here even though spacing has no
+ * negative positions -- because the anchor changed, not the step rule.
  */
 
 import { ratioValue, resolveRatio } from '@rafters/math-utils';
@@ -43,19 +38,22 @@ export function generateRadiusTokens(
 
   const ratioVal = ratioValue(resolveRatio(progressionRatio));
 
-  // Convert px to rem (assuming 16px root font size)
-  const baseRadiusRem = baseRadius / 16;
+  // The multiplier that anchors radius to spacing. `baseRadius` is already
+  // `baseSpacingUnit * 1.5` from resolveConfig, so the multiplier is stable
+  // across base changes. The CSS emission references the spacing var directly.
+  const radiusMultiplier = baseRadius / config.baseSpacingUnit;
 
-  // Base radius token
+  // Base radius token -- derives from spacing
   tokens.push({
     name: 'radius-base',
-    value: `${baseRadiusRem}rem`,
+    value: `calc(var(--rafters-spacing-base) * ${radiusMultiplier})`,
     category: 'radius',
     namespace: 'radius',
-    semanticMeaning: 'Base border radius - all other radii derive from this value',
+    semanticMeaning: 'Base border radius - derives from spacing base',
     usageContext: ['calculation-reference'],
     progressionSystem: progressionRatio as 'minor-third',
-    description: `Base radius (${baseRadiusRem}rem / ${baseRadius}px). Scale uses ${progressionRatio} progression (ratio ${ratioVal}).`,
+    dependsOn: ['spacing-base'],
+    description: `Base radius = spacing-base * ${radiusMultiplier} (${baseRadius}px at base ${config.baseSpacingUnit}). Scale uses ${progressionRatio} progression (ratio ${ratioVal}).`,
     generatedAt: timestamp,
     containerQueryAware: false,
     userOverride: null,
@@ -97,9 +95,8 @@ export function generateRadiusTokens(
       value = '9999px'; // Full radius stays in px as it's a special case
       mathRelationship = 'infinite (9999px)';
     } else if (def.step === 0) {
-      // Step 0 = base value, reference the custom property directly
       value = 'var(--rafters-radius-base)';
-      mathRelationship = `${baseRadiusRem}rem (base)`;
+      mathRelationship = `spacing-base * ${radiusMultiplier} (base)`;
     } else {
       // Use calc() with var() so changing radius-base cascades via CSS
       const multiplier = Math.round(ratioVal ** def.step * 1000) / 1000;

--- a/packages/design-tokens/src/generators/types.ts
+++ b/packages/design-tokens/src/generators/types.ts
@@ -41,10 +41,21 @@ export interface BaseSystemConfig {
   /** Base font size override. System default: baseSpacingUnit * 4 = 16px */
   baseFontSizeOverride?: number;
 
-  /** Border radius override. System default: baseSpacingUnit * 1.5 = 6px */
+  /**
+   * Base radius override in pixels.
+   * System default: baseSpacingUnit * 1.5 (6px at base 4).
+   * Radius derives from spacing -- `radius-base` emits
+   * `calc(var(--rafters-spacing-base) * 1.5)` so changing the spacing base
+   * cascades into every radius token at runtime.
+   */
   baseRadiusOverride?: number;
 
-  /** Focus ring width override. System default: baseSpacingUnit / 2 = 2px */
+  /**
+   * Focus ring width override in pixels.
+   * System default: baseSpacingUnit / 2 (2px at base 4).
+   * Focus derives from spacing -- `focus-ring-width` emits
+   * `calc(var(--rafters-spacing-base) / 2)` so the ring scales with the base.
+   */
   focusRingWidthOverride?: number;
 
   /** Base transition duration override (ms). System default: baseSpacingUnit * 37.5 = 150ms */
@@ -92,14 +103,11 @@ export function resolveConfig(config: BaseSystemConfig): ResolvedSystemConfig {
 /**
  * Default configuration - Rafters aesthetic defaults (shadcn-inspired)
  *
- * These are our CHOSEN values. If you want pure mathematical defaults,
- * omit the overrides and let the system compute from baseSpacingUnit.
- *
- * Pure math example (no overrides):
- * - baseFontSize = 4 * 4 = 16px
- * - baseRadius = 4 * 1.5 = 6px
- * - focusRingWidth = 4 / 2 = 2px
- * - baseTransitionDuration = 4 * 37.5 = 150ms
+ * Radius and focus have no override pin because they derive from
+ * baseSpacingUnit (×1.5 and ÷2) and the derivation at base 4 already
+ * produces the values a pin would hold. The CSS emission references
+ * `var(--rafters-spacing-base)`, so changing the spacing base cascades
+ * into radius and focus at runtime.
  */
 export const DEFAULT_SYSTEM_CONFIG: BaseSystemConfig = {
   baseSpacingUnit: 4,
@@ -107,10 +115,12 @@ export const DEFAULT_SYSTEM_CONFIG: BaseSystemConfig = {
   fontFamily: "'Noto Sans Variable', sans-serif",
   monoFontFamily:
     "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace",
-  // Rafters aesthetic overrides (happen to match pure math at baseSpacingUnit=4)
+  // Rafters aesthetic overrides.
+  // baseRadius and focusRingWidth have NO pin here -- they derive from
+  // baseSpacingUnit (×1.5 and ÷2), and at base 4 the derivation already
+  // produces 6 and 2. A pin would hide the derivation, which is the #2031
+  // defect one layer down.
   baseFontSizeOverride: 16,
-  baseRadiusOverride: 6,
-  focusRingWidthOverride: 2,
   baseTransitionDurationOverride: 150,
 };
 

--- a/packages/design-tokens/test/progression-property.test.ts
+++ b/packages/design-tokens/test/progression-property.test.ts
@@ -8,6 +8,8 @@ import {
   DEFAULT_SPACING_BOUNDS,
   DEFAULT_TYPOGRAPHY_SCALE,
 } from '../src/generators/defaults.js';
+import { tokensToTailwind } from '../src/exporters/tailwind.js';
+import { generateBaseSystem } from '../src/generators/index.js';
 import { generateFocusTokens } from '../src/generators/focus.js';
 import { generateRadiusTokens } from '../src/generators/radius.js';
 import { generateShadowTokens } from '../src/generators/shadow.js';
@@ -194,5 +196,31 @@ describe('radius and focus derive from spacing', () => {
     const fBase = focusTokens.find((t) => t.name === 'focus-ring-width');
     expect(rBase?.value).not.toMatch(/rem$/);
     expect(fBase?.value).not.toMatch(/rem$/);
+  });
+
+  it('the exporter rewrites spacing refs so no dangling --rafters- vars remain', () => {
+    const system = generateBaseSystem({});
+    const css = tokensToTailwind(system.allTokens, { includeImport: false }, []);
+    const lines = css.split('\n');
+
+    const radiusLines = lines.filter((l) => /--radius-/.test(l));
+    const focusLines = lines.filter((l) => /--focus-/.test(l));
+
+    expect(radiusLines.length).toBeGreaterThan(0);
+    expect(focusLines.length).toBeGreaterThan(0);
+
+    for (const line of radiusLines) {
+      expect(line, `dangling in radius: ${line.trim()}`).not.toContain(
+        'var(--rafters-spacing-base)',
+      );
+    }
+    for (const line of focusLines) {
+      expect(line, `dangling in focus: ${line.trim()}`).not.toContain(
+        'var(--rafters-spacing-base)',
+      );
+      expect(line, `dangling in focus: ${line.trim()}`).not.toContain(
+        'var(--rafters-focus-ring-width)',
+      );
+    }
   });
 });

--- a/packages/design-tokens/test/progression-property.test.ts
+++ b/packages/design-tokens/test/progression-property.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  DEFAULT_FOCUS_CONFIGS,
   DEFAULT_FONT_WEIGHTS,
   DEFAULT_RADIUS_DEFINITIONS,
   DEFAULT_SHADOW_BOUNDS,
@@ -7,6 +8,7 @@ import {
   DEFAULT_SPACING_BOUNDS,
   DEFAULT_TYPOGRAPHY_SCALE,
 } from '../src/generators/defaults.js';
+import { generateFocusTokens } from '../src/generators/focus.js';
 import { generateRadiusTokens } from '../src/generators/radius.js';
 import { generateShadowTokens } from '../src/generators/shadow.js';
 import { generateSpacingTokens } from '../src/generators/spacing.js';
@@ -147,5 +149,50 @@ describe('shadow geometry follows the ratio; the coloured opacity is a defect', 
     // fixed in #2031; whether coloredOpacity keeps the ratio or gets a reason
     // of its own is still open.
     expect(after).not.toEqual(before);
+  });
+});
+
+/**
+ * Radius and focus derive from spacing (#2035). The CSS values are expressions
+ * like `calc(var(--rafters-spacing-base) * 1.5)` -- the string is the same at
+ * every base because the CASCADE resolves it at runtime. The property under
+ * test is the reference, not a numeric diff.
+ */
+describe('radius and focus derive from spacing', () => {
+  const config = resolveConfig(DEFAULT_SYSTEM_CONFIG);
+
+  it('radius-base references spacing-base, not a literal rem', () => {
+    const tokens = generateRadiusTokens(config, DEFAULT_RADIUS_DEFINITIONS).tokens;
+    const base = tokens.find((t) => t.name === 'radius-base');
+    expect(base?.value).toContain('var(--rafters-spacing-base)');
+    expect(base?.value).not.toMatch(/^\d/);
+    expect(base?.dependsOn).toContain('spacing-base');
+  });
+
+  it('focus-ring-width references spacing-base, not a literal rem', () => {
+    const tokens = generateFocusTokens(config, DEFAULT_FOCUS_CONFIGS).tokens;
+    const base = tokens.find((t) => t.name === 'focus-ring-width');
+    expect(base?.value).toContain('var(--rafters-spacing-base)');
+    expect(base?.value).not.toMatch(/^\d/);
+    expect(base?.dependsOn).toContain('spacing-base');
+  });
+
+  it('focus configs chain through focus-ring-width, not literal px', () => {
+    const tokens = generateFocusTokens(config, DEFAULT_FOCUS_CONFIGS).tokens;
+    const ring = tokens.find((t) => t.name === 'focus-ring');
+    expect(ring?.value).toContain('var(--rafters-focus-ring-width)');
+    const outline = tokens.find((t) => t.name === 'focus-outline');
+    expect(outline?.value).toContain('var(--rafters-focus-ring-width)');
+    const hc = tokens.find((t) => t.name === 'focus-high-contrast');
+    expect(hc?.value).toContain('var(--rafters-focus-ring-width)');
+  });
+
+  it('no literal rem value in radius-base or focus-ring-width', () => {
+    const radiusTokens = generateRadiusTokens(config, DEFAULT_RADIUS_DEFINITIONS).tokens;
+    const focusTokens = generateFocusTokens(config, DEFAULT_FOCUS_CONFIGS).tokens;
+    const rBase = radiusTokens.find((t) => t.name === 'radius-base');
+    const fBase = focusTokens.find((t) => t.name === 'focus-ring-width');
+    expect(rBase?.value).not.toMatch(/rem$/);
+    expect(fBase?.value).not.toMatch(/rem$/);
   });
 });

--- a/packages/design-tokens/test/scale-construction.test.ts
+++ b/packages/design-tokens/test/scale-construction.test.ts
@@ -2,12 +2,10 @@ import { ratioValue, resolveRatio } from '@rafters/math-utils';
 import { describe, expect, it } from 'vitest';
 import {
   DEFAULT_FONT_WEIGHTS,
-  DEFAULT_RADIUS_DEFINITIONS,
   DEFAULT_SHADOW_BOUNDS,
   DEFAULT_SPACING_BOUNDS,
   DEFAULT_TYPOGRAPHY_SCALE,
 } from '../src/generators/defaults.js';
-import { generateRadiusTokens } from '../src/generators/radius.js';
 import { DEFAULT_SYSTEM_CONFIG, PURE_MATH_CONFIG, resolveConfig } from '../src/generators/types.js';
 import { generateTypographyTokens } from '../src/generators/typography.js';
 import { shadowScale } from '../src/generators/shadow.js';
@@ -137,13 +135,9 @@ describe('shadow scale construction', () => {
 /**
  * PURE_MATH_CONFIG has to be observable, or it is decoration.
  *
- * It differs from DEFAULT_SYSTEM_CONFIG only by omitting the four `*Override`
- * pins, so it can only show up in namespaces whose ANCHOR is one of those four.
- * Spacing is not one of them -- it reads `baseSpacingUnit` and
- * `progressionRatio`, which both configs carry identically -- so asserting that
- * spacing moves under pure math would be asserting that spacing depends on a
- * value it has no reason to read. The honest test is that the config is live
- * where it applies, and inert where it does not.
+ * After #2035 only TWO pins remain: baseFontSize and baseTransitionDuration.
+ * Radius and focus derive from baseSpacingUnit unconditionally in both configs,
+ * so their pins were removed -- they hid the derivation at base 4.
  */
 describe('PURE_MATH_CONFIG is not decorative', () => {
   const pure = resolveConfig(PURE_MATH_CONFIG);
@@ -153,19 +147,19 @@ describe('PURE_MATH_CONFIG is not decorative', () => {
     tokens.map((t) => `${t.name}=${JSON.stringify(t.value)}`).sort();
 
   it('resolves different anchors from the same base', () => {
-    // The four pins are what pure math drops. At baseSpacingUnit 4 they were
-    // CHOSEN to coincide with the derivation, so this proves the mechanism
-    // rather than a numeric difference: move the base and they diverge.
+    // Two pins remain: baseFontSize and baseTransitionDuration. Radius and
+    // focus derive from baseSpacingUnit in both configs (#2035).
     const movedPure = resolveConfig({ ...PURE_MATH_CONFIG, baseSpacingUnit: 6 });
     const movedPinned = resolveConfig({ ...DEFAULT_SYSTEM_CONFIG, baseSpacingUnit: 6 });
 
     expect(movedPure.baseFontSize).not.toBe(movedPinned.baseFontSize);
-    expect(movedPure.baseRadius).not.toBe(movedPinned.baseRadius);
-    expect(movedPure.focusRingWidth).not.toBe(movedPinned.focusRingWidth);
     expect(movedPure.baseTransitionDuration).not.toBe(movedPinned.baseTransitionDuration);
+    // Radius and focus agree because neither config pins them anymore.
+    expect(movedPure.baseRadius).toBe(movedPinned.baseRadius);
+    expect(movedPure.focusRingWidth).toBe(movedPinned.focusRingWidth);
   });
 
-  it('changes typography and radius output once the base moves', () => {
+  it('changes typography output once the base moves', () => {
     const pureAt6 = resolveConfig({ ...PURE_MATH_CONFIG, baseSpacingUnit: 6 });
     const pinnedAt6 = resolveConfig({ ...DEFAULT_SYSTEM_CONFIG, baseSpacingUnit: 6 });
 
@@ -178,9 +172,16 @@ describe('PURE_MATH_CONFIG is not decorative', () => {
         generateTypographyTokens(pinnedAt6, DEFAULT_TYPOGRAPHY_SCALE, DEFAULT_FONT_WEIGHTS).tokens,
       ),
     );
-    expect(flatten(generateRadiusTokens(pureAt6, DEFAULT_RADIUS_DEFINITIONS).tokens)).not.toEqual(
-      flatten(generateRadiusTokens(pinnedAt6, DEFAULT_RADIUS_DEFINITIONS).tokens),
-    );
+  });
+
+  it('radius and focus move together with the base in both configs', () => {
+    const at4 = resolveConfig({ ...DEFAULT_SYSTEM_CONFIG, baseSpacingUnit: 4 });
+    const at6 = resolveConfig({ ...DEFAULT_SYSTEM_CONFIG, baseSpacingUnit: 6 });
+
+    expect(at4.baseRadius).not.toBe(at6.baseRadius);
+    expect(at4.focusRingWidth).not.toBe(at6.focusRingWidth);
+    expect(at6.baseRadius).toBe(6 * 1.5);
+    expect(at6.focusRingWidth).toBe(6 / 2);
   });
 
   it('leaves spacing alone, because spacing reads neither pin', () => {

--- a/packages/studio/test/api/vite-plugin.test.ts
+++ b/packages/studio/test/api/vite-plugin.test.ts
@@ -2031,6 +2031,10 @@ describe('studioApiPlugin', () => {
               middlewares.push(fn);
             },
           },
+          watcher: {
+            add(_paths: unknown) {},
+            on(_event: string, _handler: (...args: unknown[]) => void) {},
+          },
         },
         wsSent,
         wsHandlers,


### PR DESCRIPTION
## Summary

Radius and focus derive from `var(--rafters-spacing-base)` instead of literal rem values. `radius-base` emits `calc(var(--rafters-spacing-base) * 1.5)`, `focus-ring-width` emits `calc(var(--rafters-spacing-base) / 2)`, and every focus config chains through `var(--rafters-focus-ring-width)`. The two override pins in `DEFAULT_SYSTEM_CONFIG` that hid this derivation at base 4 are removed -- the derivation already produced the pinned values, so the pins were decorative. At runtime, changing the spacing base now cascades into radius and focus without regenerating tokens.

## Acceptance criteria mapping

### 1. radius-base references var(--rafters-spacing-base) with a multiplier, not a literal rem

`radius.ts:42` computes `radiusMultiplier = baseRadius / config.baseSpacingUnit`, which is 1.5 at the default and stable across base changes because `resolveConfig` always produces `baseRadius = baseSpacingUnit * 1.5`. The token value at `radius.ts:49` is `calc(var(--rafters-spacing-base) * ${radiusMultiplier})`. The old `baseRadiusRem` literal and the `pxToRem` division by 16 are gone. Every derived radius token already used `calc(var(--rafters-radius-base) * m)`, so the chain from spacing-base through radius-base to every scale position is transitive without further changes.

Evidence: `progression-property.test.ts` test `'radius-base references spacing-base, not a literal rem'` -- asserts `toContain('var(--rafters-spacing-base)')`, `not.toMatch(/^\d/)`, and `dependsOn` includes `'spacing-base'`.

### 2. focus-ring-width references var(--rafters-spacing-base) with a divisor; focus configs derive from the spacing var

`focus.ts:29` computes `focusDivisor = baseSpacingUnit / focusRingWidth`, which is 2 at the default. The token value at `focus.ts:31` is `calc(var(--rafters-spacing-base) / ${focusDivisor})`. Each focus config's width and offset are expressed as multipliers of `var(--rafters-focus-ring-width)` via the `focusCalc` helper at `focus.ts:75` -- so the chain is spacing-base -> focus-ring-width -> each config. The `pxToRem` function is removed entirely (no remaining call sites; the typecheck caught the unused declaration). The high-contrast token at `focus.ts:179` uses `calc(var(--rafters-focus-ring-width) * 1.5)` for its 1.5x width, and `var(--rafters-focus-ring-width)` for its offset.

Evidence: `progression-property.test.ts` tests `'focus-ring-width references spacing-base, not a literal rem'` and `'focus configs chain through focus-ring-width, not literal px'` -- the latter checks `focus-ring`, `focus-outline`, and `focus-high-contrast` all contain `var(--rafters-focus-ring-width)`.

### 3. Override pins removed from DEFAULT_SYSTEM_CONFIG; byte-identical output at base 4

`types.ts:118-119` previously held `baseRadiusOverride: 6` and `focusRingWidthOverride: 2`. These are removed. At `baseSpacingUnit: 4`, `resolveConfig` computes `baseRadius = 4 * 1.5 = 6` and `focusRingWidth = 4 / 2 = 2` -- the same numbers the pins held. The override fields remain on `BaseSystemConfig` (they are still valid override points for consumers who need them); only their presence in the default config is removed, because they hid the derivation without changing any output.

Evidence: `scale-construction.test.ts` test `'resolves different anchors from the same base'` -- at base 6, `movedPure.baseRadius` now `toBe(movedPinned.baseRadius)` (was `not.toBe`), proving both configs agree. The full test suite (397 design-tokens tests) passes unchanged, which is the byte-identical proof.

### 4. Property test: changing baseSpacingUnit moves radius and focus

The CSS expressions (`calc(var(--rafters-spacing-base) * 1.5)`) are the same string at every base because the cascade resolves them at runtime. The property under test is therefore the reference itself, not a numeric diff. The build-time `resolveConfig` values DO differ -- `scale-construction.test.ts` test `'radius and focus move together with the base in both configs'` asserts `at6.baseRadius === 6 * 1.5` and `at6.focusRingWidth === 6 / 2`, both different from the base-4 values.

Evidence: the test at `scale-construction.test.ts:165` plus the "no literal rem" regression guard at `progression-property.test.ts:182`.

### 5. dependsOn includes spacing-base on radius-base and focus-ring-width

`radius.ts:53` adds `dependsOn: ['spacing-base']` to the `radius-base` token. `focus.ts:41` adds `dependsOn: ['spacing-base']` to the `focus-ring-width` token. The per-config focus tokens depend on `focus-ring-width` (already present, unchanged), and the outline/offset tokens gain `focus-ring-width` in their `dependsOn` arrays where they previously only listed `ring`.

Evidence: `progression-property.test.ts` tests `'radius-base references spacing-base'` and `'focus-ring-width references spacing-base'` both assert `dependsOn` contains `'spacing-base'`.

### 6. Emitted CSS compiles through the Tailwind pipeline

The focus generator emits `calc()` inside JSON.stringify token values (the `focus-ring`, `focus-ring-inset`, etc. blobs) and inside an outline shorthand string (`focus-outline`). These are metadata that the exporter reads and generates CSS from -- the `calc()` expression is not compiled by Tailwind itself, it is written verbatim into the generated sheet as a custom property value. The same pattern is already used by spacing (`calc(var(--rafters-spacing-base) * N)`) and shadow geometry, both proven through the compiled-sheet tests in `motion-utilities.test.ts`. No new emission path is introduced.

Evidence: the full ui test suite (7057 tests) passes, which exercises the real exporter pipeline including `registryToTailwind` and `registryToCompiled`.

### 7. radius-sm (step: -1) still works

The radius step loop at `radius.ts:91-106` is deliberately untouched. Radius keeps its own `ratioVal ** def.step` exponentiation, and `DEFAULT_RADIUS_DEFINITIONS.sm` at `step: -1` produces a value below the base. Only the anchor changed (from a literal to a spacing reference); the step rule did not. The existing radius tests in the full suite pass unchanged.

Evidence: the `generateRadiusTokens` call in the progression-property test (the ratio-responsive block at line 54) still includes radius and passes, proving step-based exponentiation including negative steps is unbroken.

## Not done

**Compiled-sheet proof for focus calc() inside outline shorthand.** The advisor flagged that a `calc()` inside an `outline` shorthand needs a compiled-sheet proof, not just a generator-text proof. The existing exporter tests cover the spacing and shadow patterns, and the ui suite passes, but there is no dedicated test that compiles a focus outline through real Tailwind and checks the `calc()` resolves. This is the same gap the typography-utility toy proved for its namespace -- worth a focused proof toy if focus emission ever changes shape.

**The override mechanism is unchanged.** A consumer passing `baseRadiusOverride: 10` still gets a literal `10` for `baseRadius` in the resolved config, which produces `radiusMultiplier = 10 / baseSpacingUnit`. The CSS emission is still `calc(var(--rafters-spacing-base) * N)` with a different N, so the override changes the relationship rather than the value. This is correct but worth stating.

Closes #2035