### PR TITLE
feat(#2107): editor own-architecture score + classes + 3 decorators (FR-EDITOR-005)

### DIFF
--- a/packages/ui/src/components/editor/editor.astro
+++ b/packages/ui/src/components/editor/editor.astro
@@ -1,0 +1,106 @@
+---
+/**
+ * Block-based document editor with op-based undo/redo history
+ *
+ * @cognitive-load 5/10 - Sustained composition attention; undo/redo gives a safety net
+ * @attention-economics Full attention while composing -- the caret is the sole focus anchor
+ * @trust-building Every edit is reversible (Cmd/Ctrl+Z, Cmd/Ctrl+Shift+Z), so mistakes cost nothing
+ * @accessibility role=textbox, aria-multiline, a required accessible name (label or labelledBy)
+ * @semantic-meaning Primary authoring surface: prose and structured blocks, not a form field
+ *
+ * @usage-patterns
+ * DO: Always supply a real accessible name (label or labelledBy) -- axe fails an unnamed textbox
+ * DO: Seed initial content via the decorator's own data, not a post-mount DOM write
+ * NEVER: Mutate the contenteditable's DOM directly -- the model owns every edit
+ *
+ * @example
+ * ```tsx
+ * <Editor label="Document" />
+ * ```
+ */
+
+/**
+ * Astro performance for editor. Server-renders the empty contenteditable
+ * root with the closed... rather, the SEEDED-state aria projection already
+ * applied (correct before any JS), plus the seed doc/caret as data-*; the
+ * <script> then hands each instance to bindEditor -- the SAME DOM-native
+ * client the Web Component uses. Block content itself is DOM-native (built by
+ * bindEditor's own projectDocument on bind, which fires immediately off the
+ * memory cell's first paint), so this file renders no block markup itself --
+ * "SSR markup (contenteditable root, data-part=root) + a script that calls
+ * bindEditor(root) client-side", same shape as dialog.astro.
+ */
+import {
+  editorAria,
+  type EditorConfig,
+  type EditorPart,
+  type EditorState,
+} from './editor.behavior';
+import { editorClasses } from './editor.classes';
+import type { BaseBlock } from '../../primitives/types';
+import type { PartIds } from '../../lib/contract';
+
+interface Props {
+  id: string;
+  label?: string;
+  labelledBy?: string;
+  disabled?: boolean;
+  readonly?: boolean;
+  initialDoc?: BaseBlock[];
+  caret?: { blockId: string; offset: number };
+}
+
+const {
+  id,
+  label,
+  labelledBy,
+  disabled = false,
+  readonly = false,
+  initialDoc = [],
+  caret,
+} = Astro.props;
+
+const config = (
+  labelledBy ? { labelledBy, disabled, readonly } : { label, disabled, readonly }
+) as EditorConfig;
+
+const seedCaret = caret ?? { blockId: initialDoc[0]?.id ?? '', offset: 0 };
+const seedSel = { anchor: seedCaret, focus: seedCaret };
+// editorAria's state parameter is unused (the projection only reads
+// config) -- a literal in the seeded shape avoids allocating a whole
+// createEditorHistory (a nanostores atom) per server render just to throw
+// it away.
+const state = { doc: initialDoc, sel: seedSel, done: [], undone: [] } as EditorState;
+
+const ids = { root: id } as PartIds<EditorPart>;
+const aria = editorAria(state, config, ids).root;
+const classes = editorClasses(config, state);
+---
+
+<rafters-editor
+  id={id}
+  data-part="root"
+  contenteditable={disabled || readonly ? 'false' : 'true'}
+  data-label={label}
+  data-labelledby={labelledBy}
+  data-disabled={String(disabled)}
+  data-readonly={String(readonly)}
+  data-initial-doc={JSON.stringify(initialDoc)}
+  data-caret={JSON.stringify(seedCaret)}
+  class={classes.root}
+  {...aria}
+></rafters-editor>
+
+<script>
+  import { bindEditor } from './editor.behavior';
+
+  // The <script> is bundled and runs once per page; bind every instance's
+  // server-rendered markup. Same controller as the Web Component (this file
+  // does not import editor.element.ts / customElements.define -- the tag is
+  // used purely as a scoped selector, same shape as rafters-dialog).
+  for (const root of document.querySelectorAll<HTMLElement>('rafters-editor[data-part="root"]')) {
+    if (root.dataset['editorBound'] === 'true') continue;
+    root.dataset['editorBound'] = 'true';
+    bindEditor(root);
+  }
+</script>

--- a/packages/ui/src/components/editor/editor.behavior.ts
+++ b/packages/ui/src/components/editor/editor.behavior.ts
@@ -452,21 +452,39 @@ function restoreSelection(root: HTMLElement, sel: EditorHistoryState['sel']): vo
  * aria-manager, like every other DOM-native binder in this codebase) and the
  * undo/redo keymap wiring, gated on `history.canUndo`/`canRedo` -- there is no
  * `canDispatch` in this architecture.
+ *
+ * NOTE (deviates from RULING-EDITOR-HISTORY's pinned sketch
+ * `bindEditor(root: HTMLElement): () => void`, recorded deliberately): the
+ * second, optional `injectedHistory` parameter exists ONLY so React's own
+ * `createEditorHistory` cell (read via `useMemory` in editor.tsx) and this
+ * binder's imperative DOM projection stay the SAME cell rather than two
+ * divergent ones. It is additive and optional -- every call site the pinned
+ * signature covers (`bindEditor(root)`, the WC and Astro decorators) is
+ * unaffected -- so it is not a second binder or a wrapper (Spec 05), just a
+ * documented widening of the one export.
  */
 export function bindEditor(root: HTMLElement, injectedHistory?: EditorHistory): () => void {
   root.setAttribute('data-part', 'root');
-
-  const config = parseEditorConfig(root);
-  root.setAttribute('contenteditable', config.disabled || config.readonly ? 'false' : 'true');
 
   const history = injectedHistory ?? createEditorHistory(parseSeed(root));
   const { controls, memory } = history;
 
   const ids = { root: root.id } as PartIds<EditorPart>;
 
+  // Config is read fresh from `root`'s data-* on every render, NOT closed
+  // over once at bind time: disabled/readonly/label/labelledby can change
+  // post-mount (a React re-render commits new data-* attributes to the DOM
+  // declaratively, with no doc/sel change and therefore no memory
+  // notification of its own). Re-reading here, plus the attribute observer
+  // below forcing a render when only those data-* change, is what makes a
+  // toggled `disabled` actually flip `contenteditable` and keeps this
+  // binder's own aria write from reverting a label change made between
+  // renders back to a stale value.
   let prevDoc: BaseBlock[] | null = null;
   function render(): void {
     const state = memory.get();
+    const config = parseEditorConfig(root);
+    root.setAttribute('contenteditable', config.disabled || config.readonly ? 'false' : 'true');
     projectDocument(root, state.doc, prevDoc);
     prevDoc = state.doc;
     restoreSelection(root, state.sel);
@@ -477,6 +495,20 @@ export function bindEditor(root: HTMLElement, injectedHistory?: EditorHistory): 
         updateAriaAttribute(root, name as never, value as never, { validate: false });
       }
     }
+  }
+
+  // Re-render on a data-* config change alone (no doc/sel change, so no
+  // memory notification) -- e.g. a React prop toggling `disabled` with no
+  // edit in between. Deliberately excludes aria-label/aria-labelledby:
+  // render() itself writes those, and observing them would requeue a render
+  // on every render.
+  let attrObserver: MutationObserver | undefined;
+  if (typeof MutationObserver !== 'undefined') {
+    attrObserver = new MutationObserver(() => render());
+    attrObserver.observe(root, {
+      attributes: true,
+      attributeFilter: ['data-disabled', 'data-readonly', 'data-label', 'data-labelledby'],
+    });
   }
 
   // -- op construction for the doc-dependent inputs (deletes / structural) --
@@ -796,7 +828,7 @@ export function bindEditor(root: HTMLElement, injectedHistory?: EditorHistory): 
       },
       memory.get(),
       'root',
-      config,
+      parseEditorConfig(root),
     );
     if (!action) return;
     // preventDefault UNCONDITIONALLY: the model owns the edit, so the native
@@ -812,6 +844,7 @@ export function bindEditor(root: HTMLElement, injectedHistory?: EditorHistory): 
 
   return () => {
     unsubscribe();
+    attrObserver?.disconnect();
     inputHandler.cleanup();
     clipboard.cleanup();
     root.removeEventListener('paste', onPasteRaw);

--- a/packages/ui/src/components/editor/editor.behavior.ts
+++ b/packages/ui/src/components/editor/editor.behavior.ts
@@ -14,15 +14,93 @@
  * Spec 00). It borrows only the Spec 05 `bindX` LIFECYCLE (read config off
  * `root`'s `data-*`, subscribe to the memory cell, render on change, restore
  * selection, return a teardown).
+ *
+ * FR-EDITOR-005 adds the editor SCORE below (`parts`, `editorAria`,
+ * `editorKeymap`) -- hand-written, not produced by `compose()` -- and extends
+ * `bindEditor` with the aria projection and the undo/redo keymap wiring.
  */
 import { z } from 'zod';
+import type { AriaAttrs, KeyInput, PartDecl, PartIds } from '../../lib/contract';
+import { updateAriaAttribute } from '../../primitives/aria-manager';
 import { createClipboard } from '../../primitives/clipboard';
 import { createInputHandler } from '../../primitives/input-events';
 import type { BaseBlock, InlineContent } from '../../primitives/types';
-import type { EditorHistoryState } from './editor-history';
+import type { EditorHistory, EditorHistoryState } from './editor-history';
 import { createEditorHistory } from './editor-history';
 import { normalizeRuns, splitRuns, totalTextLength } from './ops/content';
 import type { EditorOp } from './ops';
+
+// ---------------------------------------------------------------------------
+// The editor score (FR-EDITOR-005): parts, editorAria, editorKeymap. Root-only
+// (settled) -- the contenteditable owns block DOM internally, no per-block
+// parts. Composed directly by `bindEditor` below; this is NOT a
+// compose()/BehaviorSpec (frozen Spec 00 line 132) -- this file imports
+// neither `compose` nor `createBehavior` and declares no `Slice`.
+// ---------------------------------------------------------------------------
+
+export type EditorPart = 'root';
+
+/** The one memory cell's shape (RULING-EDITOR-HISTORY interface contract,
+ *  point 2): `doc: BaseBlock[]`, plus FR-EDITOR-002's `sel`/`done`/`undone` --
+ *  re-exported from `editor-history.ts`'s own type rather than retyped. */
+export type EditorState = EditorHistoryState;
+
+/** Accessible-name is REQUIRED, not optional: axe fails a role=textbox with
+ *  no name, so the type forces one of the two rather than leaving it to
+ *  review. */
+export type EditorLabelConfig =
+  | { label: string; labelledBy?: undefined }
+  | { label?: undefined; labelledBy: string };
+
+export type EditorConfig = EditorLabelConfig & {
+  disabled?: boolean | undefined;
+  readonly?: boolean | undefined;
+};
+
+/** Root-only (settled): the contenteditable owns block DOM internally -- no
+ *  per-block parts. */
+export const parts: Record<EditorPart, PartDecl> = {
+  root: { role: 'textbox' },
+};
+
+/** Pure ARIA projection, same signature shape as every other score's `aria`
+ *  field but hand-written -- not produced by compose(). `ids` completes the
+ *  shared signature; unused here because the editor's root never
+ *  cross-references another part's id. */
+export function editorAria(
+  _state: EditorState,
+  config: EditorConfig,
+  _ids: PartIds<EditorPart>,
+): Partial<Record<EditorPart, AriaAttrs>> {
+  return {
+    root: {
+      role: 'textbox',
+      'aria-multiline': 'true',
+      'aria-label': config.label,
+      'aria-labelledby': config.labelledBy,
+    },
+  };
+}
+
+/**
+ * Pure keymap projection. Claims undo/redo on BOTH the Mac chord and the
+ * Windows/Linux chord. `KeyboardEvent.key` reports the shifted character
+ * (`'Z'`, not `'z'`) when Shift is held, so the comparison lowercases first --
+ * otherwise the redo chord silently never matches in a real browser. Every
+ * other key -- including plain character input -- returns null: content
+ * edits are NOT routed through keymap, they arrive via beforeinput
+ * (FR-EDITOR-004), composed by bindEditor.
+ */
+export function editorKeymap(
+  event: KeyInput,
+  _state: EditorState,
+  _part: EditorPart,
+  _config: EditorConfig,
+): 'undo' | 'redo' | null {
+  if (event.key.toLowerCase() !== 'z') return null;
+  if (!(event.metaKey || event.ctrlKey)) return null;
+  return event.shiftKey ? 'redo' : 'undo';
+}
 
 // ---------------------------------------------------------------------------
 // Config parsing (external data off `root`'s data-* attributes -> Zod).
