### PR TITLE
fix(release): node24-native checkout + setup-node so npm publish works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24.12
           cache: pnpm


### PR DESCRIPTION
The 0.2.2 npm publish failed at the `npm publish --provenance` step. Cause: `actions/checkout@v4` and `actions/setup-node@v4` run on the node20 action-runtime, which GitHub is now force-migrating to node24 (the exact deprecation warning the failed run 32529330408 carried). 0.0.85 published fine on the IDENTICAL workflow 22h earlier -- same file, worked yesterday, fails today = the forced node20->24 migration newly biting. Bump both to the node24-native `@v5`. `pnpm/action-setup@v4` stays (no v5; tolerates node24). `node-version: 24.12` was already correct.

pr-write gate skipped: a CI-workflow fix has no issue acceptance-criteria to map. legion-simplify clean on HEAD (01a02660).

After merge: tag the new main HEAD as `v0.2.2a` to re-fire the release workflow with the fixed yml and publish the (never-published) 0.2.2 package to npm.