### PR TITLE
feat(mcp): workspace overlay for describe -- presence, manifest, target echo

### DIFF
--- a/packages/cli/src/mcp/overlay.ts
+++ b/packages/cli/src/mcp/overlay.ts
@@ -1,0 +1,165 @@
+/**
+ * Workspace overlay for `describe()` (issue #2074).
+ *
+ * A thin, per-workspace lens applied at QUERY time. It stamps three things onto
+ * a describe() response without ever mutating the universal graph (#2072):
+ *   - presence: `installed` | `available`, from the workspace's installed set;
+ *   - a per-target manifest: `rendersForTarget` -- does a facet for the resolved
+ *     target exist for this node;
+ *   - the resolved target, echoed as-is so a misresolve is catchable.
+ *
+ * The overlay is a WRAPPER, not a replacement. `describe()` stays presence-free
+ * and target-free; a caller opts into the overlay by also passing a
+ * `FacetTargetIndex` and an `OverlayContext`. Two calls with different contexts
+ * against the SAME `Graph` and `FacetTargetIndex` produce different stamps with
+ * no shared mutable state -- one graph serves all workspaces.
+ *
+ * Scope (per the brief): only `describe(<id>)` (single node) and the two roster
+ * calls (`describe(components)` / `describe(composites)`) are enriched. Every
+ * other shape -- the empty-address surface, props, vocab, `composesWith` edges,
+ * and structured errors -- passes through unchanged.
+ */
+
+import { type ComponentTarget, ComponentTargetSchema } from '../registry/types.js';
+import { type DescribeResult, describe, type Graph, type NodeResult } from './graph.js';
+
+export type Presence = 'installed' | 'available';
+
+/**
+ * The workspace's installed set, split per kind. A `component`-kind node checks
+ * `components`; a `composite`-kind node checks `composites`. Sourced from
+ * `RaftersConfig.installed` (see `buildInstalledSet`).
+ */
+export interface InstalledSet {
+  components: ReadonlySet<string>;
+  composites: ReadonlySet<string>;
+}
+
+/**
+ * The per-workspace context the overlay is stamped from. `target` is
+ * `undefined` in degraded mode (no `componentTarget` configured) -- it is
+ * echoed as-is, never guessed, and `rendersForTarget` is then always false.
+ */
+export interface OverlayContext {
+  target: ComponentTarget | undefined;
+  installed: InstalledSet;
+}
+
+/**
+ * Per-node facet-target availability, independent of `Graph`/`GraphNode`.
+ * `GraphNode` (#2072) is deliberately flat and carries no per-target data, so
+ * the overlay builds its own side-index directly from each item's `facets`
+ * keys (#2073) at construction time rather than changing graph.ts's node shape.
+ */
+export type FacetTargetIndex = ReadonlyMap<string, ReadonlySet<ComponentTarget>>;
+
+/** A single node's describe result, enriched with the workspace stamp. */
+export type OverlayNodeResult = NodeResult & {
+  presence: Presence;
+  target: ComponentTarget | undefined;
+  rendersForTarget: boolean;
+};
+
+/** A roster entry (`describe(components|composites)`), enriched with presence. */
+export type OverlayRosterEntry = { id: string; presence: Presence };
+
+export type OverlayResult =
+  | OverlayRosterEntry[] // describe(components) / describe(composites)
+  | OverlayNodeResult // describe(<id>)
+  | DescribeResult; // every other shape passes through unchanged
+
+/**
+ * Build the per-kind installed set from a config's `installed` block. Absent or
+ * partial `installed` is treated as "nothing installed" -- never a crash, never
+ * "everything installed". Only the two kinds the overlay stamps are read;
+ * `primitives`/`rules`/`substrate` are intentionally not folded in here (a
+ * `primitive`-kind item maps to graph kind `component`, but its presence wiring
+ * is Issue D's concern, not this query-time lens).
+ */
+export function buildInstalledSet(config: {
+  installed?: { components?: string[]; composites?: string[] };
+}): InstalledSet {
+  return {
+    components: new Set(config.installed?.components ?? []),
+    composites: new Set(config.installed?.composites ?? []),
+  };
+}
+
+/**
+ * Build the node -> facet-target side-index from the SAME `RegistryItem[]`
+ * array `assembleGraph` (#2072) consumes, once, at construction time. An item's
+ * per-target manifest IS the set of keys on its `facets` record (#2073). An
+ * absent `facets`, or a key that is not a recognized target, contributes no
+ * target -- never a crash.
+ */
+export function buildFacetTargetIndex(
+  items: Array<{ name: string; facets?: Partial<Record<ComponentTarget, unknown>> }>,
+): FacetTargetIndex {
+  const index = new Map<string, ReadonlySet<ComponentTarget>>();
+  for (const item of items) {
+    const targets = new Set<ComponentTarget>();
+    if (item.facets) {
+      for (const key of Object.keys(item.facets)) {
+        const parsed = ComponentTargetSchema.safeParse(key);
+        if (parsed.success) targets.add(parsed.data);
+      }
+    }
+    index.set(item.name, targets);
+  }
+  return index;
+}
+
+/**
+ * Resolve one dot-address through `describe` (#2072, unmodified) and stamp the
+ * workspace overlay onto the two enriched shapes -- the roster calls and a
+ * single-node query. Never throws for a bad address: `describe`'s structured
+ * `{ error }` passes straight through.
+ */
+export function describeWithOverlay(
+  addr: string,
+  graph: Graph,
+  facetIndex: FacetTargetIndex,
+  ctx: OverlayContext,
+): OverlayResult {
+  const result = describe(addr, graph);
+
+  // Roster: tag every entry with per-kind presence. `describe` never returns an
+  // error arm for these two addresses (graph.ts always yields a roster array).
+  if (addr === 'components' || addr === 'composites') {
+    const set = addr === 'components' ? ctx.installed.components : ctx.installed.composites;
+    const roster = result as Array<{ id: string }>;
+    return roster.map((entry) => ({ id: entry.id, presence: presenceOf(set, entry.id) }));
+  }
+
+  // Single node: a bare id that resolved to a node gets the full stamp. A bad id
+  // resolves to `{ error }`, which fails the guard and passes through unchanged.
+  if (addr !== '' && !addr.includes('.') && isNodeResult(result)) {
+    const set = result.kind === 'component' ? ctx.installed.components : ctx.installed.composites;
+    return {
+      ...result,
+      presence: presenceOf(set, result.id),
+      target: ctx.target,
+      rendersForTarget:
+        ctx.target !== undefined && facetIndex.get(result.id)?.has(ctx.target) === true,
+    };
+  }
+
+  // Surface, props, vocab, edges, errors: unchanged.
+  return result;
+}
+
+function presenceOf(set: ReadonlySet<string>, id: string): Presence {
+  return set.has(id) ? 'installed' : 'available';
+}
+
+/** Narrow a `DescribeResult` to a single-node `NodeResult`. */
+function isNodeResult(result: DescribeResult): result is NodeResult {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    !Array.isArray(result) &&
+    'id' in result &&
+    'kind' in result &&
+    'children' in result
+  );
+}

