### PR TITLE
feat(#2069): unify config read/write across Studio and MCP

### DIFF
--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -12,7 +12,7 @@
  * Token import lives in `rafters init` / `rafters import`, not MCP.
  */
 
-import { readFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import {
@@ -25,10 +25,49 @@ import {
 } from '@rafters/composites';
 // node-fs adapter lives behind the server-only subpath (it imports node:fs).
 import { discoverFromDirs } from '@rafters/composites/node';
+import { z } from 'zod';
 import { migrateConfig, type RaftersConfig } from '../commands/init.js';
-import { registryClient } from '../registry/client.js';
-import { getRaftersPaths, resolveReadSet } from '../utils/paths.js';
+import { RegistryClient, registryClient } from '../registry/client.js';
+import { getRaftersPaths, PathFieldSchema, resolveReadSet } from '../utils/paths.js';
 import { resolveWorkspace, type Workspace } from '../utils/workspaces.js';
+
+/**
+ * The config fields the MCP may write -- the WIRING, everything that is not a
+ * designer decision. The three designer-owned fields (intent, darkMode, fonts)
+ * belong to Studio; `installed` is managed by `rafters add`. Those are rejected
+ * by handleConfigure with a pointer to the right surface, so this write path
+ * structurally cannot remove designer choice.
+ */
+const ConfigWiringSchema = z
+  .object({
+    // Closed set -- excludes 'unknown', which is a detection sentinel, not a
+    // valid target a caller may set.
+    framework: z.enum(['next', 'vite', 'remix', 'react-router', 'astro', 'wc', 'vanilla']),
+    registryUrl: z.string().min(1),
+    componentTarget: z.string().min(1),
+    source: z.string().min(1),
+    cssPath: z.union([z.string(), z.null()]),
+    componentsPath: PathFieldSchema,
+    primitivesPath: PathFieldSchema,
+    compositesPath: PathFieldSchema,
+    rulesPath: PathFieldSchema,
+    exports: z
+      .object({
+        tailwind: z.boolean(),
+        typescript: z.boolean(),
+        dtcg: z.boolean(),
+        compiled: z.boolean(),
+        documentation: z.boolean(),
+      })
+      .partial(),
+  })
+  .partial()
+  .strict();
+
+/** Designer-owned config keys the MCP must never write -- Studio owns these. */
+const STUDIO_OWNED_KEYS = ['intent', 'darkMode', 'fonts'] as const;
+/** Config keys `rafters add` manages -- the MCP must not write these either. */
+const ADD_MANAGED_KEYS = ['installed'] as const;
 
 const WORKSPACE_PARAM = {
   workspace: {
@@ -44,10 +83,41 @@ export const TOOL_DEFINITIONS = [
   {
     name: 'rafters_workspaces',
     description:
-      'List rafters workspaces visible to this MCP session. Returns name, path, and which one is the default for unscoped tool calls. Call this first when the project might be a monorepo.',
+      "List rafters workspaces, or update a workspace's WIRING config. Called with no arguments (or just `workspace`): returns each workspace name, path, and which is the default for unscoped tool calls -- call this first when the project might be a monorepo. Called with any wiring field: updates that workspace's .rafters/config.rafters.json -- framework, registryUrl, componentTarget, source, cssPath, and the path fields (componentsPath, primitivesPath, compositesPath, rulesPath) and exports; only fields you pass change. Cannot set designer decisions (intent, darkMode, fonts) -- those are set in Studio -- and cannot set installed -- that is managed by `rafters add`.",
     inputSchema: {
       type: 'object' as const,
-      properties: {},
+      properties: {
+        ...WORKSPACE_PARAM,
+        framework: { type: 'string', description: 'Target framework (e.g., "react", "astro")' },
+        registryUrl: {
+          type: 'string',
+          description: 'Registry to install from / query. Point at your own internal registry.',
+        },
+        componentTarget: { type: 'string', description: 'Where installed components are written' },
+        source: { type: 'string', description: 'Design system this project was imported from' },
+        cssPath: { type: ['string', 'null'], description: 'Path to the main CSS file, or null' },
+        componentsPath: {
+          oneOf: [{ type: 'string' }, { type: 'array' }],
+          description: 'Folder(s) to read/write components. String or array of entries.',
+        },
+        primitivesPath: {
+          oneOf: [{ type: 'string' }, { type: 'array' }],
+          description: 'Folder(s) to read/write primitives. String or array of entries.',
+        },
+        compositesPath: {
+          oneOf: [{ type: 'string' }, { type: 'array' }],
+          description: 'Folder(s) to read/write composites. String or array of entries.',
+        },
+        rulesPath: {
+          oneOf: [{ type: 'string' }, { type: 'array' }],
+          description: 'Folder(s) to read/write rules. String or array of entries.',
+        },
+        exports: {
+          type: 'object',
+          description:
+            'Which output formats to emit (tailwind, typescript, dtcg, compiled, documentation).',
+        },
+      },
       required: [],
     },
   },
@@ -113,6 +183,12 @@ export class RaftersToolHandler {
   private compositesLoadedFor = new Set<string>();
   /** Tracks built-in composite loading separately (loaded once globally). */
   private builtInCompositesLoaded = false;
+  /**
+   * Registry clients keyed by base URL, so each workspace's `registryUrl` gets
+   * its own fetch cache. Workspaces without a configured URL share the default
+   * singleton (which points at the public registry).
+   */
+  private registryClients = new Map<string, RegistryClient>();
 
   constructor(workspaces: Workspace[], defaultWorkspace: Workspace | null) {
     this.workspaces = workspaces;
@@ -122,26 +198,18 @@ export class RaftersToolHandler {
   async handleToolCall(name: string, args: Record<string, unknown>): Promise<CallToolResult> {
     switch (name) {
       case 'rafters_workspaces':
-        return this.handleWorkspaces();
+        return this.handleWorkspaces(args);
       case 'rafters_composite':
         return this.handleComposite(args);
       case 'rafters_pattern':
         return this.handlePattern(args as { solves?: string; query?: string; workspace?: string });
       case 'rafters_component':
-        return this.handleComponent(args.name as string);
+        return this.handleComponent(args.name as string, args.workspace as string | undefined);
       default:
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                error: `Unknown tool: ${name}`,
-                suggestion:
-                  'Available tools: rafters_workspaces, rafters_composite, rafters_pattern, rafters_component.',
-              }),
-            },
-          ],
-        };
+        return this.errorResult(`Unknown tool: ${name}`, {
+          suggestion:
+            'Available tools: rafters_workspaces, rafters_composite, rafters_pattern, rafters_component.',
+        });
     }
   }
 
@@ -160,44 +228,103 @@ export class RaftersToolHandler {
    * Use this when a tool requires a workspace and the agent didn't pick one.
    */
   private workspaceRequiredError(): CallToolResult {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: JSON.stringify({
-            error: 'workspace parameter required',
-            suggestion:
-              'Multiple workspaces are available. Pass `workspace` with one of the names below.',
-            workspaces: this.workspaces.map((w) => ({
-              name: w.name,
-              root: w.root,
-            })),
-          }),
-        },
-      ],
-    };
+    return this.errorResult('workspace parameter required', {
+      suggestion:
+        'Multiple workspaces are available. Pass `workspace` with one of the names below.',
+      workspaces: this.workspaces.map((w) => ({ name: w.name, root: w.root })),
+    });
   }
 
-  private async handleWorkspaces(): Promise<CallToolResult> {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: JSON.stringify(
-            {
-              workspaces: this.workspaces.map((w) => ({
-                name: w.name,
-                root: w.root,
-                isDefault: w.name === this.defaultWorkspace?.name,
-              })),
-              defaultWorkspace: this.defaultWorkspace?.name ?? null,
-            },
-            null,
-            2,
-          ),
-        },
-      ],
-    };
+  /** Wrap a JSON-serialisable payload as a text tool result. */
+  private jsonResult(payload: unknown): CallToolResult {
+    return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }] };
+  }
+
+  /** Wrap an error string (with optional extra fields) as a tool result. */
+  private errorResult(error: string, extra?: Record<string, unknown>): CallToolResult {
+    return this.jsonResult({ error, ...extra });
+  }
+
+  /**
+   * List workspaces, or -- when any wiring field is present -- update the
+   * target workspace's config. `workspace` selects which; every other key is
+   * treated as a wiring patch. No wiring keys means the list query.
+   */
+  private async handleWorkspaces(args: Record<string, unknown>): Promise<CallToolResult> {
+    const { workspace, ...patch } = args;
+
+    if (Object.keys(patch).length === 0) {
+      return this.jsonResult({
+        workspaces: this.workspaces.map((w) => ({
+          name: w.name,
+          root: w.root,
+          isDefault: w.name === this.defaultWorkspace?.name,
+        })),
+        defaultWorkspace: this.defaultWorkspace?.name ?? null,
+      });
+    }
+
+    return this.updateWorkspaceConfig(workspace as string | undefined, patch);
+  }
+
+  /**
+   * Write a WIRING patch to a workspace's config.rafters.json. Rejects the
+   * designer-owned keys (intent, darkMode, fonts -> Studio) and add-managed
+   * keys (installed -> `rafters add`) with a pointer to the right surface, so
+   * this path structurally cannot remove designer choice. Only the fields in
+   * the patch change; everything else in the config is preserved.
+   */
+  private async updateWorkspaceConfig(
+    workspaceName: string | undefined,
+    patch: Record<string, unknown>,
+  ): Promise<CallToolResult> {
+    const resolved = this.resolve(workspaceName);
+    if (!resolved) {
+      // A write needs a concrete target -- when none resolves, list the options.
+      return this.workspaceRequiredError();
+    }
+
+    const studioKeys = STUDIO_OWNED_KEYS.filter((k) => k in patch);
+    if (studioKeys.length > 0) {
+      return this.errorResult(
+        `${studioKeys.join(', ')} ${studioKeys.length > 1 ? 'are' : 'is'} a designer decision owned by Rafters Studio, not the MCP. Set ${studioKeys.length > 1 ? 'them' : 'it'} in Studio.`,
+      );
+    }
+    const addKeys = ADD_MANAGED_KEYS.filter((k) => k in patch);
+    if (addKeys.length > 0) {
+      return this.errorResult(`${addKeys.join(', ')} is managed by \`rafters add\`, not the MCP.`);
+    }
+
+    const result = ConfigWiringSchema.safeParse(patch);
+    if (!result.success) {
+      return this.errorResult(`invalid wiring patch: ${result.error.message}`);
+    }
+    if (Object.keys(result.data).length === 0) {
+      return this.errorResult('no writable wiring fields provided');
+    }
+
+    const config = await this.readConfig(resolved.root);
+    if (!config) {
+      return this.errorResult(
+        `no config at ${getRaftersPaths(resolved.root).config} -- run \`rafters init\` first`,
+      );
+    }
+
+    // Runtime-safe: zod omits absent keys, so this only overwrites provided
+    // wiring fields. The cast bridges RaftersConfig's nominal field types
+    // (Framework, ComponentTarget, PathField) that the merge widens under
+    // exactOptionalPropertyTypes.
+    const updated = { ...config, ...result.data } as RaftersConfig;
+    await this.writeConfig(resolved.root, updated);
+
+    // Invalidate cache derived from config so subsequent reads see the change.
+    // registryUrl is picked up fresh by registryClientFor; a changed
+    // compositesPath needs the per-workspace composite load to re-run.
+    if ('compositesPath' in result.data) {
+      this.compositesLoadedFor.delete(resolved.root);
+    }
+
+    return this.jsonResult({ ok: true, workspace: resolved.name, updated: result.data });
   }
 
   /**
@@ -232,6 +359,45 @@ export class RaftersToolHandler {
   }
 
   /**
+   * Read and migrate a workspace's `.rafters/config.rafters.json`. Returns null
+   * when the file is absent or unparseable. The single config read the MCP
+   * tools share -- composite paths and the registry URL both come through here.
+   */
+  private async readConfig(workspaceRoot: string): Promise<RaftersConfig | null> {
+    const paths = getRaftersPaths(workspaceRoot);
+    try {
+      return migrateConfig(
+        JSON.parse(await readFile(paths.config, 'utf-8')) as Record<string, unknown>,
+      ) as unknown as RaftersConfig;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Persist a workspace's config back to `.rafters/config.rafters.json`. */
+  private async writeConfig(workspaceRoot: string, config: RaftersConfig): Promise<void> {
+    const paths = getRaftersPaths(workspaceRoot);
+    await writeFile(paths.config, `${JSON.stringify(config, null, 2)}\n`);
+  }
+
+  /**
+   * Resolve the registry client for a workspace, honoring its configured
+   * `registryUrl`. Workspaces with no config, or no `registryUrl`, share the
+   * default singleton. Clients are cached per URL so each keeps its fetch cache.
+   */
+  private async registryClientFor(workspace: Workspace | null): Promise<RegistryClient> {
+    if (!workspace) return registryClient;
+    const url = (await this.readConfig(workspace.root))?.registryUrl;
+    if (!url) return registryClient;
+    let client = this.registryClients.get(url);
+    if (!client) {
+      client = new RegistryClient(url);
+      this.registryClients.set(url, client);
+    }
+    return client;
+  }
+
+  /**
    * Resolve the set of folders to scan for composite manifests in a workspace.
    * Reads `.rafters/config.rafters.json` and applies the workspace's
    * `compositesPath` (which may be a string or an array of entries to support
@@ -240,14 +406,7 @@ export class RaftersToolHandler {
    */
   private async compositeReadRoots(workspaceRoot: string): Promise<string[]> {
     const paths = getRaftersPaths(workspaceRoot);
-    let config: RaftersConfig | null = null;
-    try {
-      config = migrateConfig(
-        JSON.parse(await readFile(paths.config, 'utf-8')) as Record<string, unknown>,
-      ) as unknown as RaftersConfig;
-    } catch {
-      // No config -- fall through to default
-    }
+    const config = await this.readConfig(workspaceRoot);
     if (!config?.compositesPath) {
       return [join(paths.root, 'composites')];
     }
@@ -303,9 +462,7 @@ export class RaftersToolHandler {
         .map((b) => ({ id: b.id, type: b.type, rules: b.rules })),
     }));
 
-    return {
-      content: [{ type: 'text', text: JSON.stringify({ composites: result }, null, 2) }],
-    };
+    return this.jsonResult({ composites: result });
   }
 
   private async handlePattern(args: {
@@ -348,17 +505,7 @@ export class RaftersToolHandler {
           solves: c.manifest.solves,
         }));
 
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify({
-              error: 'No patterns found matching query',
-              available,
-            }),
-          },
-        ],
-      };
+      return this.errorResult('No patterns found matching query', { available });
     }
 
     // Return pattern-focused view of composites
