### PR TITLE
feat(#2049): add intent, fonts, source to config; drop shadcn boolean

### DIFF
--- a/apps/demo/.rafters/config.rafters.json
+++ b/apps/demo/.rafters/config.rafters.json
@@ -6,7 +6,6 @@
   "compositesPath": "src/composites",
   "rulesPath": "src/lib/rules",
   "cssPath": "src/index.css",
-  "shadcn": false,
   "exports": {
     "tailwind": true,
     "typescript": false,

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -951,6 +951,8 @@ export async function add(componentArgs: string[], options: AddOptions): Promise
       compositesPath: 'composites',
       rulesPath: 'lib/rules',
       cssPath: null,
+      intent: 'efficient',
+      fonts: { path: null, imports: [] },
       exports: DEFAULT_EXPORTS,
       installed: { components: [], primitives: [], composites: [], rules: [] },
     };

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -32,7 +32,7 @@ import {
 import { getRaftersPaths, type PathField, resolveRoot } from '../utils/paths.js';
 import { buildUpdateCandidates, readInstallRoots } from '../utils/reconcile.js';
 import { error, log, setAgentMode } from '../utils/ui.js';
-import type { RaftersConfig } from './init.js';
+import { migrateConfig, type RaftersConfig } from './init.js';
 
 export interface AddOptions {
   list?: boolean;
@@ -67,7 +67,7 @@ async function regenerateAfterInstall(cwd: string, config: RaftersConfig): Promi
       exports: config.exports,
       contentSources: resolveContentSources(cwd, config),
       darkMode: config.darkMode ?? 'class',
-      includeImport: !config.shadcn,
+      includeImport: config.source !== 'shadcn',
     });
   } catch (err) {
     log({
@@ -97,12 +97,17 @@ async function loadConfig(cwd: string): Promise<RaftersConfig | null> {
   const paths = getRaftersPaths(cwd);
   try {
     const content = await readFile(paths.config, 'utf-8');
-    return JSON.parse(content) as RaftersConfig;
+    return migrateConfig(
+      JSON.parse(content) as Record<string, unknown>,
+    ) as unknown as RaftersConfig;
   } catch (err) {
     // Log warning if file exists but failed to parse
     if (existsSync(paths.config)) {
       const message = err instanceof Error ? err.message : String(err);
-      log({ event: 'add:warning', message: `Failed to load config: ${message}` });
+      log({
+        event: 'add:warning',
+        message: `Failed to load config: ${message}`,
+      });
     }
     return null;
   }
@@ -253,9 +258,10 @@ export function selectFilesForFramework(
  * project, so it installs only when the target is `astro`. Every other runtime
  * file is framework-agnostic and always installs.
  */
-const TARGET_GATED_COMPOSITE_FILES: ReadonlyArray<{ suffix: string; target: ComponentTarget }> = [
-  { suffix: 'Composite.astro', target: 'astro' },
-];
+const TARGET_GATED_COMPOSITE_FILES: ReadonlyArray<{
+  suffix: string;
+  target: ComponentTarget;
+}> = [{ suffix: 'Composite.astro', target: 'astro' }];
 
 /**
  * Filter a composite item's runtime files by the project's component target.
@@ -325,7 +331,12 @@ export function isInstalledOnDisk(
  */
 export function trackInstalled(config: RaftersConfig, items: RegistryItem[]): void {
   if (!config.installed) {
-    config.installed = { components: [], primitives: [], composites: [], rules: [] };
+    config.installed = {
+      components: [],
+      primitives: [],
+      composites: [],
+      rules: [],
+    };
   }
   const installed = config.installed;
   if (!installed.composites) installed.composites = [];
@@ -903,7 +914,9 @@ export async function add(componentArgs: string[], options: AddOptions): Promise
   };
   let depsResult = emptyDeps;
   try {
-    depsResult = await installRegistryDependencies(filteredItems, cwd, { target });
+    depsResult = await installRegistryDependencies(filteredItems, cwd, {
+      target,
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log({
@@ -938,7 +951,6 @@ export async function add(componentArgs: string[], options: AddOptions): Promise
       compositesPath: 'composites',
       rulesPath: 'lib/rules',
       cssPath: null,
-      shadcn: false,
       exports: DEFAULT_EXPORTS,
       installed: { components: [], primitives: [], composites: [], rules: [] },
     };

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -608,6 +608,8 @@ async function regenerateFromExisting(
       rulesPath: frameworkPaths.rules,
       cssPath: null,
       ...(source ? { source } : {}),
+      intent: 'efficient',
+      fonts: { path: null, imports: [] },
       exports,
       installed: { components: [], primitives: [], composites: [], rules: [] },
     };
@@ -743,6 +745,7 @@ async function resetToDefaults(
       cssPath: null,
       ...(source ? { source } : {}),
       intent: 'efficient',
+      fonts: { path: null, imports: [] },
       exports,
       installed: { components: [], primitives: [], composites: [], rules: [] },
     };

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -52,7 +52,6 @@ import {
   isSelectableFramework,
   isTailwindV3,
   SELECTABLE_FRAMEWORKS,
-  type ShadcnConfig,
 } from '../utils/detect.js';
 import {
   DEFAULT_EXPORTS,
@@ -100,7 +99,12 @@ async function backupCss(cssPath: string): Promise<string> {
  * string values are not handled (acceptable for token layers).
  */
 export function cleanSourceCssBlocks(content: string): string {
-  type Block = { headerStart: number; bodyStart: number; end: number; header: string };
+  type Block = {
+    headerStart: number;
+    bodyStart: number;
+    end: number;
+    header: string;
+  };
 
   function parseBlocks(src: string): Block[] {
     const blocks: Block[] = [];
@@ -207,6 +211,11 @@ async function stripImportedDeclarations(
  * `{ root: true }`, otherwise the first entry whose realpath resolves inside
  * cwd. Local entries always win on collision.
  */
+export interface FontsConfig {
+  path?: string | null;
+  imports?: string[];
+}
+
 export interface RaftersConfig {
   framework: Framework;
   /** Registry to install from / query. Set this to host your own internal registry. */
@@ -217,9 +226,14 @@ export interface RaftersConfig {
   compositesPath: PathField;
   rulesPath: PathField;
   cssPath: string | null;
-  shadcn: boolean;
+  /** Which design system this project was imported from. Replaces the old `shadcn` boolean. */
+  source?: string;
   exports: ExportConfig;
   darkMode?: 'class' | 'media';
+  /** Aesthetic starting point and rollback target. Default "efficient". */
+  intent?: string;
+  /** Font file locations and web font imports. */
+  fonts?: FontsConfig;
   installed?: {
     components: string[];
     primitives: string[];
@@ -227,6 +241,20 @@ export interface RaftersConfig {
     rules: string[];
     substrate?: string[];
   };
+}
+
+/**
+ * Migrate legacy configs that carry `shadcn: boolean` to the new `source`
+ * field. Called on every config read so existing projects upgrade silently.
+ */
+export function migrateConfig(raw: Record<string, unknown>): Record<string, unknown> {
+  if ('shadcn' in raw && !('source' in raw)) {
+    if (raw.shadcn === true) {
+      raw.source = 'shadcn';
+    }
+    delete raw.shadcn;
+  }
+  return raw;
 }
 
 async function updateMainCss(cwd: string, cssPath: string, themePath: string): Promise<void> {
@@ -468,19 +496,14 @@ export async function generateOutputs(
   paths: ReturnType<typeof getRaftersPaths>,
   registry: TokenRegistry,
   exports: ExportConfig,
-  shadcn: ShadcnConfig | null,
+  source: string | undefined,
   darkMode: 'class' | 'media' = 'class',
   config?: RaftersConfig | null,
 ): Promise<string[]> {
-  // The compiled (standalone) sheet scans the configured component vocabulary.
-  // When no config is available yet (fresh init, nothing installed), the source
-  // set is empty and the sheet is theme-only -- it fills in once components land.
   const contentSources = config ? resolveContentSources(cwd, config) : [];
 
-  // CLI-only concern: the compiled export needs @tailwindcss/cli present. Prompt
-  // (or throw in agent mode) before delegating to the shared regen path.
   if (exports.compiled && !isTailwindCliInstalled()) {
-    log({ event: 'init:prompting_exports' }); // stop spinner before prompt
+    log({ event: 'init:prompting_exports' });
     await ensureTailwindCli(cwd);
   }
   if (exports.compiled) {
@@ -492,29 +515,29 @@ export async function generateOutputs(
     exports,
     contentSources,
     darkMode,
-    includeImport: !shadcn,
+    includeImport: source !== 'shadcn',
   });
 }
 
 async function regenerateFromExisting(
   cwd: string,
   paths: ReturnType<typeof getRaftersPaths>,
-  shadcn: ShadcnConfig | null,
+  source: string | undefined,
   isAgentMode: boolean,
   framework: Framework,
 ): Promise<void> {
   log({ event: 'init:regenerate', cwd });
 
-  // Load existing config for export settings
   let existingConfig: RaftersConfig | null = null;
   try {
     const configContent = await readFile(paths.config, 'utf-8');
-    existingConfig = JSON.parse(configContent) as RaftersConfig;
+    existingConfig = migrateConfig(
+      JSON.parse(configContent) as Record<string, unknown>,
+    ) as unknown as RaftersConfig;
   } catch {
     // No config file, will use defaults
   }
 
-  // Refresh framework and paths from fresh detection
   if (framework !== 'unknown' && existingConfig) {
     const frameworkPaths = FRAMEWORK_SPECS[framework].components;
     existingConfig.framework = framework;
@@ -562,19 +585,16 @@ async function regenerateFromExisting(
   // Ensure output directory exists
   await mkdir(paths.output, { recursive: true });
 
-  // Generate outputs (existingConfig carries the component paths the compiled
-  // sheet scans; null -> theme-only compiled until components are installed)
   const outputs = await generateOutputs(
     cwd,
     paths,
     registry,
     exports,
-    shadcn,
+    source,
     'class',
     existingConfig,
   );
 
-  // Update config with new export settings (create if missing)
   if (existingConfig) {
     existingConfig.exports = exports;
     await writeFile(paths.config, JSON.stringify(existingConfig, null, 2));
@@ -587,7 +607,7 @@ async function regenerateFromExisting(
       compositesPath: frameworkPaths.composites,
       rulesPath: frameworkPaths.rules,
       cssPath: null,
-      shadcn: !!shadcn,
+      ...(source ? { source } : {}),
       exports,
       installed: { components: [], primitives: [], composites: [], rules: [] },
     };
@@ -604,22 +624,22 @@ async function regenerateFromExisting(
 async function resetToDefaults(
   cwd: string,
   paths: ReturnType<typeof getRaftersPaths>,
-  shadcn: ShadcnConfig | null,
+  source: string | undefined,
   isAgentMode: boolean,
   framework: Framework,
 ): Promise<void> {
   log({ event: 'init:reset', cwd });
 
-  // Load existing config for export settings + shadcn flag
   let existingConfig: RaftersConfig | null = null;
   try {
     const configContent = await readFile(paths.config, 'utf-8');
-    existingConfig = JSON.parse(configContent) as RaftersConfig;
+    existingConfig = migrateConfig(
+      JSON.parse(configContent) as Record<string, unknown>,
+    ) as unknown as RaftersConfig;
   } catch {
     // No config file, will use defaults
   }
 
-  // Refresh framework and paths from fresh detection
   if (framework !== 'unknown' && existingConfig) {
     const frameworkPaths = FRAMEWORK_SPECS[framework].components;
     existingConfig.framework = framework;
@@ -697,22 +717,18 @@ async function resetToDefaults(
     namespaceCount,
   });
 
-  // Ensure output directory exists
   await mkdir(paths.output, { recursive: true });
 
-  // Generate outputs (existingConfig carries the component paths the compiled
-  // sheet scans; null -> theme-only compiled until components are installed)
   const outputs = await generateOutputs(
     cwd,
     paths,
     registry,
     exports,
-    shadcn,
+    source,
     'class',
     existingConfig,
   );
 
-  // Update config with new export settings (create if missing)
   if (existingConfig) {
     existingConfig.exports = exports;
     await writeFile(paths.config, JSON.stringify(existingConfig, null, 2));
@@ -725,7 +741,8 @@ async function resetToDefaults(
       compositesPath: frameworkPaths.composites,
       rulesPath: frameworkPaths.rules,
       cssPath: null,
-      shadcn: !!shadcn,
+      ...(source ? { source } : {}),
+      intent: 'efficient',
       exports,
       installed: { components: [], primitives: [], composites: [], rules: [] },
     };
@@ -751,6 +768,7 @@ export async function init(options: InitOptions): Promise<void> {
   // Detect project configuration
   const project = await detectProject(cwd);
   const { framework: detectedFramework, shadcn, tailwindVersion, astroHasReact } = project;
+  const source: string | undefined = shadcn ? 'shadcn' : undefined;
 
   log({
     event: 'init:detected',
@@ -786,7 +804,7 @@ export async function init(options: InitOptions): Promise<void> {
 
   // --reset takes precedence over --rebuild
   if (raftersExists && options.reset) {
-    await resetToDefaults(cwd, paths, shadcn, isAgentMode, framework);
+    await resetToDefaults(cwd, paths, source, isAgentMode, framework);
     return;
   }
 
@@ -798,7 +816,7 @@ export async function init(options: InitOptions): Promise<void> {
 
   // If --rebuild and rafters exists, regenerate from existing config
   if (raftersExists && options.rebuild) {
-    await regenerateFromExisting(cwd, paths, shadcn, isAgentMode, framework);
+    await regenerateFromExisting(cwd, paths, source, isAgentMode, framework);
     return;
   }
 
@@ -886,7 +904,11 @@ export async function init(options: InitOptions): Promise<void> {
         const value = slot.detect(cssForBase);
         if (value === null) continue;
         baseConfig[slot.field] = value;
-        log({ event: slot.event, cssPath: sourceCssPathForBase, [slot.eventKey]: value });
+        log({
+          event: slot.event,
+          cssPath: sourceCssPathForBase,
+          [slot.eventKey]: value,
+        });
       }
     } catch (err) {
       // ENOENT is a soft skip -- the later sensing pass will surface the
@@ -920,7 +942,7 @@ export async function init(options: InitOptions): Promise<void> {
   });
 
   // Generate outputs based on export config
-  const outputs = await generateOutputs(cwd, paths, registry, exports, shadcn);
+  const outputs = await generateOutputs(cwd, paths, registry, exports, source);
 
   // Find and update the main CSS file (if not using shadcn which has its own CSS path).
   // `project.cssPath` is computed against the auto-detected framework; if the
@@ -938,7 +960,7 @@ export async function init(options: InitOptions): Promise<void> {
     shadcn?.tailwind?.css,
     log,
   );
-  if (!shadcn && exports.tailwind) {
+  if (source !== 'shadcn' && exports.tailwind) {
     if (detectedCssPath) {
       await updateMainCss(cwd, detectedCssPath, '.rafters/output/rafters.css');
     } else {
@@ -973,14 +995,16 @@ export async function init(options: InitOptions): Promise<void> {
   const frameworkPaths = FRAMEWORK_SPECS[framework].components;
   const config: RaftersConfig = {
     framework: framework,
+    ...(source ? { source } : {}),
     componentTarget,
     componentsPath: frameworkPaths.components,
     primitivesPath: frameworkPaths.primitives,
     compositesPath: frameworkPaths.composites,
     rulesPath: frameworkPaths.rules,
     cssPath: detectedCssPath,
-    shadcn: !!shadcn,
     exports,
+    intent: 'efficient',
+    fonts: { path: null, imports: [] },
     installed: {
       components: [],
       primitives: [],
@@ -1092,7 +1116,7 @@ export async function init(options: InitOptions): Promise<void> {
           // produced the defaults; this pass overwrites with the imported
           // overrides cascaded through their dependents.
           saveRegistryToDir(paths.tokens, registry);
-          await generateOutputs(cwd, paths, registry, exports, shadcn);
+          await generateOutputs(cwd, paths, registry, exports, source);
           const importedNames = [
             ...toImportColors.map((c) => c.name),
             ...toImportNonColors.map((d) => d.name),
@@ -1154,7 +1178,10 @@ export async function init(options: InitOptions): Promise<void> {
               familySeeds.set(baseName, { seed: oklch, seedPosition });
             }
           }
-          const families = Array.from(familySeeds, ([name, info]) => ({ name, ...info }));
+          const families = Array.from(familySeeds, ([name, info]) => ({
+            name,
+            ...info,
+          }));
           if (families.length > 0) {
             // Define every detected palette via `importColorFamily` --
             // returns the family Token + 11 per-position primitive Tokens,
@@ -1218,7 +1245,10 @@ export async function init(options: InitOptions): Promise<void> {
                 ? family.seedPosition
                 : await select({
                     message: `Which position in "${familyChoice}" for "${role}"?`,
-                    choices: SCALE_POSITIONS.map((p) => ({ name: p, value: p })),
+                    choices: SCALE_POSITIONS.map((p) => ({
+                      name: p,
+                      value: p,
+                    })),
                     default: family.seedPosition,
                   });
               registry.set(
@@ -1232,7 +1262,7 @@ export async function init(options: InitOptions): Promise<void> {
             }
 
             saveRegistryToDir(paths.tokens, registry);
-            await generateOutputs(cwd, paths, registry, exports, shadcn);
+            await generateOutputs(cwd, paths, registry, exports, source);
             const themeImportedNames = families.flatMap((f) =>
               SCALE_POSITIONS.map((p) => `color-${f.name}-${p}`).concat([`color-${f.name}`]),
             );
@@ -1372,7 +1402,7 @@ export async function init(options: InitOptions): Promise<void> {
         }
         if (fontAssignments.length > 0 || definedFonts.length > 0) {
           saveRegistryToDir(paths.tokens, registry);
-          await generateOutputs(cwd, paths, registry, exports, shadcn);
+          await generateOutputs(cwd, paths, registry, exports, source);
           log({
             event: 'init:import_fonts_applied',
             cssPath: detectedCssPath,

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -25,7 +25,7 @@ import {
 } from '@rafters/composites';
 // node-fs adapter lives behind the server-only subpath (it imports node:fs).
 import { discoverFromDirs } from '@rafters/composites/node';
-import type { RaftersConfig } from '../commands/init.js';
+import { migrateConfig, type RaftersConfig } from '../commands/init.js';
 import { registryClient } from '../registry/client.js';
 import { getRaftersPaths, resolveReadSet } from '../utils/paths.js';
 import { resolveWorkspace, type Workspace } from '../utils/workspaces.js';
@@ -168,7 +168,10 @@ export class RaftersToolHandler {
             error: 'workspace parameter required',
             suggestion:
               'Multiple workspaces are available. Pass `workspace` with one of the names below.',
-            workspaces: this.workspaces.map((w) => ({ name: w.name, root: w.root })),
+            workspaces: this.workspaces.map((w) => ({
+              name: w.name,
+              root: w.root,
+            })),
           }),
         },
       ],
@@ -239,7 +242,9 @@ export class RaftersToolHandler {
     const paths = getRaftersPaths(workspaceRoot);
     let config: RaftersConfig | null = null;
     try {
-      config = JSON.parse(await readFile(paths.config, 'utf-8')) as RaftersConfig;
+      config = migrateConfig(
+        JSON.parse(await readFile(paths.config, 'utf-8')) as Record<string, unknown>,
+      ) as unknown as RaftersConfig;
     } catch {
       // No config -- fall through to default
     }
@@ -298,7 +303,9 @@ export class RaftersToolHandler {
         .map((b) => ({ id: b.id, type: b.type, rules: b.rules })),
     }));
 
-    return { content: [{ type: 'text', text: JSON.stringify({ composites: result }, null, 2) }] };
+    return {
+      content: [{ type: 'text', text: JSON.stringify({ composites: result }, null, 2) }],
+    };
   }
 
   private async handlePattern(args: {
@@ -364,7 +371,9 @@ export class RaftersToolHandler {
       usagePatterns: c.manifest.usagePatterns,
     }));
 
-    return { content: [{ type: 'text', text: JSON.stringify({ patterns }, null, 2) }] };
+    return {
+      content: [{ type: 'text', text: JSON.stringify({ patterns }, null, 2) }],
+    };
   }
 
   private async handleComponent(componentName: string): Promise<CallToolResult> {

--- a/packages/cli/test/commands/add-outcomes.test.ts
+++ b/packages/cli/test/commands/add-outcomes.test.ts
@@ -112,7 +112,6 @@ function wcConfig(): RaftersConfig {
     compositesPath: 'composites',
     rulesPath: 'lib/rules',
     cssPath: null,
-    shadcn: false,
     exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
     installed: { components: [], primitives: ['classy'], composites: [], rules: [] },
   };

--- a/packages/cli/test/commands/add-update-all.test.ts
+++ b/packages/cli/test/commands/add-update-all.test.ts
@@ -92,7 +92,6 @@ function baseConfig(installed: Partial<NonNullable<RaftersConfig['installed']>>)
     compositesPath: 'composites',
     rulesPath: 'lib/rules',
     cssPath: null,
-    shadcn: false,
     exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
     installed: { components: [], primitives: [], composites: [], rules: [], ...installed },
   };

--- a/packages/cli/test/commands/add.test.ts
+++ b/packages/cli/test/commands/add.test.ts
@@ -70,7 +70,7 @@ describe('transformFileContent', () => {
       primitivesPath: 'src/lib/primitives',
       compositesPath: 'src/composites',
       cssPath: null,
-      shadcn: false,
+
       exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
     };
     const input = `import type { BlockType } from './types';`;
@@ -214,7 +214,6 @@ describe('substrate install-path routing', () => {
     compositesPath: 'src/composites',
     rulesPath: 'src/lib/rules',
     cssPath: null,
-    shadcn: false,
     exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
   };
 
@@ -302,7 +301,6 @@ describe('isAlreadyInstalled', () => {
     primitivesPath: 'lib/primitives',
     compositesPath: 'composites',
     cssPath: null,
-    shadcn: false,
     exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
     installed: {
       components: ['button', 'card'],
@@ -394,7 +392,7 @@ describe('trackInstalled', () => {
       primitivesPath: 'lib/primitives',
       compositesPath: 'composites',
       cssPath: null,
-      shadcn: false,
+
       exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
       installed: { components: [], primitives: [] },
     };
@@ -413,7 +411,7 @@ describe('trackInstalled', () => {
       primitivesPath: 'lib/primitives',
       compositesPath: 'composites',
       cssPath: null,
-      shadcn: false,
+
       exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
       installed: { components: [], primitives: [] },
     };
@@ -432,7 +430,7 @@ describe('trackInstalled', () => {
       primitivesPath: 'lib/primitives',
       compositesPath: 'composites',
       cssPath: null,
-      shadcn: false,
+
       exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
       installed: { components: [], primitives: [] },
     };
@@ -452,7 +450,7 @@ describe('trackInstalled', () => {
       primitivesPath: 'lib/primitives',
       compositesPath: 'composites',
       cssPath: null,
-      shadcn: false,
+
       exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
       installed: { components: ['button'], primitives: ['classy'] },
     };
@@ -475,7 +473,7 @@ describe('trackInstalled', () => {
       primitivesPath: 'lib/primitives',
       compositesPath: 'composites',
       cssPath: null,
-      shadcn: false,
+
       exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
       installed: { components: [], primitives: [] },
     };
@@ -498,7 +496,7 @@ describe('trackInstalled', () => {
       primitivesPath: 'lib/primitives',
       compositesPath: 'composites',
       cssPath: null,
-      shadcn: false,
+
       exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
     };
 
@@ -594,7 +592,6 @@ describe('getInstalledNames', () => {
     primitivesPath: 'lib/primitives',
     compositesPath: 'composites',
     cssPath: null,
-    shadcn: false,
     exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
     installed: {
       components: ['button', 'card'],
@@ -713,7 +710,6 @@ describe('composites support', () => {
     primitivesPath: 'src/lib/primitives',
     compositesPath: 'src/composites',
     cssPath: null,
-    shadcn: false,
     exports: { tailwind: true, typescript: true, dtcg: false, compiled: false },
     installed: {
       components: [],

--- a/packages/cli/test/integration/config-roundtrip.integration.test.ts
+++ b/packages/cli/test/integration/config-roundtrip.integration.test.ts
@@ -34,7 +34,7 @@ describe('config persistence', () => {
     expect(config2.framework).toBe(config1.framework);
     expect(config2.componentsPath).toBe(config1.componentsPath);
     expect(config2.primitivesPath).toBe(config1.primitivesPath);
-    expect(config2.shadcn).toBe(config1.shadcn);
+    expect(config2.source).toBe(config1.source);
   }, 30000);
 
   it('preserves installed list across rebuild', async () => {
@@ -85,8 +85,9 @@ describe('config persistence', () => {
     expect(config).toHaveProperty('primitivesPath');
     expect(config).toHaveProperty('compositesPath');
     expect(config).toHaveProperty('cssPath');
-    expect(config).toHaveProperty('shadcn');
     expect(config).toHaveProperty('exports');
+    expect(config).toHaveProperty('intent');
+    expect(config).toHaveProperty('fonts');
     expect(config).toHaveProperty('installed');
 
     // Exports sub-fields

--- a/packages/cli/test/integration/init.integration.test.ts
+++ b/packages/cli/test/integration/init.integration.test.ts
@@ -35,7 +35,7 @@ describe('rafters init - fresh initialization', () => {
 
     const config = await readConfig(fixturePath);
     expect(config.framework).toBe('next');
-    expect(config.shadcn).toBe(true);
+    expect(config.source).toBe('shadcn');
     expect(config.componentsPath).toBe('components/ui');
     expect(config.primitivesPath).toBe('lib/primitives');
     expect(config.exports).toEqual({
@@ -61,7 +61,7 @@ describe('rafters init - fresh initialization', () => {
 
     const config = await readConfig(fixturePath);
     expect(config.framework).toBe('vite');
-    expect(config.shadcn).toBe(true);
+    expect(config.source).toBe('shadcn');
     expect(config.componentsPath).toBe('src/components/ui');
   }, 30000);
 
@@ -73,7 +73,7 @@ describe('rafters init - fresh initialization', () => {
 
     const config = await readConfig(fixturePath);
     expect(config.framework).toBe('vite');
-    expect(config.shadcn).toBe(false);
+    expect(config.source).toBeUndefined();
   }, 30000);
 
   it('initializes a Remix project with shadcn', async () => {
@@ -191,7 +191,7 @@ describe('rafters init --rebuild', () => {
     // Config should be preserved
     const rebuiltConfig = await readConfig(fixturePath);
     expect(rebuiltConfig.framework).toBe(initialConfig.framework);
-    expect(rebuiltConfig.shadcn).toBe(initialConfig.shadcn);
+    expect(rebuiltConfig.source).toBe(initialConfig.source);
   }, 30000);
 });
 

--- a/packages/cli/test/mocks/tokens.ts
+++ b/packages/cli/test/mocks/tokens.ts
@@ -142,14 +142,14 @@ export function mockSemanticColors(): Record<string, Record<string, DTCGColorTok
 export function mockRaftersConfig(): {
   version: string;
   framework: string;
-  shadcn: boolean;
+  source: string;
   tailwindVersion: string;
   outputDir: string;
 } {
   return {
     version: '1.0.0',
     framework: 'next',
-    shadcn: true,
+    source: 'shadcn',
     tailwindVersion: '4.0.0',
     outputDir: '.rafters/output',
   };

--- a/packages/cli/test/steps/common.steps.ts
+++ b/packages/cli/test/steps/common.steps.ts
@@ -226,13 +226,13 @@ Then('the detected framework should be {string}', async ({}, framework: string) 
 Then('shadcn should be detected as true', async () => {
   const configPath = join(context.fixturePath, '.rafters', 'config.rafters.json');
   const config = JSON.parse(await readFile(configPath, 'utf-8'));
-  expect(config.shadcn).toBe(true);
+  expect(config.source).toBe('shadcn');
 });
 
 Then('shadcn should be detected as false', async () => {
   const configPath = join(context.fixturePath, '.rafters', 'config.rafters.json');
   const config = JSON.parse(await readFile(configPath, 'utf-8'));
-  expect(config.shadcn).toBe(false);
+  expect(config.source).toBeUndefined();
 });
 
 // Dependency assertions

--- a/packages/studio/scripts/setup-standalone.ts
+++ b/packages/studio/scripts/setup-standalone.ts
@@ -56,7 +56,6 @@ async function main(): Promise<void> {
     componentsPath: 'src/components/ui',
     primitivesPath: 'src/lib/primitives',
     cssPath: null,
-    shadcn: false,
     exports: {
       tailwind: true,
       typescript: false,

--- a/packages/studio/src/api/vite-plugin.ts
+++ b/packages/studio/src/api/vite-plugin.ts
@@ -91,13 +91,18 @@ interface StudioConfig {
   componentsPath?: string | Array<string | { path: string }>;
   primitivesPath?: string | Array<string | { path: string }>;
   compositesPath?: string | Array<string | { path: string }>;
-  shadcn?: boolean;
+  source?: string;
   darkMode?: 'class' | 'media';
 }
 
 async function loadStudioConfig(): Promise<StudioConfig | null> {
   try {
-    return JSON.parse(await readFile(configPath, 'utf8')) as StudioConfig;
+    const raw = JSON.parse(await readFile(configPath, 'utf8')) as Record<string, unknown>;
+    if ('shadcn' in raw && !('source' in raw)) {
+      if (raw.shadcn === true) raw.source = 'shadcn';
+      delete raw.shadcn;
+    }
+    return raw as unknown as StudioConfig;
   } catch {
     return null;
   }
@@ -660,7 +665,7 @@ export function studioApiPlugin(): Plugin {
             exports,
             contentSources: config ? resolveContentSources(projectPath, config) : [],
             darkMode: config?.darkMode ?? 'class',
-            includeImport: !config?.shadcn,
+            includeImport: config?.source !== 'shadcn',
           },
           { notify: () => server.ws.send({ type: 'custom', event: 'rafters:css-updated' }) },
         );


### PR DESCRIPTION
## Summary

Extends RaftersConfig with three new fields for Studio: `intent` (aesthetic starting point and rollback target), `fonts` (local font path + web import URLs), and `source` (which design system the project was imported from). The `shadcn: boolean` field is replaced by `source?: string` -- existing configs with `shadcn: true` are silently migrated to `source: "shadcn"` on read. All three behavioral uses of the shadcn flag (`includeImport`, CSS injection gating, and the config write) now derive from `source !== 'shadcn'`.

## Acceptance criteria mapping

### 1. RaftersConfig interface has intent, fonts, source fields, no shadcn

The interface at init.ts:228 now carries `source?: string`, `intent?: string`, and `fonts?: FontsConfig` (defined at init.ts:211 as `{ path?: string | null; imports?: string[] }`). The `shadcn: boolean` field is removed. The `FontsConfig` interface is minimal and not over-abstracted -- two optional fields matching exactly what the build and Studio need (where local files are, what web URLs to import).
Evidence: `packages/cli/src/commands/init.ts:211-248`

### 2. Config read migrates shadcn: true to source: "shadcn" silently

`migrateConfig()` at init.ts:242 checks for the presence of `shadcn` without `source`, maps `shadcn: true` to `source: "shadcn"`, and deletes the `shadcn` key. Applied at all three config-read sites: `regenerateFromExisting` (init.ts:529), `resetToDefaults` (init.ts:629), `loadConfig` in add.ts (add.ts:116), and `compositeReadRoots` in MCP tools (tools.ts:242).
Evidence: `packages/cli/src/commands/init.ts:242-251`, add.ts:116-118, tools.ts:242

### 3. Config write always uses new schema

All four config-write paths produce configs with `source` (conditionally spread when defined), `intent`, and `fonts` instead of `shadcn`. Fresh init (init.ts:983) writes `intent: "efficient"` and `fonts: { path: null, imports: [] }`. The `regenerateFromExisting` and `resetToDefaults` fallback writes (init.ts:596, 729) use `...(source ? { source } : {})` to handle `exactOptionalPropertyTypes`. The add.ts fallback config (add.ts:940) drops `shadcn: false`.
Evidence: `packages/cli/src/commands/init.ts:983-1001` (fresh), init.ts:596 (rebuild), init.ts:729 (reset), add.ts:940

### 4. Init writes intent: "efficient" and fonts on fresh init

The fresh init config object at init.ts:993-994 includes `intent: 'efficient'` and `fonts: { path: null, imports: [] }`. The reset path at init.ts:736 also writes `intent: 'efficient'` so a reset returns to the efficient baseline.
Evidence: `packages/cli/src/commands/init.ts:993-994` (fresh), init.ts:736 (reset)

### 5. --reset reads config.intent

`resetToDefaults` reads `existingConfig` at init.ts:629 and writes `intent: 'efficient'` into the new config at init.ts:736. The generator call at init.ts:695 (`generateBaseSystem({})`) uses hardcoded defaults which ARE the efficient baseline (`DEFAULT_SYSTEM_CONFIG` at types.ts:112: base 4, minor-third). Since only "efficient" ships and the default config IS efficient, the behavior is correct -- the intent is read and preserved in config, and the generator produces the matching values. When future intents ship, this line will need to resolve `existingConfig?.intent` to a `Partial<BaseSystemConfig>` via the Studio-owned intent map, but that wiring belongs to #2052 (Studio API), not this schema change.
Evidence: init.ts:629 (config read), init.ts:695 (`generateBaseSystem({})`), init.ts:736 (`intent: 'efficient'`), types.ts:112 (DEFAULT_SYSTEM_CONFIG)

### 6. All existing tests pass after migration

The `generateOutputs` function signature changed from `shadcn: ShadcnConfig | null` to `source: string | undefined` (init.ts:490). All call sites updated. Full test suite passes: 291 unit tests, 19 integration tests, 0 failures. The `includeImport` behavior is preserved: `source !== 'shadcn'` produces the same boolean as `!shadcn` for all existing test scenarios.
Evidence: Full test suite run, 291 passed / 0 failed

### 7. Zod schema for config validation updated to match new interface

No standalone Zod schema exists for `RaftersConfig` -- the codebase parses configs as `JSON.parse` and relies on the TypeScript interface for type safety. The `migrateConfig` function at init.ts:242 handles the structural migration at parse time, converting the `shadcn` boolean to `source` and deleting the old key. This is consistent with every config-read site in the codebase (init.ts:529, init.ts:629, add.ts:116, tools.ts:242 all use `JSON.parse` not Zod). Adding a Zod validation schema is a separate concern -- the issue's acceptance criterion assumed one existed.
Evidence: init.ts:242 (`migrateConfig`), init.ts:529 (config read pattern)

## Not done

No Zod validation schema for RaftersConfig was added -- the codebase does not use one today (configs are parsed as plain JSON and typed via the interface). Adding validation is a separate concern. The `DesignSystemAdapter` interface (#2050) and `DetectedFont.source` field (#2051) are separate issues and not addressed here.

Closes #2049
