### PR TITLE
fix(#2065,#1944,#1634,#1626): design token batch -- leading vars, stale artifacts, bind order, cascade atomicity

### DIFF
--- a/packages/design-tokens/src/exporters/tailwind.ts
+++ b/packages/design-tokens/src/exporters/tailwind.ts
@@ -389,6 +389,16 @@ function generateThemeBlock(groups: GroupedTokens): string {
       if (token.lineHeight) {
         lines.push(`  --${token.name}--line-height: ${token.lineHeight};`);
       }
+      // Tailwind v4 reads --leading-* as a NAMED theme namespace for the
+      // leading-* utility (leading-tight, leading-relaxed, ...). The registry
+      // names these tokens line-height-*, so bridge to the Tailwind-native
+      // name here -- same stripped-prefix pattern as --spacing-* / --radius-*
+      // below. Additive: --line-height-* keeps carrying its existing meaning
+      // (the font-size-*--line-height pairing) for whatever already reads it.
+      if (token.name.startsWith('line-height-')) {
+        const key = token.name.replace(/^line-height-/, '');
+        lines.push(`  --leading-${key}: ${value};`);
+      }
     }
     lines.push('');
   }
@@ -1267,6 +1277,13 @@ function generateThemeBlockWithVarRefs(groups: GroupedTokens): string {
       if (token.lineHeight) {
         lines.push(`  --${token.name}--line-height: var(--rafters-${token.name}--line-height);`);
       }
+      // Same --leading-* bridge as the dynamic path (generateThemeBlock) --
+      // the two must stay in parity or Studio's leading-* utilities compile
+      // to nothing while the consumer sheet's work.
+      if (token.name.startsWith('line-height-')) {
+        const key = token.name.replace(/^line-height-/, '');
+        lines.push(`  --leading-${key}: var(--rafters-${token.name});`);
+      }
     }
     lines.push('');
   }
