### PR TITLE
feat(#2052): Studio API intent and fonts HMR endpoints

### DIFF
--- a/packages/studio/src/api/index.ts
+++ b/packages/studio/src/api/index.ts
@@ -18,6 +18,49 @@ interface SetTokenOptions {
 
 type UpdateResult = { ok: true; name: string; persisted: boolean } | { ok: false; error: string };
 
+// ============================================================================
+// Config channel types
+// ============================================================================
+
+/** Font file locations and web font imports. */
+export interface FontsConfig {
+  path?: string | null;
+  imports?: string[];
+}
+
+/** Full config.rafters.json shape as returned by getConfig. */
+export interface RaftersConfig {
+  framework?: string;
+  registryUrl?: string;
+  componentTarget?: string;
+  componentsPath?: string | string[];
+  primitivesPath?: string | string[];
+  compositesPath?: string | string[];
+  rulesPath?: string | string[];
+  cssPath?: string | null;
+  source?: string;
+  exports?: Record<string, boolean>;
+  darkMode?: 'class' | 'media';
+  intent?: string;
+  fonts?: FontsConfig;
+  installed?: Record<string, string[]>;
+}
+
+export interface SetIntentOptions {
+  intent: string;
+}
+
+export interface SetFontsOptions {
+  path?: string | null;
+  imports?: string[];
+}
+
+export type ConfigResult = { ok: true; config: RaftersConfig } | { ok: false; error: string };
+
+export type IntentResult = { ok: true; intent: string } | { ok: false; error: string };
+
+export type FontsResult = { ok: true; fonts: FontsConfig } | { ok: false; error: string };
+
 const TOKEN_UPDATE_TIMEOUT_MS = 10_000;
 
 /**
@@ -104,4 +147,128 @@ export function onCssUpdated(callback: () => void): () => void {
   const hot = import.meta.hot!;
   hot.on('rafters:css-updated', callback);
   return () => hot.off('rafters:css-updated', callback);
+}
+
+/**
+ * Read the current config.rafters.json from the Vite plugin.
+ */
+export function getConfig(): Promise<ConfigResult> {
+  return new Promise((resolve) => {
+    if (!isHmrAvailable()) {
+      console.warn('[rafters] getConfig called but HMR is not available');
+      resolve({ ok: false, error: 'HMR not available' });
+      return;
+    }
+
+    // biome-ignore lint/style/noNonNullAssertion: checked by isHmrAvailable
+    const hot = import.meta.hot!;
+    // oxlint-disable-next-line prefer-const -- assigned below but captured by the cleanup closure first (forward reference)
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    const cleanup = () => {
+      clearTimeout(timeoutId);
+      hot.off('rafters:config', handler);
+    };
+
+    const handler = (result: ConfigResult) => {
+      cleanup();
+      resolve(result);
+    };
+
+    timeoutId = setTimeout(() => {
+      cleanup();
+      resolve({ ok: false, error: `Config read timed out after ${TOKEN_UPDATE_TIMEOUT_MS}ms` });
+    }, TOKEN_UPDATE_TIMEOUT_MS);
+
+    hot.on('rafters:config', handler);
+    hot.send('rafters:get-config', {});
+  });
+}
+
+/**
+ * Write an intent name to config.rafters.json.
+ *
+ * Only known intent names are accepted; unknown names are rejected with the
+ * known list. The caller (Studio UI) sequences token writes after the config
+ * write -- this channel does not regenerate tokens.
+ */
+export function setIntent(options: SetIntentOptions): Promise<IntentResult> {
+  return new Promise((resolve) => {
+    if (!isHmrAvailable()) {
+      console.warn('[rafters] setIntent called but HMR is not available');
+      resolve({ ok: false, error: 'HMR not available' });
+      return;
+    }
+
+    // biome-ignore lint/style/noNonNullAssertion: checked by isHmrAvailable
+    const hot = import.meta.hot!;
+    // oxlint-disable-next-line prefer-const -- assigned below but captured by the cleanup closure first (forward reference)
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    const cleanup = () => {
+      clearTimeout(timeoutId);
+      hot.off('rafters:intent-updated', handler);
+    };
+
+    const handler = (result: IntentResult) => {
+      // Match response to our request by intent, or accept any error
+      if ((result.ok && result.intent === options.intent) || !result.ok) {
+        cleanup();
+        resolve(result);
+      }
+    };
+
+    timeoutId = setTimeout(() => {
+      cleanup();
+      resolve({
+        ok: false,
+        error: `Intent update timed out after ${TOKEN_UPDATE_TIMEOUT_MS}ms`,
+      });
+    }, TOKEN_UPDATE_TIMEOUT_MS);
+
+    hot.on('rafters:intent-updated', handler);
+    hot.send('rafters:set-intent', options);
+  });
+}
+
+/**
+ * Update the fonts config in config.rafters.json.
+ *
+ * Does NOT regenerate tokens -- fonts path/imports are build config, not token
+ * values. Font role assignments are handled separately via setToken.
+ */
+export function setFonts(options: SetFontsOptions): Promise<FontsResult> {
+  return new Promise((resolve) => {
+    if (!isHmrAvailable()) {
+      console.warn('[rafters] setFonts called but HMR is not available');
+      resolve({ ok: false, error: 'HMR not available' });
+      return;
+    }
+
+    // biome-ignore lint/style/noNonNullAssertion: checked by isHmrAvailable
+    const hot = import.meta.hot!;
+    // oxlint-disable-next-line prefer-const -- assigned below but captured by the cleanup closure first (forward reference)
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    const cleanup = () => {
+      clearTimeout(timeoutId);
+      hot.off('rafters:fonts-updated', handler);
+    };
+
+    const handler = (result: FontsResult) => {
+      cleanup();
+      resolve(result);
+    };
+
+    timeoutId = setTimeout(() => {
+      cleanup();
+      resolve({
+        ok: false,
+        error: `Fonts update timed out after ${TOKEN_UPDATE_TIMEOUT_MS}ms`,
+      });
+    }, TOKEN_UPDATE_TIMEOUT_MS);
+
+    hot.on('rafters:fonts-updated', handler);
+    hot.send('rafters:set-fonts', options);
+  });
 }

--- a/packages/studio/src/api/vite-plugin.ts
+++ b/packages/studio/src/api/vite-plugin.ts
@@ -76,42 +76,45 @@ const outputDir = join(projectPath, '.rafters', 'output');
 const configPath = join(projectPath, '.rafters', 'config.rafters.json');
 
 // ============================================================================
-// Config types (local mirrors -- studio does not import from @rafters/cli)
+// Config schemas and types (local mirrors -- studio does not import from @rafters/cli)
+// Zod validates external data from config.rafters.json per repo invariant.
 // ============================================================================
 
-/** Font file locations and web font imports. */
-export interface FontsConfig {
-  path?: string | null;
-  imports?: string[];
-}
+/** Zod schema for font file locations and web font imports. */
+export const FontsConfigSchema = z.object({
+  path: z.union([z.string(), z.null()]).optional(),
+  imports: z.array(z.string()).optional(),
+});
+export type FontsConfig = z.infer<typeof FontsConfigSchema>;
 
-/** Full config.rafters.json shape. Only the fields Studio reads/writes. */
-export interface RaftersConfig {
-  framework?: string;
-  registryUrl?: string;
-  componentTarget?: string;
-  componentsPath?: string | string[];
-  primitivesPath?: string | string[];
-  compositesPath?: string | string[];
-  rulesPath?: string | string[];
-  cssPath?: string | null;
-  source?: string;
-  exports?: Record<string, boolean>;
-  darkMode?: 'class' | 'media';
-  intent?: string;
-  fonts?: FontsConfig;
-  installed?: Record<string, string[]>;
-}
+/**
+ * Permissive schema for config.rafters.json. Uses passthrough so unknown
+ * fields (framework, installed, etc.) survive the parse and are returned
+ * to the client by getConfig.
+ */
+export const RaftersConfigSchema = z
+  .object({
+    intent: z.string().optional(),
+    fonts: FontsConfigSchema.optional(),
+    source: z.string().optional(),
+    darkMode: z.enum(['class', 'media']).optional(),
+    framework: z.string().optional(),
+    cssPath: z.union([z.string(), z.null()]).optional(),
+    exports: z.record(z.string(), z.boolean()).optional(),
+  })
+  .passthrough();
+export type RaftersConfig = z.infer<typeof RaftersConfigSchema>;
 
 /** Intent names Studio knows how to resolve. */
 export const KNOWN_INTENTS = ['efficient'] as const;
 export type KnownIntent = (typeof KNOWN_INTENTS)[number];
 
 /**
- * Read config.rafters.json with shadcn->source migration applied.
- * Returns null when the file cannot be read.
+ * Read config.rafters.json with shadcn->source migration and Zod
+ * validation applied. Returns null when the file cannot be read or
+ * fails validation.
  */
-export async function readRaftersConfig(): Promise<Record<string, unknown> | null> {
+export async function readRaftersConfig(): Promise<RaftersConfig | null> {
   try {
     const raw = JSON.parse(await readFile(configPath, 'utf8')) as Record<string, unknown>;
     // shadcn -> source migration (#2049)
@@ -119,7 +122,12 @@ export async function readRaftersConfig(): Promise<Record<string, unknown> | nul
       if (raw.shadcn === true) raw.source = 'shadcn';
       delete raw.shadcn;
     }
-    return raw;
+    const result = RaftersConfigSchema.safeParse(raw);
+    if (!result.success) {
+      console.log(`[rafters] Config validation failed: ${result.error.message}`);
+      return null;
+    }
+    return result.data;
   } catch {
     return null;
   }
@@ -890,18 +898,15 @@ export function studioApiPlugin(): Plugin {
 
       // Listen for config reads from client
       server.ws.on('rafters:get-config', async (_rawData: unknown, client) => {
-        const raw = await readRaftersConfig();
-        if (!raw) {
+        const config = await readRaftersConfig();
+        if (!config) {
           client.send('rafters:config', {
             ok: false,
             error: `config not found at ${configPath}`,
           });
           return;
         }
-        client.send('rafters:config', {
-          ok: true,
-          config: raw as RaftersConfig,
-        });
+        client.send('rafters:config', { ok: true, config });
       });
 
       // Listen for intent updates from client
@@ -922,8 +927,8 @@ export function studioApiPlugin(): Plugin {
           return;
         }
 
-        const raw = await readRaftersConfig();
-        if (!raw) {
+        const config = await readRaftersConfig();
+        if (!config) {
           client.send('rafters:intent-updated', {
             ok: false,
             error: `config not found at ${configPath}`,
@@ -931,9 +936,9 @@ export function studioApiPlugin(): Plugin {
           return;
         }
 
-        raw.intent = intent;
+        const updated = { ...config, intent };
         try {
-          await writeFile(configPath, JSON.stringify(raw, null, 2));
+          await writeFile(configPath, JSON.stringify(updated, null, 2));
           client.send('rafters:intent-updated', { ok: true, intent });
         } catch (error) {
           console.log(`[rafters] Intent update failed: ${error}`);
@@ -943,12 +948,7 @@ export function studioApiPlugin(): Plugin {
 
       // Listen for fonts config updates from client
       server.ws.on('rafters:set-fonts', async (rawData: unknown, client) => {
-        const parsed = z
-          .object({
-            path: z.union([z.string(), z.null()]).optional(),
-            imports: z.array(z.string()).optional(),
-          })
-          .safeParse(rawData);
+        const parsed = FontsConfigSchema.safeParse(rawData);
         if (!parsed.success) {
           client.send('rafters:fonts-updated', {
             ok: false,
@@ -964,8 +964,8 @@ export function studioApiPlugin(): Plugin {
           return;
         }
 
-        const raw = await readRaftersConfig();
-        if (!raw) {
+        const config = await readRaftersConfig();
+        if (!config) {
           client.send('rafters:fonts-updated', {
             ok: false,
             error: `config not found at ${configPath}`,
@@ -973,22 +973,17 @@ export function studioApiPlugin(): Plugin {
           return;
         }
 
-        // Build the fonts object, avoiding undefined values (exactOptionalPropertyTypes)
-        const fonts: Record<string, unknown> = {};
+        // Merge incoming fonts over existing, preserving fields not in the patch.
+        // undefined means "leave alone"; explicit null or value means "set".
+        const existing = config.fonts ?? {};
+        const fonts: FontsConfig = { ...existing };
         if (fontsData.path !== undefined) fonts.path = fontsData.path;
-        else if ((raw.fonts as Record<string, unknown> | undefined)?.path !== undefined)
-          fonts.path = (raw.fonts as Record<string, unknown>).path;
         if (fontsData.imports !== undefined) fonts.imports = fontsData.imports;
-        else if ((raw.fonts as Record<string, unknown> | undefined)?.imports !== undefined)
-          fonts.imports = (raw.fonts as Record<string, unknown>).imports;
 
-        raw.fonts = fonts;
+        const updated = { ...config, fonts };
         try {
-          await writeFile(configPath, JSON.stringify(raw, null, 2));
-          client.send('rafters:fonts-updated', {
-            ok: true,
-            fonts: fonts as FontsConfig,
-          });
+          await writeFile(configPath, JSON.stringify(updated, null, 2));
+          client.send('rafters:fonts-updated', { ok: true, fonts });
         } catch (error) {
           console.log(`[rafters] Fonts update failed: ${error}`);
           client.send('rafters:fonts-updated', { ok: false, error: String(error) });

--- a/packages/studio/src/api/vite-plugin.ts
+++ b/packages/studio/src/api/vite-plugin.ts
@@ -9,8 +9,8 @@
  * Use `persist: true` (default) when enrichment is complete.
  */
 
-import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { readFile, writeFile } from 'node:fs/promises';
+import { isAbsolute, join } from 'node:path';
 import { buildColorValue, rebakeAccessibility } from '@rafters/color-utils';
 import {
   contrastPlugin,
@@ -75,6 +75,77 @@ const projectPath = process.env.RAFTERS_PROJECT_PATH || process.cwd();
 const outputDir = join(projectPath, '.rafters', 'output');
 const configPath = join(projectPath, '.rafters', 'config.rafters.json');
 
+// ============================================================================
+// Config types (local mirrors -- studio does not import from @rafters/cli)
+// ============================================================================
+
+/** Font file locations and web font imports. */
+export interface FontsConfig {
+  path?: string | null;
+  imports?: string[];
+}
+
+/** Full config.rafters.json shape. Only the fields Studio reads/writes. */
+export interface RaftersConfig {
+  framework?: string;
+  registryUrl?: string;
+  componentTarget?: string;
+  componentsPath?: string | string[];
+  primitivesPath?: string | string[];
+  compositesPath?: string | string[];
+  rulesPath?: string | string[];
+  cssPath?: string | null;
+  source?: string;
+  exports?: Record<string, boolean>;
+  darkMode?: 'class' | 'media';
+  intent?: string;
+  fonts?: FontsConfig;
+  installed?: Record<string, string[]>;
+}
+
+/** Intent names Studio knows how to resolve. */
+export const KNOWN_INTENTS = ['efficient'] as const;
+export type KnownIntent = (typeof KNOWN_INTENTS)[number];
+
+/**
+ * Read config.rafters.json with shadcn->source migration applied.
+ * Returns null when the file cannot be read.
+ */
+export async function readRaftersConfig(): Promise<Record<string, unknown> | null> {
+  try {
+    const raw = JSON.parse(await readFile(configPath, 'utf8')) as Record<string, unknown>;
+    // shadcn -> source migration (#2049)
+    if ('shadcn' in raw && !('source' in raw)) {
+      if (raw.shadcn === true) raw.source = 'shadcn';
+      delete raw.shadcn;
+    }
+    return raw;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validate that a fonts path is relative (or null/undefined).
+ * Returns an error string if invalid, null if valid.
+ */
+export function validateFontsPath(path: string | null | undefined): string | null {
+  if (path === null || path === undefined) return null;
+  if (isAbsolute(path)) return 'fonts path must be relative';
+  return null;
+}
+
+/**
+ * Validate an intent name against known intents.
+ * Returns an error string if invalid, null if valid.
+ */
+export function validateIntent(intent: string): string | null {
+  if (!(KNOWN_INTENTS as readonly string[]).includes(intent)) {
+    return `unknown intent "${intent}". Known: ${KNOWN_INTENTS.join(', ')}`;
+  }
+  return null;
+}
+
 /**
  * The slice of config.rafters.json the regen path needs: which outputs to emit
  * and the component paths the compiled sheet scans. Read fresh on each regen so
@@ -96,16 +167,8 @@ interface StudioConfig {
 }
 
 async function loadStudioConfig(): Promise<StudioConfig | null> {
-  try {
-    const raw = JSON.parse(await readFile(configPath, 'utf8')) as Record<string, unknown>;
-    if ('shadcn' in raw && !('source' in raw)) {
-      if (raw.shadcn === true) raw.source = 'shadcn';
-      delete raw.shadcn;
-    }
-    return raw as unknown as StudioConfig;
-  } catch {
-    return null;
-  }
+  const raw = await readRaftersConfig();
+  return raw as unknown as StudioConfig | null;
 }
 
 // Zod schema for incoming WebSocket messages
@@ -822,6 +885,113 @@ export function studioApiPlugin(): Plugin {
         } catch (error) {
           console.log(`[rafters] Token update failed for "${data.name}": ${error}`);
           client.send('rafters:token-updated', { ok: false, error: String(error) });
+        }
+      });
+
+      // Listen for config reads from client
+      server.ws.on('rafters:get-config', async (_rawData: unknown, client) => {
+        const raw = await readRaftersConfig();
+        if (!raw) {
+          client.send('rafters:config', {
+            ok: false,
+            error: `config not found at ${configPath}`,
+          });
+          return;
+        }
+        client.send('rafters:config', {
+          ok: true,
+          config: raw as RaftersConfig,
+        });
+      });
+
+      // Listen for intent updates from client
+      server.ws.on('rafters:set-intent', async (rawData: unknown, client) => {
+        const parsed = z.object({ intent: z.string().min(1) }).safeParse(rawData);
+        if (!parsed.success) {
+          client.send('rafters:intent-updated', {
+            ok: false,
+            error: `Invalid message: ${parsed.error.message}`,
+          });
+          return;
+        }
+
+        const { intent } = parsed.data;
+        const intentError = validateIntent(intent);
+        if (intentError) {
+          client.send('rafters:intent-updated', { ok: false, error: intentError });
+          return;
+        }
+
+        const raw = await readRaftersConfig();
+        if (!raw) {
+          client.send('rafters:intent-updated', {
+            ok: false,
+            error: `config not found at ${configPath}`,
+          });
+          return;
+        }
+
+        raw.intent = intent;
+        try {
+          await writeFile(configPath, JSON.stringify(raw, null, 2));
+          client.send('rafters:intent-updated', { ok: true, intent });
+        } catch (error) {
+          console.log(`[rafters] Intent update failed: ${error}`);
+          client.send('rafters:intent-updated', { ok: false, error: String(error) });
+        }
+      });
+
+      // Listen for fonts config updates from client
+      server.ws.on('rafters:set-fonts', async (rawData: unknown, client) => {
+        const parsed = z
+          .object({
+            path: z.union([z.string(), z.null()]).optional(),
+            imports: z.array(z.string()).optional(),
+          })
+          .safeParse(rawData);
+        if (!parsed.success) {
+          client.send('rafters:fonts-updated', {
+            ok: false,
+            error: `Invalid message: ${parsed.error.message}`,
+          });
+          return;
+        }
+
+        const fontsData = parsed.data;
+        const pathError = validateFontsPath(fontsData.path);
+        if (pathError) {
+          client.send('rafters:fonts-updated', { ok: false, error: pathError });
+          return;
+        }
+
+        const raw = await readRaftersConfig();
+        if (!raw) {
+          client.send('rafters:fonts-updated', {
+            ok: false,
+            error: `config not found at ${configPath}`,
+          });
+          return;
+        }
+
+        // Build the fonts object, avoiding undefined values (exactOptionalPropertyTypes)
+        const fonts: Record<string, unknown> = {};
+        if (fontsData.path !== undefined) fonts.path = fontsData.path;
+        else if ((raw.fonts as Record<string, unknown> | undefined)?.path !== undefined)
+          fonts.path = (raw.fonts as Record<string, unknown>).path;
+        if (fontsData.imports !== undefined) fonts.imports = fontsData.imports;
+        else if ((raw.fonts as Record<string, unknown> | undefined)?.imports !== undefined)
+          fonts.imports = (raw.fonts as Record<string, unknown>).imports;
+
+        raw.fonts = fonts;
+        try {
+          await writeFile(configPath, JSON.stringify(raw, null, 2));
+          client.send('rafters:fonts-updated', {
+            ok: true,
+            fonts: fonts as FontsConfig,
+          });
+        } catch (error) {
+          console.log(`[rafters] Fonts update failed: ${error}`);
+          client.send('rafters:fonts-updated', { ok: false, error: String(error) });
         }
       });
 

--- a/packages/studio/test/api/client-api.test.ts
+++ b/packages/studio/test/api/client-api.test.ts
@@ -83,4 +83,81 @@ describe('Client API', () => {
       expect(error.error).toBe('Something went wrong');
     });
   });
+
+  describe('getConfig without HMR', () => {
+    it('exports getConfig function', async () => {
+      const module = await import('../../src/api/index');
+      expect(typeof module.getConfig).toBe('function');
+    });
+
+    it('returns error result when HMR not available', async () => {
+      const { getConfig } = await import('../../src/api/index');
+      const result = await getConfig();
+      expect(result).toEqual({ ok: false, error: 'HMR not available' });
+    });
+  });
+
+  describe('setIntent without HMR', () => {
+    it('exports setIntent function', async () => {
+      const module = await import('../../src/api/index');
+      expect(typeof module.setIntent).toBe('function');
+    });
+
+    it('returns error result when HMR not available', async () => {
+      const { setIntent } = await import('../../src/api/index');
+      const result = await setIntent({ intent: 'efficient' });
+      expect(result).toEqual({ ok: false, error: 'HMR not available' });
+    });
+  });
+
+  describe('setFonts without HMR', () => {
+    it('exports setFonts function', async () => {
+      const module = await import('../../src/api/index');
+      expect(typeof module.setFonts).toBe('function');
+    });
+
+    it('returns error result when HMR not available', async () => {
+      const { setFonts } = await import('../../src/api/index');
+      const result = await setFonts({ path: './fonts' });
+      expect(result).toEqual({ ok: false, error: 'HMR not available' });
+    });
+
+    it('accepts null path', async () => {
+      const { setFonts } = await import('../../src/api/index');
+      const result = await setFonts({ path: null });
+      expect(result.ok).toBe(false);
+    });
+
+    it('accepts imports array', async () => {
+      const { setFonts } = await import('../../src/api/index');
+      const result = await setFonts({
+        imports: ['https://fonts.googleapis.com/css2?family=Inter'],
+      });
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe('ConfigResult type', () => {
+    it('success result has config field', () => {
+      const success = { ok: true as const, config: { intent: 'efficient' } };
+      expect(success.ok).toBe(true);
+      expect(success.config.intent).toBe('efficient');
+    });
+  });
+
+  describe('IntentResult type', () => {
+    it('success result has intent field', () => {
+      const success = { ok: true as const, intent: 'efficient' };
+      expect(success.ok).toBe(true);
+      expect(success.intent).toBe('efficient');
+    });
+  });
+
+  describe('FontsResult type', () => {
+    it('success result has fonts field', () => {
+      const success = { ok: true as const, fonts: { path: './fonts', imports: [] } };
+      expect(success.ok).toBe(true);
+      expect(success.fonts.path).toBe('./fonts');
+    });
+  });
 });

--- a/packages/studio/test/api/vite-plugin.test.ts
+++ b/packages/studio/test/api/vite-plugin.test.ts
@@ -25,8 +25,11 @@ import {
   handleGetTokens,
   handlePostToken,
   handlePostTokens,
+  KNOWN_INTENTS,
   studioApiPlugin,
   TokenPatchSchema,
+  validateFontsPath,
+  validateIntent,
 } from '../../src/api/vite-plugin';
 
 // Replicate schemas from vite-plugin.ts to test validation logic
@@ -2092,5 +2095,48 @@ describe('studioApiPlugin', () => {
       expect(readFileSync(varsPath, 'utf-8')).toBe('original');
       expect(wsSent).not.toContainEqual({ type: 'custom', event: 'rafters:css-updated' });
     });
+  });
+});
+
+describe('Intent validation', () => {
+  it('accepts known intent "efficient"', () => {
+    expect(validateIntent('efficient')).toBeNull();
+  });
+
+  it('rejects unknown intent with descriptive error', () => {
+    const error = validateIntent('fancy');
+    expect(error).toBe('unknown intent "fancy". Known: efficient');
+  });
+
+  it('rejects empty string', () => {
+    const error = validateIntent('');
+    expect(error).toContain('unknown intent');
+  });
+
+  it('KNOWN_INTENTS contains efficient', () => {
+    expect(KNOWN_INTENTS).toContain('efficient');
+  });
+});
+
+describe('Fonts path validation', () => {
+  it('accepts relative path', () => {
+    expect(validateFontsPath('./fonts')).toBeNull();
+  });
+
+  it('accepts relative path without dot prefix', () => {
+    expect(validateFontsPath('fonts/inter')).toBeNull();
+  });
+
+  it('accepts null (explicit clear)', () => {
+    expect(validateFontsPath(null)).toBeNull();
+  });
+
+  it('accepts undefined', () => {
+    expect(validateFontsPath(undefined)).toBeNull();
+  });
+
+  it('rejects absolute path', () => {
+    const error = validateFontsPath('/usr/share/fonts');
+    expect(error).toBe('fonts path must be relative');
   });
 });


### PR DESCRIPTION
## Summary

Adds three HMR endpoints to the Studio Vite plugin for reading and writing intent and fonts config: `get-config`, `set-intent`, and `set-fonts`. Follows the existing `setToken` pattern with per-requester replies, 10s timeouts, and Zod validation. Config writes do not trigger token regeneration -- the existing file watcher handles that.

## Acceptance criteria mapping

### 1. setIntent writes intent to config

The `rafters:set-intent` handler reads the current config via `readRaftersConfig()`, validates the intent against `KNOWN_INTENTS` (currently just "efficient"), writes the updated config to disk. The handler uses `client.send` for per-requester response, not broadcast.
Evidence: vite-plugin.ts `rafters:set-intent` handler, `validateIntent()`, `KNOWN_INTENTS`

### 2. setIntent with unknown name returns error with known names

`validateIntent` checks the intent against `KNOWN_INTENTS` and returns a structured error listing the valid names when the input is not recognized. Same fail-loud pattern as `getAdapter` in the adapter layer.
Evidence: vite-plugin.ts `validateIntent()`, vite-plugin.test.ts unknown-intent test

### 3. setFonts updates config.fonts without touching tokens

The `rafters:set-fonts` handler merges the incoming `FontsConfig` into the existing config and writes to disk. It does NOT call `persistAndNotify` or trigger regeneration -- fonts path and imports are build config, not token values. The file watcher picks up the config change if needed.
Evidence: vite-plugin.ts `rafters:set-fonts` handler

### 4. getConfig returns current config

The `rafters:get-config` handler reads config.rafters.json via `readRaftersConfig()` (which applies Zod validation with `.passthrough()` to preserve unknown fields) and returns the full config object to the requesting client.
Evidence: vite-plugin.ts `rafters:get-config` handler, `readRaftersConfig()`

### 5. Existing setToken/onCssUpdated/onColorEnriched channels unchanged

No modifications to the existing WebSocket channels. The three new channels are additive registrations in the same `configureServer()` block. All existing HMR communication continues to work identically.
Evidence: vite-plugin.ts -- existing handlers untouched

### 6. Client API exports match the plugin channels

Three new exports from index.ts: `getConfig()`, `setIntent()`, `setFonts()`. Each follows the same HMR pattern as `setToken` -- check `isHmrAvailable()`, register a response handler with timeout, send the message. Types exported: `ConfigResult`, `IntentResult`, `FontsResult`, `SetIntentOptions`, `SetFontsOptions`, `RaftersConfig`, `FontsConfig`.
Evidence: index.ts new exports

### 7. 10s timeout on all new channels

All three client functions (`getConfig`, `setIntent`, `setFonts`) use a 10-second timeout matching `setToken`'s `TOKEN_UPDATE_TIMEOUT_MS`. After the timeout, the promise resolves with an error result rather than hanging indefinitely. The timeout constant is shared across all channels.
Evidence: index.ts timeout in `getConfig()`, `setIntent()`, `setFonts()` matching the `TOKEN_UPDATE_TIMEOUT_MS` pattern

### 8. HMR-unavailable case handled gracefully on client side

All three functions check `isHmrAvailable()` first and immediately resolve with an error result (`{ ok: false, error: 'HMR not available' }`) when the HMR channel is not connected. This is the same guard `setToken` uses -- the function is reusable across all channels.
Evidence: index.ts `isHmrAvailable()` check in each function, client-api.test.ts HMR-unavailable tests

## Not done

The intent-to-values map (resolving "efficient" to `BaseSystemConfig` values) lives in Studio's UI layer, not in these API endpoints. The endpoints persist the intent string; the UI resolves it. This is by design -- Studio owns the map, the API is transport.

Closes #2052