@@ -92,6 +170,29 @@ function sliceContent(
   const [, fromStart] = splitRuns(runs, start);
   const [middle] = splitRuns(fromStart, end - start);
   return middle;
+}
+
+/**
+ * DOM-attribute config read for the score's aria/keymap projections --
+ * label/labelledBy/disabled/readonly off `root`'s `data-*`, falling back to
+ * an already-present `aria-label`/`aria-labelledby` (the Astro performance
+ * sets these server-side; the Web Component's light-DOM markup can too).
+ * Neither present projects no accessible name rather than inventing one --
+ * the three decorators are the enforcement point for a required name
+ * (`EditorLabelConfig`'s type-level union), not this runtime fallback, so an
+ * unnamed root here means the decorator that rendered it didn't pass one.
+ */
+function parseEditorConfig(root: HTMLElement): EditorConfig {
+  const labelledBy = root.dataset.labelledby ?? root.getAttribute('aria-labelledby') ?? undefined;
+  const label = labelledBy
+    ? undefined
+    : (root.dataset.label ?? root.getAttribute('aria-label') ?? undefined);
+  return {
+    label,
+    labelledBy,
+    disabled: root.dataset.disabled === 'true',
+    readonly: root.dataset.readonly === 'true',
+  } as EditorConfig;
 }
 
 function mintBlockId(): string {
@@ -335,20 +436,33 @@ function restoreSelection(root: HTMLElement, sel: EditorHistoryState['sel']): vo
 // ---------------------------------------------------------------------------
 
 /**
- * Bind a controlled contenteditable to a fresh editor history seeded from
- * `root`'s `data-initial-doc` / `data-caret`. Returns a teardown that removes
- * every listener and the history subscription.
+ * Bind a controlled contenteditable to an editor history seeded from `root`'s
+ * `data-initial-doc` / `data-caret`. Returns a teardown that removes every
+ * listener and the history subscription.
  *
- * FR-EDITOR-005 EXTENDS this same export with aria/keymap wiring for
- * undo/redo; it does not add a second binder. Nothing undo/redo-keymap-shaped
- * lives here.
+ * `history` is normally omitted: the WC and Astro decorators call
+ * `bindEditor(root)` and get a fresh `createEditorHistory` built from `root`'s
+ * seed data. React injects the SAME `EditorHistory` it reads via `useMemory`
+ * (own `createEditorHistory` call in `editor.tsx`) so the declarative aria
+ * projection and this binder's imperative DOM projection read one cell, not
+ * two divergent ones -- still the ONE `bindEditor` export, no second binder,
+ * no wrapper around it (Spec 05).
+ *
+ * FR-EDITOR-005 EXTENDS this same export with the aria projection (applied via
+ * aria-manager, like every other DOM-native binder in this codebase) and the
+ * undo/redo keymap wiring, gated on `history.canUndo`/`canRedo` -- there is no
+ * `canDispatch` in this architecture.
  */
-export function bindEditor(root: HTMLElement): () => void {
+export function bindEditor(root: HTMLElement, injectedHistory?: EditorHistory): () => void {
   root.setAttribute('data-part', 'root');
-  root.setAttribute('contenteditable', 'true');
 
-  const history = createEditorHistory(parseSeed(root));
+  const config = parseEditorConfig(root);
+  root.setAttribute('contenteditable', config.disabled || config.readonly ? 'false' : 'true');
+
+  const history = injectedHistory ?? createEditorHistory(parseSeed(root));
   const { controls, memory } = history;
+
+  const ids = { root: root.id } as PartIds<EditorPart>;
 
   let prevDoc: BaseBlock[] | null = null;
   function render(): void {
@@ -356,6 +470,13 @@ export function bindEditor(root: HTMLElement): () => void {
     projectDocument(root, state.doc, prevDoc);
     prevDoc = state.doc;
     restoreSelection(root, state.sel);
+
+    const projection = editorAria(state, config, ids).root;
+    if (projection) {
+      for (const [name, value] of Object.entries(projection)) {
+        updateAriaAttribute(root, name as never, value as never, { validate: false });
+      }
+    }
   }
 
   // -- op construction for the doc-dependent inputs (deletes / structural) --
@@ -662,6 +783,31 @@ export function bindEditor(root: HTMLElement): () => void {
     },
   });
 
+  // -- keydown: undo/redo (FR-EDITOR-005) --
+
+  const onKeydown = (event: KeyboardEvent): void => {
+    const action = editorKeymap(
+      {
+        key: event.key,
+        shiftKey: event.shiftKey,
+        ctrlKey: event.ctrlKey,
+        altKey: event.altKey,
+        metaKey: event.metaKey,
+      },
+      memory.get(),
+      'root',
+      config,
+    );
+    if (!action) return;
+    // preventDefault UNCONDITIONALLY: the model owns the edit, so the native
+    // contenteditable undo/redo must never run even when the gate below turns
+    // this into a no-op (an empty done/undone log).
+    event.preventDefault();
+    if (action === 'undo' && history.canUndo) controls.undo();
+    else if (action === 'redo' && history.canRedo) controls.redo();
+  };
+  root.addEventListener('keydown', onKeydown);
+
   const unsubscribe = memory.subscribe(() => render());
 
   return () => {
@@ -670,5 +816,6 @@ export function bindEditor(root: HTMLElement): () => void {
     clipboard.cleanup();
     root.removeEventListener('paste', onPasteRaw);
     root.removeEventListener('beforeinput', onBeforeInputRaw);
+    root.removeEventListener('keydown', onKeydown);
   };
 }

--- a/packages/ui/src/components/editor/editor.classes.ts
+++ b/packages/ui/src/components/editor/editor.classes.ts
@@ -1,0 +1,26 @@
+/**
+ * editor.classes.ts -- the editor score's visual projection (FR-EDITOR-005).
+ *
+ * Root-only (settled): one class string, for the contenteditable root. No
+ * per-block classes -- the contenteditable owns block DOM internally, and
+ * this file makes no reducer/aria/keymap decision (those live in
+ * editor.behavior.ts).
+ */
+import type { EditorConfig, EditorState } from './editor.behavior';
+
+export interface EditorClassSet {
+  root: string;
+}
+
+const rootClasses =
+  'min-h-32 w-full whitespace-pre-wrap rounded-md border border-input bg-transparent px-3 py-2 ' +
+  'text-body-medium ts-body-medium outline-none cursor-text ' +
+  'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ' +
+  'aria-disabled:cursor-not-allowed aria-disabled:opacity-50 ' +
+  '[&_a]:underline [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:font-mono';
+
+export function editorClasses(_config: EditorConfig, _state: EditorState): EditorClassSet {
+  return {
+    root: rootClasses,
+  };
+}

--- a/packages/ui/src/components/editor/editor.classes.ts
+++ b/packages/ui/src/components/editor/editor.classes.ts
@@ -12,11 +12,22 @@ export interface EditorClassSet {
   root: string;
 }
 
+// Disabled/readonly styling keys off data-disabled/data-readonly (the same
+// data-* config attributes bindEditor itself reads via parseEditorConfig),
+// NOT aria-disabled: editorAria never projects aria-disabled (the spec
+// enumerates only role/aria-multiline/label), so an `aria-disabled:` variant
+// here would be permanently dead. The exact-value arbitrary selector
+// (`data-[disabled=true]:`, not the bare-presence `data-disabled:`) matters
+// too: editor.astro always renders the attribute (`data-disabled={String(disabled)}`,
+// so `data-disabled="false"` is present when NOT disabled) while editor.tsx
+// omits it when false -- a presence-based selector would style the Astro
+// performance as disabled even when it isn't.
 const rootClasses =
   'min-h-32 w-full whitespace-pre-wrap rounded-md border border-input bg-transparent px-3 py-2 ' +
   'text-body-medium ts-body-medium outline-none cursor-text ' +
   'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ' +
-  'aria-disabled:cursor-not-allowed aria-disabled:opacity-50 ' +
+  'data-[disabled=true]:cursor-not-allowed data-[disabled=true]:opacity-50 ' +
+  'data-[readonly=true]:cursor-not-allowed data-[readonly=true]:opacity-50 ' +
   '[&_a]:underline [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:font-mono';
 
 export function editorClasses(_config: EditorConfig, _state: EditorState): EditorClassSet {

--- a/packages/ui/src/components/editor/editor.element.ts
+++ b/packages/ui/src/components/editor/editor.element.ts
@@ -1,0 +1,47 @@
+/**
+ * Block-based document editor with op-based undo/redo history
+ *
+ * @cognitive-load 5/10 - Sustained composition attention; undo/redo gives a safety net
+ * @attention-economics Full attention while composing -- the caret is the sole focus anchor
+ * @trust-building Every edit is reversible (Cmd/Ctrl+Z, Cmd/Ctrl+Shift+Z), so mistakes cost nothing
+ * @accessibility role=textbox, aria-multiline, a required accessible name (label or labelledBy)
+ * @semantic-meaning Primary authoring surface: prose and structured blocks, not a form field
+ *
+ * @usage-patterns
+ * DO: Always supply a real accessible name (label or labelledBy) -- axe fails an unnamed textbox
+ * DO: Seed initial content via the decorator's own data, not a post-mount DOM write
+ * NEVER: Mutate the contenteditable's DOM directly -- the model owns every edit
+ *
+ * @example
+ * ```tsx
+ * <Editor label="Document" />
+ * ```
+ */
+
+/**
+ * WC performance for editor: the thinnest wrapper. The score AND the
+ * DOM-native binding (bindEditor) live in editor.behavior.ts, shared with the
+ * Astro performance. This file only adapts that binding to the custom-element
+ * lifecycle -- deferring the bind one microtask because connectedCallback can
+ * fire before `data-initial-doc`/`data-caret`/`data-label` are parsed.
+ */
+import { bindEditor } from './editor.behavior';
+
+export class RaftersEditorElement extends HTMLElement {
+  private teardown: (() => void) | null = null;
+
+  connectedCallback(): void {
+    queueMicrotask(() => {
+      if (this.isConnected && !this.teardown) this.teardown = bindEditor(this);
+    });
+  }
+
+  disconnectedCallback(): void {
+    this.teardown?.();
+    this.teardown = null;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('rafters-editor')) {
+  customElements.define('rafters-editor', RaftersEditorElement);
+}

--- a/packages/ui/src/components/editor/editor.element.ts
+++ b/packages/ui/src/components/editor/editor.element.ts
@@ -24,6 +24,15 @@
  * Astro performance. This file only adapts that binding to the custom-element
  * lifecycle -- deferring the bind one microtask because connectedCallback can
  * fire before `data-initial-doc`/`data-caret`/`data-label` are parsed.
+ *
+ * `data-editor-bound` is the SAME guard editor.astro's own <script> checks
+ * before calling `bindEditor(root)` there. A page that both renders the
+ * Astro markup and ships this file in its bundle upgrades ONE
+ * `<rafters-editor>` through both paths; without a shared guard each would
+ * bind independently (two histories, two keydown listeners, one Cmd+Z firing
+ * undo twice). Whichever runs first sets the flag synchronously between its
+ * own check and set, so there is no race between this microtask and the
+ * script's own (synchronous) loop.
  */
 import { bindEditor } from './editor.behavior';
 
@@ -32,13 +41,24 @@ export class RaftersEditorElement extends HTMLElement {
 
   connectedCallback(): void {
     queueMicrotask(() => {
-      if (this.isConnected && !this.teardown) this.teardown = bindEditor(this);
+      if (!this.isConnected || this.teardown) return;
+      if (this.dataset['editorBound'] === 'true') return;
+      this.dataset['editorBound'] = 'true';
+      this.teardown = bindEditor(this);
     });
   }
 
   disconnectedCallback(): void {
-    this.teardown?.();
+    // Only tear down (and clear the shared guard) when THIS instance is the
+    // one that bound: `data-editor-bound` may have been set by editor.astro's
+    // <script> instead, with THAT closure holding the live teardown -- if
+    // this callback cleared the guard unconditionally, a later reconnect
+    // would see no flag and bind a SECOND time over the script's still-live
+    // binding (the exact double-bind the shared guard exists to prevent).
+    if (!this.teardown) return;
+    this.teardown();
     this.teardown = null;
+    delete this.dataset['editorBound'];
   }
 }
 

--- a/packages/ui/src/components/editor/editor.tsx
+++ b/packages/ui/src/components/editor/editor.tsx
@@ -1,0 +1,81 @@
+/**
+ * Block-based document editor with op-based undo/redo history
+ *
+ * @cognitive-load 5/10 - Sustained composition attention; undo/redo gives a safety net
+ * @attention-economics Full attention while composing -- the caret is the sole focus anchor
+ * @trust-building Every edit is reversible (Cmd/Ctrl+Z, Cmd/Ctrl+Shift+Z), so mistakes cost nothing
+ * @accessibility role=textbox, aria-multiline, a required accessible name (label or labelledBy)
+ * @semantic-meaning Primary authoring surface: prose and structured blocks, not a form field
+ *
+ * @usage-patterns
+ * DO: Always supply a real accessible name (label or labelledBy) -- axe fails an unnamed textbox
+ * DO: Seed initial content via the decorator's own data, not a post-mount DOM write
+ * NEVER: Mutate the contenteditable's DOM directly -- the model owns every edit
+ *
+ * @example
+ * ```tsx
+ * <Editor label="Document" />
+ * ```
+ */
+
+/**
+ * React performance for editor. Unlike most scores, this one is NOT fully
+ * declarative: a contenteditable can't be safely virtual-DOM-diffed (Spec 00
+ * -- the editor is own-project-scale, outside the composer, precisely because
+ * of this), so `Editor` still delegates the actual binding to `bindEditor` --
+ * the SAME DOM-native client the Web Component and Astro performances use --
+ * and only adds the declarative layer `bindEditor` cannot: `useMemory` over
+ * its own `createEditorHistory` cell, injected into `bindEditor` so both read
+ * ONE cell, not two divergent ones.
+ */
+import * as React from 'react';
+import type { PartIds } from '../../lib/contract';
+import { useMemory } from '../../hooks/use-memory';
+import { bindEditor, editorAria, type EditorConfig, type EditorPart } from './editor.behavior';
+import { editorClasses } from './editor.classes';
+import { createEditorHistory } from './editor-history';
+
+export type EditorProps = (
+  | { label: string; labelledBy?: undefined }
+  | { label?: undefined; labelledBy: string }
+) & {
+  disabled?: boolean;
+  readonly?: boolean;
+};
+
+export function Editor(props: EditorProps): React.JSX.Element {
+  const { disabled, readonly } = props;
+  const rootRef = React.useRef<HTMLDivElement | null>(null);
+  const uid = React.useId();
+
+  // Own createEditorHistory instance, injected into bindEditor below so the
+  // DOM-native binder and useMemory here read the SAME cell -- bindEditor
+  // would otherwise construct its own from root's data-* (the WC/Astro path).
+  const history = React.useMemo(() => createEditorHistory(), []);
+  const state = useMemory(history.memory);
+
+  const config = props as EditorConfig;
+  const ids = { root: uid } as PartIds<EditorPart>;
+  const aria = editorAria(state, config, ids).root;
+  const classes = editorClasses(config, state);
+
+  React.useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    return bindEditor(root, history);
+  }, [history]);
+
+  return (
+    <div
+      ref={rootRef}
+      id={uid}
+      data-part="root"
+      data-label={props.label}
+      data-labelledby={props.labelledBy}
+      data-disabled={disabled ? 'true' : undefined}
+      data-readonly={readonly ? 'true' : undefined}
+      className={classes.root}
+      {...aria}
+    />
+  );
+}

--- a/packages/ui/src/components/editor/index.ts
+++ b/packages/ui/src/components/editor/index.ts
@@ -1,14 +1,33 @@
 /**
- * Editor component -- op vocabulary (FR-EDITOR-003) and history core
- * (FR-EDITOR-002).
+ * Editor component -- op vocabulary (FR-EDITOR-003), history core
+ * (FR-EDITOR-002), and the editor score + bindEditor (FR-EDITOR-005).
  *
- * Later editor.behavior.ts (FR-EDITOR-005) composes createEditorHistory's
- * controls/memory rather than reimplementing op/undo/redo.
+ * editor.behavior.ts composes createEditorHistory's controls/memory rather
+ * than reimplementing op/undo/redo; it is NOT a compose()/BehaviorSpec (the
+ * editor is out of the behavior-layer composer, frozen Spec 00 line 132).
+ *
+ * Framework-agnostic surface only (functions + types, no module-level side
+ * effects) -- same as the rest of this barrel. The three decorators
+ * (editor.tsx, editor.element.ts, editor.astro) are imported directly by
+ * path, per this codebase's existing convention: no other component funnels
+ * its React/WC/Astro performance through a folder index either, and
+ * editor.element.ts's customElements.define is a real side effect this
+ * barrel should not force on every consumer.
  */
 export { applyOp, applyOpSequence } from './ops';
 export type { EditorOp, FormatOp, OpResult, StructuralOp, TextOp } from './ops';
 export { createEditorHistory } from './editor-history';
-export { bindEditor, projectDocument, translateBeforeInput } from './editor.behavior';
+export {
+  bindEditor,
+  editorAria,
+  editorKeymap,
+  parts as editorParts,
+  projectDocument,
+  translateBeforeInput,
+} from './editor.behavior';
+export type { EditorConfig, EditorLabelConfig, EditorPart, EditorState } from './editor.behavior';
+export { editorClasses } from './editor.classes';
+export type { EditorClassSet } from './editor.classes';
 export type {
   EditorHistory,
   EditorHistoryConfig,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -29,15 +29,31 @@ export { createHtmlSerializer, htmlSerializer } from './primitives/serializer-ht
 export { createMdxSerializer, mdxSerializer } from './primitives/serializer-mdx.js';
 export { createTextSerializer, textSerializer } from './primitives/serializer-text.js';
 export type { BaseBlock } from './primitives/types.js';
-export { applyOp, applyOpSequence, createEditorHistory } from './components/editor/index.js';
+export {
+  applyOp,
+  applyOpSequence,
+  bindEditor,
+  createEditorHistory,
+  editorAria,
+  editorClasses,
+  editorKeymap,
+  editorParts,
+  projectDocument,
+  translateBeforeInput,
+} from './components/editor/index.js';
 export type {
+  EditorClassSet,
+  EditorConfig,
   EditorHistory,
   EditorHistoryConfig,
   EditorHistoryControls,
   EditorHistoryState,
+  EditorLabelConfig,
   EditorOp,
+  EditorPart,
   EditorPosition,
   EditorSelection,
+  EditorState,
   FormatOp,
   HistoryEntry,
   OpResult,

--- a/packages/ui/src/primitives/document-editor.ts
+++ b/packages/ui/src/primitives/document-editor.ts
@@ -8,7 +8,7 @@
  * - cursor-tracker: cursor position relative to blocks
  * - block-operations: split/merge/delete/convert (pure functions)
  * - inline-formatter: bold/italic/code/etc
- * - history: undo/redo
+ * - editor-history (FR-EDITOR-002): undo/redo, op-based
  * - serializer-html/text: paste deserialization, copy serialization
  *
  * The React component layer is a thin wrapper: state + render. This primitive
@@ -23,17 +23,14 @@
  * @dependencies nanostores
  * @internal-dependencies primitives/input-events.ts, primitives/clipboard.ts,
  *   primitives/keyboard-handler.ts, primitives/cursor-tracker.ts,
- *   primitives/block-operations.ts, primitives/history.ts,
- *   primitives/serializer-html.ts, primitives/serializer-text.ts
+ *   primitives/block-operations.ts, components/editor/editor-history.ts,
+ *   components/editor/ops, primitives/serializer-html.ts, primitives/serializer-text.ts
  */
 import {
   blockContentToText,
-  convertBlockType,
   deleteBlock,
-  insertBlocksAt,
   mergeWithNext,
   mergeWithPrevious,
-  splitBlock,
 } from './block-operations';
 import { createClipboard } from './clipboard';
 import {
@@ -45,7 +42,9 @@ import {
   setCursorAtBlockStart,
   setCursorInBlock,
 } from './cursor-tracker';
-import { createHistory } from './history';
+import { createEditorHistory } from '../components/editor/editor-history';
+import { normalizeRuns } from '../components/editor/ops/content';
+import type { EditorOp } from '../components/editor/ops';
 import { createInputHandler } from './input-events';
 import { createKeyboardHandler } from './keyboard-handler';
 import { createMemory } from './memory';
@@ -123,10 +122,18 @@ export function createDocumentEditor(options: DocumentEditorOptions): DocumentEd
   const cleanups: CleanupFunction[] = [];
 
   // -- Shared state --
-  const history = createHistory<BaseBlock[]>({
-    initialState: initialBlocks,
-    limit: 100,
-  });
+  // FR-EDITOR-002's op-based history (RULING-EDITOR-HISTORY): the OLD
+  // primitives/history.ts (snapshot push/pop) is gone from this file's
+  // dependency path. `history.memory`'s own `doc` field is this editor's
+  // canonical block array; `state` below mirrors it into the
+  // DocumentEditorState shape this primitive's public API already commits to
+  // (blocks/canUndo/canRedo), via `syncFromHistory`.
+  const firstId = initialBlocks[0]?.id ?? '';
+  const initialPos = { blockId: firstId, offset: 0 };
+  const history = createEditorHistory(
+    { doc: initialBlocks, sel: { anchor: initialPos, focus: initialPos } },
+    { cap: 100 },
+  );
 
   const state = createMemory<DocumentEditorState>({
     blocks: initialBlocks,
@@ -134,14 +141,95 @@ export function createDocumentEditor(options: DocumentEditorOptions): DocumentEd
     canRedo: false,
   });
 
-  function updateBlocks(next: BaseBlock[]): void {
-    history.push(next);
+  function syncFromHistory(): void {
+    const next = history.memory.get().doc;
     state.set({
       blocks: next,
-      canUndo: history.canUndo(),
-      canRedo: history.canRedo(),
+      canUndo: history.canUndo,
+      canRedo: history.canRedo,
     });
     onBlocksChange?.(next);
+  }
+
+  /** Apply one EditorOp through FR-EDITOR-002's history (one `done` entry),
+   *  WITHOUT publishing -- the caller decides when to call `syncFromHistory`.
+   *  `applyOp` (FR-EDITOR-003) throws on an unresolvable op -- a stale
+   *  blockId or an out-of-bounds offset, which can happen when the DOM has
+   *  drifted from the model between reconciles. Mirrors editor.behavior.ts's
+   *  `applyOps` discipline: skip, leave the cell at its last valid state, let
+   *  the next reconcile re-sync from the DOM. Typing must never throw.
+   *  Returns whether the op actually applied. */
+  function commitOpSilent(op: EditorOp): boolean {
+    try {
+      history.controls.apply(op);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Apply one EditorOp and publish immediately -- the single-op call sites
+   *  below (Enter, Backspace, Delete, block-type shortcuts, paste) each
+   *  represent one user action, one `done` entry, one `onBlocksChange`. */
+  function commitOp(op: EditorOp): void {
+    if (commitOpSilent(op)) syncFromHistory();
+  }
+
+  /** Diff `nextBlocks` (freshly read off the DOM by `reconcileDOM`) against
+   *  the history's current `doc` and commit the difference as EditorOps: a
+   *  `delete` per removed block, a whole-block `removeText` + `insertText`
+   *  pair per content-changed block. `reconcileDOM` only ever drops or
+   *  edits blocks already in the model (never introduces a new id -- see its
+   *  own comment), so no `insert` case is needed here.
+   *
+   *  This is a coarser undo grain than a real keystroke-level diff (two
+   *  `done` entries per changed block instead of one), because
+   *  FR-EDITOR-003's vocabulary has no "replace this block's content"
+   *  primitive -- but every commit still lands on FR-EDITOR-002's op-log, so
+   *  typing driven through this DOM-first reconciliation path stays
+   *  undoable, which a raw `memory.set` bypass would not preserve.
+   *
+   *  Every op in one reconcile is applied via `commitOpSilent` (no publish),
+   *  then `syncFromHistory` runs ONCE at the end, iff anything actually
+   *  applied. Publishing after each op would expose the cell's INTERMEDIATE
+   *  state to `onBlocksChange` -- a changed block sits with empty content
+   *  between its `removeText` and `insertText` -- which a persisting
+   *  consumer (`onBlocksChange={(blocks) => save(blocks)}`, per
+   *  `old/ui/editor.tsx`'s own doc comment) would write on every keystroke.
+   *  The original snapshot-push `updateBlocks` fired the callback exactly
+   *  once per reconcile; this preserves that. */
+  function commitReconciled(nextBlocks: BaseBlock[]): void {
+    const prevBlocks = history.memory.get().doc;
+    const nextIds = new Set(nextBlocks.map((b) => b.id));
+    let changed = false;
+
+    for (const prev of prevBlocks) {
+      if (!nextIds.has(prev.id)) {
+        if (commitOpSilent({ kind: 'delete', blockId: prev.id })) changed = true;
+      }
+    }
+
+    const prevById = new Map(prevBlocks.map((b) => [b.id, b]));
+    for (const next of nextBlocks) {
+      const prev = prevById.get(next.id);
+      if (!prev) continue;
+      if (blockContentToText(prev.content) === blockContentToText(next.content)) continue;
+
+      const removed = normalizeRuns(prev.content);
+      if (removed.length > 0) {
+        if (commitOpSilent({ kind: 'removeText', blockId: next.id, offset: 0, text: removed })) {
+          changed = true;
+        }
+      }
+      const inserted = normalizeRuns(next.content);
+      if (inserted.length > 0) {
+        if (commitOpSilent({ kind: 'insertText', blockId: next.id, offset: 0, text: inserted })) {
+          changed = true;
+        }
+      }
+    }
+
+    if (changed) syncFromHistory();
   }
 
   // -- Make container contentEditable --
@@ -197,7 +285,7 @@ export function createDocumentEditor(options: DocumentEditorOptions): DocumentEd
         );
       })
     ) {
-      updateBlocks(reconciled);
+      commitReconciled(reconciled);
     }
   }
 
@@ -212,11 +300,11 @@ export function createDocumentEditor(options: DocumentEditorOptions): DocumentEd
 
       // insertParagraph = Enter key (browser already split the DOM)
       if (data.inputType === 'insertParagraph') {
-        const result = splitBlock(state.get().blocks, pos.blockId, pos.offset, crypto.randomUUID());
-        updateBlocks(result.blocks);
+        const newBlockId = crypto.randomUUID();
+        commitOp({ kind: 'split', blockId: pos.blockId, offset: pos.offset, newBlockId });
         // Focus the new block after React re-renders
         requestAnimationFrame(() => {
-          setCursorAtBlockStart(container, result.newBlockId);
+          setCursorAtBlockStart(container, newBlockId);
         });
         return;
       }
@@ -242,10 +330,26 @@ export function createDocumentEditor(options: DocumentEditorOptions): DocumentEd
             // Prevent the space from being inserted
             // Note: we return here, the beforeinput handler in input-events
             // will check the preventDefault array
-            const next = convertBlockType(blocks, pos.blockId, shortcut.type, shortcut.meta);
-            // Clear the prefix content
-            const converted = next.map((b) => (b.id === pos.blockId ? { ...b, content: '' } : b));
-            updateBlocks(converted);
+            commitOp({
+              kind: 'convert',
+              blockId: pos.blockId,
+              newType: shortcut.type,
+              ...(shortcut.meta ? { meta: shortcut.meta } : {}),
+            });
+            // Clear the prefix content -- read the CONVERTED block back (not
+            // the pre-convert one) since convertBlockType may itself have
+            // transformed content (e.g. code blocks flatten marks); this must
+            // match what's actually in the cell or removeText throws.
+            const converted = state.get().blocks.find((b) => b.id === pos.blockId);
+            const prefixRuns = normalizeRuns(converted?.content);
+            if (prefixRuns.length > 0) {
+              commitOp({
+                kind: 'removeText',
+                blockId: pos.blockId,
+                offset: 0,
+                text: prefixRuns,
+              });
+            }
             requestAnimationFrame(() => {
               setCursorAtBlockStart(container, pos.blockId);
             });
@@ -278,7 +382,7 @@ export function createDocumentEditor(options: DocumentEditorOptions): DocumentEd
       // Empty block: delete it
       if (pos.blockLength === 0 && index > 0) {
         const result = deleteBlock(blocks, pos.blockId);
-        updateBlocks(result.blocks);
+        commitOp({ kind: 'delete', blockId: pos.blockId });
         if (result.focusBlockId) {
           requestAnimationFrame(() => {
             if (result.focusAtEnd) {
@@ -293,8 +397,7 @@ export function createDocumentEditor(options: DocumentEditorOptions): DocumentEd
 
       // Heading/quote at start: convert to text
       if (block.type === 'heading' || block.type === 'quote') {
-        const next = convertBlockType(blocks, pos.blockId, 'text');
-        updateBlocks(next);
+        commitOp({ kind: 'convert', blockId: pos.blockId, newType: 'text' });
         requestAnimationFrame(() => {
           setCursorAtBlockStart(container, pos.blockId);
         });
@@ -304,7 +407,7 @@ export function createDocumentEditor(options: DocumentEditorOptions): DocumentEd
       // Merge with previous
       if (index > 0) {
         const result = mergeWithPrevious(blocks, pos.blockId);
-        updateBlocks(result.blocks);
+        commitOp({ kind: 'mergePrev', blockId: pos.blockId });
         requestAnimationFrame(() => {
           setCursorInBlock(container, result.survivorId, result.cursorOffset);
         });
@@ -325,7 +428,7 @@ export function createDocumentEditor(options: DocumentEditorOptions): DocumentEd
 
       const blocks = state.get().blocks;
       const result = mergeWithNext(blocks, pos.blockId);
-      updateBlocks(result.blocks);
+      commitOp({ kind: 'mergeNext', blockId: pos.blockId });
       requestAnimationFrame(() => {
         setCursorInBlock(container, result.survivorId, result.cursorOffset);
       });
@@ -344,30 +447,29 @@ export function createDocumentEditor(options: DocumentEditorOptions): DocumentEd
     const pos = getCursorPosition();
     if (!pos) return;
 
-    const blocks = state.get().blocks;
-    let next: BaseBlock[] | null = null;
+    let op: EditorOp | null = null;
 
     switch (event.key) {
       case '0':
-        next = convertBlockType(blocks, pos.blockId, 'text');
+        op = { kind: 'convert', blockId: pos.blockId, newType: 'text' };
         break;
       case '1':
-        next = convertBlockType(blocks, pos.blockId, 'heading', { level: 1 });
+        op = { kind: 'convert', blockId: pos.blockId, newType: 'heading', meta: { level: 1 } };
         break;
       case '2':
-        next = convertBlockType(blocks, pos.blockId, 'heading', { level: 2 });
+        op = { kind: 'convert', blockId: pos.blockId, newType: 'heading', meta: { level: 2 } };
         break;
       case '3':
-        next = convertBlockType(blocks, pos.blockId, 'heading', { level: 3 });
+        op = { kind: 'convert', blockId: pos.blockId, newType: 'heading', meta: { level: 3 } };
         break;
       case '4':
-        next = convertBlockType(blocks, pos.blockId, 'heading', { level: 4 });
+        op = { kind: 'convert', blockId: pos.blockId, newType: 'heading', meta: { level: 4 } };
         break;
     }
 
-    if (next) {
+    if (op) {
       event.preventDefault();
-      updateBlocks(next);
+      commitOp(op);
     }
   }
 
@@ -410,17 +512,20 @@ export function createDocumentEditor(options: DocumentEditorOptions): DocumentEd
         }
       }
 
-      // Multiple blocks: insert at cursor position
-      const result = insertBlocksAt(
-        blocks,
-        pastedBlocks,
-        pos.blockId,
-        pos.offset,
-        crypto.randomUUID(),
-      );
-      updateBlocks(result.blocks);
+      // Multiple blocks: insert at cursor position. `lastInsertedId` is
+      // always the last element of `pastedBlocks` (insertBlocksAt's own
+      // convention -- see block-operations.ts) regardless of whether a
+      // mid-block split occurs, so no extra call is needed to learn it.
+      const lastInsertedId = pastedBlocks[pastedBlocks.length - 1]?.id ?? pos.blockId;
+      commitOp({
+        kind: 'insert',
+        blocks: pastedBlocks,
+        atBlockId: pos.blockId,
+        atOffset: pos.offset,
+        splitBlockId: crypto.randomUUID(),
+      });
       requestAnimationFrame(() => {
-        setCursorAtBlockEnd(container, result.lastInsertedId);
+        setCursorAtBlockEnd(container, lastInsertedId);
       });
     },
     onCopy: () => {
@@ -468,42 +573,46 @@ export function createDocumentEditor(options: DocumentEditorOptions): DocumentEd
 
   // -- Public API --
   function setBlocks(blocks: BaseBlock[]): void {
-    updateBlocks(blocks);
+    // A wholesale replace (external load/import) has no natural EditorOp:
+    // every op in FR-EDITOR-003's vocabulary anchors on an EXISTING block,
+    // which an arbitrary externally-supplied document may not share with the
+    // current one at all. Reset the cell directly through its public
+    // `memory` -- editor-history.ts exposes a Memory<EditorHistoryState> for
+    // exactly this kind of non-incremental write -- and clear the op-log:
+    // there is no derived op sequence back to the replaced document, so it
+    // is not meaningfully "undoable" through this history.
+    const firstBlockId = blocks[0]?.id ?? '';
+    const pos = { blockId: firstBlockId, offset: 0 };
+    history.memory.set({ doc: blocks, sel: { anchor: pos, focus: pos }, done: [], undone: [] });
+    syncFromHistory();
   }
 
   function addBlocks(newBlocks: BaseBlock[], index?: number): void {
-    const current = state.get().blocks;
-    const next = [...current];
+    // Same rationale as setBlocks: the target document may currently be
+    // empty (no anchor block for FR-EDITOR-003's `insert` op) or the insert
+    // may span a position `insert` doesn't address (append past the end);
+    // expressed directly on the memory cell rather than fabricated as ops.
+    const current = history.memory.get();
+    const next = [...current.doc];
     if (index !== undefined && index >= 0 && index <= next.length) {
       next.splice(index, 0, ...newBlocks);
     } else {
       next.push(...newBlocks);
     }
-    updateBlocks(next);
+    history.memory.set({ ...current, doc: next });
+    syncFromHistory();
   }
 
   function undo(): void {
-    const prev = history.undo();
-    if (prev) {
-      state.set({
-        blocks: prev,
-        canUndo: history.canUndo(),
-        canRedo: history.canRedo(),
-      });
-      onBlocksChange?.(prev);
-    }
+    if (!history.canUndo) return;
+    history.controls.undo();
+    syncFromHistory();
   }
 
   function redo(): void {
-    const next = history.redo();
-    if (next) {
-      state.set({
-        blocks: next,
-        canUndo: history.canUndo(),
-        canRedo: history.canRedo(),
-      });
-      onBlocksChange?.(next);
-    }
+    if (!history.canRedo) return;
+    history.controls.redo();
+    syncFromHistory();
   }
 
   function focusBlock(blockId: string, offset?: number): void {

--- a/packages/ui/test/components/editor/editor.astro.conformance.test.ts
+++ b/packages/ui/test/components/editor/editor.astro.conformance.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Astro performance of the editor score, driven end to end. AstroContainer
+ * renders the SSR markup but does NOT run the <script> (same limitation
+ * dialog.astro.conformance.test.ts documents), so this test binds
+ * `bindEditor` directly -- that IS the script's job -- then drives the same
+ * score the React and WC performances drive. One score, three performances.
+ */
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { afterEach, describe, expect, it } from 'vitest';
+import Editor from '../../../src/components/editor/editor.astro';
+import { bindEditor } from '../../../src/components/editor/editor.behavior';
+import { assertAxeClean } from '../../harness/conformance';
+import type { BaseBlock } from '../../../src/primitives/types';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const seededDoc: BaseBlock[] = [{ id: 'b1', type: 'text', content: 'hello' }];
+
+/** happy-dom's HTML parser does not decode numeric character references
+ *  (`&#34;` etc.) WITHIN an attribute value back to their literal characters
+ *  -- a real browser always does, so this is a test-environment quirk, not
+ *  an Astro or bindEditor bug. It only bites `data-initial-doc`/`data-caret`
+ *  (quotes get entity-encoded by Astro's own attribute serialization since
+ *  they carry JSON). Decoding the RAW HTML STRING before parsing would be
+ *  wrong -- the outer quotes delimiting the attribute are real `"`
+ *  characters, and turning the inner `&#34;`s into literal `"` first would
+ *  prematurely close that delimiter and truncate the value. Decode AFTER
+ *  parsing instead, rewriting just the two attributes on the mounted
+ *  element via getAttribute/setAttribute. */
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&#34;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#38;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>');
+}
+
+async function mount(props: Record<string, unknown> = {}): Promise<HTMLElement> {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Editor, {
+    props: { id: 'e1', initialDoc: seededDoc, caret: { blockId: 'b1', offset: 5 }, ...props },
+  });
+  document.body.innerHTML = html;
+  const el = document.body.querySelector('rafters-editor') as HTMLElement;
+  for (const attr of ['data-initial-doc', 'data-caret']) {
+    const raw = el.getAttribute(attr);
+    if (raw !== null) el.setAttribute(attr, decodeHtmlEntities(raw));
+  }
+  return el;
+}
+
+describe('editor conformance [astro]', () => {
+  it('SSR renders role=textbox, aria-multiline, and the label -- correct before any JS', async () => {
+    const el = await mount({ label: 'Document' });
+    expect(el.getAttribute('data-part')).toBe('root');
+    expect(el.getAttribute('role')).toBe('textbox');
+    expect(el.getAttribute('aria-multiline')).toBe('true');
+    expect(el.getAttribute('aria-label')).toBe('Document');
+    expect(el.getAttribute('contenteditable')).toBe('true');
+  });
+
+  it('SSR: disabled/readonly project contenteditable=false before any JS', async () => {
+    const el = await mount({ label: 'Document', disabled: true });
+    expect(el.getAttribute('contenteditable')).toBe('false');
+  });
+
+  it('omitted label + labelledby projects aria-labelledby, never aria-label', async () => {
+    const el = await mount({ labelledBy: 'external-heading' });
+    expect(el.getAttribute('aria-labelledby')).toBe('external-heading');
+    expect(el.hasAttribute('aria-label')).toBe(false);
+  });
+
+  it('is axe-clean pre-bind with a real accessible name', async () => {
+    const el = await mount({ label: 'Document' });
+    await assertAxeClean(el);
+  });
+
+  it('bind: script-equivalent call projects the seeded doc and is axe-clean bound', async () => {
+    const el = await mount({ label: 'Document' });
+    bindEditor(el); // what the <script> does per instance on a real page
+    expect(el.querySelector('[data-block-id="b1"]')?.textContent).toBe('hello');
+    await assertAxeClean(el);
+  });
+
+  it('bind: undo/redo gate works through the SSR + script path', async () => {
+    const el = await mount({ label: 'Document' });
+    bindEditor(el);
+
+    el.dispatchEvent(
+      new InputEvent('beforeinput', {
+        inputType: 'insertText',
+        data: '!',
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    expect(el.querySelector('[data-block-id="b1"]')?.textContent).toBe('hello!');
+
+    el.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'z', metaKey: true, bubbles: true, cancelable: true }),
+    );
+    expect(el.querySelector('[data-block-id="b1"]')?.textContent).toBe('hello');
+  });
+
+  it('WC + Astro script both targeting one SSR root bind exactly once (double-bind guard)', async () => {
+    // Dynamically imported, and only in this test: editor.element.ts
+    // registers the custom element as a MODULE-LOAD side effect, which would
+    // otherwise upgrade -- and auto-bind -- every `<rafters-editor>` this
+    // file's OTHER (SSR-only, pre-bind) tests render too.
+    const { RaftersEditorElement } = await import('../../../src/components/editor/editor.element');
+    if (!customElements.get('rafters-editor')) {
+      customElements.define('rafters-editor', RaftersEditorElement);
+    }
+    const el = await mount({ label: 'Document' });
+    // Registering the custom element upgrades the SSR-rendered
+    // <rafters-editor> automatically; its connectedCallback (deferred one
+    // microtask) binds and sets data-editor-bound, per editor.element.ts.
+    await Promise.resolve();
+    expect(el.dataset['editorBound']).toBe('true');
+
+    // The script's own loop (editor.astro's <script>, replicated here since
+    // AstroContainer does not execute it): must see the guard already set
+    // and skip, not bind a second time.
+    let scriptBound = false;
+    for (const candidate of document.querySelectorAll<HTMLElement>(
+      'rafters-editor[data-part="root"]',
+    )) {
+      if (candidate.dataset['editorBound'] === 'true') continue;
+      candidate.dataset['editorBound'] = 'true';
+      scriptBound = true; // would call bindEditor(candidate) here
+    }
+    expect(scriptBound).toBe(false);
+  });
+});

--- a/packages/ui/test/components/editor/editor.behavior.test.ts
+++ b/packages/ui/test/components/editor/editor.behavior.test.ts
@@ -11,8 +11,12 @@
 import { describe, expect, it } from 'vitest';
 import { createEditorHistory } from '../../../src/components/editor/editor-history';
 import {
+  editorAria,
+  editorKeymap,
+  parts,
   projectDocument,
   translateBeforeInput,
+  type EditorConfig,
 } from '../../../src/components/editor/editor.behavior';
 import { applyOp } from '../../../src/components/editor/ops';
 import type { BaseBlock } from '../../../src/primitives/types';
@@ -164,5 +168,76 @@ describe('capture-side coalescing shape (translateBeforeInput -> controls)', () 
     // The doc reflects every op (sanity that the shape actually applied).
     const block = history.memory.get().doc.find((b) => b.id === 'b1');
     expect(block?.content).toBe('hey!');
+  });
+});
+
+// -----------------------------------------------------------------------------
+// The editor score (FR-EDITOR-005) -- parts, editorAria, editorKeymap.
+// -----------------------------------------------------------------------------
+
+describe('parts', () => {
+  it('declares exactly one part, root, with role: textbox', () => {
+    expect(Object.keys(parts)).toEqual(['root']);
+    expect(parts.root.role).toBe('textbox');
+  });
+});
+
+describe('editorAria', () => {
+  const config: EditorConfig = { label: 'Document' };
+  const { memory } = createEditorHistory();
+  const state = memory.get();
+
+  it('projects role, aria-multiline, and aria-label from config.label', () => {
+    expect(editorAria(state, config, { root: 'doc-1' }).root).toMatchObject({
+      role: 'textbox',
+      'aria-multiline': 'true',
+      'aria-label': 'Document',
+    });
+  });
+
+  it('projects aria-labelledby instead when config.labelledBy is set', () => {
+    const byId: EditorConfig = { labelledBy: 'external-heading' };
+    const projection = editorAria(state, byId, { root: 'doc-1' }).root;
+    expect(projection).toMatchObject({
+      role: 'textbox',
+      'aria-multiline': 'true',
+      'aria-labelledby': 'external-heading',
+    });
+    expect(projection?.['aria-label']).toBeUndefined();
+  });
+});
+
+describe('editorKeymap', () => {
+  const config: EditorConfig = { label: 'Document' };
+  const { memory } = createEditorHistory();
+  const state = memory.get();
+
+  it('claims Cmd+Z and Ctrl+Z as undo', () => {
+    expect(editorKeymap({ key: 'z', metaKey: true }, state, 'root', config)).toBe('undo');
+    expect(editorKeymap({ key: 'z', ctrlKey: true }, state, 'root', config)).toBe('undo');
+  });
+
+  it('claims Cmd+Shift+Z and Ctrl+Shift+Z as redo', () => {
+    expect(editorKeymap({ key: 'z', metaKey: true, shiftKey: true }, state, 'root', config)).toBe(
+      'redo',
+    );
+    expect(editorKeymap({ key: 'z', ctrlKey: true, shiftKey: true }, state, 'root', config)).toBe(
+      'redo',
+    );
+  });
+
+  it('claims the shifted-character chord a real browser sends for Shift', () => {
+    // KeyboardEvent.key reports the shifted character ('Z', not 'z') when
+    // Shift is held -- a strict `key === 'z'` check would pass the fixture
+    // above and still silently fail in a real browser.
+    expect(editorKeymap({ key: 'Z', metaKey: true, shiftKey: true }, state, 'root', config)).toBe(
+      'redo',
+    );
+  });
+
+  it('leaves every other key unclaimed, including plain character input', () => {
+    expect(editorKeymap({ key: 'a' }, state, 'root', config)).toBeNull();
+    expect(editorKeymap({ key: 'z' }, state, 'root', config)).toBeNull(); // no modifier
+    expect(editorKeymap({ key: 'y', metaKey: true }, state, 'root', config)).toBeNull();
   });
 });

--- a/packages/ui/test/components/editor/editor.classes.test.ts
+++ b/packages/ui/test/components/editor/editor.classes.test.ts
@@ -18,4 +18,13 @@ describe('editorClasses', () => {
     expect(typeof classes.root).toBe('string');
     expect(classes.root.length).toBeGreaterThan(0);
   });
+
+  it('styles disabled/readonly off data-disabled/data-readonly, not aria-disabled', () => {
+    // editorAria never projects aria-disabled (spec: role/aria-multiline/label
+    // only) -- an aria-disabled: variant here would be permanently dead.
+    const classes = editorClasses(config, state);
+    expect(classes.root).not.toContain('aria-disabled:');
+    expect(classes.root).toContain('data-[disabled=true]:');
+    expect(classes.root).toContain('data-[readonly=true]:');
+  });
 });

--- a/packages/ui/test/components/editor/editor.classes.test.ts
+++ b/packages/ui/test/components/editor/editor.classes.test.ts
@@ -1,0 +1,21 @@
+/**
+ * editor.classes.test.ts -- the editor score's visual projection
+ * (FR-EDITOR-005). Root-only: one class string, no per-block classes.
+ */
+import { describe, expect, it } from 'vitest';
+import { createEditorHistory } from '../../../src/components/editor/editor-history';
+import type { EditorConfig } from '../../../src/components/editor/editor.behavior';
+import { editorClasses } from '../../../src/components/editor/editor.classes';
+
+describe('editorClasses', () => {
+  const config: EditorConfig = { label: 'Document' };
+  const { memory } = createEditorHistory();
+  const state = memory.get();
+
+  it('returns exactly one class string, keyed root', () => {
+    const classes = editorClasses(config, state);
+    expect(Object.keys(classes)).toEqual(['root']);
+    expect(typeof classes.root).toBe('string');
+    expect(classes.root.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/ui/test/components/editor/editor.conformance.test.tsx
+++ b/packages/ui/test/components/editor/editor.conformance.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * React performance of the editor score, driven end to end -- same shared
+ * `bindEditor` client the WC and Astro performances use (editor.tsx injects
+ * its own `createEditorHistory` cell so `useMemory` and the binder read one
+ * cell, per editor.behavior.ts's own doc comment).
+ *
+ * `assertContractFulfillment` (the shared conformance harness's Tier-2
+ * helper) is typed to `BehaviorSpec` and cannot be reused here: the editor is
+ * deliberately NOT a compose()/BehaviorSpec component (RULING-EDITOR-HISTORY,
+ * frozen Spec 00 line 132) -- `editorAria`/`parts` are hand-written, not
+ * bundled into that shape. Assertions below compare the rendered DOM against
+ * `editorAria`'s own projection entry-by-entry instead, including the
+ * undefined -> absent case.
+ */
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Editor, type EditorProps } from '../../../src/components/editor/editor';
+import {
+  editorAria,
+  parts,
+  type EditorConfig,
+} from '../../../src/components/editor/editor.behavior';
+import { assertAxeClean, partElement } from '../../harness/conformance';
+
+afterEach(() => {
+  cleanup();
+});
+
+const root = () => partElement(document.body, 'root') as HTMLElement;
+
+describe('editor conformance [react]', () => {
+  it('renders exactly the root part, role=textbox, matching editorAria(label)', () => {
+    render(<Editor label="Document" />);
+    expect(root()).not.toBeNull();
+    expect(root().getAttribute('role')).toBe(parts.root.role);
+
+    const config: EditorConfig = { label: 'Document' };
+    const projection = editorAria({} as never, config, { root: root().id }).root;
+    for (const [attr, value] of Object.entries(projection ?? {})) {
+      if (value === undefined) {
+        expect(root().hasAttribute(attr), `must NOT render ${attr}`).toBe(false);
+      } else {
+        expect(root().getAttribute(attr)).toBe(String(value));
+      }
+    }
+  });
+
+  it('projects aria-labelledby instead of aria-label when labelledBy is set', () => {
+    render(<Editor labelledBy="external-heading" />);
+    expect(root().getAttribute('aria-labelledby')).toBe('external-heading');
+    expect(root().hasAttribute('aria-label')).toBe(false);
+  });
+
+  it('is axe-clean with a real accessible name', async () => {
+    render(<Editor label="Document" />);
+    // Scoped to the editor root, not document.body: axe's "region" rule
+    // (page content must be contained by a landmark) is a page-layout
+    // concern, not a property of this widget in isolation.
+    await assertAxeClean(root());
+  });
+
+  it('sanity: assertAxeClean, scoped this same way, DOES fail an unnamed textbox', async () => {
+    // Negative control for the assertion above (and for the WC/Astro suites'
+    // identically-scoped axe checks): proves narrowing assertAxeClean's
+    // target from document.body to the widget root did not also narrow away
+    // the violation the axe tier exists to catch (an incidentally-passing
+    // unnamed role=textbox). If this ever stops throwing, the axe tier in
+    // every editor conformance suite has gone vacuous.
+    const unnamed = document.createElement('div');
+    unnamed.setAttribute('role', 'textbox');
+    unnamed.setAttribute('aria-multiline', 'true');
+    unnamed.setAttribute('contenteditable', 'true');
+    document.body.appendChild(unnamed);
+    await expect(assertAxeClean(unnamed)).rejects.toThrow();
+  });
+
+  it('disabled/readonly toggle contenteditable post-mount (no re-bind needed)', async () => {
+    const { rerender } = render(<Editor label="Document" />);
+    expect(root().getAttribute('contenteditable')).toBe('true');
+
+    rerender(<Editor label="Document" disabled />);
+    // The attribute-change MutationObserver bindEditor installs is
+    // microtask-scheduled; a macrotask tick is a reliable point past which
+    // it has run.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(root().getAttribute('contenteditable')).toBe('false');
+
+    rerender(<Editor label="Document" />);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(root().getAttribute('contenteditable')).toBe('true');
+  });
+
+  it('a changed label is not reverted to a stale value by bindEditor', async () => {
+    const { rerender } = render(<Editor label="First" />);
+    expect(root().getAttribute('aria-label')).toBe('First');
+
+    rerender(<Editor label="Second" />);
+    // React's own declarative aria spread updates this synchronously; the
+    // regression this guards is bindEditor's OWN imperative render() later
+    // overwriting it with the config it read at bind time.
+    expect(root().getAttribute('aria-label')).toBe('Second');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(root().getAttribute('aria-label')).toBe('Second');
+  });
+
+  it('undo/redo gate: Cmd+Z before any edit is a silent no-op', () => {
+    render(<Editor label="Document" />);
+    // A freshly-mounted editor has no seeded content (React's EditorProps has
+    // no initial-doc field in this issue's interface) and therefore an empty
+    // `done` log -- history.canUndo is false. Confirms the gate, not a
+    // reducer: no throw, root stays present and unchanged.
+    expect(() =>
+      root().dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'z', metaKey: true, bubbles: true, cancelable: true }),
+      ),
+    ).not.toThrow();
+    expect(root()).not.toBeNull();
+
+    expect(() =>
+      root().dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'z',
+          metaKey: true,
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      ),
+    ).not.toThrow();
+    // The full "gate opens after a real edit" half of this scenario --
+    // dispatching the chord before AND after an actual insertText -- is
+    // proven in editor.element.conformance.test.ts and
+    // editor.astro.conformance.test.ts, which seed a real block via
+    // data-initial-doc; React's <Editor> has no such prop in this issue's
+    // pinned interface, so it cannot produce a first edit to gate around
+    // without going through the same empty-doc limitation this test already
+    // covers the "before" half of. Same bindEditor, same editorKeymap, same
+    // history.canUndo/canRedo gate in every performance -- proven once at the
+    // DOM-native layer covers all three.
+  });
+
+  // FR-EDITOR-005 acceptance: "EditorConfig/EditorProps type-reject a value
+  // that omits both label and labelledBy (compile-time check, e.g. a
+  // `// @ts-expect-error` fixture in the test suite)". This file is listed in
+  // tsconfig.json's `files` (not `include` -- an explicit `include` entry is
+  // still subject to the blanket `**/*.test.tsx` `exclude`, which is why the
+  // repo's prior `test/components/dialog.test.tsx` include entry pointed at a
+  // file that doesn't exist and was never actually being typechecked; `files`
+  // is the one array `exclude` cannot filter) specifically so `pnpm
+  // typecheck` exercises this line -- vitest itself only transpiles types
+  // away, it does not check them. Verified by temporarily deleting the
+  // `@ts-expect-error` comment below and confirming `tsc --noEmit` then
+  // reports `Type '{}' is not assignable to type 'EditorProps'`.
+  it('compile-time: EditorProps rejects a value with neither label nor labelledBy', () => {
+    function unnamed(): EditorProps {
+      // @ts-expect-error -- EditorLabelConfig is a required union; omitting
+      // both label and labelledBy must fail to typecheck, not just fail axe.
+      return {};
+    }
+    expect(typeof unnamed).toBe('function');
+  });
+});

--- a/packages/ui/test/components/editor/editor.element.conformance.test.ts
+++ b/packages/ui/test/components/editor/editor.element.conformance.test.ts
@@ -1,0 +1,208 @@
+/**
+ * WC performance of the editor score, driven end to end against light-DOM
+ * markup -- same shared `bindEditor` client the React and Astro performances
+ * use. `assertContractFulfillment` (the shared harness's Tier-2 helper)
+ * cannot be reused here: it is typed to `BehaviorSpec`, and the editor is
+ * deliberately NOT a compose()/BehaviorSpec component (RULING-EDITOR-HISTORY,
+ * frozen Spec 00 line 132) -- `parts`/`editorAria` are hand-written, not
+ * bundled into that shape. Assertions below compare the rendered DOM against
+ * `editorAria`'s own projection directly instead.
+ */
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { assertAxeClean } from '../../harness/conformance';
+import {
+  editorAria,
+  parts,
+  type EditorConfig,
+} from '../../../src/components/editor/editor.behavior';
+import { RaftersEditorElement } from '../../../src/components/editor/editor.element';
+import type { BaseBlock } from '../../../src/primitives/types';
+
+beforeAll(() => {
+  if (!customElements.get('rafters-editor')) {
+    customElements.define('rafters-editor', RaftersEditorElement);
+  }
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+function seededDoc(): BaseBlock[] {
+  return [{ id: 'b1', type: 'text', content: 'hello' }];
+}
+
+async function mount(attrs: Record<string, string> = {}, seed = true): Promise<HTMLElement> {
+  const el = document.createElement('rafters-editor');
+  el.id = 'e1';
+  if (seed) {
+    el.dataset.initialDoc = JSON.stringify(seededDoc());
+    el.dataset.caret = JSON.stringify({ blockId: 'b1', offset: 5 });
+  }
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.appendChild(el);
+  await Promise.resolve(); // connectedCallback defers one microtask
+  return el;
+}
+
+const root = () => document.querySelector<HTMLElement>('rafters-editor')!;
+
+describe('editor conformance [wc]', () => {
+  it('declares exactly one part, root, with role=textbox, matching editorAria', async () => {
+    await mount({ 'data-label': 'Document' });
+    expect(root().getAttribute('data-part')).toBe('root');
+    expect(Object.keys(parts)).toEqual(['root']);
+    expect(root().getAttribute('role')).toBe(parts.root.role);
+
+    const config: EditorConfig = { label: 'Document' };
+    const projection = editorAria({} as never, config, { root: 'e1' }).root;
+    for (const [attr, value] of Object.entries(projection ?? {})) {
+      if (value === undefined) {
+        expect(root().hasAttribute(attr), `must NOT render ${attr}`).toBe(false);
+      } else {
+        expect(root().getAttribute(attr)).toBe(String(value));
+      }
+    }
+  });
+
+  it('projects aria-labelledby instead of aria-label when data-labelledby is set', async () => {
+    await mount({ 'data-labelledby': 'external-heading' });
+    expect(root().getAttribute('aria-labelledby')).toBe('external-heading');
+    expect(root().hasAttribute('aria-label')).toBe(false);
+  });
+
+  it('is axe-clean with a real accessible name', async () => {
+    await mount({ 'data-label': 'Document' });
+    // Scoped to the editor root itself, not document.body: axe's "region"
+    // rule (page content must be contained by a landmark) is a page-layout
+    // concern, not a property of this widget in isolation -- the same reason
+    // the WC dialog conformance suite (dialog.element.conformance.test.ts)
+    // has no body-level axe check either.
+    await assertAxeClean(root());
+  });
+
+  it('contenteditable reflects data-disabled/data-readonly at bind, and MutationObserver keeps it live', async () => {
+    await mount({ 'data-label': 'Document' });
+    expect(root().getAttribute('contenteditable')).toBe('true');
+
+    root().dataset['disabled'] = 'true';
+    // MutationObserver callbacks are microtask-scheduled but not necessarily
+    // drained by a single `await Promise.resolve()` hop in every environment
+    // -- a macrotask tick is a reliable point past which it has run.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(root().getAttribute('contenteditable')).toBe('false');
+
+    root().dataset['disabled'] = 'false';
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(root().getAttribute('contenteditable')).toBe('true');
+  });
+
+  it('gates undo/redo on history.canUndo/canRedo: Cmd+Z before any edit no-ops; after a real edit it undoes', async () => {
+    await mount({ 'data-label': 'Document' });
+    const before = root().querySelector('[data-block-id="b1"]')?.textContent;
+    expect(before).toBe('hello');
+
+    // Before any edit: canUndo is false, so the gate blocks the call -- no
+    // throw, content unchanged.
+    root().dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'z', metaKey: true, bubbles: true, cancelable: true }),
+    );
+    expect(root().querySelector('[data-block-id="b1"]')?.textContent).toBe('hello');
+
+    // A real edit: bindEditor is a controlled contenteditable (Spec 04) --
+    // the DOM mutation is applied by projectDocument from the model, not by
+    // native contenteditable editing, so a synthetic `beforeinput` drives the
+    // SAME production code path a real keystroke would (only the BROWSER's
+    // own native-edit semantics are Playwright-only, per FR-EDITOR-006 and
+    // this suite's editor.behavior.test.ts note -- dispatching the event
+    // itself is ordinary DOM EventTarget behavior every environment supports).
+    root().dispatchEvent(
+      new InputEvent('beforeinput', {
+        inputType: 'insertText',
+        data: '!',
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    expect(root().querySelector('[data-block-id="b1"]')?.textContent).toBe('hello!');
+
+    // Now canUndo is true: Cmd+Z undoes the edit.
+    root().dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'z', metaKey: true, bubbles: true, cancelable: true }),
+    );
+    expect(root().querySelector('[data-block-id="b1"]')?.textContent).toBe('hello');
+
+    // canRedo is now true: Cmd+Shift+Z redoes it.
+    root().dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'z',
+        metaKey: true,
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    expect(root().querySelector('[data-block-id="b1"]')?.textContent).toBe('hello!');
+  });
+
+  it('sets data-editor-bound on connect -- the SAME guard editor.astro checks before its own bind', async () => {
+    await mount({ 'data-label': 'Document' });
+    expect(root().dataset['editorBound']).toBe('true');
+  });
+
+  it("a script-style bind attempt sees the WC's guard already set and skips", async () => {
+    await mount({ 'data-label': 'Document' });
+    // Mirrors editor.astro's own <script> loop verbatim: check-then-set the
+    // SAME `data-editor-bound` key. Since the WC already bound (and set it)
+    // during connectedCallback above, this must take the skip branch --
+    // proving the two paths interlock instead of each binding independently
+    // (two histories, two keydown listeners, one Cmd+Z firing undo twice).
+    let reboundByScript = false;
+    if (root().dataset['editorBound'] !== 'true') {
+      root().dataset['editorBound'] = 'true';
+      reboundByScript = true; // would call bindEditor(root) here on a real page
+    }
+    expect(reboundByScript).toBe(false);
+  });
+
+  it('disconnect clears the guard so a later reconnect can rebind', async () => {
+    const el = await mount({ 'data-label': 'Document' });
+    expect(el.dataset['editorBound']).toBe('true');
+
+    el.remove();
+    expect(el.dataset['editorBound']).toBeUndefined();
+
+    document.body.appendChild(el);
+    await Promise.resolve();
+    expect(el.dataset['editorBound']).toBe('true');
+  });
+
+  it('does NOT clear the guard on disconnect when the SCRIPT (not this WC instance) owns the binding', async () => {
+    // The Astro-script-binds-first ordering: bindEditor(el) is called
+    // directly (what the <script> does) and the guard is set BEFORE the WC's
+    // own connectedCallback microtask has a chance to run.
+    const el = document.createElement('rafters-editor');
+    el.id = 'e2';
+    el.dataset.initialDoc = JSON.stringify(seededDoc());
+    el.dataset.caret = JSON.stringify({ blockId: 'b1', offset: 5 });
+    el.setAttribute('data-label', 'Document');
+    el.dataset['editorBound'] = 'true';
+    const { bindEditor } = await import('../../../src/components/editor/editor.behavior');
+    const scriptTeardown = bindEditor(el);
+    document.body.appendChild(el);
+
+    // The WC's connectedCallback (deferred one microtask) sees the guard
+    // already set and must NOT take ownership -- its own `teardown` stays
+    // null, per editor.element.ts.
+    await Promise.resolve();
+    expect(el.dataset['editorBound']).toBe('true');
+
+    // Detaching must NOT clear a guard this instance never owned: clearing
+    // it here would let a later reconnect bind a SECOND time over the
+    // script's still-live binding (the double-bind #4 exists to prevent).
+    el.remove();
+    expect(el.dataset['editorBound']).toBe('true');
+
+    scriptTeardown();
+  });
+});

--- a/packages/ui/test/primitives/document-editor.test.ts
+++ b/packages/ui/test/primitives/document-editor.test.ts
@@ -1,0 +1,148 @@
+/**
+ * document-editor.test.ts -- smoke coverage for FR-EDITOR-005's swap of this
+ * primitive's history dependency from primitives/history.ts (snapshot
+ * push/pop) to FR-EDITOR-002's editor-history.ts (op-based, undoable).
+ *
+ * document-editor.ts renders no block markup itself (the consumer does --
+ * see old/ui/editor.tsx); these tests build minimal `[data-block-id]` markup
+ * by hand to exercise the primitive's own event handling and public API.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { createDocumentEditor } from '../../src/primitives/document-editor';
+import { setCursorInBlock } from '../../src/primitives/cursor-tracker';
+import type { BaseBlock } from '../../src/primitives/types';
+
+let container: HTMLElement;
+
+afterEach(() => {
+  container?.remove();
+});
+
+function mountContainer(): HTMLElement {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  return container;
+}
+
+function renderBlock(id: string, text: string): HTMLElement {
+  const el = document.createElement('div');
+  el.setAttribute('data-block-id', id);
+  el.textContent = text;
+  container.appendChild(el);
+  return el;
+}
+
+describe('createDocumentEditor (FR-EDITOR-002 history)', () => {
+  it('undo/redo round-trip via a real keyboard action (Cmd+Alt+1 -> convert), publishing exactly once', () => {
+    mountContainer();
+    renderBlock('a', 'hello');
+    const changes: BaseBlock[][] = [];
+    const editor = createDocumentEditor({
+      container,
+      initialBlocks: [{ id: 'a', type: 'text', content: 'hello' }],
+      onBlocksChange: (blocks) => changes.push(blocks),
+    });
+
+    expect(editor.$state.get()).toMatchObject({ canUndo: false, canRedo: false });
+
+    setCursorInBlock(container, 'a', 0);
+    container.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: '1',
+        metaKey: true,
+        altKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+
+    expect(editor.$state.get().canUndo).toBe(true);
+    expect(editor.$state.get().blocks[0]).toMatchObject({ id: 'a', type: 'heading' });
+    expect(changes).toHaveLength(1); // one user action, one publish
+
+    editor.undo();
+    expect(editor.$state.get().canUndo).toBe(false);
+    expect(editor.$state.get().canRedo).toBe(true);
+    expect(editor.$state.get().blocks[0]).toMatchObject({ id: 'a', type: 'text' });
+
+    editor.redo();
+    expect(editor.$state.get().canUndo).toBe(true);
+    expect(editor.$state.get().blocks[0]).toMatchObject({ id: 'a', type: 'heading' });
+
+    editor.destroy();
+  });
+
+  it('reconcileDOM batches a changed block into ONE publish, never exposing the transient empty-content step', () => {
+    mountContainer();
+    const blockEl = renderBlock('a', 'hello');
+    const changes: BaseBlock[][] = [];
+    const editor = createDocumentEditor({
+      container,
+      initialBlocks: [{ id: 'a', type: 'text', content: 'hello' }],
+      onBlocksChange: (blocks) => changes.push(blocks),
+    });
+
+    // Simulate what native contenteditable editing would have already done
+    // to the DOM (browser mutates first, THEN fires `input`) -- the
+    // reconciler's job is to read this back into the model.
+    blockEl.textContent = 'hello world';
+    container.dispatchEvent(
+      new InputEvent('input', { inputType: 'insertText', data: ' world', bubbles: true }),
+    );
+
+    expect(changes).toHaveLength(1); // NOT one publish per internal op
+    expect(changes[0]?.[0]?.content).toBe('hello world'); // final state, never the empty intermediate
+    expect(editor.$state.get().blocks[0]?.content).toBe('hello world');
+    expect(editor.$state.get().canUndo).toBe(true);
+
+    // Two `done` entries land here (a removeText + an insertText -- see
+    // commitReconciled's own doc comment: FR-EDITOR-003 has no whole-block
+    // "replace content" op, so a content diff is two ops, two undo steps),
+    // so full round-trip back to the original text takes two undos.
+    editor.undo();
+    expect(editor.$state.get().blocks[0]?.content).toBe('');
+    editor.undo();
+    expect(editor.$state.get().blocks[0]?.content).toBe('hello');
+    expect(editor.$state.get().canUndo).toBe(false);
+
+    editor.destroy();
+  });
+
+  it('setBlocks replaces the doc and is reflected in $state and onBlocksChange (op-log bypass, by design)', () => {
+    mountContainer();
+    const changes: BaseBlock[][] = [];
+    const editor = createDocumentEditor({
+      container,
+      initialBlocks: [{ id: 'a', type: 'text', content: 'hello' }],
+      onBlocksChange: (blocks) => changes.push(blocks),
+    });
+
+    editor.setBlocks([{ id: 'z', type: 'text', content: 'fresh' }]);
+
+    expect(editor.$state.get().blocks).toEqual([{ id: 'z', type: 'text', content: 'fresh' }]);
+    expect(changes.at(-1)).toEqual([{ id: 'z', type: 'text', content: 'fresh' }]);
+    // A wholesale replace has no derived op sequence back to the prior doc
+    // (FR-EDITOR-003 has no such op) -- not undoable through this history,
+    // by design (see document-editor.ts's setBlocks doc comment).
+    expect(editor.$state.get().canUndo).toBe(false);
+
+    editor.destroy();
+  });
+
+  it('addBlocks inserts at an index and is reflected in $state and onBlocksChange', () => {
+    mountContainer();
+    const changes: BaseBlock[][] = [];
+    const editor = createDocumentEditor({
+      container,
+      initialBlocks: [{ id: 'a', type: 'text', content: 'first' }],
+      onBlocksChange: (blocks) => changes.push(blocks),
+    });
+
+    editor.addBlocks([{ id: 'b', type: 'text', content: 'second' }], 1);
+
+    expect(editor.$state.get().blocks.map((b) => b.id)).toEqual(['a', 'b']);
+    expect(changes.at(-1)?.map((b) => b.id)).toEqual(['a', 'b']);
+
+    editor.destroy();
+  });
+});

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -6,5 +6,6 @@
     "types": ["node", "vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["src/**/*", "test/components/dialog.test.tsx"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"],
+  "files": ["test/components/editor/editor.conformance.test.tsx"]
 }


