### PR TITLE
chore(release): v0.0.82

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rafters
 
+## 0.0.82
+
+### Bug Fixes
+
+- fix(design-tokens): documentation CSS generation unreachable in 0.0.81 (#2060). `postProcessDocSheet` used `require('css-tree')` inside the function body. When the CLI is bundled by tsup and run via `pnpm dlx`, the runtime require cannot resolve the module, so `registryToDocumentation` throws silently and the sheet is never written. Moved to a top-level ESM import.
+
 ## 0.0.81
 
 ### Features

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.81",
+  "version": "0.0.82",
   "description": "Design Intelligence CLI. Scaffold tokens, import existing shadcn/Tailwind v4 sources, add components, and serve an MCP server so AI agents read decisions instead of guessing.",
   "homepage": "https://rafters.studio",
   "license": "MIT",


### PR DESCRIPTION
Hotfix release: css-tree import fix (#2060) so documentation CSS generation works when run via pnpm dlx.