### PR TITLE
feat(mcp): intel graph + recursive describe() core resolver

### DIFF
--- a/packages/cli/src/mcp/graph.ts
+++ b/packages/cli/src/mcp/graph.ts
@@ -1,0 +1,231 @@
+/**
+ * Intel graph + recursive `describe` resolver (issue #2072).
+ *
+ * Assembles the component/composite intel graph in-memory from registry items,
+ * and answers a single recursive verb: `describe(addr, graph)`. One verb, a
+ * narrowing dot-address argument, no `?`/`*` operators -- the depth of the
+ * argument IS the request. Every node response advertises its own drillable,
+ * type-marked children; cross-kind `composesWith` edges resolve to the target's
+ * layer-0 only, cycle-safe.
+ *
+ * This slice is universal and presence-free: no installed/target dimension (that
+ * is the workspace overlay, issue #2074). `props`/`vocab` are fixture-driven
+ * here; per-target facet extraction (issue #2073) feeds them from source later.
+ * Behavioral reference: `.claude/scratch/describe-toy.ts`.
+ */
+
+import type { RegistryItem } from '../registry/types.js';
+
+// A child a caller can drill into next. `type` says whether to drill and what returns.
+export type ChildType = 'enum' | 'grammar' | 'leaf' | 'edge' | 'deprecated';
+
+export interface DrillableChild {
+  addr: string;
+  type: ChildType;
+  deprecatedFor?: string; // present only when type === 'deprecated'
+}
+
+// A structured, machine-actionable cross-part rule -- never a prose string.
+export interface Constraint {
+  when: { prop: string; matches: string };
+  requires: { prop: string };
+}
+
+export type PropNode =
+  | {
+      type: 'enum';
+      values: string[];
+      default?: string;
+      required?: boolean;
+      constraint?: Constraint;
+    }
+  | {
+      type: 'grammar';
+      grammar: string[];
+      vocab: string;
+      onInvalid: 'silent-noop';
+      default?: string;
+    } // vocab: a drillable addr, never inlined, never withheld
+  | { type: 'deprecated'; deprecatedFor: string };
+
+export interface GraphIntel {
+  cognitiveLoad?: number;
+  dos: string[];
+  nevers: string[];
+  semanticMeaning?: string;
+}
+
+export interface GraphNode {
+  id: string;
+  kind: 'component' | 'composite';
+  intel: GraphIntel;
+  props: Record<string, PropNode>; // empty until per-target extraction (#2073) lands
+  vocab: Record<string, string[]>; // addr -> real token values
+  composesWith: string[]; // edges; the only edge-bearing field the registry schema provides
+}
+
+export interface Graph {
+  nodes: Map<string, GraphNode>;
+}
+
+export interface NodeResult {
+  id: string;
+  kind: 'component' | 'composite';
+  intel: GraphIntel;
+  children: DrillableChild[];
+}
+
+export type DescribeResult =
+  | { kinds: DrillableChild[]; nodeCount: number } // describe('')
+  | Array<{ id: string }> // describe('components' | 'composites')
+  | NodeResult // describe('<id>')
+  | PropNode // describe('<id>.props.<name>')
+  | { type: 'leaf'; values: string[] } // describe('<id>.props.<name>.vocab')
+  | NodeResult[] // describe('<id>.composesWith') -- each entry a target's layer-0, one level
+  | { error: string };
+
+/**
+ * Build the graph once, in-memory, from registry items already validated by
+ * `RegistryItemSchema`. `id`, `kind`, `intel`, and `composesWith` come from the
+ * registry; `props`/`vocab` are left empty here (extraction is #2073).
+ *
+ * Fails fast (throws at build time / MCP startup) if a `composesWith` edge names
+ * an id that appears in no item -- a broken graph must never reach a query. A
+ * self-edge (a node listing its own id) is valid: the id exists.
+ */
+export function assembleGraph(items: RegistryItem[]): Graph {
+  const nodes = new Map<string, GraphNode>();
+
+  for (const item of items) {
+    const kind = kindOf(item.type);
+    if (kind === null) continue; // rule/substrate are not describe-able nodes
+
+    const intel: GraphIntel = {
+      dos: item.intelligence?.usagePatterns?.dos ?? [],
+      nevers: item.intelligence?.usagePatterns?.nevers ?? [],
+    };
+    if (item.intelligence?.cognitiveLoad !== undefined) {
+      intel.cognitiveLoad = item.intelligence.cognitiveLoad;
+    }
+    if (item.intelligence?.semanticMeaning !== undefined) {
+      intel.semanticMeaning = item.intelligence.semanticMeaning;
+    }
+
+    nodes.set(item.name, {
+      id: item.name,
+      kind,
+      intel,
+      props: {},
+      vocab: {},
+      composesWith: item.composites,
+    });
+  }
+
+  for (const node of nodes.values()) {
+    for (const target of node.composesWith) {
+      if (!nodes.has(target)) {
+        throw new Error(`graph: node "${node.id}" composesWith unknown id "${target}"`);
+      }
+    }
+  }
+
+  return { nodes };
+}
+
+function kindOf(type: RegistryItem['type']): GraphNode['kind'] | null {
+  if (type === 'composite') return 'composite';
+  if (type === 'ui' || type === 'primitive') return 'component';
+  return null;
+}
+
+/**
+ * Resolve one dot-address against the graph. Never throws for a bad caller
+ * address -- always returns a structured `{ error }`. Assembly-time / data
+ * errors surface earlier, in `assembleGraph`.
+ */
+export function describe(addr: string, graph: Graph): DescribeResult {
+  const parts = addr === '' ? [] : addr.split('.');
+
+  // describe('') -> the surface: the two kinds as drillable edges + a count.
+  if (parts.length === 0) {
+    return {
+      kinds: [
+        { addr: 'components', type: 'edge' },
+        { addr: 'composites', type: 'edge' },
+      ],
+      nodeCount: graph.nodes.size,
+    };
+  }
+
+  const [head, ...rest] = parts;
+  if (head === undefined) return { error: `cannot resolve: ${addr}` };
+
+  // describe('components' | 'composites') -> the kind roster (untagged here).
+  if (head === 'components' || head === 'composites') {
+    const kind: GraphNode['kind'] = head === 'components' ? 'component' : 'composite';
+    const roster: Array<{ id: string }> = [];
+    for (const node of graph.nodes.values()) {
+      if (node.kind === kind) roster.push({ id: node.id });
+    }
+    return roster;
+  }
+
+  const node = graph.nodes.get(head);
+  if (!node) return { error: `unknown node: ${head}` };
+
+  // describe('<id>') -> layer 0.
+  if (rest.length === 0) return layer0(node);
+
+  // describe('<id>.composesWith') -> edges resolved to target layer-0, one level.
+  if (rest.length === 1 && rest[0] === 'composesWith') {
+    return resolveEdges(node, graph);
+  }
+
+  // describe('<id>.props.<name>[.vocab]')
+  if (rest[0] === 'props') {
+    const propName = rest[1];
+    const prop = propName === undefined ? undefined : node.props[propName];
+    if (!prop) return { error: `cannot resolve: ${addr}` };
+    if (rest.length === 2) return prop;
+    if (rest.length === 3 && rest[2] === 'vocab') {
+      if (prop.type !== 'grammar') return { error: `cannot drill: ${addr}` };
+      return { type: 'leaf', values: node.vocab[prop.vocab] ?? [] };
+    }
+    return { error: `cannot resolve: ${addr}` };
+  }
+
+  return { error: `cannot resolve: ${addr}` };
+}
+
+/** Layer 0: intel + self-advertising, type-marked children. Never expands. */
+function layer0(node: GraphNode): NodeResult {
+  const children: DrillableChild[] = [];
+  for (const [name, prop] of Object.entries(node.props)) {
+    const child: DrillableChild = { addr: `${node.id}.props.${name}`, type: prop.type };
+    if (prop.type === 'deprecated') child.deprecatedFor = prop.deprecatedFor;
+    children.push(child);
+  }
+  if (node.composesWith.length > 0) {
+    children.push({ addr: `${node.id}.composesWith`, type: 'edge' });
+  }
+  return { id: node.id, kind: node.kind, intel: node.intel, children };
+}
+
+/**
+ * Resolve `composesWith` edges to each target's layer-0 -- ONE level only. A
+ * target's own `composesWith` never expands inside this response; it appears
+ * only as the `<targetId>.composesWith` address inside that target's children.
+ * A visited-id set collapses exact-duplicate entries and makes a self-edge
+ * (or any cycle) terminate; every distinct declared edge still resolves.
+ */
+function resolveEdges(node: GraphNode, graph: Graph): NodeResult[] {
+  const seen = new Set<string>();
+  const results: NodeResult[] = [];
+  for (const targetId of node.composesWith) {
+    if (seen.has(targetId)) continue;
+    seen.add(targetId);
+    const target = graph.nodes.get(targetId);
+    if (target) results.push(layer0(target));
+  }
+  return results;
+}

