### PR TITLE
fix(#2060): import css-tree at module level, not runtime require

### DIFF
--- a/packages/design-tokens/src/exporters/tailwind.ts
+++ b/packages/design-tokens/src/exporters/tailwind.ts
@@ -13,6 +13,7 @@
  * @see https://ui.shadcn.com/docs/theming
  */
 
+import * as csstree from 'css-tree';
 import type { ColorReference, ColorValue, Token, TypographyElementOverride } from '@rafters/shared';
 import type { MotionNamespace } from '../generators/motion.js';
 import type { TokenRegistry } from '../registry.js';
@@ -1830,7 +1831,6 @@ export async function registryToDocumentation(
  * output is a real stylesheet and should be processed as one.
  */
 function postProcessDocSheet(css: string): string {
-  const csstree = require('css-tree') as typeof import('css-tree');
   const ast = csstree.parse(css);
   const parts: string[] = [];
   let hasHostContainer = false;


### PR DESCRIPTION
One-line fix: postProcessDocSheet used require("css-tree") inside the function body. When bundled by tsup and run via pnpm dlx, the runtime require cannot resolve, so registryToDocumentation throws silently and the documentation sheet is never written. Moved to top-level ESM import so the bundler includes it.

Closes #2060