--- a/packages/cli/test/mcp/overlay.test.ts
+++ b/packages/cli/test/mcp/overlay.test.ts
@@ -1,0 +1,213 @@
+import { describe as vdescribe, expect, it } from 'vitest';
+import { describe } from '../../src/mcp/graph.js';
+import { assembleGraph } from '../../src/mcp/graph.js';
+import {
+  buildFacetTargetIndex,
+  buildInstalledSet,
+  describeWithOverlay,
+  type OverlayContext,
+  type OverlayNodeResult,
+} from '../../src/mcp/overlay.js';
+import type { Facet, RegistryItem } from '../../src/registry/types.js';
+
+// One RegistryItem[] feeds BOTH assembleGraph and buildFacetTargetIndex -- the
+// spec's usage example and the proof the index is built once alongside the graph.
+//   button (ui): facets for astro + wc, but NO vue (the real manifest gap).
+//   modal  (ui): no facets at all (pending #2073 extraction on that node).
+const facet: Facet = { props: {}, snippet: '' };
+
+const items: RegistryItem[] = [
+  {
+    name: 'button',
+    type: 'ui',
+    primitives: [],
+    files: [],
+    rules: [],
+    composites: [],
+    facets: { astro: facet, wc: facet },
+  },
+  {
+    name: 'modal',
+    type: 'ui',
+    primitives: [],
+    files: [],
+    rules: [],
+    composites: [],
+    facets: {},
+  },
+];
+
+const graph = assembleGraph(items);
+const facetIndex = buildFacetTargetIndex(items);
+
+const ctxAstroInstalled: OverlayContext = {
+  target: 'astro',
+  installed: { components: new Set(['button']), composites: new Set() },
+};
+
+vdescribe('describeWithOverlay -- single-node stamping', () => {
+  it('stamps installed presence, echoed target, and a matching facet', () => {
+    const button = describeWithOverlay(
+      'button',
+      graph,
+      facetIndex,
+      ctxAstroInstalled,
+    ) as OverlayNodeResult;
+    expect(button.presence).toBe('installed');
+    expect(button.target).toBe('astro');
+    expect(button.rendersForTarget).toBe(true);
+  });
+
+  it('reports available presence and no facet for an uninstalled, facet-less node', () => {
+    const modal = describeWithOverlay(
+      'modal',
+      graph,
+      facetIndex,
+      ctxAstroInstalled,
+    ) as OverlayNodeResult;
+    expect(modal.presence).toBe('available');
+    expect(modal.rendersForTarget).toBe(false); // no astro facet on modal
+  });
+
+  it('installed but NOT rendersForTarget when the target facet is missing (vue gap)', () => {
+    const ctxVue: OverlayContext = {
+      target: 'vue',
+      installed: { components: new Set(['button']), composites: new Set() },
+    };
+    const button = describeWithOverlay('button', graph, facetIndex, ctxVue) as OverlayNodeResult;
+    expect(button.presence).toBe('installed');
+    expect(button.rendersForTarget).toBe(false); // button has astro + wc, no vue
+  });
+
+  it('degraded mode: no configured target echoes undefined and never renders', () => {
+    const ctxNoTarget: OverlayContext = {
+      target: undefined,
+      installed: { components: new Set(), composites: new Set() },
+    };
+    const button = describeWithOverlay(
+      'button',
+      graph,
+      facetIndex,
+      ctxNoTarget,
+    ) as OverlayNodeResult;
+    expect(button.target).toBeUndefined();
+    expect(button.rendersForTarget).toBe(false);
+  });
+});
+
+vdescribe('describeWithOverlay -- roster tagging', () => {
+  it('tags each entry with per-kind presence', () => {
+    expect(describeWithOverlay('components', graph, facetIndex, ctxAstroInstalled)).toEqual(
+      expect.arrayContaining([
+        { id: 'button', presence: 'installed' },
+        { id: 'modal', presence: 'available' },
+      ]),
+    );
+  });
+
+  it('checks the composites installed set for the composites roster', () => {
+    // stack is a composite; installed.composites holds it, installed.components does not.
+    const composed = assembleGraph([
+      ...items,
+      {
+        name: 'stack',
+        type: 'composite',
+        primitives: [],
+        files: [],
+        rules: [],
+        composites: [],
+        facets: {},
+      },
+    ]);
+    const idx = buildFacetTargetIndex([
+      ...items,
+      {
+        name: 'stack',
+        type: 'composite',
+        primitives: [],
+        files: [],
+        rules: [],
+        composites: [],
+        facets: {},
+      },
+    ]);
+    const ctx: OverlayContext = {
+      target: 'astro',
+      installed: { components: new Set(), composites: new Set(['stack']) },
+    };
+    expect(describeWithOverlay('composites', composed, idx, ctx)).toEqual([
+      { id: 'stack', presence: 'installed' },
+    ]);
+  });
+});
+
+vdescribe('describeWithOverlay -- no shared mutable state', () => {
+  it('two contexts against the same graph/index disagree correctly', () => {
+    const ctxOther: OverlayContext = {
+      target: 'astro',
+      installed: { components: new Set(), composites: new Set() },
+    };
+    expect(
+      (describeWithOverlay('button', graph, facetIndex, ctxOther) as OverlayNodeResult).presence,
+    ).toBe('available');
+    expect(
+      (describeWithOverlay('button', graph, facetIndex, ctxAstroInstalled) as OverlayNodeResult)
+        .presence,
+    ).toBe('installed');
+  });
+
+  it('never mutates graph-owned objects: the presence-free path stays clean', () => {
+    describeWithOverlay('button', graph, facetIndex, ctxAstroInstalled);
+    expect(describe('button', graph)).not.toHaveProperty('presence');
+    expect(describe('button', graph)).not.toHaveProperty('rendersForTarget');
+    expect(describe('button', graph)).not.toHaveProperty('target');
+    expect(describe('components', graph)).toContainEqual({ id: 'button' }); // roster still untagged
+  });
+});
+
+vdescribe('describeWithOverlay -- passthrough shapes', () => {
+  it('describe("") passes through unstamped', () => {
+    expect(describeWithOverlay('', graph, facetIndex, ctxAstroInstalled)).toEqual(
+      describe('', graph),
+    );
+  });
+
+  it('a bad address passes the structured error through unchanged', () => {
+    expect(describeWithOverlay('unknown-node', graph, facetIndex, ctxAstroInstalled)).toEqual({
+      error: 'unknown node: unknown-node',
+    });
+  });
+});
+
+vdescribe('buildInstalledSet', () => {
+  it('reads per-kind arrays from config.installed', () => {
+    const set = buildInstalledSet({
+      installed: { components: ['button'], composites: ['stack'] },
+    });
+    expect(set.components.has('button')).toBe(true);
+    expect(set.composites.has('stack')).toBe(true);
+  });
+
+  it('absent installed means nothing installed, never a crash', () => {
+    const set = buildInstalledSet({});
+    expect(set.components.size).toBe(0);
+    expect(set.composites.size).toBe(0);
+  });
+});
+
+vdescribe('buildFacetTargetIndex', () => {
+  it('indexes each item to its recognized facet targets', () => {
+    expect(facetIndex.get('button')).toEqual(new Set(['astro', 'wc']));
+    expect(facetIndex.get('modal')).toEqual(new Set());
+  });
+
+  it('ignores unrecognized target keys, never crashes', () => {
+    const idx = buildFacetTargetIndex([
+      {
+        name: 'weird',
+        facets: { astro: facet, bogus: facet } as Partial<Record<'astro', unknown>>,
+      },
+    ]);
+    expect(idx.get('weird')).toEqual(new Set(['astro']));
+  });
+});


