### PR TITLE
feat(#2051): DetectedFont carries source field for font origin

### DIFF
--- a/packages/design-tokens/src/importers/fonts.ts
+++ b/packages/design-tokens/src/importers/fonts.ts
@@ -50,6 +50,23 @@ const GENERIC_KEYWORDS: ReadonlySet<string> = new Set([
   'revert-layer',
 ]);
 
+/**
+ * How a font family was detected. The build uses this to decide emission
+ * strategy: `@import` for web URLs, `@font-face` for local files, nothing
+ * for system/declaration-only fonts.
+ *
+ * Priority order for merge conflicts (same family from multiple sources):
+ *   font-face (2) > google (1) > declaration (0)
+ */
+export type FontSource = 'google' | 'font-face' | 'declaration';
+
+/** Numeric priority for FontSource merge -- higher wins. */
+const SOURCE_PRIORITY: Readonly<Record<FontSource, number>> = {
+  declaration: 0,
+  google: 1,
+  'font-face': 2,
+};
+
 export interface DetectedFont {
   /** Canonical family name, unquoted, single-spaced. e.g. `Inter`, `JetBrains Mono`. */
   readonly name: string;
@@ -67,6 +84,12 @@ export interface DetectedFont {
    * canonical-base list lives in the registry, not in this module.
    */
   readonly sourceDeclName?: string;
+  /**
+   * Which detection path found this font. When the same family appears
+   * from multiple sources, the merge keeps the most specific one:
+   * `font-face` > `google` > `declaration`.
+   */
+  readonly source: FontSource;
 }
 
 /**
@@ -76,7 +99,12 @@ export interface DetectedFont {
 export function detectFonts(css: string): readonly DetectedFont[] {
   const found = new Map<string, DetectedFont>();
 
-  const accept = (name: string | null, stack: string, sourceDeclName?: string): void => {
+  const accept = (
+    name: string | null,
+    stack: string,
+    source: FontSource,
+    sourceDeclName?: string,
+  ): void => {
     if (name === null) return;
     const canonical = normalizeFamilyName(name);
     if (canonical === '' || GENERIC_KEYWORDS.has(canonical.toLowerCase())) return;
@@ -86,26 +114,31 @@ export function detectFonts(css: string): readonly DetectedFont[] {
       found.set(key, {
         name: canonical,
         stack,
+        source,
         ...(sourceDeclName && { sourceDeclName }),
       });
       return;
     }
-    // Merge: prefer the fuller stack and the first source declaration name.
+    // Merge: prefer the more specific source (font-face > google > declaration),
+    // the fuller stack, and the first source declaration name.
+    const mergedSource =
+      SOURCE_PRIORITY[source] > SOURCE_PRIORITY[existing.source] ? source : existing.source;
     const mergedStack = stack.length > existing.stack.length ? stack : existing.stack;
     const mergedDeclName = existing.sourceDeclName ?? sourceDeclName;
     found.set(key, {
       name: existing.name,
       stack: mergedStack,
+      source: mergedSource,
       ...(mergedDeclName && { sourceDeclName: mergedDeclName }),
     });
   };
 
   for (const family of extractGoogleFontFamilies(css)) {
-    accept(family, quoteIfNeeded(family));
+    accept(family, quoteIfNeeded(family), 'google');
   }
 
   for (const family of extractFontFaceFamilies(css)) {
-    accept(family, quoteIfNeeded(family));
+    accept(family, quoteIfNeeded(family), 'font-face');
   }
 
   const rootDecls = extractShadcnRoot(css);
@@ -113,7 +146,7 @@ export function detectFonts(css: string): readonly DetectedFont[] {
   for (const decl of [...rootDecls, ...themeDecls]) {
     if (!decl.name.startsWith('font-')) continue;
     const first = firstFamilyFromStack(decl.value);
-    accept(first, decl.value.trim(), decl.name);
+    accept(first, decl.value.trim(), 'declaration', decl.name);
   }
 
   return Array.from(found.values());

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -18,7 +18,7 @@ export {
 export { classifyDeclarations } from './importers/classify.js';
 export { importColorFamily } from './importers/color.js';
 export { colorsFromClassification } from './importers/colors.js';
-export { type DetectedFont, detectFonts } from './importers/fonts.js';
+export { type DetectedFont, type FontSource, detectFonts } from './importers/fonts.js';
 export { senseShadcnCss } from './importers/sense.js';
 export { extractShadcnRoot } from './importers/shadcn.js';
 export {

--- a/packages/design-tokens/test/importers/fonts.test.ts
+++ b/packages/design-tokens/test/importers/fonts.test.ts
@@ -8,21 +8,21 @@ describe('detectFonts', () => {
 
   it('extracts a single Google Fonts family from @import', () => {
     const css = `@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;700");`;
-    expect(detectFonts(css)).toEqual([{ name: 'Inter', stack: 'Inter' }]);
+    expect(detectFonts(css)).toEqual([{ name: 'Inter', stack: 'Inter', source: 'google' }]);
   });
 
   it('extracts multiple Google Fonts families across one @import', () => {
     const css = `@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=JetBrains+Mono:wght@400");`;
     const result = detectFonts(css);
     expect(result).toEqual([
-      { name: 'Inter', stack: 'Inter' },
-      { name: 'JetBrains Mono', stack: '"JetBrains Mono"' },
+      { name: 'Inter', stack: 'Inter', source: 'google' },
+      { name: 'JetBrains Mono', stack: '"JetBrains Mono"', source: 'google' },
     ]);
   });
 
   it('extracts from Google Fonts v1 URL shape', () => {
     const css = `@import url('https://fonts.googleapis.com/css?family=Roboto:400,700');`;
-    expect(detectFonts(css)).toEqual([{ name: 'Roboto', stack: 'Roboto' }]);
+    expect(detectFonts(css)).toEqual([{ name: 'Roboto', stack: 'Roboto', source: 'google' }]);
   });
 
   it('extracts from @font-face declarations', () => {
@@ -33,7 +33,9 @@ describe('detectFonts', () => {
         font-weight: 400;
       }
     `;
-    expect(detectFonts(css)).toEqual([{ name: 'MyCustom', stack: 'MyCustom' }]);
+    expect(detectFonts(css)).toEqual([
+      { name: 'MyCustom', stack: 'MyCustom', source: 'font-face' },
+    ]);
   });
 
   it('extracts the first family from --font-* declarations in :root', () => {
@@ -43,6 +45,7 @@ describe('detectFonts', () => {
         name: 'Inter Variable',
         stack: '"Inter Variable", system-ui, sans-serif',
         sourceDeclName: 'font-sans',
+        source: 'declaration',
       },
     ]);
   });
@@ -54,6 +57,7 @@ describe('detectFonts', () => {
         name: 'JetBrains Mono',
         stack: '"JetBrains Mono", monospace',
         sourceDeclName: 'font-mono',
+        source: 'declaration',
       },
     ]);
   });
@@ -65,6 +69,7 @@ describe('detectFonts', () => {
         name: 'Aurabesh',
         stack: '"Aurabesh", sans-serif',
         sourceDeclName: 'font-aurabesh',
+        source: 'declaration',
       },
     ]);
   });
@@ -80,10 +85,12 @@ describe('detectFonts', () => {
       :root { --font-sans: "inter", sans-serif; }
     `;
     // Same family detected twice; we keep one entry. The full stack from
-    // the :root declaration is longer, so it wins for `stack`.
+    // the :root declaration is longer, so it wins for `stack`. Google source
+    // is more specific than declaration, so it wins for `source`.
     const result = detectFonts(css);
     expect(result).toHaveLength(1);
     expect(result[0]?.stack).toBe('"inter", sans-serif');
+    expect(result[0]?.source).toBe('google');
   });
 
   it('combines all detection sources into one list', () => {
@@ -94,6 +101,7 @@ describe('detectFonts', () => {
     `;
     const result = detectFonts(css);
     expect(result.map((f) => f.name)).toEqual(['Inter', 'MyCustom', 'JetBrains Mono']);
+    expect(result.map((f) => f.source)).toEqual(['google', 'font-face', 'declaration']);
   });
 
   it('handles malformed CSS without throwing', () => {
@@ -107,7 +115,9 @@ describe('detectFonts', () => {
 
   it('preserves spaces in Google Fonts family names', () => {
     const css = `@import url("https://fonts.googleapis.com/css2?family=Source+Sans+3");`;
-    expect(detectFonts(css)).toEqual([{ name: 'Source Sans 3', stack: '"Source Sans 3"' }]);
+    expect(detectFonts(css)).toEqual([
+      { name: 'Source Sans 3', stack: '"Source Sans 3"', source: 'google' },
+    ]);
   });
 
   it('preserves sourceDeclName from the first --font-* declaration when same family appears elsewhere', () => {
@@ -120,5 +130,38 @@ describe('detectFonts', () => {
     `;
     const inter = detectFonts(css).find((f) => f.name === 'Inter');
     expect(inter?.sourceDeclName).toBe('font-sans');
+    // font-face is more specific than declaration, so it wins.
+    expect(inter?.source).toBe('font-face');
+  });
+
+  it('prefers font-face source over google when same family detected from both', () => {
+    // Designer downloaded the Google font locally -- local source wins.
+    const css = `
+      @import url("https://fonts.googleapis.com/css2?family=Inter");
+      @font-face { font-family: "Inter"; src: url("/fonts/Inter.woff2"); }
+    `;
+    const result = detectFonts(css);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.source).toBe('font-face');
+  });
+
+  it('prefers google source over declaration when same family detected from both', () => {
+    const css = `
+      @import url("https://fonts.googleapis.com/css2?family=Inter");
+      :root { --font-sans: "Inter", sans-serif; }
+    `;
+    const result = detectFonts(css);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.source).toBe('google');
+  });
+
+  it('prefers font-face over declaration when same family detected from both', () => {
+    const css = `
+      :root { --font-sans: "Inter", sans-serif; }
+      @font-face { font-family: "Inter"; src: url("/fonts/Inter.woff2"); }
+    `;
+    const result = detectFonts(css);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.source).toBe('font-face');
   });
 });


### PR DESCRIPTION
## Summary

Adds a `source` field to `DetectedFont` so the build knows how each font was detected -- Google import, @font-face block, or CSS declaration. When the same family appears from multiple detection paths, the merge logic prefers local sources over web over declarations (font-face > google > declaration). Exported as `FontSource` type alongside `DetectedFont`.

## Acceptance criteria mapping

### 1. DetectedFont has required source field on every instance

The `DetectedFont` interface at fonts.ts:70 now requires `source: FontSource` where `FontSource = 'google' | 'font-face' | 'declaration'` (fonts.ts:61). The `accept()` helper at fonts.ts:79 takes a required `source` parameter, and every call site passes it. A `DetectedFont` without `source` is a type error.
Evidence: fonts.ts:61 (FontSource type), fonts.ts:70 (source field on interface), fonts.ts:79 (accept signature)

### 2. Google-detected fonts carry source: "google"

The Google Fonts extraction loop at fonts.ts:103 passes the literal `'google'` to `accept()` for every family parsed from `@import url(https://fonts.googleapis.com/...)` URLs. The existing `extractGoogleFontFamilies` function is unchanged -- only the threading of the source through accept is new.
Evidence: fonts.ts:103 (`accept(family, quoteIfNeeded(family), 'google')`)

### 3. @font-face-detected fonts carry source: "font-face"

The @font-face extraction loop at fonts.ts:107 passes `'font-face'` to `accept()` for every family parsed from `@font-face { font-family: "X" }` blocks. Same pattern as Google -- the extraction function is unchanged.
Evidence: fonts.ts:107 (`accept(family, quoteIfNeeded(family), 'font-face')`)

### 4. Declaration-detected fonts carry source: "declaration"

The `--font-*` declaration walk at fonts.ts:113 passes `'declaration'` to `accept()` for every family found in `:root` or `@theme` CSS variable declarations. System fonts and `var()` references both carry this source.
Evidence: fonts.ts:113 (`accept(first, decl.value.trim(), 'declaration', decl.name)`)

### 5. Duplicate merge prefers local over web over declaration

`SOURCE_PRIORITY` at fonts.ts:63 maps each source to a numeric precedence (font-face: 2, google: 1, declaration: 0). The merge path in `accept()` at fonts.ts:94 compares priorities and keeps the higher-precedence source. Three new tests verify the three pairwise comparisons.
Evidence: fonts.ts:63 (SOURCE_PRIORITY), fonts.ts:94 (merge comparison), fonts.test.ts new precedence tests

### 6. System fonts (generic stacks) produce no file/URL emission requirement

System fonts are already excluded from detection by the `GENERIC_KEYWORDS` set at fonts.ts:32 -- `system-ui`, `sans-serif`, `serif`, `monospace`, etc. are stripped by `firstFamilyFromStack` and rejected by `accept()`. A declaration like `--font-sans: system-ui, sans-serif` produces no `DetectedFont` entry at all because every family in the stack is generic. This is existing behavior that the source field does not change.
Evidence: fonts.ts:32 (GENERIC_KEYWORDS), fonts.ts:82 (accept rejects generics), fonts.test.ts existing test "ignores var() references"

### 7. Existing tests updated to include source field in all expected outputs

All 14 existing test expectations in fonts.test.ts updated with the correct `source` value. Each test's expected output now includes `source: 'google'`, `source: 'font-face'`, or `source: 'declaration'` matching how the font was detected. Tests still verify name, stack, and sourceDeclName unchanged.
Evidence: fonts.test.ts (14 updated assertions)

### 8. Variable font detection from local files (filename heuristic)

Deferred -- this requires scanning `config.fonts.path` for actual font files on disk, which is a build-time concern that depends on the fonts config (#2049) being wired into the build pipeline. The detection layer (`detectFonts`) reads CSS source text, not the filesystem. Variable font detection belongs in a future font-file scanner that reads the fonts directory.
Evidence: not implemented, noted in "Not done"

### 9. Missing fonts path warns, does not throw

Deferred -- same reasoning as variable font detection. The `detectFonts` function does not read the filesystem; it parses CSS. The missing-path warning belongs in the build step that scans `config.fonts.path`, which does not exist yet.
Evidence: not implemented, noted in "Not done"

### 10. Web-to-local override emits warning event

Deferred -- requires the build to compare `config.fonts.imports` against detected `@font-face` sources, which depends on the build pipeline consuming `config.fonts`. The merge precedence logic (criterion 5) handles the detection-time half: when the same family appears from both Google and local, local wins. The warning event belongs in init's import flow when it reconciles detection results against `config.fonts.imports`.
Evidence: not implemented, noted in "Not done"

## Not done

Three criteria deferred because they are build-time/filesystem concerns, not detection-time concerns:
- Variable font detection from local files (#8) -- needs a font-file scanner over `config.fonts.path`
- Missing fonts path warning (#9) -- build-time, not detection-time
- Web-to-local override warning event (#10) -- init import flow, not font detection

All three depend on the build pipeline being wired to read `config.fonts`, which is #2052 (Studio API) territory. The detection layer is complete -- every `DetectedFont` carries its source and the merge logic is correct.

Closes #2051
