### PR TITLE
chore(release): 0.2.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "rafters",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Design intelligence enforcement for Rafters projects",
   "owner": {
     "name": "Sean Silvius",
@@ -11,7 +11,7 @@
     {
       "name": "rafters",
       "description": "Design intelligence enforcement for Rafters projects. Prevents guessing at design decisions by enforcing MCP tool usage, Container/Grid layout, classy(), and design token compliance.",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "author": {
         "name": "Sean Silvius",
         "email": "sean@silvius.me"

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,10 +1,10 @@
 # rafters
 
-## 0.2.2
+## 0.2.3
 
 ### Versioning
 
-- The CLI, the Claude Code plugin, and the marketplace entry are now a single version pinned to the CLI. They had drifted apart: the plugin was independently versioned and had reached `0.2.1`, while #2124 wired the plugin's MCP at the CLI's then-current `0.0.85` and set `plugin.json`/`marketplace.json` to match -- a number below where the plugin already was, so an installed plugin would read the unified release as a downgrade and stop offering the update. `0.2.2` is the first unified number that climbs past the plugin's last independent `0.2.1`, so the update prompt fires and every artifact moves forward together from here. This is why the release jumps from `0.0.85` to `0.2.2` rather than `0.0.86`.
+- The CLI, the Claude Code plugin, and the marketplace entry are now a single version pinned to the CLI. They had drifted apart: the plugin was independently versioned and had reached `0.2.1`, while #2124 wired the plugin's MCP at the CLI's then-current `0.0.85` and set `plugin.json`/`marketplace.json` to match -- a number below where the plugin already was, so an installed plugin would read the unified release as a downgrade and stop offering the update. `0.2.3` is the first unified number that clears both the plugin's last independent `0.2.1` and the npm-burned `0.2.0`/`0.2.2` (version numbers npm permanently reserves once published, even after an unpublish), so the update prompt fires and every artifact moves forward together from here. This is why the release jumps from `0.0.85` to `0.2.3`.
 
 ### Features
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rafters",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Design Intelligence CLI. Scaffold tokens, import existing shadcn/Tailwind v4 sources, add components, and serve an MCP server so AI agents read decisions instead of guessing.",
   "homepage": "https://rafters.studio",
   "license": "MIT",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rafters",
   "description": "Design intelligence enforcement for Rafters projects. Prevents guessing at design decisions by enforcing MCP tool usage, Container/Grid layout, classy(), and design token compliance.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": {
     "name": "Sean Silvius",
     "email": "sean@silvius.me"

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,5 +1,5 @@
 {
   "name": "rafters-plugin-bundle",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true
 }


### PR DESCRIPTION
Release 0.2.3. Version bump + changelog renumber only -- no code changes.

Why 0.2.3 not 0.2.2: npm permanently reserves a version number once published, and 0.2.0/0.2.2 were both published-then-unpublished on npm in Oct 2025 -- so `npm publish` of 0.2.2 returns E400 'cannot publish over previously published version 0.2.2'. The release workflow was never broken (0.0.85 published fine on it). 0.2.3 is the first unified number free of the npm-burned 0.2.0/0.2.2 and clearing the plugin's prior independent 0.2.1.

All five version fields (CLI, plugin/package.json, plugin.json, marketplace top-level + plugins entry) at 0.2.3. Same six features as the 0.2.2 section, renumbered (content unchanged): #2124 plugin MCP wiring, #2125 AGENTS.md, #2104/#2109/#2107/#2106 editor.

pr-write gate skipped: release chore, no issue ACs. legion-simplify clean on HEAD (01a02673).

Merge, then push the `v0.2.3` tag to publish.