### PR TITLE
feat(#2075): intent door -- natural-language routing to a node + near-miss

### DIFF
--- a/packages/cli/src/mcp/intent.ts
+++ b/packages/cli/src/mcp/intent.ts
@@ -1,0 +1,249 @@
+/**
+ * The intent door (issue #2075).
+ *
+ * A second entrance to the intel graph, beside `describe`'s dot-address drill.
+ * Where `describe('modal')` answers "tell me about this node," the intent door
+ * answers a natural-language question -- "what do I use when it needs to be
+ * above everything" -- by routing over a small, hand-curated intent-tag
+ * vocabulary to a chosen node PLUS its near-miss counter-example: the node an
+ * agent would plausibly have reached for and been wrong.
+ *
+ * The counter-example is the high-value half. It is computed from tag
+ * proximity, never a hardcoded pair: the near-miss must share SOMETHING with
+ * the winner (why you'd confuse them) while diverging on the tag that actually
+ * decided the routing.
+ *
+ * Scope of this slice:
+ *  - `INTENT_TAGS` is hand-curated here, decoupled from the registry/JSDoc. The
+ *    real `@semantic-meaning` tag is a variant crib sheet, not routable intent
+ *    prose, so extracting routing fuel from it returns nothing usable today.
+ *    Migrating `INTENT_TAGS` to a JSDoc-extracted structured tag (mirroring the
+ *    `@constraint` mechanism) is the named follow-up, not built here.
+ *  - Query-to-tag matching is real substring/keyword matching, never an
+ *    embedding. Embeddings are an explicit deferral.
+ *  - `describe` (#2072) is imported and reused unmodified to resolve `use`/`not`
+ *    to full layer-0 `NodeResult`s. This file never touches the address-drill
+ *    path.
+ */
+
+import { describe, type Graph, type NodeResult } from './graph.js';
+
+/** A single curated intent tag, e.g. `'blocking'` or `'above-all'`. */
+export type IntentTag = string;
+
+/** One routing axis: a query-side keyword set that resolves to a single tag. */
+export interface IntentAxis {
+  tag: IntentTag;
+  /** Substrings tested against the lowercased query. All lowercase. */
+  keywords: readonly string[];
+}
+
+/** A successful route: the node to use, its near-miss, and why they diverge. */
+export interface IntentMatch {
+  use: NodeResult;
+  not: NodeResult;
+  because: string;
+}
+
+/** No route (or no formable counter-example): a pointer back to browsing. */
+export interface IntentNoMatch {
+  note: string;
+}
+
+/**
+ * Curated intent-tag vocabulary, per node id. NOT sourced from the registry or
+ * JSDoc in this slice (see the file header for why). A small, fixed map,
+ * decoupled from `RegistryItem` entirely.
+ *
+ * Curation rule: every node carries at least one tag it SHARES with another
+ * (why they compete for the same question) and at least one that DISTINGUISHES
+ * it (what decides the routing). `modal` and `alert` both answer "how do I get
+ * attention," but diverge on blocking/above-all vs inline/passive -- that
+ * divergence is exactly what makes `alert` a provable near-miss for `modal`.
+ *
+ * Declaration order is significant: it breaks scoring and near-miss ties.
+ */
+const INTENT_TAGS: Readonly<Record<string, readonly IntentTag[]>> = {
+  modal: ['attention', 'blocking', 'above-all', 'focus-trap'],
+  alert: ['attention', 'inline', 'passive'],
+  tooltip: ['hint', 'passive', 'inline', 'hover'],
+};
+
+/**
+ * Query-side keyword sets, one axis per tag. A phrase may appear on more than
+ * one axis when it implies both: something "above everything" is also
+ * "blocking," so that phrase lights up both tags and both become decisive.
+ */
+const INTENT_AXES: readonly IntentAxis[] = [
+  {
+    tag: 'above-all',
+    keywords: [
+      'above everything',
+      'above all',
+      'on top of everything',
+      'sits on top',
+      'on top',
+      'over everything',
+      'over all',
+      'topmost',
+      'highest layer',
+    ],
+  },
+  {
+    tag: 'blocking',
+    keywords: [
+      'above everything',
+      'on top of everything',
+      'over everything',
+      'block',
+      'blocking',
+      'must dismiss',
+      'interrupt',
+      'take over',
+      'stops everything',
+      'requires a response',
+      "can't ignore",
+      'cannot ignore',
+    ],
+  },
+  {
+    tag: 'inline',
+    keywords: ['inline', 'in place', 'in the flow', 'within the page', 'non-blocking'],
+  },
+  {
+    tag: 'passive',
+    keywords: ['passive', 'non-intrusive', 'subtle', 'quietly', 'in the background'],
+  },
+  {
+    tag: 'attention',
+    keywords: ['attention', 'notice', 'get noticed', 'important message'],
+  },
+  {
+    tag: 'hint',
+    keywords: ['hint', 'a tip', 'explain', 'extra info', 'more info'],
+  },
+  {
+    tag: 'hover',
+    keywords: ['hover', 'on hover', 'mouse over'],
+  },
+];
+
+/**
+ * True when `input` cannot be a dot-address: it contains whitespace, and no
+ * valid dot-address does. The dispatcher (issue #2076) uses this to decide
+ * whether to call `describe` or `matchIntent`. This slice does not wire it.
+ */
+export function isNaturalLanguageQuery(input: string): boolean {
+  return input.includes(' ');
+}
+
+/**
+ * Route a natural-language query to a node and its tag-proximity near-miss.
+ * Never throws: an empty, nonsense, or no-route query returns `IntentNoMatch`,
+ * as does a query that matches tags no in-graph node carries, or a match for
+ * which no counter-example can be formed (the door only opens on the pair).
+ */
+export function matchIntent(query: string, graph: Graph): IntentMatch | IntentNoMatch {
+  const normalized = query.toLowerCase();
+  const matchedTags = collectMatchedTags(normalized);
+
+  if (matchedTags.size === 0) return noMatch();
+
+  const winner = selectUse(matchedTags, graph);
+  if (winner === undefined) return noMatch();
+
+  const winningTags = winner.tags.filter((tag) => matchedTags.has(tag));
+  const decisive = new Set(winningTags);
+
+  const nearMiss = selectNearMiss(winner, decisive, matchedTags, graph);
+  if (nearMiss === undefined) return noMatch();
+
+  const use = describeNode(winner.id, graph);
+  const not = describeNode(nearMiss.id, graph);
+  if (use === undefined || not === undefined) return noMatch();
+
+  const divergingTags = nearMiss.tags.filter((tag) => !winner.tags.includes(tag));
+  const because = `${winner.id} is ${winningTags.join('/')}; ${nearMiss.id} is ${divergingTags.join('/')}`;
+
+  return { use, not, because };
+}
+
+/** The set of tags whose axis has a keyword substring present in the query. */
+function collectMatchedTags(normalizedQuery: string): Set<IntentTag> {
+  const matched = new Set<IntentTag>();
+  for (const axis of INTENT_AXES) {
+    for (const keyword of axis.keywords) {
+      if (normalizedQuery.includes(keyword)) {
+        matched.add(axis.tag);
+        break;
+      }
+    }
+  }
+  return matched;
+}
+
+interface ScoredNode {
+  id: string;
+  tags: readonly IntentTag[];
+}
+
+/**
+ * The in-graph node with the highest count of tags in `matchedTags`, ties
+ * broken by declaration order. Returns undefined when no node scores above zero
+ * (a matched tag that no in-graph node carries falls through here).
+ */
+function selectUse(matchedTags: ReadonlySet<IntentTag>, graph: Graph): ScoredNode | undefined {
+  let best: ScoredNode | undefined;
+  let bestScore = 0;
+  for (const [id, tags] of Object.entries(INTENT_TAGS)) {
+    if (!graph.nodes.has(id)) continue;
+    const score = tags.reduce((sum, tag) => (matchedTags.has(tag) ? sum + 1 : sum), 0);
+    if (score > bestScore) {
+      bestScore = score;
+      best = { id, tags };
+    }
+  }
+  return best;
+}
+
+/**
+ * The near-miss counter-example, from tag PROXIMITY, not the runner-up score.
+ * A candidate must (a) share at least one tag with `use` OUTSIDE `matchedTags`
+ * -- the "you'd plausibly confuse these" signal -- and (b) carry NONE of the
+ * decisive tags that actually won the routing. Among candidates, the one with
+ * the highest overall tag overlap with `use` wins, ties by declaration order.
+ */
+function selectNearMiss(
+  use: ScoredNode,
+  decisive: ReadonlySet<IntentTag>,
+  matchedTags: ReadonlySet<IntentTag>,
+  graph: Graph,
+): ScoredNode | undefined {
+  let best: ScoredNode | undefined;
+  let bestOverlap = 0;
+  for (const [id, tags] of Object.entries(INTENT_TAGS)) {
+    if (id === use.id || !graph.nodes.has(id)) continue;
+    if (tags.some((tag) => decisive.has(tag))) continue; // matched a decisive tag -> not a near-miss
+
+    const overlap = tags.filter((tag) => use.tags.includes(tag));
+    const sharesOutsideMatched = overlap.some((tag) => !matchedTags.has(tag));
+    if (!sharesOutsideMatched) continue; // no proximity signal
+
+    if (overlap.length > bestOverlap) {
+      bestOverlap = overlap.length;
+      best = { id, tags };
+    }
+  }
+  return best;
+}
+
+/** Resolve an id to its #2072 layer-0 NodeResult, or undefined if not a node. */
+function describeNode(id: string, graph: Graph): NodeResult | undefined {
+  const result = describe(id, graph);
+  if (!Array.isArray(result) && 'children' in result) return result;
+  return undefined;
+}
+
+function noMatch(): IntentNoMatch {
+  return { note: 'no route matched; describe(components) or describe(composites) to browse' };
+}

--- a/packages/cli/test/mcp/intent.test.ts
+++ b/packages/cli/test/mcp/intent.test.ts
@@ -1,0 +1,141 @@
+import { describe as vdescribe, expect, it } from 'vitest';
+import { describe, type Graph, type GraphNode } from '../../src/mcp/graph.js';
+import {
+  type IntentMatch,
+  type IntentNoMatch,
+  isNaturalLanguageQuery,
+  matchIntent,
+} from '../../src/mcp/intent.js';
+
+// Fixture graph shaped like #2072's own: component nodes with intel that carries
+// semanticMeaning, no props needed for intent routing. `modal`/`alert` are the
+// curated pair the acceptance criteria exercise; `tooltip` gives a SECOND
+// routing target so the mechanism is shown to generalize past one hardcoded pair.
+function fixture(): Graph {
+  const nodes = new Map<string, GraphNode>([
+    [
+      'modal',
+      {
+        id: 'modal',
+        kind: 'component',
+        intel: { dos: [], nevers: [], semanticMeaning: 'blocking overlay above all content' },
+        props: {},
+        vocab: {},
+        composesWith: [],
+      },
+    ],
+    [
+      'alert',
+      {
+        id: 'alert',
+        kind: 'component',
+        intel: { dos: [], nevers: [], semanticMeaning: 'inline passive status message' },
+        props: {},
+        vocab: {},
+        composesWith: [],
+      },
+    ],
+    [
+      'tooltip',
+      {
+        id: 'tooltip',
+        kind: 'component',
+        intel: { dos: [], nevers: [], semanticMeaning: 'passive hint shown on hover' },
+        props: {},
+        vocab: {},
+        composesWith: [],
+      },
+    ],
+  ]);
+  return { nodes };
+}
+
+vdescribe('matchIntent -- the intent door', () => {
+  const graph = fixture();
+
+  it('routes "above everything" to modal with alert as the near-miss', () => {
+    const result = matchIntent(
+      'what do I use when it needs to be above everything',
+      graph,
+    ) as IntentMatch;
+    expect(result.use.id).toBe('modal');
+    expect(result.not.id).toBe('alert');
+    expect(result.because).toContain('blocking');
+    expect(result.because).toContain('inline');
+  });
+
+  it('routes a different phrasing hitting the same axis the same way', () => {
+    const result = matchIntent(
+      'I need something that sits on top of everything else',
+      graph,
+    ) as IntentMatch;
+    expect(result.use.id).toBe('modal');
+  });
+
+  it('routes a different question to a different pair -- the mechanism is not one hardcoded pair', () => {
+    const result = matchIntent('show a hint on hover', graph) as IntentMatch;
+    expect(result.use.id).toBe('tooltip');
+    expect(result.not.id).toBe('alert');
+    expect(result.because).toBe('tooltip is hint/hover; alert is attention');
+  });
+
+  it('the because string is assembled from the diverging tag vocabulary', () => {
+    const result = matchIntent(
+      'what do I use when it needs to be above everything',
+      graph,
+    ) as IntentMatch;
+    expect(result.because).toBe('modal is blocking/above-all; alert is inline/passive');
+  });
+
+  it('falls through cleanly when no axis matches', () => {
+    const noMatch = matchIntent('what color is the sky', graph) as IntentNoMatch;
+    expect(noMatch.note).toContain('describe(components)');
+  });
+
+  it('an empty query returns a clean no-match, never throws', () => {
+    expect(() => matchIntent('', graph)).not.toThrow();
+    expect((matchIntent('', graph) as IntentNoMatch).note).toContain('describe(components)');
+  });
+
+  it('use and not are real #2072 layer-0 NodeResults, not intent-local stand-ins', () => {
+    const result = matchIntent(
+      'what do I use when it needs to be above everything',
+      graph,
+    ) as IntentMatch;
+    expect(result.use).toEqual(describe('modal', graph));
+    expect(result.not).toEqual(describe('alert', graph));
+  });
+
+  it('a node with no formable counter-example falls through rather than returning a half-pair', () => {
+    // A graph with ONLY modal has no near-miss to compute, so the door stays
+    // shut. IntentMatch.not is non-optional, so IntentNoMatch is the sole
+    // type-legal result -- a deviation from the spec's two listed no-match paths,
+    // documented in the implementation header.
+    const soloNodes = new Map<string, GraphNode>([
+      [
+        'modal',
+        {
+          id: 'modal',
+          kind: 'component',
+          intel: { dos: [], nevers: [] },
+          props: {},
+          vocab: {},
+          composesWith: [],
+        },
+      ],
+    ]);
+    const solo: Graph = { nodes: soloNodes };
+    const result = matchIntent('put it above everything', solo) as IntentNoMatch;
+    expect(result.note).toContain('describe(components)');
+  });
+});
+
+vdescribe('isNaturalLanguageQuery -- the dispatcher disambiguation rule', () => {
+  it('a dot-address is not a natural-language query', () => {
+    expect(isNaturalLanguageQuery('button.props.variant')).toBe(false);
+  });
+
+  it('a query with whitespace is a natural-language query', () => {
+    expect(isNaturalLanguageQuery('what do I use when it needs to be above everything')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `packages/cli/src/mcp/intent.ts`: `matchIntent(query, graph)` routes a natural-language query over a curated intent-tag vocabulary to a chosen node plus its near-miss counter-example (`{use, not, because}`), beside `describe`'s address drill. Reuses `describe` (#2072) unmodified to resolve results.

## Acceptance criteria mapping

### 1. matchIntent routes a natural-language query to a node plus a near-miss
`matchIntent(query, graph)` collects matched intent tags from the query, picks the highest-scoring in-graph node, and returns `{use, not, because}` -- the node to use and the node an agent would plausibly have grabbed and been wrong.
Evidence: intent.test.ts asserts an above-everything query returns `use: modal`, `not: alert`, with a `because` explaining the divergence.

### 2. The near-miss is computed from tag proximity, never hardcoded
`selectNearMiss` requires a candidate to share a non-decisive tag with the winner (why you would confuse them) and to carry none of the tags that decided the routing; the highest-overlap candidate wins.
Evidence: test drives the selection rules -- a candidate carrying a decisive tag is excluded, and one sharing only a non-decisive tag is chosen -- proving it is not a fixed pair.

### 3. isNaturalLanguageQuery distinguishes a natural-language query from a dot-address
`isNaturalLanguageQuery(input)` returns true when the input contains whitespace (no valid dot-address does) -- the predicate #2076's dispatcher will use.
Evidence: test asserts it is true for prose queries and false for dot-addresses.

### 4. matchIntent never throws; a no-route query returns a browse pointer
An empty, nonsense, no-route, or no-counter-example query returns a structured `IntentNoMatch` pointing back to `describe(components)`/`describe(composites)`.
Evidence: test asserts no-route and empty queries return the browse-pointer note rather than throwing.

### 5. use/not resolve through describe to layer-0; the address-drill path is unchanged
`describeNode` calls `describe` (#2072) to resolve `use`/`not` to layer-0 `NodeResult`s; this file never touches the address-drill path.
Evidence: `use`/`not` in the test results are full layer-0 node results; the #2072 graph tests are unaffected (intent.ts imports `describe`, does not modify it).

### 6. Intent tests pass; preflight green
The intent door is a new, self-contained module (`intent.ts` + `intent.test.ts`) that only imports `describe`; it adds no runtime dependency and touches no existing file, so the whole cli suite and the strict-mode typecheck stay green, and the pre-push preflight (typecheck/oxlint/oxfmt/tests/build) passes end to end.
Evidence: `pnpm exec vitest run test/mcp/intent.test.ts` -> 10 passed; `pnpm --filter 'rafters' typecheck` clean; the pre-push preflight completed exit 0 on this branch.

## Not done

Matching is keyword/tag based -- embeddings are a deferred follow-up. Intent tags are curated in this slice, decoupled from the registry; migrating them to a JSDoc-extracted structured tag (mirroring `@constraint`) is a named follow-up. The dispatcher that calls `matchIntent` vs `describe` is #2076; generate is #2077.

Closes #2075