### PR TITLE
fix(#2046): preserve @property, @keyframes, and @layer properties in documentation CSS

### DIFF
--- a/packages/design-tokens/src/exporters/tailwind.ts
+++ b/packages/design-tokens/src/exporters/tailwind.ts
@@ -1821,7 +1821,10 @@ export async function registryToDocumentation(
  * Post-process the compiled documentation sheet for shadow-DOM adoption:
  * - Extract theme vars from `@layer theme`, rewrite `:root,:host` to `:host`
  *   with `container-type: inline-size` added
- * - Strip `@layer properties` (Tailwind internal fallback vars)
+ * - Keep `@layer properties` (Tailwind fallback initial values for --tw-* vars)
+ *   with its universal selector rewritten for shadow-DOM scope
+ * - Keep top-level `@property` declarations (modern initial-value registrations)
+ * - Keep top-level `@keyframes` blocks (animation definitions)
  * - Strip `@layer theme` (replaced by the `:host` block)
  * - Strip the Tailwind banner comment
  * - Keep `@layer base`, `@layer components`, `@layer utilities` intact
@@ -1838,8 +1841,45 @@ function postProcessDocSheet(css: string): string {
     parts.push(`:host{container-type:inline-size}${themeContent}`);
   }
 
-  // Keep base, components, utilities layers
-  const layerRe = /@layer (base|components|utilities)\{/g;
+  // Keep top-level @property declarations (outside all @layer blocks).
+  // Tailwind v4 emits these for --tw-shadow, --tw-translate-*, --tw-ring-*
+  // etc. Without them, declarations referencing unset --tw-* vars are
+  // guaranteed-invalid and silently dropped (shadows, transforms, rings
+  // all inert).
+  const propertyRe = /@property\s+--[\w-]+\s*\{[^}]*\}/g;
+  let propMatch: RegExpExecArray | null;
+  while ((propMatch = propertyRe.exec(css)) !== null) {
+    parts.push(propMatch[0]);
+  }
+
+  // Keep top-level @keyframes blocks. Tailwind emits these outside @layer
+  // for built-in animations (spin, pulse) and custom keyframes from @theme.
+  const keyframesRe = /@keyframes\s+[\w-]+\s*\{/g;
+  let kfMatch: RegExpExecArray | null;
+  while ((kfMatch = keyframesRe.exec(css)) !== null) {
+    const start = kfMatch.index;
+    let depth = 0;
+    let end = start;
+    for (let i = start; i < css.length; i++) {
+      if (css[i] === '{') depth++;
+      if (css[i] === '}') {
+        depth--;
+        if (depth === 0) {
+          end = i + 1;
+          break;
+        }
+      }
+    }
+    parts.push(css.slice(start, end));
+  }
+
+  // Keep base, components, utilities, AND properties layers.
+  // The properties layer wraps a @supports fallback that sets --tw-* initial
+  // values on *, ::before, ::after, ::backdrop for browsers without @property
+  // support. Rewrite to add :host (not matched by * from inside its own
+  // shadow root) and drop ::backdrop (not relevant in shadow DOM). The bare *
+  // stays -- adoptedStyleSheets scopes it to the shadow tree automatically.
+  const layerRe = /@layer (base|components|utilities|properties)\{/g;
   let match: RegExpExecArray | null;
   while ((match = layerRe.exec(css)) !== null) {
     const start = match.index;
@@ -1855,7 +1895,14 @@ function postProcessDocSheet(css: string): string {
         }
       }
     }
-    parts.push(css.slice(start, end));
+    let block = css.slice(start, end);
+    if (match[1] === 'properties') {
+      block = block.replace(
+        /\*\s*,\s*:?:?before\s*,\s*:?:?after\s*,\s*:?:?backdrop/g,
+        ':host,*,::before,::after',
+      );
+    }
+    parts.push(block);
   }
 
   return parts.join('');

--- a/packages/design-tokens/test/exporters/documentation-sheet.test.ts
+++ b/packages/design-tokens/test/exporters/documentation-sheet.test.ts
@@ -71,7 +71,7 @@ describe('documentation sheet (#2039)', () => {
     for (const rule of CONTENT_ONLY_UTILITIES) {
       expect(css, `missing utility from content source: .${rule}`).toContain(`.${rule}`);
     }
-  });
+  }, 30_000);
 
   it('omits content-sourced utilities when no contentSources are provided', async () => {
     const css = await registryToDocumentation(baseRegistry());
@@ -81,11 +81,35 @@ describe('documentation sheet (#2039)', () => {
         `utility .${rule} present without content sources -- it should only appear via scanning`,
       ).not.toContain(`.${rule}`);
     }
-  });
+  }, 30_000);
 
   it('always includes token-derived utilities regardless of contentSources', async () => {
     const css = await registryToDocumentation(baseRegistry());
     expect(css).toContain('bg-surface');
     expect(css).toContain('text-foreground');
-  });
+  }, 30_000);
+
+  it('includes @property registrations for --tw-* initial values', async () => {
+    const css = await registryToDocumentation(baseRegistry(), {
+      contentSources: [fixtureDir],
+    });
+    expect(css).toContain('@property');
+  }, 30_000);
+
+  it('preserves @layer properties fallback with universal selector', async () => {
+    const css = await registryToDocumentation(baseRegistry(), {
+      contentSources: [fixtureDir],
+    });
+    expect(css).toContain('@layer properties');
+    expect(css, 'properties block must carry bare * for shadow-tree elements').toMatch(
+      /:host,\*,::?before,::?after/,
+    );
+  }, 30_000);
+
+  it('does not reintroduce :root selector', async () => {
+    const css = await registryToDocumentation(baseRegistry(), {
+      contentSources: [fixtureDir],
+    });
+    expect(css).not.toMatch(/:root(?![^{]*\{[^}]*container-type)/);
+  }, 30_000);
 });


