### PR TITLE
feat(#2100,#2101,#2102): MCP follow-up -- tool desc, overlay stamp, generator @parent

### DIFF
--- a/apps/registry/src/lib/registry/componentService.ts
+++ b/apps/registry/src/lib/registry/componentService.ts
@@ -86,6 +86,7 @@ export interface RegistryItem {
   composites?: string[];
   intelligence?: ComponentIntelligence;
   facets?: Partial<Record<ComponentTarget, Facet>>;
+  parent?: string;
 }
 
 /** Source file extension -> framework target. Parallel to COMPONENT_EXTENSIONS. */
@@ -717,6 +718,33 @@ export function extractDepsFromSource(content: string): {
 }
 
 /**
+ * Extract the @parent tag from JSDoc comments in source content.
+ *
+ * Uses comment-parser (like extractDepsFromSource) so that @parent appearing
+ * in string literals or line comments is not matched. Returns the first
+ * match, or undefined when no @parent tag is present.
+ */
+export function extractParentFromSource(content: string): string | undefined {
+  let blocks: ReturnType<typeof parse>;
+  try {
+    blocks = parse(content);
+  } catch {
+    return undefined;
+  }
+
+  for (const block of blocks) {
+    for (const tag of block.tags) {
+      if (tag.tag.toLowerCase() === 'parent') {
+        const value = getTagValue(tag).trim();
+        if (value) return value;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/**
  * Analyze source content to extract merged dependencies and intelligence metadata.
  * Shared by loadComponent and loadPrimitive.
  */
@@ -1008,6 +1036,7 @@ export function loadComponent(name: string): RegistryItem | null {
   const targetSources: Array<{ ext: string; content: string }> = [];
   let primitivesAll: string[] = [];
   let intelligence: ReturnType<typeof parseJSDocFromSource> | undefined;
+  let parent: string | undefined;
 
   // Load framework-specific variants
   // Strict intel is enforced only on the primary .tsx file. Other extensions
@@ -1045,6 +1074,12 @@ export function loadComponent(name: string): RegistryItem | null {
       // Use intelligence from first variant that has it (typically .tsx)
       if (!intelligence && analysis.intelligence) {
         intelligence = analysis.intelligence;
+      }
+
+      // Use parent from first variant that declares it
+      if (!parent) {
+        const p = extractParentFromSource(content);
+        if (p) parent = p;
       }
     } catch {
       // Variant doesn't exist for this extension -- skip
@@ -1204,6 +1239,13 @@ export function loadComponent(name: string): RegistryItem | null {
 
   if (intelligence) {
     result.intelligence = intelligence;
+  }
+
+  // A component cannot be its own parent -- guard against @parent tags on
+  // sub-component JSDoc blocks inside the primary file (e.g. card.tsx carries
+  // @parent card on CardHeader et al., but card itself has no parent).
+  if (parent && parent !== name) {
+    result.parent = parent;
   }
 
   return result;

--- a/packages/cli/src/mcp/overlay.ts
+++ b/packages/cli/src/mcp/overlay.ts
@@ -16,15 +16,33 @@
  * stamps with no shared mutable state -- one universal graph serves all
  * workspaces.
  *
- * Scope: only `describe(<id>)` (single node) and the two roster calls
- * (`describe(components)` / `describe(composites)`) are STAMPED here (presence,
- * echoed target, rendersForTarget). Every other shape -- the empty-address
- * surface, props, vocab, `composesWith` edges, and structured errors -- passes
- * through as `describe` returned it (already target-lensed).
+ * Scope: `describe(<id>)` (single node), `describe(<id>.*)` (expanded node --
+ * issue #2101), and the two roster calls (`describe(components)` /
+ * `describe(composites)`) are STAMPED here (presence, echoed target,
+ * rendersForTarget). Every other shape -- the empty-address surface,
+ * `describe(<id>.props.*)`, a single prop, `.vocab`, `composesWith` edges, the
+ * probe miss (`null`), and structured errors -- passes through as `describe`
+ * returned it (already target-lensed). `describe(<id>.props.*)` and `null` have
+ * no node identity (no `id`) to hang a stamp on, so they stay unstamped by
+ * construction, not by an address check.
+ *
+ * KNOWN GAP (pre-existing, #2074, out of #2101's scope): `describe(<id>.?)` --
+ * probing a BARE node id -- peels the probe and re-resolves to the same
+ * `NodeResult` shape `describe(<id>)` returns, but is address-gated OUT of the
+ * single-node branch below (`!addr.includes('.')`) and so returns unstamped.
+ * The expanded-node branch is deliberately structural (no such gate) so
+ * `describe(<id>.*.?)` IS stamped; closing the bare-id asymmetry is a named
+ * follow-up, not this issue's surface.
  */
 
 import type { ComponentTarget } from '../registry/types.js';
-import { type DescribeResult, describe, type Graph, type NodeResult } from './graph.js';
+import {
+  type DescribeResult,
+  describe,
+  type ExpandedNodeResult,
+  type Graph,
+  type NodeResult,
+} from './graph.js';
 
 export type Presence = 'installed' | 'available';
 
@@ -55,12 +73,24 @@ export type OverlayNodeResult = NodeResult & {
   rendersForTarget: boolean;
 };
 
+/**
+ * An expanded node (`describe(<id>.*)`, #2101), enriched with the same
+ * workspace stamp as `OverlayNodeResult`. Same three fields, different base
+ * shape -- `ExpandedNodeResult` carries `props` inline and has no `children`.
+ */
+export type OverlayExpandedNodeResult = ExpandedNodeResult & {
+  presence: Presence;
+  target: ComponentTarget | undefined;
+  rendersForTarget: boolean;
+};
+
 /** A roster entry (`describe(components|composites)`), enriched with presence. */
 export type OverlayRosterEntry = { id: string; presence: Presence };
 
 export type OverlayResult =
   | OverlayRosterEntry[] // describe(components) / describe(composites)
   | OverlayNodeResult // describe(<id>)
+  | OverlayExpandedNodeResult // describe(<id>.*)
   | DescribeResult; // every other shape passes through unchanged
 
 /**
@@ -82,9 +112,10 @@ export function buildInstalledSet(config: {
 
 /**
  * Resolve one dot-address through `describe`, handing it the workspace's target
- * as the reader's lens, and stamp the workspace overlay onto the two enriched
- * shapes -- the roster calls and a single-node query. Never throws for a bad
- * address: `describe`'s structured `{ error }` passes straight through.
+ * as the reader's lens, and stamp the workspace overlay onto the three enriched
+ * shapes -- the roster calls, a single-node query, and an expanded node
+ * (`<id>.*`). Never throws for a bad address: `describe`'s structured `{ error
+ * }` passes straight through.
  */
 export function describeWithOverlay(
   addr: string,
@@ -103,25 +134,44 @@ export function describeWithOverlay(
 
   // Single node: a bare id that resolved to a node gets the full stamp. A bad id
   // resolves to `{ error }`, which fails the guard and passes through unchanged.
-  // rendersForTarget reads the node's own facets (now on the universal graph):
-  // does a facet for the resolved target exist?
   if (addr !== '' && !addr.includes('.') && isNodeResult(result)) {
-    const set = result.kind === 'component' ? ctx.installed.components : ctx.installed.composites;
-    return {
-      ...result,
-      presence: presenceOf(set, result.id),
-      target: ctx.target,
-      rendersForTarget:
-        ctx.target !== undefined && graph.nodes.get(result.id)?.facets[ctx.target] !== undefined,
-    };
+    return { ...result, ...stampOf(result.id, result.kind, graph, ctx) };
   }
 
-  // Surface, props, vocab, edges, errors: pass through as describe lensed them.
+  // Expanded node (`<id>.*`, #2101): same stamp, structural detection so
+  // `<id>.*.?` (probe re-resolving to the same expanded shape) is caught too --
+  // gating on the address suffix would miss that case. `describe(<id>.props.*)`
+  // has no `id` key and fails this guard on purpose: it has no node identity to
+  // stamp (see the file header).
+  if (isExpandedNodeResult(result)) {
+    return { ...result, ...stampOf(result.id, result.kind, graph, ctx) };
+  }
+
+  // Surface, props, vocab, edges, probe miss (null), errors: pass through as
+  // describe lensed them.
   return result;
 }
 
 function presenceOf(set: ReadonlySet<string>, id: string): Presence {
   return set.has(id) ? 'installed' : 'available';
+}
+
+/** The three-field workspace stamp shared by `OverlayNodeResult` and `OverlayExpandedNodeResult`. */
+function stampOf(
+  id: string,
+  kind: NodeResult['kind'],
+  graph: Graph,
+  ctx: OverlayContext,
+): { presence: Presence; target: ComponentTarget | undefined; rendersForTarget: boolean } {
+  const set = kind === 'component' ? ctx.installed.components : ctx.installed.composites;
+  return {
+    presence: presenceOf(set, id),
+    target: ctx.target,
+    // rendersForTarget reads the node's own facets (on the universal graph):
+    // does a facet for the resolved target exist?
+    rendersForTarget:
+      ctx.target !== undefined && graph.nodes.get(id)?.facets[ctx.target] !== undefined,
+  };
 }
 
 /** Narrow a `DescribeResult` to a single-node `NodeResult`. */
@@ -133,5 +183,25 @@ function isNodeResult(result: DescribeResult): result is NodeResult {
     'id' in result &&
     'kind' in result &&
     'children' in result
+  );
+}
+
+/**
+ * Narrow a `DescribeResult` to an expanded node (`describe(<id>.*)`).
+ * Requiring both `id` and `props` excludes `ExpandedPropsResult`
+ * (`{ expanded: true, props }`, no `id`); excluding `children` excludes
+ * `NodeResult`; `!Array.isArray` excludes the roster and `composesWith`
+ * arrays. `expandNode` always sets `props` (possibly `{}`), so a node with no
+ * facet for the target still matches.
+ */
+function isExpandedNodeResult(result: DescribeResult): result is ExpandedNodeResult {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    !Array.isArray(result) &&
+    'id' in result &&
+    'kind' in result &&
+    'props' in result &&
+    !('children' in result)
   );
 }

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -177,7 +177,9 @@ export const TOOL_DEFINITIONS = [
       'installed surface; describe(components)/describe(composites) list the kind roster; ' +
       'describe(button) returns a node -- intel plus type-marked, drillable children; ' +
       'describe(button.props.fill) drills into a prop; describe(button.props.fill.vocab) ' +
-      'returns the real token values. A natural-language question (e.g. "what do I use when ' +
+      'returns the real token values. describe(button.*) expands all props inline in one ' +
+      'call (no more drill-per-prop round trips); describe(button.props.fill.?) probes ' +
+      'safely (null on miss, not an error). A natural-language question (e.g. "what do I use when ' +
       'it needs to be above everything") routes to the best-matching node plus a near-miss ' +
       'counter-example instead of an address.',
     inputSchema: {

--- a/packages/cli/test/mcp/overlay.test.ts
+++ b/packages/cli/test/mcp/overlay.test.ts
@@ -4,6 +4,7 @@ import {
   buildInstalledSet,
   describeWithOverlay,
   type OverlayContext,
+  type OverlayExpandedNodeResult,
   type OverlayNodeResult,
 } from '../../src/mcp/overlay.js';
 import type { Facet, RegistryItem } from '../../src/registry/types.js';
@@ -12,7 +13,16 @@ import type { Facet, RegistryItem } from '../../src/registry/types.js';
 // per-target facets, so the overlay reads rendersForTarget straight off the node.
 //   button (ui): facets for astro + wc, but NO vue (the real manifest gap).
 //   modal  (ui): no facets at all.
-const facet: Facet = { props: {}, snippet: '' };
+// astro and wc carry DIFFERENT props -- proof that the expanded payload is
+// target-lensed, not just that the stamp landed on a shared empty fixture.
+const astroFacet: Facet = {
+  props: { size: { type: 'enum', values: ['sm', 'md', 'lg'] } },
+  snippet: '<Button size="md" />',
+};
+const wcFacet: Facet = {
+  props: { variant: { type: 'enum', values: ['solid', 'outline'] } },
+  snippet: '<raf-button variant="solid"></raf-button>',
+};
 
 const items: RegistryItem[] = [
   {
@@ -22,7 +32,7 @@ const items: RegistryItem[] = [
     files: [],
     rules: [],
     composites: [],
-    facets: { astro: facet, wc: facet },
+    facets: { astro: astroFacet, wc: wcFacet },
   },
   { name: 'modal', type: 'ui', primitives: [], files: [], rules: [], composites: [], facets: {} },
 ];
@@ -66,6 +76,94 @@ vdescribe('describeWithOverlay -- single-node stamping', () => {
     const button = describeWithOverlay('button', graph, ctxNoTarget) as OverlayNodeResult;
     expect(button.target).toBeUndefined();
     expect(button.rendersForTarget).toBe(false);
+  });
+});
+
+vdescribe('describeWithOverlay -- known gap: bare-id probe (#2074)', () => {
+  it('button.? re-resolves to a NodeResult but is address-gated out and stays unstamped', () => {
+    // Pins the KNOWN GAP documented in overlay.ts's file header: `<id>.?` peels
+    // the probe and re-resolves to the same NodeResult shape `describe(<id>)`
+    // returns, but `!addr.includes('.')` gates it OUT of the single-node
+    // stamping branch (the address still contains a dot). Contrast with
+    // `button.*.?` below, which the expanded-node branch stamps because that
+    // branch is structural, not address-gated. An unwitting "fix" to the
+    // single-node guard would silently flip this -- this test is the tripwire.
+    const button = describeWithOverlay('button.?', graph, ctxAstroInstalled);
+    expect(button).not.toHaveProperty('presence');
+    expect(button).not.toHaveProperty('rendersForTarget');
+    expect(button).not.toHaveProperty('target');
+    expect(button).toMatchObject({ id: 'button', kind: 'component' });
+  });
+});
+
+vdescribe('describeWithOverlay -- expanded-node stamping (#2101)', () => {
+  it('stamps installed presence, echoed target, and rendersForTarget on button.*', () => {
+    const button = describeWithOverlay(
+      'button.*',
+      graph,
+      ctxAstroInstalled,
+    ) as OverlayExpandedNodeResult;
+    expect(button.presence).toBe('installed');
+    expect(button.target).toBe('astro');
+    expect(button.rendersForTarget).toBe(true);
+    // Target-lensed: astro's facet ('size'), never wc's ('variant').
+    expect(button.props).toHaveProperty('size');
+    expect(button.props).not.toHaveProperty('variant');
+  });
+
+  it('reports available presence and rendersForTarget false for an uninstalled, facet-less node', () => {
+    const modal = describeWithOverlay(
+      'modal.*',
+      graph,
+      ctxAstroInstalled,
+    ) as OverlayExpandedNodeResult;
+    expect(modal.presence).toBe('available');
+    expect(modal.rendersForTarget).toBe(false);
+  });
+
+  it('checks the composites installed set on the expanded path (stack.*)', () => {
+    const composed = assembleGraph([
+      ...items,
+      {
+        name: 'stack',
+        type: 'composite',
+        primitives: [],
+        files: [],
+        rules: [],
+        composites: [],
+        facets: {},
+      },
+    ]);
+    const ctx: OverlayContext = {
+      target: 'astro',
+      installed: { components: new Set(), composites: new Set(['stack']) },
+    };
+    const stack = describeWithOverlay('stack.*', composed, ctx) as OverlayExpandedNodeResult;
+    expect(stack.presence).toBe('installed');
+    expect(stack.rendersForTarget).toBe(false); // stack has no astro facet
+  });
+
+  it('probing an expanded node (button.*.?) still stamps -- structural, not address-gated', () => {
+    const button = describeWithOverlay(
+      'button.*.?',
+      graph,
+      ctxAstroInstalled,
+    ) as OverlayExpandedNodeResult;
+    expect(button.presence).toBe('installed');
+    expect(button.rendersForTarget).toBe(true);
+  });
+
+  it('describe(<id>.props.*) has no node identity and stays unstamped', () => {
+    const props = describeWithOverlay('button.props.*', graph, ctxAstroInstalled);
+    expect(props).toEqual({
+      expanded: true,
+      props: { size: { type: 'enum', values: ['sm', 'md', 'lg'] } },
+    });
+    expect(props).not.toHaveProperty('presence');
+  });
+
+  it('a probe miss (nope.?) passes through as null, unstamped', () => {
+    expect(describeWithOverlay('nope.?', graph, ctxAstroInstalled)).toBeNull();
   });
 });
 

--- a/packages/ui/src/components/card/card-action.astro
+++ b/packages/ui/src/components/card/card-action.astro
@@ -6,6 +6,8 @@
  * Outside a CardHeader they resolve against no grid and do nothing.
  *
  * `class` is NOT a prop; design travels through token props only.
+ *
+ * @parent card
  */
 import type { HTMLAttributes } from 'astro/types';
 import { cardActionClasses } from './card.classes';

--- a/packages/ui/src/components/card/card-content.astro
+++ b/packages/ui/src/components/card/card-content.astro
@@ -5,6 +5,8 @@
  * lets an arbitrary child dropped straight into a Card share the same rhythm.
  *
  * `class` is NOT a prop; design travels through token props only.
+ *
+ * @parent card
  */
 import type { HTMLAttributes } from 'astro/types';
 import { cardContentClasses } from './card.classes';

--- a/packages/ui/src/components/card/card-footer.astro
+++ b/packages/ui/src/components/card/card-footer.astro
@@ -4,6 +4,8 @@
  * root owns the vertical rhythm.
  *
  * `class` is NOT a prop; design travels through token props only.
+ *
+ * @parent card
  */
 import type { HTMLAttributes } from 'astro/types';
 import { cardFooterClasses } from './card.classes';

--- a/packages/ui/src/components/card/card-header.astro
+++ b/packages/ui/src/components/card/card-header.astro
@@ -14,6 +14,8 @@
  *
  * `class` is NOT a prop -- design travels through token props only. It is
  * discarded so `...attrs` cannot carry it onto the element.
+ *
+ * @parent card
  */
 import type { HTMLAttributes } from 'astro/types';
 import { cardHeaderClasses } from './card.classes';

--- a/packages/ui/src/components/card/card-title.astro
+++ b/packages/ui/src/components/card/card-title.astro
@@ -7,6 +7,8 @@
  * never skip levels.
  *
  * `class` is NOT a prop; design travels through token props only.
+ *
+ * @parent card
  */
 import type { HTMLAttributes } from 'astro/types';
 import { cardTitleClasses } from './card.classes';

--- a/packages/ui/src/components/card/card.tsx
+++ b/packages/ui/src/components/card/card.tsx
@@ -128,6 +128,8 @@ export type CardHeaderProps = NoClassName<React.HTMLAttributes<HTMLDivElement>>;
 /**
  * The header is a grid (shadcn v4), not a flex column: that is the parent
  * CardAction's placement utilities need in order to place at all.
+ *
+ * @parent card
  */
 export const CardHeader = React.forwardRef<HTMLDivElement, CardHeaderProps>((props, ref) => (
   <div
@@ -151,6 +153,8 @@ export interface CardTitleProps extends NoClassName<React.HTMLAttributes<HTMLHea
  * 2.4.10 Section Headings at AAA) and invisible to a swap -- same component
  * name, same children, same data-slot, one added prop. `as` places the heading
  * at the correct outline level for the surrounding page. See card.md.
+ *
+ * @parent card
  */
 export const CardTitle = React.forwardRef<HTMLHeadingElement, CardTitleProps>(
   ({ as: Element = 'h3', children, ...rest }, ref) =>
@@ -174,6 +178,8 @@ export type CardDescriptionProps = NoClassName<React.HTMLAttributes<HTMLParagrap
  * A real `p`, where shadcn renders a div -- the same accepted AAA divergence as
  * the title, and behavior-additive for the same reason: prose in a paragraph is
  * navigable and correctly announced, and the swap sees no API change.
+ *
+ * @parent card
  */
 export const CardDescription = React.forwardRef<HTMLParagraphElement, CardDescriptionProps>(
   ({ children, ...rest }, ref) =>
@@ -197,6 +203,8 @@ export type CardActionProps = NoClassName<React.HTMLAttributes<HTMLDivElement>>;
  * Trailing control slot (dismiss/menu). Its placement utilities only resolve as
  * a DIRECT CHILD of CardHeader -- the header's `has-data-[slot=card-action]`
  * variant is what opens the second column for it.
+ *
+ * @parent card
  */
 export const CardAction = React.forwardRef<HTMLDivElement, CardActionProps>((props, ref) => (
   <div
@@ -211,6 +219,7 @@ CardAction.displayName = 'CardAction';
 
 export type CardContentProps = NoClassName<React.HTMLAttributes<HTMLDivElement>>;
 
+/** @parent card */
 export const CardContent = React.forwardRef<HTMLDivElement, CardContentProps>((props, ref) => (
   <div
     ref={ref}
@@ -224,6 +233,7 @@ CardContent.displayName = 'CardContent';
 
 export type CardFooterProps = NoClassName<React.HTMLAttributes<HTMLDivElement>>;
 
+/** @parent card */
 export const CardFooter = React.forwardRef<HTMLDivElement, CardFooterProps>((props, ref) => (
   <div
     ref={ref}


### PR DESCRIPTION
Follow-up to #2099. Three changes to complete the describe operator surface:

1. **Tool description** (#2100): rafters_describe now mentions * (expand) and ? (probe) operators so agents discover them from the manifest.

2. **Overlay stamp** (#2101): ExpandedNodeResult from button.* is now stamped with presence/target/rendersForTarget, same as bare NodeResult. ExpandedPropsResult and null (probe miss) pass through unstamped.

3. **Generator @parent** (#2102): Registry generator parses @parent from JSDoc. Card sub-components (card-header, card-title, card-content, card-footer, card-action) carry @parent card in both their .astro and .tsx JSDoc blocks.

Closes #2100
Closes #2101
Closes #2102