### PR DESCRIPTION
## Summary

Ships `editor.behavior.ts` as the editor's own score per Spec 05's authoring shape (`parts`,
`editorAria`, `editorKeymap`, one `bindEditor`) -- explicitly not a `compose()`/`BehaviorSpec`
component, per RULING-EDITOR-HISTORY's pinned interface contract. `bindEditor` now composes
`editor-history.ts` (FR-EDITOR-002) directly and adds undo/redo keymap wiring, gated on
`history.canUndo`/`canRedo`. Three thin decorators (`editor.tsx`, `editor.element.ts`,
`editor.astro`), a view layer (`editor.classes.ts`), and `document-editor.ts`'s swap off the old
`primitives/history.ts` onto FR-EDITOR-002's op-based history round out the issue.

## Acceptance criteria mapping

### 1. editor.behavior.ts exports the score plus bindEditor; no compose/createBehavior, no Slice
`editor.behavior.ts` adds `parts`, `editorAria`, `editorKeymap` as hand-written exports and
extends the existing `bindEditor` in place -- no second binder. The file's import list contains
neither `compose` nor `createBehavior` (only `zod`, `aria-manager`, `clipboard`, `input-events`,
`editor-history`, `ops/content`, `ops` are imported), and no `Slice`/`GlueSlice`/`EditorOpActions`
type is declared anywhere in the file.
Evidence: packages/ui/src/components/editor/editor.behavior.ts:17-30 (import list), :52-72
(`parts`/`editorAria`/`editorKeymap` exports).

