### PR TITLE
chore(release): 0.0.83

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # rafters
 
-## Unreleased
+## 0.0.83
 
 ### Features
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.0.82",
+  "version": "0.0.83",
   "description": "Design Intelligence CLI. Scaffold tokens, import existing shadcn/Tailwind v4 sources, add components, and serve an MCP server so AI agents read decisions instead of guessing.",
   "homepage": "https://rafters.studio",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Cut `rafters` 0.0.83. Version bump + changelog only; no code changes.

This release ships the MCP redesign merged this cycle:

- `rafters_describe` / `rafters_workspaces` / `rafters_generate` replace the old tool surface (#2076); `component`/`composite`/`pattern` remain as deprecated aliases that now forward through `describe`.
- `describe` returns the whole node -- the complete six-field intelligence and all per-target facets -- through the workspace's target as the reader's lens (#2090).
- The grammar-prop surface exposes composition rules but never the token vocabulary or raw class layer, so nothing an agent reads lands in `className` around the designer's decisions (#2094).

## Release steps

- [x] Bump `packages/cli/package.json` to 0.0.83
- [x] Finalize CHANGELOG (`## Unreleased` -> `## 0.0.83`)
- [ ] Merge this PR
- [ ] Tag `v0.0.83` and push (the tag-triggered workflow builds + publishes)

## Not done

Nothing beyond the changelog + version bump. Publishing is handled by the `v*`-tag release workflow after merge.