### PR TITLE
fix(ui): stop happy-dom from fetching iframe srcs in tests

### DIFF
--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -6,6 +6,19 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'happy-dom',
+    // Stop happy-dom from fetching iframe `src`s (and other subresources) over
+    // the live network during component tests. Without this, rendering a
+    // component that emits an iframe -- e.g. Embed with a YouTube URL -- makes
+    // happy-dom fetch https://www.youtube-nocookie.com/... for real, which
+    // hangs preflight whenever that host is slow or unreachable. Tests must
+    // never depend on network access.
+    environmentOptions: {
+      happyDOM: {
+        settings: {
+          disableIframePageLoading: true,
+        },
+      },
+    },
     setupFiles: ['./vitest.setup.ts'],
     include: [
       'src/**/*.test.{ts,tsx}',


### PR DESCRIPTION
## Summary

happy-dom (the packages/ui test DOM) loads iframe `src`s over the live network by default. Rendering the Embed component with a YouTube URL therefore made the unit suite fetch `youtube-nocookie.com` for real, hanging `pnpm preflight` for 30+ minutes whenever that host was slow or unreachable. This sets happy-dom's `disableIframePageLoading` so no test touches the network.

## Acceptance criteria mapping

### 1. ui test:unit completes offline, all tests still pass, no external fetch
The vitest environment config now sets `environmentOptions.happyDOM.settings.disableIframePageLoading: true`, so happy-dom never loads an iframe's `src` (the mechanism that was calling `fetch()` to YouTube). The change is at the environment layer, so it covers every test, not just Embed. The previously-hanging suite now runs to completion with every test still green.
Evidence: `pnpm --filter '@rafters/ui' test:unit` → 56 files, 351 tests passed, 13.22s (was hanging 30min+); no `youtube-nocookie` fetch in the run.

### 2. preflight no longer stalls in packages/ui test:unit
The preflight stall was exactly this fetch inside `test:unit`; the same setting suppresses it, so preflight proceeds past `packages/ui test:unit`.
Evidence: the stall was reproduced directly by running preflight to a log (it stopped in `packages/ui test:unit` on the youtube fetch); with the setting, `@rafters/ui test:unit` exits 0 in seconds.

## Not done

No dedicated fetch-spy regression test asserting "rendering an iframe emits no network call" -- the config setting is global and the suite completing offline is the proof. Worth noting the Embed component has no unit test at all today; adding one (which would also cover this) is a separate coverage gap, not this fix's scope.

Closes #2081