### PR DESCRIPTION
## Summary

Tailwind v4 emits `@property` declarations and `@keyframes` blocks at top level (outside all `@layer` blocks), and wraps `--tw-*` initial value defaults in `@layer properties`. `postProcessDocSheet` was only extracting `@layer base|components|utilities`, silently dropping all three. This made shadows, transforms, rings, gradients, and animations inert in the documentation sheet -- declarations referencing unset `--tw-*` vars are guaranteed-invalid per CSS spec and silently dropped. Veneer measured 23 of 45 `--tw-*` vars never assigned and 0 keyframes against 104 animation declarations.

## Acceptance criteria mapping

### 1. Documentation CSS contains @property registrations for --tw-* custom properties

`postProcessDocSheet` now extracts all top-level `@property` declarations with a dedicated regex pass (`/@property\s+--[\w-]+\s*\{[^}]*\}/g`) before the `@layer` extraction loop. These sit outside every `@layer` in Tailwind v4 output -- the existing layer-only extraction never saw them. Test `includes @property registrations for --tw-* initial values` at `test/exporters/documentation-sheet.test.ts:88` asserts `@property` appears in the output.
Evidence: `packages/design-tokens/src/exporters/tailwind.ts:1847-1852` (extraction), `test/exporters/documentation-sheet.test.ts:88-92` (test)

### 2. Documentation CSS contains @keyframes blocks for animation definitions

A second extraction pass (`/@keyframes\s+[\w-]+\s*\{/g`) with brace-depth matching captures top-level `@keyframes` blocks. Tailwind emits these outside `@layer` for built-in animations (spin, pulse) and custom keyframes from `@theme`. The tw-animate-css family (animate-in, fade-in-0, etc.) is a separate dependency question -- those rules are not in the compile input and are not addressed here.
Evidence: `packages/design-tokens/src/exporters/tailwind.ts:1855-1870` (extraction)

### 3. Documentation CSS contains @layer properties fallback block with universal selector for shadow-tree elements

The `@layer` extraction regex now includes `properties` in its alternation (`base|components|utilities|properties`). The universal selector inside the block is rewritten from `*, ::before, ::after, ::backdrop` to `:host, *, ::before, ::after` -- adding `:host` (not matched by `*` from inside its own shadow root) and dropping `::backdrop` (not relevant in shadow DOM). The bare `*` stays because `adoptedStyleSheets` scopes it to the shadow tree automatically. An earlier version rewrote to `::slotted(*)` which would have been inert -- veneer caught this pre-commit since `::slotted` only matches light-DOM slot assignments, not elements created inside the shadow root. Test `preserves @layer properties fallback with universal selector` at `test/exporters/documentation-sheet.test.ts:94` asserts both the block and the selector pattern.
Evidence: `packages/design-tokens/src/exporters/tailwind.ts:1889-1898` (rewrite), `test/exporters/documentation-sheet.test.ts:94-101` (selector assertion)

### 4. Contract markers preserved: :root 0, @theme 0, @import 0, container-type:inline-size on :host

No new code paths introduce `:root`, `@theme`, or `@import`. The `:host` block with `container-type:inline-size` is produced by the existing theme extraction at line 1841 and is unchanged. The `@layer properties` rewrite targets only the universal selector inside that block and does not add `:root`. Test `does not reintroduce :root selector` at `test/exporters/documentation-sheet.test.ts:103` guards against regression.
Evidence: `test/exporters/documentation-sheet.test.ts:103-107` (no-:root assertion)

### 5. Existing documentation-sheet tests continue to pass

All three original tests pass with increased timeouts (30s, up from the default 5s that was causing sporadic failures). The content-sourced utilities test, the no-content-sources test, and the token-derived utilities test are unchanged in assertion logic.
Evidence: 35 test files, 404 tests, 0 failures in full suite run

## Not done

The tw-animate-css family (animate-in, fade-in-0, zoom-in-95, slide-in-from-*) is absent from the documentation sheet because tw-animate is not imported by rafters.css and is not in the Tailwind compile input. This is a dependency question, not a postprocess bug, and is not addressed here. Veneer acknowledges this and is not blocked on it -- previews will have no enter/exit animation, which is honest absence rather than a wrong render.

Closes #2046
