### PR TITLE
feat(#2109): bindEditor controlled contenteditable (FR-EDITOR-004)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@vitejs/plugin-react": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "@vitest/ui": "catalog:",
-    "esbuild": "^0.27.3",
+    "esbuild": "catalog:",
     "happy-dom": "catalog:",
     "lefthook": "catalog:",
     "msw": "catalog:",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@vitejs/plugin-react": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "@vitest/ui": "catalog:",
+    "esbuild": "^0.27.3",
     "happy-dom": "catalog:",
     "lefthook": "catalog:",
     "msw": "catalog:",

--- a/packages/ui/src/components/editor/editor.behavior.ts
+++ b/packages/ui/src/components/editor/editor.behavior.ts
@@ -429,6 +429,27 @@ export function bindEditor(root: HTMLElement): () => void {
     return { start: Math.min(start, end), end: Math.max(start, end) };
   }
 
+  /** A range selection on a SINGLE block (`anchor.blockId === focus.blockId`,
+   *  not collapsed): remove [start, end) as one `removeText` op. Shared by
+   *  `deleteBackwardOp` and `deleteForwardOp` -- a range delete removes the
+   *  same span regardless of which key triggered it. */
+  function sameBlockRangeRemoveOp(
+    doc: EditorHistoryState['doc'],
+    sel: EditorHistoryState['sel'],
+  ): EditorOp[] {
+    const start = Math.min(sel.anchor.offset, sel.focus.offset);
+    const end = Math.max(sel.anchor.offset, sel.focus.offset);
+    const block = doc.find((b) => b.id === sel.focus.blockId);
+    return [
+      {
+        kind: 'removeText',
+        blockId: sel.focus.blockId,
+        offset: start,
+        text: sliceContent(block?.content, start, end),
+      },
+    ];
+  }
+
   function deleteBackwardOp(
     state: EditorHistoryState,
     targetRanges: readonly StaticRange[],
@@ -436,17 +457,7 @@ export function bindEditor(root: HTMLElement): () => void {
     const { sel, doc } = state;
     if (!isCollapsed(sel)) {
       if (sel.anchor.blockId !== sel.focus.blockId) return deleteRangeAcrossBlocksOps(doc, sel);
-      const start = Math.min(sel.anchor.offset, sel.focus.offset);
-      const end = Math.max(sel.anchor.offset, sel.focus.offset);
-      const block = doc.find((b) => b.id === sel.focus.blockId);
-      return [
-        {
-          kind: 'removeText',
-          blockId: sel.focus.blockId,
-          offset: start,
-          text: sliceContent(block?.content, start, end),
-        },
-      ];
+      return sameBlockRangeRemoveOp(doc, sel);
     }
     const { blockId, offset } = sel.focus;
     if (offset === 0) {
@@ -473,17 +484,7 @@ export function bindEditor(root: HTMLElement): () => void {
     const { sel, doc } = state;
     if (!isCollapsed(sel)) {
       if (sel.anchor.blockId !== sel.focus.blockId) return deleteRangeAcrossBlocksOps(doc, sel);
-      const start = Math.min(sel.anchor.offset, sel.focus.offset);
-      const end = Math.max(sel.anchor.offset, sel.focus.offset);
-      const block = doc.find((b) => b.id === sel.focus.blockId);
-      return [
-        {
-          kind: 'removeText',
-          blockId: sel.focus.blockId,
-          offset: start,
-          text: sliceContent(block?.content, start, end),
-        },
-      ];
+      return sameBlockRangeRemoveOp(doc, sel);
     }
     const { blockId, offset } = sel.focus;
     const block = doc.find((b) => b.id === blockId);

--- a/packages/ui/src/components/editor/editor.behavior.ts
+++ b/packages/ui/src/components/editor/editor.behavior.ts
@@ -285,6 +285,30 @@ function locatePosition(
   return { node: last, offset: last.data.length };
 }
 
+/** Inverse of `locatePosition`: map a DOM (node, offset) boundary -- from a
+ *  native `beforeinput` target range -- to the model text offset within
+ *  `blockEl`. Measures with `Range.toString().length`, the same UTF-16
+ *  code-unit count `sliceContent`/`removeText` use, so it agrees exactly with
+ *  the model even when the boundary lands on an element (not just a text
+ *  node) or inside a mark wrapper. Returns `null` when `node` isn't inside
+ *  `blockEl` at all. */
+function domOffsetInBlock(blockEl: Element, node: Node, offset: number): number | null {
+  if (!blockEl.contains(node)) return null;
+  try {
+    const range = blockEl.ownerDocument.createRange();
+    range.setStart(blockEl, 0);
+    range.setEnd(node, offset);
+    return range.toString().length;
+  } catch {
+    // A target range whose (node, offset) `Range.setStart`/`setEnd` rejects
+    // (bad container/offset) must never escape into the `beforeinput`
+    // listener -- per this file's own rule, typing must never break.
+    // `deletionRange`'s caller already falls back to the UTF-16 arithmetic
+    // for a `null` result.
+    return null;
+  }
+}
+
 function restoreSelection(root: HTMLElement, sel: EditorHistoryState['sel']): void {
   const view = root.ownerDocument.defaultView;
   const selection = view?.getSelection?.() ?? null;
@@ -336,61 +360,148 @@ export function bindEditor(root: HTMLElement): () => void {
 
   // -- op construction for the doc-dependent inputs (deletes / structural) --
 
-  function deleteBackwardOp(state: EditorHistoryState): EditorOp | null {
+  /** A range selection spanning two OR MORE blocks (`anchor.blockId !==
+   *  focus.blockId`, not collapsed): truncate the earlier block from its
+   *  offset to its end, truncate the later block from its start to its
+   *  offset, `delete` any block strictly between them, then `mergeNext` the
+   *  (now-truncated) earlier block into the (now-truncated) later one --
+   *  landing the caret at the earlier block's offset, same as a same-block
+   *  range delete. Built entirely from the existing op vocabulary (no new op
+   *  kind), the same compound-ops-for-one-user-action shape `splitOps` below
+   *  already uses for a range-remove-then-split. */
+  function deleteRangeAcrossBlocksOps(
+    doc: EditorHistoryState['doc'],
+    sel: EditorHistoryState['sel'],
+  ): EditorOp[] {
+    const anchorIndex = doc.findIndex((b) => b.id === sel.anchor.blockId);
+    const focusIndex = doc.findIndex((b) => b.id === sel.focus.blockId);
+    if (anchorIndex === -1 || focusIndex === -1) return [];
+    const anchorFirst = anchorIndex <= focusIndex;
+    const startIndex = anchorFirst ? anchorIndex : focusIndex;
+    const endIndex = anchorFirst ? focusIndex : anchorIndex;
+    const startOffset = anchorFirst ? sel.anchor.offset : sel.focus.offset;
+    const endOffset = anchorFirst ? sel.focus.offset : sel.anchor.offset;
+
+    const startBlock = doc[startIndex] as BaseBlock;
+    const endBlock = doc[endIndex] as BaseBlock;
+    const startTotal = totalTextLength(normalizeRuns(startBlock.content));
+
+    const ops: EditorOp[] = [
+      {
+        kind: 'removeText',
+        blockId: startBlock.id,
+        offset: startOffset,
+        text: sliceContent(startBlock.content, startOffset, startTotal),
+      },
+      {
+        kind: 'removeText',
+        blockId: endBlock.id,
+        offset: 0,
+        text: sliceContent(endBlock.content, 0, endOffset),
+      },
+    ];
+    for (let i = startIndex + 1; i < endIndex; i++) {
+      ops.push({ kind: 'delete', blockId: (doc[i] as BaseBlock).id });
+    }
+    ops.push({ kind: 'mergeNext', blockId: startBlock.id });
+    return ops;
+  }
+
+  /** The [start, end) model-offset range a native `deleteContentBackward`/
+   *  `Forward` actually removes, per the browser's own `beforeinput`
+   *  `targetRanges` (`InputData.targetRanges`, from `getTargetRanges()`) --
+   *  grapheme- and surrogate-pair-aware, unlike the UTF-16 code-unit `offset
+   *  +/- 1` arithmetic `fallback` carries. Falls back to that arithmetic when
+   *  no usable target range is available: no browser support, or a driver
+   *  that never dispatches a real `beforeinput` (vitest/happy-dom -- see this
+   *  file's test's own note that capture is Playwright-only). */
+  function deletionRange(
+    blockId: string,
+    fallback: { start: number; end: number },
+    targetRanges: readonly StaticRange[],
+  ): { start: number; end: number } {
+    const range = targetRanges[0];
+    const blockEl = root.querySelector(`[data-block-id="${CSS.escape(blockId)}"]`);
+    if (range === undefined || blockEl === null) return fallback;
+    const start = domOffsetInBlock(blockEl, range.startContainer, range.startOffset);
+    const end = domOffsetInBlock(blockEl, range.endContainer, range.endOffset);
+    if (start === null || end === null) return fallback;
+    return { start: Math.min(start, end), end: Math.max(start, end) };
+  }
+
+  function deleteBackwardOp(
+    state: EditorHistoryState,
+    targetRanges: readonly StaticRange[],
+  ): EditorOp[] {
     const { sel, doc } = state;
-    if (!isCollapsed(sel) && sel.anchor.blockId === sel.focus.blockId) {
+    if (!isCollapsed(sel)) {
+      if (sel.anchor.blockId !== sel.focus.blockId) return deleteRangeAcrossBlocksOps(doc, sel);
       const start = Math.min(sel.anchor.offset, sel.focus.offset);
       const end = Math.max(sel.anchor.offset, sel.focus.offset);
       const block = doc.find((b) => b.id === sel.focus.blockId);
-      return {
-        kind: 'removeText',
-        blockId: sel.focus.blockId,
-        offset: start,
-        text: sliceContent(block?.content, start, end),
-      };
+      return [
+        {
+          kind: 'removeText',
+          blockId: sel.focus.blockId,
+          offset: start,
+          text: sliceContent(block?.content, start, end),
+        },
+      ];
     }
     const { blockId, offset } = sel.focus;
     if (offset === 0) {
       const index = doc.findIndex((b) => b.id === blockId);
-      if (index <= 0) return null; // first block: nothing to merge into
-      return { kind: 'mergePrev', blockId };
+      if (index <= 0) return []; // first block: nothing to merge into
+      return [{ kind: 'mergePrev', blockId }];
     }
     const block = doc.find((b) => b.id === blockId);
-    return {
-      kind: 'removeText',
-      blockId,
-      offset: offset - 1,
-      text: sliceContent(block?.content, offset - 1, offset),
-    };
+    const { start, end } = deletionRange(blockId, { start: offset - 1, end: offset }, targetRanges);
+    return [
+      {
+        kind: 'removeText',
+        blockId,
+        offset: start,
+        text: sliceContent(block?.content, start, end),
+      },
+    ];
   }
 
-  function deleteForwardOp(state: EditorHistoryState): EditorOp | null {
+  function deleteForwardOp(
+    state: EditorHistoryState,
+    targetRanges: readonly StaticRange[],
+  ): EditorOp[] {
     const { sel, doc } = state;
-    if (!isCollapsed(sel) && sel.anchor.blockId === sel.focus.blockId) {
+    if (!isCollapsed(sel)) {
+      if (sel.anchor.blockId !== sel.focus.blockId) return deleteRangeAcrossBlocksOps(doc, sel);
       const start = Math.min(sel.anchor.offset, sel.focus.offset);
       const end = Math.max(sel.anchor.offset, sel.focus.offset);
       const block = doc.find((b) => b.id === sel.focus.blockId);
-      return {
-        kind: 'removeText',
-        blockId: sel.focus.blockId,
-        offset: start,
-        text: sliceContent(block?.content, start, end),
-      };
+      return [
+        {
+          kind: 'removeText',
+          blockId: sel.focus.blockId,
+          offset: start,
+          text: sliceContent(block?.content, start, end),
+        },
+      ];
     }
     const { blockId, offset } = sel.focus;
     const block = doc.find((b) => b.id === blockId);
     const total = totalTextLength(normalizeRuns(block?.content));
     if (offset >= total) {
       const index = doc.findIndex((b) => b.id === blockId);
-      if (index === -1 || index >= doc.length - 1) return null; // last block: nothing to merge
-      return { kind: 'mergeNext', blockId };
+      if (index === -1 || index >= doc.length - 1) return []; // last block: nothing to merge
+      return [{ kind: 'mergeNext', blockId }];
     }
-    return {
-      kind: 'removeText',
-      blockId,
-      offset,
-      text: sliceContent(block?.content, offset, offset + 1),
-    };
+    const { start, end } = deletionRange(blockId, { start: offset, end: offset + 1 }, targetRanges);
+    return [
+      {
+        kind: 'removeText',
+        blockId,
+        offset: start,
+        text: sliceContent(block?.content, start, end),
+      },
+    ];
   }
 
   /** Enter -> split. With a range selection, remove the range first (as a
@@ -506,13 +617,11 @@ export function bindEditor(root: HTMLElement): () => void {
           return;
         }
         case 'deleteContentBackward': {
-          const op = deleteBackwardOp(state);
-          if (op) applyOps([op]);
+          applyOps(deleteBackwardOp(state, data.targetRanges));
           return;
         }
         case 'deleteContentForward': {
-          const op = deleteForwardOp(state);
-          if (op) applyOps([op]);
+          applyOps(deleteForwardOp(state, data.targetRanges));
           return;
         }
         case 'insertParagraph':

--- a/packages/ui/src/components/editor/editor.behavior.ts
+++ b/packages/ui/src/components/editor/editor.behavior.ts
@@ -1,0 +1,564 @@
+/**
+ * editor.behavior.ts -- controlled contenteditable binding (FR-EDITOR-004).
+ *
+ * `bindEditor` intercepts `beforeinput`, translates each input into an
+ * `EditorOp` applied through the editor history's `controls`, `preventDefault`s
+ * so the MODEL owns the edit (the browser never mutates the contenteditable),
+ * projects model state -> DOM (`projectDocument`), and restores the DOM
+ * selection from `state.sel` after every render.
+ *
+ * Per RULING-EDITOR-HISTORY's pinned "Editor interface contract" this file
+ * composes `createEditorHistory` (FR-EDITOR-002) and `applyOp`'s op vocabulary
+ * (FR-EDITOR-003) DIRECTLY -- there is NO import of `compose`, `createBehavior`,
+ * or `BehaviorSpec`; the editor is out of the behavior-layer composer (frozen
+ * Spec 00). It borrows only the Spec 05 `bindX` LIFECYCLE (read config off
+ * `root`'s `data-*`, subscribe to the memory cell, render on change, restore
+ * selection, return a teardown).
+ */
+import { z } from 'zod';
+import { createClipboard } from '../../primitives/clipboard';
+import { createInputHandler } from '../../primitives/input-events';
+import type { BaseBlock, InlineContent } from '../../primitives/types';
+import type { EditorHistoryState } from './editor-history';
+import { createEditorHistory } from './editor-history';
+import { normalizeRuns, splitRuns, totalTextLength } from './ops/content';
+import type { EditorOp } from './ops';
+
+// ---------------------------------------------------------------------------
+// Config parsing (external data off `root`'s data-* attributes -> Zod).
+// ---------------------------------------------------------------------------
+
+const inlineContentSchema = z.object({
+  text: z.string(),
+  marks: z.array(z.enum(['bold', 'italic', 'code', 'strikethrough', 'link'])).optional(),
+  href: z.string().optional(),
+});
+
+const baseBlockSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  content: z.union([z.string(), z.array(inlineContentSchema)]).optional(),
+  children: z.array(z.string()).optional(),
+  parentId: z.string().optional(),
+  meta: z.record(z.string(), z.unknown()).optional(),
+});
+
+const docSchema = z.array(baseBlockSchema);
+const caretSchema = z.object({ blockId: z.string(), offset: z.number() });
+
+function parseSeed(root: HTMLElement): Pick<EditorHistoryState, 'doc' | 'sel'> {
+  const rawDoc = root.dataset.initialDoc;
+  // Zod validates the external shape; the inferred `optional` fields widen to
+  // `... | undefined`, so narrow back to BaseBlock[] for the history seed.
+  const doc = (rawDoc ? docSchema.parse(JSON.parse(rawDoc)) : []) as BaseBlock[];
+
+  const rawCaret = root.dataset.caret;
+  const firstId = doc[0]?.id ?? '';
+  const caret = rawCaret
+    ? caretSchema.parse(JSON.parse(rawCaret))
+    : { blockId: firstId, offset: 0 };
+
+  const pos = { blockId: caret.blockId, offset: caret.offset };
+  return { doc, sel: { anchor: pos, focus: pos } };
+}
+
+// ---------------------------------------------------------------------------
+// Selection arithmetic helpers (generic, doc-free).
+// ---------------------------------------------------------------------------
+
+function isCollapsed(sel: EditorHistoryState['sel']): boolean {
+  return sel.anchor.blockId === sel.focus.blockId && sel.anchor.offset === sel.focus.offset;
+}
+
+/** The block id + offset the caret/anchor of an edit acts at. For a range on
+ *  one block this is the ordered start; otherwise the focus position. */
+function caretStart(sel: EditorHistoryState['sel']): { blockId: string; offset: number } {
+  if (sel.anchor.blockId === sel.focus.blockId) {
+    return { blockId: sel.focus.blockId, offset: Math.min(sel.anchor.offset, sel.focus.offset) };
+  }
+  return { blockId: sel.focus.blockId, offset: sel.focus.offset };
+}
+
+/** Slice content to [start, end) preserving marks/href per run -- identical to
+ *  the splice `removeText` itself computes (both go through `splitRuns`), so a
+ *  `removeText` op built from this slice passes `removeText`'s exact
+ *  `runsEqual` check instead of throwing. */
+function sliceContent(
+  content: string | InlineContent[] | undefined,
+  start: number,
+  end: number,
+): InlineContent[] {
+  const runs = normalizeRuns(content);
+  const [, fromStart] = splitRuns(runs, start);
+  const [middle] = splitRuns(fromStart, end - start);
+  return middle;
+}
+
+function mintBlockId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  // Fallback for environments without the Web Crypto API. Block ids only need
+  // to be unique within one document session, not cryptographically strong.
+  return `block-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+// ---------------------------------------------------------------------------
+// translateBeforeInput -- the PURE, doc-free translation.
+// ---------------------------------------------------------------------------
+
+/**
+ * Pure translation: a native `beforeinput` event + the current selection ->
+ * the `EditorOp` it represents, or `null` when the inputType is unhandled.
+ *
+ * Only the ops fully determined WITHOUT the document are produced here --
+ * `insertText`, whose payload is `event.data`. Deletes, merges, and paste are
+ * NOT translated here and return `null`: a `removeText` op carries the removed
+ * `InlineContent[]`, and `removeText()` throws unless that content
+ * `runsEqual`s what is actually in the block, so it cannot be constructed
+ * without reading the doc. `bindEditor` owns those doc-dependent ops; this
+ * function is what vitest drives without a browser, `bindEditor` is what
+ * Playwright drives with one. `text` is `InlineContent[]` end to end
+ * (RULING-EDITOR-HISTORY AMENDMENT A), never a bare string.
+ */
+export function translateBeforeInput(
+  event: Pick<InputEvent, 'inputType' | 'data'>,
+  sel: EditorHistoryState['sel'],
+): EditorOp | null {
+  switch (event.inputType) {
+    case 'insertText':
+    case 'insertReplacementText': {
+      if (event.data == null) return null;
+      const { blockId, offset } = caretStart(sel);
+      return { kind: 'insertText', blockId, offset, text: [{ text: event.data }] };
+    }
+    default:
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// projectDocument -- model -> DOM, touching only changed blocks.
+// ---------------------------------------------------------------------------
+
+const MARK_TAG: Record<string, string> = {
+  bold: 'strong',
+  italic: 'em',
+  code: 'code',
+  strikethrough: 's',
+  link: 'a',
+};
+
+/** Render one InlineContent run to a DOM node (text node, or nested mark
+ *  wrappers around it). */
+function renderRun(doc: Document, run: InlineContent): Node {
+  let node: Node = doc.createTextNode(run.text);
+  for (const mark of run.marks ?? []) {
+    const tag = MARK_TAG[mark] ?? 'span';
+    const wrapper = doc.createElement(tag);
+    if (mark === 'link' && run.href !== undefined) wrapper.setAttribute('href', run.href);
+    wrapper.appendChild(node);
+    node = wrapper;
+  }
+  return node;
+}
+
+/** (Re)build a block element's content children from its model content. An
+ *  empty block gets a single `<br>` -- as browsers render natively -- so it
+ *  has height and accepts a caret; a `<br>` contributes nothing to
+ *  `textContent`. */
+function renderBlockContent(el: HTMLElement, block: BaseBlock): void {
+  const doc = el.ownerDocument;
+  el.replaceChildren();
+  const runs = normalizeRuns(block.content);
+  if (runs.length === 0 || totalTextLength(runs) === 0) {
+    el.appendChild(doc.createElement('br'));
+    return;
+  }
+  for (const run of runs) {
+    if (run.text.length === 0) continue;
+    el.appendChild(renderRun(doc, run));
+  }
+}
+
+function createBlockElement(doc: Document, block: BaseBlock): HTMLElement {
+  const el = doc.createElement('div');
+  el.setAttribute('data-block-id', block.id);
+  el.setAttribute('data-block-type', block.type);
+  renderBlockContent(el, block);
+  return el;
+}
+
+/**
+ * Projects `doc` onto the contenteditable subtree under `root`, touching only
+ * the DOM for blocks whose object identity changed since `previousDoc`
+ * (NFR-EDITOR-004). Blocks reference-equal to their `previousDoc` entry are
+ * left entirely untouched -- zero DOM writes for that subtree. Object-identity
+ * preservation across an edit is `applyOp`'s job (FR-EDITOR-003's copy-on-write
+ * convention); this function ACTS on that identity. Each block element carries
+ * `data-block-id`; the bound root carries `data-part="root"`.
+ */
+export function projectDocument(
+  root: HTMLElement,
+  doc: EditorHistoryState['doc'],
+  previousDoc: EditorHistoryState['doc'] | null,
+): void {
+  const ownerDoc = root.ownerDocument;
+
+  const prevById = new Map<string, BaseBlock>();
+  if (previousDoc) for (const block of previousDoc) prevById.set(block.id, block);
+
+  const existing = new Map<string, HTMLElement>();
+  for (const child of Array.from(root.children)) {
+    const id = child.getAttribute('data-block-id');
+    if (id !== null) existing.set(id, child as HTMLElement);
+  }
+
+  const docIds = new Set(doc.map((block) => block.id));
+  for (const [id, el] of existing) {
+    if (!docIds.has(id)) {
+      el.remove();
+      existing.delete(id);
+    }
+  }
+
+  const desired: HTMLElement[] = [];
+  for (const block of doc) {
+    let el = existing.get(block.id);
+    if (el === undefined) {
+      el = createBlockElement(ownerDoc, block);
+    } else if (prevById.get(block.id) !== block) {
+      // Identity changed (or first sight of this block after a `null`
+      // previousDoc): rebuild only this block's content in place.
+      if (el.getAttribute('data-block-type') !== block.type) {
+        el.setAttribute('data-block-type', block.type);
+      }
+      renderBlockContent(el, block);
+    }
+    desired.push(el);
+  }
+
+  // Order the children to match `doc`. Reusing an already-correctly-placed
+  // element is a no-op; moving an untouched block's element is a mutation on
+  // `root`, never on that block's own subtree, so it does not disturb the
+  // reference-equality skip above.
+  for (let i = 0; i < desired.length; i++) {
+    const want = desired[i] as HTMLElement;
+    const current = root.children[i] ?? null;
+    if (current !== want) root.insertBefore(want, current);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Selection restore -- state.sel -> DOM Selection/Range.
+// ---------------------------------------------------------------------------
+
+function collectTextNodes(el: Node, out: Text[]): void {
+  for (const child of Array.from(el.childNodes)) {
+    if (child.nodeType === 3 /* TEXT_NODE */) out.push(child as Text);
+    else collectTextNodes(child, out);
+  }
+}
+
+/** Map a model (blockId, offset) to a concrete DOM (node, offset). */
+function locatePosition(
+  root: HTMLElement,
+  pos: { blockId: string; offset: number },
+): { node: Node; offset: number } | null {
+  const blockEl = root.querySelector(`[data-block-id="${CSS.escape(pos.blockId)}"]`);
+  if (blockEl === null) return null;
+
+  const textNodes: Text[] = [];
+  collectTextNodes(blockEl, textNodes);
+  if (textNodes.length === 0) {
+    // Empty block (renders a <br>): place the caret in the block element.
+    return { node: blockEl, offset: 0 };
+  }
+
+  let remaining = pos.offset;
+  for (const textNode of textNodes) {
+    const len = textNode.data.length;
+    if (remaining <= len) return { node: textNode, offset: remaining };
+    remaining -= len;
+  }
+  const last = textNodes[textNodes.length - 1] as Text;
+  return { node: last, offset: last.data.length };
+}
+
+function restoreSelection(root: HTMLElement, sel: EditorHistoryState['sel']): void {
+  const view = root.ownerDocument.defaultView;
+  const selection = view?.getSelection?.() ?? null;
+  if (selection === null) return;
+
+  const focus = locatePosition(root, sel.focus);
+  if (focus === null) return;
+  const anchor = isCollapsed(sel) ? focus : locatePosition(root, sel.anchor);
+  if (anchor === null) return;
+
+  if (typeof selection.setBaseAndExtent === 'function') {
+    selection.setBaseAndExtent(anchor.node, anchor.offset, focus.node, focus.offset);
+    return;
+  }
+  const range = root.ownerDocument.createRange();
+  range.setStart(anchor.node, anchor.offset);
+  range.setEnd(focus.node, focus.offset);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+// ---------------------------------------------------------------------------
+// bindEditor -- the controlled contenteditable lifecycle.
+// ---------------------------------------------------------------------------
+
+/**
+ * Bind a controlled contenteditable to a fresh editor history seeded from
+ * `root`'s `data-initial-doc` / `data-caret`. Returns a teardown that removes
+ * every listener and the history subscription.
+ *
+ * FR-EDITOR-005 EXTENDS this same export with aria/keymap wiring for
+ * undo/redo; it does not add a second binder. Nothing undo/redo-keymap-shaped
+ * lives here.
+ */
+export function bindEditor(root: HTMLElement): () => void {
+  root.setAttribute('data-part', 'root');
+  root.setAttribute('contenteditable', 'true');
+
+  const history = createEditorHistory(parseSeed(root));
+  const { controls, memory } = history;
+
+  let prevDoc: BaseBlock[] | null = null;
+  function render(): void {
+    const state = memory.get();
+    projectDocument(root, state.doc, prevDoc);
+    prevDoc = state.doc;
+    restoreSelection(root, state.sel);
+  }
+
+  // -- op construction for the doc-dependent inputs (deletes / structural) --
+
+  function deleteBackwardOp(state: EditorHistoryState): EditorOp | null {
+    const { sel, doc } = state;
+    if (!isCollapsed(sel) && sel.anchor.blockId === sel.focus.blockId) {
+      const start = Math.min(sel.anchor.offset, sel.focus.offset);
+      const end = Math.max(sel.anchor.offset, sel.focus.offset);
+      const block = doc.find((b) => b.id === sel.focus.blockId);
+      return {
+        kind: 'removeText',
+        blockId: sel.focus.blockId,
+        offset: start,
+        text: sliceContent(block?.content, start, end),
+      };
+    }
+    const { blockId, offset } = sel.focus;
+    if (offset === 0) {
+      const index = doc.findIndex((b) => b.id === blockId);
+      if (index <= 0) return null; // first block: nothing to merge into
+      return { kind: 'mergePrev', blockId };
+    }
+    const block = doc.find((b) => b.id === blockId);
+    return {
+      kind: 'removeText',
+      blockId,
+      offset: offset - 1,
+      text: sliceContent(block?.content, offset - 1, offset),
+    };
+  }
+
+  function deleteForwardOp(state: EditorHistoryState): EditorOp | null {
+    const { sel, doc } = state;
+    if (!isCollapsed(sel) && sel.anchor.blockId === sel.focus.blockId) {
+      const start = Math.min(sel.anchor.offset, sel.focus.offset);
+      const end = Math.max(sel.anchor.offset, sel.focus.offset);
+      const block = doc.find((b) => b.id === sel.focus.blockId);
+      return {
+        kind: 'removeText',
+        blockId: sel.focus.blockId,
+        offset: start,
+        text: sliceContent(block?.content, start, end),
+      };
+    }
+    const { blockId, offset } = sel.focus;
+    const block = doc.find((b) => b.id === blockId);
+    const total = totalTextLength(normalizeRuns(block?.content));
+    if (offset >= total) {
+      const index = doc.findIndex((b) => b.id === blockId);
+      if (index === -1 || index >= doc.length - 1) return null; // last block: nothing to merge
+      return { kind: 'mergeNext', blockId };
+    }
+    return {
+      kind: 'removeText',
+      blockId,
+      offset,
+      text: sliceContent(block?.content, offset, offset + 1),
+    };
+  }
+
+  /** Enter -> split. With a range selection, remove the range first (as a
+   *  separate op) so the split lands at the collapsed point. */
+  function splitOps(state: EditorHistoryState): EditorOp[] {
+    const { sel } = state;
+    const ops: EditorOp[] = [];
+    let offset = sel.focus.offset;
+    const blockId = sel.focus.blockId;
+    if (!isCollapsed(sel) && sel.anchor.blockId === blockId) {
+      const start = Math.min(sel.anchor.offset, sel.focus.offset);
+      const end = Math.max(sel.anchor.offset, sel.focus.offset);
+      const block = state.doc.find((b) => b.id === blockId);
+      ops.push({
+        kind: 'removeText',
+        blockId,
+        offset: start,
+        text: sliceContent(block?.content, start, end),
+      });
+      offset = start;
+    }
+    ops.push({ kind: 'split', blockId, offset, newBlockId: mintBlockId() });
+    return ops;
+  }
+
+  function applyOps(ops: EditorOp[]): void {
+    try {
+      for (const op of ops) controls.apply(op);
+    } catch {
+      // applyOp threw (unresolvable blockId / out-of-bounds offset): the native
+      // edit was already prevented and the cell is untouched (commitEntry runs
+      // the whole applyOp pass before any memory.set), so the next render
+      // re-projects from the last valid state -- the DOM never diverges.
+    }
+  }
+
+  // -- paste: read via createClipboard, own the insert --
+
+  function pasteText(text: string): void {
+    const lines = text.split('\n');
+    const start = caretStart(memory.get().sel);
+    controls.apply({
+      kind: 'insertText',
+      blockId: start.blockId,
+      offset: start.offset,
+      text: [{ text: lines[0] ?? '' }],
+    });
+    for (let i = 1; i < lines.length; i++) {
+      const afterSplit = memory.get().sel.focus;
+      controls.apply({
+        kind: 'split',
+        blockId: afterSplit.blockId,
+        offset: afterSplit.offset,
+        newBlockId: mintBlockId(),
+      });
+      const line = lines[i] ?? '';
+      if (line.length > 0) {
+        const at = memory.get().sel.focus;
+        controls.apply({
+          kind: 'insertText',
+          blockId: at.blockId,
+          offset: 0,
+          text: [{ text: line }],
+        });
+      }
+    }
+  }
+
+  const clipboard = createClipboard({
+    container: root,
+    onPaste: (data) => {
+      if (data.text) {
+        try {
+          pasteText(data.text);
+        } catch {
+          // See applyOps: the cell is left valid; the next render re-projects.
+        }
+      }
+    },
+  });
+  // createClipboard reads the payload but does NOT preventDefault; the model
+  // owns the edit, so the browser paste must be cancelled here.
+  const onPasteRaw = (event: Event): void => {
+    event.preventDefault();
+  };
+  root.addEventListener('paste', onPasteRaw);
+
+  // -- capture: preventDefault + translate, IME via composition --
+
+  let composing = false;
+  let compositionAnchor = memory.get().sel;
+
+  // Every `beforeinput` is preventDefault'd unconditionally so the browser
+  // never mutates the contenteditable -- EXCEPT while an IME composition is
+  // active, when the browser must render the in-progress composition (the
+  // finalized string commits as one op on `compositionend`). Composition
+  // inputTypes are otherwise not translated (see createInputHandler, which
+  // suppresses insertText while composing).
+  const onBeforeInputRaw = (event: Event): void => {
+    if (composing || (event as InputEvent).isComposing) return;
+    event.preventDefault();
+  };
+  root.addEventListener('beforeinput', onBeforeInputRaw);
+
+  const inputHandler = createInputHandler({
+    element: root,
+    onBeforeInput: (data) => {
+      const state = memory.get();
+      switch (data.inputType) {
+        case 'insertText': {
+          const op = translateBeforeInput(data, state.sel);
+          if (op) applyOps([op]);
+          return;
+        }
+        case 'deleteContentBackward': {
+          const op = deleteBackwardOp(state);
+          if (op) applyOps([op]);
+          return;
+        }
+        case 'deleteContentForward': {
+          const op = deleteForwardOp(state);
+          if (op) applyOps([op]);
+          return;
+        }
+        case 'insertParagraph':
+        case 'insertLineBreak':
+          applyOps(splitOps(state));
+          return;
+        case 'insertFromPaste':
+          // Handled by the clipboard read path above -- preventDefault only,
+          // never apply here (double-apply guard).
+          return;
+        default:
+          // Unrecognized/unsupported inputType (e.g. a native formatBold
+          // shortcut): already preventDefault'd, treated as a no-op, never
+          // throws -- typing must never break.
+          return;
+      }
+    },
+    onCompositionStart: () => {
+      composing = true;
+      compositionAnchor = memory.get().sel;
+    },
+    onCompositionEnd: (event) => {
+      composing = false;
+      const text = event.data;
+      if (text) {
+        const start = caretStart(compositionAnchor);
+        applyOps([
+          { kind: 'insertText', blockId: start.blockId, offset: start.offset, text: [{ text }] },
+        ]);
+      }
+      // Force a full re-projection: the browser rendered the composition into
+      // the DOM directly, and a CANCELLED composition applies no op (no block
+      // identity changes), so the reference-equality skip would otherwise leave
+      // the browser's leftover composition DOM in place forever.
+      prevDoc = null;
+      render();
+    },
+  });
+
+  const unsubscribe = memory.subscribe(() => render());
+
+  return () => {
+    unsubscribe();
+    inputHandler.cleanup();
+    clipboard.cleanup();
+    root.removeEventListener('paste', onPasteRaw);
+    root.removeEventListener('beforeinput', onBeforeInputRaw);
+  };
+}

--- a/packages/ui/src/components/editor/index.ts
+++ b/packages/ui/src/components/editor/index.ts
@@ -8,6 +8,7 @@
 export { applyOp, applyOpSequence } from './ops';
 export type { EditorOp, FormatOp, OpResult, StructuralOp, TextOp } from './ops';
 export { createEditorHistory } from './editor-history';
+export { bindEditor, projectDocument, translateBeforeInput } from './editor.behavior';
 export type {
   EditorHistory,
   EditorHistoryConfig,

--- a/packages/ui/test/components/editor/editor.behavior.test.ts
+++ b/packages/ui/test/components/editor/editor.behavior.test.ts
@@ -1,0 +1,168 @@
+/**
+ * editor.behavior.test.ts (vitest / happy-dom) -- the PURE, browser-free
+ * surface of FR-EDITOR-004: `translateBeforeInput` (event -> op),
+ * `projectDocument` (model -> DOM, identity-gated), and the capture-side
+ * coalescing SHAPE (translateBeforeInput -> controls -> one `done` entry).
+ *
+ * `beforeinput` CAPTURE itself is proven only in Playwright
+ * (test/editor/editor-capture.e2e.ts) -- happy-dom has no real `beforeinput`
+ * semantics, so no synthetic `beforeinput` is dispatched here (AC).
+ */
+import { describe, expect, it } from 'vitest';
+import { createEditorHistory } from '../../../src/components/editor/editor-history';
+import {
+  projectDocument,
+  translateBeforeInput,
+} from '../../../src/components/editor/editor.behavior';
+import { applyOp } from '../../../src/components/editor/ops';
+import type { BaseBlock } from '../../../src/primitives/types';
+
+describe('translateBeforeInput', () => {
+  it('maps insertText to an insertText op at the current selection (InlineContent[] text)', () => {
+    const op = translateBeforeInput(
+      { inputType: 'insertText', data: 'y' },
+      { anchor: { blockId: 'b1', offset: 2 }, focus: { blockId: 'b1', offset: 2 } },
+    );
+    expect(op).toEqual({ kind: 'insertText', blockId: 'b1', offset: 2, text: [{ text: 'y' }] });
+  });
+
+  it('inserts at the ordered start of a range selection on one block', () => {
+    const op = translateBeforeInput(
+      { inputType: 'insertText', data: 'z' },
+      { anchor: { blockId: 'b1', offset: 5 }, focus: { blockId: 'b1', offset: 2 } },
+    );
+    expect(op).toEqual({ kind: 'insertText', blockId: 'b1', offset: 2, text: [{ text: 'z' }] });
+  });
+
+  it('returns null for an unhandled inputType', () => {
+    const op = translateBeforeInput(
+      { inputType: 'formatBold', data: null },
+      { anchor: { blockId: 'b1', offset: 0 }, focus: { blockId: 'b1', offset: 0 } },
+    );
+    expect(op).toBeNull();
+  });
+
+  it('returns null for a delete (doc-dependent, owned by bindEditor)', () => {
+    const op = translateBeforeInput(
+      { inputType: 'deleteContentBackward', data: null },
+      { anchor: { blockId: 'b1', offset: 3 }, focus: { blockId: 'b1', offset: 3 } },
+    );
+    expect(op).toBeNull();
+  });
+});
+
+describe('projectDocument', () => {
+  it("touches only the changed block's DOM subtree, for a real applyOp edit over 1000 blocks", () => {
+    const doc: BaseBlock[] = Array.from({ length: 1000 }, (_, i) => ({
+      id: `b${i}`,
+      type: 'text',
+      content: 'x',
+    }));
+
+    const root = document.createElement('div');
+    projectDocument(root, doc, null);
+
+    // Real op, real structural sharing (FR-EDITOR-003) -- not a hand-built spread.
+    const { blocks: nextDoc } = applyOp(doc, {
+      kind: 'insertText',
+      blockId: 'b500',
+      offset: 1,
+      text: [{ text: 'y' }],
+    });
+    for (let i = 0; i < 1000; i++) {
+      if (i !== 500) expect(nextDoc[i]).toBe(doc[i]); // reference-equal, from applyOp itself
+    }
+
+    const b0El = root.querySelector('[data-block-id="b0"]');
+    expect(b0El).not.toBeNull();
+    const observer = new MutationObserver(() => {});
+    (observer as MutationObserver).observe(b0El as Element, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+
+    projectDocument(root, nextDoc, doc);
+
+    // Drain synchronously: MutationObserver callbacks are microtask-scheduled,
+    // so an assertion right after projectDocument would pass vacuously without
+    // takeRecords().
+    const records = observer.takeRecords();
+    expect(records).toHaveLength(0); // b0's subtree saw zero mutations
+    expect(root.querySelector('[data-block-id="b500"]')?.textContent).toBe('xy');
+
+    // Negative control: the observer IS wired -- a deliberate touch of b0's
+    // subtree produces records. Without this, "zero mutations" is
+    // indistinguishable from "observer never fired in happy-dom".
+    (b0El as Element).appendChild(document.createTextNode('!'));
+    expect(observer.takeRecords().length).toBeGreaterThan(0);
+    observer.disconnect();
+  });
+
+  it('adds new block elements and removes deleted ones', () => {
+    const root = document.createElement('div');
+    const a: BaseBlock = { id: 'a', type: 'text', content: 'one' };
+    const b: BaseBlock = { id: 'b', type: 'text', content: 'two' };
+    projectDocument(root, [a, b], null);
+    expect(Array.from(root.children).map((c) => c.getAttribute('data-block-id'))).toEqual([
+      'a',
+      'b',
+    ]);
+
+    // Split a into a + c (real op), keeping a's identity? split replaces a's
+    // content, so both a and the new block render; b stays reference-equal.
+    const { blocks: next } = applyOp([a, b], {
+      kind: 'split',
+      blockId: 'a',
+      offset: 1,
+      newBlockId: 'c',
+    });
+    projectDocument(root, next, [a, b]);
+    const ids = Array.from(root.children).map((c) => c.getAttribute('data-block-id'));
+    expect(ids).toEqual(['a', 'c', 'b']);
+  });
+
+  it('renders an empty block as a <br> so it can hold a caret', () => {
+    const root = document.createElement('div');
+    projectDocument(root, [{ id: 'e', type: 'text', content: '' }], null);
+    const el = root.querySelector('[data-block-id="e"]');
+    expect(el?.querySelector('br')).not.toBeNull();
+    expect(el?.textContent).toBe('');
+  });
+});
+
+describe('capture-side coalescing shape (translateBeforeInput -> controls)', () => {
+  it('coalesces a run of typed characters into one done entry; closeGroup breaks it', () => {
+    const first: BaseBlock = { id: 'b1', type: 'text', content: '' };
+    const history = createEditorHistory({
+      doc: [first],
+      sel: { anchor: { blockId: 'b1', offset: 0 }, focus: { blockId: 'b1', offset: 0 } },
+    });
+
+    // Type "hey" one char at a time, each op built by translateBeforeInput from
+    // the live selection (which controls.apply advances) -- the exact
+    // capture-side call shape bindEditor issues.
+    for (const ch of ['h', 'e', 'y']) {
+      const op = translateBeforeInput(
+        { inputType: 'insertText', data: ch },
+        history.memory.get().sel,
+      );
+      expect(op).not.toBeNull();
+      history.controls.apply(op as NonNullable<typeof op>);
+    }
+    expect(history.memory.get().done).toHaveLength(1); // coalesced within the window
+
+    // A forced boundary starts a new entry even inside the coalescing window.
+    history.controls.closeGroup();
+    const op = translateBeforeInput(
+      { inputType: 'insertText', data: '!' },
+      history.memory.get().sel,
+    );
+    history.controls.apply(op as NonNullable<typeof op>);
+    expect(history.memory.get().done).toHaveLength(2);
+
+    // The doc reflects every op (sanity that the shape actually applied).
+    const block = history.memory.get().doc.find((b) => b.id === 'b1');
+    expect(block?.content).toBe('hey!');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       '@vitest/ui':
         specifier: 'catalog:'
         version: 4.1.0(vitest@4.1.0)
+      esbuild:
+        specifier: ^0.27.3
+        version: 0.27.3
       happy-dom:
         specifier: 'catalog:'
         version: 20.0.10
@@ -344,7 +347,7 @@ importers:
         version: 9.0.0
       vite:
         specifier: ^8.0.0
-        version: 8.0.0(@types/node@24.10.0)(esbuild@0.27.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
+        version: 8.0.0(@types/node@24.10.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'
@@ -387,7 +390,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.0(@types/node@24.10.0)(@vitest/ui@4.1.0)(happy-dom@20.0.10)(jsdom@26.1.0)(msw@2.11.6(@types/node@24.10.0)(typescript@5.9.3))(vite@8.0.0(@types/node@24.10.0)(esbuild@0.27.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.0(@types/node@24.10.0)(@vitest/ui@4.1.0)(happy-dom@20.0.10)(jsdom@26.1.0)(msw@2.11.6(@types/node@24.10.0)(typescript@5.9.3))(vite@8.0.0(@types/node@24.10.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
       zocker:
         specifier: 'catalog:'
         version: 3.0.0(zod@4.3.6)
@@ -8896,15 +8899,6 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(msw@2.11.6(@types/node@24.10.0)(typescript@5.9.3))(vite@8.0.0(@types/node@24.10.0)(esbuild@0.27.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.0
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.11.6(@types/node@24.10.0)(typescript@5.9.3)
-      vite: 8.0.0(@types/node@24.10.0)(esbuild@0.27.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
-
   '@vitest/mocker@4.1.0(msw@2.11.6(@types/node@24.10.0)(typescript@5.9.3))(vite@8.0.0(@types/node@24.10.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.0
@@ -9403,9 +9397,9 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
-  bundle-require@5.1.0(esbuild@0.27.0):
+  bundle-require@5.1.0(esbuild@0.27.3):
     dependencies:
-      esbuild: 0.27.0
+      esbuild: 0.27.3
       load-tsconfig: 0.2.5
 
   bytes@3.1.2: {}
@@ -12093,12 +12087,12 @@ snapshots:
 
   tsup@8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.0)
+      bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      esbuild: 0.27.0
+      esbuild: 0.27.3
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
@@ -12339,23 +12333,6 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vite@8.0.0(@types/node@24.10.0)(esbuild@0.27.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0):
-    dependencies:
-      '@oxc-project/runtime': 0.115.0
-      lightningcss: 1.32.0
-      picomatch: 4.0.5
-      postcss: 8.5.8
-      rolldown: 1.0.0-rc.9
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 24.10.0
-      esbuild: 0.27.0
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      terser: 5.44.1
-      tsx: 4.21.0
-      yaml: 2.9.0
-
   vite@8.0.0(@types/node@24.10.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       '@oxc-project/runtime': 0.115.0
@@ -12420,36 +12397,6 @@ snapshots:
       chalk: 5.6.2
       lodash-es: 4.17.22
       vitest: 4.1.0(@types/node@24.10.0)(@vitest/ui@4.1.0)(happy-dom@20.0.10)(jsdom@26.1.0)(msw@2.11.6(@types/node@24.10.0)(typescript@5.9.3))(vite@8.1.5(@types/node@24.10.0)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
-
-  vitest@4.1.0(@types/node@24.10.0)(@vitest/ui@4.1.0)(happy-dom@20.0.10)(jsdom@26.1.0)(msw@2.11.6(@types/node@24.10.0)(typescript@5.9.3))(vite@8.0.0(@types/node@24.10.0)(esbuild@0.27.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(msw@2.11.6(@types/node@24.10.0)(typescript@5.9.3))(vite@8.0.0(@types/node@24.10.0)(esbuild@0.27.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/runner': 4.1.0
-      '@vitest/snapshot': 4.1.0
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.1.0
-      vite: 8.0.0(@types/node@24.10.0)(esbuild@0.27.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 24.10.0
-      '@vitest/ui': 4.1.0(vitest@4.1.0)
-      happy-dom: 20.0.10
-      jsdom: 26.1.0
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.0(@types/node@24.10.0)(@vitest/ui@4.1.0)(happy-dom@20.0.10)(jsdom@26.1.0)(msw@2.11.6(@types/node@24.10.0)(typescript@5.9.3))(vite@8.0.0(@types/node@24.10.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ catalogs:
     comment-parser:
       specifier: ^1.4.1
       version: 1.4.1
+    esbuild:
+      specifier: ^0.27.3
+      version: 0.27.3
     happy-dom:
       specifier: ^20.0.10
       version: 20.0.10
@@ -129,7 +132,7 @@ importers:
         specifier: 'catalog:'
         version: 4.1.0(vitest@4.1.0)
       esbuild:
-        specifier: ^0.27.3
+        specifier: 'catalog:'
         version: 0.27.3
       happy-dom:
         specifier: 'catalog:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,6 +27,7 @@ catalog:
   '@vitest/coverage-v8': ^4.1.0
   '@vitest/ui': ^4.1.0
   comment-parser: ^1.4.1
+  esbuild: ^0.27.3
   happy-dom: ^20.0.10
   hono: 4.11.0
   lefthook: ^1.10.0

--- a/test/editor/editor-capture.e2e.ts
+++ b/test/editor/editor-capture.e2e.ts
@@ -40,6 +40,23 @@ test('backspace at block start merges with the previous block', async ({ page })
   await expect(page.locator('[data-part="root"]')).toHaveText('firstsecond');
 });
 
+test('backspace removes a whole emoji grapheme, not half a surrogate pair', async ({ page }) => {
+  // Canary for the targetRanges fix: raw UTF-16 `offset - 1` arithmetic would
+  // remove only the low surrogate of the astral emoji, leaving a lone
+  // surrogate (`'a\uD83D'`) instead of `'a'`. Only the browser's own
+  // `getTargetRanges()` knows the grapheme spans 2 code units.
+  await page.goto('about:blank');
+  await page.setContent(
+    await buildEditorHarness({
+      blocks: [{ id: 'b1', type: 'text', content: `a${String.fromCodePoint(0x1f600)}` }],
+      caret: { blockId: 'b1', offset: 3 },
+    }),
+  );
+  await page.locator('[data-part="root"]').click();
+  await page.keyboard.press('Backspace');
+  await expect(page.locator('[data-block-id="b1"]')).toHaveText('a');
+});
+
 test('delete at intra-text position removes the following character', async ({ page }) => {
   await page.goto('about:blank');
   await page.setContent(
@@ -59,15 +76,45 @@ test('pasting plain text produces insert ops and the resulting doc matches', asy
   );
   const surface = page.locator('[data-part="root"]');
   await surface.click();
-  // Drive paste through a real ClipboardEvent carrying text/plain.
+  // Drive paste through a real ClipboardEvent carrying text/plain. Gecko does
+  // NOT populate `event.clipboardData` from the `ClipboardEvent` constructor's
+  // init dict for a synthetic (untrusted) event -- only Chromium/WebKit honor
+  // it that way -- so the constructor-injected `clipboardData` is invisible to
+  // `createClipboard`'s `getData('text/plain')` there. `clipboardData` is
+  // otherwise an ordinary configurable accessor on the event instance, so
+  // shadowing it with `Object.defineProperty` after construction sidesteps
+  // that native getter entirely (in every engine) instead of depending on the
+  // constructor init dict being honored.
   await surface.evaluate((el) => {
     const dt = new DataTransfer();
     dt.setData('text/plain', 'pasted');
-    el.dispatchEvent(
-      new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }),
-    );
+    const event = new ClipboardEvent('paste', { bubbles: true, cancelable: true });
+    Object.defineProperty(event, 'clipboardData', { value: dt, configurable: true });
+    el.dispatchEvent(event);
   });
   await expect(surface).toHaveText('pasted');
+});
+
+test('IME composition commits as one insertText op on compositionend', async ({ page }) => {
+  await page.goto('about:blank');
+  await page.setContent(
+    await buildEditorHarness({ blocks: [{ id: 'b1', type: 'text', content: '' }] }),
+  );
+  const surface = page.locator('[data-part="root"]');
+  await surface.click();
+  // Real OS-level IME automation isn't available through Playwright, so drive
+  // the composition lifecycle with the same synthetic-dispatch technique the
+  // paste test uses. `bindEditor` never inspects the DOM the browser rendered
+  // mid-composition -- `onCompositionEnd` commits `event.data` as one
+  // `insertText` and force-reprojects (`prevDoc = null`) -- so this proves the
+  // commit path (the one this issue's AC actually covers) regardless of
+  // whether a real IME painted intermediate glyphs.
+  await surface.evaluate((el) => {
+    el.dispatchEvent(new CompositionEvent('compositionstart', { data: '', bubbles: true }));
+    el.dispatchEvent(new CompositionEvent('compositionupdate', { data: 'nihongo', bubbles: true }));
+    el.dispatchEvent(new CompositionEvent('compositionend', { data: '日本語', bubbles: true }));
+  });
+  await expect(surface).toHaveText('日本語');
 });
 
 test('selection is restored from state.sel after every edit', async ({ page }) => {

--- a/test/editor/editor-capture.e2e.ts
+++ b/test/editor/editor-capture.e2e.ts
@@ -1,0 +1,84 @@
+/**
+ * editor-capture.e2e.ts (Playwright, REAL browser -- chromium/firefox/webkit
+ * per playwright.config.ts).
+ *
+ * FR-EDITOR-004 is the highest-risk part of the editor rewrite; `beforeinput`
+ * capture, projection, and selection restore are proven HERE and only here.
+ * happy-dom has no real `beforeinput` semantics, so it is deliberately NOT used
+ * to claim capture coverage (issue AC).
+ *
+ * No dev server (see test/presence/presence-exit.e2e.ts): `about:blank` +
+ * `page.setContent(harness)`, where the harness's inline script is the REAL
+ * compiled `bindEditor` bundled by `buildEditorHarness`.
+ */
+import { expect, test } from '@playwright/test';
+import { buildEditorHarness } from './support/build-editor-harness';
+
+test('typing dispatches insertText ops and projects them', async ({ page }) => {
+  await page.goto('about:blank');
+  await page.setContent(
+    await buildEditorHarness({ blocks: [{ id: 'b1', type: 'text', content: '' }] }),
+  );
+  const surface = page.locator('[data-part="root"]');
+  await surface.click();
+  await page.keyboard.type('hello');
+  await expect(surface).toHaveText('hello');
+});
+
+test('backspace at block start merges with the previous block', async ({ page }) => {
+  await page.goto('about:blank');
+  await page.setContent(
+    await buildEditorHarness({
+      blocks: [
+        { id: 'b1', type: 'text', content: 'first' },
+        { id: 'b2', type: 'text', content: 'second' },
+      ],
+      caret: { blockId: 'b2', offset: 0 },
+    }),
+  );
+  await page.keyboard.press('Backspace');
+  await expect(page.locator('[data-part="root"]')).toHaveText('firstsecond');
+});
+
+test('delete at intra-text position removes the following character', async ({ page }) => {
+  await page.goto('about:blank');
+  await page.setContent(
+    await buildEditorHarness({
+      blocks: [{ id: 'b1', type: 'text', content: 'abc' }],
+      caret: { blockId: 'b1', offset: 1 },
+    }),
+  );
+  await page.keyboard.press('Delete');
+  await expect(page.locator('[data-block-id="b1"]')).toHaveText('ac');
+});
+
+test('pasting plain text produces insert ops and the resulting doc matches', async ({ page }) => {
+  await page.goto('about:blank');
+  await page.setContent(
+    await buildEditorHarness({ blocks: [{ id: 'b1', type: 'text', content: '' }] }),
+  );
+  const surface = page.locator('[data-part="root"]');
+  await surface.click();
+  // Drive paste through a real ClipboardEvent carrying text/plain.
+  await surface.evaluate((el) => {
+    const dt = new DataTransfer();
+    dt.setData('text/plain', 'pasted');
+    el.dispatchEvent(
+      new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }),
+    );
+  });
+  await expect(surface).toHaveText('pasted');
+});
+
+test('selection is restored from state.sel after every edit', async ({ page }) => {
+  await page.goto('about:blank');
+  await page.setContent(
+    await buildEditorHarness({ blocks: [{ id: 'b1', type: 'text', content: '' }] }),
+  );
+  await page.locator('[data-part="root"]').click();
+  await page.keyboard.type('hey');
+  // Black-box: after typing 3 characters into an empty block, the native caret
+  // must land at offset 3 in that text node.
+  const focusOffset = await page.evaluate(() => window.getSelection()?.focusOffset);
+  expect(focusOffset).toBe(3);
+});

--- a/test/editor/support/build-editor-harness.ts
+++ b/test/editor/support/build-editor-harness.ts
@@ -1,0 +1,79 @@
+/**
+ * buildEditorHarness (FR-EDITOR-004) -- the no-dev-server Playwright harness.
+ *
+ * This repo has no e2e dev server (see test/presence/presence-exit.e2e.ts:
+ * "There is no dev server in this repo and a spec may not start one"). So we
+ * compile the REAL `bindEditor` (via `harness-entry.ts`) into an injectable
+ * IIFE with esbuild and hand it to `page.setContent`. `buildEditorHarness`
+ * seeds BOTH `doc` and `sel`: `caret` selects the initial `state.sel`,
+ * defaulting to the start of the first block -- the boundary-key and
+ * selection-restore tests need a specific caret, not just a specific document.
+ */
+import { build } from 'esbuild';
+import { fileURLToPath } from 'node:url';
+
+interface SeedCaret {
+  blockId: string;
+  offset: number;
+}
+
+interface SeedBlock {
+  id: string;
+  type: string;
+  content?: string;
+}
+
+export interface EditorHarnessOptions {
+  blocks: SeedBlock[];
+  /** Initial `state.sel`; defaults to the start of the first block. */
+  caret?: SeedCaret;
+}
+
+const ENTRY = fileURLToPath(new URL('./harness-entry.ts', import.meta.url));
+
+let bundlePromise: Promise<string> | null = null;
+
+/** Bundle the real `bindEditor` once and reuse it across every test in a run. */
+async function bundleBindEditor(): Promise<string> {
+  if (bundlePromise === null) {
+    bundlePromise = build({
+      entryPoints: [ENTRY],
+      bundle: true,
+      format: 'iife',
+      globalName: 'RaftersEditor',
+      platform: 'browser',
+      write: false,
+    }).then((result) => {
+      const file = result.outputFiles[0];
+      if (file === undefined) throw new Error('buildEditorHarness: esbuild produced no output');
+      return file.text;
+    });
+  }
+  return bundlePromise;
+}
+
+export async function buildEditorHarness(options: EditorHarnessOptions): Promise<string> {
+  const script = await bundleBindEditor();
+  const caret = options.caret ?? { blockId: options.blocks[0]?.id ?? '', offset: 0 };
+
+  const doc = JSON.stringify(options.blocks);
+  const sel = JSON.stringify(caret);
+
+  return `<!doctype html>
+<meta charset="utf-8">
+<style>
+  [data-part="root"] { white-space: pre-wrap; outline: none; min-height: 1em; }
+  [data-block-id] { min-height: 1em; }
+</style>
+<div id="editor"></div>
+<script>${script}</script>
+<script>
+  (function () {
+    var root = document.getElementById('editor');
+    root.dataset.initialDoc = ${JSON.stringify(doc)};
+    root.dataset.caret = ${JSON.stringify(sel)};
+    window.__editorTeardown = RaftersEditor.bindEditor(root);
+    root.focus();
+  })();
+</script>`;
+}

--- a/test/editor/support/harness-entry.ts
+++ b/test/editor/support/harness-entry.ts
@@ -1,0 +1,8 @@
+/**
+ * Playwright harness entry (FR-EDITOR-004).
+ *
+ * esbuild bundles THIS file -- which re-exports the REAL `bindEditor` -- into a
+ * single IIFE injected via `page.setContent`. The e2e drives the genuine
+ * compiled capture path, never hand-copied logic (issue File Locations).
+ */
+export { bindEditor } from '../../../packages/ui/src/components/editor/editor.behavior';


### PR DESCRIPTION
## Summary

Implements `bindEditor` -- the controlled-contenteditable capture/projection/selection
binding for the rafters block editor (FR-EDITOR-004). It intercepts `beforeinput`,
translates each input into an `EditorOp` applied through `createEditorHistory`'s
`controls` (FR-EDITOR-002/#2104), `preventDefault`s so the model owns every edit,
projects `state.doc` onto the contenteditable DOM touching only changed blocks
(`projectDocument`), and restores the DOM selection from `state.sel` after every
render. Composes `createEditorHistory` and `applyOp` (FR-EDITOR-003/#2105) directly,
per the pinned interface contract -- no `compose()`/`createBehavior`/`BehaviorSpec`.
A new no-dev-server Playwright harness (`buildEditorHarness`, esbuild-bundling the
real `editor.behavior.ts`) proves capture, delete, paste, IME-commit, and
selection-restore behavior in a real browser (chromium/firefox/webkit), since
`beforeinput` has no meaningful happy-dom semantics.

## Acceptance criteria mapping

### 1. Playwright: typing a run of characters produces the insertText ops the model-level BDD expects
`typing dispatches insertText ops and projects them` types `"hello"` into an empty
contenteditable block and asserts the projected DOM text equals `"hello"`. Each
keystroke fires a real `beforeinput` (`insertText`), which `translateBeforeInput`
turns into one `insertText` op per character, applied via `controls.apply` and
committed to the history's `done` list -- the same shape FR-EDITOR-002's BDD scenarios
drive at the model level, just entered through the real capture path here.
Evidence: `test/editor/editor-capture.e2e.ts:17-26`, passing in chromium/firefox/webkit
(`pnpm exec playwright test test/editor/editor-capture.e2e.ts` -- 21/21 passed).

### 2. Playwright: Backspace/Delete at intra-text and block-boundary positions produce removeText/merge ops
Three tests cover this: `backspace at block start merges with the previous block`
(boundary -> `mergePrev`), `backspace removes a whole emoji grapheme, not half a
surrogate pair` (intra-text, grapheme-safe via the browser's own
`getTargetRanges()`), and `delete at intra-text position removes the following
character` (`deleteContentForward` -> `removeText`). `deleteBackwardOp`/
`deleteForwardOp` in `editor.behavior.ts` build the matching op from `state.sel` and
`event.getTargetRanges()`, falling back to UTF-16 offset arithmetic only when no
target range is available (vitest/happy-dom, never in the browser tests here).
Evidence: `test/editor/editor-capture.e2e.ts:28-41` (block-start merge), `:43-58`
(grapheme-safe backspace), `:60-70` (delete-forward); `editor.behavior.ts:418-506`
(`deletionRange`, `sameBlockRangeRemoveOp`, `deleteBackwardOp`, `deleteForwardOp`).

### 3. Playwright: pasting plain text produces the insert ops the model-level BDD expects and the resulting doc matches
`pasting plain text produces insert ops and the resulting doc matches` dispatches a
real `ClipboardEvent` carrying `text/plain` and asserts the projected surface text
equals the pasted string. `createClipboard` (existing primitive) reads the payload;
`pasteText` in `editor.behavior.ts` turns it into `insertText`/`split` ops (one
`insertText` per line, `split` between lines) applied through `controls`, and the raw
`paste` listener cancels the native paste so only the model-driven insert lands.
Evidence: `test/editor/editor-capture.e2e.ts:72-96`; `editor.behavior.ts:544-591`
(`pasteText`, clipboard wiring).

### 4. IME/composition handled -- a composed string commits as one insertText op on compositionend
`IME composition commits as one insertText op on compositionend` drives
`compositionstart` -> `compositionupdate` -> `compositionend` and asserts the final
committed text (`日本語`) appears in the DOM. `bindEditor` suppresses normal
`beforeinput` handling while `composing` is true (letting the browser render the
in-progress composition), then on `compositionend` applies the finalized
`event.data` as a single `insertText` op and force-reprojects (`prevDoc = null`) to
replace the browser's in-place composition DOM with the model's authoritative
render. Not deferred -- fully implemented and proven in all three engines.
Evidence: `test/editor/editor-capture.e2e.ts:98-118`; `editor.behavior.ts:595-596`
(composing state), `:643-663` (`onCompositionStart`/`onCompositionEnd`).

### 5. Playwright: after every edit, document.getSelection() matches the DOM position state.sel projects to
`selection is restored from state.sel after every edit` types `"hey"` into an empty
block and asserts `window.getSelection().focusOffset === 3`. `restoreSelection` in
`editor.behavior.ts` runs synchronously inside `render()` (itself called from the
`memory.subscribe` callback on every state change), mapping `state.sel`'s
block-id+offset to a concrete DOM `(node, offset)` via `locatePosition` and setting it
with `Selection.setBaseAndExtent` -- same task as the render, so the caret never
visibly jumps.
Evidence: `test/editor/editor-capture.e2e.ts:120-131`; `editor.behavior.ts:312-331`
(`restoreSelection`), `editor.behavior.ts:354-359` (`render`).

### 6. editor.behavior.ts contains no import of compose, createBehavior, or a BehaviorSpec type
The file's import block pulls only `zod`, `createClipboard` and `createInputHandler`
(existing primitives), types from `../../primitives/types`, `createEditorHistory` and
its state type, ops helpers, and `EditorOp` -- there is no `compose`, `createBehavior`,
or `BehaviorSpec` import anywhere in the file, satisfying the pinned "editor is out of
the behavior-layer composer" contract.
Evidence: `editor.behavior.ts:18-25` (full import list).

### 7. Vitest: projectDocument touches only the one changed block's DOM subtree over a real applyOp on 1000 blocks
The `projectDocument` describe block builds a 1000-block doc, calls the REAL `applyOp`
with an `insertText` op on block 500 (not a hand-built spread), confirms the other 999
blocks are reference-equal to their prior entries (structural sharing from `applyOp`
itself), then attaches a `MutationObserver` to block 0's subtree and asserts zero
records after `projectDocument(root, nextDoc, doc)` -- plus a negative control that
deliberately mutates block 0 afterward to prove the observer is actually wired.
Evidence: `packages/ui/test/components/editor/editor.behavior.test.ts:55-100`.

### 8. Vitest: a coalescing-window sequence through translateBeforeInput + controls lands as one done entry; closeGroup breaks it
The coalescing-shape test types `"hey"` one character at a time through
`translateBeforeInput` + `history.controls.apply` (the exact capture-side call shape
`bindEditor` issues) and asserts `history.memory.get().done` has length 1 -- the
history's own coalescing window merged them. It then calls `controls.closeGroup()`
and applies one more character, asserting `done` grows to length 2 -- a forced
boundary starts a new entry inside the window.
Evidence: `packages/ui/test/components/editor/editor.behavior.test.ts:134-167`.

### 9. happy-dom is NOT used to assert beforeinput capture behavior
`editor.behavior.test.ts` never constructs or dispatches a `beforeinput`/`InputEvent`
-- every test either calls `translateBeforeInput` directly with a plain data object, or
calls `projectDocument`/`controls.apply` without touching the event layer at all. The
file's header comment states this explicitly as the reason. All `beforeinput` capture
is proven exclusively in `test/editor/editor-capture.e2e.ts` under real Playwright
browsers (criteria 1-5 above).
Evidence: `packages/ui/test/components/editor/editor.behavior.test.ts:1-10` (header),
no `InputEvent`/`dispatchEvent('beforeinput'...)` calls in that file.

### 10. Unit tests for translateBeforeInput pass under vitest
The `translateBeforeInput` describe block covers: mapping `insertText` to an
`insertText` op at the current selection, inserting at the ordered start of a
same-block range selection, returning `null` for an unhandled `inputType`
(`formatBold`), and returning `null` for a doc-dependent delete (owned by
`bindEditor`, not this pure function). All four pass.
Evidence: `packages/ui/test/components/editor/editor.behavior.test.ts:20-52`;
`pnpm --filter @rafters/ui exec vitest run test/components/editor/editor.behavior.test.ts`
-- 8/8 passed.

### 11. Unit tests pass; pnpm preflight is green
Ran `pnpm preflight` (typecheck + lint + format:check + test:unit + test:a11y + build)
across the full monorepo from this branch's HEAD: exit code 0. `packages/ui`
test:unit reports 459 test files passed (including the new
`editor.behavior.test.ts`), `packages/ui` test:a11y reports 61 passed, every other
workspace package's typecheck/build/test steps completed with no failures.
Additionally ran the Playwright suite for this issue's new file directly:
`pnpm exec playwright test test/editor/editor-capture.e2e.ts --project=chromium
--project=firefox --project=webkit` -- 21/21 passed (7 tests x 3 browsers).
Evidence: preflight exit code 0; `packages/ui test:unit: Test Files 459 passed (459)`;
`packages/ui test:a11y: Test Files 61 passed (61)`; Playwright run above.

## Not done

- Rich paste (HTML/markdown structure, images) -- plain-text paste only, per the
  issue's explicit scope. `pasteText` reads `data.text` only; `createClipboard`'s
  other payload shapes are not consumed here.
- FR-EDITOR-005's `parts`/`aria`/`keymap` wiring for undo/redo and the three
  decorators -- a separate issue (#2107) that extends this same `bindEditor` export;
  nothing keymap- or undo/redo-shortcut-shaped was added here.
- Toolbar UI, slash-command palette, block drag handles, rule palette -- out of scope,
  covered by existing separate primitives.
- Collaboration/CRDT/multi-cursor/any sync transport -- explicitly excluded by
  RULING-EDITOR-HISTORY.
- Any refactor of `src/old/ui/editor.tsx` or `primitives/document-editor.ts` -- this is
  new code at a new location, not a port.
- Real OS-level IME automation in the e2e test -- Playwright cannot drive a genuine IME,
  so the composition test synthesizes the `compositionstart`/`update`/`end` event
  sequence directly (documented inline in the test) rather than relying on unavailable
  browser IME automation. The commit-path behavior this issue's AC covers is proven
  regardless.

Closes #2109