--- a/packages/cli/test/mcp/graph.test.ts
+++ b/packages/cli/test/mcp/graph.test.ts
@@ -1,0 +1,203 @@
+import { describe as vdescribe, expect, it } from 'vitest';
+import {
+  assembleGraph,
+  describe,
+  type DrillableChild,
+  type Graph,
+  type GraphNode,
+} from '../../src/mcp/graph.js';
+import type { RegistryItem } from '../../src/registry/types.js';
+
+// Fixture graph (no target/presence dimension in this slice):
+//   button (component): props { variant: enum, size: enum + constraint },
+//     composesWith: ['page-header', 'page-header']  // duplicate -> dedup
+//   page-header (composite): composesWith: ['button']  // mutual pair -> one-level bound
+//   container (component): props { fill: grammar }, vocab for the fill grammar
+//   modal (component): composesWith: ['modal']  // self-edge
+function fixture(): Graph {
+  const nodes = new Map<string, GraphNode>([
+    [
+      'button',
+      {
+        id: 'button',
+        kind: 'component',
+        intel: { cognitiveLoad: 2, dos: [], nevers: [] },
+        props: {
+          variant: { type: 'enum', values: ['default', 'primary'], default: 'default' },
+          size: {
+            type: 'enum',
+            values: ['default', 'icon'],
+            default: 'default',
+            constraint: {
+              when: { prop: 'size', matches: 'icon*' },
+              requires: { prop: 'aria-label' },
+            },
+          },
+        },
+        vocab: {},
+        composesWith: ['page-header', 'page-header'],
+      },
+    ],
+    [
+      'page-header',
+      {
+        id: 'page-header',
+        kind: 'composite',
+        intel: { dos: [], nevers: [] },
+        props: {},
+        vocab: {},
+        composesWith: ['button'],
+      },
+    ],
+    [
+      'container',
+      {
+        id: 'container',
+        kind: 'component',
+        intel: { cognitiveLoad: 1, dos: [], nevers: [] },
+        props: {
+          fill: {
+            type: 'grammar',
+            grammar: ['word', 'word/alpha', 'word-to-word'],
+            vocab: 'container.props.fill.vocab',
+            onInvalid: 'silent-noop',
+            default: 'transparent',
+          },
+        },
+        vocab: { 'container.props.fill.vocab': ['surface', 'card', 'muted', 'primary', 'accent'] },
+        composesWith: [],
+      },
+    ],
+    [
+      'modal',
+      {
+        id: 'modal',
+        kind: 'component',
+        intel: { dos: [], nevers: [] },
+        props: {},
+        vocab: {},
+        composesWith: ['modal'],
+      },
+    ],
+  ]);
+  return { nodes };
+}
+
+vdescribe('describe(addr, graph)', () => {
+  const graph = fixture();
+
+  it('describe("") returns the surface: kinds as edges + a node count', () => {
+    expect(describe('', graph)).toEqual({
+      kinds: [
+        { addr: 'components', type: 'edge' },
+        { addr: 'composites', type: 'edge' },
+      ],
+      nodeCount: 4,
+    });
+  });
+
+  it('describe(components) rosters only components', () => {
+    const roster = describe('components', graph);
+    expect(roster).toEqual(
+      expect.arrayContaining([{ id: 'button' }, { id: 'container' }, { id: 'modal' }]),
+    );
+    expect(roster).not.toContainEqual({ id: 'page-header' });
+  });
+
+  it('describe(<id>) returns layer 0 with type-marked self-advertising children', () => {
+    const node = describe('button', graph) as {
+      id: string;
+      kind: string;
+      children: DrillableChild[];
+    };
+    expect(node).toMatchObject({ id: 'button', kind: 'component' });
+    expect(node.children).toEqual(
+      expect.arrayContaining([
+        { addr: 'button.props.variant', type: 'enum' },
+        { addr: 'button.props.size', type: 'enum' },
+        { addr: 'button.composesWith', type: 'edge' },
+      ]),
+    );
+  });
+
+  it('describe(<id>.props.<name>) returns the prop node; enum values inline', () => {
+    expect(describe('button.props.variant', graph)).toMatchObject({
+      type: 'enum',
+      values: ['default', 'primary'],
+    });
+  });
+
+  it('constraints are structured, not prose', () => {
+    expect(describe('button.props.size', graph)).toMatchObject({
+      constraint: { when: { prop: 'size', matches: 'icon*' }, requires: { prop: 'aria-label' } },
+    });
+  });
+
+  it('a grammar prop exposes vocab as a drillable address, and it resolves to real tokens', () => {
+    const fill = describe('container.props.fill', graph) as { type: string; vocab: string };
+    expect(fill).toMatchObject({ type: 'grammar', vocab: 'container.props.fill.vocab' });
+    expect(describe(fill.vocab, graph)).toEqual({
+      type: 'leaf',
+      values: ['surface', 'card', 'muted', 'primary', 'accent'],
+    });
+  });
+
+  it('edges resolve to target layer-0 only, one level, and dedup exact duplicates', () => {
+    const edges = describe('button.composesWith', graph) as Array<{
+      id: string;
+      children: DrillableChild[];
+    }>;
+    expect(edges).toHaveLength(1);
+    expect(edges[0]?.id).toBe('page-header');
+    // one-level bound: the target's own edge appears as an ADDRESS, never expanded
+    expect(edges[0]?.children).toContainEqual({ addr: 'page-header.composesWith', type: 'edge' });
+    expect(edges[0]).not.toHaveProperty('composesWith');
+  });
+
+  it('a self-edge resolves cleanly and terminates', () => {
+    const edges = describe('modal.composesWith', graph) as Array<{ id: string }>;
+    expect(edges).toHaveLength(1);
+    expect(edges[0]?.id).toBe('modal');
+  });
+
+  it('bad addresses return structured errors, never throw', () => {
+    expect(describe('unknown-node', graph)).toEqual({ error: 'unknown node: unknown-node' });
+    expect(describe('button.props.color', graph)).toEqual({
+      error: expect.stringContaining('button.props.color'),
+    });
+    expect(describe('button.props.variant.vocab', graph)).toEqual({
+      error: expect.stringContaining('cannot drill'),
+    });
+  });
+});
+
+vdescribe('assembleGraph(items)', () => {
+  const validItem: RegistryItem = {
+    name: 'button',
+    type: 'ui',
+    primitives: [],
+    files: [],
+    rules: [],
+    composites: [],
+  };
+
+  it('maps registry items to nodes (kind, intel, composesWith)', () => {
+    const graph = assembleGraph([
+      {
+        ...validItem,
+        name: 'card',
+        composites: ['stack'],
+        intelligence: { cognitiveLoad: 3, usagePatterns: { dos: ['a'], nevers: ['b'] } },
+      },
+      { ...validItem, name: 'stack', type: 'composite' },
+    ]);
+    const card = describe('card', graph) as { kind: string; intel: { cognitiveLoad?: number } };
+    expect(card.kind).toBe('component');
+    expect(card.intel.cognitiveLoad).toBe(3);
+    expect(describe('composites', graph)).toContainEqual({ id: 'stack' });
+  });
+
+  it('throws when a composesWith edge names an id that appears in no item', () => {
+    expect(() => assembleGraph([{ ...validItem, composites: ['nonexistent-id'] }])).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Adds the intel graph + recursive `describe(addr)` core resolver (`packages/cli/src/mcp/graph.ts`): `assembleGraph(items)` builds the component/composite graph in-memory from registry items; `describe(addr, graph)` resolves it recursively -- one verb, a narrowing dot-address, no `?`/`*` operators. Universal and presence-free; `props`/`vocab` are fixture-driven until extraction (#2073).

## Acceptance criteria mapping

### 1. describe is one recursive verb keyed on address depth, no ?/* operators
`describe(addr, graph)` splits the dot-address and dispatches on depth: empty -> surface (kinds + count), `components`/`composites` -> kind roster, `<id>` -> layer-0, `<id>.props.<name>` -> the prop node, `<id>.props.<name>.vocab` -> a leaf. There is no `?` or `*`; the depth of the argument is the request, so discovery and drilling are the same verb.
Evidence: `test/mcp/graph.test.ts` asserts each of those five address shapes returns the expected result.

### 2. Every node layer-0 advertises type-marked drillable children
`layer0()` emits one `{addr, type}` child per prop (type taken from the prop's own discriminant) plus a single `edge`-typed `composesWith` child when edges exist, so a caller can see what to drill and what it returns without a schema.
Evidence: test asserts `button` children include `{addr:'button.props.variant',type:'enum'}` and `{addr:'button.composesWith',type:'edge'}`.

### 3. Constraints are structured; grammar vocab is a drillable address to real tokens
A prop's `constraint` is a `{when,requires}` object, never prose; a `grammar` prop carries a `vocab` address that `describe` resolves to the real token array (a leaf), rather than inlining or withholding it.
Evidence: test asserts `button.props.size.constraint` equals `{when:{prop:'size',matches:'icon*'},requires:{prop:'aria-label'}}`, and `describe(container.props.fill.vocab)` returns `{type:'leaf',values:['surface','card','muted','primary','accent']}`.

### 4. composesWith edges resolve to target layer-0 only, cycle-safe
`resolveEdges` maps each `composesWith` id to that target's layer-0 (never its subtree), guarded by a visited-set that drops exact-duplicate entries and makes a self-edge (or any cycle) terminate; the target's own edge appears only as an address inside its children.
Evidence: test -- `button.composesWith` (duplicate entries) yields one `page-header` layer-0 whose own edge is an address not an expansion; `modal.composesWith` (self-edge) resolves once and terminates.

### 5. assembleGraph fails fast; describe returns structured errors, never throws
`assembleGraph` validates every `composesWith` target exists and throws with the offending id at build time; `describe` returns `{error}` for an unknown node, unknown prop, or an illegal drill, and never throws for a caller address.
Evidence: test -- `assembleGraph([...composites:['nonexistent-id']])` throws; `describe('unknown-node')`, `describe('button.props.color')`, and `describe('button.props.variant.vocab')` each return a structured error.

### 6. Unit tests pass; preflight green
The full `graph.test.ts` suite (11 cases covering the five criteria above) passes, TypeScript is clean under strict mode with no `any`, and the pre-push preflight (typecheck/oxlint/oxfmt/tests/build) is green.
Evidence: `pnpm exec vitest run test/mcp/graph.test.ts` -> 11 passed; `pnpm --filter 'rafters' typecheck` clean; preflight green on push.

## Not done

`props`/`vocab` are fixture-driven in this slice -- real per-target extraction is #2073, and `describe`'s `composesWith` has no real edges to resolve against production data until #2073 populates them (flagged in the issue). The overlay (#2074), intent door (#2075), dispatch wiring (#2076), and generate (#2077) are separate slices; this module is not yet reachable via any MCP tool call.

Closes #2072