### 2. parts declares exactly one part, root, with role: 'textbox'
`export const parts: Record<EditorPart, PartDecl> = { root: { role: 'textbox' } }` is the sole
entry; `EditorPart` is typed as the literal `'root'`, so no second part can be added without a
type error. Covered by a direct unit assertion.
Evidence: packages/ui/src/components/editor/editor.behavior.ts:44-47; test assertion at
packages/ui/test/components/editor/editor.behavior.test.ts:180 (`expect(Object.keys(parts)).toEqual(['root'])`).

### 3. editorAria projects role, aria-multiline, and the label on root for every state
`editorAria` ignores its `_state` parameter entirely (prefixed `_`, unused) and derives the
projection purely from `config`, so the same `role: 'textbox'`, `'aria-multiline': 'true'`, and
`aria-label`/`aria-labelledby` land on `root` regardless of document state -- there is no state
branch that could omit them. Verified for both the labelled and labelledBy-only configs, and via
the conformance suites which compare the live DOM against this same function's output.
Evidence: packages/ui/src/components/editor/editor.behavior.ts:59-72; tests at
packages/ui/test/components/editor/editor.behavior.test.ts (`describe('editorAria')`).

### 4. EditorConfig/EditorProps type-reject a config with neither label nor labelledBy
`EditorLabelConfig` is a discriminated union (`{ label: string; labelledBy?: undefined } | {
label?: undefined; labelledBy: string }`), not two optional fields, so `{}` fails to typecheck.
A `// @ts-expect-error` fixture proves this at compile time, and `tsconfig.json` gained a `files`
entry specifically so `tsc --noEmit` actually type-checks that `.test.tsx` file (vitest alone only
transpiles types away). Every React/WC/Astro conformance fixture renders with `label` or
`labelledBy` set, and a negative-control test confirms `assertAxeClean` does fail an unnamed
`role=textbox` when one is deliberately constructed outside the type system, so the axe tier is
proven non-vacuous.
Evidence: packages/ui/src/components/editor/editor.behavior.ts:34-36 (`EditorLabelConfig`);
packages/ui/test/components/editor/editor.conformance.test.tsx (`@ts-expect-error` test and the
"sanity: assertAxeClean ... DOES fail" test); packages/ui/tsconfig.json:9 (`files` entry).

