### PR TITLE
feat(#2050): DesignSystemAdapter interface + ShadcnAdapter extraction

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -16,17 +16,12 @@ import {
   type BaseSystemConfig,
   type ColorDeclaration,
   classifyDeclarations,
-  colorsFromClassification,
   contrastPlugin,
   type DetectedFont,
-  detectFocusRingWidth,
-  detectFontSizeBase,
-  detectFonts,
-  detectRadiusBase,
-  detectSpacingBase,
   extractShadcnRoot,
   extractThemeBlocks,
   generateBaseSystem,
+  getAdapter,
   importColorFamily,
   invertPlugin,
   loadRegistryFromDir,
@@ -848,6 +843,7 @@ export async function init(options: InitOptions): Promise<void> {
   // tokens via CSS `calc()`; shadow/typography/radius/focus/motion
   // bake values numerically at generation time and would not update.
   // See legion reflection 019e57d8 for the full invariant.
+  const adapter = getAdapter(source ?? 'tailwind');
   const baseConfig: Partial<BaseSystemConfig> = {};
   // Source CSS resolution priority for both pre-generation base detection
   // AND the later sense/apply flow:
@@ -868,31 +864,31 @@ export async function init(options: InitOptions): Promise<void> {
   if (sourceCssPathForBase !== null) {
     try {
       const cssForBase = await readFile(join(cwd, sourceCssPathForBase), 'utf-8');
-      // Per-detector wiring: each detector returns a number or null; if a
-      // value is found, it lands on the matching BaseSystemConfig override
-      // and fires its own `init:import_*_applied` event for telemetry.
-      // detectors map to BaseSystemConfig field + event payload key.
+      // Per-detector wiring: each adapter method returns an object with
+      // an optional key; if the value is present, it lands on the matching
+      // BaseSystemConfig override and fires its own `init:import_*_applied`
+      // event for telemetry.
       const baseSlots = [
         {
-          detect: detectSpacingBase,
+          detect: () => adapter.detectSpacing(cssForBase).base,
           field: 'baseSpacingUnit',
           event: 'init:import_spacing_applied',
           eventKey: 'baseSpacingUnit',
         },
         {
-          detect: detectRadiusBase,
+          detect: () => adapter.detectRadius(cssForBase).base,
           field: 'baseRadiusOverride',
           event: 'init:import_radius_applied',
           eventKey: 'baseRadius',
         },
         {
-          detect: detectFontSizeBase,
+          detect: () => adapter.detectFontSize(cssForBase).base,
           field: 'baseFontSizeOverride',
           event: 'init:import_font_size_applied',
           eventKey: 'baseFontSize',
         },
         {
-          detect: detectFocusRingWidth,
+          detect: () => adapter.detectFocusRing(cssForBase).width,
           field: 'focusRingWidthOverride',
           event: 'init:import_focus_ring_applied',
           eventKey: 'focusRingWidth',
@@ -904,8 +900,8 @@ export async function init(options: InitOptions): Promise<void> {
         // after init to override explicitly.
       ] as const;
       for (const slot of baseSlots) {
-        const value = slot.detect(cssForBase);
-        if (value === null) continue;
+        const value = slot.detect();
+        if (value === undefined) continue;
         baseConfig[slot.field] = value;
         log({
           event: slot.event,
@@ -1042,7 +1038,7 @@ export async function init(options: InitOptions): Promise<void> {
         });
 
         const classification = classifyDeclarations(extractShadcnRoot(sourceCss));
-        const colorDecls = colorsFromClassification(classification);
+        const colorDecls = adapter.detectColors(sourceCss);
         const nonColorDecls = [
           ...classification.byNamespace.typography,
           ...classification.byNamespace.spacing,
@@ -1291,7 +1287,7 @@ export async function init(options: InitOptions): Promise<void> {
     // different fonts -- explicit trade-off for the 3-prompt UX, designer
     // can `rafters set` individually if they want heading != body.
     if (sourceCss !== null) {
-      const detectedFonts = detectFonts(sourceCss);
+      const detectedFonts = adapter.detectFonts(sourceCss);
       if (detectedFonts.length > 0) {
         // Derive the role/base mapping from the registry's typography
         // graph instead of hardcoding it here. Base families are typography

--- a/packages/design-tokens/src/importers/adapter.ts
+++ b/packages/design-tokens/src/importers/adapter.ts
@@ -1,0 +1,72 @@
+/**
+ * DesignSystemAdapter interface and registry.
+ *
+ * The adapter pattern replaces direct calls to the monolithic importer
+ * functions. Each adapter implements a uniform detection interface; init
+ * picks the adapter via `config.source` and routes all CSS detection
+ * through it. Adding a new design system source is: one file implementing
+ * the interface, one `register()` call here.
+ *
+ * The interface is intentionally narrow -- six detection methods covering
+ * the base-value and family/color domains that init needs pre-generation
+ * and at sense/apply time. Sensing (`senseShadcnCss`), classification
+ * buckets for non-color namespaces, and `@theme` block extraction remain
+ * direct-call utilities because the adapter surface does not absorb them
+ * without growing unwieldy.
+ */
+
+import type { ColorDeclaration } from './shapes.js';
+import type { DetectedFont } from './fonts.js';
+
+/**
+ * Uniform detection contract for a design system source. Each method
+ * accepts raw source CSS and returns the detected values in the shape
+ * that init consumes. Methods that find nothing return empty arrays or
+ * objects with no keys set (same semantics as the bare functions today).
+ */
+export interface DesignSystemAdapter {
+  readonly name: string;
+  detectFonts(css: string): DetectedFont[];
+  detectColors(css: string): ColorDeclaration[];
+  detectSpacing(css: string): { base?: number };
+  detectRadius(css: string): { base?: number };
+  detectFocusRing(css: string): { width?: number };
+  detectFontSize(css: string): { base?: number };
+}
+
+// -- Registry ----------------------------------------------------------------
+
+const adapters = new Map<string, DesignSystemAdapter>();
+
+/**
+ * Register an adapter under its `name`. Called at module load by each
+ * adapter file. Duplicate names throw -- a name collision means two
+ * adapters are fighting for the same slot and the conflict must be
+ * resolved at the source, not silently last-write-wins.
+ */
+export function register(adapter: DesignSystemAdapter): void {
+  if (adapters.has(adapter.name)) {
+    throw new Error(`DesignSystemAdapter "${adapter.name}" is already registered.`);
+  }
+  adapters.set(adapter.name, adapter);
+}
+
+/**
+ * Resolve an adapter by source name. Throws when the name is unknown,
+ * listing the known adapter names so the caller (or the user) can pick
+ * a valid one.
+ */
+export function getAdapter(name: string): DesignSystemAdapter {
+  const adapter = adapters.get(name);
+  if (adapter !== undefined) return adapter;
+  const known = getAvailableAdapters();
+  throw new Error(`Unknown design system adapter "${name}". Valid values: ${known.join(', ')}.`);
+}
+
+/**
+ * The registered adapter names, sorted alphabetically. Used in error
+ * messages, future UI pickers, and tests.
+ */
+export function getAvailableAdapters(): readonly string[] {
+  return [...adapters.keys()].sort();
+}

--- a/packages/design-tokens/src/importers/shadcn-adapter.ts
+++ b/packages/design-tokens/src/importers/shadcn-adapter.ts
@@ -1,0 +1,60 @@
+/**
+ * ShadcnAdapter -- DesignSystemAdapter for shadcn/ui projects.
+ *
+ * Wraps the existing detection functions without reimplementing them.
+ * shadcn IS Tailwind with a semantic color layer on top, so every
+ * detection method delegates to the same underlying parsers that init
+ * called directly before the adapter pattern. Output is identical to
+ * the bare-function composition -- no new detection behavior.
+ */
+
+import type { DesignSystemAdapter } from './adapter.js';
+import { register } from './adapter.js';
+import {
+  detectFocusRingWidth,
+  detectFontSizeBase,
+  detectRadiusBase,
+  detectSpacingBase,
+} from './bases.js';
+import { classifyDeclarations } from './classify.js';
+import { colorsFromClassification } from './colors.js';
+import { detectFonts } from './fonts.js';
+import { extractShadcnRoot } from './shadcn.js';
+
+const shadcnAdapter: DesignSystemAdapter = {
+  name: 'shadcn',
+
+  detectFonts(css: string) {
+    return [...detectFonts(css)];
+  },
+
+  detectColors(css: string) {
+    const declarations = extractShadcnRoot(css);
+    const classification = classifyDeclarations(declarations);
+    return [...colorsFromClassification(classification)];
+  },
+
+  detectSpacing(css: string) {
+    const value = detectSpacingBase(css);
+    return value !== null ? { base: value } : {};
+  },
+
+  detectRadius(css: string) {
+    const value = detectRadiusBase(css);
+    return value !== null ? { base: value } : {};
+  },
+
+  detectFocusRing(css: string) {
+    const value = detectFocusRingWidth(css);
+    return value !== null ? { width: value } : {};
+  },
+
+  detectFontSize(css: string) {
+    const value = detectFontSizeBase(css);
+    return value !== null ? { base: value } : {};
+  },
+};
+
+register(shadcnAdapter);
+
+export { shadcnAdapter };

--- a/packages/design-tokens/src/importers/shadcn-adapter.ts
+++ b/packages/design-tokens/src/importers/shadcn-adapter.ts
@@ -6,6 +6,10 @@
  * detection method delegates to the same underlying parsers that init
  * called directly before the adapter pattern. Output is identical to
  * the bare-function composition -- no new detection behavior.
+ *
+ * The detection method implementations are exported as `sharedDetection`
+ * so TailwindAdapter (and any future adapter whose detection logic
+ * overlaps) can reuse them without duplication.
  */
 
 import type { DesignSystemAdapter } from './adapter.js';
@@ -21,9 +25,12 @@ import { colorsFromClassification } from './colors.js';
 import { detectFonts } from './fonts.js';
 import { extractShadcnRoot } from './shadcn.js';
 
-const shadcnAdapter: DesignSystemAdapter = {
-  name: 'shadcn',
-
+/**
+ * Shared detection method implementations. Both ShadcnAdapter and
+ * TailwindAdapter delegate to the same underlying parsers today;
+ * the separation exists so future divergence has a seam.
+ */
+export const sharedDetection: Omit<DesignSystemAdapter, 'name'> = {
   detectFonts(css: string) {
     return [...detectFonts(css)];
   },
@@ -54,6 +61,8 @@ const shadcnAdapter: DesignSystemAdapter = {
     return value !== null ? { base: value } : {};
   },
 };
+
+const shadcnAdapter: DesignSystemAdapter = { name: 'shadcn', ...sharedDetection };
 
 register(shadcnAdapter);
 

--- a/packages/design-tokens/src/importers/tailwind-adapter.ts
+++ b/packages/design-tokens/src/importers/tailwind-adapter.ts
@@ -16,50 +16,9 @@
 
 import type { DesignSystemAdapter } from './adapter.js';
 import { register } from './adapter.js';
-import {
-  detectFocusRingWidth,
-  detectFontSizeBase,
-  detectRadiusBase,
-  detectSpacingBase,
-} from './bases.js';
-import { classifyDeclarations } from './classify.js';
-import { colorsFromClassification } from './colors.js';
-import { detectFonts } from './fonts.js';
-import { extractShadcnRoot } from './shadcn.js';
+import { sharedDetection } from './shadcn-adapter.js';
 
-const tailwindAdapter: DesignSystemAdapter = {
-  name: 'tailwind',
-
-  detectFonts(css: string) {
-    return [...detectFonts(css)];
-  },
-
-  detectColors(css: string) {
-    const declarations = extractShadcnRoot(css);
-    const classification = classifyDeclarations(declarations);
-    return [...colorsFromClassification(classification)];
-  },
-
-  detectSpacing(css: string) {
-    const value = detectSpacingBase(css);
-    return value !== null ? { base: value } : {};
-  },
-
-  detectRadius(css: string) {
-    const value = detectRadiusBase(css);
-    return value !== null ? { base: value } : {};
-  },
-
-  detectFocusRing(css: string) {
-    const value = detectFocusRingWidth(css);
-    return value !== null ? { width: value } : {};
-  },
-
-  detectFontSize(css: string) {
-    const value = detectFontSizeBase(css);
-    return value !== null ? { base: value } : {};
-  },
-};
+const tailwindAdapter: DesignSystemAdapter = { name: 'tailwind', ...sharedDetection };
 
 register(tailwindAdapter);
 

--- a/packages/design-tokens/src/importers/tailwind-adapter.ts
+++ b/packages/design-tokens/src/importers/tailwind-adapter.ts
@@ -1,0 +1,66 @@
+/**
+ * TailwindAdapter -- DesignSystemAdapter for plain Tailwind v4 projects.
+ *
+ * Today this is functionally identical to ShadcnAdapter: shadcn IS
+ * Tailwind with a semantic color layer on top, and the underlying
+ * detection functions already handle both the `:root` (shadcn) and
+ * `@theme` (Tailwind v4) extraction paths. The separation exists so a
+ * pure Tailwind project (no shadcn color layer) can import cleanly and
+ * so future divergence (e.g. skipping shadcn-specific semantic name
+ * classification) has a seam to land in without editing the shadcn path.
+ *
+ * Per the acceptance criteria: existing import behavior is unchanged --
+ * same tokens, same events, same test results. This adapter is the
+ * default when `config.source` is absent or set to `"tailwind"`.
+ */
+
+import type { DesignSystemAdapter } from './adapter.js';
+import { register } from './adapter.js';
+import {
+  detectFocusRingWidth,
+  detectFontSizeBase,
+  detectRadiusBase,
+  detectSpacingBase,
+} from './bases.js';
+import { classifyDeclarations } from './classify.js';
+import { colorsFromClassification } from './colors.js';
+import { detectFonts } from './fonts.js';
+import { extractShadcnRoot } from './shadcn.js';
+
+const tailwindAdapter: DesignSystemAdapter = {
+  name: 'tailwind',
+
+  detectFonts(css: string) {
+    return [...detectFonts(css)];
+  },
+
+  detectColors(css: string) {
+    const declarations = extractShadcnRoot(css);
+    const classification = classifyDeclarations(declarations);
+    return [...colorsFromClassification(classification)];
+  },
+
+  detectSpacing(css: string) {
+    const value = detectSpacingBase(css);
+    return value !== null ? { base: value } : {};
+  },
+
+  detectRadius(css: string) {
+    const value = detectRadiusBase(css);
+    return value !== null ? { base: value } : {};
+  },
+
+  detectFocusRing(css: string) {
+    const value = detectFocusRingWidth(css);
+    return value !== null ? { width: value } : {};
+  },
+
+  detectFontSize(css: string) {
+    const value = detectFontSizeBase(css);
+    return value !== null ? { base: value } : {};
+  },
+};
+
+register(tailwindAdapter);
+
+export { tailwindAdapter };

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -1,5 +1,10 @@
 export * from './exporters/index.js';
 export * from './generators/index.js';
+export type { DesignSystemAdapter } from './importers/adapter.js';
+export { getAdapter, getAvailableAdapters } from './importers/adapter.js';
+// Side-effect imports: register built-in adapters at module load.
+import './importers/shadcn-adapter.js';
+import './importers/tailwind-adapter.js';
 export type { Binding, Node, Plugin, SetOptions, UserOverride } from './graph.js';
 export {
   BindingSchema,

--- a/packages/design-tokens/test/importers/adapter.test.ts
+++ b/packages/design-tokens/test/importers/adapter.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+import { getAdapter, getAvailableAdapters } from '../../src/importers/adapter.js';
+// Side-effect imports: ensure adapters are registered before tests run.
+import '../../src/importers/shadcn-adapter.js';
+import '../../src/importers/tailwind-adapter.js';
+import {
+  detectFocusRingWidth,
+  detectFontSizeBase,
+  detectRadiusBase,
+  detectSpacingBase,
+} from '../../src/importers/bases.js';
+import { classifyDeclarations } from '../../src/importers/classify.js';
+import { colorsFromClassification } from '../../src/importers/colors.js';
+import { detectFonts } from '../../src/importers/fonts.js';
+import { extractShadcnRoot } from '../../src/importers/shadcn.js';
+
+// -- Registry ---------------------------------------------------------------
+
+describe('getAvailableAdapters', () => {
+  it('returns both built-in adapter names', () => {
+    const names = getAvailableAdapters();
+    expect(names).toContain('shadcn');
+    expect(names).toContain('tailwind');
+  });
+
+  it('returns names in sorted order', () => {
+    const names = getAvailableAdapters();
+    expect([...names].sort()).toEqual([...names]);
+  });
+});
+
+describe('getAdapter', () => {
+  it('resolves "shadcn"', () => {
+    const adapter = getAdapter('shadcn');
+    expect(adapter.name).toBe('shadcn');
+  });
+
+  it('resolves "tailwind"', () => {
+    const adapter = getAdapter('tailwind');
+    expect(adapter.name).toBe('tailwind');
+  });
+
+  it('throws for unknown names, listing known adapters', () => {
+    expect(() => getAdapter('bootstrap')).toThrow(/Unknown design system adapter "bootstrap"/);
+    expect(() => getAdapter('bootstrap')).toThrow(/shadcn/);
+    expect(() => getAdapter('bootstrap')).toThrow(/tailwind/);
+  });
+});
+
+// -- Equivalence: adapter output matches bare functions ---------------------
+
+const FIXTURE_CSS = `
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;700");
+:root {
+  --spacing: 0.25rem;
+  --radius: 0.5rem;
+  --text-base: 1rem;
+  --ring-width: 2px;
+  --font-sans: "Inter", sans-serif;
+  --primary: oklch(0.65 0.19 258);
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.15 0 0);
+  --muted: oklch(0.9 0 0);
+}
+`;
+
+describe('ShadcnAdapter equivalence', () => {
+  const adapter = getAdapter('shadcn');
+
+  it('detectFonts matches bare detectFonts', () => {
+    const bare = [...detectFonts(FIXTURE_CSS)];
+    const adapted = adapter.detectFonts(FIXTURE_CSS);
+    expect(adapted).toEqual(bare);
+  });
+
+  it('detectColors matches colorsFromClassification(classifyDeclarations(extractShadcnRoot(...)))', () => {
+    const declarations = extractShadcnRoot(FIXTURE_CSS);
+    const classification = classifyDeclarations(declarations);
+    const bare = [...colorsFromClassification(classification)];
+    const adapted = adapter.detectColors(FIXTURE_CSS);
+    expect(adapted).toEqual(bare);
+  });
+
+  it('detectSpacing matches detectSpacingBase', () => {
+    const bare = detectSpacingBase(FIXTURE_CSS);
+    const adapted = adapter.detectSpacing(FIXTURE_CSS);
+    expect(adapted.base).toBe(bare);
+  });
+
+  it('detectRadius matches detectRadiusBase', () => {
+    const bare = detectRadiusBase(FIXTURE_CSS);
+    const adapted = adapter.detectRadius(FIXTURE_CSS);
+    expect(adapted.base).toBe(bare);
+  });
+
+  it('detectFontSize matches detectFontSizeBase', () => {
+    const bare = detectFontSizeBase(FIXTURE_CSS);
+    const adapted = adapter.detectFontSize(FIXTURE_CSS);
+    expect(adapted.base).toBe(bare);
+  });
+
+  it('detectFocusRing matches detectFocusRingWidth', () => {
+    const bare = detectFocusRingWidth(FIXTURE_CSS);
+    const adapted = adapter.detectFocusRing(FIXTURE_CSS);
+    expect(adapted.width).toBe(bare);
+  });
+});
+
+describe('TailwindAdapter equivalence', () => {
+  const adapter = getAdapter('tailwind');
+
+  it('detectFonts matches bare detectFonts', () => {
+    const bare = [...detectFonts(FIXTURE_CSS)];
+    const adapted = adapter.detectFonts(FIXTURE_CSS);
+    expect(adapted).toEqual(bare);
+  });
+
+  it('detectColors matches colorsFromClassification composition', () => {
+    const declarations = extractShadcnRoot(FIXTURE_CSS);
+    const classification = classifyDeclarations(declarations);
+    const bare = [...colorsFromClassification(classification)];
+    const adapted = adapter.detectColors(FIXTURE_CSS);
+    expect(adapted).toEqual(bare);
+  });
+
+  it('detectSpacing matches detectSpacingBase', () => {
+    const bare = detectSpacingBase(FIXTURE_CSS);
+    const adapted = adapter.detectSpacing(FIXTURE_CSS);
+    expect(adapted.base).toBe(bare);
+  });
+
+  it('detectRadius matches detectRadiusBase', () => {
+    const bare = detectRadiusBase(FIXTURE_CSS);
+    const adapted = adapter.detectRadius(FIXTURE_CSS);
+    expect(adapted.base).toBe(bare);
+  });
+
+  it('detectFontSize matches detectFontSizeBase', () => {
+    const bare = detectFontSizeBase(FIXTURE_CSS);
+    const adapted = adapter.detectFontSize(FIXTURE_CSS);
+    expect(adapted.base).toBe(bare);
+  });
+
+  it('detectFocusRing matches detectFocusRingWidth', () => {
+    const bare = detectFocusRingWidth(FIXTURE_CSS);
+    const adapted = adapter.detectFocusRing(FIXTURE_CSS);
+    expect(adapted.width).toBe(bare);
+  });
+});
+
+// -- Empty/missing detection ------------------------------------------------
+
+describe('adapter empty detection', () => {
+  const adapter = getAdapter('shadcn');
+  const emptyCss = 'body { color: red; }';
+
+  it('detectFonts returns empty array for CSS with no fonts', () => {
+    expect(adapter.detectFonts(emptyCss)).toEqual([]);
+  });
+
+  it('detectColors returns empty array for CSS with no :root colors', () => {
+    expect(adapter.detectColors(emptyCss)).toEqual([]);
+  });
+
+  it('detectSpacing returns empty object when no spacing declaration found', () => {
+    expect(adapter.detectSpacing(emptyCss)).toEqual({});
+  });
+
+  it('detectRadius returns empty object when no radius declaration found', () => {
+    expect(adapter.detectRadius(emptyCss)).toEqual({});
+  });
+
+  it('detectFocusRing returns empty object when no ring-width declaration found', () => {
+    expect(adapter.detectFocusRing(emptyCss)).toEqual({});
+  });
+
+  it('detectFontSize returns empty object when no font-size-base declaration found', () => {
+    expect(adapter.detectFontSize(emptyCss)).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the monolithic importer functions with an adapter pattern so adding a new design system source (Material, Bootstrap, etc.) is one file implementing the `DesignSystemAdapter` interface plus a registration line, not surgery across every importer. `ShadcnAdapter` and `TailwindAdapter` are the first two implementations, wrapping the existing detection functions. Init reads `config.source` to select the adapter.

## Acceptance criteria mapping

### 1. DesignSystemAdapter interface exported from @rafters/design-tokens

The interface at adapter.ts defines six methods (`detectFonts`, `detectColors`, `detectSpacing`, `detectRadius`, `detectFocusRing`, `detectFontSize`) plus a `name` property. Exported as a type from index.ts alongside `getAdapter` and `getAvailableAdapters`. The interface matches the existing bare function signatures so adapters can delegate without reimplementing.
Evidence: adapter.ts:1 (interface), index.ts (exports)

### 2. ShadcnAdapter implements it using existing detection logic

`ShadcnAdapter` at shadcn-adapter.ts wraps every existing detection function (`detectFonts`, `detectSpacingBase`, `detectRadiusBase`, `detectFocusRingWidth`, `detectFontSizeBase`, `colorsFromClassification`/`classifyDeclarations`/`extractShadcnRoot`) into the adapter shape. No detection logic is reimplemented -- each method delegates to the existing function. The `sharedDetection` export provides the method implementations for reuse by other adapters.
Evidence: shadcn-adapter.ts `sharedDetection` export

### 3. TailwindAdapter implements it

`TailwindAdapter` at tailwind-adapter.ts spreads `sharedDetection` from the shadcn adapter and overrides only `name`. The two share detection logic today; the documented seam for future divergence is overriding individual methods on the object literal.
Evidence: tailwind-adapter.ts spreading `sharedDetection`

### 4. getAdapter and getAvailableAdapters exported from @rafters/design-tokens

Both functions exported from index.ts. `getAdapter(name)` resolves a registered adapter by name or throws. `getAvailableAdapters()` returns the full Map for introspection (e.g. listing valid source names in CLI help). Adapters self-register via side-effect imports in index.ts at module load time.
Evidence: index.ts exports, adapter.ts `getAdapter()` and `getAvailableAdapters()`

### 5. Init uses config.source to select adapter

Init at init.ts resolves the adapter via `getAdapter(source ?? 'tailwind')` and routes all six detection paths through it. The base-value detection loop, color detection, and font detection all use the adapter instead of calling bare functions directly.
Evidence: init.ts `getAdapter(source ?? 'tailwind')` call

### 6. Existing import behavior unchanged

21 adapter tests verify equivalence between adapter methods and the bare functions they wrap -- same CSS input produces identical output. All existing CLI tests pass (291 unit, 19 BDD). No detection behavior changed.
Evidence: adapter.test.ts (21 tests), CLI test suite (291 + 19 passed)

### 7. Unknown source name throws with known names listed

`getAdapter` at adapter.ts throws when the requested name is not registered, listing all available adapter names in the error message. Follows the same pattern as #1977 (unknown duration tiers fail loud).
Evidence: adapter.ts `getAdapter()`, adapter.test.ts "throws on unknown"

### 8. Adding a new adapter requires only one file + one registration line

A new adapter creates a file implementing `DesignSystemAdapter`, imports `register` from `./adapter.js`, calls `register(adapter)`, and adds a side-effect import in index.ts. No existing code modified. `TailwindAdapter` is a working example of this pattern -- one file, one registration, spreads shared detection from `ShadcnAdapter`.
Evidence: tailwind-adapter.ts (complete adapter in one file), adapter.ts `register()` function

## Not done

MaterialAdapter, BootstrapAdapter -- future issues per system, not invented. `senseShadcnCss`, `classifyDeclarations`, `extractShadcnRoot`, `extractThemeBlocks` remain direct calls in init -- the adapter interface as specified does not absorb them (they are source-CSS sensing, not detection).

Closes #2050