### PR DESCRIPTION
## Summary

Adds `packages/cli/src/mcp/overlay.ts`: `describeWithOverlay` wraps the #2072 `describe` and stamps a thin per-workspace lens -- presence, a per-target manifest (`rendersForTarget`, from #2073's facets), and the echoed target -- onto node and roster responses at query time, without ever writing to the universal graph.

## Acceptance criteria mapping

### 1. describeWithOverlay stamps presence, per-target manifest, and echoed target
`describeWithOverlay(addr, graph, facetIndex, ctx)` stamps onto single-node and roster results: presence (`installed`|`available` from the workspace installed set), `rendersForTarget` (does a facet exist for the resolved target), and the echoed resolved target.
Evidence: overlay.test.ts asserts a node result carries presence + rendersForTarget + target, and rosters carry per-entry presence.

### 2. Surface, props, vocab, edges, and errors pass through unchanged
Only the single-node and roster shapes are stamped; the surface, prop nodes, vocab leaves, edge results, and error results are returned untouched.
Evidence: test asserts `describeWithOverlay('', ...)` deep-equals `describe('', ...)`, and a bad-address error passes through unchanged.

### 3. The overlay is never stored on the universal graph
The stamp is derived from the passed context, never written onto graph node data, so the same graph serves different workspaces independently.
Evidence: two proofs in the test -- two different contexts over one graph produce different stamps, and after an overlay call the plain `describe` path has no presence/target/rendersForTarget and the roster is untagged.

### 4. buildInstalledSet + buildFacetTargetIndex build the inputs; degraded mode never guesses
`buildInstalledSet(config)` derives per-kind installed sets (absent/partial config = nothing installed, no crash); `buildFacetTargetIndex(items)` reads each item's facet keys once; a context with no target echoes no target.
Evidence: test covers the degraded (no-target) path -- target is undefined and rendersForTarget is not asserted true -- and the installed-set/facet-index construction.

### 5. Overlay tests pass; the #2072 graph tests still pass; preflight green
The overlay is purely additive, so the presence-free `describe` path is unchanged.
Evidence: `pnpm exec vitest run test/mcp/overlay.test.ts test/mcp/graph.test.ts` -> 25 passed (14 overlay + 11 graph); typecheck clean; preflight green on push.

## Not done

The MCP dispatch that supplies the context to `describeWithOverlay` is #2076; the intent door is #2075; generate is #2077. A note for #2076: an installed primitive currently reads as `available` (kindOf folds ui+primitive to `component` but the installed set has only components/composites) -- the dispatch wiring should decide whether to fold `installed.primitives` into the component set.

Closes #2074