### 5. editorKeymap claims Cmd/Ctrl+Z -> undo, Cmd/Ctrl+Shift+Z -> redo; other keys unclaimed
`editorKeymap` lowercases `event.key` before comparing to `'z'` (browsers report the shifted
character `'Z'` under Shift, which a naive `key === 'z'` check would silently miss), requires
`metaKey || ctrlKey`, and returns `'redo'` when `shiftKey` else `'undo'`; every other key falls
through to `null`, including plain character input -- edits arrive via `beforeinput`, not keymap.
Evidence: packages/ui/src/components/editor/editor.behavior.ts:74-84; tests at
packages/ui/test/components/editor/editor.behavior.test.ts (`describe('editorKeymap')`, including
the shifted-character regression test).

### 6. bindEditor gates undo/redo on history.canUndo/canRedo; no dispatch, no canDispatch
The `keydown` handler calls `editorKeymap`, unconditionally `preventDefault`s so native
contenteditable undo/redo never fires, then only invokes `controls.undo()`/`controls.redo()` when
`history.canUndo`/`history.canRedo` is true -- a chord pressed against an empty log is a silent
no-op. There is no `dispatch()` or `canDispatch` anywhere in this file; gating reads FR-EDITOR-002's
derived booleans directly.
Evidence: packages/ui/src/components/editor/editor.behavior.ts (`onKeydown`, gated
`history.canUndo`/`history.canRedo` calls); WC end-to-end proof at
packages/ui/test/components/editor/editor.element.conformance.test.ts ("gates undo/redo on
history.canUndo/canRedo" test, asserting a no-op before any edit and a real undo/redo after one).

### 7. Three decorators exist with the identical 6-tag JSDoc; no decision logic in any of them
`editor.tsx`, `editor.element.ts`, and `editor.astro` each open with the byte-identical
`@cognitive-load`/`@attention-economics`/`@trust-building`/`@accessibility`/`@semantic-meaning`/
`@usage-patterns` block. None of the three contains an aria string literal, a keymap comparison,
or history logic -- each calls `editorAria`/`editorClasses`/`bindEditor` from `editor.behavior.ts`
rather than reimplementing any of them.
Evidence: packages/ui/src/components/editor/editor.tsx:1-16, editor.element.ts:1-16,
editor.astro:1-16 (identical JSDoc header in all three).

### 8. React reads state via useMemory over the history's memory cell; WC and Astro call bindEditor
`Editor` (editor.tsx) builds its own `createEditorHistory()` instance via `React.useMemo`, reads
it with `useMemory(history.memory)`, and passes that same `history` into `bindEditor(root,
history)` so the declarative aria projection and the imperative DOM binder read one cell, not two.
`RaftersEditorElement.connectedCallback` and `editor.astro`'s `<script>` both call the unmodified
`bindEditor(root)` (no injected history -- they build their own from `root`'s seed data), sharing
the `data-editor-bound` guard so a page using both never double-binds.
Evidence: packages/ui/src/components/editor/editor.tsx:37-53 (`useMemory`, `bindEditor(root,
history)`); editor.element.ts:30-35 (`bindEditor(this)`); editor.astro (script block, `bindEditor(root)`).

### 9. Conformance is green for React, WC, and Astro, including the axe tier
All three new conformance suites pass, each with its own axe-clean assertion scoped to the editor
root (not `document.body`, matching the rest of this codebase's widget-level axe scoping) plus a
negative control proving the axe tier is not vacuous. Ran locally:
`npx vitest run test/components/editor test/primitives/document-editor.test.ts` -> 7 files, 95
tests passed; `npx vitest run -c vitest.config.astro.ts test/components/editor/editor.astro.conformance.test.ts`
-> 1 file, 7 tests passed (Astro's SSR path needs the separate Astro vitest config the rest of the
suite already uses for `.astro` components).
Evidence: packages/ui/test/components/editor/editor.conformance.test.tsx ("is axe-clean" test),
editor.element.conformance.test.ts ("is axe-clean" test), editor.astro.conformance.test.ts
("is axe-clean pre-bind" test); local run output, 102/102 tests passed across both vitest configs.

### 10. primitives/history.ts is no longer imported on the editor's dependency path
`document-editor.ts` no longer imports `createHistory` from `./history` -- it imports
`createEditorHistory` from `../components/editor/editor-history` instead; its own comment marks
the old dependency "gone from this file's dependency path." Confirmed by search: the only
remaining import of `primitives/history` in the whole package is in `hooks/use-history.ts`, which
the issue explicitly scopes out (tracked separately under FR-EDITOR-001) -- nothing under
`components/editor/` or `document-editor.ts` references it, directly or transitively.
Evidence: packages/ui/src/primitives/document-editor.ts:37-45 (import swap), :126-136 (doc
comment); `git grep -n "primitives/history"` across `packages/ui/src` and `packages/ui/test`
returns only `hooks/use-history.ts` (out of scope) and comment-only mentions in
`document-editor.ts` and `editor-toolbar.ts` (the latter has no import statement at all -- the
mention is a doc comment about a consumer-provided callback).

### 11. Unit tests for the above pass; pnpm preflight is green
The five new/extended unit and conformance suites (95 + 7 = 102 tests) pass locally, and
`tsc --noEmit` for `packages/ui` is clean. `pnpm preflight` (typecheck, lint, format check,
test:unit, test:a11y, build across the whole monorepo) was run from the branch root and
completed with exit code 0: `packages/ui` test:unit 57 files / 358 tests passed, `composites`
test:unit 13 files / 196 tests passed, `cli` test:unit 23 files / 360 tests passed (12 skipped),
followed by a11y and a clean build across every workspace package.
Evidence: local `npx tsc --noEmit` (packages/ui) exit 0; local vitest runs above (102/102);
`pnpm preflight` full run, exit code 0 (typecheck, oxlint, oxfmt --check, test:unit, test:a11y,
build all green).

## Not done

- No `compose()`/`createBehavior`/`Slice`/`GlueSlice`/`EditorOpActions` -- explicitly excluded by
  RULING-EDITOR-HISTORY; not attempted.
- The op-based history model, op-log, and op vocabulary/`applyOp` themselves -- FR-EDITOR-002 and
  FR-EDITOR-003's scope, composed here, not rebuilt.
- Per-block parts (blocks-as-many-parts) -- root-only is the settled decision; not implemented.
- `hooks/use-history.ts` was not touched or ported -- tracked separately under FR-EDITOR-001, and
  its existing import of `primitives/history.ts` is left in place as that issue's starting point.
- `packages/ui/docs/spec/matrix/components.md`'s "Excluded: editor, ..." note was not updated in
  this PR (the issue marks this docs-only step as following once conformance is green, not gated
  by `pnpm preflight`) -- left for a follow-up now that conformance is green.
- DOM-to-model selection recovery, team-shared history, the smugglr/nanostores adapter, a zustand
  backend, and any CRDT/OT/sync -- all explicitly out of scope per the ruling; not attempted.
- The `deleteBlock`/`mergeWithPrevious`/`mergeWithNext` calls in `document-editor.ts` that discard
  `result.blocks` and read only cursor metadata (`focusBlockId`/`survivorId`/`cursorOffset`) were
  left as-is rather than refactored to avoid the redundant pure-function call -- fixing it would
  mean extending FR-EDITOR-003's op vocabulary to carry cursor metadata or duplicating
  survivor-id logic out of `block-operations.ts`, both bigger than this issue's mandate (noted in
  the simplify articulation as a LOW-severity, deliberately-unfixed observation).
- `packages/ui/tsconfig.json`'s pre-existing dead `include` entry (`test/components/dialog.test.tsx`,
  a path that does not exist -- dialog's tests live under `test/components/dialog/*`) was left
  alone; it predates this branch and cleaning it up is out of this issue's scope.

Closes #2107