@@ -1720,6 +1737,8 @@ function deriveCandidates(themeCSS: string): string[] {
     } else if (name.startsWith('font-weight-')) {
       candidates.add(`font-${name.slice(12)}`);
     } else if (name.startsWith('ease-')) {
+      candidates.add(name);
+    } else if (name.startsWith('leading-')) {
       candidates.add(name);
     } else if (name.startsWith('animate-')) {
       candidates.add(name);

--- a/packages/design-tokens/src/graph.ts
+++ b/packages/design-tokens/src/graph.ts
@@ -161,17 +161,26 @@ export class TokenGraph {
     for (const [k, v] of this.nodes) this.snapshot.set(k, structuredClone(v));
   }
 
+  // The caller (set/bind) takes a snapshot before invoking this. If any
+  // dependent's transform throws partway through, we roll the whole graph
+  // back to that snapshot and re-throw -- cascade is all-or-nothing, never
+  // half-applied.
   private cascadeFrom(changed: string): void {
-    const dependents = this.collectDependents(changed);
-    if (dependents.size === 0) return;
-    const ordered = this.topoSort(dependents);
-    for (const name of ordered) {
-      const node = this.nodes.get(name);
-      if (!node || node.userOverride || !node.binding) continue;
-      const plugin = this.requirePlugin(node.binding.plugin);
-      const value = plugin.transform(node.binding.input, (n) => this.get(n));
-      plugin.outputSchema.parse(value);
-      this.nodes.set(name, { ...node, value });
+    try {
+      const dependents = this.collectDependents(changed);
+      if (dependents.size === 0) return;
+      const ordered = this.topoSort(dependents);
+      for (const name of ordered) {
+        const node = this.nodes.get(name);
+        if (!node || node.userOverride || !node.binding) continue;
+        const plugin = this.requirePlugin(node.binding.plugin);
+        const value = plugin.transform(node.binding.input, (n) => this.get(n));
+        plugin.outputSchema.parse(value);
+        this.nodes.set(name, { ...node, value });
+      }
+    } catch (error) {
+      this.undo();
+      throw error;
     }
   }
 

--- a/packages/design-tokens/src/outputs.ts
+++ b/packages/design-tokens/src/outputs.ts
@@ -5,7 +5,8 @@
  * Every trigger (CLI init, CLI add/update, studio token mutation, the file
  * watch) funnels through {@link regenerateOutputs}. There is exactly one
  * function that writes `rafters.css` / `rafters.ts` / `rafters.json` /
- * `rafters.standalone.css` / `rafters.documentation.css` and fires the HMR
+ * `rafters.standalone.css` / `rafters.documentation.css`, prunes any of those
+ * files left behind by a now-disabled export, and fires the HMR
  * notification, so the emitted set
  * can never drift between callers and there is no second regen/HMR mechanism.
  *
@@ -14,7 +15,7 @@
  */
 
 import { existsSync, realpathSync } from 'node:fs';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, unlink, writeFile } from 'node:fs/promises';
 import { isAbsolute, join, resolve } from 'node:path';
 import { toDTCG } from './exporters/dtcg.js';
 import {
@@ -58,6 +59,20 @@ export interface RegenerateOutputsHooks {
   /** Fired once after all outputs are written (e.g. studio HMR signal). */
   notify?: () => void;
 }
+
+/**
+ * Every filename {@link regenerateOutputs} can ever write. Fixed and
+ * exhaustive -- used to sweep away a format's artifact when its export is
+ * disabled, so a toggled-off format doesn't leave a stale file behind for
+ * consumers to keep picking up.
+ */
+const KNOWN_OUTPUT_FILENAMES = [
+  'rafters.css',
+  'rafters.ts',
+  'rafters.json',
+  'rafters.standalone.css',
+  'rafters.documentation.css',
+] as const;
 
 /**
  * A path-field value as stored in config: a single path, or an array of
@@ -113,9 +128,10 @@ export function resolveContentSources(
 }
 
 /**
- * Write every configured output for `registry` into `input.outputDir`, then
- * fire `hooks.notify`. Returns the filenames written. The ONLY code that writes
- * rafters output files or triggers HMR.
+ * Write every configured output for `registry` into `input.outputDir`, prune
+ * any known output file whose export is disabled, then fire `hooks.notify`.
+ * Returns the filenames written. The ONLY code that writes rafters output
+ * files or triggers HMR.
  */
 export async function regenerateOutputs(
   registry: TokenRegistry,
@@ -160,6 +176,22 @@ export async function regenerateOutputs(
     const doc = await registryToDocumentation(registry, { contentSources });
     await writeFile(join(outputDir, 'rafters.documentation.css'), doc);
     written.push('rafters.documentation.css');
+  }
+
+  // Sweep any known artifact whose export is now disabled -- a format toggled
+  // off must not leave its last-written file on disk for a consumer to keep
+  // reading stale output. Best-effort: a stale artifact that fails to delete
+  // must not fail a regen whose writes all succeeded.
+  const writtenSet = new Set(written);
+  for (const filename of KNOWN_OUTPUT_FILENAMES) {
+    if (writtenSet.has(filename)) continue;
+    const filePath = join(outputDir, filename);
+    if (!existsSync(filePath)) continue;
+    try {
+      await unlink(filePath);
+    } catch {
+      // Best-effort cleanup -- see comment above.
+    }
   }
 
   hooks.notify?.();

--- a/packages/design-tokens/src/registry.ts
+++ b/packages/design-tokens/src/registry.ts
@@ -1,6 +1,13 @@
 import { type Token, TokenSchema } from '@rafters/shared';
 import type { z } from 'zod';
-import { type Node, type Plugin, type SetOptions, TokenGraph, type UserOverride } from './graph.js';
+import {
+  CircularDependencyError,
+  type Node,
+  type Plugin,
+  type SetOptions,
+  TokenGraph,
+  type UserOverride,
+} from './graph.js';
 
 type TokenValue = z.infer<typeof TokenSchema>['value'];
 type UserOverrideField = NonNullable<z.infer<typeof TokenSchema>['userOverride']>;
@@ -18,7 +25,9 @@ export class TokenRegistry {
   constructor(initialTokens: readonly unknown[] = [], plugins: readonly Plugin[] = []) {
     this.graph = new TokenGraph(plugins);
     for (const plugin of plugins) this.plugins.set(plugin.name, plugin);
-    // Two passes so bindings can reference family tokens regardless of source order.
+    // Two passes: pass 1 seeds leaves and overridden tokens (order-independent);
+    // pass 2 binds derived tokens in dependency order so each transform sees
+    // its upstream values. Array order alone was not enough (#1634).
     const parsed: Token[] = [];
     for (const raw of initialTokens) {
       const result = TokenSchema.safeParse(raw);
@@ -42,11 +51,15 @@ export class TokenRegistry {
       });
     }
     // Pass 2: bound tokens without a userOverride re-derive against the
-    // leaves seeded in pass 1.
-    for (const t of parsed) {
-      if (!t.binding) continue;
-      if (t.userOverride) continue;
-      this.graph.bind(t.name, t.binding.plugin, t.binding.input);
+    // leaves seeded in pass 1, sorted by dependency edges so upstream
+    // tokens are bound before their dependents.
+    //
+    // TokenGraph.topoSort cannot be reused here: it discovers edges via
+    // this.nodes, but pass-2 tokens have not been added to the graph yet.
+    // A local sort over the parsed data is required.
+    const ordered = topoSortPass2(parsed, this.plugins);
+    for (const entry of ordered) {
+      this.graph.bind(entry.name, entry.binding.plugin, entry.binding.input);
     }
   }
 
@@ -181,4 +194,57 @@ function toUserOverrideField(
   if (override.context) result.context = override.context;
   if (override.kind) result.kind = override.kind;
   return result;
+}
+
+type Pass2Entry = { name: string; binding: NonNullable<Token['binding']> };
+
+/**
+ * Topologically sort the pass-2 tokens (bound, no userOverride) so each
+ * token is bound after all pass-2 tokens it depends on. Dependencies on
+ * pass-1 tokens (leaves, overrides) are already satisfied and ignored.
+ *
+ * Source order is the tiebreaker for independent tokens so list() output
+ * stays deterministic.
+ */
+function topoSortPass2(
+  parsed: readonly Token[],
+  plugins: ReadonlyMap<string, Plugin>,
+): readonly Pass2Entry[] {
+  const entries: Pass2Entry[] = [];
+  for (const t of parsed) {
+    if (!t.binding || t.userOverride) continue;
+    entries.push({ name: t.name, binding: t.binding });
+  }
+
+  const entryByName = new Map<string, Pass2Entry>();
+  for (const e of entries) entryByName.set(e.name, e);
+
+  const sorted: Pass2Entry[] = [];
+  const visited = new Set<string>();
+  const visiting = new Set<string>();
+
+  const visit = (name: string, path: readonly string[]): void => {
+    if (visited.has(name)) return;
+    if (visiting.has(name)) {
+      throw new CircularDependencyError([...path, name]);
+    }
+    visiting.add(name);
+    const entry = entryByName.get(name);
+    if (entry) {
+      const plugin = plugins.get(entry.binding.plugin);
+      // Skip edge discovery for unknown plugins; graph.bind() will throw
+      // UnknownPluginError when it processes the entry.
+      if (plugin) {
+        for (const dep of plugin.dependsOn(entry.binding.input)) {
+          if (entryByName.has(dep)) visit(dep, [...path, name]);
+        }
+      }
+    }
+    visiting.delete(name);
+    visited.add(name);
+    if (entry) sorted.push(entry);
+  };
+
+  for (const e of entries) visit(e.name, []);
+  return sorted;
 }

--- a/packages/design-tokens/test/graph.test.ts
+++ b/packages/design-tokens/test/graph.test.ts
@@ -202,6 +202,98 @@ describe('TokenGraph', () => {
     });
   });
 
+  describe('cascade atomicity (issue #1626)', () => {
+    it('rolls back the whole set when a mid-cascade plugin throws', () => {
+      let armed = false;
+      const explodingPlugin: Plugin = {
+        name: 'exploding',
+        inputSchema: z.object({ source: z.string() }),
+        outputSchema: z.number(),
+        dependsOn: (input) => [(input as { source: string }).source],
+        transform: (input, get) => {
+          if (armed) throw new Error('plugin blew up');
+          return (get((input as { source: string }).source) as number) + 1;
+        },
+      };
+      // a -> b (double, succeeds) -> c (exploding, throws once armed).
+      // topoSort recomputes b before c, so b is the "already applied"
+      // half of the partial state we're asserting gets rolled back.
+      const g = new TokenGraph([doublePlugin, explodingPlugin]);
+      g.seed('a', 1);
+      g.bind('b', 'double', { source: 'a' });
+      g.bind('c', 'exploding', { source: 'b' });
+      expect(g.get('a')).toBe(1);
+      expect(g.get('b')).toBe(2);
+      expect(g.get('c')).toBe(3);
+
+      armed = true;
+      expect(() => g.set('a', 5, R)).toThrow('plugin blew up');
+
+      // Nothing half-applied: the direct set on 'a' and the successful
+      // recompute of 'b' are both reverted, not just 'c' left stale.
+      expect(g.get('a')).toBe(1);
+      expect(g.get('b')).toBe(2);
+      expect(g.get('c')).toBe(3);
+
+      // The automatic rollback already consumed the snapshot, so a
+      // caller-invoked undo() after catching the error is a no-op.
+      g.undo();
+      expect(g.get('a')).toBe(1);
+    });
+
+    it('rolls back a bind whose own cascade throws', () => {
+      let armed = false;
+      const explodingPlugin: Plugin = {
+        name: 'exploding2',
+        inputSchema: z.object({ source: z.string() }),
+        outputSchema: z.number(),
+        dependsOn: (input) => [(input as { source: string }).source],
+        transform: (input, get) => {
+          if (armed) throw new Error('boom');
+          return (get((input as { source: string }).source) as number) + 1;
+        },
+      };
+      const g = new TokenGraph([doublePlugin, explodingPlugin]);
+      g.seed('a', 1);
+      g.bind('b', 'double', { source: 'a' });
+      g.bind('c', 'exploding2', { source: 'b' });
+
+      armed = true;
+      // Rebinding 'b' recomputes 'b' itself fine, but cascades into 'c',
+      // which throws. The bind of 'b' should not stick.
+      expect(() => g.bind('b', 'double', { source: 'a' })).toThrow('boom');
+      expect(g.get('b')).toBe(2);
+      expect(g.get('c')).toBe(3);
+    });
+
+    it('still succeeds normally after a rolled-back cascade failure', () => {
+      let armed = false;
+      const explodingPlugin: Plugin = {
+        name: 'exploding3',
+        inputSchema: z.object({ source: z.string() }),
+        outputSchema: z.number(),
+        dependsOn: (input) => [(input as { source: string }).source],
+        transform: (input, get) => {
+          if (armed) throw new Error('boom');
+          return (get((input as { source: string }).source) as number) + 1;
+        },
+      };
+      const g = new TokenGraph([doublePlugin, explodingPlugin]);
+      g.seed('a', 1);
+      g.bind('b', 'double', { source: 'a' });
+      g.bind('c', 'exploding3', { source: 'b' });
+
+      armed = true;
+      expect(() => g.set('a', 5, R)).toThrow('boom');
+
+      armed = false;
+      g.set('a', 5, R);
+      expect(g.get('a')).toBe(5);
+      expect(g.get('b')).toBe(10);
+      expect(g.get('c')).toBe(11);
+    });
+  });
+
   describe('cycle detection', () => {
     it('throws CircularDependencyError on direct cycle', () => {
       const g = new TokenGraph([identityPlugin]);

--- a/packages/design-tokens/test/outputs.test.ts
+++ b/packages/design-tokens/test/outputs.test.ts
@@ -1,0 +1,143 @@
+/**
+ * regenerateOutputs write + prune guard (#1944).
+ *
+ * regenerateOutputs is the single path that turns a TokenRegistry into the
+ * on-disk `.rafters/output` artifacts. It used to only ever write files for
+ * enabled exports -- toggling an export off left its last-written file
+ * sitting on disk for a consumer (or a stale HMR client) to keep reading.
+ * These tests pin two things: the written-filename list stays exhaustive and
+ * accurate (a mismatch there would delete a file the call just wrote), and a
+ * disabled export's stale artifact is swept on the next regen while an
+ * enabled export's file survives untouched.
+ */
+
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { generateBaseSystem } from '../src/generators/index.js';
+import {
+  contrastPlugin,
+  invertPlugin,
+  scalePlugin,
+  statePlugin,
+  TokenRegistry,
+} from '../src/index.js';
+import { type OutputExports, regenerateOutputs } from '../src/outputs.js';
+
+const ALL_ON: OutputExports = {
+  tailwind: true,
+  typescript: true,
+  dtcg: true,
+  compiled: true,
+  documentation: true,
+};
+
+const ALL_OFF: OutputExports = {
+  tailwind: false,
+  typescript: false,
+  dtcg: false,
+  compiled: false,
+  documentation: false,
+};
+
+const KNOWN_FILES = [
+  'rafters.css',
+  'rafters.ts',
+  'rafters.json',
+  'rafters.standalone.css',
+  'rafters.documentation.css',
+];
+
+function baseRegistry(): TokenRegistry {
+  const system = generateBaseSystem({});
+  return new TokenRegistry(system.allTokens, [
+    scalePlugin,
+    contrastPlugin,
+    statePlugin,
+    invertPlugin,
+  ]);
+}
+
+describe('regenerateOutputs (#1944)', () => {
+  let outputDir: string;
+
+  beforeEach(() => {
+    outputDir = mkdtempSync(join(tmpdir(), 'rafters-outputs-'));
+  });
+
+  afterEach(() => {
+    rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  it('writes exactly one file per enabled export, matching the known filename set', async () => {
+    const written = await regenerateOutputs(baseRegistry(), { outputDir, exports: ALL_ON });
+
+    expect(written.sort()).toEqual([...KNOWN_FILES].sort());
+    for (const filename of KNOWN_FILES) {
+      expect(existsSync(join(outputDir, filename))).toBe(true);
+    }
+  }, 20000);
+
+  it('writes nothing when every export is disabled', async () => {
+    const written = await regenerateOutputs(baseRegistry(), { outputDir, exports: ALL_OFF });
+
+    expect(written).toEqual([]);
+    for (const filename of KNOWN_FILES) {
+      expect(existsSync(join(outputDir, filename))).toBe(false);
+    }
+  });
+
+  it('removes a disabled export artifact left over from a prior regen', async () => {
+    // First regen with everything on -- all five files land on disk.
+    await regenerateOutputs(baseRegistry(), { outputDir, exports: ALL_ON });
+    for (const filename of KNOWN_FILES) {
+      expect(existsSync(join(outputDir, filename))).toBe(true);
+    }
+
+    // Second regen only re-enables tailwind + typescript.
+    const written = await regenerateOutputs(baseRegistry(), {
+      outputDir,
+      exports: {
+        tailwind: true,
+        typescript: true,
+        dtcg: false,
+        compiled: false,
+        documentation: false,
+      },
+    });
+
+    expect(written.sort()).toEqual(['rafters.css', 'rafters.ts']);
+    expect(existsSync(join(outputDir, 'rafters.css'))).toBe(true);
+    expect(existsSync(join(outputDir, 'rafters.ts'))).toBe(true);
+    expect(existsSync(join(outputDir, 'rafters.json'))).toBe(false);
+    expect(existsSync(join(outputDir, 'rafters.standalone.css'))).toBe(false);
+    expect(existsSync(join(outputDir, 'rafters.documentation.css'))).toBe(false);
+  }, 20000);
+
+  it('never touches a file outside the known output filename set', async () => {
+    const untouched = join(outputDir, 'notes.txt');
+    writeFileSync(untouched, 'keep me');
+
+    await regenerateOutputs(baseRegistry(), { outputDir, exports: ALL_OFF });
+
+    expect(existsSync(untouched)).toBe(true);
+    await expect(readFile(untouched, 'utf-8')).resolves.toBe('keep me');
+  });
+
+  it('does not throw when there is nothing stale to prune', async () => {
+    await expect(
+      regenerateOutputs(baseRegistry(), {
+        outputDir,
+        exports: {
+          tailwind: true,
+          typescript: false,
+          dtcg: false,
+          compiled: false,
+          documentation: false,
+        },
+      }),
+    ).resolves.toEqual(['rafters.css']);
+  });
+});

--- a/packages/design-tokens/test/progression-property.test.ts
+++ b/packages/design-tokens/test/progression-property.test.ts
@@ -223,4 +223,26 @@ describe('radius and focus derive from spacing', () => {
       );
     }
   });
+
+  it('the @theme block registers --leading-* for Tailwind v4 leading-* utility generation (#2065)', () => {
+    const system = generateBaseSystem({});
+    const css = tokensToTailwind(system.allTokens, { includeImport: false }, []);
+
+    const lineHeightTokens = system.allTokens.filter((t) => t.name.startsWith('line-height-'));
+    expect(lineHeightTokens.length).toBeGreaterThan(0);
+
+    for (const token of lineHeightTokens) {
+      const key = token.name.replace(/^line-height-/, '');
+      // --leading-* is a Tailwind v4 NAMED theme namespace (leading-tight,
+      // leading-relaxed, ...); --line-height-* is not, so the leading-*
+      // utility compiles to nothing without this bridge. Additive: the
+      // existing --line-height-* declaration must still be present too.
+      expect(css, `missing --leading-${key} theme var`).toContain(
+        `  --leading-${key}: ${token.value};`,
+      );
+      expect(css, `--line-height-${key} should still be emitted`).toContain(
+        `  --${token.name}: ${token.value};`,
+      );
+    }
+  });
 });


### PR DESCRIPTION
Four design token fixes:

1. **#2065**: Tailwind exporter now emits --leading-* theme vars in the @theme block for v4 leading-* utility generation. Same strip-prefix pattern as spacing/radius.

2. **#1944**: regenerateOutputs deletes stale artifacts when an export is disabled. Best-effort unlink -- never fails the regen.

3. **#1634**: Pass-2 token binding uses toposort by dependency edges instead of array order. A token never reads a stale dependency value during initial bind.

4. **#1626**: cascadeFrom wrapped in try/catch with undo() on error. Mid-cascade plugin failure rolls back the entire mutation instead of leaving partial state.

Closes #2065
Closes #1944
Closes #1634
Closes #1626