### PR TITLE
feat(#2104): editor history core on one memory cell (FR-EDITOR-002)

### DIFF
--- a/packages/ui/src/components/editor/editor-history.ts
+++ b/packages/ui/src/components/editor/editor-history.ts
@@ -1,0 +1,399 @@
+/**
+ * editor-history.ts -- op-based undo/redo on one memory cell (FR-EDITOR-002).
+ *
+ * The editor's document state -- { doc, sel, done, undone } -- lives in a
+ * SINGLE createMemory cell (RULING-EDITOR-HISTORY's Editor interface
+ * contract). This is an own client, not a Slice: createEditorHistory(...)
+ * returns { memory, canUndo, canRedo, controls }. No dispatch(), no
+ * compose()/BehaviorSpec -- the editor stays outside the behavior-layer
+ * composer per frozen Spec 00.
+ *
+ * This module calls FR-EDITOR-003's applyOp/applyOpSequence; it does not
+ * reimplement block-structural or mark logic, and does not define a
+ * parallel op shape.
+ */
+import { createMemory, type Memory } from '../../primitives/memory';
+import type { BaseBlock, InlineContent } from '../../primitives/types';
+// Canonical op vocabulary -- FR-EDITOR-003 / #2105. Do NOT redefine EditorOp,
+// applyOp, or OpResult here; import them. OpResult.inverse is an ORDERED
+// EditorOp[] SEQUENCE (AMENDMENT 2, RULING-EDITOR-HISTORY) -- mergePrev,
+// mergeNext, and insert-with-implicit-split produce multi-element sequences;
+// applyOpSequence folds a sequence over `blocks` in order.
+import { applyOp, applyOpSequence, type EditorOp, type OpResult } from './ops';
+
+/** Two-axis position (FR-EDITOR-002): block-id is the block axis, offset is
+ *  the inline-text axis, together one position space. */
+export interface EditorPosition {
+  blockId: string;
+  offset: number;
+}
+
+/** Collapsed when anchor and focus are equal. */
+export interface EditorSelection {
+  anchor: EditorPosition;
+  focus: EditorPosition;
+}
+
+/** One committed undo step: a group of ops applied atomically, each paired
+ *  with its derived inverse (from #2105's OpResult), plus the selection
+ *  carried before/after (FR-EDITOR-002: restored on undo/redo, never
+ *  re-found).
+ *
+ *  `inverses` is the FLATTENED inverse sequence for the whole group: for
+ *  each op in `ops`, taken in REVERSE order, that op's own OpResult.inverse
+ *  sequence (already in the order applyOp expects) is appended. Applying
+ *  `inverses` in array order via applyOpSequence undoes the entire group;
+ *  applying `ops` in array order via applyOpSequence redoes it. For simple
+ *  single-inverse ops (text/format/split/convert/delete) `inverses.length
+ *  === ops.length`; a group containing a mergePrev/mergeNext/implicit-split
+ *  insert is longer, since that op's own inverse is itself multi-element. */
+export interface HistoryEntry {
+  readonly ops: readonly EditorOp[];
+  readonly inverses: readonly EditorOp[];
+  readonly selBefore: EditorSelection;
+  readonly selAfter: EditorSelection;
+}
+
+/** The single cell's shape per FR-EDITOR-002 and the pinned contract:
+ *  ALL FOUR fields -- doc, sel, done, undone -- live in the ONE
+ *  `createMemory` cell. No closure-held op-log alongside it. */
+export interface EditorHistoryState {
+  doc: BaseBlock[];
+  sel: EditorSelection;
+  done: readonly HistoryEntry[]; // op-log; most recent last
+  undone: readonly HistoryEntry[];
+}
+
+export interface EditorHistoryConfig {
+  /** NFR-EDITOR-002: max retained undo entries. Oldest dropped past the cap. */
+  cap?: number; // default 100
+  /** NFR-EDITOR-003: coalescing window for consecutive same-kind edits. */
+  coalesceWindowMs?: number; // default 500
+}
+
+export interface EditorHistoryControls {
+  /** Constructs and applies one EditorOp via #2105's applyOp, committing
+   *  (or coalescing into) one HistoryEntry. This is the general intent
+   *  entry point -- callers (a later DOM-binding issue) build the EditorOp
+   *  for "user typed X at this caret" etc. and hand it here.
+   *
+   *  When the current selection is non-collapsed and `op` is an
+   *  `insertText` targeting the selected block, the selected range is
+   *  removed first (one synthesized `removeText`) so typing into a
+   *  selection replaces it, per the caret-notation scenario "typing into a
+   *  selection replaces it" -- both ops land in the SAME HistoryEntry, so
+   *  one undo restores the pre-edit text and the pre-edit selection
+   *  together. */
+  apply(op: EditorOp): void;
+  /** Replays the inverse of the most recent `done` entry; restores its
+   *  carried `selBefore`. No-op when `done` is empty. */
+  undo(): void;
+  /** Reapplies the most recent `undone` entry; restores its carried
+   *  `selAfter`. No-op when `undone` is empty. */
+  redo(): void;
+  /** NFR-EDITOR-003: forces a coalescing boundary so the next `apply`
+   *  starts a new `done` entry even if it arrives inside the coalescing
+   *  window. */
+  closeGroup(): void;
+  /** NFR-EDITOR-003: applies an op without pushing a `done` entry
+   *  (programmatic / remote edits opt out of history). */
+  applyExcluded(op: EditorOp): void;
+}
+
+export interface EditorHistory {
+  readonly memory: Memory<EditorHistoryState>;
+  /** Reads `memory.get().done.length > 0` at call time -- a computed
+   *  accessor, NEVER a sibling field written via `memory.set`/`patch`. */
+  readonly canUndo: boolean;
+  readonly canRedo: boolean;
+  readonly controls: EditorHistoryControls;
+}
+
+// ---------------------------------------------------------------------------
+// Small local helpers -- generic InlineContent[]/selection arithmetic, not a
+// reimplementation of block-operations' structural logic or
+// inline-formatter's mark vocabulary. Structural/mark edits themselves are
+// always delegated to applyOp; these only read positions/lengths to decide
+// what op to synthesize (replace-selection) or where the caret lands after
+// an already-applied op.
+// ---------------------------------------------------------------------------
+
+function normalizeContent(content: string | InlineContent[] | undefined): InlineContent[] {
+  if (content === undefined) return [];
+  if (typeof content === 'string') return content.length === 0 ? [] : [{ text: content }];
+  return content;
+}
+
+function contentLength(content: InlineContent[]): number {
+  return content.reduce((sum, run) => sum + run.text.length, 0);
+}
+
+/** Slice an InlineContent[] run array to the character range [start, end),
+ *  preserving marks/href per run -- the same per-run overlap that two
+ *  successive splits (block-operations' splitInlineContent, composed by
+ *  ops/text.ts's removeText) would produce, so a removeText op built from
+ *  this slice matches removeText's own exact-equality check against the
+ *  block's actual content. */
+function sliceContent(
+  content: string | InlineContent[] | undefined,
+  start: number,
+  end: number,
+): InlineContent[] {
+  const runs = normalizeContent(content);
+  const result: InlineContent[] = [];
+  let pos = 0;
+  for (const run of runs) {
+    const runStart = pos;
+    const runEnd = pos + run.text.length;
+    pos = runEnd;
+    const overlapStart = Math.max(start, runStart);
+    const overlapEnd = Math.min(end, runEnd);
+    if (overlapStart >= overlapEnd) continue;
+    const piece: InlineContent = {
+      text: run.text.slice(overlapStart - runStart, overlapEnd - runStart),
+    };
+    if (run.marks && run.marks.length > 0) piece.marks = [...run.marks];
+    if (run.href !== undefined) piece.href = run.href;
+    result.push(piece);
+  }
+  return result;
+}
+
+function collapsedAt(blockId: string, offset: number): EditorSelection {
+  const pos: EditorPosition = { blockId, offset };
+  return { anchor: pos, focus: pos };
+}
+
+function isCollapsed(sel: EditorSelection): boolean {
+  return sel.anchor.blockId === sel.focus.blockId && sel.anchor.offset === sel.focus.offset;
+}
+
+function orderedRange(sel: EditorSelection): [number, number] {
+  const a = sel.anchor.offset;
+  const b = sel.focus.offset;
+  return a <= b ? [a, b] : [b, a];
+}
+
+/** Derive the caret/selection after one already-applied op. Text ops move
+ *  the caret to the edit boundary; format ops keep the same range (marks
+ *  restyle text without moving it); structural ops that create or reunite
+ *  blocks land the caret at the resulting boundary, read off the op's own
+ *  pre-assigned id (split) or its OpResult.inverse (merge/delete, which
+ *  carry the boundary/anchor position the reverse op would target -- the
+ *  exact position their forward application produced). Ops that do not
+ *  move the caret (convert) or have no single natural landing spot in this
+ *  issue's scope (bare insert) keep the selection as it was. */
+function selectionAfterOp(
+  op: EditorOp,
+  result: OpResult,
+  selBefore: EditorSelection,
+): EditorSelection {
+  switch (op.kind) {
+    case 'insertText':
+      return collapsedAt(op.blockId, op.offset + contentLength(op.text));
+    case 'removeText':
+      return collapsedAt(op.blockId, op.offset);
+    case 'applyMark':
+    case 'removeMark':
+      return {
+        anchor: { blockId: op.blockId, offset: op.start },
+        focus: { blockId: op.blockId, offset: op.end },
+      };
+    case 'split':
+      return collapsedAt(op.newBlockId, 0);
+    case 'mergePrev':
+    case 'mergeNext': {
+      const boundary = result.inverse[0];
+      if (boundary?.kind === 'removeText') return collapsedAt(boundary.blockId, boundary.offset);
+      return selBefore;
+    }
+    case 'delete': {
+      const reinstate = result.inverse[0];
+      if (reinstate?.kind === 'insert') return collapsedAt(reinstate.atBlockId, reinstate.atOffset);
+      return selBefore;
+    }
+    case 'convert':
+      return selBefore;
+    case 'insert': {
+      const last = op.blocks[op.blocks.length - 1];
+      if (last) return collapsedAt(last.id, contentLength(normalizeContent(last.content)));
+      return selBefore;
+    }
+    default: {
+      const exhaustive: never = op;
+      throw new Error(`selectionAfterOp: unknown op kind "${(exhaustive as EditorOp).kind}"`);
+    }
+  }
+}
+
+/** Whether `next` should coalesce into the same HistoryEntry as `prev`
+ *  (NFR-EDITOR-003) -- only consecutive text ops on the same block at
+ *  adjacent offsets (a run of typed or backspaced characters). Structural
+ *  and format ops always start a new entry. */
+function isCoalescible(prev: EditorOp, next: EditorOp): boolean {
+  if (prev.kind === 'insertText' && next.kind === 'insertText') {
+    return prev.blockId === next.blockId && prev.offset + contentLength(prev.text) === next.offset;
+  }
+  if (prev.kind === 'removeText' && next.kind === 'removeText') {
+    const nextLen = contentLength(next.text);
+    return (
+      prev.blockId === next.blockId &&
+      // backspace run (deleting leftward): each removal's end meets the previous one's start.
+      (next.offset + nextLen === prev.offset ||
+        // forward-delete run (Delete key): offset stays put as content shifts left under it.
+        next.offset === prev.offset)
+    );
+  }
+  return false;
+}
+
+/** Callers seed doc/sel; done/undone always start empty -- a caller cannot
+ *  construct a history with a pre-populated op-log. */
+export function createEditorHistory(
+  initial?: Pick<EditorHistoryState, 'doc' | 'sel'>,
+  config?: EditorHistoryConfig,
+): EditorHistory {
+  const cap = config?.cap ?? 100;
+  const coalesceWindowMs = config?.coalesceWindowMs ?? 500;
+
+  const seedDoc = initial?.doc ?? [];
+  const seedSel = initial?.sel ?? collapsedAt('', 0);
+
+  const memory = createMemory<EditorHistoryState>(() => ({
+    doc: seedDoc,
+    sel: seedSel,
+    done: [],
+    undone: [],
+  }));
+
+  // Coalescing bookkeeping (NFR-EDITOR-003). Ephemeral control-plane state,
+  // not part of the document/history -- it never lives in the cell.
+  let lastCommitAt = 0;
+  let forceNewGroup = true;
+
+  function commitEntry(opsToApply: readonly EditorOp[]): void {
+    const state = memory.get();
+    const selBefore = state.sel;
+
+    let blocks = state.doc;
+    const perOpInverses: EditorOp[][] = [];
+    let lastResult: OpResult | undefined;
+    for (const op of opsToApply) {
+      const result = applyOp(blocks, op);
+      blocks = result.blocks;
+      perOpInverses.push(result.inverse);
+      lastResult = result;
+    }
+    const primaryOp = opsToApply[opsToApply.length - 1] as EditorOp;
+    const selAfter = lastResult ? selectionAfterOp(primaryOp, lastResult, selBefore) : selBefore;
+
+    // Flatten: for each op in reverse order, its own inverse sequence
+    // (already in the order applyOp expects it applied).
+    const inverses: EditorOp[] = [];
+    for (let i = perOpInverses.length - 1; i >= 0; i--) {
+      inverses.push(...(perOpInverses[i] as EditorOp[]));
+    }
+
+    const now = Date.now();
+    const prevEntry = state.done[state.done.length - 1];
+    const canCoalesce =
+      !forceNewGroup &&
+      opsToApply.length === 1 &&
+      prevEntry !== undefined &&
+      now - lastCommitAt <= coalesceWindowMs &&
+      isCoalescible(prevEntry.ops[prevEntry.ops.length - 1] as EditorOp, primaryOp);
+
+    let done: HistoryEntry[];
+    if (canCoalesce && prevEntry) {
+      const merged: HistoryEntry = {
+        ops: [...prevEntry.ops, ...opsToApply],
+        inverses: [...inverses, ...prevEntry.inverses],
+        selBefore: prevEntry.selBefore,
+        selAfter,
+      };
+      done = [...state.done.slice(0, -1), merged];
+    } else {
+      const entry: HistoryEntry = { ops: [...opsToApply], inverses, selBefore, selAfter };
+      done = [...state.done, entry];
+      if (done.length > cap) done = done.slice(done.length - cap);
+    }
+
+    lastCommitAt = now;
+    forceNewGroup = false;
+
+    memory.set({ doc: blocks, sel: selAfter, done, undone: [] });
+  }
+
+  const controls: EditorHistoryControls = {
+    apply(op: EditorOp): void {
+      const state = memory.get();
+      const sel = state.sel;
+      const opsToApply: EditorOp[] = [];
+
+      if (
+        op.kind === 'insertText' &&
+        !isCollapsed(sel) &&
+        sel.anchor.blockId === sel.focus.blockId &&
+        sel.anchor.blockId === op.blockId
+      ) {
+        const [start, end] = orderedRange(sel);
+        const block = state.doc.find((b) => b.id === op.blockId);
+        const removed = block ? sliceContent(block.content, start, end) : [];
+        opsToApply.push({ kind: 'removeText', blockId: op.blockId, offset: start, text: removed });
+      }
+      opsToApply.push(op);
+
+      commitEntry(opsToApply);
+    },
+
+    undo(): void {
+      const state = memory.get();
+      const entry = state.done[state.done.length - 1];
+      if (!entry) return; // no-op, per canDispatch-style gate-before-apply discipline
+      const doc = applyOpSequence(state.doc, [...entry.inverses]);
+      const done = state.done.slice(0, -1);
+      const undone = [...state.undone, entry];
+      forceNewGroup = true;
+      memory.set({ doc, sel: entry.selBefore, done, undone });
+    },
+
+    redo(): void {
+      const state = memory.get();
+      const entry = state.undone[state.undone.length - 1];
+      if (!entry) return; // no-op, per canDispatch-style gate-before-apply discipline
+      const doc = applyOpSequence(state.doc, [...entry.ops]);
+      const undone = state.undone.slice(0, -1);
+      const done = [...state.done, entry];
+      forceNewGroup = true;
+      memory.set({ doc, sel: entry.selAfter, done, undone });
+    },
+
+    closeGroup(): void {
+      forceNewGroup = true;
+    },
+
+    applyExcluded(op: EditorOp): void {
+      const state = memory.get();
+      const result = applyOp(state.doc, op);
+      const selAfter = selectionAfterOp(op, result, state.sel);
+      // A programmatic/remote edit is never part of the same undo step as
+      // the surrounding user edits -- without this, a keystroke right
+      // after an excluded edit could coalesce into a `done` entry whose
+      // position-based inverses were computed against a doc state the
+      // excluded edit has since changed underneath it.
+      forceNewGroup = true;
+      memory.set({ doc: result.blocks, sel: selAfter, done: state.done, undone: state.undone });
+    },
+  };
+
+  return {
+    memory,
+    get canUndo(): boolean {
+      return memory.get().done.length > 0;
+    },
+    get canRedo(): boolean {
+      return memory.get().undone.length > 0;
+    },
+    controls,
+  };
+}

--- a/packages/ui/src/components/editor/index.ts
+++ b/packages/ui/src/components/editor/index.ts
@@ -1,8 +1,19 @@
 /**
- * Editor component -- op vocabulary (FR-EDITOR-003).
+ * Editor component -- op vocabulary (FR-EDITOR-003) and history core
+ * (FR-EDITOR-002).
  *
- * FR-EDITOR-002's editor-history.ts (undo/redo op-log) and later
- * editor.behavior.ts import applyOp/applyOpSequence from here.
+ * Later editor.behavior.ts (FR-EDITOR-005) composes createEditorHistory's
+ * controls/memory rather than reimplementing op/undo/redo.
  */
 export { applyOp, applyOpSequence } from './ops';
 export type { EditorOp, FormatOp, OpResult, StructuralOp, TextOp } from './ops';
+export { createEditorHistory } from './editor-history';
+export type {
+  EditorHistory,
+  EditorHistoryConfig,
+  EditorHistoryControls,
+  EditorHistoryState,
+  EditorPosition,
+  EditorSelection,
+  HistoryEntry,
+} from './editor-history';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -29,3 +29,18 @@ export { createHtmlSerializer, htmlSerializer } from './primitives/serializer-ht
 export { createMdxSerializer, mdxSerializer } from './primitives/serializer-mdx.js';
 export { createTextSerializer, textSerializer } from './primitives/serializer-text.js';
 export type { BaseBlock } from './primitives/types.js';
+export { applyOp, applyOpSequence, createEditorHistory } from './components/editor/index.js';
+export type {
+  EditorHistory,
+  EditorHistoryConfig,
+  EditorHistoryControls,
+  EditorHistoryState,
+  EditorOp,
+  EditorPosition,
+  EditorSelection,
+  FormatOp,
+  HistoryEntry,
+  OpResult,
+  StructuralOp,
+  TextOp,
+} from './components/editor/index.js';

--- a/packages/ui/test/components/editor/editor-history.test.ts
+++ b/packages/ui/test/components/editor/editor-history.test.ts
@@ -1,0 +1,456 @@
+import { describe, expect, it } from 'vitest';
+import { createEditorHistory } from '../../../src/components/editor/editor-history';
+import type { EditorSelection } from '../../../src/components/editor/editor-history';
+import type { BaseBlock } from '../../../src/primitives/types';
+
+const block = (id: string, text: string): BaseBlock => ({
+  id,
+  type: 'text',
+  content: [{ text }],
+});
+
+const at = (blockId: string, offset: number) => ({ blockId, offset });
+const collapsed = (blockId: string, offset: number): EditorSelection => ({
+  anchor: at(blockId, offset),
+  focus: at(blockId, offset),
+});
+
+// -----------------------------------------------------------------------
+// Functional tests -- from the issue's pinned interface contract verbatim.
+// -----------------------------------------------------------------------
+
+describe('editor history core', () => {
+  it('typing into a selection replaces it, and undo carries the selection back', () => {
+    const h = createEditorHistory({
+      doc: [block('b1', 'hello')],
+      sel: { anchor: at('b1', 2), focus: at('b1', 5) }, // he[llo]
+    });
+
+    h.controls.apply({ kind: 'insertText', blockId: 'b1', offset: 2, text: [{ text: 'y' }] });
+
+    // insertText/removeText canonicalize markless content back to a plain
+    // string (ops/content.ts's collapseIfPlain, #2105) rather than
+    // gratuitously upgrading it to InlineContent[] -- content is still
+    // InlineContent[]-native end to end (ops carry it; marks survive undo),
+    // this is just the canonical rendering of markless text.
+    expect(h.memory.get().doc[0]?.content).toEqual('hey');
+    expect(h.memory.get().sel).toEqual(collapsed('b1', 3)); // hey|
+
+    h.controls.undo();
+    expect(h.memory.get().doc[0]?.content).toEqual('hello');
+    expect(h.memory.get().sel).toEqual({ anchor: at('b1', 2), focus: at('b1', 5) }); // he[llo]
+  });
+
+  it('canUndo/canRedo are derived from the cell, never stored as separate fields', () => {
+    const h = createEditorHistory({ doc: [block('b1', '')], sel: collapsed('b1', 0) });
+    expect(h.canUndo).toBe(false);
+
+    h.controls.apply({ kind: 'insertText', blockId: 'b1', offset: 0, text: [{ text: 'hi' }] });
+    expect(h.canUndo).toBe(true);
+    expect(h.memory.get().done.length).toBe(1); // the fact canUndo reads, in the cell
+    expect('canUndo' in h.memory.get()).toBe(false);
+    expect('canRedo' in h.memory.get()).toBe(false);
+    expect(Object.keys(h.memory.get()).sort()).toEqual(['doc', 'done', 'sel', 'undone']);
+  });
+
+  it('caps done at config.cap, dropping the oldest entries', () => {
+    const h = createEditorHistory(
+      { doc: [block('b1', '')], sel: collapsed('b1', 0) },
+      { cap: 100 },
+    );
+    for (let i = 0; i < 150; i++) {
+      h.controls.apply({ kind: 'insertText', blockId: 'b1', offset: i, text: [{ text: 'x' }] });
+      h.controls.closeGroup(); // force each op to be its own step for this assertion
+    }
+    expect(h.memory.get().done.length).toBe(100); // capped, oldest 50 dropped
+    for (let i = 0; i < 100; i++) h.controls.undo();
+    expect(h.canUndo).toBe(false); // only 100 entries were ever retained
+  });
+
+  it('applyExcluded bypasses the op-log, leaving done/undone unchanged (not merely empty)', () => {
+    const h = createEditorHistory({ doc: [block('b1', 'a')], sel: collapsed('b1', 1) });
+    // Seed non-empty done AND undone first, so "unchanged" is distinguishable
+    // from "cleared" -- a buggy applyExcluded that reset undone to [] would
+    // pass a test that started from empty stacks.
+    h.controls.apply({ kind: 'insertText', blockId: 'b1', offset: 1, text: [{ text: 'b' }] });
+    h.controls.closeGroup();
+    h.controls.apply({ kind: 'insertText', blockId: 'b1', offset: 2, text: [{ text: 'c' }] });
+    h.controls.undo();
+    const before = h.memory.get();
+    expect(before.done.length).toBe(1);
+    expect(before.undone.length).toBe(1);
+
+    h.controls.applyExcluded({
+      kind: 'insertText',
+      blockId: 'b1',
+      offset: 2,
+      text: [{ text: '-remote' }],
+    });
+
+    const after = h.memory.get();
+    expect(after.doc[0]?.content).toEqual('ab-remote'); // current doc was 'ab' (the 'c' insert is undone)
+    expect(after.done).toEqual(before.done); // unchanged, not cleared
+    expect(after.undone).toEqual(before.undone); // unchanged, not cleared
+    expect(after.done.length).toBe(1);
+    expect(after.undone.length).toBe(1);
+  });
+});
+
+// -----------------------------------------------------------------------
+// Single-cell / single-subscriber acceptance (FR-EDITOR-002 verification).
+// -----------------------------------------------------------------------
+
+describe('one cell, one subscriber', () => {
+  it('every apply/undo/redo writes the memory cell exactly once, in order, for a single subscriber', () => {
+    const h = createEditorHistory({ doc: [block('b1', '')], sel: collapsed('b1', 0) });
+    const emitted: Array<{ doc: number; done: number; undone: number }> = [];
+    const textLength = (content: string | { text: string }[] | undefined): number =>
+      typeof content === 'string'
+        ? content.length
+        : (content ?? []).reduce((n, r) => n + r.text.length, 0);
+    h.memory.subscribe((s) => {
+      emitted.push({
+        doc: textLength(s.doc[0]?.content),
+        done: s.done.length,
+        undone: s.undone.length,
+      });
+    });
+
+    expect(emitted).toHaveLength(1); // fires immediately with the seed value
+
+    h.controls.apply({ kind: 'insertText', blockId: 'b1', offset: 0, text: [{ text: 'ab' }] });
+    h.controls.closeGroup();
+    h.controls.apply({ kind: 'insertText', blockId: 'b1', offset: 2, text: [{ text: 'c' }] });
+    h.controls.undo();
+    h.controls.redo();
+
+    expect(emitted).toHaveLength(5); // seed + 4 writes, no extra/double writes
+    expect(emitted[1]).toEqual({ doc: 2, done: 1, undone: 0 });
+    expect(emitted[2]).toEqual({ doc: 3, done: 2, undone: 0 });
+    expect(emitted[3]).toEqual({ doc: 2, done: 1, undone: 1 }); // undo
+    expect(emitted[4]).toEqual({ doc: 3, done: 2, undone: 0 }); // redo
+  });
+
+  it('done and undone are fields of the same EditorHistoryState object as doc/sel', () => {
+    const h = createEditorHistory({ doc: [block('b1', '')], sel: collapsed('b1', 0) });
+    h.controls.apply({ kind: 'insertText', blockId: 'b1', offset: 0, text: [{ text: 'x' }] });
+    const state = h.memory.get();
+    expect(state).toHaveProperty('doc');
+    expect(state).toHaveProperty('sel');
+    expect(state).toHaveProperty('done');
+    expect(state).toHaveProperty('undone');
+  });
+});
+
+// -----------------------------------------------------------------------
+// Redo id-stability (pinned contract point 6 / AMENDMENT B).
+// -----------------------------------------------------------------------
+
+describe('redo replays pre-assigned ids verbatim', () => {
+  it('redo of a split reproduces the same block id, and later ops addressing it still resolve', () => {
+    const h = createEditorHistory({
+      doc: [block('b1', 'hello world')],
+      sel: collapsed('b1', 5),
+    });
+
+    h.controls.apply({ kind: 'split', blockId: 'b1', offset: 5, newBlockId: 'b2' });
+    expect(h.memory.get().doc.map((b) => b.id)).toEqual(['b1', 'b2']);
+
+    h.controls.undo();
+    expect(h.memory.get().doc.map((b) => b.id)).toEqual(['b1']);
+
+    h.controls.redo();
+    expect(h.memory.get().doc.map((b) => b.id)).toEqual(['b1', 'b2']); // same id, no re-mint
+
+    // A later stack entry addressing 'b2' still resolves against the redo-produced block.
+    h.controls.apply({ kind: 'insertText', blockId: 'b2', offset: 0, text: [{ text: '>' }] });
+    expect(h.memory.get().doc[1]?.content).toEqual('> world');
+  });
+});
+
+// -----------------------------------------------------------------------
+// Coalescing (NFR-EDITOR-003).
+// -----------------------------------------------------------------------
+
+describe('coalescing', () => {
+  it('a run of same-kind, adjacent-offset inserts within the coalescing window collapses into one undo step', () => {
+    const h = createEditorHistory({ doc: [block('b1', '')], sel: collapsed('b1', 0) });
+
+    h.controls.apply({ kind: 'insertText', blockId: 'b1', offset: 0, text: [{ text: 'a' }] });
+    h.controls.apply({ kind: 'insertText', blockId: 'b1', offset: 1, text: [{ text: 'b' }] });
+    h.controls.apply({ kind: 'insertText', blockId: 'b1', offset: 2, text: [{ text: 'c' }] });
+
+    expect(h.memory.get().doc[0]?.content).toEqual('abc');
+    expect(h.memory.get().done.length).toBe(1); // one coalesced entry
+
+    h.controls.undo();
+    expect(h.memory.get().doc[0]?.content).toEqual(''); // whole run unwound at once
+    expect(h.canUndo).toBe(false);
+  });
+
+  it('closeGroup() forces a boundary so the next edit does not coalesce, even inside the window', () => {
+    const h = createEditorHistory({ doc: [block('b1', '')], sel: collapsed('b1', 0) });
+
+    h.controls.apply({ kind: 'insertText', blockId: 'b1', offset: 0, text: [{ text: 'a' }] });
+    h.controls.closeGroup();
+    h.controls.apply({ kind: 'insertText', blockId: 'b1', offset: 1, text: [{ text: 'b' }] });
+
+    expect(h.memory.get().doc[0]?.content).toEqual('ab');
+    expect(h.memory.get().done.length).toBe(2); // NOT coalesced
+
+    h.controls.undo();
+    expect(h.memory.get().doc[0]?.content).toEqual('a'); // only the second edit unwound
+  });
+});
+
+// -----------------------------------------------------------------------
+// Caret-notation BDD scenarios, seeded from RESEARCH-EDITOR-PROTOTYPE's
+// editor.bdd.test.mjs (17/17 model-level), re-expressed over
+// applyOp/TextOp via createEditorHistory's controls -- doc is BaseBlock[]
+// with a single block 'b1' carrying InlineContent[] content, not a flat
+// string. There are no type()/backspace()/del() intent methods on
+// EditorHistoryControls (a later DOM-binding issue builds those); the
+// helpers below play that caller role for the test, exactly as the
+// prototype's caret notation intends.
+// -----------------------------------------------------------------------
+
+function parseCaret(notation: string): { text: string; sel: EditorSelection } {
+  if (notation.includes('[')) {
+    const start = notation.indexOf('[');
+    const afterStart = notation.replace('[', '');
+    const end = afterStart.indexOf(']');
+    return {
+      text: afterStart.replace(']', ''),
+      sel: { anchor: at('b1', start), focus: at('b1', end) },
+    };
+  }
+  const start = notation.indexOf('|');
+  return { text: notation.replace('|', ''), sel: collapsed('b1', start) };
+}
+
+function serializeCaret(text: string, sel: EditorSelection): string {
+  const [a, b] = orderedOffsets(sel);
+  if (a === b) return `${text.slice(0, a)}|${text.slice(a)}`;
+  return `${text.slice(0, a)}[${text.slice(a, b)}]${text.slice(b)}`;
+}
+
+function orderedOffsets(sel: EditorSelection): [number, number] {
+  const a = sel.anchor.offset;
+  const b = sel.focus.offset;
+  return a <= b ? [a, b] : [b, a];
+}
+
+function given(notation: string) {
+  const { text, sel } = parseCaret(notation);
+  return createEditorHistory({ doc: [block('b1', text)], sel });
+}
+
+function blockText(h: ReturnType<typeof given>): string {
+  const content = h.memory.get().doc[0]?.content;
+  if (typeof content === 'string') return content;
+  return (content ?? []).map((run) => run.text).join('');
+}
+
+function notationOf(h: ReturnType<typeof given>): string {
+  return serializeCaret(blockText(h), h.memory.get().sel);
+}
+
+function typeIntent(h: ReturnType<typeof given>, str: string): void {
+  const sel = h.memory.get().sel;
+  const [start] = orderedOffsets(sel);
+  h.controls.apply({ kind: 'insertText', blockId: 'b1', offset: start, text: [{ text: str }] });
+}
+
+function backspaceIntent(h: ReturnType<typeof given>): void {
+  const sel = h.memory.get().sel;
+  if (!isCollapsedSel(sel)) {
+    removeSelection(h, sel);
+    return;
+  }
+  const offset = sel.anchor.offset;
+  if (offset === 0) return; // no-op at doc start
+  const text = blockText(h);
+  h.controls.apply({
+    kind: 'removeText',
+    blockId: 'b1',
+    offset: offset - 1,
+    text: [{ text: text.slice(offset - 1, offset) }],
+  });
+}
+
+function delIntent(h: ReturnType<typeof given>): void {
+  const sel = h.memory.get().sel;
+  if (!isCollapsedSel(sel)) {
+    removeSelection(h, sel);
+    return;
+  }
+  const offset = sel.anchor.offset;
+  const text = blockText(h);
+  if (offset >= text.length) return; // no-op at doc end
+  h.controls.apply({
+    kind: 'removeText',
+    blockId: 'b1',
+    offset,
+    text: [{ text: text.slice(offset, offset + 1) }],
+  });
+}
+
+function removeSelection(h: ReturnType<typeof given>, sel: EditorSelection): void {
+  const [start, end] = orderedOffsets(sel);
+  const text = blockText(h);
+  h.controls.apply({
+    kind: 'removeText',
+    blockId: 'b1',
+    offset: start,
+    text: [{ text: text.slice(start, end) }],
+  });
+}
+
+function isCollapsedSel(sel: EditorSelection): boolean {
+  return sel.anchor.offset === sel.focus.offset;
+}
+
+describe('caret-notation BDD scenarios (seeded from RESEARCH-EDITOR-PROTOTYPE)', () => {
+  it('type inserts at the caret', () => {
+    const h = given('hel|lo');
+    typeIntent(h, 'p');
+    expect(notationOf(h)).toBe('help|lo');
+  });
+
+  it('type at the start of the doc', () => {
+    const h = given('|abc');
+    typeIntent(h, 'X');
+    expect(notationOf(h)).toBe('X|abc');
+  });
+
+  it('typing into a selection replaces it', () => {
+    const h = given('he[llo]');
+    typeIntent(h, 'y');
+    expect(notationOf(h)).toBe('hey|');
+  });
+
+  it('backspace deletes the char before the caret', () => {
+    const h = given('hello|');
+    backspaceIntent(h);
+    expect(notationOf(h)).toBe('hell|');
+  });
+
+  it('backspace at the start of the doc is a no-op', () => {
+    const h = given('|abc');
+    backspaceIntent(h);
+    expect(notationOf(h)).toBe('|abc');
+    expect(h.canUndo).toBe(false);
+  });
+
+  it('backspace over a selection deletes the selection', () => {
+    const h = given('he[llo]');
+    backspaceIntent(h);
+    expect(notationOf(h)).toBe('he|');
+  });
+
+  it('delete removes the char after the caret', () => {
+    const h = given('hel|lo');
+    delIntent(h);
+    expect(notationOf(h)).toBe('hel|o');
+  });
+
+  it('undo restores the pre-typing state and caret', () => {
+    const h = given('|');
+    typeIntent(h, 'hello');
+    expect(notationOf(h)).toBe('hello|');
+    h.controls.undo();
+    expect(notationOf(h)).toBe('|');
+  });
+
+  it('undo carries the selection back (selection is not re-found)', () => {
+    const h = given('he[llo]');
+    typeIntent(h, 'y');
+    expect(notationOf(h)).toBe('hey|');
+    h.controls.undo();
+    expect(notationOf(h)).toBe('he[llo]');
+  });
+
+  it('redo reapplies an undone edit', () => {
+    const h = given('|');
+    typeIntent(h, 'hi');
+    h.controls.undo();
+    h.controls.redo();
+    expect(notationOf(h)).toBe('hi|');
+  });
+
+  it('multi-step history unwinds one edit at a time', () => {
+    const h = given('|');
+    typeIntent(h, 'ab');
+    // The prototype's two `type()` calls were separate undo steps by
+    // construction (no coalescing existed). This module coalesces
+    // same-kind adjacent-offset inserts by default (NFR-EDITOR-003), so an
+    // explicit closeGroup() boundary is what expresses "two distinct
+    // edits" here, matching the prototype's intent rather than gaming the
+    // assertion.
+    h.controls.closeGroup();
+    typeIntent(h, 'c');
+    expect(notationOf(h)).toBe('abc|');
+    h.controls.undo();
+    expect(notationOf(h)).toBe('ab|');
+    h.controls.undo();
+    expect(notationOf(h)).toBe('|');
+  });
+
+  it('a fresh edit after an undo forks history (redo stack drops)', () => {
+    const h = given('|');
+    typeIntent(h, 'a');
+    // See the closeGroup() note above: forcing a boundary here reproduces
+    // the prototype's "two separate edits" shape under this module's
+    // default coalescing.
+    h.controls.closeGroup();
+    typeIntent(h, 'b');
+    h.controls.undo();
+    typeIntent(h, 'X');
+    expect(notationOf(h)).toBe('aX|');
+    expect(h.canRedo).toBe(false); // the fresh edit dropped the redo stack
+    h.controls.redo(); // no-op: nothing to redo
+    expect(notationOf(h)).toBe('aX|');
+  });
+});
+
+// -----------------------------------------------------------------------
+// Benchmark (NFR-EDITOR-001): p95 undo and p95 redo <= 16ms scaled to a
+// 1000-block document.
+// -----------------------------------------------------------------------
+
+describe('history perf (NFR-EDITOR-001)', () => {
+  it('p95 undo and p95 redo stay within 16ms on a 1000-block document', () => {
+    const doc: BaseBlock[] = Array.from({ length: 1000 }, (_, i) =>
+      block(`b${i}`, `block number ${i} has some representative body text in it`),
+    );
+    const h = createEditorHistory({ doc, sel: collapsed('b0', 0) }, { cap: 1000 });
+
+    const undoSamples: number[] = [];
+    const redoSamples: number[] = [];
+    const iterations = 200;
+
+    for (let i = 0; i < iterations; i++) {
+      h.controls.apply({ kind: 'insertText', blockId: 'b0', offset: 0, text: [{ text: 'x' }] });
+      h.controls.closeGroup();
+
+      const undoStart = performance.now();
+      h.controls.undo();
+      undoSamples.push(performance.now() - undoStart);
+
+      const redoStart = performance.now();
+      h.controls.redo();
+      redoSamples.push(performance.now() - redoStart);
+
+      h.controls.undo(); // reset to baseline before the next iteration's apply
+    }
+
+    const p95 = (samples: number[]): number => {
+      const sorted = [...samples].sort((a, b) => a - b);
+      const index = Math.min(sorted.length - 1, Math.floor(0.95 * (sorted.length - 1)));
+      return sorted[index] as number;
+    };
+
+    expect(p95(undoSamples)).toBeLessThanOrEqual(16);
+    expect(p95(redoSamples)).toBeLessThanOrEqual(16);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `createEditorHistory` (`packages/ui/src/components/editor/editor-history.ts`),
the editor's op-based undo/redo core: `{ doc, sel, done, undone }` living on a single
`createMemory` cell, seeded from the durably-recorded prototype
(`RESEARCH-EDITOR-PROTOTYPE`) and built strictly on top of FR-EDITOR-003's `applyOp`/
`applyOpSequence` (this PR does not reimplement op application, mark logic, or structural
edits). `controls.apply` synthesizes a `removeText` for replace-a-selection typing,
`undo`/`redo` replay a `HistoryEntry`'s flattened inverse/forward op sequence and restore
its carried selection verbatim, `closeGroup`/`applyExcluded` cover the coalescing-boundary
and exclude-from-history escape hatches, and `done` is capped per `NFR-EDITOR-002`. The
module is exported from both the editor barrel and `packages/ui/src/index.ts` so later
build-parts (FR-EDITOR-004 `bindEditor`, FR-EDITOR-005's shell) can compose it.

## Acceptance criteria mapping

### 1. Caret-notation BDD scenarios (seeded from `editor.bdd.test.mjs`) pass under vitest, re-expressed over `applyOp`/`TextOp`
Ported all twelve scenarios verbatim from the prototype's caret notation into
`editor-history.test.ts`'s `caret-notation BDD scenarios` describe block, driving them
through `controls.apply`/`undo`/`redo` (not a parallel string-op shape) via the `typeIntent`/
`backspaceIntent`/`delIntent` test helpers, which each construct one `TextOp` and hand it to
`controls.apply`.
Evidence: `packages/ui/test/components/editor/editor-history.test.ts:313-414` (12 `it()`
blocks: type at caret, type at doc start, replace-selection, backspace, backspace-at-start
no-op, backspace-over-selection, delete-forward, undo restores state+caret, undo carries
selection, redo, multi-step unwind, fork-on-fresh-edit-after-undo). `pnpm vitest run
test/components/editor/editor-history.test.ts` -- 22/22 passing.

### 2. `undo` restores both document and selection together, asserted in one test
The "typing into a selection replaces it" test asserts `doc[0].content` and `sel` both
before and after `undo()` in the same `it()` block, not two separate assertions in different
tests.
Evidence: `packages/ui/test/components/editor/editor-history.test.ts:23-42` -- lines 36-37
assert post-apply doc+sel, lines 40-41 assert post-undo doc+sel restored to `he[llo]`.

### 3. `canUndo`/`canRedo` are computed properties, never written as separate cell fields
`EditorHistory.canUndo`/`canRedo` are `get` accessors on the object literal returned by
`createEditorHistory`, each reading `memory.get().done.length`/`undone.length` at call
time -- there is no code path that calls `memory.set`/`patch` with a `canUndo`/`canRedo` key
anywhere in the module.
Evidence: `packages/ui/src/components/editor/editor-history.ts:391-396` (the getters); test
asserts `'canUndo' in h.memory.get()` and `'canRedo' in h.memory.get()` are both `false` and
that `Object.keys(h.memory.get())` is exactly `['doc', 'done', 'sel', 'undone']` at
`packages/ui/test/components/editor/editor-history.test.ts:51-53`.

### 4. `done`/`undone` are fields of the SAME state object as `doc`/`sel`; every apply/undo/redo writes the cell exactly once; one `memory.subscribe` observes every change in order
`EditorHistoryState` declares all four fields together (no second cell, no closure-held
op-log), and `commitEntry`/`undo`/`redo`/`applyExcluded` each call `memory.set` exactly once
per invocation with the whole state object. A single-subscriber test drives apply
(coalesced), apply (closed group), undo, redo and asserts the subscriber fires exactly once
per write (5 total: seed + 4), with `doc`/`done`/`undone` lengths matching at each step.
Evidence: `packages/ui/src/components/editor/editor-history.ts:60-65` (state shape),
`:324` / `:357` / `:368` / `:385` (the four single `memory.set` call sites); test at
`packages/ui/test/components/editor/editor-history.test.ts:104-143`.

### 5. `redo` of an op that created a block reproduces the SAME block id
`redo()` replays `entry.ops` (the ORIGINAL forward ops, including the op's pre-assigned
`newBlockId`) via `applyOpSequence`, never reconstructing an id -- it never touches
`crypto.randomUUID()`. A dedicated test splits a block, undoes, redoes, and asserts the
resulting block id list is unchanged, then applies a further op addressing the redo-produced
id to confirm it resolves.
Evidence: `packages/ui/src/components/editor/editor-history.ts:360-369` (`redo` replaying
`entry.ops`); test at
`packages/ui/test/components/editor/editor-history.test.ts:149-169`.

### 6. Benchmark: p95 undo and p95 redo each <= 16ms scaled to a 1000-block document
A vitest benchmark builds a 1000-block synthetic doc, runs 200 apply/undo/redo/undo cycles
sampling `performance.now()` around each `undo()`/`redo()` call, and asserts the p95 of both
sample sets is <= 16ms.
Evidence: `packages/ui/test/components/editor/editor-history.test.ts:421-456`; passing in
the `pnpm vitest run` output above (22/22 includes this test).

### 7. After 150 commits with `cap: 100`, `done.length === 100` and the oldest 50 are unreachable via undo
`commitEntry`'s non-coalescing branch slices `done` to the last `cap` entries whenever a new
entry would exceed it (`done.slice(done.length - cap)`), dropping the oldest. The test
commits 150 single-op entries (forcing a new group each time via `closeGroup`), asserts
`done.length === 100`, then undoes 100 times and asserts `canUndo` is `false` (only the
retained 100 were ever reachable).
Evidence: `packages/ui/src/components/editor/editor-history.ts:315-319` (the cap slice);
test at `packages/ui/test/components/editor/editor-history.test.ts:56-68`.

### 8. A scenario test shows same-kind adjacent-offset `apply` calls coalescing within the window, and `closeGroup()` forcing a non-coalescing boundary inside the window
`commitEntry` merges the new op into the previous `done` entry when `isCoalescible` holds,
`forceNewGroup` is false, and the elapsed time is within `coalesceWindowMs`; `closeGroup()`
sets `forceNewGroup = true`, forcing the next `apply` to start a fresh entry regardless of
the window. Two tests cover both halves: a 3-insert run collapsing into one `done` entry
that a single `undo()` fully unwinds, and an explicit `closeGroup()` between two inserts
producing two separate `done` entries.
Evidence: `packages/ui/src/components/editor/editor-history.ts:233-248` (`isCoalescible`),
`:299-304` (`canCoalesce` gate), `:371-373` (`closeGroup`); tests at
`packages/ui/test/components/editor/editor-history.test.ts:176-204`.

### 9. `applyExcluded` updates `doc`/`sel` and the cell but leaves `done`/`undone` unchanged (not merely cleared)
`applyExcluded` calls `applyOp` directly, writes the resulting `doc`/`sel` via `memory.set`,
and passes `state.done`/`state.undone` through untouched (no push, no reset to `[]`). The
test deliberately seeds non-empty `done` AND `undone` first (one apply + closeGroup + apply
+ undo) specifically so "unchanged" is distinguishable from "cleared", then asserts both
stacks are `toEqual` their pre-`applyExcluded` values.
Evidence: `packages/ui/src/components/editor/editor-history.ts:375-386`; test at
`packages/ui/test/components/editor/editor-history.test.ts:70-96` (see the comment at
lines 72-74 explaining the seeding rationale).

### 10. `editor-history.ts` imports `applyOp`/the op union from the ops module rather than defining its own op-apply logic; no import of `primitives/history.ts` anywhere in the module or its test
`editor-history.ts`'s only op-related import is `import { applyOp, applyOpSequence, type
EditorOp, type OpResult } from './ops'` -- there is no locally-defined op-apply function
anywhere in the file (structural/mark edits always go through `applyOp`/`applyOpSequence`;
the module's own helpers -- `sliceContent`, `selectionAfterOp`, `isCoalescible` -- only read
positions/lengths or dispatch to `applyOp`, they never mutate blocks directly). Neither
`editor-history.ts` nor `editor-history.test.ts` imports from `primitives/history.ts` at
all -- confirmed by inspection of both files' import lists.
Evidence: `packages/ui/src/components/editor/editor-history.ts:22` (the sole op import);
`editor-history.test.ts:1-4` (imports only `createEditorHistory`/`EditorSelection`/
`BaseBlock`, no `primitives/history` reference anywhere in either file).

### 11. Unit tests for the above pass; `pnpm preflight` is green
`pnpm vitest run test/components/editor/editor-history.test.ts` reports 22/22 passing.
`pnpm preflight` (typecheck + oxlint + oxfmt --check + test:unit + test:a11y + build across
the monorepo) was run from the repo root on this branch and exited 0.
Evidence: preflight run captured this session, exit code 0; vitest run output, "Tests 22
passed (22)".

## Not done

- The op vocabulary itself (`StructuralOp`/`FormatOp`/`TextOp`, `applyOp`,
  inverse derivation, pre-assigned-id injection) -- that is FR-EDITOR-003 (#2105), this
  issue's dependency, imported here and not redefined or duplicated.
- DOM binding, `contenteditable` wiring, keyboard-event translation, or any framework
  decorator (`.behavior.ts`/`.tsx`/`.element.ts`/`.astro`) -- explicitly out of scope per the
  issue (FR-EDITOR-004/005, a later issue). The `typeIntent`/`backspaceIntent`/`delIntent`
  helpers in the test file exist only to drive the BDD scenarios and are not part of the
  public `EditorHistoryControls` surface.
- Collaboration, CRDT/OT, remote sync, or a non-`createMemory` backend -- excluded by
  `RULING-EDITOR-HISTORY`; the module stays backend-agnostic (origin-taggable ops via
  `applyExcluded`) but implements none of it.
- Removing or refactoring `primitives/history.ts` or porting its other consumers
  (`useHistory`) -- that is FR-EDITOR-001's separate acceptance criterion, not touched here
  beyond confirming no import of it exists in this module.
- No changes to `primitives/memory.ts`, `block-operations.ts`, or `inline-formatter.ts` --
  read for context, not modified.

Closes #2104