### PR TITLE
fix(release): pnpm/action-setup to node24 v6.0.10 -- the real publish fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@v5


### PR DESCRIPTION
The 0.2.2 publish failed twice at `npm publish` because `pnpm/action-setup@v4` runs on the node20 action-runtime GitHub is force-migrating to node24 -- the last node20 action left after checkout/setup-node went to v5. Bumped to `pnpm/action-setup@v6.0.10` (verified action.yml declares `using: node24`). pnpm version still resolves from the root `packageManager: pnpm@11.9.0`, so no `with:` change. All three actions are now node24-native.

pr-write gate skipped: CI-workflow fix, no issue ACs. legion-simplify clean on HEAD (01a02668).

After merge: tag main HEAD `v0.2.2b` to re-fire the workflow and publish the (still-unpublished) 0.2.2 package.