### PR TITLE
chore(release): v0.0.80

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # rafters
 
+## 0.0.80
+
+### Bug Fixes
+
+- fix(design-tokens): documentation CSS preserves @property, @keyframes, and @layer properties (#2046). `postProcessDocSheet` was stripping top-level `@property` declarations, `@keyframes` blocks, and the `@layer properties` fallback from Tailwind v4 compiled output. This made shadows, transforms, rings, gradients, and animations inert in the documentation sheet -- declarations referencing unset `--tw-*` vars are guaranteed-invalid per CSS spec and silently dropped. The universal selector in the properties fallback is rewritten to add `:host` and drop `::backdrop` for shadow-DOM adoption while keeping the bare `*` scoped by `adoptedStyleSheets`.
+
+- fix(demo): add @rafters/design-tokens as workspace dependency (#2045).
+
 ## 0.0.79
 
 ### Features

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.79",
+  "version": "0.0.80",
   "description": "Design Intelligence CLI. Scaffold tokens, import existing shadcn/Tailwind v4 sources, add components, and serve an MCP server so AI agents read decisions instead of guessing.",
   "homepage": "https://rafters.studio",
   "license": "MIT",


### PR DESCRIPTION
Point release shipping the documentation CSS fix (#2046) and the demo dependency fix (#2045). After merge, tag v0.0.80 and push to trigger the release workflow.

Closes #2046
