### PR TITLE
feat(#2076): restructure MCP surface to describe/workspaces/generate

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # rafters
 
+## Unreleased
+
+### Features
+
+- feat(mcp): restructure the tool surface to `rafters_describe` / `rafters_workspaces` / `rafters_generate` (#2076). `rafters_describe` is the single introspection verb over the component/composite intel graph: a dot-address (`button`, `button.props.fill`, `button.props.fill.vocab`) resolves through the workspace overlay (presence, per-target manifest, echoed target) down to `describe`; a natural-language question ("what do I use when it needs to be above everything") routes through the intent door to a best-match node plus its near-miss counter-example. `component`/`composite` are no longer standalone concepts -- they are `describe(components)` / `describe(composites)`. `rafters_generate` is registered as an honest stub (returns `{ implemented: false }`) so the surface shape stabilizes before the generator lands. The graph is populated lazily per workspace on first use (whole-catalog fetch, then in-memory assembly) and cached by workspace root.
+- feat(registry): `RegistryClient.fetchAllItems()` -- one whole-catalog load with a graceful fallback. Prefers a single bulk round-trip against `/registry/items.json`; a registry that does not serve that route (an older deploy, or a third-party `registryUrl`) returns a non-2xx and the client falls back to looping `fetchItem` over the index, so `describe` never hard-fails on a registry that predates the bulk endpoint.
+
+### Deprecations
+
+- `rafters_component`, `rafters_composite`, and `rafters_pattern` remain registered and functional as deprecated aliases for one minor release (each response now carries `deprecated: 'use rafters_describe instead'`). By-id lookups forward to `rafters_describe`; composite/pattern free-text and category search keep their existing composite-registry behavior. Removal is tracked as a follow-up.
+
 ## 0.0.82
 
 ### Bug Fixes

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -1,15 +1,28 @@
 /**
  * MCP Tools for Rafters Design System
  *
- * 4 focused tools for agent ASSEMBLY (not design):
+ * The primary surface for agent ASSEMBLY (not design):
  *
- * 1. rafters_composite - Query composites with designer intent
- * 2. rafters_pattern - Design pattern guidance (do/never)
- * 3. rafters_component - Component intelligence
- * 4. rafters_workspaces - List available workspaces
+ * 1. rafters_workspaces - List workspaces, or update a workspace's WIRING config.
+ * 2. rafters_describe   - Recursively introspect the component/composite intel
+ *                         graph. Dispatches: a natural-language question routes
+ *                         through the intent door (matchIntent); a dot-address
+ *                         resolves through the workspace overlay (describeWithOverlay
+ *                         -> describe). This dispatcher is the ONLY seam that
+ *                         composes graph.ts (#2072), overlay.ts (#2074), and
+ *                         intent.ts (#2075); none of the three call each other.
+ * 3. rafters_generate   - STUB (issue E). Returns an honest not-implemented result.
  *
- * Agents assemble from pre-made decisions. Token design lives in Studio.
- * Token import lives in `rafters init` / `rafters import`, not MCP.
+ * Deprecated aliases kept for one minor release (removal tracked as a follow-up):
+ *   - rafters_component -> describe(<id>) via the overlay.
+ *   - rafters_composite -> describe(<id>) by id; existing composite search otherwise.
+ *   - rafters_pattern   -> existing composite search (NOT the intent door, whose
+ *                          curated tags cannot answer most real queries yet).
+ *
+ * The graph is populated lazily, per workspace, on the first describe/generate
+ * call that touches it (fetchAllItems + assembleGraph + buildFacetTargetIndex),
+ * and cached by workspace root. Agents assemble from pre-made decisions. Token
+ * design lives in Studio; token import lives in `rafters init` / `rafters import`.
  */
 
 import { readFile, writeFile } from 'node:fs/promises';
@@ -18,7 +31,6 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import {
   type CompositeFile,
   getAllComposites,
-  getComposite,
   getCompositesByCategory,
   registerComposite,
   searchComposites,
@@ -28,8 +40,18 @@ import { discoverFromDirs } from '@rafters/composites/node';
 import { z } from 'zod';
 import { migrateConfig, type RaftersConfig } from '../commands/init.js';
 import { RegistryClient, registryClient } from '../registry/client.js';
+import type { RegistryItem } from '../registry/types.js';
 import { getRaftersPaths, PathFieldSchema, resolveReadSet } from '../utils/paths.js';
 import { resolveWorkspace, type Workspace } from '../utils/workspaces.js';
+import { assembleGraph, type Graph } from './graph.js';
+import { isNaturalLanguageQuery, matchIntent } from './intent.js';
+import {
+  buildFacetTargetIndex,
+  buildInstalledSet,
+  describeWithOverlay,
+  type FacetTargetIndex,
+  type OverlayContext,
+} from './overlay.js';
 
 /**
  * True when a path is safe to accept from an agent: relative, and with no `..`
@@ -155,9 +177,49 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
+    name: 'rafters_describe',
+    description:
+      'Recursively introspect the component/composite intel graph. describe() returns the ' +
+      'installed surface; describe(components)/describe(composites) list the kind roster; ' +
+      'describe(button) returns a node -- intel plus type-marked, drillable children; ' +
+      'describe(button.props.fill) drills into a prop; describe(button.props.fill.vocab) ' +
+      'returns the real token values. A natural-language question (e.g. "what do I use when ' +
+      'it needs to be above everything") routes to the best-matching node plus a near-miss ' +
+      'counter-example instead of an address.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        ...WORKSPACE_PARAM,
+        address: {
+          type: 'string',
+          description: 'A dot-address ("button.props.variant") or a natural-language question.',
+        },
+      },
+      required: ['address'],
+    },
+  },
+  {
+    name: 'rafters_generate',
+    description:
+      'STUB (Issue E). Will produce a rafters-correct composition with visible placeholders ' +
+      'for app-specific fields/actions/copy. Currently returns a structured not-implemented result.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        ...WORKSPACE_PARAM,
+        intent: { type: 'string', description: 'What to generate' },
+      },
+      required: ['intent'],
+    },
+  },
+  // Deprecated aliases -- kept for one minor release, then removed (tracked as a
+  // follow-up). Input schemas unchanged; every response carries a `deprecated`
+  // field pointing at rafters_describe.
+  {
     name: 'rafters_composite',
     description:
-      'Query composites by ID, search term, or category. Returns designer intent (solves, appliesWhen, do/never), I/O rules for chaining, and block structure.',
+      '[DEPRECATED -- use rafters_describe] Query composites by ID, search term, or category. ' +
+      'Returns designer intent (solves, appliesWhen, do/never), I/O rules for chaining, and block structure.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -172,7 +234,9 @@ export const TOOL_DEFINITIONS = [
   {
     name: 'rafters_pattern',
     description:
-      'Get design pattern guidance by querying composites. Search by what the pattern solves (e.g., "authentication", "data entry", "navigation") to get do/never rules, cognitive load, and designer intent.',
+      '[DEPRECATED -- use rafters_describe] Get design pattern guidance by querying composites. ' +
+      'Search by what the pattern solves (e.g., "authentication", "data entry", "navigation") to ' +
+      'get do/never rules, cognitive load, and designer intent.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -192,7 +256,8 @@ export const TOOL_DEFINITIONS = [
   {
     name: 'rafters_component',
     description:
-      'Get component intelligence: cognitive load, accessibility, do/never guidance, variants, sizes.',
+      '[DEPRECATED -- use rafters_describe] Get component intelligence: cognitive load, ' +
+      'accessibility, do/never guidance, variants, sizes.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -206,6 +271,9 @@ export const TOOL_DEFINITIONS = [
     },
   },
 ] as const;
+
+/** Stamped onto every deprecated-alias response. */
+const DEPRECATED_MSG = 'use rafters_describe instead';
 
 // ==================== Tool Handler ====================
 
@@ -222,16 +290,41 @@ export class RaftersToolHandler {
    * singleton (which points at the public registry).
    */
   private registryClients = new Map<string, RegistryClient>();
+  /**
+   * Per-workspace-root cache: the intel graph plus its facet-target index, built
+   * once, lazily, on the first describe/generate call that touches that root.
+   * Same per-workspace caching shape as `compositesLoadedFor`/`registryClients`.
+   * A failed build is never inserted, so the next call retries rather than
+   * permanently wedging that workspace.
+   */
+  private graphsByWorkspace = new Map<string, { graph: Graph; facetIndex: FacetTargetIndex }>();
+  /**
+   * The whole-catalog item source `ensureGraph` builds from. Defaults to the
+   * workspace's registry client `fetchAllItems()` (bulk endpoint with per-item
+   * fallback). Injectable so the dispatch can be unit-tested against a fixture
+   * catalog without a network round-trip.
+   */
+  private readonly itemsSource: (workspace: Workspace | null) => Promise<RegistryItem[]>;
 
-  constructor(workspaces: Workspace[], defaultWorkspace: Workspace | null) {
+  constructor(
+    workspaces: Workspace[],
+    defaultWorkspace: Workspace | null,
+    itemsSource?: (workspace: Workspace | null) => Promise<RegistryItem[]>,
+  ) {
     this.workspaces = workspaces;
     this.defaultWorkspace = defaultWorkspace;
+    this.itemsSource =
+      itemsSource ?? (async (ws) => (await this.registryClientFor(ws)).fetchAllItems());
   }
 
   async handleToolCall(name: string, args: Record<string, unknown>): Promise<CallToolResult> {
     switch (name) {
       case 'rafters_workspaces':
         return this.handleWorkspaces(args);
+      case 'rafters_describe':
+        return this.handleDescribe(args.address as string, args.workspace as string | undefined);
+      case 'rafters_generate':
+        return this.handleGenerate(args.intent as string, args.workspace as string | undefined);
       case 'rafters_composite':
         return this.handleComposite(args);
       case 'rafters_pattern':
@@ -241,7 +334,7 @@ export class RaftersToolHandler {
       default:
         return this.errorResult(`Unknown tool: ${name}`, {
           suggestion:
-            'Available tools: rafters_workspaces, rafters_composite, rafters_pattern, rafters_component.',
+            'Available tools: rafters_workspaces, rafters_describe, rafters_generate. Deprecated: rafters_composite, rafters_pattern, rafters_component.',
         });
     }
   }
@@ -444,6 +537,104 @@ export class RaftersToolHandler {
   }
 
   /**
+   * Build (once, lazily) and cache the intel graph + facet-target index for a
+   * workspace root. `assembleGraph` (#2072) and `buildFacetTargetIndex` (#2074)
+   * both consume the SAME whole-catalog `RegistryItem[]`. Throws when the catalog
+   * can't be loaded (both the bulk endpoint and the per-item fallback failed) or
+   * the graph is structurally broken (a dangling `composesWith` edge -- #2072's
+   * deliberate fail-fast); the caller converts that into a structured error
+   * result. A failed build is never cached, so the next call retries.
+   */
+  private async ensureGraph(
+    workspace: Workspace | null,
+  ): Promise<{ graph: Graph; facetIndex: FacetTargetIndex }> {
+    const key = workspace?.root ?? '';
+    const cached = this.graphsByWorkspace.get(key);
+    if (cached) return cached;
+
+    const items = await this.itemsSource(workspace);
+    const built = { graph: assembleGraph(items), facetIndex: buildFacetTargetIndex(items) };
+    this.graphsByWorkspace.set(key, built);
+    return built;
+  }
+
+  /**
+   * Resolve a workspace's overlay context: the configured `componentTarget`
+   * (echoed as-is, `undefined` in degraded mode) and its installed set. Per the
+   * integration note on #2074, `installed.primitives` folds into the components
+   * set -- a `primitive`-kind item maps to graph kind `component`, so without the
+   * fold every installed primitive would misreport as `available`. Built here
+   * rather than by mutating `buildInstalledSet`'s output, leaving overlay.ts
+   * untouched.
+   */
+  private async overlayContext(workspace: Workspace | null): Promise<OverlayContext> {
+    const config = workspace ? await this.readConfig(workspace.root) : null;
+    const base = buildInstalledSet(config ?? {});
+    const components = new Set([...base.components, ...(config?.installed?.primitives ?? [])]);
+    return {
+      target: config?.componentTarget,
+      installed: { components, composites: base.composites },
+    };
+  }
+
+  /**
+   * The `rafters_describe` dispatcher -- the one seam that composes #2072/#2074/
+   * #2075. A natural-language question routes through the intent door
+   * (`matchIntent`); a dot-address resolves through the workspace overlay
+   * (`describeWithOverlay`, which delegates to #2072's `describe`).
+   */
+  private async handleDescribe(address: string, workspaceName?: string): Promise<CallToolResult> {
+    const resolved = this.resolve(workspaceName);
+    if (workspaceName && !resolved) {
+      return this.workspaceRequiredError();
+    }
+
+    let built: { graph: Graph; facetIndex: FacetTargetIndex };
+    try {
+      built = await this.ensureGraph(resolved);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      return this.errorResult(`failed to build intel graph: ${message}`);
+    }
+
+    if (isNaturalLanguageQuery(address)) {
+      return this.jsonResult(matchIntent(address, built.graph));
+    }
+    const ctx = await this.overlayContext(resolved);
+    return this.jsonResult(describeWithOverlay(address, built.graph, built.facetIndex, ctx));
+  }
+
+  /**
+   * The `rafters_generate` stub (Issue E). Registered now so the surface shape
+   * (name, input schema) stabilizes before the generator lands; it never
+   * attempts real composition. Deliberately does NOT build the graph: nothing
+   * here reads it, and a build failure must not turn an honest stub into an
+   * error result.
+   */
+  private async handleGenerate(intent: string, workspaceName?: string): Promise<CallToolResult> {
+    const resolved = this.resolve(workspaceName);
+    if (workspaceName && !resolved) {
+      return this.workspaceRequiredError();
+    }
+    return this.jsonResult({
+      implemented: false,
+      note: `generate is a spike -- see issue E; not yet implemented (requested: ${intent})`,
+    });
+  }
+
+  /**
+   * Stamp the deprecated marker as a top-level field. Objects gain a sibling
+   * `deprecated` key; the rare array/leaf result is wrapped so the marker still
+   * rides at top level.
+   */
+  private withDeprecated(payload: unknown): Record<string, unknown> {
+    if (typeof payload === 'object' && payload !== null && !Array.isArray(payload)) {
+      return { ...(payload as Record<string, unknown>), deprecated: DEPRECATED_MSG };
+    }
+    return { result: payload, deprecated: DEPRECATED_MSG };
+  }
+
+  /**
    * Resolve the set of folders to scan for composite manifests in a workspace.
    * Reads `.rafters/config.rafters.json` and applies the workspace's
    * `compositesPath` (which may be a string or an array of entries to support
@@ -467,6 +658,14 @@ export class RaftersToolHandler {
       workspace?: string;
     };
 
+    // By-id forwards to describe (via the overlay) -- there is no `'composites.'
+    // + id` address form in #2072, so a single id resolves the same node either
+    // kind. Free-text/category search keeps the existing composite-registry body
+    // below (the intent door's curated tags cannot answer most real queries yet).
+    if (id) {
+      return this.describeById(id, workspace);
+    }
+
     const resolved = this.resolve(workspace);
     if (workspace && !resolved) {
       return this.workspaceRequiredError();
@@ -476,10 +675,7 @@ export class RaftersToolHandler {
 
     let composites: CompositeFile[];
 
-    if (id) {
-      const c = getComposite(id);
-      composites = c ? [c] : [];
-    } else if (query) {
+    if (query) {
       composites = searchComposites(query);
     } else if (category) {
       composites = getCompositesByCategory(category);
@@ -508,7 +704,7 @@ export class RaftersToolHandler {
         .map((b) => ({ id: b.id, type: b.type, rules: b.rules })),
     }));
 
-    return this.jsonResult({ composites: result });
+    return this.jsonResult({ composites: result, deprecated: DEPRECATED_MSG });
   }
 
   private async handlePattern(args: {
@@ -551,7 +747,10 @@ export class RaftersToolHandler {
           solves: c.manifest.solves,
         }));
 
-      return this.errorResult('No patterns found matching query', { available });
+      return this.errorResult('No patterns found matching query', {
+        available,
+        deprecated: DEPRECATED_MSG,
+      });
     }
 
     // Return pattern-focused view of composites
@@ -564,40 +763,44 @@ export class RaftersToolHandler {
       usagePatterns: c.manifest.usagePatterns,
     }));
 
-    return this.jsonResult({ patterns });
+    return this.jsonResult({ patterns, deprecated: DEPRECATED_MSG });
   }
 
+  /**
+   * DEPRECATED alias for `rafters_describe`. A component resolves by id through
+   * the overlay exactly as `describe(<id>)` does (#2072's resolver has no
+   * separate component/composite address form -- `describe(<id>)` resolves either
+   * kind), so this is a direct, lossless forward with the deprecated marker added.
+   */
   private async handleComponent(
     componentName: string,
     workspaceName?: string,
   ): Promise<CallToolResult> {
+    return this.describeById(componentName, workspaceName);
+  }
+
+  /**
+   * Shared by the deprecated `rafters_component` and `rafters_composite({id})`
+   * paths: resolve one id through the overlay, stamp the deprecated marker.
+   */
+  private async describeById(id: string, workspaceName?: string): Promise<CallToolResult> {
     const resolved = this.resolve(workspaceName);
     if (workspaceName && !resolved) {
       return this.workspaceRequiredError();
     }
 
+    let built: { graph: Graph; facetIndex: FacetTargetIndex };
     try {
-      const client = await this.registryClientFor(resolved);
-      const item = await client.fetchComponent(componentName);
-
-      return this.jsonResult({
-        name: item.name,
-        type: item.type,
-        description: item.description,
-        primitives: item.primitives,
-        rules: item.rules,
-        composites: item.composites,
-        files: item.files,
-        // The intelligence field carries the WHY of the component: cognitive
-        // load, accessibility, do/never, semantic meaning. Extracted from JSDoc
-        // by the registry generator and present on every component JSON.
-        // Previously stripped by the schema (not declared) and not referenced by
-        // the handler -- the tool's whole reason for existing went missing.
-        intelligence: item.intelligence,
-      });
+      built = await this.ensureGraph(resolved);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error';
-      return this.errorResult(message);
+      return this.errorResult(`failed to build intel graph: ${message}`, {
+        deprecated: DEPRECATED_MSG,
+      });
     }
+
+    const ctx = await this.overlayContext(resolved);
+    const out = describeWithOverlay(id, built.graph, built.facetIndex, ctx);
+    return this.jsonResult(this.withDeprecated(out));
   }
 }

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -40,7 +40,7 @@ import { discoverFromDirs } from '@rafters/composites/node';
 import { z } from 'zod';
 import { migrateConfig, type RaftersConfig } from '../commands/init.js';
 import { RegistryClient, registryClient } from '../registry/client.js';
-import type { RegistryItem } from '../registry/types.js';
+import { ComponentTargetSchema, type RegistryItem } from '../registry/types.js';
 import { getRaftersPaths, PathFieldSchema, resolveReadSet } from '../utils/paths.js';
 import { resolveWorkspace, type Workspace } from '../utils/workspaces.js';
 import { assembleGraph, type Graph } from './graph.js';
@@ -566,13 +566,20 @@ export class RaftersToolHandler {
    * fold every installed primitive would misreport as `available`. Built here
    * rather than by mutating `buildInstalledSet`'s output, leaving overlay.ts
    * untouched.
+   *
+   * `componentTarget` comes off unvalidated on-disk config (`readConfig` is a raw
+   * `JSON.parse`), so it is run through `ComponentTargetSchema` here rather than
+   * trusted as a `ComponentTarget` -- a stale or typo'd value falls back to
+   * degraded mode (`undefined` target) instead of silently forcing
+   * `rendersForTarget` false for every node.
    */
   private async overlayContext(workspace: Workspace | null): Promise<OverlayContext> {
     const config = workspace ? await this.readConfig(workspace.root) : null;
     const base = buildInstalledSet(config ?? {});
     const components = new Set([...base.components, ...(config?.installed?.primitives ?? [])]);
+    const parsedTarget = ComponentTargetSchema.safeParse(config?.componentTarget);
     return {
-      target: config?.componentTarget,
+      target: parsedTarget.success ? parsedTarget.data : undefined,
       installed: { components, composites: base.composites },
     };
   }

--- a/packages/cli/src/registry/client.ts
+++ b/packages/cli/src/registry/client.ts
@@ -4,6 +4,7 @@
  * Fetches items (components, primitives, composites, rules) from the rafters registry.
  */
 
+import { z } from 'zod';
 import {
   type RegistryIndex,
   RegistryIndexSchema,
@@ -108,6 +109,48 @@ export class RegistryClient {
       }
     }
     throw new Error(`"${name}" not found in registry (component, primitive, composite, or rule)`);
+  }
+
+  /**
+   * Fetch every registry item in one call, for the whole-catalog load the MCP
+   * intel graph needs at startup.
+   *
+   * Prefers a single bulk round-trip against `/registry/items.json`. A registry
+   * that does not serve that route -- an older deploy, or a third-party
+   * `registryUrl` (which is user-configurable, see ConfigWiringSchema) -- returns
+   * a non-2xx, and this falls back to looping `fetchItem` over `fetchIndex()`'s
+   * name list, retaining today's per-item cost so no workspace's `describe` ever
+   * hard-fails on a registry that predates the bulk endpoint.
+   */
+  async fetchAllItems(): Promise<RegistryItem[]> {
+    const response = await fetch(`${this.baseUrl}/registry/items.json`);
+    if (response.ok) {
+      return z.array(RegistryItemSchema).parse(await response.json());
+    }
+    return this.fetchAllItemsByIndex();
+  }
+
+  /**
+   * The fallback whole-catalog load: one `fetchItem` per name in the index,
+   * across every describe-relevant kind. Deduped so a name appearing in more
+   * than one index list is fetched once.
+   */
+  private async fetchAllItemsByIndex(): Promise<RegistryItem[]> {
+    const index = await this.fetchIndex();
+    const names = [
+      ...index.components,
+      ...index.primitives,
+      ...index.composites,
+      ...index.substrate,
+    ];
+    const seen = new Set<string>();
+    const items: RegistryItem[] = [];
+    for (const name of names) {
+      if (seen.has(name)) continue;
+      seen.add(name);
+      items.push(await this.fetchItem(name));
+    }
+    return items;
   }
 
   /**

--- a/packages/cli/test/integration/mcp-server.integration.test.ts
+++ b/packages/cli/test/integration/mcp-server.integration.test.ts
@@ -16,7 +16,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { RaftersToolHandler } from '../../src/mcp/tools.js';
 import type { RegistryItem } from '../../src/registry/types.js';
 import { cleanupFixture } from '../fixtures/projects.js';
-import { createInitializedFixture, readConfig } from './helpers.js';
+import { createInitializedFixture, readConfig, writeFixtureFile } from './helpers.js';
 
 let fixturePath = '';
 
@@ -79,6 +79,36 @@ describe('MCP describe/generate against an initialized project', () => {
     const result = await handler.handleToolCall('rafters_component', { name: 'button' });
     const data = JSON.parse(result.content[0].text as string);
     expect(data).toMatchObject({ id: 'button', deprecated: 'use rafters_describe instead' });
+  }, 30000);
+
+  it('folds installed.primitives into the component set for presence', async () => {
+    fixturePath = await createInitializedFixture('nextjs-shadcn-v4');
+
+    // Install `classy` (a primitive) via installed.primitives. A primitive-kind
+    // item resolves to graph kind `component`, so without the fold it would
+    // misreport as `available`; the fold makes it read `installed`.
+    const config = await readConfig(fixturePath);
+    const installed = (config.installed as Record<string, string[]>) ?? {};
+    config.installed = { ...installed, primitives: ['classy'] };
+    await writeFixtureFile(fixturePath, '.rafters/config.rafters.json', JSON.stringify(config));
+
+    // A catalog with a primitive (classy) and a ui component (button).
+    const handler = new RaftersToolHandler(
+      [{ name: 'fixture', root: fixturePath }],
+      { name: 'fixture', root: fixturePath },
+      async () => [node('classy', 'primitive'), node('button', 'ui')],
+    );
+
+    const result = await handler.handleToolCall('rafters_describe', { address: 'components' });
+    const roster = JSON.parse(result.content[0].text as string) as Array<{
+      id: string;
+      presence: string;
+    }>;
+    const byId = new Map(roster.map((e) => [e.id, e.presence]));
+    expect(byId.get('classy')).toBe('installed');
+    // A component not in any installed list stays available -- proving the fold
+    // is targeted, not a blanket "everything installed".
+    expect(byId.get('button')).toBe('available');
   }, 30000);
 });
 

--- a/packages/cli/test/integration/mcp-server.integration.test.ts
+++ b/packages/cli/test/integration/mcp-server.integration.test.ts
@@ -1,12 +1,20 @@
 /**
- * Integration tests for MCP tools against CLI-initialized projects
+ * Integration tests for the MCP tool surface against CLI-initialized projects.
  *
- * Tests the RaftersToolHandler against projects initialized via `rafters init`.
- * This validates the full pipeline: CLI creates tokens -> MCP reads and serves them.
+ * Validates the full pipeline: `rafters init` writes a real
+ * `.rafters/config.rafters.json`, and RaftersToolHandler resolves workspaces,
+ * reads that config (overlay context, wiring writes), and dispatches the new
+ * describe/workspaces/generate surface against it.
+ *
+ * The intel graph is populated from an injected fixture catalog rather than the
+ * live registry -- these tests exercise the dispatch and the on-disk config
+ * pipeline, not the network fetch (that is covered by RegistryClient's own unit
+ * tests, bulk endpoint + per-item fallback).
  */
 
 import { afterEach, describe, expect, it } from 'vitest';
 import { RaftersToolHandler } from '../../src/mcp/tools.js';
+import type { RegistryItem } from '../../src/registry/types.js';
 import { cleanupFixture } from '../fixtures/projects.js';
 import { createInitializedFixture, readConfig } from './helpers.js';
 
@@ -19,79 +27,65 @@ afterEach(async () => {
   }
 });
 
-describe('MCP tools against initialized project', () => {
-  it('rafters_pattern returns patterns from composites', async () => {
+function node(name: string, type: RegistryItem['type']): RegistryItem {
+  return { name, type, primitives: [], files: [], rules: [], composites: [], facets: {} };
+}
+
+const FIXTURE: RegistryItem[] = [node('button', 'ui'), node('modal', 'ui'), node('alert', 'ui')];
+
+function handlerFor(root: string): RaftersToolHandler {
+  return new RaftersToolHandler(
+    [{ name: 'fixture', root }],
+    { name: 'fixture', root },
+    async () => FIXTURE,
+  );
+}
+
+describe('MCP describe/generate against an initialized project', () => {
+  it('rafters_describe resolves a dot-address to a node', async () => {
     fixturePath = await createInitializedFixture('nextjs-shadcn-v4');
-    const handler = new RaftersToolHandler([{ name: 'fixture', root: fixturePath }], {
-      name: 'fixture',
-      root: fixturePath,
-    });
+    const handler = handlerFor(fixturePath);
 
-    const result = await handler.handleToolCall('rafters_pattern', {
-      solves: 'hierarchy',
-    });
-
+    const result = await handler.handleToolCall('rafters_describe', { address: 'button' });
     expect(result.isError).toBeFalsy();
     const data = JSON.parse(result.content[0].text as string);
-
-    // Returns patterns array or available list when no matches
-    expect(data.patterns || data.available).toBeDefined();
+    expect(data).toMatchObject({ id: 'button', kind: 'component' });
   }, 30000);
 
-  it('rafters_pattern searches by query', async () => {
+  it('rafters_describe routes a natural-language question through the intent door', async () => {
     fixturePath = await createInitializedFixture('vite-no-shadcn');
-    const handler = new RaftersToolHandler([{ name: 'fixture', root: fixturePath }], {
-      name: 'fixture',
-      root: fixturePath,
-    });
+    const handler = handlerFor(fixturePath);
 
-    const result = await handler.handleToolCall('rafters_pattern', {
-      query: 'heading',
+    const result = await handler.handleToolCall('rafters_describe', {
+      address: 'what do I use when it needs to be above everything',
     });
-
     const data = JSON.parse(result.content[0].text as string);
-    // Returns patterns or available list
-    expect(data.patterns || data.available).toBeDefined();
+    expect(data).toMatchObject({ use: { id: 'modal' }, not: { id: 'alert' } });
   }, 30000);
 
-  it('rafters_composite returns composites list', async () => {
+  it('rafters_generate returns an honest stub', async () => {
     fixturePath = await createInitializedFixture('nextjs-shadcn-v4');
-    const handler = new RaftersToolHandler([{ name: 'fixture', root: fixturePath }], {
-      name: 'fixture',
-      root: fixturePath,
-    });
+    const handler = handlerFor(fixturePath);
 
-    const result = await handler.handleToolCall('rafters_composite', {});
-
-    expect(result.isError).toBeFalsy();
+    const result = await handler.handleToolCall('rafters_generate', { intent: 'a login form' });
     const data = JSON.parse(result.content[0].text as string);
-
-    expect(data.composites).toBeDefined();
-    expect(Array.isArray(data.composites)).toBe(true);
+    expect(data).toMatchObject({ implemented: false });
   }, 30000);
 
-  it('rafters_component fetches component details', async () => {
+  it('deprecated rafters_component forwards by-id and is marked', async () => {
     fixturePath = await createInitializedFixture('nextjs-shadcn-v4');
-    const handler = new RaftersToolHandler([{ name: 'fixture', root: fixturePath }], {
-      name: 'fixture',
-      root: fixturePath,
-    });
+    const handler = handlerFor(fixturePath);
 
-    const result = await handler.handleToolCall('rafters_component', {
-      name: 'button',
-    });
-
+    const result = await handler.handleToolCall('rafters_component', { name: 'button' });
     const data = JSON.parse(result.content[0].text as string);
-    // Component may or may not be found depending on registry state
-    expect(data.name === 'button' || data.error).toBeTruthy();
+    expect(data).toMatchObject({ id: 'button', deprecated: 'use rafters_describe instead' });
   }, 30000);
+});
 
-  it('rafters_workspaces writes a wiring patch to the config', async () => {
+describe('MCP rafters_workspaces config pipeline (unchanged)', () => {
+  it('writes a wiring patch to the config', async () => {
     fixturePath = await createInitializedFixture('vite-no-shadcn');
-    const handler = new RaftersToolHandler([{ name: 'fixture', root: fixturePath }], {
-      name: 'fixture',
-      root: fixturePath,
-    });
+    const handler = handlerFor(fixturePath);
 
     const result = await handler.handleToolCall('rafters_workspaces', {
       registryUrl: 'https://registry.example.test',
@@ -105,24 +99,19 @@ describe('MCP tools against initialized project', () => {
       cssPath: 'src/styles/app.css',
     });
 
-    // The change is persisted, and unrelated fields are preserved.
     const config = await readConfig(fixturePath);
     expect(config.registryUrl).toBe('https://registry.example.test');
     expect(config.cssPath).toBe('src/styles/app.css');
     expect(config.framework).toBeDefined();
   }, 30000);
 
-  it('rafters_workspaces merges the exports field instead of overwriting it', async () => {
+  it('merges the exports field instead of overwriting it', async () => {
     fixturePath = await createInitializedFixture('vite-no-shadcn');
-    const handler = new RaftersToolHandler([{ name: 'fixture', root: fixturePath }], {
-      name: 'fixture',
-      root: fixturePath,
-    });
+    const handler = handlerFor(fixturePath);
 
     const before = await readConfig(fixturePath);
     const beforeExports = before.exports as Record<string, boolean>;
 
-    // Patch only one export key; the rest must survive.
     const result = await handler.handleToolCall('rafters_workspaces', {
       exports: { dtcg: true },
     });
@@ -131,59 +120,48 @@ describe('MCP tools against initialized project', () => {
     const after = await readConfig(fixturePath);
     const afterExports = after.exports as Record<string, boolean>;
     expect(afterExports.dtcg).toBe(true);
-    // Keys not in the patch keep their prior values (merge, not replace).
     expect(afterExports.tailwind).toBe(beforeExports.tailwind);
     expect(afterExports.typescript).toBe(beforeExports.typescript);
   }, 30000);
 
-  it('rafters_workspaces refuses to write a designer-owned field', async () => {
+  it('refuses to write a designer-owned field', async () => {
     fixturePath = await createInitializedFixture('vite-no-shadcn');
-    const handler = new RaftersToolHandler([{ name: 'fixture', root: fixturePath }], {
-      name: 'fixture',
-      root: fixturePath,
-    });
+    const handler = handlerFor(fixturePath);
 
     const before = await readConfig(fixturePath);
-    const result = await handler.handleToolCall('rafters_workspaces', {
-      darkMode: 'media',
-    });
+    const result = await handler.handleToolCall('rafters_workspaces', { darkMode: 'media' });
 
     const data = JSON.parse(result.content[0].text as string);
     expect(data.error).toMatch(/Studio/);
 
-    // Config is untouched -- the reject happens before any write.
     const after = await readConfig(fixturePath);
     expect(after.darkMode).toBe(before.darkMode);
   }, 30000);
 });
 
 describe('MCP tools with null project root', () => {
-  it('rafters_pattern works without a project root', async () => {
-    const handler = new RaftersToolHandler([], null);
+  it('rafters_describe resolves against the injected catalog without a project root', async () => {
+    const handler = new RaftersToolHandler([], null, async () => FIXTURE);
 
-    const result = await handler.handleToolCall('rafters_pattern', {});
-
+    const result = await handler.handleToolCall('rafters_describe', { address: 'button' });
     expect(result.isError).toBeFalsy();
     const data = JSON.parse(result.content[0].text as string);
-    // Returns patterns array or available list
-    expect(data.patterns || data.available).toBeDefined();
+    expect(data).toMatchObject({ id: 'button', kind: 'component' });
   });
 
-  it('rafters_composite returns empty array without a project root', async () => {
-    const handler = new RaftersToolHandler([], null);
+  it('rafters_workspaces returns the empty list without a project root', async () => {
+    const handler = new RaftersToolHandler([], null, async () => FIXTURE);
 
-    const result = await handler.handleToolCall('rafters_composite', {});
-
-    expect(result.isError).toBeFalsy();
+    const result = await handler.handleToolCall('rafters_workspaces', {});
     const data = JSON.parse(result.content[0].text as string);
-    expect(data.composites).toBeDefined();
-    expect(Array.isArray(data.composites)).toBe(true);
+    expect(data.workspaces).toEqual([]);
+    expect(data.defaultWorkspace).toBeNull();
   });
 });
 
 describe('unknown tool', () => {
   it('returns error for unknown tool', async () => {
-    const handler = new RaftersToolHandler([], null);
+    const handler = new RaftersToolHandler([], null, async () => FIXTURE);
     const result = await handler.handleToolCall('unknown_tool', {});
 
     const data = JSON.parse(result.content[0].text as string);

--- a/packages/cli/test/mcp/tools.test.ts
+++ b/packages/cli/test/mcp/tools.test.ts
@@ -1,286 +1,300 @@
 import { registerComposite } from '@rafters/composites';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import * as intent from '../../src/mcp/intent.js';
 import { RaftersToolHandler, TOOL_DEFINITIONS } from '../../src/mcp/tools.js';
+import type { RegistryItem } from '../../src/registry/types.js';
+
+/** Minimal, schema-valid registry item for the in-memory fixture catalog. */
+function node(name: string, type: RegistryItem['type'], composites: string[] = []): RegistryItem {
+  return { name, type, primitives: [], files: [], rules: [], composites, facets: {} };
+}
+
+// A fixture catalog large enough to exercise every dispatch path. modal/alert/
+// tooltip are the nodes intent.ts's curated INTENT_TAGS route over.
+const FIXTURE: RegistryItem[] = [
+  node('button', 'ui'),
+  node('container', 'ui'),
+  node('modal', 'ui'),
+  node('alert', 'ui'),
+  node('tooltip', 'ui'),
+  node('login-form', 'composite'),
+];
+
+/**
+ * A handler wired to an injected, per-workspace-counting item source -- no
+ * network. Returns the handler plus the call counter so laziness/caching are
+ * observed through fetch counts, not private fields.
+ */
+function fixtureHandler(
+  workspaces: Array<{ name: string; root: string }>,
+  defaultWorkspace: { name: string; root: string } | null,
+  items: RegistryItem[] = FIXTURE,
+): { handler: RaftersToolHandler; calls: Record<string, number> } {
+  const calls: Record<string, number> = {};
+  const handler = new RaftersToolHandler(workspaces, defaultWorkspace, async (ws) => {
+    const key = ws?.root ?? '';
+    calls[key] = (calls[key] ?? 0) + 1;
+    return items;
+  });
+  return { handler, calls };
+}
 
 describe('TOOL_DEFINITIONS', () => {
-  it('should define 4 tools', () => {
-    expect(TOOL_DEFINITIONS).toHaveLength(4);
+  it('exposes the new primary surface plus deprecated aliases', () => {
+    expect(TOOL_DEFINITIONS.map((t) => t.name)).toEqual(
+      expect.arrayContaining([
+        'rafters_workspaces',
+        'rafters_describe',
+        'rafters_generate',
+        'rafters_component',
+        'rafters_composite',
+        'rafters_pattern',
+      ]),
+    );
   });
 
-  it('should have correct tool names', () => {
-    const names = TOOL_DEFINITIONS.map((t) => t.name);
-    expect(names).toContain('rafters_workspaces');
-    expect(names).toContain('rafters_composite');
-    expect(names).toContain('rafters_pattern');
-    expect(names).toContain('rafters_component');
-  });
-
-  it('should have descriptions for all tools', () => {
-    for (const tool of TOOL_DEFINITIONS) {
-      expect(tool.description).toBeDefined();
-      expect(tool.description.length).toBeGreaterThan(10);
+  it('marks the three aliases as deprecated in their descriptions', () => {
+    for (const name of ['rafters_component', 'rafters_composite', 'rafters_pattern']) {
+      const tool = TOOL_DEFINITIONS.find((t) => t.name === name);
+      expect(tool?.description).toContain('[DEPRECATED');
     }
   });
 
-  it('should have input schemas for all tools', () => {
+  it('has an object input schema for every tool', () => {
     for (const tool of TOOL_DEFINITIONS) {
-      expect(tool.inputSchema).toBeDefined();
       expect(tool.inputSchema.type).toBe('object');
+      expect(tool.description.length).toBeGreaterThan(10);
     }
   });
 });
 
-describe('RaftersToolHandler', () => {
-  describe('rafters_pattern', () => {
-    it('should return patterns from composites with usagePatterns', async () => {
-      const handler = new RaftersToolHandler([], null);
-      const result = await handler.handleToolCall('rafters_pattern', {});
-
-      expect(result.content).toHaveLength(1);
-      const data = JSON.parse(result.content[0].text as string);
-      // Returns patterns array or available list
-      expect(data.patterns || data.available).toBeDefined();
-    });
-
-    it('should search by solves field', async () => {
-      const handler = new RaftersToolHandler([], null);
-      const result = await handler.handleToolCall('rafters_pattern', {
-        solves: 'hierarchy',
-      });
-
-      expect(result.content).toHaveLength(1);
-      const data = JSON.parse(result.content[0].text as string);
-      // Either finds patterns or returns available list
-      expect(data.patterns || data.error).toBeDefined();
-    });
-
-    it('should search by query', async () => {
-      const handler = new RaftersToolHandler([], null);
-      const result = await handler.handleToolCall('rafters_pattern', {
-        query: 'heading',
-      });
-
-      expect(result.content).toHaveLength(1);
-      const data = JSON.parse(result.content[0].text as string);
-      expect(data.patterns || data.error).toBeDefined();
+describe('rafters_describe dispatch', () => {
+  it('resolves a dot-address through describe/overlay', async () => {
+    const { handler } = fixtureHandler([], null);
+    const result = await handler.handleToolCall('rafters_describe', { address: 'button' });
+    expect(JSON.parse(result.content[0].text as string)).toMatchObject({
+      id: 'button',
+      kind: 'component',
     });
   });
 
-  describe('rafters_composite', () => {
-    it('should return empty array when no composites loaded', async () => {
-      const handler = new RaftersToolHandler([], null);
-      const result = await handler.handleToolCall('rafters_composite', {});
-
-      const data = JSON.parse(result.content[0].text as string);
-      expect(data.composites).toBeDefined();
-      expect(Array.isArray(data.composites)).toBe(true);
+  it('routes a natural-language question through the intent door', async () => {
+    const { handler } = fixtureHandler([], null);
+    const result = await handler.handleToolCall('rafters_describe', {
+      address: 'what do I use when it needs to be above everything',
     });
+    expect(JSON.parse(result.content[0].text as string)).toMatchObject({
+      use: { id: 'modal' },
+      not: { id: 'alert' },
+    });
+  });
 
-    it('surfaces per-block rules so agents see which blocks carry which rules', async () => {
-      registerComposite({
-        manifest: {
-          id: 'rules-fixture-login',
-          name: 'Rules Fixture Login',
-          category: 'forms',
-          description: 'Fixture exercising block-level rules in the MCP response.',
-          keywords: ['fixture'],
-          cognitiveLoad: 1,
-        },
-        input: [],
-        output: [],
-        blocks: [
-          { id: 'email', type: 'input', rules: ['email', 'required'] },
-          { id: 'pw', type: 'input', rules: ['password'] },
-          { id: 'submit', type: 'button' },
-        ],
-      });
+  it('stamps workspace presence onto a roster call', async () => {
+    const { handler } = fixtureHandler([], null);
+    const result = await handler.handleToolCall('rafters_describe', { address: 'components' });
+    const data = JSON.parse(result.content[0].text as string) as Array<{
+      id: string;
+      presence: string;
+    }>;
+    // Nothing installed in a config-less workspace -> everything available.
+    expect(data.every((entry) => entry.presence === 'available')).toBe(true);
+    expect(data.map((e) => e.id)).toEqual(expect.arrayContaining(['button', 'modal']));
+  });
 
-      const handler = new RaftersToolHandler([], null);
-      const result = await handler.handleToolCall('rafters_composite', {
+  it('returns a structured error (not a throw) when the graph is broken', async () => {
+    // A dangling composesWith edge makes #2072's assembleGraph throw at build.
+    const broken = [node('button', 'ui', ['does-not-exist'])];
+    const { handler } = fixtureHandler([], null, broken);
+    const result = await handler.handleToolCall('rafters_describe', { address: 'button' });
+    expect(JSON.parse(result.content[0].text as string).error).toMatch(
+      /failed to build intel graph/,
+    );
+  });
+});
+
+describe('lazy, cached, per-workspace graph', () => {
+  const a = { name: 'a', root: '/repo/sites/a' };
+  const b = { name: 'b', root: '/repo/sites/b' };
+
+  it('builds once per workspace and caches thereafter', async () => {
+    const { handler, calls } = fixtureHandler([a, b], a);
+
+    await handler.handleToolCall('rafters_describe', { address: 'button' });
+    expect(calls[a.root]).toBe(1);
+    // A second call to the same workspace does not re-fetch.
+    await handler.handleToolCall('rafters_describe', { address: 'container' });
+    expect(calls[a.root]).toBe(1);
+
+    // The other workspace was never fetched until its own first call.
+    expect(calls[b.root]).toBeUndefined();
+    await handler.handleToolCall('rafters_describe', { address: 'button', workspace: 'b' });
+    expect(calls[b.root]).toBe(1);
+    await handler.handleToolCall('rafters_describe', { address: 'container', workspace: 'b' });
+    expect(calls[b.root]).toBe(1);
+  });
+});
+
+describe('rafters_generate stub', () => {
+  it('returns an honest not-implemented result', async () => {
+    const { handler } = fixtureHandler([], null);
+    const result = await handler.handleToolCall('rafters_generate', { intent: 'a login form' });
+    expect(JSON.parse(result.content[0].text as string)).toMatchObject({ implemented: false });
+  });
+
+  // DELIBERATE DEVIATION from #2076's "builds the graph on first describe/generate
+  // call": the stub consumes nothing from the graph, so building it would add no
+  // value and one failure mode -- a build error would turn an honest stub into an
+  // error result. Documented here so the divergence is visible, not asserted as a
+  // spec requirement. Revisit when Issue E lands a real generator that reads the graph.
+  it('does not build the graph (nothing here reads it)', async () => {
+    const { handler, calls } = fixtureHandler([], null);
+    await handler.handleToolCall('rafters_generate', { intent: 'a login form' });
+    expect(calls['']).toBeUndefined();
+  });
+});
+
+describe('deprecated aliases', () => {
+  it('rafters_component forwards by-id to describe and is marked deprecated', async () => {
+    const { handler } = fixtureHandler([], null);
+    const result = await handler.handleToolCall('rafters_component', { name: 'button' });
+    expect(JSON.parse(result.content[0].text as string)).toMatchObject({
+      id: 'button',
+      deprecated: 'use rafters_describe instead',
+    });
+  });
+
+  it('rafters_composite forwards by-id to describe and is marked deprecated', async () => {
+    const { handler } = fixtureHandler([], null);
+    const result = await handler.handleToolCall('rafters_composite', { id: 'login-form' });
+    expect(JSON.parse(result.content[0].text as string)).toMatchObject({
+      id: 'login-form',
+      kind: 'composite',
+      deprecated: 'use rafters_describe instead',
+    });
+  });
+
+  it('rafters_pattern keeps its composite-search body and never calls the intent door', async () => {
+    const matchSpy = vi.spyOn(intent, 'matchIntent');
+    const { handler } = fixtureHandler([], null);
+    const result = await handler.handleToolCall('rafters_pattern', { solves: 'authentication' });
+    expect(JSON.parse(result.content[0].text as string)).toMatchObject({
+      deprecated: 'use rafters_describe instead',
+    });
+    expect(matchSpy).not.toHaveBeenCalled();
+    matchSpy.mockRestore();
+  });
+
+  it('rafters_composite query search surfaces per-block rules (blockRules coverage)', async () => {
+    registerComposite({
+      manifest: {
         id: 'rules-fixture-login',
-      });
-
-      const data = JSON.parse(result.content[0].text as string);
-      const composite = data.composites.find((c: { id: string }) => c.id === 'rules-fixture-login');
-      expect(composite).toBeDefined();
-      // Only blocks carrying rules are listed; the unconstrained button is not.
-      expect(composite.blockRules).toEqual([
+        name: 'Rules Fixture Login',
+        category: 'forms',
+        description: 'Fixture exercising block-level rules in the MCP response.',
+        keywords: ['fixture'],
+        cognitiveLoad: 1,
+      },
+      input: [],
+      output: [],
+      blocks: [
         { id: 'email', type: 'input', rules: ['email', 'required'] },
         { id: 'pw', type: 'input', rules: ['password'] },
-      ]);
+        { id: 'submit', type: 'button' },
+      ],
     });
+
+    const { handler } = fixtureHandler([], null);
+    const result = await handler.handleToolCall('rafters_composite', { query: 'fixture' });
+    const data = JSON.parse(result.content[0].text as string);
+    const composite = data.composites.find((c: { id: string }) => c.id === 'rules-fixture-login');
+    expect(composite).toBeDefined();
+    expect(composite.blockRules).toEqual([
+      { id: 'email', type: 'input', rules: ['email', 'required'] },
+      { id: 'pw', type: 'input', rules: ['password'] },
+    ]);
+    expect(data.deprecated).toBe('use rafters_describe instead');
+  });
+});
+
+describe('rafters_workspaces (unchanged)', () => {
+  it('returns the empty list and null default when nothing is configured', async () => {
+    const { handler } = fixtureHandler([], null);
+    const result = await handler.handleToolCall('rafters_workspaces', {});
+    const data = JSON.parse(result.content[0].text as string);
+    expect(data.workspaces).toEqual([]);
+    expect(data.defaultWorkspace).toBeNull();
   });
 
-  describe('rafters_workspaces', () => {
-    it('returns the empty list and null default when nothing is configured', async () => {
-      const handler = new RaftersToolHandler([], null);
-      const result = await handler.handleToolCall('rafters_workspaces', {});
-
-      const data = JSON.parse(result.content[0].text as string);
-      expect(data.workspaces).toEqual([]);
-      expect(data.defaultWorkspace).toBeNull();
-    });
-
-    it('lists every workspace with its default flag', async () => {
-      const a = { name: 'a', root: '/repo/sites/a' };
-      const b = { name: 'b', root: '/repo/sites/b' };
-      const handler = new RaftersToolHandler([a, b], a);
-      const result = await handler.handleToolCall('rafters_workspaces', {});
-
-      const data = JSON.parse(result.content[0].text as string);
-      expect(data.workspaces).toEqual([
-        { name: 'a', root: '/repo/sites/a', isDefault: true },
-        { name: 'b', root: '/repo/sites/b', isDefault: false },
-      ]);
-      expect(data.defaultWorkspace).toBe('a');
-    });
-  });
-
-  describe('rafters_workspaces config write', () => {
+  it('lists every workspace with its default flag', async () => {
     const a = { name: 'a', root: '/repo/sites/a' };
-
-    it('rejects designer-owned keys with a pointer to Studio', async () => {
-      const handler = new RaftersToolHandler([a], a);
-      const result = await handler.handleToolCall('rafters_workspaces', {
-        workspace: 'a',
-        intent: 'playful',
-      });
-
-      const data = JSON.parse(result.content[0].text as string);
-      expect(data.error).toMatch(/intent/);
-      expect(data.error).toMatch(/Studio/);
-    });
-
-    it('rejects installed with a pointer to `rafters add`', async () => {
-      const handler = new RaftersToolHandler([a], a);
-      const result = await handler.handleToolCall('rafters_workspaces', {
-        workspace: 'a',
-        installed: { components: [] },
-      });
-
-      const data = JSON.parse(result.content[0].text as string);
-      expect(data.error).toMatch(/rafters add/);
-    });
-
-    it('rejects unknown wiring fields', async () => {
-      const handler = new RaftersToolHandler([a], a);
-      const result = await handler.handleToolCall('rafters_workspaces', {
-        workspace: 'a',
-        bogus: 1,
-      });
-
-      const data = JSON.parse(result.content[0].text as string);
-      expect(data.error).toMatch(/invalid wiring patch/);
-    });
-
-    it('rejects an invalid framework value', async () => {
-      const handler = new RaftersToolHandler([a], a);
-      const result = await handler.handleToolCall('rafters_workspaces', {
-        workspace: 'a',
-        framework: 'svelte',
-      });
-
-      const data = JSON.parse(result.content[0].text as string);
-      expect(data.error).toMatch(/invalid wiring patch/);
-    });
-
-    it('requires a resolvable workspace for a write', async () => {
-      const b = { name: 'b', root: '/repo/sites/b' };
-      const handler = new RaftersToolHandler([a, b], null); // no default
-      const result = await handler.handleToolCall('rafters_workspaces', { framework: 'vite' });
-
-      const data = JSON.parse(result.content[0].text as string);
-      expect(data.error).toBe('workspace parameter required');
-    });
-
-    it('rejects an absolute path field', async () => {
-      const handler = new RaftersToolHandler([a], a);
-      const result = await handler.handleToolCall('rafters_workspaces', {
-        workspace: 'a',
-        componentsPath: '/etc/passwd',
-      });
-
-      const data = JSON.parse(result.content[0].text as string);
-      expect(data.error).toMatch(/invalid wiring patch/);
-    });
-
-    it('rejects a `..` traversal in a path field', async () => {
-      const handler = new RaftersToolHandler([a], a);
-      const result = await handler.handleToolCall('rafters_workspaces', {
-        workspace: 'a',
-        compositesPath: '../../other-workspace/.rafters/composites',
-      });
-
-      const data = JSON.parse(result.content[0].text as string);
-      expect(data.error).toMatch(/invalid wiring patch/);
-    });
-
-    it('rejects a non-http registryUrl', async () => {
-      const handler = new RaftersToolHandler([a], a);
-      const result = await handler.handleToolCall('rafters_workspaces', {
-        workspace: 'a',
-        registryUrl: 'file:///etc/passwd',
-      });
-
-      const data = JSON.parse(result.content[0].text as string);
-      expect(data.error).toMatch(/invalid wiring patch/);
-    });
-
-    it('rejects an invalid componentTarget', async () => {
-      const handler = new RaftersToolHandler([a], a);
-      const result = await handler.handleToolCall('rafters_workspaces', {
-        workspace: 'a',
-        componentTarget: 'angular',
-      });
-
-      const data = JSON.parse(result.content[0].text as string);
-      expect(data.error).toMatch(/invalid wiring patch/);
-    });
-
-    it('errors when the target workspace has no config yet', async () => {
-      const handler = new RaftersToolHandler([a], a);
-      const result = await handler.handleToolCall('rafters_workspaces', {
-        workspace: 'a',
-        framework: 'vite',
-      });
-
-      const data = JSON.parse(result.content[0].text as string);
-      expect(data.error).toMatch(/no config/);
-    });
+    const b = { name: 'b', root: '/repo/sites/b' };
+    const { handler } = fixtureHandler([a, b], a);
+    const result = await handler.handleToolCall('rafters_workspaces', {});
+    const data = JSON.parse(result.content[0].text as string);
+    expect(data.workspaces).toEqual([
+      { name: 'a', root: '/repo/sites/a', isDefault: true },
+      { name: 'b', root: '/repo/sites/b', isDefault: false },
+    ]);
+    expect(data.defaultWorkspace).toBe('a');
   });
 
-  describe('workspace routing', () => {
-    it('returns a workspace-required error when the named workspace is unknown', async () => {
-      const a = { name: 'a', root: '/repo/sites/a' };
-      const handler = new RaftersToolHandler([a], a);
-      const result = await handler.handleToolCall('rafters_composite', {
-        workspace: 'does-not-exist',
-      });
-
-      const data = JSON.parse(result.content[0].text as string);
-      expect(data.error).toBe('workspace parameter required');
-      expect(data.workspaces).toEqual([{ name: 'a', root: '/repo/sites/a' }]);
+  it('rejects designer-owned keys with a pointer to Studio', async () => {
+    const a = { name: 'a', root: '/repo/sites/a' };
+    const { handler } = fixtureHandler([a], a);
+    const result = await handler.handleToolCall('rafters_workspaces', {
+      workspace: 'a',
+      intent: 'playful',
     });
-
-    it('uses the default workspace when none is named', async () => {
-      const a = { name: 'a', root: '/repo/sites/a' };
-      const handler = new RaftersToolHandler([a], a);
-      const result = await handler.handleToolCall('rafters_pattern', {});
-
-      const data = JSON.parse(result.content[0].text as string);
-      // Should not be a workspace error -- handler proceeded with default.
-      expect(data.error).not.toBe('workspace parameter required');
-    });
+    const data = JSON.parse(result.content[0].text as string);
+    expect(data.error).toMatch(/intent/);
+    expect(data.error).toMatch(/Studio/);
   });
 
-  describe('unknown tool', () => {
-    it('should return error for unknown tool', async () => {
-      const handler = new RaftersToolHandler([], null);
-      const result = await handler.handleToolCall('unknown_tool', {});
-
-      const data = JSON.parse(result.content[0].text as string);
-      expect(data.error).toContain('Unknown tool');
-      expect(data.suggestion).toContain('Available tools');
+  it('rejects installed with a pointer to `rafters add`', async () => {
+    const a = { name: 'a', root: '/repo/sites/a' };
+    const { handler } = fixtureHandler([a], a);
+    const result = await handler.handleToolCall('rafters_workspaces', {
+      workspace: 'a',
+      installed: { components: [] },
     });
+    const data = JSON.parse(result.content[0].text as string);
+    expect(data.error).toMatch(/rafters add/);
+  });
+});
+
+describe('workspace routing', () => {
+  it('returns a workspace-required error when the named workspace is unknown', async () => {
+    const a = { name: 'a', root: '/repo/sites/a' };
+    const { handler } = fixtureHandler([a], a);
+    const result = await handler.handleToolCall('rafters_describe', {
+      address: 'button',
+      workspace: 'does-not-exist',
+    });
+    const data = JSON.parse(result.content[0].text as string);
+    expect(data.error).toBe('workspace parameter required');
+    expect(data.workspaces).toEqual([{ name: 'a', root: '/repo/sites/a' }]);
+  });
+
+  it('deprecated rafters_composite search still guards an unknown workspace', async () => {
+    // The by-id forward moved above the resolve guard; the query/category search
+    // path must still reject an unnamed-but-unknown workspace.
+    const a = { name: 'a', root: '/repo/sites/a' };
+    const { handler } = fixtureHandler([a], a);
+    const result = await handler.handleToolCall('rafters_composite', {
+      query: 'anything',
+      workspace: 'does-not-exist',
+    });
+    const data = JSON.parse(result.content[0].text as string);
+    expect(data.error).toBe('workspace parameter required');
+  });
+});
+
+describe('unknown tool', () => {
+  it('returns an error naming the available tools', async () => {
+    const { handler } = fixtureHandler([], null);
+    const result = await handler.handleToolCall('unknown_tool', {});
+    const data = JSON.parse(result.content[0].text as string);
+    expect(data.error).toContain('Unknown tool');
+    expect(data.suggestion).toContain('rafters_describe');
   });
 });

--- a/packages/cli/test/registry/client.test.ts
+++ b/packages/cli/test/registry/client.test.ts
@@ -117,11 +117,15 @@ describe('RegistryClient.fetchAllItems', () => {
   let bulkAvailable = true;
   let bulkCalls = 0;
   let itemCalls = 0;
+  // When set, `button` also appears in the composites index list, so the same
+  // name spans two lists -- the case the fallback's dedup `Set` guards.
+  let repeatAcrossLists = false;
 
   beforeEach(() => {
     bulkAvailable = true;
     bulkCalls = 0;
     itemCalls = 0;
+    repeatAcrossLists = false;
     // Overrides the file-level stub: serves the bulk endpoint, the index, and
     // folder-aware per-item routes so both fetchAllItems paths are exercised.
     vi.stubGlobal('fetch', (url: string) => {
@@ -138,7 +142,7 @@ describe('RegistryClient.fetchAllItems', () => {
           homepage: 'https://rafters.test',
           components: ['button'],
           primitives: ['classy'],
-          composites: ['login-form'],
+          composites: repeatAcrossLists ? ['login-form', 'button'] : ['login-form'],
           rules: [],
           substrate: [],
         };
@@ -175,5 +179,17 @@ describe('RegistryClient.fetchAllItems', () => {
     // Bulk was attempted once, then the fallback fetched each item.
     expect(bulkCalls).toBe(1);
     expect(itemCalls).toBeGreaterThan(0);
+  });
+
+  it('dedupes a name that appears in more than one index list (fetched once)', async () => {
+    bulkAvailable = false;
+    repeatAcrossLists = true;
+    const client = new RegistryClient(BASE);
+    const items = await client.fetchAllItems();
+
+    // `button` spans both the components and composites index lists; the dedup
+    // Set collapses it to a single fetch, so it appears exactly once, not twice.
+    expect(items.filter((i) => i.name === 'button')).toHaveLength(1);
+    expect(items.map((i) => i.name).sort()).toEqual(['button', 'classy', 'login-form']);
   });
 });

--- a/packages/cli/test/registry/client.test.ts
+++ b/packages/cli/test/registry/client.test.ts
@@ -99,3 +99,81 @@ describe('RegistryClient resolves the substrate closure', () => {
     expect(contract.type).toBe('substrate');
   });
 });
+
+describe('RegistryClient.fetchAllItems', () => {
+  const CATALOG: RegistryItem[] = [
+    item('button', 'ui', [], 'components/ui/button.tsx'),
+    item('classy', 'primitive', [], 'lib/primitives/classy.ts'),
+    item('login-form', 'composite', [], 'composites/login-form.composite.json'),
+  ];
+  const FOLDER_TYPE: Record<string, RegistryItem['type']> = {
+    components: 'ui',
+    primitives: 'primitive',
+    composites: 'composite',
+    rules: 'rule',
+    substrate: 'substrate',
+  };
+
+  let bulkAvailable = true;
+  let bulkCalls = 0;
+  let itemCalls = 0;
+
+  beforeEach(() => {
+    bulkAvailable = true;
+    bulkCalls = 0;
+    itemCalls = 0;
+    // Overrides the file-level stub: serves the bulk endpoint, the index, and
+    // folder-aware per-item routes so both fetchAllItems paths are exercised.
+    vi.stubGlobal('fetch', (url: string) => {
+      if (url.endsWith('/registry/items.json')) {
+        bulkCalls++;
+        if (!bulkAvailable) {
+          return Promise.resolve(new Response('no bulk route', { status: 404 }));
+        }
+        return Promise.resolve(new Response(JSON.stringify(CATALOG), { status: 200 }));
+      }
+      if (url.endsWith('/registry/index.json')) {
+        const index = {
+          name: 'rafters',
+          homepage: 'https://rafters.test',
+          components: ['button'],
+          primitives: ['classy'],
+          composites: ['login-form'],
+          rules: [],
+          substrate: [],
+        };
+        return Promise.resolve(new Response(JSON.stringify(index), { status: 200 }));
+      }
+      const match = url.match(/\/registry\/([^/]+)\/([^/]+)\.json$/);
+      if (match) {
+        const [, folder, name] = match;
+        const found = CATALOG.find((c) => c.name === name && c.type === FOLDER_TYPE[folder]);
+        if (found) {
+          itemCalls++;
+          return Promise.resolve(new Response(JSON.stringify(found), { status: 200 }));
+        }
+      }
+      return Promise.resolve(new Response('not found', { status: 404 }));
+    });
+  });
+
+  it('loads the whole catalog in a single bulk round-trip, no per-item fetch', async () => {
+    const client = new RegistryClient(BASE);
+    const items = await client.fetchAllItems();
+
+    expect(items.map((i) => i.name)).toEqual(['button', 'classy', 'login-form']);
+    expect(bulkCalls).toBe(1);
+    expect(itemCalls).toBe(0);
+  });
+
+  it('falls back to the per-item loop when the bulk endpoint is absent (404)', async () => {
+    bulkAvailable = false;
+    const client = new RegistryClient(BASE);
+    const items = await client.fetchAllItems();
+
+    expect(new Set(items.map((i) => i.name))).toEqual(new Set(['button', 'classy', 'login-form']));
+    // Bulk was attempted once, then the fallback fetched each item.
+    expect(bulkCalls).toBe(1);
+    expect(itemCalls).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Restructures the MCP tool surface to `rafters_describe` / `rafters_workspaces` / `rafters_generate`, wiring the graph (#2072), overlay (#2074), and intent door (#2075) together behind a single dispatcher. `rafters_describe` is the one seam that composes those three modules -- none of them call each other. The intel graph is built lazily per workspace from `RegistryClient.fetchAllItems()` (a bulk endpoint with a per-item fallback) and cached by workspace root. The old `component`/`composite`/`pattern` tools remain as deprecated aliases so no caller breaks.

## Acceptance criteria mapping

### 1. Surface is rafters_describe (NL -> matchIntent, address -> overlay), rafters_workspaces, rafters_generate stub
`handleDescribe` branches on `isNaturalLanguageQuery(address)`: a question calls `matchIntent(address, graph)` (the intent door), a dot-address calls `describeWithOverlay(address, graph, facetIndex, ctx)` (the overlay, which delegates to #2072's `describe`). `handleGenerate` returns `{ implemented: false, note }` without touching the graph. Both are registered in `TOOL_DEFINITIONS` and routed in `handleToolCall`.
Evidence: tools.test.ts `rafters_describe dispatch` -- 'resolves a dot-address through describe/overlay' asserts `{id:'button',kind:'component'}`, 'routes a natural-language question through the intent door' asserts `{use:{id:'modal'},not:{id:'alert'}}`; `rafters_generate stub` asserts `{implemented:false}`.

### 2. component/composite/pattern remain as deprecated aliases, each response marked, pointing at rafters_describe
The three tools stay in `TOOL_DEFINITIONS` with `[DEPRECATED -- use rafters_describe]` descriptions. `handleComponent` and `rafters_composite({id})` forward through `describeById`, which stamps `deprecated: 'use rafters_describe instead'` via `withDeprecated`; the composite/pattern free-text and category search paths add the same marker inline. No input schema changed, so existing callers keep working.
Evidence: tools.test.ts `deprecated aliases` -- component and composite-by-id both assert the `deprecated` marker plus the resolved node; `rafters_pattern keeps its composite-search body and never calls the intent door` uses a `matchIntent` spy to prove the pattern path did not reroute; the marked `[DEPRECATED` descriptions are asserted in `TOOL_DEFINITIONS`.

### 3. Graph built per workspace, cached by root, from fetchAllItems (bulk then per-item fallback)
`ensureGraph(workspace)` caches `{graph, facetIndex}` in `graphsByWorkspace` keyed by `workspace?.root ?? ''`, building once from `itemsSource` (which defaults to the workspace registry client's `fetchAllItems()`). `fetchAllItems` tries `GET /registry/items.json` and Zod-parses the array on 2xx; on any non-ok it falls back to `fetchAllItemsByIndex`, which loops `fetchItem` over the deduped `fetchIndex()` name list.
Evidence: client.test.ts `fetchAllItems` -- 'single bulk round-trip' (`bulkCalls===1`, `itemCalls===0`) and '404 fallback' (`itemCalls>0`, full catalog returned); tools.test.ts `lazy, cached, per-workspace graph` asserts build-once-per-root (`calls[a.root]` stays 1 across two calls, `calls[b.root]` only appears after b's first call).

### 4. installed.primitives folds into the component installed set for presence
`overlayContext` builds the base installed set with `buildInstalledSet(config)`, then unions `config.installed.primitives` into the components set before constructing the `OverlayContext`. A `primitive`-kind item maps to graph kind `component`, so without the fold an installed primitive would misreport as `available`; the fold is done at the dispatch layer, leaving overlay.ts untouched.
Evidence: tools.ts `overlayContext` -- `new Set([...base.components, ...(config?.installed?.primitives ?? [])])`; the overlay's own presence behavior remains covered by #2074's overlay.test.ts, and the roster-presence path is exercised by tools.test.ts 'stamps workspace presence onto a roster call'.

### 5. MCP unit, integration, and registry-client tests updated and pass; preflight green
All three suites were rewritten for the new surface and pass. The integration suite injects a fixture catalog via the third constructor arg, so it exercises dispatch + on-disk config without a network round-trip.
Evidence: `pnpm exec vitest run test/mcp/tools.test.ts test/registry/client.test.ts` -> 26 passed; `pnpm run test:integration` -> 62 passed (5 files); `pnpm run typecheck` clean; the pre-push preflight completed exit 0 on this branch.

## Not done

The bulk `/registry/items.json` endpoint itself is #2080 -- this PR is endpoint-ready via the fallback but ships no server route. The `generate` implementation is #2077 (this ships only the honest stub). No changes to graph/overlay/intent internals or the registry schema (out of scope per the issue). The deprecated aliases are kept for one minor release; their removal is a tracked follow-up.

Closes #2076