@@ -371,52 +518,40 @@ export class RaftersToolHandler {
       usagePatterns: c.manifest.usagePatterns,
     }));
 
-    return {
-      content: [{ type: 'text', text: JSON.stringify({ patterns }, null, 2) }],
-    };
+    return this.jsonResult({ patterns });
   }
 
-  private async handleComponent(componentName: string): Promise<CallToolResult> {
-    try {
-      const item = await registryClient.fetchComponent(componentName);
+  private async handleComponent(
+    componentName: string,
+    workspaceName?: string,
+  ): Promise<CallToolResult> {
+    const resolved = this.resolve(workspaceName);
+    if (workspaceName && !resolved) {
+      return this.workspaceRequiredError();
+    }
 
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(
-              {
-                name: item.name,
-                type: item.type,
-                description: item.description,
-                primitives: item.primitives,
-                rules: item.rules,
-                composites: item.composites,
-                files: item.files,
-                // The intelligence field carries the WHY of the component:
-                // cognitive load, accessibility, do/never, semantic meaning.
-                // Extracted from JSDoc by the registry generator and present
-                // on every component JSON. Previously stripped by the schema
-                // (not declared) and not referenced by the handler -- the
-                // tool's whole reason for existing went missing somewhere.
-                intelligence: item.intelligence,
-              },
-              null,
-              2,
-            ),
-          },
-        ],
-      };
+    try {
+      const client = await this.registryClientFor(resolved);
+      const item = await client.fetchComponent(componentName);
+
+      return this.jsonResult({
+        name: item.name,
+        type: item.type,
+        description: item.description,
+        primitives: item.primitives,
+        rules: item.rules,
+        composites: item.composites,
+        files: item.files,
+        // The intelligence field carries the WHY of the component: cognitive
+        // load, accessibility, do/never, semantic meaning. Extracted from JSDoc
+        // by the registry generator and present on every component JSON.
+        // Previously stripped by the schema (not declared) and not referenced by
+        // the handler -- the tool's whole reason for existing went missing.
+        intelligence: item.intelligence,
+      });
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error';
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify({ error: message }),
-          },
-        ],
-      };
+      return this.errorResult(message);
     }
   }
 }

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -13,7 +13,7 @@
  */
 
 import { readFile, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import {
   type CompositeFile,
@@ -32,25 +32,58 @@ import { getRaftersPaths, PathFieldSchema, resolveReadSet } from '../utils/paths
 import { resolveWorkspace, type Workspace } from '../utils/workspaces.js';
 
 /**
+ * True when a path is safe to accept from an agent: relative, and with no `..`
+ * segment that would escape the workspace. Absolute paths and traversal are
+ * rejected because these fields drive on-disk reads (composite discovery) and
+ * writes for out-of-diff commands -- an agent-supplied path must stay inside the
+ * workspace. Mirrors Studio's `validateFontsPath`.
+ */
+function isSafeRelPath(p: string): boolean {
+  if (isAbsolute(p)) return false;
+  return !p.split(/[/\\]/).includes('..');
+}
+
+/** Apply {@link isSafeRelPath} across a PathField (string or array of entries). */
+const SafePathFieldSchema = PathFieldSchema.refine(
+  (field) => {
+    const entries = typeof field === 'string' ? [field] : field;
+    return entries.every((e) => isSafeRelPath(typeof e === 'string' ? e : e.path));
+  },
+  { message: 'path must be relative and stay inside the workspace (no absolute or `..` paths)' },
+);
+
+/**
  * The config fields the MCP may write -- the WIRING, everything that is not a
  * designer decision. The three designer-owned fields (intent, darkMode, fonts)
  * belong to Studio; `installed` is managed by `rafters add`. Those are rejected
- * by handleConfigure with a pointer to the right surface, so this write path
- * structurally cannot remove designer choice.
+ * by updateWorkspaceConfig with a pointer to the right surface, so this write
+ * path structurally cannot remove designer choice. Path and URL fields are
+ * bounded (relative-in-workspace, http(s)) so an agent-driven write -- including
+ * one steered by prompt injection -- cannot repoint reads/fetches out of bounds.
  */
 const ConfigWiringSchema = z
   .object({
     // Closed set -- excludes 'unknown', which is a detection sentinel, not a
     // valid target a caller may set.
     framework: z.enum(['next', 'vite', 'remix', 'react-router', 'astro', 'wc', 'vanilla']),
-    registryUrl: z.string().min(1),
-    componentTarget: z.string().min(1),
+    // Must be a valid http(s) URL. (Blocking private/link-local/metadata hosts
+    // is tracked as a follow-up -- see the registryUrl SSRF issue.)
+    registryUrl: z
+      .string()
+      .url()
+      .refine((u) => /^https?:$/.test(new URL(u).protocol), {
+        message: 'registryUrl must be an http(s) URL',
+      }),
+    // Closed set derived from the framework (see ComponentTarget in detect.ts).
+    componentTarget: z.enum(['react', 'astro', 'vue', 'svelte', 'wc']),
     source: z.string().min(1),
-    cssPath: z.union([z.string(), z.null()]),
-    componentsPath: PathFieldSchema,
-    primitivesPath: PathFieldSchema,
-    compositesPath: PathFieldSchema,
-    rulesPath: PathFieldSchema,
+    cssPath: z.union([z.string(), z.null()]).refine((v) => v === null || isSafeRelPath(v), {
+      message: 'cssPath must be relative and stay inside the workspace',
+    }),
+    componentsPath: SafePathFieldSchema,
+    primitivesPath: SafePathFieldSchema,
+    compositesPath: SafePathFieldSchema,
+    rulesPath: SafePathFieldSchema,
     exports: z
       .object({
         tailwind: z.boolean(),
@@ -315,14 +348,27 @@ export class RaftersToolHandler {
     // (Framework, ComponentTarget, PathField) that the merge widens under
     // exactOptionalPropertyTypes.
     const updated = { ...config, ...result.data } as RaftersConfig;
-    await this.writeConfig(resolved.root, updated);
-
-    // Invalidate cache derived from config so subsequent reads see the change.
-    // registryUrl is picked up fresh by registryClientFor; a changed
-    // compositesPath needs the per-workspace composite load to re-run.
-    if ('compositesPath' in result.data) {
-      this.compositesLoadedFor.delete(resolved.root);
+    // `exports` is a partial patch -- merge it over the existing object rather
+    // than replacing wholesale, matching the tool's "only fields you pass
+    // change" contract (the top-level spread would drop the unlisted keys).
+    if (result.data.exports !== undefined) {
+      updated.exports = { ...config.exports, ...result.data.exports } as RaftersConfig['exports'];
     }
+
+    try {
+      await this.writeConfig(resolved.root, updated);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      return this.errorResult(`failed to write config: ${message}`);
+    }
+
+    // NOTE: the written config takes effect for reads on the next MCP server
+    // start. We deliberately do NOT hot-reload composites on a compositesPath
+    // change here: the composite registry is process-global and first-write-
+    // wins, so a mid-session reload would leave old-path composites registered
+    // alongside new ones (inconsistent), and same-id composites in the new path
+    // would silently fail to register. In the normal setup flow -- configure
+    // paths, then read -- nothing is loaded yet, so this costs nothing.
 
     return this.jsonResult({ ok: true, workspace: resolved.name, updated: result.data });
   }

--- a/packages/cli/test/integration/mcp-server.integration.test.ts
+++ b/packages/cli/test/integration/mcp-server.integration.test.ts
@@ -8,7 +8,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { RaftersToolHandler } from '../../src/mcp/tools.js';
 import { cleanupFixture } from '../fixtures/projects.js';
-import { createInitializedFixture } from './helpers.js';
+import { createInitializedFixture, readConfig } from './helpers.js';
 
 let fixturePath = '';
 
@@ -84,6 +84,52 @@ describe('MCP tools against initialized project', () => {
     const data = JSON.parse(result.content[0].text as string);
     // Component may or may not be found depending on registry state
     expect(data.name === 'button' || data.error).toBeTruthy();
+  }, 30000);
+
+  it('rafters_workspaces writes a wiring patch to the config', async () => {
+    fixturePath = await createInitializedFixture('vite-no-shadcn');
+    const handler = new RaftersToolHandler([{ name: 'fixture', root: fixturePath }], {
+      name: 'fixture',
+      root: fixturePath,
+    });
+
+    const result = await handler.handleToolCall('rafters_workspaces', {
+      registryUrl: 'https://registry.example.test',
+      cssPath: 'src/styles/app.css',
+    });
+
+    const data = JSON.parse(result.content[0].text as string);
+    expect(data.ok).toBe(true);
+    expect(data.updated).toEqual({
+      registryUrl: 'https://registry.example.test',
+      cssPath: 'src/styles/app.css',
+    });
+
+    // The change is persisted, and unrelated fields are preserved.
+    const config = await readConfig(fixturePath);
+    expect(config.registryUrl).toBe('https://registry.example.test');
+    expect(config.cssPath).toBe('src/styles/app.css');
+    expect(config.framework).toBeDefined();
+  }, 30000);
+
+  it('rafters_workspaces refuses to write a designer-owned field', async () => {
+    fixturePath = await createInitializedFixture('vite-no-shadcn');
+    const handler = new RaftersToolHandler([{ name: 'fixture', root: fixturePath }], {
+      name: 'fixture',
+      root: fixturePath,
+    });
+
+    const before = await readConfig(fixturePath);
+    const result = await handler.handleToolCall('rafters_workspaces', {
+      darkMode: 'media',
+    });
+
+    const data = JSON.parse(result.content[0].text as string);
+    expect(data.error).toMatch(/Studio/);
+
+    // Config is untouched -- the reject happens before any write.
+    const after = await readConfig(fixturePath);
+    expect(after.darkMode).toBe(before.darkMode);
   }, 30000);
 });
 

--- a/packages/cli/test/integration/mcp-server.integration.test.ts
+++ b/packages/cli/test/integration/mcp-server.integration.test.ts
@@ -112,6 +112,30 @@ describe('MCP tools against initialized project', () => {
     expect(config.framework).toBeDefined();
   }, 30000);
 
+  it('rafters_workspaces merges the exports field instead of overwriting it', async () => {
+    fixturePath = await createInitializedFixture('vite-no-shadcn');
+    const handler = new RaftersToolHandler([{ name: 'fixture', root: fixturePath }], {
+      name: 'fixture',
+      root: fixturePath,
+    });
+
+    const before = await readConfig(fixturePath);
+    const beforeExports = before.exports as Record<string, boolean>;
+
+    // Patch only one export key; the rest must survive.
+    const result = await handler.handleToolCall('rafters_workspaces', {
+      exports: { dtcg: true },
+    });
+    expect(JSON.parse(result.content[0].text as string).ok).toBe(true);
+
+    const after = await readConfig(fixturePath);
+    const afterExports = after.exports as Record<string, boolean>;
+    expect(afterExports.dtcg).toBe(true);
+    // Keys not in the patch keep their prior values (merge, not replace).
+    expect(afterExports.tailwind).toBe(beforeExports.tailwind);
+    expect(afterExports.typescript).toBe(beforeExports.typescript);
+  }, 30000);
+
   it('rafters_workspaces refuses to write a designer-owned field', async () => {
     fixturePath = await createInitializedFixture('vite-no-shadcn');
     const handler = new RaftersToolHandler([{ name: 'fixture', root: fixturePath }], {

--- a/packages/cli/test/mcp/tools.test.ts
+++ b/packages/cli/test/mcp/tools.test.ts
@@ -193,6 +193,50 @@ describe('RaftersToolHandler', () => {
       expect(data.error).toBe('workspace parameter required');
     });
 
+    it('rejects an absolute path field', async () => {
+      const handler = new RaftersToolHandler([a], a);
+      const result = await handler.handleToolCall('rafters_workspaces', {
+        workspace: 'a',
+        componentsPath: '/etc/passwd',
+      });
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.error).toMatch(/invalid wiring patch/);
+    });
+
+    it('rejects a `..` traversal in a path field', async () => {
+      const handler = new RaftersToolHandler([a], a);
+      const result = await handler.handleToolCall('rafters_workspaces', {
+        workspace: 'a',
+        compositesPath: '../../other-workspace/.rafters/composites',
+      });
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.error).toMatch(/invalid wiring patch/);
+    });
+
+    it('rejects a non-http registryUrl', async () => {
+      const handler = new RaftersToolHandler([a], a);
+      const result = await handler.handleToolCall('rafters_workspaces', {
+        workspace: 'a',
+        registryUrl: 'file:///etc/passwd',
+      });
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.error).toMatch(/invalid wiring patch/);
+    });
+
+    it('rejects an invalid componentTarget', async () => {
+      const handler = new RaftersToolHandler([a], a);
+      const result = await handler.handleToolCall('rafters_workspaces', {
+        workspace: 'a',
+        componentTarget: 'angular',
+      });
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.error).toMatch(/invalid wiring patch/);
+    });
+
     it('errors when the target workspace has no config yet', async () => {
       const handler = new RaftersToolHandler([a], a);
       const result = await handler.handleToolCall('rafters_workspaces', {

--- a/packages/cli/test/mcp/tools.test.ts
+++ b/packages/cli/test/mcp/tools.test.ts
@@ -136,6 +136,75 @@ describe('RaftersToolHandler', () => {
     });
   });
 
+  describe('rafters_workspaces config write', () => {
+    const a = { name: 'a', root: '/repo/sites/a' };
+
+    it('rejects designer-owned keys with a pointer to Studio', async () => {
+      const handler = new RaftersToolHandler([a], a);
+      const result = await handler.handleToolCall('rafters_workspaces', {
+        workspace: 'a',
+        intent: 'playful',
+      });
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.error).toMatch(/intent/);
+      expect(data.error).toMatch(/Studio/);
+    });
+
+    it('rejects installed with a pointer to `rafters add`', async () => {
+      const handler = new RaftersToolHandler([a], a);
+      const result = await handler.handleToolCall('rafters_workspaces', {
+        workspace: 'a',
+        installed: { components: [] },
+      });
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.error).toMatch(/rafters add/);
+    });
+
+    it('rejects unknown wiring fields', async () => {
+      const handler = new RaftersToolHandler([a], a);
+      const result = await handler.handleToolCall('rafters_workspaces', {
+        workspace: 'a',
+        bogus: 1,
+      });
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.error).toMatch(/invalid wiring patch/);
+    });
+
+    it('rejects an invalid framework value', async () => {
+      const handler = new RaftersToolHandler([a], a);
+      const result = await handler.handleToolCall('rafters_workspaces', {
+        workspace: 'a',
+        framework: 'svelte',
+      });
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.error).toMatch(/invalid wiring patch/);
+    });
+
+    it('requires a resolvable workspace for a write', async () => {
+      const b = { name: 'b', root: '/repo/sites/b' };
+      const handler = new RaftersToolHandler([a, b], null); // no default
+      const result = await handler.handleToolCall('rafters_workspaces', { framework: 'vite' });
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.error).toBe('workspace parameter required');
+    });
+
+    it('errors when the target workspace has no config yet', async () => {
+      const handler = new RaftersToolHandler([a], a);
+      const result = await handler.handleToolCall('rafters_workspaces', {
+        workspace: 'a',
+        framework: 'vite',
+      });
+
+      const data = JSON.parse(result.content[0].text as string);
+      expect(data.error).toMatch(/no config/);
+    });
+  });
+
   describe('workspace routing', () => {
     it('returns a workspace-required error when the named workspace is unknown', async () => {
       const a = { name: 'a', root: '/repo/sites/a' };

--- a/packages/studio/src/api/index.ts
+++ b/packages/studio/src/api/index.ts
@@ -46,22 +46,19 @@ export interface RaftersConfig {
   installed?: Record<string, string[]>;
 }
 
-export interface SetIntentOptions {
-  intent: string;
-}
-
-export interface SetFontsOptions {
-  path?: string | null;
-  imports?: string[];
+/**
+ * The designer-owned slice of the config Studio may write. Absent keys are
+ * left untouched; `fonts` merges over the existing object field-by-field.
+ */
+export interface ConfigPatch {
+  intent?: string;
+  darkMode?: 'class' | 'media';
+  fonts?: FontsConfig;
 }
 
 export type ConfigResult = { ok: true; config: RaftersConfig } | { ok: false; error: string };
 
-export type IntentResult = { ok: true; intent: string } | { ok: false; error: string };
-
-export type FontsResult = { ok: true; fonts: FontsConfig } | { ok: false; error: string };
-
-const TOKEN_UPDATE_TIMEOUT_MS = 10_000;
+const ROUNDTRIP_TIMEOUT_MS = 10_000;
 
 /**
  * Check if HMR is fully available (not just partially defined)
@@ -76,15 +73,20 @@ function isHmrAvailable(): boolean {
 }
 
 /**
- * Send a token update to the Vite plugin.
- *
- * @param options.persist - Set to false for instant feedback without disk write.
- *                          Default true persists to .rafters/tokens/*.json
+ * One request/response round-trip over the HMR socket. Every get/set below is
+ * this shape: send `sendEvent` with `payload`, resolve on the first `recvEvent`
+ * the `match` predicate accepts (default: the first reply). Resolves to a
+ * structured error when HMR is unavailable or the reply times out.
  */
-export function setToken(options: SetTokenOptions): Promise<UpdateResult> {
+function roundtrip<T extends { ok: boolean }>(
+  sendEvent: string,
+  recvEvent: string,
+  payload: unknown,
+  match: (result: T) => boolean = () => true,
+): Promise<T | { ok: false; error: string }> {
   return new Promise((resolve) => {
     if (!isHmrAvailable()) {
-      console.warn('[rafters] setToken called but HMR is not available');
+      console.warn(`[rafters] ${sendEvent} called but HMR is not available`);
       resolve({ ok: false, error: 'HMR not available' });
       return;
     }
@@ -96,26 +98,40 @@ export function setToken(options: SetTokenOptions): Promise<UpdateResult> {
 
     const cleanup = () => {
       clearTimeout(timeoutId);
-      hot.off('rafters:token-updated', handler);
+      hot.off(recvEvent, handler);
     };
 
-    const handler = (result: UpdateResult) => {
-      // Match response to our request by name, or accept any error
-      if ((result.ok && result.name === options.name) || !result.ok) {
+    const handler = (result: T) => {
+      // Accept any error, or a success the caller's predicate matches.
+      if (!result.ok || match(result)) {
         cleanup();
         resolve(result);
       }
     };
 
-    // Timeout after 10 seconds
     timeoutId = setTimeout(() => {
       cleanup();
-      resolve({ ok: false, error: `Token update timed out after ${TOKEN_UPDATE_TIMEOUT_MS}ms` });
-    }, TOKEN_UPDATE_TIMEOUT_MS);
+      resolve({ ok: false, error: `${sendEvent} timed out after ${ROUNDTRIP_TIMEOUT_MS}ms` });
+    }, ROUNDTRIP_TIMEOUT_MS);
 
-    hot.on('rafters:token-updated', handler);
-    hot.send('rafters:set-token', options);
+    hot.on(recvEvent, handler);
+    hot.send(sendEvent, payload);
   });
+}
+
+/**
+ * Send a token update to the Vite plugin.
+ *
+ * @param options.persist - Set to false for instant feedback without disk write.
+ *                          Default true persists to .rafters/tokens/*.json
+ */
+export function setToken(options: SetTokenOptions): Promise<UpdateResult> {
+  return roundtrip<Extract<UpdateResult, { ok: true }>>(
+    'rafters:set-token',
+    'rafters:token-updated',
+    options,
+    (result) => result.name === options.name,
+  );
 }
 
 /**
@@ -153,122 +169,22 @@ export function onCssUpdated(callback: () => void): () => void {
  * Read the current config.rafters.json from the Vite plugin.
  */
 export function getConfig(): Promise<ConfigResult> {
-  return new Promise((resolve) => {
-    if (!isHmrAvailable()) {
-      console.warn('[rafters] getConfig called but HMR is not available');
-      resolve({ ok: false, error: 'HMR not available' });
-      return;
-    }
-
-    // biome-ignore lint/style/noNonNullAssertion: checked by isHmrAvailable
-    const hot = import.meta.hot!;
-    // oxlint-disable-next-line prefer-const -- assigned below but captured by the cleanup closure first (forward reference)
-    let timeoutId: ReturnType<typeof setTimeout>;
-
-    const cleanup = () => {
-      clearTimeout(timeoutId);
-      hot.off('rafters:config', handler);
-    };
-
-    const handler = (result: ConfigResult) => {
-      cleanup();
-      resolve(result);
-    };
-
-    timeoutId = setTimeout(() => {
-      cleanup();
-      resolve({ ok: false, error: `Config read timed out after ${TOKEN_UPDATE_TIMEOUT_MS}ms` });
-    }, TOKEN_UPDATE_TIMEOUT_MS);
-
-    hot.on('rafters:config', handler);
-    hot.send('rafters:get-config', {});
-  });
+  return roundtrip<Extract<ConfigResult, { ok: true }>>('rafters:get-config', 'rafters:config', {});
 }
 
 /**
- * Write an intent name to config.rafters.json.
+ * Patch the designer-owned config fields (`intent`, `darkMode`, `fonts`) in
+ * config.rafters.json. Absent keys are left untouched; `fonts` merges over the
+ * existing object. Only known intent names and valid font paths are accepted;
+ * invalid patches are rejected with an error.
  *
- * Only known intent names are accepted; unknown names are rejected with the
- * known list. The caller (Studio UI) sequences token writes after the config
- * write -- this channel does not regenerate tokens.
+ * Does NOT regenerate tokens -- these are build config, not token values. The
+ * caller (Studio UI) sequences any token writes after the config write.
  */
-export function setIntent(options: SetIntentOptions): Promise<IntentResult> {
-  return new Promise((resolve) => {
-    if (!isHmrAvailable()) {
-      console.warn('[rafters] setIntent called but HMR is not available');
-      resolve({ ok: false, error: 'HMR not available' });
-      return;
-    }
-
-    // biome-ignore lint/style/noNonNullAssertion: checked by isHmrAvailable
-    const hot = import.meta.hot!;
-    // oxlint-disable-next-line prefer-const -- assigned below but captured by the cleanup closure first (forward reference)
-    let timeoutId: ReturnType<typeof setTimeout>;
-
-    const cleanup = () => {
-      clearTimeout(timeoutId);
-      hot.off('rafters:intent-updated', handler);
-    };
-
-    const handler = (result: IntentResult) => {
-      // Match response to our request by intent, or accept any error
-      if ((result.ok && result.intent === options.intent) || !result.ok) {
-        cleanup();
-        resolve(result);
-      }
-    };
-
-    timeoutId = setTimeout(() => {
-      cleanup();
-      resolve({
-        ok: false,
-        error: `Intent update timed out after ${TOKEN_UPDATE_TIMEOUT_MS}ms`,
-      });
-    }, TOKEN_UPDATE_TIMEOUT_MS);
-
-    hot.on('rafters:intent-updated', handler);
-    hot.send('rafters:set-intent', options);
-  });
-}
-
-/**
- * Update the fonts config in config.rafters.json.
- *
- * Does NOT regenerate tokens -- fonts path/imports are build config, not token
- * values. Font role assignments are handled separately via setToken.
- */
-export function setFonts(options: SetFontsOptions): Promise<FontsResult> {
-  return new Promise((resolve) => {
-    if (!isHmrAvailable()) {
-      console.warn('[rafters] setFonts called but HMR is not available');
-      resolve({ ok: false, error: 'HMR not available' });
-      return;
-    }
-
-    // biome-ignore lint/style/noNonNullAssertion: checked by isHmrAvailable
-    const hot = import.meta.hot!;
-    // oxlint-disable-next-line prefer-const -- assigned below but captured by the cleanup closure first (forward reference)
-    let timeoutId: ReturnType<typeof setTimeout>;
-
-    const cleanup = () => {
-      clearTimeout(timeoutId);
-      hot.off('rafters:fonts-updated', handler);
-    };
-
-    const handler = (result: FontsResult) => {
-      cleanup();
-      resolve(result);
-    };
-
-    timeoutId = setTimeout(() => {
-      cleanup();
-      resolve({
-        ok: false,
-        error: `Fonts update timed out after ${TOKEN_UPDATE_TIMEOUT_MS}ms`,
-      });
-    }, TOKEN_UPDATE_TIMEOUT_MS);
-
-    hot.on('rafters:fonts-updated', handler);
-    hot.send('rafters:set-fonts', options);
-  });
+export function setConfig(patch: ConfigPatch): Promise<ConfigResult> {
+  return roundtrip<Extract<ConfigResult, { ok: true }>>(
+    'rafters:set-config',
+    'rafters:config',
+    patch,
+  );
 }

--- a/packages/studio/src/api/index.ts
+++ b/packages/studio/src/api/index.ts
@@ -60,6 +60,9 @@ export type ConfigResult = { ok: true; config: RaftersConfig } | { ok: false; er
 
 const ROUNDTRIP_TIMEOUT_MS = 10_000;
 
+/** Monotonic per-page counter used to correlate a request with its reply. */
+let requestSeq = 0;
+
 /**
  * Check if HMR is fully available (not just partially defined)
  */
@@ -77,6 +80,13 @@ function isHmrAvailable(): boolean {
  * this shape: send `sendEvent` with `payload`, resolve on the first `recvEvent`
  * the `match` predicate accepts (default: the first reply). Resolves to a
  * structured error when HMR is unavailable or the reply times out.
+ *
+ * Each call carries a correlation id (`__rid`) that the server echoes back.
+ * `getConfig` and `setConfig` share the `rafters:config` reply event, so
+ * without the id a reply meant for one in-flight call could resolve another
+ * (a get racing a set, or two rapid sets). The handler ignores any reply whose
+ * id is not ours; a reply with no id (older server) falls through to the
+ * predicate for backward compatibility.
  */
 function roundtrip<T extends { ok: boolean }>(
   sendEvent: string,
@@ -93,6 +103,7 @@ function roundtrip<T extends { ok: boolean }>(
 
     // biome-ignore lint/style/noNonNullAssertion: checked by isHmrAvailable
     const hot = import.meta.hot!;
+    const rid = `${sendEvent}#${(requestSeq += 1)}`;
     // oxlint-disable-next-line prefer-const -- assigned below but captured by the cleanup closure first (forward reference)
     let timeoutId: ReturnType<typeof setTimeout>;
 
@@ -101,7 +112,10 @@ function roundtrip<T extends { ok: boolean }>(
       hot.off(recvEvent, handler);
     };
 
-    const handler = (result: T) => {
+    const handler = (result: T & { __rid?: string }) => {
+      // A reply tagged for a different request belongs to another in-flight
+      // call on the same event -- ignore it. Untagged replies fall through.
+      if (result.__rid !== undefined && result.__rid !== rid) return;
       // Accept any error, or a success the caller's predicate matches.
       if (!result.ok || match(result)) {
         cleanup();
@@ -115,7 +129,7 @@ function roundtrip<T extends { ok: boolean }>(
     }, ROUNDTRIP_TIMEOUT_MS);
 
     hot.on(recvEvent, handler);
-    hot.send(sendEvent, payload);
+    hot.send(sendEvent, { ...(payload as Record<string, unknown>), __rid: rid });
   });
 }
 

--- a/packages/studio/src/api/vite-plugin.ts
+++ b/packages/studio/src/api/vite-plugin.ts
@@ -203,6 +203,18 @@ const ConfigPatchSchema = z
     message: 'patch must set at least one of: intent, darkMode, fonts',
   });
 
+/**
+ * The correlation id the client attaches to a request so it can match the reply
+ * to the right in-flight call (get-config and set-config share the
+ * `rafters:config` reply event). Echoed back verbatim on every reply. `__rid`
+ * is stripped by the config schemas' object parse, so it never lands in the
+ * written config.
+ */
+function ridOf(rawData: unknown): string | undefined {
+  const rid = (rawData as { __rid?: unknown } | null)?.__rid;
+  return typeof rid === 'string' ? rid : undefined;
+}
+
 // Schema for POST /api/tokens/:name - partial token update
 // Derived from TokenSchema: value required, patchable fields optional.
 // userOverride is nullable on Token (required, null = baseline) but optional in
@@ -913,28 +925,30 @@ export function studioApiPlugin(): Plugin {
       });
 
       // Listen for config reads from client
-      server.ws.on('rafters:get-config', async (_rawData: unknown, client) => {
+      server.ws.on('rafters:get-config', async (rawData: unknown, client) => {
+        const __rid = ridOf(rawData);
+        const reply = (msg: Record<string, unknown>): void =>
+          client.send('rafters:config', { ...msg, __rid });
         const config = await readRaftersConfig();
         if (!config) {
-          client.send('rafters:config', {
-            ok: false,
-            error: `config not found at ${configPath}`,
-          });
+          reply({ ok: false, error: `config not found at ${configPath}` });
           return;
         }
-        client.send('rafters:config', { ok: true, config });
+        reply({ ok: true, config });
       });
 
       // Listen for config patches from client. One setter for every
       // designer-owned field (intent, darkMode, fonts); absent keys are left
-      // untouched. Replies on the same `rafters:config` event as get-config.
+      // untouched. Replies on the same `rafters:config` event as get-config,
+      // tagged with the request's correlation id.
       server.ws.on('rafters:set-config', async (rawData: unknown, client) => {
+        const __rid = ridOf(rawData);
+        const reply = (msg: Record<string, unknown>): void =>
+          client.send('rafters:config', { ...msg, __rid });
+
         const parsed = ConfigPatchSchema.safeParse(rawData);
         if (!parsed.success) {
-          client.send('rafters:config', {
-            ok: false,
-            error: `Invalid patch: ${parsed.error.message}`,
-          });
+          reply({ ok: false, error: `Invalid patch: ${parsed.error.message}` });
           return;
         }
         const patch = parsed.data;
@@ -943,24 +957,21 @@ export function studioApiPlugin(): Plugin {
         if (patch.intent !== undefined) {
           const intentError = validateIntent(patch.intent);
           if (intentError) {
-            client.send('rafters:config', { ok: false, error: intentError });
+            reply({ ok: false, error: intentError });
             return;
           }
         }
         if (patch.fonts?.path !== undefined) {
           const pathError = validateFontsPath(patch.fonts.path);
           if (pathError) {
-            client.send('rafters:config', { ok: false, error: pathError });
+            reply({ ok: false, error: pathError });
             return;
           }
         }
 
         const config = await readRaftersConfig();
         if (!config) {
-          client.send('rafters:config', {
-            ok: false,
-            error: `config not found at ${configPath}`,
-          });
+          reply({ ok: false, error: `config not found at ${configPath}` });
           return;
         }
 
@@ -977,11 +988,11 @@ export function studioApiPlugin(): Plugin {
         }
 
         try {
-          await writeFile(configPath, JSON.stringify(updated, null, 2));
-          client.send('rafters:config', { ok: true, config: updated });
+          await writeFile(configPath, `${JSON.stringify(updated, null, 2)}\n`);
+          reply({ ok: true, config: updated });
         } catch (error) {
           console.log(`[rafters] Config update failed: ${error}`);
-          client.send('rafters:config', { ok: false, error: String(error) });
+          reply({ ok: false, error: String(error) });
         }
       });
 

--- a/packages/studio/src/api/vite-plugin.ts
+++ b/packages/studio/src/api/vite-plugin.ts
@@ -187,6 +187,22 @@ const SetTokenMessageSchema = z.object({
   reason: z.string().optional(),
 });
 
+/**
+ * The designer-owned config fields Studio may patch over `rafters:set-config`.
+ * Every key is optional -- absent keys are left untouched; `fonts` merges over
+ * the existing object. Intent/font values are further checked by
+ * validateIntent / validateFontsPath before the write.
+ */
+const ConfigPatchSchema = z
+  .object({
+    intent: z.string().min(1).optional(),
+    darkMode: z.enum(['class', 'media']).optional(),
+    fonts: FontsConfigSchema.optional(),
+  })
+  .refine((patch) => Object.keys(patch).length > 0, {
+    message: 'patch must set at least one of: intent, darkMode, fonts',
+  });
+
 // Schema for POST /api/tokens/:name - partial token update
 // Derived from TokenSchema: value required, patchable fields optional.
 // userOverride is nullable on Token (required, null = baseline) but optional in
@@ -909,84 +925,63 @@ export function studioApiPlugin(): Plugin {
         client.send('rafters:config', { ok: true, config });
       });
 
-      // Listen for intent updates from client
-      server.ws.on('rafters:set-intent', async (rawData: unknown, client) => {
-        const parsed = z.object({ intent: z.string().min(1) }).safeParse(rawData);
+      // Listen for config patches from client. One setter for every
+      // designer-owned field (intent, darkMode, fonts); absent keys are left
+      // untouched. Replies on the same `rafters:config` event as get-config.
+      server.ws.on('rafters:set-config', async (rawData: unknown, client) => {
+        const parsed = ConfigPatchSchema.safeParse(rawData);
         if (!parsed.success) {
-          client.send('rafters:intent-updated', {
+          client.send('rafters:config', {
             ok: false,
-            error: `Invalid message: ${parsed.error.message}`,
+            error: `Invalid patch: ${parsed.error.message}`,
           });
           return;
         }
+        const patch = parsed.data;
 
-        const { intent } = parsed.data;
-        const intentError = validateIntent(intent);
-        if (intentError) {
-          client.send('rafters:intent-updated', { ok: false, error: intentError });
-          return;
+        // Per-field validation, gathered in one place. Rules unchanged.
+        if (patch.intent !== undefined) {
+          const intentError = validateIntent(patch.intent);
+          if (intentError) {
+            client.send('rafters:config', { ok: false, error: intentError });
+            return;
+          }
+        }
+        if (patch.fonts?.path !== undefined) {
+          const pathError = validateFontsPath(patch.fonts.path);
+          if (pathError) {
+            client.send('rafters:config', { ok: false, error: pathError });
+            return;
+          }
         }
 
         const config = await readRaftersConfig();
         if (!config) {
-          client.send('rafters:intent-updated', {
+          client.send('rafters:config', {
             ok: false,
             error: `config not found at ${configPath}`,
           });
           return;
         }
 
-        const updated = { ...config, intent };
+        const updated: RaftersConfig = { ...config };
+        if (patch.intent !== undefined) updated.intent = patch.intent;
+        if (patch.darkMode !== undefined) updated.darkMode = patch.darkMode;
+        if (patch.fonts !== undefined) {
+          // Merge incoming fonts over existing, field-by-field. undefined means
+          // "leave alone"; explicit null or value means "set".
+          const merged: FontsConfig = { ...config.fonts };
+          if (patch.fonts.path !== undefined) merged.path = patch.fonts.path;
+          if (patch.fonts.imports !== undefined) merged.imports = patch.fonts.imports;
+          updated.fonts = merged;
+        }
+
         try {
           await writeFile(configPath, JSON.stringify(updated, null, 2));
-          client.send('rafters:intent-updated', { ok: true, intent });
+          client.send('rafters:config', { ok: true, config: updated });
         } catch (error) {
-          console.log(`[rafters] Intent update failed: ${error}`);
-          client.send('rafters:intent-updated', { ok: false, error: String(error) });
-        }
-      });
-
-      // Listen for fonts config updates from client
-      server.ws.on('rafters:set-fonts', async (rawData: unknown, client) => {
-        const parsed = FontsConfigSchema.safeParse(rawData);
-        if (!parsed.success) {
-          client.send('rafters:fonts-updated', {
-            ok: false,
-            error: `Invalid message: ${parsed.error.message}`,
-          });
-          return;
-        }
-
-        const fontsData = parsed.data;
-        const pathError = validateFontsPath(fontsData.path);
-        if (pathError) {
-          client.send('rafters:fonts-updated', { ok: false, error: pathError });
-          return;
-        }
-
-        const config = await readRaftersConfig();
-        if (!config) {
-          client.send('rafters:fonts-updated', {
-            ok: false,
-            error: `config not found at ${configPath}`,
-          });
-          return;
-        }
-
-        // Merge incoming fonts over existing, preserving fields not in the patch.
-        // undefined means "leave alone"; explicit null or value means "set".
-        const existing = config.fonts ?? {};
-        const fonts: FontsConfig = { ...existing };
-        if (fontsData.path !== undefined) fonts.path = fontsData.path;
-        if (fontsData.imports !== undefined) fonts.imports = fontsData.imports;
-
-        const updated = { ...config, fonts };
-        try {
-          await writeFile(configPath, JSON.stringify(updated, null, 2));
-          client.send('rafters:fonts-updated', { ok: true, fonts });
-        } catch (error) {
-          console.log(`[rafters] Fonts update failed: ${error}`);
-          client.send('rafters:fonts-updated', { ok: false, error: String(error) });
+          console.log(`[rafters] Config update failed: ${error}`);
+          client.send('rafters:config', { ok: false, error: String(error) });
         }
       });
 

--- a/packages/studio/test/api/client-api.test.ts
+++ b/packages/studio/test/api/client-api.test.ts
@@ -97,42 +97,41 @@ describe('Client API', () => {
     });
   });
 
-  describe('setIntent without HMR', () => {
-    it('exports setIntent function', async () => {
+  describe('setConfig without HMR', () => {
+    it('exports setConfig function', async () => {
       const module = await import('../../src/api/index');
-      expect(typeof module.setIntent).toBe('function');
+      expect(typeof module.setConfig).toBe('function');
     });
 
     it('returns error result when HMR not available', async () => {
-      const { setIntent } = await import('../../src/api/index');
-      const result = await setIntent({ intent: 'efficient' });
-      expect(result).toEqual({ ok: false, error: 'HMR not available' });
-    });
-  });
-
-  describe('setFonts without HMR', () => {
-    it('exports setFonts function', async () => {
-      const module = await import('../../src/api/index');
-      expect(typeof module.setFonts).toBe('function');
-    });
-
-    it('returns error result when HMR not available', async () => {
-      const { setFonts } = await import('../../src/api/index');
-      const result = await setFonts({ path: './fonts' });
+      const { setConfig } = await import('../../src/api/index');
+      const result = await setConfig({ intent: 'efficient' });
       expect(result).toEqual({ ok: false, error: 'HMR not available' });
     });
 
-    it('accepts null path', async () => {
-      const { setFonts } = await import('../../src/api/index');
-      const result = await setFonts({ path: null });
+    it('accepts a darkMode patch', async () => {
+      const { setConfig } = await import('../../src/api/index');
+      const result = await setConfig({ darkMode: 'media' });
       expect(result.ok).toBe(false);
     });
 
-    it('accepts imports array', async () => {
-      const { setFonts } = await import('../../src/api/index');
-      const result = await setFonts({
-        imports: ['https://fonts.googleapis.com/css2?family=Inter'],
+    it('accepts a fonts patch with null path', async () => {
+      const { setConfig } = await import('../../src/api/index');
+      const result = await setConfig({ fonts: { path: null } });
+      expect(result.ok).toBe(false);
+    });
+
+    it('accepts a fonts patch with imports array', async () => {
+      const { setConfig } = await import('../../src/api/index');
+      const result = await setConfig({
+        fonts: { imports: ['https://fonts.googleapis.com/css2?family=Inter'] },
       });
+      expect(result.ok).toBe(false);
+    });
+
+    it('accepts a combined patch', async () => {
+      const { setConfig } = await import('../../src/api/index');
+      const result = await setConfig({ intent: 'efficient', darkMode: 'class' });
       expect(result.ok).toBe(false);
     });
   });
@@ -142,22 +141,6 @@ describe('Client API', () => {
       const success = { ok: true as const, config: { intent: 'efficient' } };
       expect(success.ok).toBe(true);
       expect(success.config.intent).toBe('efficient');
-    });
-  });
-
-  describe('IntentResult type', () => {
-    it('success result has intent field', () => {
-      const success = { ok: true as const, intent: 'efficient' };
-      expect(success.ok).toBe(true);
-      expect(success.intent).toBe('efficient');
-    });
-  });
-
-  describe('FontsResult type', () => {
-    it('success result has fonts field', () => {
-      const success = { ok: true as const, fonts: { path: './fonts', imports: [] } };
-      expect(success.ok).toBe(true);
-      expect(success.fonts.path).toBe('./fonts');
     });
   });
 });


### PR DESCRIPTION
## Summary

Config plumbing was duplicated and inconsistent: the Studio HMR client hand-rolled the same request/response promise four times, the server had one handler per config field with `darkMode` never wired, and the MCP read config two different ways while `rafters_component` ignored the workspace's `registryUrl` entirely. This change establishes one config reader on each side and splits the write pen by category -- Studio writes the designer-owned slice (`intent`/`darkMode`/`fonts`), the MCP writes wiring (paths, registry, exports) and structurally cannot touch designer decisions, preserving the "agents consume, don't edit" ruling.

## Acceptance criteria mapping

### 1. Studio client exposes exactly one getConfig and one setConfig on a shared round-trip
The four per-channel promise bodies (`setToken`/`getConfig`/`setIntent`/`setFonts`) collapsed into a single `roundtrip` primitive that captures the HMR guard, timeout, cleanup, and match predicate once. `setIntent`/`setFonts` are gone; `getConfig` and `setConfig(patch)` are the only config entry points, both thin callers of `roundtrip`, and `setToken` shares it too.
Evidence: `roundtrip` at packages/studio/src/api/index.ts:81; `getConfig` at :171 and `setConfig` at :184 both delegate to it; test `client-api.test.ts:100` (`setConfig without HMR`).

### 2. Studio server handles rafters:set-config for intent/darkMode/fonts with per-field validation; set-intent/set-fonts removed
The two per-field handlers were replaced by one `rafters:set-config` handler gated by `ConfigPatchSchema`. It runs `validateIntent` and `validateFontsPath` on the present fields, wires `darkMode` (which never had a handler before), merges `fonts` field-by-field preserving prior semantics, and replies on the shared `rafters:config` event.
Evidence: handler at packages/studio/src/api/vite-plugin.ts:931; `ConfigPatchSchema` at :196; the removed `set-intent`/`set-fonts` `server.ws.on` blocks no longer appear in the diff.

### 3. MCP reads config through a single readConfig; rafters_component uses the workspace registryUrl
Config reading is now one `readConfig` helper consumed by `compositeReadRoots`, `registryClientFor`, and the write path. `rafters_component` resolves the workspace, reads its `registryUrl` via `registryClientFor` (clients cached per URL), and fetches from that registry instead of the hardcoded public default -- and it now uses the `workspace` param it already declared but previously dropped on dispatch.
Evidence: `readConfig` at packages/cli/src/mcp/tools.ts:366; `registryClientFor` reads `registryUrl` and caches per URL; integration test `rafters_component fetches component details` still passes against the default-URL fallback.

### 4. rafters_workspaces writes wiring fields; rejects designer slice and installed; no-arg call still lists
`handleWorkspaces` branches on the args: no wiring keys returns the workspace list unchanged; any wiring key routes to `updateWorkspaceConfig`, which validates against `ConfigWiringSchema`, rejects `intent`/`darkMode`/`fonts` (pointing at Studio) and `installed` (pointing at `rafters add`) before any write, then merges and persists only the passed fields.
Evidence: `updateWorkspaceConfig` at packages/cli/src/mcp/tools.ts:277; reject tests `tools.test.ts:139` (`rafters_workspaces config write`, incl. designer-key/installed/unknown-field/invalid-framework/missing-workspace/missing-config branches).

### 5. Unit + integration tests cover the write path (success, persistence, reject branches); preflight green
Six unit tests cover every reject branch fs-free (they short-circuit before `readConfig`); two integration tests prove a real write persists (`registryUrl`/`cssPath` read back from the fixture config, unrelated fields preserved) and that a designer field is refused with the config left untouched via before/after read. Full `pnpm preflight` passes (typecheck, lint, format, unit, a11y, build).
Evidence: `packages/cli/test/mcp/tools.test.ts:139` and `packages/cli/test/integration/mcp-server.integration.test.ts:89`; preflight run green on HEAD.

## Not done

No hand-written CHANGELOG entry -- this repo composes the CHANGELOG at release via the legion changelog agent from the merged-PR range, not per-commit. The `@rafters/config` package extraction (unifying the config type/read/write that still lives split across cli and studio) was deliberately deferred as a larger follow-up; this PR keeps the simple, working DRY inside each package. The stale duplicate `RaftersConfig` declaration in studio's `index.ts` is left as-is for that follow-up.

Closes #2069
